### PR TITLE
Add drop move checkmate logic

### DIFF
--- a/src/domain/service/checkmate.test.ts
+++ b/src/domain/service/checkmate.test.ts
@@ -3,6 +3,7 @@ import type { Board } from "../model/board";
 import type { Piece } from "../model/piece";
 import type { Square } from "../model/square";
 import { isCheckmate } from "./checkmate";
+import { createEmptyHands } from "./moveService";
 
 // 駒配置ユーティリティ
 const place = (board: Board, square: Square, piece: Piece): Board => ({
@@ -25,7 +26,8 @@ describe("Checkmate detection tests", () => {
             },
         } as Board;
 
-        const result = isCheckmate(board, "black");
+        const hands = createEmptyHands();
+        const result = isCheckmate(board, hands, "black");
         expect(result).toBe(false);
     });
 
@@ -50,7 +52,8 @@ describe("Checkmate detection tests", () => {
             },
         );
 
-        const result = isCheckmate(board, "black");
+        const hands = createEmptyHands();
+        const result = isCheckmate(board, hands, "black");
         expect(result).toBe(false); // 王は左や右に逃げられる
     });
 
@@ -102,7 +105,8 @@ describe("Checkmate detection tests", () => {
             { kind: "金", promoted: false, owner: "white" },
         ); // 右下
 
-        const result = isCheckmate(board, "black");
+        const hands = createEmptyHands();
+        const result = isCheckmate(board, hands, "black");
         expect(result).toBe(true); // 王がどこにも動けない
     });
 
@@ -115,7 +119,64 @@ describe("Checkmate detection tests", () => {
             },
         } as Board;
 
-        const result = isCheckmate(board, "white");
+        const hands = createEmptyHands();
+        const result = isCheckmate(board, hands, "white");
         expect(result).toBe(false);
+    });
+
+    it("駒打ちで王手を防いで詰みを回避できる", () => {
+        let board: Board = {} as Board;
+        board = place(
+            board,
+            { row: 5, column: 5 },
+            { kind: "王", promoted: false, owner: "black" },
+        );
+        board = place(
+            board,
+            { row: 1, column: 5 },
+            { kind: "飛", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 5, column: 4 },
+            { kind: "銀", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 5, column: 6 },
+            { kind: "銀", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 6, column: 5 },
+            { kind: "桂", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 6, column: 4 },
+            { kind: "金", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 6, column: 6 },
+            { kind: "金", promoted: false, owner: "white" },
+        );
+        board = place(
+            board,
+            { row: 4, column: 4 },
+            { kind: "歩", promoted: false, owner: "black" },
+        );
+        board = place(
+            board,
+            { row: 4, column: 6 },
+            { kind: "歩", promoted: false, owner: "black" },
+        );
+
+        const noHand = createEmptyHands();
+        expect(isCheckmate(board, noHand, "black")).toBe(true);
+
+        const hands = createEmptyHands();
+        hands.black.金 = 1;
+        expect(isCheckmate(board, hands, "black")).toBe(false);
     });
 });

--- a/src/domain/service/generateDropMoves.ts
+++ b/src/domain/service/generateDropMoves.ts
@@ -2,16 +2,13 @@ import { type Board, getPiece } from "../model/board";
 import type { DropMove } from "../model/move";
 import type { HandKind, Player } from "../model/piece";
 import type { Column, Row, Square } from "../model/square";
+import type { Hands } from "./moveService";
 
 /**
  * Generate possible drop moves for a given player and piece kind.
  * Currently only implements the nifu rule for pawns.
  */
-export function generateDropMoves(
-    board: Board,
-    player: Player,
-    kind: HandKind,
-): DropMove[] {
+export function generateDropMoves(board: Board, player: Player, kind: HandKind): DropMove[] {
     const moves: DropMove[] = [];
     for (let r = 1 as Row; r <= 9; r++) {
         for (let c = 1 as Column; c <= 9; c++) {
@@ -33,6 +30,22 @@ export function generateDropMoves(
                 to: square,
                 piece: { kind, owner: player, promoted: false },
             });
+        }
+    }
+    return moves;
+}
+
+const handKinds: readonly HandKind[] = ["歩", "香", "桂", "銀", "金", "角", "飛"] as const;
+
+/**
+ * Generate drop moves for all pieces currently in the player's hand.
+ */
+export function generateAllDropMoves(board: Board, hands: Hands, player: Player): DropMove[] {
+    const moves: DropMove[] = [];
+    const hand = hands[player];
+    for (const kind of handKinds) {
+        if (hand[kind] > 0) {
+            moves.push(...generateDropMoves(board, player, kind));
         }
     }
     return moves;

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -2,13 +2,8 @@ import { initialBoard } from "@/domain/initialBoard";
 import type { Board } from "@/domain/model/board";
 import type { Move } from "@/domain/model/move";
 import type { HandKind, Player } from "@/domain/model/piece";
-import {
-    applyMove,
-    createEmptyHands,
-    replayMoves,
-    toggleSide,
-} from "@/domain/service/moveService";
 import { isCheckmate } from "@/domain/service/checkmate";
+import { applyMove, createEmptyHands, replayMoves, toggleSide } from "@/domain/service/moveService";
 import { produce } from "immer";
 import { create } from "zustand";
 import { devtools, persist, subscribeWithSelector } from "zustand/middleware";
@@ -67,7 +62,7 @@ export const useGameStore = create<GameState>()(
                             s.turn = nextTurn;
 
                             // ③ 勝敗判定
-                            if (isCheckmate(board, nextTurn)) {
+                            if (isCheckmate(board, hands, nextTurn)) {
                                 s.result = {
                                     winner: toggleSide(nextTurn),
                                     reason: "checkmate",


### PR DESCRIPTION
## Summary
- generate all drop moves by iterating through player's hand
- checkmate detection now evaluates drop moves
- update game store and tests for new isCheckmate API
- test scenario where dropping a piece escapes check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684841dc4d648329a162683869396ea9