### PR TITLE
fix: WASM版では並列処理が使えないのでSIMD最適化を外す

### DIFF
--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -623,25 +623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,12 +783,6 @@ dependencies = [
  "signature",
  "spki",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1057,11 +1032,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1894,26 +1867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,16 +2231,15 @@ dependencies = [
  "clap",
  "flate2",
  "futures",
- "getrandom 0.3.3",
+ "getrandom 0.2.16",
  "ggrs",
  "gloo-timers 0.3.0",
  "js-sys",
- "lazy_static",
  "log",
  "matchbox_socket",
+ "once_cell",
  "rand 0.8.5",
  "rand_xoshiro",
- "rayon",
  "serde",
  "serde_json",
  "wasm-bindgen",

--- a/packages/rust-core/Cargo.toml
+++ b/packages/rust-core/Cargo.toml
@@ -37,16 +37,14 @@ serde_json = "1.0"
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 flate2 = "1.0"
-rayon = "1.7"
 clap = { version = "4.0", features = ["derive"] }
 anyhow = "1.0"
-lazy_static = "1.4"
+once_cell = "1.19"
 rand = "0.8"
 rand_xoshiro = "0.6"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
-wasm-bindgen-futures = "0.4"
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/packages/rust-core/src/ai/attacks.rs
+++ b/packages/rust-core/src/ai/attacks.rs
@@ -3,7 +3,7 @@
 //! Pre-computed attack patterns for fast move generation
 
 use super::board::{Bitboard, Color, PieceType, Square};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 /// Direction offsets for piece movements
 #[derive(Clone, Copy, Debug)]
@@ -426,9 +426,7 @@ impl AttackTables {
 }
 
 // Global attack tables instance
-lazy_static! {
-    pub static ref ATTACK_TABLES: AttackTables = AttackTables::new();
-}
+pub static ATTACK_TABLES: Lazy<AttackTables> = Lazy::new(AttackTables::new);
 
 #[cfg(test)]
 mod tests {

--- a/packages/rust-core/src/ai/nnue/simd/wasm32.rs
+++ b/packages/rust-core/src/ai/nnue/simd/wasm32.rs
@@ -5,8 +5,10 @@
 // Note: WASM SIMD support is still experimental and requires specific flags
 // For now, we'll provide stubs that fall back to scalar implementations
 
-#[cfg(target_arch = "wasm32")]
-use std::arch::wasm32::*;
+// WASM SIMD support is currently disabled
+// The import below will be used when WASM SIMD is enabled
+// #[cfg(target_arch = "wasm32")]
+// use std::arch::wasm32::*;
 
 // Placeholder implementations that use scalar fallbacks
 // In the future, these can be replaced with actual WASM SIMD implementations

--- a/packages/rust-core/src/ai/zobrist.rs
+++ b/packages/rust-core/src/ai/zobrist.rs
@@ -3,7 +3,7 @@
 //! Provides fast incremental hash computation for transposition tables and repetition detection
 
 use super::board::{Color, Piece, PieceType, Square, BOARD_SQUARES, MAX_PIECE_INDEX};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
@@ -94,9 +94,7 @@ impl ZobristTable {
 }
 
 // Global Zobrist table instance
-lazy_static! {
-    pub static ref ZOBRIST: ZobristTable = ZobristTable::new();
-}
+pub static ZOBRIST: Lazy<ZobristTable> = Lazy::new(ZobristTable::new);
 
 /// Extension trait for Position to add Zobrist hashing
 pub trait ZobristHashing {

--- a/packages/rust-core/src/lib.rs
+++ b/packages/rust-core/src/lib.rs
@@ -1,5 +1,8 @@
 use wasm_bindgen::prelude::*;
 
+// WASM utilities module (must be first for macro exports)
+pub mod wasm_utils;
+
 // Keep only WebRTC module for demo purposes
 mod simple_webrtc;
 pub use simple_webrtc::*;
@@ -17,17 +20,6 @@ pub mod opening_book_reader;
 
 // Add AI module
 pub mod ai;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-
-#[allow(unused_macros)]
-macro_rules! console_log {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
-}
 
 // Dummy structs for now - will be replaced with actual game logic
 #[wasm_bindgen]

--- a/packages/rust-core/src/simple_webrtc.rs
+++ b/packages/rust-core/src/simple_webrtc.rs
@@ -7,15 +7,8 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use web_sys::{RtcConfiguration, RtcPeerConnection, RtcPeerConnectionIceEvent};
 
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-
-macro_rules! console_log {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
-}
+// Use console_log macro from wasm_utils
+use crate::console_log;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SignalData {

--- a/packages/rust-core/src/wasm_utils.rs
+++ b/packages/rust-core/src/wasm_utils.rs
@@ -1,0 +1,44 @@
+//! WebAssembly utilities shared across the crate
+//!
+//! This module provides common utilities for WASM targets,
+//! including console logging and other browser-specific functionality.
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
+// Single extern block for console logging
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+/// Macro for logging to the browser console
+#[macro_export]
+macro_rules! console_log {
+    ($($t:tt)*) => {
+        #[cfg(target_arch = "wasm32")]
+        {
+            use $crate::wasm_utils::__console_log_impl;
+            __console_log_impl(&format_args!($($t)*).to_string());
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            eprintln!($($t)*);
+        }
+    }
+}
+
+// Internal function used by the macro
+#[doc(hidden)]
+#[cfg(target_arch = "wasm32")]
+pub fn __console_log_impl(s: &str) {
+    log(s);
+}
+
+// Re-export common WASM types
+#[cfg(target_arch = "wasm32")]
+pub use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+pub use wasm_bindgen::JsValue;


### PR DESCRIPTION
背景
CIで wasm-optの「Only 1 table definition allowed in  MVP」エラーが発生
原因調査をclaudeにさせたところ以下の回答

```
  WASMでのSIMD/並列処理の制限

  1. 並列処理（Rayon）

  - WASMは単一スレッドモデルのため、Rayonなどの並列処理ライブラリは使用できません
  - Web Workersを使った並列処理は可能ですが、SharedArrayBufferやAtomicsが必要で、セキュリティ制
  限があります

  2. SIMD最適化

  - WASM MVPではSIMD命令はサポートされていません
  - WASM SIMD提案は存在しますが、まだ全ブラウザで有効ではありません
  - 現在のコードのsrc/ai/nnue/simd/wasm32.rsは将来のWASM
  SIMD対応を見据えたものですが、実際には使用されていません

  3. 現在のWASM版の動作

  // src/ai/nnue/mod.rsで条件分岐されているはず
  #[cfg(target_arch = "wasm32")]
  mod wasm32;  // 将来のSIMD対応用

  #[cfg(not(target_arch = "wasm32"))]
  mod native;  // x86_64やARM向けのSIMD実装

  実際にはWASM版では：
  - 基本的なスカラー演算のみ使用
  - SIMD最適化なし
  - 並列処理なし
  - そのため、ネイティブ版と比べて性能は劣る

  4. テーブル制限エラーの原因

  「Only 1 table definition allowed in MVP」エラーは、以下の複合的な要因で発生：
  - lazy_static!マクロが複数のグローバルテーブルを生成
  - 複数のwasm-bindgen外部関数定義
  - 依存クレートも含めた全体でテーブル数が制限を超える
  ```