### PR TITLE
Add repetition detection and draw handling

### DIFF
--- a/src/domain/service/repetition.test.ts
+++ b/src/domain/service/repetition.test.ts
@@ -1,0 +1,59 @@
+import type { Move } from "@/domain/model/move";
+import type { Piece } from "@/domain/model/piece";
+import type { Column, Row, Square } from "@/domain/model/square";
+import { describe, expect, it } from "vitest";
+import { isRepetition } from "./repetition";
+
+const sq = (row: Row, col: Column): Square => ({ row, column: col });
+const makePiece = (kind: Piece["kind"], owner: Piece["owner"], promoted = false): Piece => ({
+    kind,
+    owner,
+    promoted,
+});
+
+const cycleMoves = (): Move[] => [
+    {
+        type: "move",
+        from: sq(8, 8),
+        to: sq(8, 7),
+        piece: makePiece("飛", "black"),
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: sq(2, 8),
+        to: sq(2, 7),
+        piece: makePiece("飛", "white"),
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: sq(8, 7),
+        to: sq(8, 8),
+        piece: makePiece("飛", "black"),
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: sq(2, 7),
+        to: sq(2, 8),
+        piece: makePiece("飛", "white"),
+        promote: false,
+        captured: null,
+    },
+];
+
+describe("isRepetition", () => {
+    it("returns true when a board state appears four times", () => {
+        const history: Move[] = [...cycleMoves(), ...cycleMoves(), ...cycleMoves()];
+        expect(isRepetition(history)).toBe(true);
+    });
+
+    it("returns false when repetition count is below four", () => {
+        const history: Move[] = [...cycleMoves(), ...cycleMoves()];
+        expect(isRepetition(history)).toBe(false);
+    });
+});

--- a/src/domain/service/repetition.ts
+++ b/src/domain/service/repetition.ts
@@ -1,0 +1,53 @@
+import { initialBoard } from "@/domain/initialBoard";
+import type { Board } from "@/domain/model/board";
+import type { Move } from "@/domain/model/move";
+import type { Player } from "@/domain/model/piece";
+import type { Column, Row, SquareKey } from "@/domain/model/square";
+import { type Hands, applyMove, createEmptyHands } from "./moveService";
+
+/**
+ * Convert board, hands and turn into a stable string key.
+ */
+const stateKey = (board: Board, hands: Hands, turn: Player): string => {
+    const cells: string[] = [];
+    for (let r = 1 as Row; r <= 9; r++) {
+        for (let c = 1 as Column; c <= 9; c++) {
+            const sq = `${r}${c}` as SquareKey;
+            const p = board[sq];
+            if (!p) {
+                cells.push(".");
+            } else {
+                cells.push(`${p.owner[0]}${p.kind}${p.promoted ? "+" : "-"}`);
+            }
+        }
+    }
+    return `${cells.join("")}|${JSON.stringify(hands)}|${turn}`;
+};
+
+/**
+ * Determine if the same board position with identical hands and turn
+ * appears four times within the given move history.
+ */
+export const isRepetition = (history: Move[]): boolean => {
+    let board = initialBoard;
+    let hands = createEmptyHands();
+    let turn: Player = "black";
+
+    const counts = new Map<string, number>();
+    const record = () => {
+        const key = stateKey(board, hands, turn);
+        const v = (counts.get(key) ?? 0) + 1;
+        counts.set(key, v);
+        return v;
+    };
+
+    if (record() >= 4) return true;
+    for (const mv of history) {
+        const res = applyMove(board, hands, turn, mv);
+        board = res.board;
+        hands = res.hands;
+        turn = res.nextTurn;
+        if (record() >= 4) return true;
+    }
+    return false;
+};

--- a/src/state/gameStore.test.ts
+++ b/src/state/gameStore.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { initialBoard } from "@/domain/initialBoard";
 import type { Board } from "@/domain/model/board";
 import type { Move } from "@/domain/model/move";
 import type { Piece } from "@/domain/model/piece";
 import { createEmptyHands } from "@/domain/service/moveService";
+import { describe, expect, it } from "vitest";
 import { useGameStore } from "./gameStore";
 
 // 簡易盤面設定ユーティリティ
@@ -10,6 +11,41 @@ const place = (board: Board, key: string, piece: Piece): Board => ({
     ...board,
     [key]: piece,
 });
+
+const cycleMoves = (): Move[] => [
+    {
+        type: "move",
+        from: { row: 8, column: 8 },
+        to: { row: 8, column: 7 },
+        piece: { kind: "飛", promoted: false, owner: "black" },
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: { row: 2, column: 8 },
+        to: { row: 2, column: 7 },
+        piece: { kind: "飛", promoted: false, owner: "white" },
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: { row: 8, column: 7 },
+        to: { row: 8, column: 8 },
+        piece: { kind: "飛", promoted: false, owner: "black" },
+        promote: false,
+        captured: null,
+    },
+    {
+        type: "move",
+        from: { row: 2, column: 7 },
+        to: { row: 2, column: 8 },
+        piece: { kind: "飛", promoted: false, owner: "white" },
+        promote: false,
+        captured: null,
+    },
+];
 
 describe("useGameStore makeMove", () => {
     it("updates result when move results in checkmate", () => {
@@ -47,6 +83,27 @@ describe("useGameStore makeMove", () => {
         expect(useGameStore.getState().result).toEqual({
             winner: "white",
             reason: "checkmate",
+        });
+    });
+
+    it("sets draw result when fourfold repetition occurs", () => {
+        useGameStore.setState({
+            board: initialBoard,
+            hands: createEmptyHands(),
+            history: [],
+            cursor: -1,
+            turn: "black",
+            result: null,
+        });
+
+        const history: Move[] = [...cycleMoves(), ...cycleMoves(), ...cycleMoves()];
+        for (const mv of history) {
+            useGameStore.getState().makeMove(mv);
+        }
+
+        expect(useGameStore.getState().result).toEqual({
+            winner: null,
+            reason: "repetition",
         });
     });
 });

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -2,20 +2,16 @@ import { initialBoard } from "@/domain/initialBoard";
 import type { Board } from "@/domain/model/board";
 import type { Move } from "@/domain/model/move";
 import type { HandKind, Player } from "@/domain/model/piece";
-import {
-    applyMove,
-    createEmptyHands,
-    replayMoves,
-    toggleSide,
-} from "@/domain/service/moveService";
 import { isCheckmate } from "@/domain/service/checkmate";
+import { applyMove, createEmptyHands, replayMoves, toggleSide } from "@/domain/service/moveService";
+import { isRepetition } from "@/domain/service/repetition";
 import { produce } from "immer";
 import { create } from "zustand";
 import { devtools, persist, subscribeWithSelector } from "zustand/middleware";
 
 interface GameResult {
     winner: Player | null; // 勝者（null は未決定）
-    reason: "checkmate" | "timeout" | "resign"; // 勝因（例：王手放置: checkmate、持ち時間切れ: timeout、投了: resign）
+    reason: "checkmate" | "timeout" | "resign" | "repetition"; // 勝因（例：王手放置: checkmate、持ち時間切れ: timeout、投了: resign）
 }
 
 interface GameState {
@@ -71,6 +67,11 @@ export const useGameStore = create<GameState>()(
                                 s.result = {
                                     winner: toggleSide(nextTurn),
                                     reason: "checkmate",
+                                };
+                            } else if (isRepetition(s.history)) {
+                                s.result = {
+                                    winner: null,
+                                    reason: "repetition",
                                 };
                             }
                         }),


### PR DESCRIPTION
## Summary
- add `isRepetition` utility to detect fourfold board repetition
- mark game as draw when repetition occurs
- test repetition logic and game store integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684841dd9ef083298c1c2214277c8dbd