### PR TITLE
Fix build and tests after structuredClone update

### DIFF
--- a/src/domain/service/checkmate.test.ts
+++ b/src/domain/service/checkmate.test.ts
@@ -23,14 +23,14 @@ describe("Checkmate detection tests", () => {
                 promoted: false,
                 owner: "white",
             },
-        };
+        } as Board;
 
         const result = isCheckmate(board, "black");
         expect(result).toBe(false);
     });
 
     it("王の逃げ道がある場合は詰みでない", () => {
-        let board: Board = {};
+        let board: Board = {} as Board;
         board = place(
             board,
             { row: 5, column: 5 },
@@ -55,7 +55,7 @@ describe("Checkmate detection tests", () => {
     });
 
     it("逃げ道がなく、詰みである場合", () => {
-        let board: Board = {};
+        let board: Board = {} as Board;
         board = place(
             board,
             { row: 5, column: 5 },
@@ -113,7 +113,7 @@ describe("Checkmate detection tests", () => {
                 promoted: false,
                 owner: "white",
             },
-        };
+        } as Board;
 
         const result = isCheckmate(board, "white");
         expect(result).toBe(false);

--- a/src/domain/service/moveService.ts
+++ b/src/domain/service/moveService.ts
@@ -50,8 +50,11 @@ export function applyMove(
 ): ApplyMoveResult {
     // Board は浅い構造なのでスプレッドで OK
     let newBoard: Board = { ...board };
-    // Hands はネストしているので深いコピーを取る
-    const newHands: Hands = structuredClone(hands);
+    // Hands はネストしているため plain object 化してから deep copy する
+    const newHands: Hands = structuredClone({
+        black: { ...hands.black },
+        white: { ...hands.white },
+    });
 
     const mover = currentTurn;
     const nextTurn = toggleSide(currentTurn);
@@ -105,7 +108,11 @@ export function revertMove(
 ): ApplyMoveResult {
     const mover = toggleSide(currentTurn); // 元の指し手側
     let newBoard: Board = { ...board };
-    const newHands: Hands = structuredClone(hands);
+    // Hands はネストしているため plain object 化してから deep copy する
+    const newHands: Hands = structuredClone({
+        black: { ...hands.black },
+        white: { ...hands.white },
+    });
 
     if (move.type === "move") {
         const dstPiece = getPiece(board, move.to);

--- a/src/state/gameStore.test.ts
+++ b/src/state/gameStore.test.ts
@@ -13,7 +13,7 @@ const place = (board: Board, key: string, piece: Piece): Board => ({
 
 describe("useGameStore makeMove", () => {
     it("updates result when move results in checkmate", () => {
-        let board: Board = {};
+        let board: Board = {} as Board;
         board = place(board, "55", { kind: "王", promoted: false, owner: "black" });
         board = place(board, "45", { kind: "飛", promoted: false, owner: "white" });
         board = place(board, "54", { kind: "銀", promoted: false, owner: "white" });


### PR DESCRIPTION
## Summary
- handle immer draft objects when cloning hands
- fix type errors in tests by asserting `as Board`

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684575e9ce088329b516ee4347491ba7