### PR TITLE
feat: Move構造体にピースタイプと捕獲ピースタイプの情報を追加し、関連するメソッドを実装

### DIFF
--- a/packages/rust-core/src/ai/movegen.rs
+++ b/packages/rust-core/src/ai/movegen.rs
@@ -41,6 +41,12 @@ impl<'a> MoveGenImpl<'a> {
         gen
     }
 
+    /// Helper to get captured piece type at a square
+    #[inline]
+    fn get_captured_type(&self, to: Square) -> Option<PieceType> {
+        self.pos.board.piece_on(to).map(|p| p.piece_type)
+    }
+
     /// Generate all legal moves
     pub fn generate_all(&mut self) -> MoveList {
         self.moves.clear();
@@ -241,7 +247,14 @@ impl<'a> MoveGenImpl<'a> {
         while let Some(to) = moves.pop_lsb() {
             // Check if king would be in check on target square
             if !self.would_be_in_check(from, to) {
-                self.moves.push(Move::normal(from, to, false));
+                let captured_type = self.get_captured_type(to);
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::King,
+                    captured_type,
+                ));
             }
         }
     }
@@ -273,13 +286,32 @@ impl<'a> MoveGenImpl<'a> {
 
         let mut moves = valid_targets;
         while let Some(to) = moves.pop_lsb() {
+            let captured_type = self.get_captured_type(to);
             // Check if can promote
             if self.can_promote(from, to, us) {
-                self.moves.push(Move::normal(from, to, true));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    true,
+                    PieceType::Silver,
+                    captured_type,
+                ));
                 // Silver promotion is optional
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Silver,
+                    captured_type,
+                ));
             } else {
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Silver,
+                    captured_type,
+                ));
             }
         }
     }
@@ -297,6 +329,7 @@ impl<'a> MoveGenImpl<'a> {
 
         let mut moves = targets;
         while let Some(to) = moves.pop_lsb() {
+            let captured_type = self.get_captured_type(to);
             // Knight must promote if it can't move further
             let must_promote = match us {
                 Color::Black => to.rank() >= 7, // Black can't move from rank 7-8
@@ -304,12 +337,36 @@ impl<'a> MoveGenImpl<'a> {
             };
 
             if must_promote {
-                self.moves.push(Move::normal(from, to, true));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    true,
+                    PieceType::Knight,
+                    captured_type,
+                ));
             } else if self.can_promote(from, to, us) {
-                self.moves.push(Move::normal(from, to, true));
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    true,
+                    PieceType::Knight,
+                    captured_type,
+                ));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Knight,
+                    captured_type,
+                ));
             } else {
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Knight,
+                    captured_type,
+                ));
             }
         }
     }
@@ -346,13 +403,38 @@ impl<'a> MoveGenImpl<'a> {
                         Color::White => to.rank() == 0, // White's last rank
                     };
 
+                    let captured_type = self.get_captured_type(to);
                     if must_promote {
-                        self.moves.push(Move::normal(from, to, true));
+                        self.moves.push(Move::normal_with_piece(
+                            from,
+                            to,
+                            true,
+                            PieceType::Lance,
+                            captured_type,
+                        ));
                     } else if self.can_promote(from, to, us) {
-                        self.moves.push(Move::normal(from, to, true));
-                        self.moves.push(Move::normal(from, to, false));
+                        self.moves.push(Move::normal_with_piece(
+                            from,
+                            to,
+                            true,
+                            PieceType::Lance,
+                            captured_type,
+                        ));
+                        self.moves.push(Move::normal_with_piece(
+                            from,
+                            to,
+                            false,
+                            PieceType::Lance,
+                            captured_type,
+                        ));
                     } else {
-                        self.moves.push(Move::normal(from, to, false));
+                        self.moves.push(Move::normal_with_piece(
+                            from,
+                            to,
+                            false,
+                            PieceType::Lance,
+                            captured_type,
+                        ));
                     }
                 }
                 break; // Blocked, can't move further
@@ -365,13 +447,38 @@ impl<'a> MoveGenImpl<'a> {
                     Color::White => to.rank() == 0, // White's last rank
                 };
 
+                let captured_type = self.get_captured_type(to);
                 if must_promote {
-                    self.moves.push(Move::normal(from, to, true));
+                    self.moves.push(Move::normal_with_piece(
+                        from,
+                        to,
+                        true,
+                        PieceType::Lance,
+                        captured_type,
+                    ));
                 } else if self.can_promote(from, to, us) {
-                    self.moves.push(Move::normal(from, to, true));
-                    self.moves.push(Move::normal(from, to, false));
+                    self.moves.push(Move::normal_with_piece(
+                        from,
+                        to,
+                        true,
+                        PieceType::Lance,
+                        captured_type,
+                    ));
+                    self.moves.push(Move::normal_with_piece(
+                        from,
+                        to,
+                        false,
+                        PieceType::Lance,
+                        captured_type,
+                    ));
                 } else {
-                    self.moves.push(Move::normal(from, to, false));
+                    self.moves.push(Move::normal_with_piece(
+                        from,
+                        to,
+                        false,
+                        PieceType::Lance,
+                        captured_type,
+                    ));
                 }
             }
 
@@ -392,6 +499,7 @@ impl<'a> MoveGenImpl<'a> {
 
         let mut moves = targets;
         while let Some(to) = moves.pop_lsb() {
+            let captured_type = self.get_captured_type(to);
             // Pawn must promote if it can't move further
             let must_promote = match us {
                 Color::Black => to.rank() == 8, // Black's last rank
@@ -399,12 +507,36 @@ impl<'a> MoveGenImpl<'a> {
             };
 
             if must_promote {
-                self.moves.push(Move::normal(from, to, true));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    true,
+                    PieceType::Pawn,
+                    captured_type,
+                ));
             } else if self.can_promote(from, to, us) {
-                self.moves.push(Move::normal(from, to, true));
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    true,
+                    PieceType::Pawn,
+                    captured_type,
+                ));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Pawn,
+                    captured_type,
+                ));
             } else {
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    PieceType::Pawn,
+                    captured_type,
+                ));
             }
         }
     }
@@ -423,11 +555,25 @@ impl<'a> MoveGenImpl<'a> {
 
         let mut moves = targets;
         while let Some(to) = moves.pop_lsb() {
+            let captured_type = self.get_captured_type(to);
             if !promoted && self.can_promote(from, to, us) {
-                self.moves.push(Move::normal(from, to, true));
-                self.moves.push(Move::normal(from, to, false));
+                self.moves
+                    .push(Move::normal_with_piece(from, to, true, piece_type, captured_type));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    piece_type,
+                    captured_type,
+                ));
             } else {
-                self.moves.push(Move::normal(from, to, false));
+                self.moves.push(Move::normal_with_piece(
+                    from,
+                    to,
+                    false,
+                    piece_type,
+                    captured_type,
+                ));
             }
         }
     }
@@ -941,7 +1087,15 @@ impl<'a> MoveGenImpl<'a> {
     }
 
     /// Add moves from a square to target squares
-    fn add_moves(&mut self, from: Square, mut targets: Bitboard, _promoted: bool) {
+    fn add_moves(&mut self, from: Square, targets: Bitboard, _promoted: bool) {
+        // Get piece type from the board
+        let piece = self.pos.board.piece_on(from).expect("Piece must exist at from square");
+        let piece_type = piece.piece_type;
+        self.add_moves_with_type(from, targets, piece_type);
+    }
+
+    /// Add moves from a square to target squares with known piece type
+    fn add_moves_with_type(&mut self, from: Square, mut targets: Bitboard, piece_type: PieceType) {
         // If we're in check, only allow moves that block or capture checker
         if !self.checkers.is_empty() && self.checkers.count_ones() == 1 {
             let checker_sq = self.checkers.lsb().unwrap();
@@ -960,7 +1114,9 @@ impl<'a> MoveGenImpl<'a> {
         targets &= !enemy_king_bb;
 
         while let Some(to) = targets.pop_lsb() {
-            self.moves.push(Move::normal(from, to, false));
+            let captured_type = self.get_captured_type(to);
+            self.moves
+                .push(Move::normal_with_piece(from, to, false, piece_type, captured_type));
         }
     }
 

--- a/packages/rust-core/src/ai/test_move_picker_comprehensive.rs
+++ b/packages/rust-core/src/ai/test_move_picker_comprehensive.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::ai::board::{Color, Position, Square};
+    use crate::ai::board::{Color, PieceType, Position, Square};
     use crate::ai::history::History;
     use crate::ai::move_picker::MovePicker;
     use crate::ai::movegen::MoveGen;
@@ -75,9 +75,28 @@ mod tests {
 
         // Set up different move types
         // The TT move should be a legal capture in this position
-        let tt_move = Some(Move::normal(Square::new(2, 4), Square::new(2, 5), false)); // Legal move
-        let killer_move = Move::normal(Square::new(7, 2), Square::new(7, 3), false); // Quiet
-        let history_move = Move::normal(Square::new(6, 2), Square::new(6, 3), false); // Quiet
+        // In starting position after a few moves, set up proper piece types
+        let tt_move = Some(Move::normal_with_piece(
+            Square::new(2, 4),
+            Square::new(2, 5),
+            false,
+            PieceType::Pawn,
+            None,
+        )); // Legal move
+        let killer_move = Move::normal_with_piece(
+            Square::new(7, 2),
+            Square::new(7, 3),
+            false,
+            PieceType::Pawn,
+            None,
+        ); // Quiet
+        let history_move = Move::normal_with_piece(
+            Square::new(6, 2),
+            Square::new(6, 3),
+            false,
+            PieceType::Pawn,
+            None,
+        ); // Quiet
 
         // Set killers
         stack.killers[0] = Some(killer_move);

--- a/packages/rust-core/src/ai/test_move_picker_integration.rs
+++ b/packages/rust-core/src/ai/test_move_picker_integration.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::ai::board::{Color, Position, Square};
+    use crate::ai::board::{Color, PieceType, Position, Square};
     use crate::ai::evaluate::MaterialEvaluator;
     use crate::ai::history::History;
     use crate::ai::move_picker::MovePicker;
@@ -198,7 +198,14 @@ mod tests {
         let stack = SearchStack::default();
 
         // Update history for a specific move (5g5f)
-        let good_move = Move::normal(Square::new(4, 2), Square::new(4, 3), false);
+        // In the starting position, square 4,2 has a Pawn piece for Black
+        let good_move = Move::normal_with_piece(
+            Square::new(4, 2),
+            Square::new(4, 3),
+            false,
+            PieceType::Pawn,
+            None,
+        );
         history.update_cutoff(Color::Black, good_move, 10, None);
 
         let history_arc = Arc::new(history);


### PR DESCRIPTION
# Move構造体への駒タイプ保存実装計画

案１（Move構造体を32ビットに拡張）を採用し、実装を完了しました。

## 概要

現在、`Move`構造体は移動元と移動先の升目、成り・持ち駒フラグを保存していますが、駒タイプは保存していません。これにより、継続履歴（Continuation History）の実装が制限されています。本ドキュメントでは、この課題を解決するための実装方針を検討します。

## 現状の問題点

### 1. Move構造体の現在の実装
- 16ビットでエンコード
  - bits 0-6: 移動先 (0-80)
  - bits 7-13: 移動元 (0-80) または持ち駒タイプ (81-87)
  - bit 14: 成りフラグ
  - bit 15: 持ち駒フラグ
- 通常の移動では駒タイプが保存されない
- 持ち駒を打つ場合のみ駒タイプが保存される

### 2. 継続履歴の制限
`history.rs`において、継続履歴は以下の情報が必要：
- 2手前の駒タイプと移動先
- 現在の手の駒タイプと移動先

しかし、`Move`構造体に駒タイプが含まれていないため、継続履歴の更新ができない（288-289行目、306行目のTODOコメント）。

### 3. 影響範囲
- 継続履歴によるmove orderingの最適化ができない
- 探索の効率性が低下する可能性がある

## 実装方針案

### 案1: Move構造体を32ビットに拡張

**メリット：**
- 追加の16ビットで駒タイプを保存できる
- 実装がシンプル
- 将来的な拡張にも対応可能

**デメリット：**
- メモリ使用量が2倍になる
- 探索で大量のMoveを扱うため、キャッシュ効率が低下する可能性
- 既存のコードへの影響が大きい

**実装例：**
```rust
pub struct Move {
    data: u32,  // 16ビット → 32ビット
}

// bits 16-19: 駒タイプ（0-13で14種類の駒を表現）
```

### 案2: 駒タイプを別途渡す（現在のTODOの提案）

**メリット：**
- Move構造体のサイズを変更しない
- メモリ効率が良い
- 必要な場所だけで駒タイプを扱える

**デメリット：**
- APIが複雑になる
- 多くの関数シグネチャを変更する必要がある
- 駒タイプの管理が分散する

**実装例：**
```rust
// history.rsの関数を拡張
pub fn update_cutoff(
    &mut self,
    color: Color,
    mv: Move,
    piece_type: PieceType,  // 追加
    depth: i32,
    prev_move: Option<(Move, PieceType, Square)>,  // 拡張
)
```

### 案3: Move構造体のビット配置を最適化

**メリット：**
- 16ビットのまま駒タイプを保存できる可能性
- メモリ効率を維持
- APIの変更が最小限

**デメリット：**
- ビット数が足りない可能性が高い
- 実装が複雑
- 将来の拡張性が低い

**分析：**
- 移動先・移動元: 各7ビット（0-80）
- 成り・持ち駒フラグ: 各1ビット
- 合計: 16ビット（すでに使い切っている）
- 駒タイプ: 4ビット必要（14種類）

→ **ビット数が不足するため、この案は実現困難**

### 案4: ExtendedMove構造体を新規作成

**メリット：**
- 既存のMove構造体は変更しない
- 必要な場所だけで拡張版を使用
- 段階的な移行が可能

**デメリット：**
- 2つのMove型が存在することによる混乱
- 変換処理のオーバーヘッド
- コードの重複

**実装例：**
```rust
pub struct ExtendedMove {
    base_move: Move,
    piece_type: PieceType,
}
```

## 推奨実装方針

### 短期的解決策：案2（駒タイプを別途渡す）

理由：
1. 即座に実装可能
2. Move構造体のメモリ効率を維持
3. 影響範囲を限定できる

実装手順：
1. `History`構造体の関数に駒タイプパラメータを追加
2. 呼び出し元で`board.piece_on()`を使って駒タイプを取得
3. 継続履歴の実装を完成させる

### 長期的検討事項：案1（32ビット拡張）

理由：
1. よりクリーンなAPI設計
2. 将来的な機能拡張に対応
3. Stockfishなど他のチェスエンジンも同様のアプローチ

ただし、以下の点を事前に検証する必要がある：
- パフォーマンスへの影響（ベンチマーク）
- メモリ使用量の増加が許容範囲か
- 既存コードへの影響範囲

## 判断に迷うポイント

### 1. パフォーマンス vs 設計の美しさ
- 16ビットMove：メモリ効率は良いが、APIが複雑
- 32ビットMove：設計はクリーンだが、メモリ使用量が増加

### 2. 移行戦略
- 一度に全体を変更するか、段階的に移行するか
- 互換性をどこまで維持するか

### 3. 他のエンジンとの互換性
- 既存の将棋エンジンのMove表現との互換性
- 定跡データベースなどとの連携

### 4. 継続履歴の効果測定
- 実装コストに見合う効果があるか
- 他の最適化と比較した優先度

## 次のステップ

1. **ベンチマークの作成**
   - 現在の探索性能を測定
   - メモリ使用量を測定

2. **プロトタイプ実装**
   - 案2（駒タイプ別渡し）の最小実装
   - 継続履歴の効果測定

3. **チーム内レビュー**
   - 実装方針の最終決定
   - 移行計画の策定

4. **段階的実装** ✅ 完了
   - ~~まず案2で継続履歴を有効化~~ → 案1を直接実装
   - ~~効果を確認後、必要に応じて案1を検討~~ → パフォーマンスへの影響は今後評価