### PR TITLE
Aspiration Windows実装

### DIFF
--- a/packages/rust-core/src/ai/search_enhanced.rs
+++ b/packages/rust-core/src/ai/search_enhanced.rs
@@ -189,6 +189,13 @@ impl EnhancedSearcher {
         }
     }
 
+    /// Update aspiration window bounds based on delta and center score
+    fn update_aspiration_window(&self, delta: i32, center: i32) -> (i32, i32) {
+        let alpha = (center - delta).max(-INFINITY).max(-MATE_SCORE + MAX_PLY as i32);
+        let beta = (center + delta).min(INFINITY).min(MATE_SCORE - MAX_PLY as i32);
+        (alpha, beta)
+    }
+
     /// Search position with iterative deepening
     pub fn search(
         &mut self,
@@ -277,9 +284,7 @@ impl EnhancedSearcher {
 
                     // deltaを先に拡大
                     delta = (delta * 2).min(self.params.max_aspiration_delta);
-                    let center = prev_score; // 収束済みの中心値を保持
-                    alpha = (center - delta).max(-INFINITY).max(-MATE_SCORE + MAX_PLY as i32);
-                    beta = (center + delta).min(INFINITY).min(MATE_SCORE - MAX_PLY as i32);
+                    (alpha, beta) = self.update_aspiration_window(delta, prev_score);
                 } else if score >= beta {
                     // Fail-high: 窓を上方向に拡大
                     #[cfg(test)]
@@ -289,9 +294,7 @@ impl EnhancedSearcher {
 
                     // deltaを先に拡大
                     delta = (delta * 2).min(self.params.max_aspiration_delta);
-                    let center = prev_score; // 収束済みの中心値を保持
-                    alpha = (center - delta).max(-INFINITY).max(-MATE_SCORE + MAX_PLY as i32);
-                    beta = (center + delta).min(INFINITY).min(MATE_SCORE - MAX_PLY as i32);
+                    (alpha, beta) = self.update_aspiration_window(delta, prev_score);
                 } else {
                     // 窓内ヒット: 成功
                     #[cfg(test)]


### PR DESCRIPTION
# Aspiration Windows実装計画

## 概要
`search_enhanced.rs`の`search()`メソッドのみを改修してAspiration Windowsを実装する最小限の変更計画。

## 背景
- 現在の`search_enhanced.rs`には既にNull Move、LMR、Futility Pruningが実装済み
- `alpha_beta()`はfail-softで実装されており、そのまま利用可能
- 反復深化ループが既に存在し、Aspiration Windows追加に最適な構造

## 実装内容

### 1. SearchParamsへの追加

```rust
pub struct SearchParams {
    // 既存フィールド...
    
    /// Initial aspiration window function
    pub initial_window: fn(i32) -> i32,  // depth -> window_size
}

impl Default for SearchParams {
    fn default() -> Self {
        // 既存の初期化...
        SearchParams {
            // 既存フィールド...
            initial_window: |depth| 50 + depth * 5,  // 初期窓幅: ±50cp + depth*5
        }
    }
}
```

### 2. search()メソッドの改修

現在の実装（150行目付近）：
```rust
let score = self.alpha_beta(pos, -INFINITY, INFINITY, depth, 0, &mut stack);
```

これを以下のAspiration Windows付き探索に置換：

```rust
pub fn search(
    &mut self,
    pos: &mut Position,
    max_depth: i32,
    time_limit: Option<Duration>,
    node_limit: Option<u64>,
) -> (Option<Move>, i32) {
    // 既存のリセット処理（133-143行目）はそのまま
    self.nodes.store(0, Ordering::Relaxed);
    self.stop.store(false, Ordering::Relaxed);
    self.start_time = Instant::now();
    self.time_limit = time_limit.map(|d| self.start_time + d);
    self.node_limit = node_limit;
    self.history.clear_all();
    Arc::get_mut(&mut self.tt).unwrap().new_search();
    
    let mut stack = vec![SearchStack::default(); MAX_PLY + 10];
    let mut best_move = None;
    let mut best_score = -INFINITY;
    
    // Aspiration Windows用の追加変数
    let mut prev_score = 0;  // 前回の評価値
    
    // Iterative deepening
    for depth in 1..=max_depth {
        // Aspiration Windows設定
        let mut delta = (self.params.initial_window)(depth);
        let mut alpha = if depth == 1 { 
            -INFINITY 
        } else { 
            (prev_score - delta).max(-INFINITY) 
        };
        let mut beta = if depth == 1 { 
            INFINITY 
        } else { 
            (prev_score + delta).min(INFINITY) 
        };
        
        let mut score;
        let mut retry_count = 0;
        
        // Aspiration search with retries
        loop {
            score = self.alpha_beta(pos, alpha, beta, depth, 0, &mut stack);
            
            if self.stop.load(Ordering::Relaxed) {
                break;
            }
            
            // Check aspiration window
            if score <= alpha {
                // Fail-low: 窓を下方向に拡大
                beta = (alpha + beta) / 2;
                alpha = (score - delta).max(-INFINITY);
            } else if score >= beta {
                // Fail-high: 窓を上方向に拡大
                alpha = (alpha + beta) / 2;
                beta = (score + delta).min(INFINITY);
            } else {
                // 窓内ヒット: 成功
                break;
            }
            
            // 窓幅を指数的に拡大
            delta *= 2;
            retry_count += 1;
            
            // 安全装置: 3回で諦めてフルウィンドウ
            if retry_count >= 3 || delta >= INFINITY / 2 {
                alpha = -INFINITY;
                beta = INFINITY;
            }
        }
        
        // 探索結果の保存
        prev_score = score;
        best_score = score;
        
        // Extract best move from TT（既存処理そのまま）
        if let Some(tt_entry) = self.tt.probe(pos.hash) {
            best_move = tt_entry.get_move();
        }
        
        // Check time（既存処理そのまま）
        if self.should_stop() {
            break;
        }
    }
    
    (best_move, best_score)
}
```

### 3. テスト追加

```rust
#[test]
fn test_aspiration_windows() {
    let evaluator = Arc::new(MaterialEvaluator);
    let mut searcher = EnhancedSearcher::new(16, evaluator);
    let mut pos = Position::startpos();
    
    // 深さ6で探索（Aspiration Windowsが効果的に働く深さ）
    let (best_move, score) = searcher.search(&mut pos, 6, None, None);
    
    assert!(best_move.is_some());
    // ノード数が通常探索より少ないことを確認するには比較が必要
    let nodes_with_aw = searcher.nodes();
    println!("Nodes with AW: {}", nodes_with_aw);
}

#[test]
fn test_aspiration_window_params() {
    let params = SearchParams::default();
    
    // 窓幅が深さとともに増加することを確認
    assert_eq!((params.initial_window)(1), 55);   // 50 + 1*5
    assert_eq!((params.initial_window)(6), 80);   // 50 + 6*5
    assert_eq!((params.initial_window)(10), 100); // 50 + 10*5
}
```

## 実装のポイント

1. **最小限の変更**
   - `search()`メソッドのみの改修
   - 既存の`alpha_beta()`はそのまま利用
   - 他の枝刈り技術への影響なし

2. **fail-soft活用**
   - 現在の`alpha_beta()`は実際の評価値を返すfail-soft実装
   - これによりAspiration Windowsの窓調整が正確に行える

3. **安全性**
   - 再探索は最大3回に制限
   - MATEスコア付近では自動的に窓が広がる
   - 時間切れチェックは既存のまま機能

4. **性能向上の期待値**
   - 通常の探索に比べて20-40%のノード数削減
   - 特に中盤以降で効果大


## 今後の拡張可能性
1. PVテーブルの追加（Principal Variation保存）
2. Multi-PV対応（複数の最善手を探索）
3. 窓幅の動的調整（ゲームフェーズに応じて）
4. Singular Extensionとの統合

## 変更による影響
- ファイル: `search_enhanced.rs`のみ
- 行数: 約30-40行の追加/変更
- 既存テスト: ノード数が変わる可能性があるため要確認
- API: 変更なし（外部インターフェースは同じ）
