### PR TITLE
TT保存時のAspiration失敗を考慮

### DIFF
--- a/packages/rust-core/src/ai/tt.rs
+++ b/packages/rust-core/src/ai/tt.rs
@@ -260,7 +260,7 @@ impl TranspositionTable {
         let should_replace = !old_entry.matches(hash)
             || old_entry.depth() == 0
             || (entry.age() == self.age && old_entry.age() != self.age)
-            || (!aspiration_fail && old_entry.aspiration_fail())  // Aspiration成功を優先
+            || (!entry.aspiration_fail() && old_entry.aspiration_fail())  // Aspiration成功を優先
             || (entry.aspiration_fail() == old_entry.aspiration_fail() && depth >= old_entry.depth());
 
         if should_replace {


### PR DESCRIPTION
## 概要
1. TT保存時のAspiration失敗を考慮
  - Aspiration失敗フラグを追跡
  - ルートノードでAspiration失敗時、EXACT型以外のみBOUND型として記録
2. TTエントリにaspiration_failフラグを追加
  - TTエントリのデータ構造を拡張（ビット21に1ビット追加）
  - aspiration_fail()メソッドで失敗情報を取得可能
  - ageフィールドを6ビットから5ビットに削減して空間を確保
3. TTのoverwriteポリシー改善
  - Aspiration成功時の値を優先的に保存
  - 既存エントリがaspiration失敗で新エントリが成功の場合は常に上書き
  - 同じaspiration状態の場合は深さで判定

これにより、Aspiration Windowsの探索結果の信頼性が向上し、TTから取得する値の質も改善されます。


## clippy::too_many_arguments警告への対応
clippy::too_many_arguments警告に対して以下の対応を実施しました：

1. SearchContext構造体の導入

- alpha_beta関数のパラメータをグループ化
- 関連するパラメータを構造体にまとめることで、関数シグネチャを簡潔に
- 将来の拡張性も向上

2. 警告の抑制

- TTエントリ作成関数には#[allow(clippy::too_many_arguments)]を適用
- これらの関数は低レベルのパッキング処理で、パラメータ数が多いのは妥当

選択した理由：

- SearchContext導入により、探索関数のインターフェースが改善
- TTエントリ関数は既存APIとの互換性を維持
- Builderパターンも検討したが、パフォーマンスクリティカルな部分では避けた