### PR TITLE
Add checkmate detection to game store

### DIFF
--- a/src/state/gameStore.test.ts
+++ b/src/state/gameStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import type { Board } from "@/domain/model/board";
+import type { Move } from "@/domain/model/move";
+import type { Piece } from "@/domain/model/piece";
+import { createEmptyHands } from "@/domain/service/moveService";
+import { useGameStore } from "./gameStore";
+
+// 簡易盤面設定ユーティリティ
+const place = (board: Board, key: string, piece: Piece): Board => ({
+    ...board,
+    [key]: piece,
+});
+
+describe("useGameStore makeMove", () => {
+    it("updates result when move results in checkmate", () => {
+        let board: Board = {};
+        board = place(board, "55", { kind: "王", promoted: false, owner: "black" });
+        board = place(board, "45", { kind: "飛", promoted: false, owner: "white" });
+        board = place(board, "54", { kind: "銀", promoted: false, owner: "white" });
+        board = place(board, "56", { kind: "銀", promoted: false, owner: "white" });
+        board = place(board, "65", { kind: "桂", promoted: false, owner: "white" });
+        board = place(board, "44", { kind: "金", promoted: false, owner: "white" });
+        board = place(board, "46", { kind: "金", promoted: false, owner: "white" });
+        board = place(board, "64", { kind: "金", promoted: false, owner: "white" });
+        board = place(board, "66", { kind: "金", promoted: false, owner: "white" });
+
+        const hands = createEmptyHands();
+        hands.white.歩 = 1;
+
+        useGameStore.setState({
+            board,
+            hands,
+            history: [],
+            cursor: -1,
+            turn: "white",
+            result: null,
+        });
+
+        const move: Move = {
+            type: "drop",
+            to: { row: 1, column: 1 },
+            piece: { kind: "歩", promoted: false, owner: "white" },
+        };
+
+        useGameStore.getState().makeMove(move);
+
+        expect(useGameStore.getState().result).toEqual({
+            winner: "white",
+            reason: "checkmate",
+        });
+    });
+});

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -2,7 +2,13 @@ import { initialBoard } from "@/domain/initialBoard";
 import type { Board } from "@/domain/model/board";
 import type { Move } from "@/domain/model/move";
 import type { HandKind, Player } from "@/domain/model/piece";
-import { applyMove, createEmptyHands, replayMoves } from "@/domain/service/moveService";
+import {
+    applyMove,
+    createEmptyHands,
+    replayMoves,
+    toggleSide,
+} from "@/domain/service/moveService";
+import { isCheckmate } from "@/domain/service/checkmate";
 import { produce } from "immer";
 import { create } from "zustand";
 import { devtools, persist, subscribeWithSelector } from "zustand/middleware";
@@ -60,10 +66,13 @@ export const useGameStore = create<GameState>()(
                             s.hands = hands;
                             s.turn = nextTurn;
 
-                            // ③ 勝敗判定（TODO: checkmate 判定が実装済みならここで result をセット）
-                            // if (isCheckmate(board, nextTurn)) {
-                            //   s.result = { winner: toggleSide(nextTurn), reason: "checkmate" };
-                            // }
+                            // ③ 勝敗判定
+                            if (isCheckmate(board, nextTurn)) {
+                                s.result = {
+                                    winner: toggleSide(nextTurn),
+                                    reason: "checkmate",
+                                };
+                            }
                         }),
                         false,
                         "MAKE_MOVE",


### PR DESCRIPTION
## Summary
- import `isCheckmate` and `toggleSide` into game store
- update `makeMove` to set result when checkmate occurs
- add a store level test for checkmate handling

## Testing
- `npm run typecheck`
- `npm test` *(fails: vitest not found)*
- `npm run lint:biome` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684571eed7ec83298548c904c9ffd1f6