### PR TITLE
Refactor move vectors and clean store partialization

### DIFF
--- a/src/domain/service/moveService.ts
+++ b/src/domain/service/moveService.ts
@@ -96,6 +96,7 @@ export function applyMove(
  * 引数が never 型でなければコンパイルエラーになる。
  */
 function assertNever(_value: never): never {
+    void _value;
     throw new Error("未定義の Move タイプ");
 }
 
@@ -228,10 +229,18 @@ function getMoveVectors(piece: Piece): Vec[] {
 
     switch (piece.kind) {
         case "歩":
-            piece.promoted ? v.push(...gold) : add(f, 0);
+            if (piece.promoted) {
+                v.push(...gold);
+            } else {
+                add(f, 0);
+            }
             break;
         case "香":
-            piece.promoted ? v.push(...gold) : add(f, 0, true);
+            if (piece.promoted) {
+                v.push(...gold);
+            } else {
+                add(f, 0, true);
+            }
             break;
         case "桂":
             if (piece.promoted) {
@@ -244,7 +253,11 @@ function getMoveVectors(piece: Piece): Vec[] {
             }
             break;
         case "銀":
-            piece.promoted ? v.push(...gold) : v.push(...silver);
+            if (piece.promoted) {
+                v.push(...gold);
+            } else {
+                v.push(...silver);
+            }
             break;
         case "金":
             v.push(...gold);

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -2,13 +2,8 @@ import { initialBoard } from "@/domain/initialBoard";
 import type { Board } from "@/domain/model/board";
 import type { Move } from "@/domain/model/move";
 import type { HandKind, Player } from "@/domain/model/piece";
-import {
-    applyMove,
-    createEmptyHands,
-    replayMoves,
-    toggleSide,
-} from "@/domain/service/moveService";
 import { isCheckmate } from "@/domain/service/checkmate";
+import { applyMove, createEmptyHands, replayMoves, toggleSide } from "@/domain/service/moveService";
 import { produce } from "immer";
 import { create } from "zustand";
 import { devtools, persist, subscribeWithSelector } from "zustand/middleware";
@@ -122,7 +117,11 @@ export const useGameStore = create<GameState>()(
             name: "shogi-game",
             version: 2,
             // 棋譜はストレージに持たせなくても良い場合が多いので除外
-            partialize: ({ history, cursor, ...rest }) => rest,
+            partialize: ({ history: _history, cursor: _cursor, ...rest }) => {
+                void _history;
+                void _cursor;
+                return rest;
+            },
         },
     ),
 );


### PR DESCRIPTION
## Summary
- expand `assertNever` helper to avoid lint error
- replace ternary operators with if/else in `moveService`
- mark unused state store parameters in `partialize`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684841e210048329b97c44acf2d67d7f