### PR TITLE
Fix king move generation

### DIFF
--- a/src/domain/service/checkmate.test.ts
+++ b/src/domain/service/checkmate.test.ts
@@ -105,4 +105,17 @@ describe("Checkmate detection tests", () => {
         const result = isCheckmate(board, "black");
         expect(result).toBe(true); // 王がどこにも動けない
     });
+
+    it("玉を使用する後手の王が無攻撃なら詰みでない", () => {
+        const board: Board = {
+            "55": {
+                kind: "玉",
+                promoted: false,
+                owner: "white",
+            },
+        };
+
+        const result = isCheckmate(board, "white");
+        expect(result).toBe(false);
+    });
 });

--- a/src/domain/service/checkmate.ts
+++ b/src/domain/service/checkmate.ts
@@ -9,12 +9,15 @@ const allSquares: Square[] = Array.from({ length: 9 * 9 }, (_, i) => ({
     column: ((i % 9) + 1) as Column,
 }));
 
-// 王の位置を取得
+// 王または玉の位置を取得
 const findKingSquare = (board: Board, player: Player): Square | null => {
     return (
         allSquares.find((sq) => {
             const piece = getPiece(board, sq);
-            return piece?.kind === "王" && piece.owner === player;
+            return (
+                (piece?.kind === "王" || piece?.kind === "玉") &&
+                piece.owner === player
+            );
         }) || null
     );
 };

--- a/src/domain/service/moveService.test.ts
+++ b/src/domain/service/moveService.test.ts
@@ -213,4 +213,16 @@ describe("generateMoves", () => {
         expect(targets).not.toContain("33");
         expect(targets).toContain("77");
     });
+
+    it("generates king moves for 玉", () => {
+        let board: Board = { ...nullBoard };
+        board = setPiece(board, sq(5, 5), makePiece("玉", "white"));
+
+        const moves = generateMoves(board, sq(5, 5));
+        const targets = moves.map((m) => `${m.to.row}${m.to.column}`);
+        expect(targets.length).toBe(8);
+        for (const t of ["44", "45", "46", "54", "56", "64", "65", "66"]) {
+            expect(targets).toContain(t);
+        }
+    });
 });

--- a/src/domain/service/moveService.ts
+++ b/src/domain/service/moveService.ts
@@ -252,6 +252,7 @@ function getMoveVectors(piece: Piece): Vec[] {
                 v.push(...king.filter(([dr, dc]) => Math.abs(dr) === 1 && Math.abs(dc) === 1));
             break;
         case "王":
+        case "玉":
             v.push(...king);
             break;
     }


### PR DESCRIPTION
## Summary
- support `玉` in move generation by treating it like `王`
- test king moves for `玉`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455dcbd4408329b23134b92327c2d7