### PR TITLE
Implement drop restrictions

### DIFF
--- a/src/domain/service/generateDropMoves.test.ts
+++ b/src/domain/service/generateDropMoves.test.ts
@@ -1,17 +1,13 @@
-import { describe, expect, it } from "vitest";
 import type { Board } from "@/domain/model/board";
 import { setPiece } from "@/domain/model/board";
 import type { Piece } from "@/domain/model/piece";
 import type { Column, Row, Square } from "@/domain/model/square";
 import { generateDropMoves } from "@/domain/service/generateDropMoves";
+import { describe, expect, it } from "vitest";
 
 const sq = (row: Row, col: Column): Square => ({ row, column: col });
 
-const makePiece = (
-    kind: Piece["kind"],
-    owner: Piece["owner"],
-    promoted = false,
-): Piece => ({
+const makePiece = (kind: Piece["kind"], owner: Piece["owner"], promoted = false): Piece => ({
     kind,
     owner,
     promoted,
@@ -124,5 +120,25 @@ describe("generateDropMoves", () => {
         board = setPiece(board, sq(7, 5), makePiece("歩", "black"));
         const moves = generateDropMoves(board, "black", "角");
         expect(moves.some((m) => m.to.column === 5)).toBe(true);
+    });
+
+    it("prevents pawn and lance drops on last rank", () => {
+        const board: Board = { ...nullBoard };
+        const pawnBlack = generateDropMoves(board, "black", "歩");
+        const pawnWhite = generateDropMoves(board, "white", "歩");
+        const lanceBlack = generateDropMoves(board, "black", "香");
+        const lanceWhite = generateDropMoves(board, "white", "香");
+        expect(pawnBlack.some((m) => m.to.row === 1)).toBe(false);
+        expect(pawnWhite.some((m) => m.to.row === 9)).toBe(false);
+        expect(lanceBlack.some((m) => m.to.row === 1)).toBe(false);
+        expect(lanceWhite.some((m) => m.to.row === 9)).toBe(false);
+    });
+
+    it("prevents knight drops on last two ranks", () => {
+        const board: Board = { ...nullBoard };
+        const movesBlack = generateDropMoves(board, "black", "桂");
+        const movesWhite = generateDropMoves(board, "white", "桂");
+        expect(movesBlack.some((m) => m.to.row === 1 || m.to.row === 2)).toBe(false);
+        expect(movesWhite.some((m) => m.to.row === 8 || m.to.row === 9)).toBe(false);
     });
 });

--- a/src/domain/service/generateDropMoves.ts
+++ b/src/domain/service/generateDropMoves.ts
@@ -7,16 +7,24 @@ import type { Column, Row, Square } from "../model/square";
  * Generate possible drop moves for a given player and piece kind.
  * Currently only implements the nifu rule for pawns.
  */
-export function generateDropMoves(
-    board: Board,
-    player: Player,
-    kind: HandKind,
-): DropMove[] {
+export function generateDropMoves(board: Board, player: Player, kind: HandKind): DropMove[] {
     const moves: DropMove[] = [];
     for (let r = 1 as Row; r <= 9; r++) {
         for (let c = 1 as Column; c <= 9; c++) {
             const square: Square = { row: r as Row, column: c as Column };
             if (getPiece(board, square)) continue;
+
+            // ----- piece specific drop restrictions -----
+            if (kind === "歩" || kind === "香") {
+                const lastRank = player === "black" ? 1 : 9;
+                if (r === lastRank) continue; // cannot drop on last rank
+            }
+            if (kind === "桂") {
+                const last1 = player === "black" ? 1 : 9;
+                const last2 = player === "black" ? 2 : 8;
+                if (r === last1 || r === last2) continue; // cannot drop on last two ranks
+            }
+
             if (kind === "歩") {
                 let blocked = false;
                 for (let rr = 1 as Row; rr <= 9; rr++) {
@@ -28,6 +36,7 @@ export function generateDropMoves(
                 }
                 if (blocked) continue;
             }
+
             moves.push({
                 type: "drop",
                 to: square,


### PR DESCRIPTION
## Summary
- disallow dropping pawn and lance on last rank
- disallow dropping knight on last two ranks
- test drop restrictions for each player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684841dd27308329a35718e39e069fd1