### PR TITLE
Time management

### DIFF
--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "lazy_static",
  "log",
  "loom",
+ "parking_lot",
  "rand",
  "rand_xoshiro",
  "serde",
@@ -580,6 +581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +677,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -814,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +926,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -316,6 +316,8 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -625,6 +627,16 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1219,6 +1231,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/rust-core/crates/engine-core/Cargo.toml
+++ b/packages/rust-core/crates/engine-core/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.4"
 rand = { workspace = true }
 rand_xoshiro = { workspace = true }
 smallvec = "1.15"
+parking_lot = "0.12"
 
 # Loom is only available for non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/packages/rust-core/crates/engine-core/docs/time-management-integration.md
+++ b/packages/rust-core/crates/engine-core/docs/time-management-integration.md
@@ -1,0 +1,516 @@
+# Time Management Integration Guide
+
+This guide explains how to properly integrate the time management system with your Shogi engine GUI or USI adapter.
+
+## ⚠️ IMPORTANT: API Changes in v1.0.0
+
+The `finish_move` method has been **removed** as of version 1.0.0. You must use the `update_after_move` API for all time management updates.
+
+**Breaking change**: If you're upgrading from pre-1.0.0, you must migrate to the new API.
+
+## Critical Concepts
+
+### TimeControl vs. TimeState
+
+- **TimeControl**: Immutable configuration containing initial time settings
+- **TimeState**: Current runtime state, especially important for Byoyomi transitions
+
+### Byoyomi Transitions
+
+**CRITICAL**: The engine requires explicit notification of remaining main time to properly transition from main time to byoyomi periods.
+
+## API Usage
+
+### Recommended: Type-Safe API
+
+Use the `update_after_move` method with `TimeState` enum for type safety:
+
+```rust
+use engine_core::time_management::{TimeManager, TimeState, SearchLimits, TimeControl};
+
+// After each move, update time based on current state
+match current_time_control {
+    TimeControl::Byoyomi { .. } => {
+        if main_time_remaining > 0 {
+            time_manager.update_after_move(
+                time_spent_ms,
+                TimeState::Main { main_left_ms: main_time_remaining }
+            );
+        } else {
+            time_manager.update_after_move(
+                time_spent_ms,
+                TimeState::Byoyomi { main_left_ms: 0 }
+            );
+        }
+    }
+    _ => {
+        time_manager.update_after_move(time_spent_ms, TimeState::NonByoyomi);
+    }
+}
+```
+
+### Only One API
+
+There is now only one API for time updates: `update_after_move`. This ensures type safety and prevents Byoyomi transition bugs.
+
+## Integration Examples
+
+### USI Protocol Integration
+
+```rust
+use engine_core::time_management::*;
+
+fn handle_go_command(params: &UsiGoParams) -> SearchLimits {
+    // Parse time control from USI parameters
+    let time_control = if let Some(byoyomi_ms) = params.byoyomi {
+        // Determine current main time based on side to move
+        let main_time = if position.side_to_move() == Color::Black {
+            params.btime.unwrap_or(0)
+        } else {
+            params.wtime.unwrap_or(0)
+        };
+        
+        TimeControl::Byoyomi {
+            main_time_ms: main_time,  // Current remaining main time
+            byoyomi_ms,
+            periods: 1,  // USI typically uses 1 period
+        }
+    } else if let (Some(wtime), Some(btime)) = (params.wtime, params.btime) {
+        TimeControl::Fischer {
+            white_ms: wtime,
+            black_ms: btime,
+            increment_ms: params.winc.unwrap_or(0),
+        }
+    } else {
+        TimeControl::Infinite
+    };
+    
+    SearchLimits {
+        time_control,
+        moves_to_go: params.movestogo,
+        depth: params.depth.map(|d| d as u32),
+        nodes: params.nodes,
+        time_parameters: None,
+    }
+}
+
+fn report_move_time(engine: &Engine, move_time_ms: u64, usi_params: &UsiGoParams) {
+    let time_state = if let Some(byoyomi_ms) = usi_params.byoyomi {
+        // Calculate remaining main time after this move
+        let side = engine.position().side_to_move();
+        let current_main = if side == Color::Black {
+            usi_params.btime.unwrap_or(0)
+        } else {
+            usi_params.wtime.unwrap_or(0)
+        };
+        
+        if current_main > 0 {
+            TimeState::Main { main_left_ms: current_main.saturating_sub(move_time_ms) }
+        } else {
+            TimeState::Byoyomi { main_left_ms: 0 }
+        }
+    } else {
+        TimeState::NonByoyomi
+    };
+    
+    engine.time_manager().update_after_move(move_time_ms, time_state);
+}
+```
+
+### Web/RPC Integration
+
+```rust
+use engine_core::time_management::*;
+
+#[derive(Deserialize)]
+struct MoveRequest {
+    position: String,
+    time_left: TimeInfo,
+}
+
+#[derive(Deserialize)]
+struct TimeInfo {
+    main_time_ms: Option<u64>,
+    byoyomi_ms: Option<u64>,
+    periods_left: Option<u32>,
+    fischer_time_ms: Option<u64>,
+    increment_ms: Option<u64>,
+}
+
+fn handle_move_request(req: MoveRequest) -> MoveResponse {
+    let limits = create_search_limits(&req.time_left);
+    let engine = create_engine();
+    
+    // Perform search
+    let result = engine.search(limits);
+    let time_spent = result.time_ms;
+    
+    // Update time state
+    let time_state = match &req.time_left {
+        TimeInfo { main_time_ms: Some(main), byoyomi_ms: Some(_), .. } if *main > 0 => {
+            TimeState::Main { main_left_ms: main.saturating_sub(time_spent) }
+        }
+        TimeInfo { byoyomi_ms: Some(_), .. } => {
+            TimeState::Byoyomi { main_left_ms: 0 }
+        }
+        _ => TimeState::NonByoyomi,
+    };
+    
+    engine.time_manager().update_after_move(time_spent, time_state);
+    
+    MoveResponse {
+        best_move: result.best_move,
+        time_used_ms: time_spent,
+    }
+}
+```
+
+## Common Pitfalls
+
+### ❌ Never Do This
+
+```rust
+// WRONG: Using NonByoyomi state with Byoyomi time control
+let limits = SearchLimits {
+    time_control: TimeControl::Byoyomi {
+        main_time_ms: 300000,
+        byoyomi_ms: 10000,
+        periods: 3,
+    },
+    ..Default::default()
+};
+
+// Later...
+time_manager.update_after_move(5000, TimeState::NonByoyomi);  // BUG: No transition will occur!
+```
+
+### ✅ Always Do This
+
+```rust
+// CORRECT: Provide current main time
+let limits = SearchLimits {
+    time_control: TimeControl::Byoyomi {
+        main_time_ms: current_main_time,  // Current remaining time
+        byoyomi_ms: 10000,
+        periods: 3,
+    },
+    ..Default::default()
+};
+
+// Later...
+time_manager.update_after_move(5000, TimeState::Main { 
+    main_left_ms: current_main_time - 5000 
+});
+```
+
+## WASM Integration
+
+For WASM environments, time tracking works the same but uses `performance.now()`:
+
+```rust
+#[wasm_bindgen]
+pub struct WasmEngine {
+    engine: Engine,
+}
+
+#[wasm_bindgen]
+impl WasmEngine {
+    pub fn update_time_after_move(&mut self, time_spent_ms: u64, main_time_left: Option<u64>) {
+        let time_state = if let Some(main) = main_time_left {
+            if main > 0 {
+                TimeState::Main { main_left_ms: main }
+            } else {
+                TimeState::Byoyomi { main_left_ms: 0 }
+            }
+        } else {
+            TimeState::NonByoyomi
+        };
+        
+        self.engine.time_manager().update_after_move(time_spent_ms, time_state);
+    }
+}
+```
+
+## Testing Your Integration
+
+Always test these scenarios:
+
+1. **Main Time to Byoyomi Transition**
+   ```rust
+   // Start with 5s main time
+   let limits = create_byoyomi_limits(5000, 1000, 3);
+   
+   // Use 3s
+   tm.update_after_move(3000, TimeState::Main { main_left_ms: 2000 });
+   assert!(!tm.get_time_info().byoyomi_info.unwrap().in_byoyomi);
+   
+   // Use remaining 2s + 0.5s from byoyomi
+   tm.update_after_move(2500, TimeState::Main { main_left_ms: 2000 });
+   assert!(tm.get_time_info().byoyomi_info.unwrap().in_byoyomi);
+   ```
+
+2. **Multiple Period Consumption**
+   ```rust
+   // In byoyomi with 3 periods of 1s each
+   tm.update_after_move(2500, TimeState::Byoyomi { main_left_ms: 0 });
+   
+   let info = tm.get_time_info().byoyomi_info.unwrap();
+   assert_eq!(info.periods_left, 1);  // Consumed 2 periods
+   ```
+
+3. **Time Forfeit Detection**
+   ```rust
+   // Last period
+   tm.update_after_move(1500, TimeState::Byoyomi { main_left_ms: 0 });
+   assert!(tm.should_stop(0));  // Time forfeit
+   ```
+
+## Debug Mode
+
+In debug builds, the engine will assert if you use Byoyomi without providing main time:
+
+```
+thread 'main' panicked at 'Byoyomi: main_time_left_ms required when not in byoyomi (initial main_time: 300000ms)'
+```
+
+This helps catch integration bugs during development.
+
+## Migration from Pre-1.0.0
+
+### Breaking Changes
+
+The `finish_move` API has been completely removed in v1.0.0. This was necessary because:
+- The old API allowed dangerous usage patterns that could cause time forfeits
+- The optional parameter made it easy to forget critical information for Byoyomi
+- Type safety was not enforced
+
+### Migration Steps
+
+1. **Update all time management calls**
+   If you have any code using `finish_move`, it will no longer compile.
+
+2. **Determine the time control type**
+   - For Byoyomi: You MUST track whether in main time or byoyomi
+   - For other modes: Use `TimeState::NonByoyomi`
+
+3. **Replace with type-safe API**
+
+```rust
+// ❌ Old code (NO LONGER AVAILABLE)
+// time_manager.finish_move(time_spent, None);  // This API is removed!
+
+// ✅ New code (REQUIRED in v1.0.0)
+// For Byoyomi:
+let time_state = if main_time_remaining > 0 {
+    TimeState::Main { main_left_ms: main_time_remaining }
+} else {
+    TimeState::Byoyomi { main_left_ms: 0 }
+};
+time_manager.update_after_move(time_spent, time_state);
+
+// For Fischer/FixedTime/Infinite:
+time_manager.update_after_move(time_spent, TimeState::NonByoyomi);
+```
+
+### Complete Migration Example
+
+```rust
+// Old implementation (pre-1.0.0) - NO LONGER COMPILES
+fn handle_move_complete(tm: &TimeManager, result: &SearchResult) {
+    let time_spent = result.elapsed_ms;
+    // This won't compile in v1.0.0:
+    // tm.finish_move(time_spent, Some(remaining_main_time));
+}
+
+// New implementation (v1.0.0+)
+fn handle_move_complete(tm: &TimeManager, result: &SearchResult) {
+    let time_spent = result.elapsed_ms;
+    
+    let time_state = match tm.time_control() {
+        TimeControl::Byoyomi { .. } => {
+            // Type system ensures you handle the state
+            if self.main_time_remaining > 0 {
+                TimeState::Main { main_left_ms: self.main_time_remaining }
+            } else {
+                TimeState::Byoyomi { main_left_ms: 0 }
+            }
+        }
+        TimeControl::Fischer { .. } => TimeState::NonByoyomi,
+        TimeControl::FixedTime { .. } => TimeState::NonByoyomi,
+        TimeControl::FixedNodes { .. } => TimeState::NonByoyomi,
+        TimeControl::Infinite => TimeState::NonByoyomi,
+        TimeControl::Ponder => TimeState::NonByoyomi,
+    };
+    
+    tm.update_after_move(time_spent, time_state);
+}
+```
+
+### Testing Your Migration
+
+After migration, test these scenarios:
+
+1. **Byoyomi main time to period transition**
+2. **Multiple byoyomi period consumption**
+3. **Time forfeit detection**
+4. **Non-byoyomi time controls still work**
+
+See the test examples earlier in this guide.
+
+## Ponder Mode Integration
+
+### Overview
+
+Ponder mode allows the engine to think on the opponent's time by predicting their move. When the predicted move is played (ponder hit), the search continues with proper time management.
+
+### Creating a Ponder Search
+
+Use the `new_ponder` method to create a TimeManager for pondering:
+
+```rust
+use engine_core::time_management::*;
+
+// Prepare the actual time control for when ponder hit occurs
+let actual_limits = SearchLimits {
+    time_control: TimeControl::Fischer {
+        white_ms: 60000,
+        black_ms: 50000,
+        increment_ms: 1000,
+    },
+    ..Default::default()
+};
+
+// Create TimeManager in ponder mode
+let tm = TimeManager::new_ponder(
+    &actual_limits,          // Pending time control
+    Color::White,            // Side to move
+    20,                      // Current ply
+    GamePhase::MiddleGame    // Game phase
+);
+
+// Start search - will run indefinitely until ponder hit or stop
+engine.search_with_time_manager(tm);
+```
+
+### Handling Ponder Hit
+
+When the opponent plays the expected move:
+
+```rust
+// Time already spent pondering (in milliseconds)
+let ponder_time_ms = tm.elapsed_ms();
+
+// Option 1: Use the pending time control
+tm.ponder_hit(None, ponder_time_ms);
+
+// Option 2: Provide updated time information
+let updated_limits = SearchLimits {
+    time_control: TimeControl::Fischer {
+        white_ms: 58000,  // Updated after opponent's move
+        black_ms: 48000,
+        increment_ms: 1000,
+    },
+    moves_to_go: Some(30),  // Additional info
+    ..Default::default()
+};
+tm.ponder_hit(Some(&updated_limits), ponder_time_ms);
+```
+
+### USI Protocol Example
+
+```
+// Start position
+position startpos moves 7g7f 3c3d
+
+// Start pondering (predict opponent plays 8c8d)
+position startpos moves 7g7f 3c3d 8c8d
+go ponder
+
+// If opponent plays the expected move
+ponderhit
+
+// If opponent plays a different move
+stop
+position startpos moves 7g7f 3c3d 2b8h+
+go btime 58000 wtime 48000 byoyomi 10000
+```
+
+### Implementation Example
+
+```rust
+impl UsiEngine {
+    fn handle_go(&mut self, params: &GoParams) {
+        if params.ponder {
+            // Create ponder search
+            let limits = self.create_search_limits_from_params(params);
+            let tm = TimeManager::new_ponder(
+                &limits,
+                self.position.side_to_move(),
+                self.position.ply(),
+                self.estimate_game_phase()
+            );
+            
+            self.current_search = Some(SearchHandle {
+                time_manager: tm,
+                is_ponder: true,
+            });
+            
+            // Start search in background
+            self.start_search();
+        } else {
+            // Normal search
+            // ...
+        }
+    }
+    
+    fn handle_ponderhit(&mut self) {
+        if let Some(ref search) = self.current_search {
+            if search.is_ponder {
+                let elapsed = search.time_manager.elapsed_ms();
+                
+                // Convert ponder to normal search
+                search.time_manager.ponder_hit(None, elapsed);
+                search.is_ponder = false;
+                
+                // Search continues with proper time management
+            }
+        }
+    }
+}
+```
+
+### Important Notes
+
+1. **Force Stop**: Even during ponder, `force_stop()` will immediately halt the search
+2. **Time Tracking**: The start time is preserved from ponder start, so `elapsed_ms()` includes all pondering time
+3. **Minimum Time**: After ponder hit, at least 100ms soft / 200ms hard limits are guaranteed
+4. **No Recursive Ponder**: Only one level of pondering is supported
+
+### Testing Ponder Mode
+
+```rust
+#[test]
+fn test_ponder_behavior() {
+    let limits = create_test_limits();
+    let tm = TimeManager::new_ponder(&limits, Color::White, 0, GamePhase::Opening);
+    
+    // During ponder
+    assert!(tm.is_pondering());
+    assert!(!tm.should_stop(1000000));  // Won't stop on time
+    
+    // After ponder hit
+    tm.ponder_hit(None, 5000);
+    assert!(!tm.is_pondering());
+    // Now normal time management applies
+}
+```
+
+## Summary
+
+1. Always track current remaining main time for Byoyomi
+2. Use `TimeState` enum for type safety
+3. Test transition scenarios thoroughly
+4. Watch for debug assertions during development
+5. Migrate to new API for better maintainability
+6. Use `new_ponder` for ponder mode searches
+7. Call `ponder_hit` when predicted move is played

--- a/packages/rust-core/crates/engine-core/src/engine/controller.rs
+++ b/packages/rust-core/crates/engine-core/src/engine/controller.rs
@@ -5,8 +5,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::{
-    evaluate::{Evaluator, MaterialEvaluator},
-    nnue::NNUEEvaluatorWrapper,
+    evaluation::evaluate::{Evaluator, MaterialEvaluator},
+    evaluation::nnue::NNUEEvaluatorWrapper,
     search::search_basic::{SearchLimits, SearchResult, Searcher},
     Position,
 };

--- a/packages/rust-core/crates/engine-core/src/lib.rs
+++ b/packages/rust-core/crates/engine-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod movegen;
 pub mod opening_book;
 pub mod search;
 pub mod shogi;
+pub mod time_management;
 pub mod util;
 
 pub use engine::zobrist;
@@ -12,6 +13,7 @@ pub use evaluation::{evaluate, nnue};
 pub use movegen::{MoveGen, MovePicker};
 pub use opening_book::{BookMove, MoveEncoder, OpeningBookReader, PositionHasher};
 pub use search::history::History;
-pub use search::TranspositionTable;
+pub use search::{GamePhase, TranspositionTable};
 pub use shogi::{Bitboard, Board, Color, Piece, PieceType, Position, Square};
+pub use time_management::{SearchLimits, TimeControl, TimeManager, TimeParameters};
 pub use util::sync_compat::{Arc, AtomicU64, Ordering};

--- a/packages/rust-core/crates/engine-core/src/search/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/mod.rs
@@ -3,4 +3,5 @@ pub mod search_basic;
 pub mod search_enhanced;
 pub mod tt;
 
+pub use search_enhanced::GamePhase;
 pub use tt::TranspositionTable;

--- a/packages/rust-core/crates/engine-core/src/search/search_basic.rs
+++ b/packages/rust-core/crates/engine-core/src/search/search_basic.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::evaluate::Evaluator;
+use crate::evaluation::evaluate::Evaluator;
 use crate::shogi::{Move, MoveList};
 use crate::{MoveGen, Position};
 

--- a/packages/rust-core/crates/engine-core/src/search/search_enhanced.rs
+++ b/packages/rust-core/crates/engine-core/src/search/search_enhanced.rs
@@ -11,6 +11,7 @@ use super::history::History;
 use super::tt::{NodeType, TranspositionTable};
 use crate::evaluate::Evaluator;
 use crate::shogi::Move;
+use crate::time_management::{SearchLimits, TimeManager};
 use crate::zobrist::ZOBRIST;
 use crate::{Color, MovePicker, PieceType, Position};
 use smallvec::SmallVec;
@@ -331,9 +332,9 @@ pub struct EnhancedSearcher {
     nodes: AtomicU64,
     /// Stop flag
     stop: AtomicBool,
-    /// Time limit
+    /// Time limit (deprecated - use time_manager instead)
     time_limit: Option<Instant>,
-    /// Node limit
+    /// Node limit (deprecated - use time_manager instead)
     node_limit: Option<u64>,
     /// Search start time
     start_time: Instant,
@@ -341,6 +342,8 @@ pub struct EnhancedSearcher {
     evaluator: Arc<dyn Evaluator + Send + Sync>,
     /// Principal variation table
     pv: PVTable,
+    /// Time manager for sophisticated time control
+    time_manager: Option<TimeManager>,
     /// Search statistics (for testing)
     #[cfg(test)]
     pub stats: SearchStats,
@@ -360,6 +363,7 @@ impl EnhancedSearcher {
             start_time: Instant::now(),
             evaluator,
             pv: PVTable::new(),
+            time_manager: None,
             #[cfg(test)]
             stats: SearchStats::default(),
         }
@@ -417,7 +421,29 @@ impl EnhancedSearcher {
         self.pv.get_pv()
     }
 
-    /// Search position with iterative deepening
+    /// Search position with new SearchLimits interface
+    pub fn search_with_limits(
+        &mut self,
+        pos: &mut Position,
+        limits: SearchLimits,
+    ) -> (Option<Move>, i32) {
+        // Create time manager if time control is specified
+        self.time_manager = match &limits.time_control {
+            crate::time_management::TimeControl::Infinite => None,
+            _ => {
+                let game_phase = self.estimate_game_phase(pos);
+                Some(TimeManager::new(&limits, pos.side_to_move, pos.ply as u32, game_phase))
+            }
+        };
+
+        // Extract max depth (default to 127 if not specified)
+        let max_depth = limits.depth.map(|d| d as i32).unwrap_or(MAX_DEPTH);
+
+        // Call internal search implementation
+        self.search_internal(pos, max_depth)
+    }
+
+    /// Search position with iterative deepening (legacy interface)
     pub fn search(
         &mut self,
         pos: &mut Position,
@@ -425,12 +451,31 @@ impl EnhancedSearcher {
         time_limit: Option<Duration>,
         node_limit: Option<u64>,
     ) -> (Option<Move>, i32) {
+        // Convert legacy parameters to SearchLimits
+        let limits = SearchLimits {
+            time_control: match (time_limit, node_limit) {
+                (Some(duration), _) => crate::time_management::TimeControl::FixedTime {
+                    ms_per_move: duration.as_millis() as u64,
+                },
+                (None, Some(nodes)) => crate::time_management::TimeControl::FixedNodes { nodes },
+                _ => crate::time_management::TimeControl::Infinite,
+            },
+            moves_to_go: None,
+            depth: Some(max_depth as u32),
+            nodes: node_limit,
+            time_parameters: None,
+        };
+
+        self.search_with_limits(pos, limits)
+    }
+
+    /// Internal search implementation
+    fn search_internal(&mut self, pos: &mut Position, max_depth: i32) -> (Option<Move>, i32) {
         // Reset search state
         self.nodes.store(0, Ordering::Relaxed);
         self.stop.store(false, Ordering::Relaxed);
         self.start_time = Instant::now();
-        self.time_limit = time_limit.map(|d| self.start_time + d);
-        self.node_limit = node_limit;
+        // Time and node limits are now managed by TimeManager
         self.history.clear_all();
 
         #[cfg(test)]
@@ -910,6 +955,13 @@ impl EnhancedSearcher {
                     // Update PV
                     self.pv.update(ctx.ply, mv);
 
+                    // Notify TimeManager of PV change
+                    if ctx.ply == 0 && score < ctx.beta {
+                        if let Some(ref tm) = self.time_manager {
+                            tm.on_pv_change(ctx.depth as u32);
+                        }
+                    }
+
                     if score >= ctx.beta {
                         // Update history for good quiet move
                         if !self.is_capture(pos, mv) {
@@ -1108,17 +1160,23 @@ impl EnhancedSearcher {
             return true;
         }
 
-        // Check time limit
-        if let Some(limit) = self.time_limit {
-            if Instant::now() >= limit {
+        // Use TimeManager if available
+        if let Some(ref tm) = self.time_manager {
+            let nodes = self.nodes.load(Ordering::Relaxed);
+            if tm.should_stop(nodes) {
                 return true;
             }
-        }
-
-        // Check node limit
-        if let Some(limit) = self.node_limit {
-            if self.nodes.load(Ordering::Relaxed) >= limit {
-                return true;
+        } else {
+            // Fallback to legacy time/node limits
+            if let Some(limit) = self.time_limit {
+                if Instant::now() >= limit {
+                    return true;
+                }
+            }
+            if let Some(limit) = self.node_limit {
+                if self.nodes.load(Ordering::Relaxed) >= limit {
+                    return true;
+                }
             }
         }
 
@@ -1133,7 +1191,8 @@ impl EnhancedSearcher {
         }
 
         // Skip time check completely for deterministic behavior
-        // Only check node limit
+        // For TimeManager, we can't easily check if it's FixedNodes without exposing internals
+        // So in test mode, we rely on the legacy node_limit field
         if let Some(limit) = self.node_limit {
             if self.nodes.load(Ordering::Relaxed) >= limit {
                 return true;

--- a/packages/rust-core/crates/engine-core/src/search/search_enhanced.rs
+++ b/packages/rust-core/crates/engine-core/src/search/search_enhanced.rs
@@ -9,7 +9,7 @@
 
 use super::history::History;
 use super::tt::{NodeType, TranspositionTable};
-use crate::evaluate::Evaluator;
+use crate::evaluation::evaluate::Evaluator;
 use crate::shogi::Move;
 use crate::time_management::{SearchLimits, TimeManager};
 use crate::zobrist::ZOBRIST;

--- a/packages/rust-core/crates/engine-core/src/time_management/allocation.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/allocation.rs
@@ -69,18 +69,25 @@ fn calculate_fischer_time(
     let moves_left = moves_to_go.unwrap_or_else(|| estimate_moves_remaining(ply));
 
     // Base allocation: (remaining_time / moves_left) + increment * usage_factor
-    let base_ms =
-        (remain_ms / moves_left as u64) + ((increment_ms as f64 * params.increment_usage) as u64);
+    // Use integer arithmetic to avoid rounding errors: 0.8 = 8/10
+    let increment_bonus = if params.increment_usage == 0.8 {
+        (increment_ms * 8) / 10
+    } else {
+        ((increment_ms as f64 * params.increment_usage) + 0.5) as u64 // Round to nearest
+    };
+    let base_ms = (remain_ms / moves_left as u64) + increment_bonus;
 
     // Apply game phase factor
+    // Note: We apply phase_factor first, then soft_multiplier for clarity
     let phase_factor = match game_phase {
         GamePhase::Opening => params.opening_factor,
         GamePhase::MiddleGame => 1.0,
         GamePhase::EndGame => params.endgame_factor,
     };
 
-    let soft_ms = ((base_ms as f64) * phase_factor * params.soft_multiplier) as u64;
-    let hard_ms = (((soft_ms as f64) * params.hard_multiplier) as u64).min(remain_ms * 8 / 10); // Never use more than 80% of remaining time
+    let soft_ms = ((base_ms as f64 * phase_factor * params.soft_multiplier) + 0.5) as u64;
+    let hard_ms =
+        (((soft_ms as f64 * params.hard_multiplier) + 0.5) as u64).min(remain_ms * 8 / 10); // Never use more than 80% of remaining time
 
     // Apply overhead
     let overhead = params.overhead_ms;
@@ -89,7 +96,8 @@ fn calculate_fischer_time(
 
 /// Calculate time for fixed time per move
 fn calculate_fixed_time(ms_per_move: u64, params: &TimeParameters) -> (u64, u64) {
-    let soft = ((ms_per_move as f64) * 0.9) as u64; // Use 90% as soft limit
+    // Use integer arithmetic: 90% = 9/10
+    let soft = (ms_per_move * 9) / 10;
     let overhead = params.overhead_ms;
     (soft.saturating_sub(overhead), ms_per_move.saturating_sub(overhead))
 }
@@ -102,12 +110,14 @@ fn calculate_byoyomi_time(
 ) -> (u64, u64) {
     if main_time_ms > 0 {
         // Still in main time - treat like Fischer without increment
-        let soft = ((main_time_ms as f64) * 0.2) as u64; // Conservative in main time
-        let hard = ((main_time_ms as f64) * 0.5) as u64;
+        // Conservative allocation: 20% soft, 50% hard
+        let soft = main_time_ms / 5; // 20% = 1/5
+        let hard = main_time_ms / 2; // 50% = 1/2
         (soft, hard)
     } else {
         // In byoyomi period
-        let soft = ((byoyomi_ms as f64) * 0.8) as u64;
+        // Use 80% of period as soft limit
+        let soft = (byoyomi_ms * 4) / 5; // 80% = 4/5
         let hard = byoyomi_ms;
         let overhead = params.overhead_ms;
         (soft.saturating_sub(overhead), hard.saturating_sub(overhead))
@@ -116,7 +126,6 @@ fn calculate_byoyomi_time(
 
 /// Estimate remaining moves in the game
 fn estimate_moves_remaining(ply: u32) -> u32 {
-    const AVERAGE_GAME_LENGTH: u32 = 120;
     let moves_played = ply / 2;
 
     // Use a curve based on typical game progression
@@ -190,5 +199,82 @@ mod tests {
 
         assert_eq!(soft, 900 - params.overhead_ms); // 90% - overhead
         assert_eq!(hard, 1000 - params.overhead_ms);
+    }
+
+    #[test]
+    fn test_byoyomi_main_time() {
+        let params = TimeParameters::default();
+        let (soft, hard) = calculate_time_allocation(
+            &TimeControl::Byoyomi {
+                main_time_ms: 10000, // 10 seconds main time
+                byoyomi_ms: 30000,   // 30 seconds per period
+                periods: 3,
+            },
+            Color::White,
+            0,
+            None,
+            GamePhase::Opening,
+            &params,
+        );
+
+        // Conservative allocation during main time
+        assert_eq!(soft, 2000); // 20% of 10000
+        assert_eq!(hard, 5000); // 50% of 10000
+    }
+
+    #[test]
+    fn test_byoyomi_period() {
+        let params = TimeParameters::default();
+        let (soft, hard) = calculate_time_allocation(
+            &TimeControl::Byoyomi {
+                main_time_ms: 0,   // No main time, already in byoyomi
+                byoyomi_ms: 30000, // 30 seconds per period
+                periods: 3,
+            },
+            Color::Black,
+            80,
+            None,
+            GamePhase::EndGame,
+            &params,
+        );
+
+        // Should use 80% of period as soft limit
+        assert_eq!(soft, 24000 - params.overhead_ms); // 80% of 30000 - overhead
+        assert_eq!(hard, 30000 - params.overhead_ms); // Full period - overhead
+    }
+
+    #[test]
+    fn test_integer_arithmetic_precision() {
+        let params = TimeParameters::default();
+
+        // Test increment calculation with default 0.8 factor
+        let (soft1, _) = calculate_time_allocation(
+            &TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            Color::White,
+            60,       // Late game
+            Some(40), // 40 moves to go
+            GamePhase::MiddleGame,
+            &params,
+        );
+
+        // Verify integer arithmetic produces consistent results
+        let (soft2, _) = calculate_time_allocation(
+            &TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            Color::White,
+            60,
+            Some(40),
+            GamePhase::MiddleGame,
+            &params,
+        );
+
+        assert_eq!(soft1, soft2, "Integer arithmetic should be deterministic");
     }
 }

--- a/packages/rust-core/crates/engine-core/src/time_management/allocation.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/allocation.rs
@@ -1,0 +1,194 @@
+//! Time allocation algorithms
+
+use super::{TimeControl, TimeParameters};
+use crate::search::GamePhase;
+use crate::Color;
+
+/// Calculate time allocation for the current move
+pub fn calculate_time_allocation(
+    time_control: &TimeControl,
+    side: Color,
+    ply: u32,
+    moves_to_go: Option<u32>,
+    game_phase: GamePhase,
+    params: &TimeParameters,
+) -> (u64, u64) {
+    // (soft_limit_ms, hard_limit_ms)
+    match time_control {
+        TimeControl::Fischer {
+            white_ms,
+            black_ms,
+            increment_ms,
+        } => calculate_fischer_time(
+            if side == Color::White {
+                *white_ms
+            } else {
+                *black_ms
+            },
+            *increment_ms,
+            ply,
+            moves_to_go,
+            game_phase,
+            params,
+        ),
+
+        TimeControl::FixedTime { ms_per_move } => calculate_fixed_time(*ms_per_move, params),
+
+        TimeControl::Byoyomi {
+            main_time_ms,
+            byoyomi_ms,
+            ..
+        } => calculate_byoyomi_time(*main_time_ms, *byoyomi_ms, params),
+
+        TimeControl::FixedNodes { .. } => {
+            // No time limits for fixed nodes
+            (u64::MAX, u64::MAX)
+        }
+
+        TimeControl::Infinite | TimeControl::Ponder => {
+            // No time limits for infinite/ponder
+            (u64::MAX, u64::MAX)
+        }
+    }
+}
+
+/// Calculate time for Fischer time control
+fn calculate_fischer_time(
+    remain_ms: u64,
+    increment_ms: u64,
+    ply: u32,
+    moves_to_go: Option<u32>,
+    game_phase: GamePhase,
+    params: &TimeParameters,
+) -> (u64, u64) {
+    // Safety fail: critically low time
+    if remain_ms < params.critical_fischer_ms && increment_ms == 0 {
+        return (50, 100); // Minimal time to return a move
+    }
+
+    let moves_left = moves_to_go.unwrap_or_else(|| estimate_moves_remaining(ply));
+
+    // Base allocation: (remaining_time / moves_left) + increment * usage_factor
+    let base_ms =
+        (remain_ms / moves_left as u64) + ((increment_ms as f64 * params.increment_usage) as u64);
+
+    // Apply game phase factor
+    let phase_factor = match game_phase {
+        GamePhase::Opening => params.opening_factor,
+        GamePhase::MiddleGame => 1.0,
+        GamePhase::EndGame => params.endgame_factor,
+    };
+
+    let soft_ms = ((base_ms as f64) * phase_factor * params.soft_multiplier) as u64;
+    let hard_ms = (((soft_ms as f64) * params.hard_multiplier) as u64).min(remain_ms * 8 / 10); // Never use more than 80% of remaining time
+
+    // Apply overhead
+    let overhead = params.overhead_ms;
+    (soft_ms.saturating_sub(overhead), hard_ms.saturating_sub(overhead))
+}
+
+/// Calculate time for fixed time per move
+fn calculate_fixed_time(ms_per_move: u64, params: &TimeParameters) -> (u64, u64) {
+    let soft = ((ms_per_move as f64) * 0.9) as u64; // Use 90% as soft limit
+    let overhead = params.overhead_ms;
+    (soft.saturating_sub(overhead), ms_per_move.saturating_sub(overhead))
+}
+
+/// Calculate time for byoyomi
+fn calculate_byoyomi_time(
+    main_time_ms: u64,
+    byoyomi_ms: u64,
+    params: &TimeParameters,
+) -> (u64, u64) {
+    if main_time_ms > 0 {
+        // Still in main time - treat like Fischer without increment
+        let soft = ((main_time_ms as f64) * 0.2) as u64; // Conservative in main time
+        let hard = ((main_time_ms as f64) * 0.5) as u64;
+        (soft, hard)
+    } else {
+        // In byoyomi period
+        let soft = ((byoyomi_ms as f64) * 0.8) as u64;
+        let hard = byoyomi_ms;
+        let overhead = params.overhead_ms;
+        (soft.saturating_sub(overhead), hard.saturating_sub(overhead))
+    }
+}
+
+/// Estimate remaining moves in the game
+fn estimate_moves_remaining(ply: u32) -> u32 {
+    const AVERAGE_GAME_LENGTH: u32 = 120;
+    let moves_played = ply / 2;
+
+    // Use a curve based on typical game progression
+    if moves_played < 30 {
+        60 // Opening: expect longer game
+    } else if moves_played < 80 {
+        40 // Middle game
+    } else {
+        20 // Endgame: minimum 20 moves buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fischer_allocation() {
+        let params = TimeParameters::default();
+        let (soft, hard) = calculate_time_allocation(
+            &TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            Color::White,
+            0,
+            None,
+            GamePhase::Opening,
+            &params,
+        );
+
+        // Opening gets 1.2x factor
+        assert!(soft > 1000);
+        assert!(hard > soft);
+        assert!(hard <= 48000); // 80% of 60000
+    }
+
+    #[test]
+    fn test_critical_time() {
+        let params = TimeParameters::default();
+        let (soft, hard) = calculate_time_allocation(
+            &TimeControl::Fischer {
+                white_ms: 200, // Less than critical threshold
+                black_ms: 200,
+                increment_ms: 0,
+            },
+            Color::White,
+            100,
+            None,
+            GamePhase::EndGame,
+            &params,
+        );
+
+        // Should return minimal time
+        assert_eq!(soft, 50);
+        assert_eq!(hard, 100);
+    }
+
+    #[test]
+    fn test_fixed_time() {
+        let params = TimeParameters::default();
+        let (soft, hard) = calculate_time_allocation(
+            &TimeControl::FixedTime { ms_per_move: 1000 },
+            Color::Black,
+            50,
+            None,
+            GamePhase::MiddleGame,
+            &params,
+        );
+
+        assert_eq!(soft, 900 - params.overhead_ms); // 90% - overhead
+        assert_eq!(hard, 1000 - params.overhead_ms);
+    }
+}

--- a/packages/rust-core/crates/engine-core/src/time_management/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/mod.rs
@@ -14,7 +14,7 @@
 //! - State changes don't affect the original settings
 //! - Current state is accessible via `TimeInfo::byoyomi_info`
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
@@ -28,25 +28,37 @@ mod allocation;
 mod parameters;
 mod types;
 
+#[cfg(test)]
+mod test_utils;
+
 pub use allocation::calculate_time_allocation;
 pub use parameters::TimeParameters;
-pub use types::{ByoyomiInfo, SearchLimits, TimeControl, TimeInfo};
+pub use types::{ByoyomiInfo, SearchLimits, TimeControl, TimeInfo, TimeState};
 
 /// Time manager coordinating all time-related decisions
 pub struct TimeManager {
     inner: Arc<TimeManagerInner>,
 }
 
+#[cfg(test)]
+pub use test_utils::{mock_advance_time, mock_current_ms, mock_now, mock_set_time};
+
 /// Internal state shared between threads
 struct TimeManagerInner {
     // === Immutable after initialization ===
-    time_control: TimeControl,
+    #[allow(dead_code)]
+    time_control: TimeControl, // Initial time control (kept for reference)
     side_to_move: Color,
     #[allow(dead_code)] // May be used in future for advanced time management
     start_ply: u32,
     params: TimeParameters,
+    game_phase: GamePhase, // Game phase at creation time
 
     // === Mutable state (Atomic/Mutex) ===
+    // Active time control (can change after ponder_hit)
+    // Using RwLock for better read performance in hot path
+    active_time_control: RwLock<TimeControl>,
+
     // Time tracking (Mutex to avoid UB with Instant)
     start_time: Mutex<Instant>,
 
@@ -66,6 +78,10 @@ struct TimeManagerInner {
 
     // Byoyomi-specific state
     byoyomi_state: Mutex<ByoyomiState>,
+
+    // Ponder-specific state
+    pending_time_control: Mutex<Option<TimeControl>>, // Time control to switch to after ponder_hit
+    is_ponder: AtomicBool,                            // Whether currently pondering
 }
 
 /// Byoyomi (Japanese overtime) state management
@@ -109,10 +125,12 @@ impl TimeManager {
         };
 
         let inner = Arc::new(TimeManagerInner {
-            time_control: limits.time_control,
+            time_control: limits.time_control.clone(),
             side_to_move: side,
             start_ply: ply,
             params,
+            game_phase,
+            active_time_control: RwLock::new(limits.time_control.clone()),
             start_time: Mutex::new(Instant::now()),
             soft_limit_ms: AtomicU64::new(soft_ms),
             hard_limit_ms: AtomicU64::new(hard_ms),
@@ -122,9 +140,88 @@ impl TimeManager {
             last_pv_change_ms: AtomicU64::new(0),
             pv_threshold_ms: AtomicU64::new(params.pv_base_threshold_ms),
             byoyomi_state: Mutex::new(byoyomi_state),
+            pending_time_control: Mutex::new(None),
+            is_ponder: AtomicBool::new(matches!(&limits.time_control, TimeControl::Ponder)),
         });
 
         Self { inner }
+    }
+
+    /// Create a new time manager for pondering
+    #[inline]
+    pub fn new_ponder(
+        pending_limits: &SearchLimits,
+        side: Color,
+        ply: u32,
+        game_phase: GamePhase,
+    ) -> Self {
+        // Create ponder limits with infinite time
+        let ponder_limits = SearchLimits {
+            time_control: TimeControl::Ponder,
+            moves_to_go: pending_limits.moves_to_go,
+            depth: pending_limits.depth,
+            nodes: pending_limits.nodes,
+            time_parameters: pending_limits.time_parameters,
+        };
+
+        // Create TimeManager with ponder mode
+        let tm = Self::new(&ponder_limits, side, ply, game_phase);
+
+        // Store the pending time control
+        {
+            let mut pending = tm.inner.pending_time_control.lock();
+            *pending = Some(pending_limits.time_control.clone());
+        }
+
+        // Initialize byoyomi state if pending time control is Byoyomi
+        if let TimeControl::Byoyomi {
+            periods,
+            byoyomi_ms,
+            main_time_ms,
+        } = &pending_limits.time_control
+        {
+            let mut byoyomi_state = tm.inner.byoyomi_state.lock();
+            *byoyomi_state = ByoyomiState {
+                periods_left: *periods,
+                current_period_ms: *byoyomi_ms,
+                in_byoyomi: *main_time_ms == 0,
+            };
+        }
+
+        tm
+    }
+
+    /// Check if currently pondering
+    #[inline]
+    pub fn is_pondering(&self) -> bool {
+        self.inner.is_ponder.load(Ordering::Acquire)
+    }
+
+    /// Get the active time control (helper for internal use)
+    ///
+    /// Returns a read guard that should be dropped as soon as possible
+    /// to avoid blocking other threads. Current usage is minimal (match/if let),
+    /// but be mindful of lock duration if code complexity increases.
+    #[inline]
+    fn get_active_time_control(&self) -> parking_lot::RwLockReadGuard<'_, TimeControl> {
+        self.inner.active_time_control.read()
+    }
+
+    /// Create a new time manager with mock time for testing
+    #[cfg(test)]
+    fn new_with_mock_time(
+        limits: &SearchLimits,
+        side: Color,
+        ply: u32,
+        game_phase: GamePhase,
+    ) -> Self {
+        let tm = Self::new(limits, side, ply, game_phase);
+        // Replace start_time with mock time
+        {
+            let mut start_time = tm.inner.start_time.lock();
+            *start_time = mock_now();
+        } // MutexGuard is dropped here
+        tm
     }
 
     /// Check if search should stop (called frequently from search loop)
@@ -134,11 +231,20 @@ impl TimeManager {
             return true;
         }
 
+        // If pondering, only stop on force_stop
+        if self.is_pondering() {
+            return false;
+        }
+
         // Update nodes searched (using fetch_max to avoid lost updates)
+        // Note: This ignores node count decreases, which is acceptable as it's
+        // extremely rare in practice. If history reset is needed, a separate
+        // reset_nodes() API with swap(0, Ordering::Relaxed) would be cleaner.
         self.inner.nodes_searched.fetch_max(current_nodes, Ordering::Relaxed);
 
         // Check node limit
-        if let TimeControl::FixedNodes { nodes } = &self.inner.time_control {
+        let active_tc = self.get_active_time_control();
+        if let TimeControl::FixedNodes { nodes } = &*active_tc {
             if current_nodes >= *nodes {
                 return true;
             }
@@ -186,65 +292,108 @@ impl TimeManager {
     /// Get elapsed time since search start
     pub fn elapsed_ms(&self) -> u64 {
         let start = self.inner.start_time.lock();
-        start.elapsed().as_millis() as u64
+        #[cfg(test)]
+        {
+            // In test mode, use mock time
+            let now = mock_now();
+            now.duration_since(*start).as_millis() as u64
+        }
+        #[cfg(not(test))]
+        {
+            start.elapsed().as_millis() as u64
+        }
     }
 
-    /// Update remaining time after move (for Fischer/Byoyomi)
-    ///
-    /// For Byoyomi time control, this method manages period consumption:
-    /// - If time_spent_ms >= byoyomi_ms, periods are consumed
-    /// - Multiple periods can be consumed if time_spent_ms >> byoyomi_ms
-    /// - If all periods are consumed, sets stop flag for time forfeit
+    /// Update time after move completion (recommended API)
     ///
     /// # Arguments
     /// - `time_spent_ms`: Time spent on this move
-    /// - `main_time_left_ms`: Remaining main time (for GUI-based transition to byoyomi)
+    /// - `time_state`: Current time state (required for proper Byoyomi transition)
     ///
-    /// Note: The original TimeControl settings remain unchanged.
-    /// Current state is tracked internally and exposed via get_time_info().
-    pub fn finish_move(&self, time_spent_ms: u64, main_time_left_ms: Option<u64>) {
-        match &self.inner.time_control {
-            TimeControl::Byoyomi { byoyomi_ms, .. } => {
-                let mut state = self.inner.byoyomi_state.lock();
-
-                if !state.in_byoyomi {
-                    // Still in main time
-                    // Check if we should transition to byoyomi based on GUI's report
-                    if let Some(main_left) = main_time_left_ms {
-                        if main_left == 0 || time_spent_ms >= main_left {
-                            // Transition to byoyomi
-                            state.in_byoyomi = true;
-                            // If we overspent, consume from first byoyomi period
-                            if time_spent_ms > main_left {
-                                let overspent = time_spent_ms - main_left;
-                                state.current_period_ms = byoyomi_ms.saturating_sub(overspent);
-                            }
-                        }
-                    }
-                } else {
-                    // In byoyomi - handle multiple period consumption
-                    let mut remaining_time = time_spent_ms;
-                    let mut current_ms = state.current_period_ms;
-
-                    // Consume periods while time exceeds current period
-                    while remaining_time >= current_ms && state.periods_left > 0 {
-                        remaining_time -= current_ms;
-                        state.periods_left = state.periods_left.saturating_sub(1);
-                        current_ms = *byoyomi_ms; // Reset to full period
-                    }
-
-                    if state.periods_left == 0 {
-                        // Time forfeit - set stop flag
-                        self.inner.stop_flag.store(true, Ordering::Release);
-                        state.current_period_ms = 0;
-                    } else {
-                        // Set remaining time in current period
-                        state.current_period_ms = current_ms.saturating_sub(remaining_time);
-                    }
-                }
+    /// # Example
+    /// ```
+    /// use engine_core::time_management::{TimeManager, TimeState, SearchLimits, TimeControl};
+    /// use engine_core::search::GamePhase;
+    /// use engine_core::Color;
+    ///
+    /// let limits = SearchLimits {
+    ///     time_control: TimeControl::Byoyomi {
+    ///         main_time_ms: 150000,
+    ///         byoyomi_ms: 10000,
+    ///         periods: 3,
+    ///     },
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let time_manager = TimeManager::new(&limits, Color::Black, 20, GamePhase::MiddleGame);
+    ///
+    /// // USI: go btime 150000 wtime 140000 byoyomi 10000
+    /// let time_state = TimeState::Main { main_left_ms: 150000 };
+    /// time_manager.update_after_move(2000, time_state);
+    /// ```
+    pub fn update_after_move(&self, time_spent_ms: u64, time_state: TimeState) {
+        let active_tc = self.get_active_time_control();
+        match (&*active_tc, time_state) {
+            (
+                TimeControl::Byoyomi { byoyomi_ms, .. },
+                TimeState::Main { main_left_ms } | TimeState::Byoyomi { main_left_ms },
+            ) => {
+                self.handle_byoyomi_update(time_spent_ms, Some(main_left_ms), *byoyomi_ms);
+            }
+            (TimeControl::Byoyomi { .. }, TimeState::NonByoyomi) => {
+                debug_assert!(false, "TimeState::NonByoyomi used with Byoyomi time control");
             }
             _ => {
                 // Fischer and other modes: time update handled by GUI
+            }
+        }
+    }
+
+    /// Internal helper for Byoyomi time updates
+    fn handle_byoyomi_update(
+        &self,
+        time_spent_ms: u64,
+        main_time_left_ms: Option<u64>,
+        byoyomi_ms: u64,
+    ) {
+        let mut state = self.inner.byoyomi_state.lock();
+
+        if !state.in_byoyomi {
+            // Still in main time
+            // Check if we should transition to byoyomi based on GUI's report
+            if let Some(main_left) = main_time_left_ms {
+                if main_left == 0 || time_spent_ms >= main_left {
+                    // Transition to byoyomi
+                    state.in_byoyomi = true;
+                    // If we overspent, handle it with the byoyomi period consumption logic
+                    if time_spent_ms > main_left {
+                        let overspent = time_spent_ms - main_left;
+                        // Drop the lock and recursively call to handle overspent time
+                        // Note: This recursion is bounded to max one level (main->byoyomi transition)
+                        drop(state);
+                        self.handle_byoyomi_update(overspent, None, byoyomi_ms);
+                    }
+                }
+            }
+        } else {
+            // In byoyomi - handle multiple period consumption
+            let mut remaining_time = time_spent_ms;
+            let mut current_ms = state.current_period_ms;
+
+            // Consume periods while time exceeds current period
+            while remaining_time >= current_ms && state.periods_left > 0 {
+                remaining_time -= current_ms;
+                state.periods_left = state.periods_left.saturating_sub(1);
+                current_ms = byoyomi_ms; // Reset to full period
+            }
+
+            if state.periods_left == 0 {
+                // Time forfeit - set stop flag
+                self.inner.stop_flag.store(true, Ordering::Release);
+                state.current_period_ms = 0;
+            } else {
+                // Set remaining time in current period
+                state.current_period_ms = current_ms.saturating_sub(remaining_time);
             }
         }
     }
@@ -257,22 +406,25 @@ impl TimeManager {
         // Calculate time pressure
         let hard_limit = self.inner.hard_limit_ms.load(Ordering::Relaxed);
         let time_pressure = if hard_limit == u64::MAX {
-            0.0
+            0.0 // During ponder or infinite search, no time pressure
         } else {
             (elapsed as f32 / hard_limit as f32).min(1.0)
         };
 
-        // Get byoyomi info if applicable
-        let byoyomi_info = match &self.inner.time_control {
-            TimeControl::Byoyomi { .. } => {
-                let state = self.inner.byoyomi_state.lock();
-                Some(ByoyomiInfo {
-                    in_byoyomi: state.in_byoyomi,
-                    periods_left: state.periods_left,
-                    current_period_ms: state.current_period_ms,
-                })
+        // Get byoyomi info if applicable (consistent lock order: RwLock before Mutex)
+        let byoyomi_info = {
+            let active_tc = self.inner.active_time_control.read();
+            match &*active_tc {
+                TimeControl::Byoyomi { .. } => {
+                    let state = self.inner.byoyomi_state.lock();
+                    Some(ByoyomiInfo {
+                        in_byoyomi: state.in_byoyomi,
+                        periods_left: state.periods_left,
+                        current_period_ms: state.current_period_ms,
+                    })
+                }
+                _ => None,
             }
-            _ => None,
         };
 
         TimeInfo {
@@ -293,44 +445,95 @@ impl TimeManager {
     /// # Arguments
     /// - `new_limits`: Updated search limits with actual time control
     /// - `time_already_spent_ms`: Time already spent during pondering
-    ///
-    /// # TODO
-    /// Current implementation is a placeholder. Full implementation requires:
-    /// - Integration with USI protocol for time updates
-    /// - Proper handling of different time control modes
-    /// - Adjustment for time already spent
     pub fn ponder_hit(&self, new_limits: Option<&SearchLimits>, time_already_spent_ms: u64) {
-        if !matches!(self.inner.time_control, TimeControl::Ponder) {
+        // Check if currently pondering
+        if !self.is_pondering() {
             return;
         }
 
-        if let Some(limits) = new_limits {
-            // Calculate new time allocation based on updated limits
-            let params = limits.time_parameters.unwrap_or_default();
-            let (soft_ms, hard_ms) = calculate_time_allocation(
-                &limits.time_control,
-                self.inner.side_to_move,
-                self.inner.start_ply,
+        // Get the actual time control from new_limits or pending_time_control
+        let (actual_time_control, moves_to_go, params) = if let Some(limits) = new_limits {
+            (
+                limits.time_control.clone(),
                 limits.moves_to_go,
-                GamePhase::MiddleGame, // TODO: Get actual game phase
-                &params,
-            );
-
-            // Adjust for time already spent
-            let adjusted_soft = soft_ms.saturating_sub(time_already_spent_ms);
-            let adjusted_hard = hard_ms.saturating_sub(time_already_spent_ms);
-
-            // Update limits atomically
-            self.inner.soft_limit_ms.store(adjusted_soft.max(100), Ordering::Release);
-            self.inner.hard_limit_ms.store(adjusted_hard.max(200), Ordering::Release);
-
-            // TODO: Update time_control to reflect actual mode
-            // This requires making time_control mutable or redesigning the structure
+                limits.time_parameters.unwrap_or_default(),
+            )
         } else {
-            // Fallback: Set conservative limits if no new limits provided
-            self.inner.soft_limit_ms.store(1000, Ordering::Release);
-            self.inner.hard_limit_ms.store(2000, Ordering::Release);
+            // Use pending time control if no new limits provided
+            let pending = self.inner.pending_time_control.lock();
+            if let Some(ref tc) = *pending {
+                (tc.clone(), None, self.inner.params)
+            } else {
+                // Fallback: Set conservative limits
+                self.inner.soft_limit_ms.store(1000, Ordering::Release);
+                self.inner.hard_limit_ms.store(2000, Ordering::Release);
+                self.inner.is_ponder.store(false, Ordering::Release);
+                return;
+            }
+        };
+
+        // Calculate new time allocation using saved game phase
+        let (soft_ms, hard_ms) = calculate_time_allocation(
+            &actual_time_control,
+            self.inner.side_to_move,
+            self.inner.start_ply,
+            moves_to_go,
+            self.inner.game_phase, // Use saved game phase
+            &params,
+        );
+
+        // Adjust for time already spent
+        let adjusted_soft = soft_ms.saturating_sub(time_already_spent_ms).max(100);
+        let adjusted_hard = hard_ms.saturating_sub(time_already_spent_ms).max(200);
+
+        // Ensure soft <= hard invariant with reasonable margin
+        // Use 50% of hard limit for soft limit when extremely time-constrained
+        let adjusted_soft = if adjusted_soft >= adjusted_hard {
+            adjusted_hard / 2
+        } else {
+            adjusted_soft
+        };
+
+        // Update limits atomically
+        self.inner.soft_limit_ms.store(adjusted_soft, Ordering::Release);
+        self.inner.hard_limit_ms.store(adjusted_hard, Ordering::Release);
+
+        // Update active time control first (consistent lock order: RwLock before Mutex)
+        {
+            let mut active_tc = self.inner.active_time_control.write();
+            *active_tc = actual_time_control.clone();
         }
+
+        // Then initialize byoyomi state if needed
+        if let TimeControl::Byoyomi {
+            periods,
+            byoyomi_ms,
+            main_time_ms,
+        } = &actual_time_control
+        {
+            let mut byoyomi = self.inner.byoyomi_state.lock();
+            *byoyomi = ByoyomiState {
+                periods_left: *periods,
+                current_period_ms: *byoyomi_ms,
+                in_byoyomi: *main_time_ms == 0,
+            };
+        }
+
+        // Reset start time to avoid double counting
+        {
+            let mut start = self.inner.start_time.lock();
+            #[cfg(test)]
+            {
+                *start = mock_now();
+            }
+            #[cfg(not(test))]
+            {
+                *start = Instant::now();
+            }
+        }
+
+        // Clear ponder flag
+        self.inner.is_ponder.store(false, Ordering::Release);
     }
 
     /// Get byoyomi-specific information
@@ -338,7 +541,8 @@ impl TimeManager {
     /// Returns None if not using byoyomi time control.
     /// Returns Some((periods_left, current_period_ms, in_byoyomi)) for byoyomi.
     pub fn get_byoyomi_state(&self) -> Option<(u32, u64, bool)> {
-        match &self.inner.time_control {
+        let active_tc = self.get_active_time_control();
+        match &*active_tc {
             TimeControl::Byoyomi { .. } => {
                 let state = self.inner.byoyomi_state.lock();
                 Some((state.periods_left, state.current_period_ms, state.in_byoyomi))
@@ -358,7 +562,8 @@ impl TimeManager {
 
     /// Check if we're critically low on time
     fn is_time_critical(&self) -> bool {
-        match &self.inner.time_control {
+        let active_tc = self.get_active_time_control();
+        match &*active_tc {
             TimeControl::Fischer {
                 white_ms,
                 black_ms,
@@ -441,7 +646,7 @@ mod tests {
         let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::MiddleGame);
 
         // Spend exactly one period
-        tm.finish_move(1000, None);
+        tm.update_after_move(1000, TimeState::Byoyomi { main_left_ms: 0 });
         let state = tm.get_byoyomi_state().unwrap();
         assert_eq!(state.0, 2); // Should have 2 periods left
         assert_eq!(state.1, 1000); // Should reset to full period
@@ -463,7 +668,7 @@ mod tests {
         let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::MiddleGame);
 
         // Spend 2.5 periods worth of time
-        tm.finish_move(2500, None);
+        tm.update_after_move(2500, TimeState::Byoyomi { main_left_ms: 0 });
         let state = tm.get_byoyomi_state().unwrap();
         assert_eq!(state.0, 3); // Should have consumed 2 periods, 3 left
         assert_eq!(state.1, 500); // 500ms left in current period
@@ -488,17 +693,142 @@ mod tests {
         assert!(!state.2); // Should not be in byoyomi
 
         // Transition to byoyomi when main time runs out
-        tm.finish_move(3000, Some(2000)); // 2s left, spent 3s
+        tm.update_after_move(3000, TimeState::Main { main_left_ms: 2000 }); // 2s left, spent 3s
         let state = tm.get_byoyomi_state().unwrap();
         assert!(state.2); // Should now be in byoyomi
-        assert_eq!(state.0, 3); // All periods available
-        assert_eq!(state.1, 0); // Overspent by 1s, so 0ms left
+        assert_eq!(state.0, 2); // Overspent by 1s, so consumed 1 period
+        assert_eq!(state.1, 1000); // Full period remains after consuming the overspent period
 
         // Another move that consumes a period
-        tm.finish_move(1500, None);
+        tm.update_after_move(1500, TimeState::Byoyomi { main_left_ms: 0 });
         let state = tm.get_byoyomi_state().unwrap();
-        assert_eq!(state.0, 1); // Should have 1 period left (consumed 2)
+        assert_eq!(state.0, 1); // Should have 1 period left (consumed 1 from the 2 remaining)
         assert_eq!(state.1, 500); // 500ms left in current period
+    }
+
+    #[test]
+    fn test_pv_stability_with_mock_time() {
+        // Test PV stability tracking with MockClock
+        mock_set_time(0);
+
+        let limits = create_test_limits();
+        let tm = TimeManager::new_with_mock_time(&limits, Color::White, 0, GamePhase::Opening);
+
+        // Initial PV change
+        tm.on_pv_change(10);
+        assert!(!tm.is_pv_stable()); // Just changed
+
+        // Advance time but not enough for stability
+        mock_advance_time(50);
+        assert!(!tm.is_pv_stable()); // 50ms < 80ms base + 10*5ms = 130ms
+
+        // Advance past threshold
+        mock_advance_time(100); // Total 150ms
+        assert!(tm.is_pv_stable()); // 150ms > 130ms
+
+        // Another PV change at deeper depth
+        tm.on_pv_change(20);
+        assert!(!tm.is_pv_stable()); // Just changed again
+
+        // Deeper searches require more stability
+        mock_advance_time(150); // Need 80 + 20*5 = 180ms
+        assert!(!tm.is_pv_stable()); // 150ms < 180ms
+
+        mock_advance_time(50); // Total 200ms
+        assert!(tm.is_pv_stable()); // 200ms > 180ms
+    }
+
+    #[test]
+    fn test_time_pressure_calculation() {
+        mock_set_time(0);
+
+        let limits = SearchLimits {
+            time_control: TimeControl::FixedTime { ms_per_move: 1000 },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_with_mock_time(&limits, Color::Black, 0, GamePhase::MiddleGame);
+
+        // Initially no pressure
+        let info = tm.get_time_info();
+        assert!(info.time_pressure < 0.1);
+
+        // Half way through
+        mock_advance_time(500);
+        let info = tm.get_time_info();
+        assert!((info.time_pressure - 0.5).abs() < 0.1);
+
+        // Near hard limit
+        mock_advance_time(450); // Total 950ms
+        let info = tm.get_time_info();
+        assert!(info.time_pressure > 0.9);
+    }
+
+    #[test]
+    fn test_emergency_stop_with_mock_time() {
+        mock_set_time(0);
+
+        // Test Fischer emergency stop
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 200, // Critical time
+                black_ms: 200,
+                increment_ms: 0,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_with_mock_time(&limits, Color::White, 100, GamePhase::EndGame);
+        assert!(tm.is_time_critical()); // Should be critical immediately
+
+        // Test Byoyomi emergency stop
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 0,
+                byoyomi_ms: 1000,
+                periods: 1,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_with_mock_time(&limits, Color::Black, 80, GamePhase::EndGame);
+
+        // Use most of the period
+        tm.update_after_move(950, TimeState::Byoyomi { main_left_ms: 0 });
+        assert!(tm.is_time_critical()); // Only 50ms left < 80ms critical threshold
+    }
+
+    #[test]
+    fn test_soft_limit_extension() {
+        mock_set_time(0);
+
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_with_mock_time(&limits, Color::White, 20, GamePhase::MiddleGame);
+        let info = tm.get_time_info();
+        let soft_limit = info.soft_limit_ms;
+
+        // Advance to soft limit
+        mock_advance_time(soft_limit);
+
+        // With unstable PV, should not stop
+        tm.on_pv_change(15);
+        assert!(!tm.should_stop(1000));
+
+        // Advance past soft limit but PV still unstable
+        mock_advance_time(50);
+        assert!(!tm.should_stop(2000)); // Should continue searching
+
+        // Make PV stable
+        mock_advance_time(200); // Well past stability threshold
+        assert!(tm.should_stop(3000)); // Now should stop
     }
 
     #[test]
@@ -516,7 +846,7 @@ mod tests {
         let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::MiddleGame);
 
         // Consume all periods
-        tm.finish_move(2000, None); // Consume both periods
+        tm.update_after_move(2000, TimeState::Byoyomi { main_left_ms: 0 }); // Consume both periods
 
         // Should trigger stop flag
         assert!(tm.should_stop(0));
@@ -524,5 +854,461 @@ mod tests {
         let state = tm.get_byoyomi_state().unwrap();
         assert_eq!(state.0, 0); // No periods left
         assert_eq!(state.1, 0); // No time left
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_byoyomi_transition_with_wrong_state() {
+        // Test that using wrong TimeState doesn't cause transition
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 5000,
+                byoyomi_ms: 1000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::MiddleGame);
+
+        // Using NonByoyomi state with Byoyomi time control
+        // This should not cause transition to byoyomi
+        tm.update_after_move(2000, TimeState::NonByoyomi);
+        tm.update_after_move(2000, TimeState::NonByoyomi);
+        tm.update_after_move(2000, TimeState::NonByoyomi); // Total 6s spent
+
+        let state = tm.get_byoyomi_state().unwrap();
+        assert!(!state.2); // Still not in byoyomi - wrong TimeState prevents transition
+    }
+
+    #[test]
+    fn test_byoyomi_proper_transition_with_new_api() {
+        // Test proper transition with new API
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 5000,
+                byoyomi_ms: 1000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::MiddleGame);
+
+        // First move: still in main time
+        tm.update_after_move(2000, TimeState::Main { main_left_ms: 3000 });
+        let state = tm.get_byoyomi_state().unwrap();
+        assert!(!state.2); // Still in main time
+
+        // Second move: transition to byoyomi
+        tm.update_after_move(3500, TimeState::Main { main_left_ms: 3000 });
+
+        let state = tm.get_byoyomi_state().unwrap();
+        assert!(state.2); // Now in byoyomi
+        assert_eq!(state.0, 3); // All periods still available
+        assert_eq!(state.1, 500); // 500ms left in first period (overspent by 500ms)
+    }
+
+    #[test]
+    fn test_byoyomi_transition_with_multiple_period_overspend() {
+        // Test transition from main time to byoyomi with overspend > 2 periods
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 1000,
+                byoyomi_ms: 1000,
+                periods: 5,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::EndGame);
+
+        // Overspend main time by 2.5 periods worth
+        tm.update_after_move(3500, TimeState::Main { main_left_ms: 1000 });
+
+        let state = tm.get_byoyomi_state().unwrap();
+        assert!(state.2); // In byoyomi
+        assert_eq!(state.0, 3); // Should have consumed 2 periods (2500ms), 3 left
+        assert_eq!(state.1, 500); // 500ms left in current period
+    }
+
+    #[test]
+    fn test_continuous_byoyomi_to_time_forfeit() {
+        // Test main=0 start → consume all periods → time forfeit
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 0, // Start in byoyomi
+                byoyomi_ms: 1000,
+                periods: 2,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::EndGame);
+
+        // Consume first period
+        tm.update_after_move(1200, TimeState::Byoyomi { main_left_ms: 0 });
+        assert!(!tm.should_stop(0));
+
+        let state = tm.get_byoyomi_state().unwrap();
+        assert_eq!(state.0, 1); // One period left
+        assert_eq!(state.1, 800); // 800ms left in current period
+
+        // Consume second period - time forfeit
+        tm.update_after_move(1500, TimeState::Byoyomi { main_left_ms: 0 });
+        assert!(tm.should_stop(0)); // Time forfeit
+
+        let state = tm.get_byoyomi_state().unwrap();
+        assert_eq!(state.0, 0); // No periods left
+        assert_eq!(state.1, 0); // No time left
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "TimeState::NonByoyomi used with Byoyomi")]
+    fn test_debug_assertion_on_wrong_time_state() {
+        // Test debug assertion fires on API misuse
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 5000,
+                byoyomi_ms: 1000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::MiddleGame);
+        tm.update_after_move(1000, TimeState::NonByoyomi); // Wrong state!
+    }
+
+    #[test]
+    fn test_new_api_with_various_time_controls() {
+        // Test that new API works correctly with non-byoyomi time controls
+        let fischer_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&fischer_limits, Color::White, 0, GamePhase::Opening);
+        tm.update_after_move(2000, TimeState::NonByoyomi); // Should work fine
+
+        let fixed_limits = SearchLimits {
+            time_control: TimeControl::FixedTime { ms_per_move: 1000 },
+            ..Default::default()
+        };
+
+        let tm2 = TimeManager::new(&fixed_limits, Color::Black, 0, GamePhase::MiddleGame);
+        tm2.update_after_move(500, TimeState::NonByoyomi); // Should work fine
+    }
+
+    #[test]
+    fn test_ponder_to_fischer() {
+        mock_set_time(0);
+
+        // Create pending limits with Fischer time control
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        // Create TimeManager in ponder mode
+        let tm = TimeManager::new_ponder(&pending_limits, Color::White, 0, GamePhase::Opening);
+
+        // Verify it's pondering
+        assert!(tm.is_pondering());
+        assert!(!tm.should_stop(1000)); // Should not stop during ponder
+
+        // Simulate 5 seconds of pondering
+        mock_advance_time(5000);
+
+        // Ponder hit
+        tm.ponder_hit(None, 5000);
+
+        // Verify ponder mode is off
+        assert!(!tm.is_pondering());
+
+        // Check time allocation is adjusted for spent time
+        let info = tm.get_time_info();
+        assert!(info.soft_limit_ms < 60000 - 5000); // Less than remaining time
+        assert!(info.hard_limit_ms < 60000 - 5000);
+    }
+
+    #[test]
+    fn test_ponder_to_byoyomi() {
+        mock_set_time(0);
+
+        // Create pending limits with Byoyomi
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 10000, // 10 seconds main time
+                byoyomi_ms: 30000,   // 30 seconds per period
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&pending_limits, Color::Black, 40, GamePhase::MiddleGame);
+        assert!(tm.is_pondering());
+
+        // Ponder for 3 seconds
+        mock_advance_time(3000);
+        tm.ponder_hit(None, 3000);
+
+        assert!(!tm.is_pondering());
+
+        // Should have conservative allocation from remaining main time
+        let info = tm.get_time_info();
+        assert!(info.soft_limit_ms > 0);
+        assert!(info.soft_limit_ms < 10000 - 3000); // Less than remaining main time
+    }
+
+    #[test]
+    fn test_ponder_edge_cases() {
+        mock_set_time(0);
+
+        // Test 1: Ponder hit with spent > remain
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 2000, // Only 2 seconds
+                black_ms: 2000,
+                increment_ms: 0,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&pending_limits, Color::White, 80, GamePhase::EndGame);
+
+        // Ponder for 5 seconds (more than available time)
+        mock_advance_time(5000);
+        tm.ponder_hit(None, 5000);
+
+        // Should have minimal time allocation
+        let info = tm.get_time_info();
+        assert_eq!(info.soft_limit_ms, 100); // Minimum safety limit
+        assert_eq!(info.hard_limit_ms, 200);
+
+        // Test 2: Force stop during ponder
+        let tm2 = TimeManager::new_ponder(&pending_limits, Color::Black, 0, GamePhase::Opening);
+        assert!(!tm2.should_stop(1000)); // Normal check returns false
+
+        tm2.force_stop();
+        assert!(tm2.should_stop(1000)); // Force stop works even during ponder
+    }
+
+    #[test]
+    fn test_ponder_with_new_limits() {
+        mock_set_time(0);
+
+        // Initial pending limits
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 50000,
+                black_ms: 50000,
+                increment_ms: 500,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&pending_limits, Color::White, 20, GamePhase::MiddleGame);
+
+        mock_advance_time(2000);
+
+        // New limits provided at ponder hit (e.g., opponent's time updated)
+        let new_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 48000, // Updated time
+                black_ms: 45000,
+                increment_ms: 500,
+            },
+            moves_to_go: Some(30), // Additional info
+            ..Default::default()
+        };
+
+        tm.ponder_hit(Some(&new_limits), 2000);
+
+        // Should use new limits for calculation
+        let info = tm.get_time_info();
+        assert!(info.soft_limit_ms > 0);
+        assert!(info.soft_limit_ms < 48000 - 2000);
+    }
+
+    #[test]
+    fn test_active_time_control_switch() {
+        mock_set_time(0);
+
+        // Start with Fischer in pending
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&pending_limits, Color::White, 0, GamePhase::Opening);
+
+        // Initially, active time control should be Ponder
+        assert!(tm.is_pondering());
+        // No byoyomi state since we're not in byoyomi mode
+        assert!(tm.get_byoyomi_state().is_none());
+
+        // After ponder hit, active time control should be Fischer
+        tm.ponder_hit(None, 1000);
+        assert!(!tm.is_pondering());
+
+        // Still no byoyomi state (Fischer mode)
+        assert!(tm.get_byoyomi_state().is_none());
+
+        // Test with Byoyomi
+        let byoyomi_limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 5000,
+                byoyomi_ms: 10000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm2 = TimeManager::new_ponder(&byoyomi_limits, Color::Black, 0, GamePhase::MiddleGame);
+        tm2.ponder_hit(None, 1000);
+
+        // Now should have byoyomi state
+        let state = tm2.get_byoyomi_state();
+        assert!(state.is_some());
+        let (periods, _, in_byoyomi) = state.unwrap();
+        assert_eq!(periods, 3);
+        assert!(!in_byoyomi); // Still in main time
+    }
+
+    #[test]
+    fn test_ponder_hit_concurrent_access() {
+        use std::sync::Arc;
+        use std::thread;
+
+        mock_set_time(0);
+
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm =
+            Arc::new(TimeManager::new_ponder(&pending_limits, Color::White, 0, GamePhase::Opening));
+
+        // Clone for threads
+        let tm1 = Arc::clone(&tm);
+        let tm2 = Arc::clone(&tm);
+
+        // Thread 1: Continuously check should_stop
+        let handle1 = thread::spawn(move || {
+            let mut nodes = 0u64;
+            for _ in 0..1000 {
+                nodes += 1;
+                let should_stop = tm1.should_stop(nodes);
+                // During ponder, should not stop
+                if tm1.is_pondering() {
+                    assert!(!should_stop);
+                }
+                // Yield to other threads to increase chance of race
+                thread::yield_now();
+            }
+        });
+
+        // Thread 2: Call ponder_hit after ensuring thread 1 has started
+        let handle2 = thread::spawn(move || {
+            // Yield multiple times to let thread 1 get going
+            for _ in 0..10 {
+                thread::yield_now();
+            }
+            tm2.ponder_hit(None, 1000);
+        });
+
+        // Wait for both threads
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+
+        // Verify final state
+        assert!(!tm.is_pondering());
+    }
+
+    #[test]
+    fn test_fischer_to_byoyomi_switch() {
+        mock_set_time(0);
+
+        // Start with Fischer in pending
+        let fischer_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&fischer_limits, Color::White, 0, GamePhase::Opening);
+
+        // Provide new Byoyomi limits at ponder hit
+        let byoyomi_limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 10000,
+                byoyomi_ms: 5000,
+                periods: 5,
+            },
+            ..Default::default()
+        };
+
+        tm.ponder_hit(Some(&byoyomi_limits), 2000);
+
+        // Should now have byoyomi state
+        let state = tm.get_byoyomi_state();
+        assert!(state.is_some());
+        let (periods, period_ms, in_byoyomi) = state.unwrap();
+        assert_eq!(periods, 5);
+        assert_eq!(period_ms, 5000);
+        assert!(!in_byoyomi);
+    }
+
+    #[test]
+    fn test_elapsed_time_after_ponder_hit() {
+        mock_set_time(0);
+
+        let pending_limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new_ponder(&pending_limits, Color::White, 0, GamePhase::Opening);
+
+        // Ponder for 5 seconds
+        mock_advance_time(5000);
+        let elapsed_before = tm.elapsed_ms();
+        assert!(elapsed_before >= 4999 && elapsed_before <= 5001); // Allow small variance
+
+        // After ponder hit, elapsed should reset
+        tm.ponder_hit(None, 5000);
+        let elapsed_after = tm.elapsed_ms();
+        assert!(elapsed_after <= 1); // Should be reset (allow 1ms for execution time)
+
+        // Advance more time
+        mock_advance_time(2000);
+        let elapsed_final = tm.elapsed_ms();
+        assert!(elapsed_final >= 1999 && elapsed_final <= 2001); // Should count from ponder_hit
     }
 }

--- a/packages/rust-core/crates/engine-core/src/time_management/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/mod.rs
@@ -1,0 +1,337 @@
+//! Time management module for the Shogi engine
+//!
+//! This module handles all time-related decisions during search, including:
+//! - Time allocation for different time control modes
+//! - Dynamic time adjustment based on position complexity
+//! - Search termination decisions based on time constraints
+
+use parking_lot::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Instant;
+
+use crate::search::GamePhase;
+use crate::Color;
+
+mod allocation;
+mod parameters;
+mod types;
+
+pub use allocation::calculate_time_allocation;
+pub use parameters::TimeParameters;
+pub use types::{ByoyomiInfo, SearchLimits, TimeControl, TimeInfo};
+
+/// Time manager coordinating all time-related decisions
+pub struct TimeManager {
+    inner: Arc<TimeManagerInner>,
+}
+
+/// Internal state shared between threads
+struct TimeManagerInner {
+    // === Immutable after initialization ===
+    time_control: TimeControl,
+    side_to_move: Color,
+    start_ply: u32,
+    params: TimeParameters,
+
+    // === Mutable state (Atomic/Mutex) ===
+    // Time tracking (Mutex to avoid UB with Instant)
+    start_time: Mutex<Instant>,
+
+    // Limits (Atomic for lock-free access)
+    soft_limit_ms: AtomicU64,
+    hard_limit_ms: AtomicU64,
+    overhead_ms: AtomicU64,
+
+    // Search state
+    nodes_searched: AtomicU64,
+    stop_flag: AtomicBool,
+
+    // PV stability tracking
+    last_pv_change_ms: AtomicU64, // Milliseconds since start
+    pv_threshold_ms: AtomicU64,   // Stability threshold
+
+    // Byoyomi-specific state
+    byoyomi_state: Mutex<ByoyomiState>,
+}
+
+/// Byoyomi (Japanese overtime) state management
+#[derive(Debug, Clone)]
+struct ByoyomiState {
+    periods_left: u32,
+    current_period_ms: u64,
+}
+
+impl Default for ByoyomiState {
+    fn default() -> Self {
+        Self {
+            periods_left: 0,
+            current_period_ms: 0,
+        }
+    }
+}
+
+impl TimeManager {
+    /// Create a new time manager for a search
+    pub fn new(limits: &SearchLimits, side: Color, ply: u32, game_phase: GamePhase) -> Self {
+        let params = limits.time_parameters.clone().unwrap_or_else(TimeParameters::default);
+
+        // Calculate initial time allocation
+        let (soft_ms, hard_ms) = calculate_time_allocation(
+            &limits.time_control,
+            side,
+            ply,
+            limits.moves_to_go,
+            game_phase,
+            &params,
+        );
+
+        // Initialize byoyomi state if needed
+        let byoyomi_state = match &limits.time_control {
+            TimeControl::Byoyomi {
+                periods,
+                byoyomi_ms,
+                ..
+            } => ByoyomiState {
+                periods_left: *periods,
+                current_period_ms: *byoyomi_ms,
+            },
+            _ => ByoyomiState::default(),
+        };
+
+        let inner = Arc::new(TimeManagerInner {
+            time_control: limits.time_control.clone(),
+            side_to_move: side,
+            start_ply: ply,
+            params: params.clone(),
+            start_time: Mutex::new(Instant::now()),
+            soft_limit_ms: AtomicU64::new(soft_ms),
+            hard_limit_ms: AtomicU64::new(hard_ms),
+            overhead_ms: AtomicU64::new(params.overhead_ms),
+            nodes_searched: AtomicU64::new(0),
+            stop_flag: AtomicBool::new(false),
+            last_pv_change_ms: AtomicU64::new(0),
+            pv_threshold_ms: AtomicU64::new(params.pv_base_threshold_ms),
+            byoyomi_state: Mutex::new(byoyomi_state),
+        });
+
+        Self { inner }
+    }
+
+    /// Check if search should stop (called frequently from search loop)
+    pub fn should_stop(&self, current_nodes: u64) -> bool {
+        // Check force stop flag first (cheapest check)
+        if self.inner.stop_flag.load(Ordering::Acquire) {
+            return true;
+        }
+
+        // Update nodes searched (using fetch_max to avoid lost updates)
+        self.inner.nodes_searched.fetch_max(current_nodes, Ordering::Relaxed);
+
+        // Check node limit
+        if let TimeControl::FixedNodes { nodes } = &self.inner.time_control {
+            if current_nodes >= *nodes {
+                return true;
+            }
+        }
+
+        // Time-based checks
+        let elapsed = self.elapsed_ms();
+
+        // Hard limit always stops
+        let hard_limit = self.inner.hard_limit_ms.load(Ordering::Acquire);
+        if elapsed >= hard_limit {
+            return true;
+        }
+
+        // Soft limit with PV stability check
+        let soft_limit = self.inner.soft_limit_ms.load(Ordering::Acquire);
+        if elapsed >= soft_limit && self.is_pv_stable() {
+            return true;
+        }
+
+        // Emergency stop if critically low on time
+        if self.is_time_critical() {
+            return true;
+        }
+
+        false
+    }
+
+    /// Notify when PV changes (for stability-based time extension)
+    pub fn on_pv_change(&self, depth: u32) {
+        let now_ms = self.elapsed_ms();
+        self.inner.last_pv_change_ms.store(now_ms, Ordering::Relaxed);
+
+        // Adjust threshold based on depth
+        let threshold = self.inner.params.pv_base_threshold_ms
+            + (depth as u64 * self.inner.params.pv_depth_slope_ms);
+        self.inner.pv_threshold_ms.store(threshold, Ordering::Relaxed);
+    }
+
+    /// Force immediate stop (user interrupt)
+    pub fn force_stop(&self) {
+        self.inner.stop_flag.store(true, Ordering::Release);
+    }
+
+    /// Get elapsed time since search start
+    pub fn elapsed_ms(&self) -> u64 {
+        let start = self.inner.start_time.lock();
+        start.elapsed().as_millis() as u64
+    }
+
+    /// Update remaining time after move (for Fischer/Byoyomi)
+    pub fn finish_move(&self, _color: Color, time_spent_ms: u64) {
+        match &self.inner.time_control {
+            TimeControl::Byoyomi { byoyomi_ms, .. } => {
+                let mut state = self.inner.byoyomi_state.lock();
+
+                // Check if we're in byoyomi
+                if state.current_period_ms > 0 {
+                    if time_spent_ms > *byoyomi_ms {
+                        // Consumed one period
+                        state.periods_left = state.periods_left.saturating_sub(1);
+                        state.current_period_ms = *byoyomi_ms;
+
+                        if state.periods_left == 0 {
+                            // Time forfeit - set stop flag
+                            self.inner.stop_flag.store(true, Ordering::Release);
+                        }
+                    } else {
+                        // Still within period
+                        state.current_period_ms = *byoyomi_ms;
+                    }
+                }
+            }
+            _ => {
+                // Fischer and other modes: time update handled by GUI
+            }
+        }
+    }
+
+    /// Get current time information (for USI/logging)
+    pub fn get_time_info(&self) -> TimeInfo {
+        let elapsed = self.elapsed_ms();
+        let nodes = self.inner.nodes_searched.load(Ordering::Relaxed);
+
+        // Calculate time pressure
+        let hard_limit = self.inner.hard_limit_ms.load(Ordering::Relaxed);
+        let time_pressure = if hard_limit == u64::MAX {
+            0.0
+        } else {
+            (elapsed as f32 / hard_limit as f32).min(1.0)
+        };
+
+        // Get byoyomi info if applicable
+        let byoyomi_info = match &self.inner.time_control {
+            TimeControl::Byoyomi { .. } => {
+                let state = self.inner.byoyomi_state.lock();
+                Some(ByoyomiInfo {
+                    in_byoyomi: state.current_period_ms > 0,
+                    periods_left: state.periods_left,
+                    current_period_ms: state.current_period_ms,
+                })
+            }
+            _ => None,
+        };
+
+        TimeInfo {
+            elapsed_ms: elapsed,
+            soft_limit_ms: self.inner.soft_limit_ms.load(Ordering::Relaxed),
+            hard_limit_ms: hard_limit,
+            nodes_searched: nodes,
+            time_pressure,
+            byoyomi_info,
+        }
+    }
+
+    /// Handle ponder hit (convert ponder to normal search)
+    pub fn ponder_hit(&self) {
+        if matches!(self.inner.time_control, TimeControl::Ponder) {
+            // In real implementation, would recalculate time limits
+            // For now, just clear the infinite time
+            self.inner.soft_limit_ms.store(1000, Ordering::Relaxed);
+            self.inner.hard_limit_ms.store(2000, Ordering::Relaxed);
+        }
+    }
+
+    /// Check if PV is stable (no recent changes)
+    fn is_pv_stable(&self) -> bool {
+        let now_ms = self.elapsed_ms();
+        let last_change = self.inner.last_pv_change_ms.load(Ordering::Acquire);
+        let threshold = self.inner.pv_threshold_ms.load(Ordering::Acquire);
+
+        now_ms.saturating_sub(last_change) > threshold
+    }
+
+    /// Check if we're critically low on time
+    fn is_time_critical(&self) -> bool {
+        match &self.inner.time_control {
+            TimeControl::Fischer {
+                white_ms,
+                black_ms,
+                increment_ms,
+            } => {
+                let remain = if self.inner.side_to_move == Color::White {
+                    *white_ms
+                } else {
+                    *black_ms
+                };
+                remain < self.inner.params.critical_fischer_ms && *increment_ms == 0
+            }
+            TimeControl::Byoyomi { .. } => {
+                let state = self.inner.byoyomi_state.lock();
+                state.current_period_ms < self.inner.params.critical_byoyomi_ms
+            }
+            TimeControl::FixedTime { .. } => {
+                // Check for overrun
+                let elapsed = self.elapsed_ms();
+                let hard = self.inner.hard_limit_ms.load(Ordering::Acquire);
+                elapsed > hard * 11 / 10 // 110% exceeded
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_limits() -> SearchLimits {
+        SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            moves_to_go: None,
+            depth: None,
+            nodes: None,
+            time_parameters: None,
+        }
+    }
+
+    #[test]
+    fn test_time_manager_creation() {
+        let limits = create_test_limits();
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+        let info = tm.get_time_info();
+
+        assert_eq!(info.elapsed_ms, 0);
+        assert!(info.soft_limit_ms > 0);
+        assert!(info.hard_limit_ms > info.soft_limit_ms);
+    }
+
+    #[test]
+    fn test_force_stop() {
+        let limits = create_test_limits();
+        let tm = TimeManager::new(&limits, Color::Black, 20, GamePhase::MiddleGame);
+
+        assert!(!tm.should_stop(0));
+        tm.force_stop();
+        assert!(tm.should_stop(0));
+    }
+}

--- a/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
@@ -1,6 +1,9 @@
 //! Tunable parameters for time management
 
 /// Time management tunable parameters
+///
+/// This struct intentionally implements Copy trait for efficient passing.
+/// All fields should remain primitive types to maintain Copy semantics.
 #[derive(Debug, Clone, Copy, serde::Deserialize)]
 #[serde(default)]
 pub struct TimeParameters {

--- a/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
@@ -1,0 +1,44 @@
+//! Tunable parameters for time management
+
+/// Time management tunable parameters
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct TimeParameters {
+    // Overhead
+    pub overhead_ms: u64,             // Default: 50
+    pub network_overhead_factor: f64, // Default: 0.5
+
+    // PV stability
+    pub pv_base_threshold_ms: u64, // Default: 80
+    pub pv_depth_slope_ms: u64,    // Default: 5
+
+    // Critical time thresholds
+    pub critical_fischer_ms: u64, // Default: 300
+    pub critical_byoyomi_ms: u64, // Default: 80
+
+    // Time allocation multipliers
+    pub soft_multiplier: f64, // Default: 1.0
+    pub hard_multiplier: f64, // Default: 4.0
+    pub increment_usage: f64, // Default: 0.8
+
+    // Game phase factors
+    pub opening_factor: f64, // Default: 1.2
+    pub endgame_factor: f64, // Default: 0.8
+}
+
+impl Default for TimeParameters {
+    fn default() -> Self {
+        Self {
+            overhead_ms: 50,
+            network_overhead_factor: 0.5,
+            pv_base_threshold_ms: 80,
+            pv_depth_slope_ms: 5,
+            critical_fischer_ms: 300,
+            critical_byoyomi_ms: 80,
+            soft_multiplier: 1.0,
+            hard_multiplier: 4.0,
+            increment_usage: 0.8,
+            opening_factor: 1.2,
+            endgame_factor: 0.8,
+        }
+    }
+}

--- a/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/parameters.rs
@@ -1,7 +1,8 @@
 //! Tunable parameters for time management
 
 /// Time management tunable parameters
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(default)]
 pub struct TimeParameters {
     // Overhead
     pub overhead_ms: u64,             // Default: 50

--- a/packages/rust-core/crates/engine-core/src/time_management/test_utils.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/test_utils.rs
@@ -1,0 +1,130 @@
+//! Test utilities for time management module
+//!
+//! Provides MockClock for deterministic time testing
+
+#[cfg(test)]
+use parking_lot::Mutex;
+#[cfg(test)]
+use std::sync::Arc;
+#[cfg(test)]
+use std::time::{Duration, Instant};
+
+/// Mock clock for testing time-dependent behavior
+#[cfg(test)]
+pub struct MockClock {
+    /// Shared state for the mock clock
+    state: Arc<Mutex<MockClockState>>,
+}
+
+#[cfg(test)]
+struct MockClockState {
+    /// Current mock time in milliseconds
+    current_time_ms: u64,
+    /// Base instant for time calculations
+    base_instant: Instant,
+}
+
+#[cfg(test)]
+impl MockClock {
+    /// Create a new mock clock starting at the given time
+    pub fn new(start_time_ms: u64) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(MockClockState {
+                current_time_ms: start_time_ms,
+                base_instant: Instant::now(),
+            })),
+        }
+    }
+
+    /// Get the current mock time as an Instant
+    pub fn now(&self) -> Instant {
+        let state = self.state.lock();
+        state.base_instant + Duration::from_millis(state.current_time_ms)
+    }
+
+    /// Advance the mock time by the given number of milliseconds
+    pub fn advance(&self, ms: u64) {
+        let mut state = self.state.lock();
+        state.current_time_ms += ms;
+    }
+
+    /// Set the mock time to a specific value
+    pub fn set_time(&self, ms: u64) {
+        let mut state = self.state.lock();
+        state.current_time_ms = ms;
+    }
+
+    /// Get the current time in milliseconds
+    pub fn current_ms(&self) -> u64 {
+        let state = self.state.lock();
+        state.current_time_ms
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Thread-local mock clock for tests
+    static MOCK_CLOCK: MockClock = MockClock::new(0);
+}
+
+/// Set the global mock time
+#[cfg(test)]
+pub fn mock_set_time(ms: u64) {
+    MOCK_CLOCK.with(|clock| clock.set_time(ms));
+}
+
+/// Advance the global mock time
+#[cfg(test)]
+pub fn mock_advance_time(ms: u64) {
+    MOCK_CLOCK.with(|clock| clock.advance(ms));
+}
+
+/// Get the current global mock time as Instant
+#[cfg(test)]
+pub fn mock_now() -> Instant {
+    MOCK_CLOCK.with(|clock| clock.now())
+}
+
+/// Get the current global mock time in milliseconds
+#[cfg(test)]
+pub fn mock_current_ms() -> u64 {
+    MOCK_CLOCK.with(|clock| clock.current_ms())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mock_clock_basic() {
+        let clock = MockClock::new(1000);
+        assert_eq!(clock.current_ms(), 1000);
+
+        clock.advance(500);
+        assert_eq!(clock.current_ms(), 1500);
+
+        clock.set_time(2000);
+        assert_eq!(clock.current_ms(), 2000);
+    }
+
+    #[test]
+    fn test_mock_clock_instant() {
+        let clock = MockClock::new(0);
+        let start = clock.now();
+
+        clock.advance(1000);
+        let end = clock.now();
+
+        let elapsed = end.duration_since(start);
+        assert_eq!(elapsed.as_millis(), 1000);
+    }
+
+    #[test]
+    fn test_global_mock_clock() {
+        mock_set_time(5000);
+        assert_eq!(mock_current_ms(), 5000);
+
+        mock_advance_time(1500);
+        assert_eq!(mock_current_ms(), 6500);
+    }
+}

--- a/packages/rust-core/crates/engine-core/src/time_management/types.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/types.rs
@@ -3,7 +3,7 @@
 use super::TimeParameters;
 
 /// Time control settings for a game
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum TimeControl {
     /// Fischer time control: base time + increment per move
     Fischer {
@@ -58,6 +58,17 @@ impl Default for SearchLimits {
     }
 }
 
+/// Time state for move completion
+#[derive(Debug, Clone, Copy)]
+pub enum TimeState {
+    /// Still in main time with remaining milliseconds
+    Main { main_left_ms: u64 },
+    /// In byoyomi phase with remaining main time (0 for pure byoyomi)
+    Byoyomi { main_left_ms: u64 },
+    /// Non-byoyomi time controls (Fischer, FixedTime, etc.)
+    NonByoyomi,
+}
+
 /// Time information snapshot (read-only)
 #[derive(Debug, Clone, Copy)]
 pub struct TimeInfo {
@@ -65,7 +76,11 @@ pub struct TimeInfo {
     pub soft_limit_ms: u64,
     pub hard_limit_ms: u64,
     pub nodes_searched: u64,
-    pub time_pressure: f32, // 0.0 = plenty of time, 1.0 = critical
+    /// Time pressure indicator: 0.0 = plenty of time, 1.0 = critical
+    ///
+    /// During ponder mode or infinite search (hard_limit == u64::MAX),
+    /// this will always return 0.0 as there is no time pressure.
+    pub time_pressure: f32,
     pub byoyomi_info: Option<ByoyomiInfo>,
 }
 

--- a/packages/rust-core/crates/engine-core/src/time_management/types.rs
+++ b/packages/rust-core/crates/engine-core/src/time_management/types.rs
@@ -1,0 +1,69 @@
+//! Type definitions for time management
+
+use super::TimeParameters;
+
+/// Time control settings for a game
+#[derive(Debug, Clone)]
+pub enum TimeControl {
+    /// Fischer time control: base time + increment per move
+    Fischer {
+        white_ms: u64,
+        black_ms: u64,
+        increment_ms: u64,
+    },
+    /// Fixed time per move
+    FixedTime { ms_per_move: u64 },
+    /// Fixed nodes per move
+    FixedNodes { nodes: u64 },
+    /// Byoyomi (Japanese overtime)
+    Byoyomi {
+        main_time_ms: u64, // Main time
+        byoyomi_ms: u64,   // Time per period
+        periods: u32,      // Number of periods
+    },
+    /// No time limit
+    Infinite,
+    /// Pondering (thinking on opponent's time)
+    Ponder,
+}
+
+/// Search limits combining time control with other constraints
+#[derive(Debug, Clone)]
+pub struct SearchLimits {
+    pub time_control: TimeControl,
+    pub moves_to_go: Option<u32>, // Moves until next time control
+    pub depth: Option<u32>,       // Maximum search depth
+    pub nodes: Option<u64>,       // Maximum nodes to search
+    pub time_parameters: Option<TimeParameters>, // Custom parameters
+}
+
+impl Default for SearchLimits {
+    fn default() -> Self {
+        Self {
+            time_control: TimeControl::Infinite,
+            moves_to_go: None,
+            depth: None,
+            nodes: None,
+            time_parameters: None,
+        }
+    }
+}
+
+/// Time information snapshot (read-only)
+#[derive(Debug, Clone)]
+pub struct TimeInfo {
+    pub elapsed_ms: u64,
+    pub soft_limit_ms: u64,
+    pub hard_limit_ms: u64,
+    pub nodes_searched: u64,
+    pub time_pressure: f32, // 0.0 = plenty of time, 1.0 = critical
+    pub byoyomi_info: Option<ByoyomiInfo>,
+}
+
+/// Byoyomi-specific information
+#[derive(Debug, Clone)]
+pub struct ByoyomiInfo {
+    pub in_byoyomi: bool,
+    pub periods_left: u32,
+    pub current_period_ms: u64,
+}

--- a/packages/rust-core/crates/engine-core/tests/time_management_concurrency.rs
+++ b/packages/rust-core/crates/engine-core/tests/time_management_concurrency.rs
@@ -1,0 +1,195 @@
+//! Concurrency tests for time management using loom
+
+#[cfg(all(feature = "loom", not(target_arch = "wasm32")))]
+mod loom_tests {
+    use engine_core::search::GamePhase;
+    use engine_core::time_management::{SearchLimits, TimeControl, TimeManager, TimeState};
+    use engine_core::Color;
+    use loom::sync::Arc;
+    use loom::thread;
+
+    fn create_test_manager() -> Arc<TimeManager> {
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+        Arc::new(TimeManager::new(&limits, Color::White, 0, GamePhase::Opening))
+    }
+
+    #[test]
+    fn test_concurrent_should_stop() {
+        loom::model(|| {
+            let tm = create_test_manager();
+            let tm1 = tm.clone();
+            let tm2 = tm.clone();
+
+            let t1 = thread::spawn(move || {
+                // Thread 1: Continuously check should_stop
+                for i in 0..100 {
+                    tm1.should_stop(i);
+                }
+            });
+
+            let t2 = thread::spawn(move || {
+                // Thread 2: Force stop after some iterations
+                thread::yield_now();
+                tm2.force_stop();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // Verify stop flag is set
+            assert!(tm.should_stop(0));
+        });
+    }
+
+    #[test]
+    fn test_concurrent_pv_changes() {
+        loom::model(|| {
+            let tm = create_test_manager();
+            let tm1 = tm.clone();
+            let tm2 = tm.clone();
+            let tm3 = tm.clone();
+
+            let t1 = thread::spawn(move || {
+                // Thread 1: Report PV changes
+                tm1.on_pv_change(10);
+                thread::yield_now();
+                tm1.on_pv_change(15);
+            });
+
+            let t2 = thread::spawn(move || {
+                // Thread 2: Get time info (which internally uses PV stability)
+                thread::yield_now();
+                let _ = tm2.get_time_info();
+                thread::yield_now();
+                let _ = tm2.get_time_info();
+            });
+
+            let t3 = thread::spawn(move || {
+                // Thread 3: Check should_stop (depends on PV stability)
+                for _ in 0..5 {
+                    tm3.should_stop(1000);
+                    thread::yield_now();
+                }
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+            t3.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn test_concurrent_time_info_access() {
+        loom::model(|| {
+            let tm = create_test_manager();
+            let tm1 = tm.clone();
+            let tm2 = tm.clone();
+
+            let t1 = thread::spawn(move || {
+                // Thread 1: Get time info repeatedly
+                for _ in 0..10 {
+                    let _ = tm1.get_time_info();
+                    thread::yield_now();
+                }
+            });
+
+            let t2 = thread::spawn(move || {
+                // Thread 2: Update nodes and check stop
+                for i in 0..10 {
+                    tm2.should_stop(i * 1000);
+                    thread::yield_now();
+                }
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn test_concurrent_byoyomi_updates() {
+        loom::model(|| {
+            let limits = SearchLimits {
+                time_control: TimeControl::Byoyomi {
+                    main_time_ms: 0,
+                    byoyomi_ms: 1000,
+                    periods: 3,
+                },
+                ..Default::default()
+            };
+
+            let tm = Arc::new(TimeManager::new(&limits, Color::Black, 0, GamePhase::EndGame));
+            let tm1 = tm.clone();
+            let tm2 = tm.clone();
+
+            let t1 = thread::spawn(move || {
+                // Thread 1: Finish move
+                tm1.update_after_move(500, TimeState::Byoyomi { main_left_ms: 0 });
+            });
+
+            let t2 = thread::spawn(move || {
+                // Thread 2: Check byoyomi state
+                thread::yield_now();
+                let _ = tm2.get_byoyomi_state();
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // Verify state consistency
+            let state = tm.get_byoyomi_state();
+            assert!(state.is_some());
+        });
+    }
+
+    #[test]
+    fn test_force_stop_ordering() {
+        loom::model(|| {
+            let tm = create_test_manager();
+            let tm1 = tm.clone();
+            let tm2 = tm.clone();
+            let tm3 = tm.clone();
+
+            let t1 = thread::spawn(move || {
+                // Thread 1: Check should_stop before force_stop
+                let before = tm1.should_stop(0);
+                thread::yield_now();
+                let after = tm1.should_stop(0);
+                (before, after)
+            });
+
+            let t2 = thread::spawn(move || {
+                // Thread 2: Force stop
+                thread::yield_now();
+                tm2.force_stop();
+            });
+
+            let (before, after) = t1.join().unwrap();
+            t2.join().unwrap();
+
+            // After force_stop, should_stop must return true
+            assert!(tm3.should_stop(0));
+
+            // If we saw false before, we might see true after (but not vice versa)
+            if after {
+                // OK: transitioned from false to true or was already true
+            } else {
+                assert!(!before); // If after is false, before must also be false
+            }
+        });
+    }
+}
+
+// Provide a dummy test for non-loom builds
+#[cfg(not(all(feature = "loom", not(target_arch = "wasm32"))))]
+#[test]
+fn loom_tests_require_feature() {
+    eprintln!("Loom tests require --features loom and non-WASM target");
+}

--- a/packages/rust-core/crates/engine-core/tests/time_management_integration.rs
+++ b/packages/rust-core/crates/engine-core/tests/time_management_integration.rs
@@ -1,0 +1,237 @@
+//! Integration tests for time management with search
+
+use engine_core::{
+    engine::controller::{Engine, EngineType},
+    search::{search_basic::SearchLimits as CoreSearchLimits, GamePhase},
+    shogi::Position,
+    time_management::{SearchLimits, TimeControl, TimeState},
+    Color,
+};
+use std::time::{Duration, Instant};
+
+// Initial position SFEN
+const INITIAL_SFEN: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+/// Test that search respects fixed time limits
+#[test]
+fn test_search_respects_fixed_time() {
+    let engine = Engine::new(EngineType::Material);
+    let mut position = Position::from_sfen(INITIAL_SFEN).unwrap();
+
+    // Search with 100ms time limit
+    let limits = CoreSearchLimits {
+        time: Some(Duration::from_millis(100)),
+        depth: 10, // Max depth
+        nodes: None,
+    };
+
+    let start = Instant::now();
+    let result = engine.search(&mut position, limits);
+    let elapsed = start.elapsed();
+
+    // Should complete within reasonable time (allow 50ms buffer for overhead)
+    assert!(
+        elapsed.as_millis() <= 150,
+        "Search took {}ms, expected <= 150ms",
+        elapsed.as_millis()
+    );
+
+    // Should return a valid move
+    assert!(result.best_move.is_some());
+    assert!(result.score != 0); // Should have evaluated
+}
+
+/// Test that search respects node limits
+#[test]
+fn test_search_respects_node_limit() {
+    let engine = Engine::new(EngineType::Material);
+    let mut position = Position::from_sfen(INITIAL_SFEN).unwrap();
+
+    // Search with node limit
+    let limits = CoreSearchLimits {
+        time: None,
+        depth: 10, // Max depth
+        nodes: Some(10000),
+    };
+
+    let result = engine.search(&mut position, limits);
+
+    // Should return a valid move
+    assert!(result.best_move.is_some());
+    assert!(result.score != 0); // Should have evaluated
+
+    // Nodes searched should be close to limit (allow some overhead)
+    assert!(
+        result.stats.nodes <= 11000,
+        "Searched {} nodes, expected <= 11000",
+        result.stats.nodes
+    );
+}
+
+/// Test search with byoyomi time control
+#[test]
+fn test_search_with_byoyomi() {
+    // This test verifies that search can handle byoyomi time control
+    let limits = SearchLimits {
+        time_control: TimeControl::Byoyomi {
+            main_time_ms: 0,
+            byoyomi_ms: 500,
+            periods: 1,
+        },
+        moves_to_go: None,
+        depth: None,
+        nodes: None,
+        time_parameters: None,
+    };
+
+    // Create time manager for testing
+    use engine_core::time_management::TimeManager;
+    let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+
+    // Should allocate reasonable time from byoyomi
+    let info = tm.get_time_info();
+    assert!(info.soft_limit_ms > 0);
+    assert!(info.soft_limit_ms < 500); // Should not use full byoyomi time
+
+    // Simulate using most of the period
+    tm.update_after_move(450, TimeState::Byoyomi { main_left_ms: 0 });
+
+    // Should have less time available now
+    let _info = tm.get_time_info();
+    let state = tm.get_byoyomi_state().unwrap();
+    assert_eq!(state.0, 1); // Should still have 1 period (450ms < 500ms)
+    assert_eq!(state.1, 50); // 50ms left in current period
+}
+
+/// Test search with depth limit
+#[test]
+fn test_search_with_depth_limit() {
+    let engine = Engine::new(EngineType::Material);
+    let mut position = Position::from_sfen(INITIAL_SFEN).unwrap();
+
+    // Search with depth limit
+    let limits = CoreSearchLimits {
+        time: None,
+        depth: 5,
+        nodes: None,
+    };
+
+    let result = engine.search(&mut position, limits);
+
+    // Should have search result
+    assert!(result.best_move.is_some());
+    assert!(result.score != 0); // Should have evaluated
+                                // PV should not exceed depth limit
+    assert!(result.stats.pv.len() <= 5);
+}
+
+/// Test time allocation for different game phases
+#[test]
+fn test_time_allocation_by_phase() {
+    use engine_core::time_management::{calculate_time_allocation, TimeParameters};
+
+    let time_control = TimeControl::Fischer {
+        white_ms: 60000,
+        black_ms: 60000,
+        increment_ms: 1000,
+    };
+
+    let params = TimeParameters::default();
+
+    // Opening phase gets more time
+    let (soft_opening, _) = calculate_time_allocation(
+        &time_control,
+        Color::White,
+        10,
+        None,
+        GamePhase::Opening,
+        &params,
+    );
+
+    // Middle game standard time
+    let (soft_middle, _) = calculate_time_allocation(
+        &time_control,
+        Color::White,
+        40,
+        None,
+        GamePhase::MiddleGame,
+        &params,
+    );
+
+    // Endgame gets less time
+    let (soft_endgame, _) = calculate_time_allocation(
+        &time_control,
+        Color::White,
+        80,
+        None,
+        GamePhase::EndGame,
+        &params,
+    );
+
+    // Verify phase-based allocation
+    // Opening gets 1.2x, middle gets 1.0x, endgame gets 0.8x
+    // But move estimation also affects allocation
+    // - Opening (ply 10): 60 moves expected
+    // - Middle (ply 40): 40 moves expected
+    // - Endgame (ply 80): 20 moves expected
+    // So the base time allocation differs significantly
+
+    // Opening should generally get more absolute time
+    assert!(soft_opening > soft_endgame, "Opening should get more time than endgame");
+
+    // The phase factors are applied, but move estimation dominates
+    // Just verify they're all reasonable
+    assert!(soft_opening > 500, "Opening allocation too low");
+    assert!(soft_middle > 500, "Middle game allocation too low");
+    assert!(soft_endgame > 300, "Endgame allocation too low");
+}
+
+/// Test emergency time management
+#[test]
+fn test_emergency_time_management() {
+    // Test with critically low Fischer time
+    let limits = SearchLimits {
+        time_control: TimeControl::Fischer {
+            white_ms: 200, // Critical threshold
+            black_ms: 200,
+            increment_ms: 0,
+        },
+        moves_to_go: None,
+        depth: None,
+        nodes: None,
+        time_parameters: None,
+    };
+
+    use engine_core::time_management::TimeManager;
+    let tm = TimeManager::new(&limits, Color::White, 100, GamePhase::EndGame);
+
+    // Should allocate minimal time
+    let info = tm.get_time_info();
+    assert!(info.soft_limit_ms <= 50, "Emergency allocation should be minimal");
+    assert!(info.hard_limit_ms <= 100, "Emergency hard limit should be small");
+}
+
+/// Test time management with moves_to_go
+#[test]
+fn test_moves_to_go_allocation() {
+    let limits = SearchLimits {
+        time_control: TimeControl::Fischer {
+            white_ms: 30000,
+            black_ms: 30000,
+            increment_ms: 0,
+        },
+        moves_to_go: Some(10), // 10 moves until time control
+        depth: None,
+        nodes: None,
+        time_parameters: None,
+    };
+
+    use engine_core::time_management::TimeManager;
+    let tm = TimeManager::new(&limits, Color::Black, 50, GamePhase::MiddleGame);
+
+    let info = tm.get_time_info();
+
+    // Should allocate roughly 1/10 of remaining time
+    assert!(info.soft_limit_ms > 2000);
+    assert!(info.soft_limit_ms < 4000);
+}

--- a/packages/rust-core/crates/engine-wasm/Cargo.toml
+++ b/packages/rust-core/crates/engine-wasm/Cargo.toml
@@ -17,3 +17,7 @@ js-sys = { workspace = true }
 [features]
 # WebWorker でマルチスレッドを有効にするか (wasm32+atomics+bulk-memory)
 threads = []
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3", features = ["Window"] }

--- a/packages/rust-core/crates/engine-wasm/tests/time_management_wasm.rs
+++ b/packages/rust-core/crates/engine-wasm/tests/time_management_wasm.rs
@@ -1,0 +1,211 @@
+//! Time management tests for WASM environment
+
+use wasm_bindgen_test::*;
+
+// Run tests in browser
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_tests {
+    use super::*;
+    use engine_core::search::GamePhase;
+    use engine_core::time_management::{SearchLimits, TimeControl, TimeManager, TimeState};
+    use engine_core::Color;
+    use js_sys::Date;
+
+    /// Test basic TimeManager creation in WASM
+    #[wasm_bindgen_test]
+    fn test_time_manager_creation_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+        let info = tm.get_time_info();
+
+        assert_eq!(info.nodes_searched, 0);
+        assert!(info.soft_limit_ms > 0);
+        assert!(info.hard_limit_ms > info.soft_limit_ms);
+    }
+
+    /// Test time measurement using JS Date API
+    #[wasm_bindgen_test]
+    fn test_elapsed_time_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::FixedTime { ms_per_move: 1000 },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::MiddleGame);
+
+        // Get initial time
+        let start = Date::now();
+
+        // Busy wait for ~100ms (not ideal but works for testing)
+        while Date::now() - start < 100.0 {}
+
+        // Check elapsed time
+        let elapsed = tm.elapsed_ms();
+
+        // Should be at least 90ms (allowing some measurement error)
+        assert!(elapsed >= 90, "Elapsed time {} should be >= 90ms", elapsed);
+    }
+
+    /// Test Byoyomi time control in WASM
+    #[wasm_bindgen_test]
+    fn test_byoyomi_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 0,
+                byoyomi_ms: 1000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::EndGame);
+
+        // Initially should have 3 periods
+        let state = tm.get_byoyomi_state();
+        assert!(state.is_some());
+        let (periods, _, in_byoyomi) = state.unwrap();
+        assert_eq!(periods, 3);
+        assert!(in_byoyomi);
+
+        // Consume one period
+        tm.update_after_move(1500, TimeState::Byoyomi { main_left_ms: 0 });
+        let state = tm.get_byoyomi_state().unwrap();
+        assert_eq!(state.0, 2); // Should have 2 periods left
+    }
+
+    /// Test node-based stopping in WASM
+    #[wasm_bindgen_test]
+    fn test_node_limit_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::FixedNodes { nodes: 10000 },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::Opening);
+
+        // Should not stop before reaching node limit
+        assert!(!tm.should_stop(5000));
+        assert!(!tm.should_stop(9999));
+
+        // Should stop at or after node limit
+        assert!(tm.should_stop(10000));
+        assert!(tm.should_stop(15000));
+    }
+
+    /// Test force stop functionality in WASM
+    #[wasm_bindgen_test]
+    fn test_force_stop_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::Infinite,
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::MiddleGame);
+
+        // Should not stop with infinite time
+        assert!(!tm.should_stop(1000000));
+
+        // Force stop
+        tm.force_stop();
+
+        // Now should stop
+        assert!(tm.should_stop(0));
+    }
+
+    /// Test PV change tracking in WASM
+    #[wasm_bindgen_test]
+    fn test_pv_change_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 30000,
+                black_ms: 30000,
+                increment_ms: 500,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 10, GamePhase::MiddleGame);
+
+        // Report PV changes
+        tm.on_pv_change(5);
+        tm.on_pv_change(10);
+        tm.on_pv_change(15);
+
+        // Should still be able to get time info
+        let info = tm.get_time_info();
+        assert!(info.elapsed_ms < 1000); // Should be quick in test
+    }
+
+    /// Test time pressure calculation in WASM
+    #[wasm_bindgen_test]
+    fn test_time_pressure_wasm() {
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 1000, // Very low time
+                black_ms: 1000,
+                increment_ms: 0,
+            },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::White, 50, GamePhase::EndGame);
+        let info = tm.get_time_info();
+
+        // With very low time, pressure should be noticeable
+        assert!(info.time_pressure > 0.0);
+        assert!(info.time_pressure <= 1.0);
+    }
+
+    /// Test that Instant-based timing works in WASM
+    #[wasm_bindgen_test]
+    async fn test_instant_compatibility_wasm() {
+        // This test verifies that our Instant usage is compatible with WASM
+        // In WASM, std::time::Instant is implemented using performance.now()
+
+        let limits = SearchLimits {
+            time_control: TimeControl::FixedTime { ms_per_move: 500 },
+            ..Default::default()
+        };
+
+        let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::Opening);
+
+        // Initial elapsed should be very small
+        let initial = tm.elapsed_ms();
+        assert!(initial < 10, "Initial elapsed time should be < 10ms, got {}", initial);
+
+        // Use wasm_bindgen_futures to properly handle async in tests
+        let delay = wasm_bindgen_futures::js_sys::Promise::new(&mut |resolve, _| {
+            let window = web_sys::window().unwrap();
+            window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 50)
+                .unwrap();
+        });
+
+        wasm_bindgen_futures::JsFuture::from(delay).await.unwrap();
+
+        // After delay, elapsed should be at least 40ms
+        let after_delay = tm.elapsed_ms();
+        assert!(
+            after_delay >= 40,
+            "After delay elapsed time should be >= 40ms, got {}",
+            after_delay
+        );
+    }
+}
+
+// Provide informative message for non-WASM builds
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn wasm_tests_require_wasm_target() {
+    eprintln!("WASM tests require --target wasm32-unknown-unknown");
+}

--- a/packages/rust-core/docs/時間管理実装計画.md
+++ b/packages/rust-core/docs/時間管理実装計画.md
@@ -1,0 +1,804 @@
+# 将棋エンジン時間管理モジュール実装計画
+
+## 概要
+
+本ドキュメントは、rust-core将棋エンジンに実装する時間管理モジュール（`time_management`）の詳細な実装計画を示します。レビューフィードバックを反映し、実装上の詳細仕様と段階的な開発計画を定義します。
+
+## 1. 要件定義
+
+### 1.1 時間制御モード
+
+| モード | 説明 | 実装優先度 |
+|-------|------|-----------|
+| **Fischer** | 残り時間＋増分 (`remain + inc`) | 高 |
+| **FixedTime** | 1手あたり固定時間 | 高 |
+| **FixedNodes** | 指定ノード数で停止 | 中 |
+| **Byoyomi** | 基本時間＋秒読み（期管理あり） | 中 |
+| **Infinite** | ユーザー停止まで探索 | 低 |
+| **Ponder** | 相手番思考（ponderhitで即停止） | 高 |
+
+> **用語統一**: "Fixed time per move"、"MoveTime" → **FixedTime**に統一
+
+### 1.2 時間割り当てポリシー
+
+#### Move-over-Move方式
+```
+base_time = (remain_ms / moves_left) + increment_ms * 0.8
+```
+
+#### 局面係数
+- **開始局面（Opening）**: 1.2倍
+- **中盤（MiddleGame）**: 1.0倍
+- **終盤（EndGame）**: 0.8倍
+
+#### 動的オーバーヘッド
+```rust
+dynamic_overhead = max(50, rtt_estimate / 2)  // ネットワーク遅延対応
+```
+
+### 1.3 検索停止条件
+
+1. **ハードリミット到達**: `elapsed >= hard_limit`（必ず停止）
+2. **ソフトリミット＋PV安定**: `elapsed >= soft_limit && pv_stable`
+3. **ノードリミット**: `nodes >= node_limit`（FixedNodesモード）
+4. **ユーザー/GUI信号**: `force_stop()` / `ponderhit`
+5. **緊急停止**: 時間切迫時の安全フェイル
+
+### 1.4 緊急停止条件（時間制御種別ごと）
+
+| 時間制御 | 緊急停止条件 |
+|---------|-----------|
+| Fischer | `remain_ms < 300 && increment_ms == 0` |
+| Byoyomi（基本時間） | `main_remain_ms < 300` |
+| Byoyomi（秒読み） | `remain_in_period_ms < 80` |
+| FixedTime | `elapsed > hard_limit * 1.1` |
+| その他 | なし |
+
+### 1.5 技術要件
+
+- **チェック周期**: 15ms または 2048ノードごと（早い方）
+- **スレッド安全性**: エンジンごとに1インスタンス、ロックレス設計
+- **Atomic Ordering**:
+  - 書き込み: `Relaxed`
+  - 読み取り: `Acquire`（メモリ可視性保証）
+- **Instant管理**: `parking_lot::Mutex<Instant>`使用（AtomicU64変換によるUB回避）
+
+## 2. API設計
+
+### 2.1 コア構造体
+
+```rust
+// src/time_management/mod.rs
+use parking_lot::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+/// 時間管理の中核
+pub struct TimeManager {
+    inner: Arc<TimeManagerInner>,
+}
+
+/// 時間制御設定
+#[derive(Debug, Clone)]
+pub enum TimeControl {
+    /// Fischer制御: 基本時間＋増分
+    Fischer { 
+        white_ms: u64, 
+        black_ms: u64, 
+        increment_ms: u64 
+    },
+    /// 固定時間/手
+    FixedTime { 
+        ms_per_move: u64 
+    },
+    /// 固定ノード数
+    FixedNodes { 
+        nodes: u64 
+    },
+    /// 秒読み（日本式）
+    Byoyomi { 
+        main_time_ms: u64,      // 基本持ち時間
+        byoyomi_ms: u64,        // 1期あたりの秒読み時間
+        periods: u32,           // 秒読み期数
+        // 内部状態（mutableのため別管理）
+    },
+    /// 無限思考
+    Infinite,
+    /// 先読み（相手番思考）
+    Ponder,
+}
+
+/// 検索制限パラメータ
+#[derive(Debug, Clone)]
+pub struct SearchLimits {
+    pub time_control: TimeControl,
+    pub moves_to_go: Option<u32>,    // 次の時間制御までの手数
+    pub depth: Option<u32>,          // 最大深さ
+    pub nodes: Option<u64>,          // 最大ノード数
+}
+
+/// 内部状態（スレッド間共有）
+struct TimeManagerInner {
+    // === 初期化後不変 ===
+    time_control: TimeControl,
+    side_to_move: Color,
+    start_ply: u32,
+    
+    // === 可変状態（Atomic/Mutex） ===
+    // 時刻管理（Mutex使用）
+    start_time: Mutex<Instant>,
+    
+    // 制限値（Atomic）
+    soft_limit_ms: AtomicU64,
+    hard_limit_ms: AtomicU64,
+    overhead_ms: AtomicU64,
+    
+    // 検索状態
+    nodes_searched: AtomicU64,
+    stop_flag: AtomicBool,
+    
+    // PV安定性追跡
+    last_pv_change_ms: AtomicU64,     // 開始からの経過ミリ秒
+    pv_threshold_ms: AtomicU64,       // 安定判定閾値
+    
+    // Byoyomi専用状態
+    byoyomi_state: Mutex<ByoyomiState>,
+}
+
+/// 秒読み状態管理
+#[derive(Debug, Clone)]
+struct ByoyomiState {
+    periods_left: u32,
+    current_period_ms: u64,
+}
+```
+
+### 2.2 公開API
+
+```rust
+impl TimeManager {
+    /// 新規時間管理インスタンス作成
+    pub fn new(
+        limits: &SearchLimits, 
+        side: Color, 
+        ply: u32, 
+        game_phase: GamePhase
+    ) -> Self;
+    
+    /// 検索停止判定（検索ループから高頻度呼び出し）
+    pub fn should_stop(&self, current_nodes: u64) -> bool;
+    
+    /// PV変更通知（安定性ベース時間延長用）
+    pub fn on_pv_change(&self, depth: u32);
+    
+    /// 強制停止（ユーザー割り込み）
+    pub fn force_stop(&self);
+    
+    /// 経過時間取得
+    pub fn elapsed_ms(&self) -> u64;
+    
+    /// 手番終了後の時間更新
+    /// 戻り値なし（内部状態を直接更新）
+    pub fn finish_move(&self, color: Color, time_spent_ms: u64);
+    
+    /// 現在の時間情報取得（USI/ログ用）
+    pub fn get_time_info(&self) -> TimeInfo;
+    
+    /// Ponderヒット処理
+    pub fn ponder_hit(&self);
+}
+
+/// 時間情報（読み取り専用）
+#[derive(Debug, Clone)]
+pub struct TimeInfo {
+    pub elapsed_ms: u64,
+    pub soft_limit_ms: u64,
+    pub hard_limit_ms: u64,
+    pub nodes_searched: u64,
+    pub time_pressure: f32,      // 0.0=余裕あり、1.0=切迫
+    pub byoyomi_info: Option<ByoyomiInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ByoyomiInfo {
+    pub in_byoyomi: bool,
+    pub periods_left: u32,
+    pub current_period_ms: u64,
+}
+```
+
+## 3. アルゴリズム詳細
+
+### 3.1 時間割り当て計算
+
+```rust
+fn calculate_time_allocation(
+    time_control: &TimeControl,
+    side: Color,
+    ply: u32,
+    moves_to_go: Option<u32>,
+    game_phase: GamePhase,
+    params: &TimeParameters,
+) -> (u64, u64) {  // (soft_limit_ms, hard_limit_ms)
+    match time_control {
+        TimeControl::Fischer { white_ms, black_ms, increment_ms } => {
+            let remain_ms = if side == Color::White { *white_ms } else { *black_ms };
+            
+            // 安全フェイル：残り時間不足
+            if remain_ms < params.critical_fischer_ms && *increment_ms == 0 {
+                return (50, 100);  // 最小時間で即座に手を返す
+            }
+            
+            let moves_left = moves_to_go.unwrap_or_else(|| estimate_moves_remaining(ply));
+            let base_ms = (remain_ms / moves_left as u64) + (increment_ms * params.inc_usage as u64 / 10);
+            
+            // 局面係数適用
+            let phase_factor = match game_phase {
+                GamePhase::Opening => params.opening_factor,
+                GamePhase::MiddleGame => 1.0,
+                GamePhase::EndGame => params.endgame_factor,
+            };
+            
+            let soft_ms = ((base_ms as f64) * phase_factor * params.soft_multiplier) as u64;
+            let hard_ms = ((soft_ms as f64) * params.hard_multiplier) as u64
+                .min(remain_ms * 8 / 10);
+            
+            let overhead = params.overhead_ms;
+            (
+                soft_ms.saturating_sub(overhead),
+                hard_ms.saturating_sub(overhead),
+            )
+        }
+        
+        TimeControl::FixedTime { ms_per_move } => {
+            let soft = ((*ms_per_move as f64) * 0.9) as u64;
+            (soft, *ms_per_move)
+        }
+        
+        TimeControl::Byoyomi { main_time_ms, byoyomi_ms, .. } => {
+            // Byoyomi実装は3.4参照
+            calculate_byoyomi_time(main_time_ms, byoyomi_ms, params)
+        }
+        
+        TimeControl::FixedNodes { .. } => (u64::MAX, u64::MAX),
+        TimeControl::Infinite => (u64::MAX, u64::MAX),
+        TimeControl::Ponder => (u64::MAX, u64::MAX),
+    }
+}
+```
+
+### 3.2 残り手数推定
+
+```rust
+fn estimate_moves_remaining(ply: u32) -> u32 {
+    const AVERAGE_GAME_LENGTH: u32 = 120;
+    let moves_played = ply / 2;
+    
+    // 標準的なゲーム進行曲線に基づく推定
+    if moves_played < 30 {
+        60  // 序盤は長めに見積もる
+    } else if moves_played < 80 {
+        40  // 中盤
+    } else {
+        20  // 終盤は最低20手を確保
+    }
+}
+```
+
+### 3.3 PV安定性による動的調整
+
+```rust
+impl TimeManager {
+    pub fn on_pv_change(&self, depth: u32) {
+        let now_ms = self.elapsed_ms();
+        self.inner.last_pv_change_ms.store(now_ms, Ordering::Relaxed);
+        
+        // 深さに応じた閾値調整
+        let params = self.get_params();
+        let threshold = params.pv_base_threshold_ms + 
+                       (depth as u64 * params.pv_depth_slope_ms);
+        self.inner.pv_threshold_ms.store(threshold, Ordering::Relaxed);
+    }
+    
+    fn is_pv_stable(&self) -> bool {
+        let now_ms = self.elapsed_ms();
+        let last_change = self.inner.last_pv_change_ms.load(Ordering::Acquire);
+        let threshold = self.inner.pv_threshold_ms.load(Ordering::Acquire);
+        
+        now_ms.saturating_sub(last_change) > threshold
+    }
+}
+```
+
+### 3.4 秒読み（Byoyomi）実装
+
+```rust
+fn calculate_byoyomi_time(
+    main_time_ms: &u64,
+    byoyomi_ms: &u64,
+    params: &TimeParameters,
+) -> (u64, u64) {
+    if *main_time_ms > 0 {
+        // まだ基本時間内
+        let soft = (*main_time_ms as f64 * 0.8) as u64;
+        let hard = *main_time_ms;
+        (soft, hard)
+    } else {
+        // 秒読み中
+        let soft = (*byoyomi_ms as f64 * 0.8) as u64;
+        let hard = *byoyomi_ms;
+        (soft, hard)
+    }
+}
+
+impl TimeManager {
+    pub fn finish_move(&self, color: Color, time_spent_ms: u64) {
+        match &self.inner.time_control {
+            TimeControl::Byoyomi { main_time_ms, byoyomi_ms, periods } => {
+                let mut state = self.inner.byoyomi_state.lock();
+                
+                if *main_time_ms > 0 {
+                    // 基本時間から消費
+                    // ※実際の残り時間更新はGUI側で管理
+                } else {
+                    // 秒読み期管理
+                    if time_spent_ms > *byoyomi_ms {
+                        // 期を1つ消費
+                        state.periods_left = state.periods_left.saturating_sub(1);
+                        state.current_period_ms = *byoyomi_ms;
+                        
+                        if state.periods_left == 0 {
+                            // 時間切れ - 強制停止フラグを立てる
+                            self.inner.stop_flag.store(true, Ordering::Release);
+                        }
+                    } else {
+                        // 期内に指した
+                        state.current_period_ms = *byoyomi_ms;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+```
+
+### 3.5 停止判定実装
+
+```rust
+impl TimeManager {
+    pub fn should_stop(&self, current_nodes: u64) -> bool {
+        // 強制停止フラグ（最も高速なチェック）
+        if self.inner.stop_flag.load(Ordering::Acquire) {
+            return true;
+        }
+        
+        // ノード数更新（fetch_addで競合回避）
+        let prev_nodes = self.inner.nodes_searched.fetch_add(
+            current_nodes.saturating_sub(self.inner.nodes_searched.load(Ordering::Relaxed)),
+            Ordering::Relaxed
+        );
+        
+        // ノード制限チェック
+        if let TimeControl::FixedNodes { nodes } = &self.inner.time_control {
+            if current_nodes >= *nodes {
+                return true;
+            }
+        }
+        
+        // 時間ベースのチェック
+        let elapsed = self.elapsed_ms();
+        
+        // ハードリミット
+        let hard_limit = self.inner.hard_limit_ms.load(Ordering::Acquire);
+        if elapsed >= hard_limit {
+            return true;
+        }
+        
+        // ソフトリミット＋PV安定性
+        let soft_limit = self.inner.soft_limit_ms.load(Ordering::Acquire);
+        if elapsed >= soft_limit && self.is_pv_stable() {
+            return true;
+        }
+        
+        // 緊急停止チェック
+        if self.is_time_critical() {
+            return true;
+        }
+        
+        false
+    }
+    
+    fn is_time_critical(&self) -> bool {
+        match &self.inner.time_control {
+            TimeControl::Fischer { white_ms, black_ms, increment_ms } => {
+                let remain = if self.inner.side_to_move == Color::White {
+                    *white_ms
+                } else {
+                    *black_ms
+                };
+                remain < CRITICAL_FISCHER_MS && *increment_ms == 0
+            }
+            TimeControl::Byoyomi { .. } => {
+                let state = self.inner.byoyomi_state.lock();
+                state.current_period_ms < CRITICAL_BYOYOMI_MS
+            }
+            TimeControl::FixedTime { .. } => {
+                // オーバーラン防止
+                let elapsed = self.elapsed_ms();
+                let hard = self.inner.hard_limit_ms.load(Ordering::Acquire);
+                elapsed > hard * 11 / 10  // 110%超過
+            }
+            _ => false,
+        }
+    }
+}
+```
+
+## 4. 既存コードへの統合
+
+### 4.1 SearchContext修正
+
+```rust
+// search_enhanced.rs
+pub struct SearchContext<'a> {
+    // ... 既存フィールド ...
+    pub time_manager: Option<TimeManager>,
+}
+
+impl<'a> SearchContext<'a> {
+    fn should_stop(&self) -> bool {
+        // 既存の停止フラグ
+        if self.stop_flag.load(Ordering::Relaxed) {
+            return true;
+        }
+        
+        // 時間管理による停止判定
+        if let Some(ref tm) = self.time_manager {
+            if tm.should_stop(self.stats.nodes) {
+                return true;
+            }
+        }
+        
+        // 既存のノード/深さチェック
+        // ...
+    }
+}
+```
+
+### 4.2 アルファベータ探索への統合
+
+```rust
+fn alpha_beta<E: Evaluator>(
+    ctx: &mut SearchContext,
+    // ... パラメータ ...
+) -> i32 {
+    // ... 既存コード ...
+    
+    // PV更新時の通知
+    if score > alpha && score < beta {
+        // PVが変わった
+        if let Some(ref tm) = ctx.time_manager {
+            tm.on_pv_change(depth);
+        }
+        
+        // ... トランスポジションテーブル更新など ...
+    }
+    
+    // ... 残りの処理 ...
+}
+```
+
+### 4.3 Engineコントローラ統合
+
+```rust
+// engine/controller.rs
+impl Engine {
+    pub fn search(&mut self, limits: SearchLimits) -> SearchResult {
+        // ゲームフェーズ判定
+        let game_phase = estimate_game_phase(&self.position);
+        
+        // 時間管理作成
+        let time_manager = TimeManager::new(
+            &limits,
+            self.position.side_to_move(),
+            self.position.game_ply(),
+            game_phase,
+        );
+        
+        // 検索コンテキスト作成
+        let mut context = SearchContext::new(
+            &self.position,
+            self.transposition_table.as_mut(),
+            Some(time_manager),
+        );
+        
+        // 探索実行
+        let result = search_enhanced(&mut context);
+        
+        // 時間消費を記録
+        if let Some(tm) = context.time_manager {
+            tm.finish_move(
+                self.position.side_to_move(),
+                tm.elapsed_ms(),
+            );
+        }
+        
+        result
+    }
+}
+```
+
+## 5. テスト戦略
+
+### 5.1 単体テスト（MockClock使用）
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use instant::MockClock;
+    
+    #[test]
+    fn test_fischer_time_allocation() {
+        MockClock::set_time(0);
+        
+        let limits = SearchLimits {
+            time_control: TimeControl::Fischer {
+                white_ms: 60000,
+                black_ms: 60000,
+                increment_ms: 1000,
+            },
+            ..Default::default()
+        };
+        
+        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+        let info = tm.get_time_info();
+        
+        // 開始局面は1.2倍の時間
+        assert!(info.soft_limit_ms > 1200);
+        assert!(info.hard_limit_ms > info.soft_limit_ms);
+        assert!(info.hard_limit_ms <= 48000); // 60秒の80%
+    }
+    
+    #[test]
+    fn test_byoyomi_period_consumption() {
+        MockClock::set_time(0);
+        
+        let limits = SearchLimits {
+            time_control: TimeControl::Byoyomi {
+                main_time_ms: 0,  // 既に秒読み
+                byoyomi_ms: 30000,
+                periods: 3,
+            },
+            ..Default::default()
+        };
+        
+        let tm = TimeManager::new(&limits, Color::Black, 80, GamePhase::EndGame);
+        
+        // 35秒消費（期オーバー）
+        tm.finish_move(Color::Black, 35000);
+        
+        let info = tm.get_time_info();
+        assert_eq!(info.byoyomi_info.unwrap().periods_left, 2);
+    }
+    
+    #[test]
+    fn test_pv_stability_with_depth() {
+        MockClock::set_time(0);
+        let tm = create_test_manager();
+        
+        // 深さ10でPV変更
+        tm.on_pv_change(10);
+        MockClock::advance(50);
+        assert!(!tm.is_pv_stable()); // 50ms < 80+10*5=130ms
+        
+        MockClock::advance(100);
+        assert!(tm.is_pv_stable());  // 150ms > 130ms
+    }
+}
+```
+
+### 5.2 並行性テスト（loom使用）
+
+```rust
+#[cfg(loom)]
+#[test]
+fn test_concurrent_stop_check() {
+    use loom::thread;
+    
+    loom::model(|| {
+        let tm = Arc::new(create_test_manager());
+        let tm1 = tm.clone();
+        let tm2 = tm.clone();
+        
+        let t1 = thread::spawn(move || {
+            for i in 0..1000 {
+                tm1.should_stop(i);
+            }
+        });
+        
+        let t2 = thread::spawn(move || {
+            thread::yield_now();
+            tm2.force_stop();
+        });
+        
+        t1.join().unwrap();
+        t2.join().unwrap();
+        
+        assert!(tm.should_stop(0));
+    });
+}
+```
+
+### 5.3 統合テスト
+
+```rust
+#[test]
+fn test_search_respects_time_limit() {
+    let mut engine = Engine::new();
+    let position = Position::from_sfen(INITIAL_SFEN).unwrap();
+    engine.set_position(position);
+    
+    let limits = SearchLimits {
+        time_control: TimeControl::FixedTime { ms_per_move: 1000 },
+        ..Default::default()
+    };
+    
+    let start = Instant::now();
+    let result = engine.search(limits);
+    let elapsed = start.elapsed();
+    
+    // 時間制限を守っているか
+    assert!(elapsed.as_millis() <= 1100); // 100msのバッファ
+    assert!(result.best_move.is_some());
+    assert!(result.pv.len() > 0);
+}
+```
+
+### 5.4 ベンチマークテスト
+
+```rust
+// benches/time_management.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_should_stop(c: &mut Criterion) {
+    let tm = create_bench_time_manager();
+    
+    c.bench_function("should_stop", |b| {
+        let mut nodes = 0u64;
+        b.iter(|| {
+            nodes += 1;
+            black_box(tm.should_stop(nodes))
+        });
+    });
+}
+
+fn benchmark_time_allocation(c: &mut Criterion) {
+    c.bench_function("calculate_allocation_fischer", |b| {
+        b.iter(|| {
+            calculate_time_allocation(
+                &TimeControl::Fischer {
+                    white_ms: 300000,
+                    black_ms: 300000,
+                    increment_ms: 5000,
+                },
+                Color::White,
+                40,
+                None,
+                GamePhase::MiddleGame,
+                &TimeParameters::default(),
+            )
+        });
+    });
+}
+
+criterion_group!(benches, benchmark_should_stop, benchmark_time_allocation);
+criterion_main!(benches);
+```
+
+## 6. チューニングパラメータ
+
+```rust
+/// 時間管理の調整可能パラメータ
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct TimeParameters {
+    // オーバーヘッド
+    pub overhead_ms: u64,              // デフォルト: 50
+    pub network_overhead_factor: f64,   // デフォルト: 0.5
+    
+    // PV安定性
+    pub pv_base_threshold_ms: u64,     // デフォルト: 80
+    pub pv_depth_slope_ms: u64,        // デフォルト: 5
+    
+    // 緊急停止閾値
+    pub critical_fischer_ms: u64,      // デフォルト: 300
+    pub critical_byoyomi_ms: u64,      // デフォルト: 80
+    
+    // 時間配分係数
+    pub soft_multiplier: f64,          // デフォルト: 1.0
+    pub hard_multiplier: f64,          // デフォルト: 4.0
+    pub increment_usage: f64,          // デフォルト: 0.8
+    
+    // 局面係数
+    pub opening_factor: f64,           // デフォルト: 1.2
+    pub endgame_factor: f64,           // デフォルト: 0.8
+}
+
+impl Default for TimeParameters {
+    fn default() -> Self {
+        Self {
+            overhead_ms: 50,
+            network_overhead_factor: 0.5,
+            pv_base_threshold_ms: 80,
+            pv_depth_slope_ms: 5,
+            critical_fischer_ms: 300,
+            critical_byoyomi_ms: 80,
+            soft_multiplier: 1.0,
+            hard_multiplier: 4.0,
+            increment_usage: 0.8,
+            opening_factor: 1.2,
+            endgame_factor: 0.8,
+        }
+    }
+}
+```
+
+## 7. 実装フェーズ
+
+### Phase 1: 基礎実装（第1週）
+- [ ] `time_management`モジュール作成
+- [ ] `TimeManager`、`TimeControl`、`SearchLimits`実装
+- [ ] Fischer/FixedTime時間割り当てアルゴリズム
+- [ ] 基本的な単体テスト（MockClock使用）
+
+### Phase 2: 検索統合（第2週）
+- [ ] `SearchContext`へのTimeManager統合
+- [ ] `should_stop()`の時間ベース判定追加
+- [ ] PV変更追跡とon_pv_change実装
+- [ ] loomによる並行性テスト
+
+### Phase 3: 高度な機能（第3週）
+- [ ] Byoyomi期管理実装
+- [ ] Ponder機能とponderhit処理
+- [ ] 緊急時間管理と安全フェイル
+- [ ] WASM環境でのテスト
+
+### Phase 4: 最適化とチューニング（第4週）
+- [ ] ベンチマークテストと性能最適化
+- [ ] 自己対局によるパラメータチューニング
+- [ ] ドキュメント完成
+- [ ] リリース準備
+
+## 8. リスクと対策
+
+| リスク | 対策 |
+|-------|------|
+| WASM環境でのタイマー精度不足 | `performance.now()`使用、フォールバックでノードベース停止 |
+| Instant→AtomicU64変換のUB | `parking_lot::Mutex<Instant>`で安全に管理 |
+| 並行アクセスによる競合状態 | 適切なAtomic Ordering（write:Relaxed, read:Acquire） |
+| 秒読み期0での時間切れ | 強制停止＋最善手即座返却の実装 |
+| ネットワーク遅延の影響 | 動的オーバーヘッド調整機能 |
+
+## 9. パフォーマンス目標
+
+- 時間割り当て計算: < 0.1ms/回
+- should_stop()呼び出し: < 0.01ms/回
+- メモリ使用量: < 1KB/TimeManagerインスタンス
+- ホットパスでのメモリアロケーション: 0
+- 検索中のミューテックスロック: 0（ロックフリー設計）
+
+## 10. 将来の拡張
+
+1. **機械学習統合**: ゲームデータベースから時間配分パターンを学習
+2. **局面複雑度分析**: 複雑な局面により多くの時間を配分
+3. **対戦相手モデリング**: 相手の時間管理パターンに基づく調整
+4. **Multi-PV時間管理**: 複数の主要変化に時間を分配
+5. **クラスタ探索**: 分散環境での総時間管理
+
+---
+
+本実装計画は、プロフェッショナルグレードの時間管理システムを段階的に構築し、既存のコードベースとシームレスに統合することを目的としています。各フェーズでの明確な成果物とテスト戦略により、高品質な実装を保証します。

--- a/packages/rust-core/docs/時間管理実装計画.md
+++ b/packages/rust-core/docs/時間管理実装計画.md
@@ -99,11 +99,14 @@ pub enum TimeControl {
         nodes: u64 
     },
     /// 秒読み（日本式）
+    /// 
+    /// 注：このenumは初期設定のみを保持する。
+    /// 実際の残り期数などのランタイム状態はTimeManager内部の
+    /// ByoyomiStateで別途管理される。
     Byoyomi { 
-        main_time_ms: u64,      // 基本持ち時間
+        main_time_ms: u64,      // 基本持ち時間（初期値）
         byoyomi_ms: u64,        // 1期あたりの秒読み時間
-        periods: u32,           // 秒読み期数
-        // 内部状態（mutableのため別管理）
+        periods: u32,           // 秒読み期数（初期値）
     },
     /// 無限思考
     Infinite,
@@ -149,10 +152,14 @@ struct TimeManagerInner {
 }
 
 /// 秒読み状態管理
+/// 
+/// TimeControl::Byoyomiとは別に、実際のランタイム状態を追跡する。
+/// これにより設定（immutable）と状態（mutable）を明確に分離。
 #[derive(Debug, Clone)]
 struct ByoyomiState {
-    periods_left: u32,
-    current_period_ms: u64,
+    periods_left: u32,      // 残り期数
+    current_period_ms: u64, // 現在期の残り時間
+    in_byoyomi: bool,       // 基本時間を使い切って秒読みに入ったか
 }
 ```
 
@@ -181,8 +188,18 @@ impl TimeManager {
     pub fn elapsed_ms(&self) -> u64;
     
     /// 手番終了後の時間更新
-    /// 戻り値なし（内部状態を直接更新）
+    /// 
+    /// Byoyomiの場合、期の消費を管理：
+    /// - time_spent_ms > byoyomi_ms の場合、1期消費
+    /// - 全期消費で時間切れフラグ設定
+    /// 
+    /// 注：TimeControl設定は変更されず、内部のByoyomiStateのみ更新
     pub fn finish_move(&self, color: Color, time_spent_ms: u64);
+    
+    /// 秒読み状態取得（GUI向けAPI）
+    /// 
+    /// 返り値: Some((periods_left, current_period_ms, in_byoyomi)) または None
+    pub fn get_byoyomi_state(&self) -> Option<(u32, u64, bool)>;
     
     /// 現在の時間情報取得（USI/ログ用）
     pub fn get_time_info(&self) -> TimeInfo;
@@ -202,11 +219,39 @@ pub struct TimeInfo {
     pub byoyomi_info: Option<ByoyomiInfo>,
 }
 
+/// 秒読み情報（TimeInfo経由で公開）
+/// 
+/// TimeManager内部のByoyomiStateから生成される読み取り専用の情報。
+/// GUIなどへの状態通知に使用。
 #[derive(Debug, Clone)]
 pub struct ByoyomiInfo {
-    pub in_byoyomi: bool,
-    pub periods_left: u32,
-    pub current_period_ms: u64,
+    pub in_byoyomi: bool,       // 秒読み中かどうか
+    pub periods_left: u32,      // 残り期数
+    pub current_period_ms: u64, // 現在期の残り時間
+}
+```
+
+### 2.3 TimeManager初期化
+
+```rust
+impl TimeManager {
+    pub fn new(limits: &SearchLimits, side: Color, ply: u32, game_phase: GamePhase) -> Self {
+        // ... パラメータ取得と時間割り当て計算 ...
+        
+        // 秒読み状態の初期化
+        let byoyomi_state = match &limits.time_control {
+            TimeControl::Byoyomi { periods, byoyomi_ms, main_time_ms } => {
+                ByoyomiState {
+                    periods_left: *periods,
+                    current_period_ms: *byoyomi_ms,
+                    in_byoyomi: *main_time_ms == 0,  // 基本時間0なら即秒読み開始
+                }
+            }
+            _ => ByoyomiState::default(),
+        };
+        
+        // ... TimeManagerInner作成 ...
+    }
 }
 ```
 
@@ -317,20 +362,22 @@ impl TimeManager {
 
 ```rust
 fn calculate_byoyomi_time(
-    main_time_ms: &u64,
-    byoyomi_ms: &u64,
+    main_time_ms: u64,
+    byoyomi_ms: u64,
     params: &TimeParameters,
 ) -> (u64, u64) {
-    if *main_time_ms > 0 {
-        // まだ基本時間内
-        let soft = (*main_time_ms as f64 * 0.8) as u64;
-        let hard = *main_time_ms;
+    if main_time_ms > 0 {
+        // まだ基本時間内 - Fischer同様に保守的割り当て
+        // 基本時間の20%をソフトリミット、50%をハードリミットとして使用
+        let soft = main_time_ms / 5;  // 20% = 1/5
+        let hard = main_time_ms / 2;  // 50% = 1/2
         (soft, hard)
     } else {
-        // 秒読み中
-        let soft = (*byoyomi_ms as f64 * 0.8) as u64;
-        let hard = *byoyomi_ms;
-        (soft, hard)
+        // 秒読み中 - 期内時間の80%をソフトリミットとして使用
+        let soft = (byoyomi_ms * 4) / 5;  // 80% = 4/5
+        let hard = byoyomi_ms;
+        let overhead = params.overhead_ms;
+        (soft.saturating_sub(overhead), hard.saturating_sub(overhead))
     }
 }
 
@@ -340,23 +387,29 @@ impl TimeManager {
             TimeControl::Byoyomi { main_time_ms, byoyomi_ms, periods } => {
                 let mut state = self.inner.byoyomi_state.lock();
                 
-                if *main_time_ms > 0 {
-                    // 基本時間から消費
-                    // ※実際の残り時間更新はGUI側で管理
+                if !state.in_byoyomi {
+                    // まだ基本時間内
+                    // 注：実際の基本時間追跡はGUI側で管理
+                    // ここでは基本時間を0になった場合の秒読み移行を処理
+                    if *main_time_ms == 0 {
+                        state.in_byoyomi = true;
+                    }
                 } else {
-                    // 秒読み期管理
+                    // 秒読み中
                     if time_spent_ms > *byoyomi_ms {
                         // 期を1つ消費
                         state.periods_left = state.periods_left.saturating_sub(1);
-                        state.current_period_ms = *byoyomi_ms;
                         
                         if state.periods_left == 0 {
                             // 時間切れ - 強制停止フラグを立てる
                             self.inner.stop_flag.store(true, Ordering::Release);
+                        } else {
+                            // 次の期にリセット
+                            state.current_period_ms = *byoyomi_ms;
                         }
                     } else {
-                        // 期内に指した
-                        state.current_period_ms = *byoyomi_ms;
+                        // 期内に指した - 次の手で使える時間
+                        state.current_period_ms = byoyomi_ms.saturating_sub(time_spent_ms);
                     }
                 }
             }
@@ -424,7 +477,8 @@ impl TimeManager {
             }
             TimeControl::Byoyomi { .. } => {
                 let state = self.inner.byoyomi_state.lock();
-                state.current_period_ms < CRITICAL_BYOYOMI_MS
+                // 秒読み中で期内時間が少ない場合に危険
+                state.in_byoyomi && state.current_period_ms < CRITICAL_BYOYOMI_MS
             }
             TimeControl::FixedTime { .. } => {
                 // オーバーラン防止

--- a/packages/rust-core/tests/api_visibility_test.rs
+++ b/packages/rust-core/tests/api_visibility_test.rs
@@ -1,0 +1,75 @@
+// This test verifies that the time management API is used correctly
+// and that deprecated APIs are not accessible from external crates
+
+use engine_core::search::GamePhase;
+use engine_core::time_management::{SearchLimits, TimeControl, TimeManager, TimeState};
+use engine_core::Color;
+
+#[test]
+fn test_update_after_move_api_works() {
+    let limits = SearchLimits {
+        time_control: TimeControl::Byoyomi {
+            main_time_ms: 5000,
+            byoyomi_ms: 1000,
+            periods: 3,
+        },
+        ..Default::default()
+    };
+
+    let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+
+    // New API should work
+    tm.update_after_move(1000, TimeState::Main { main_left_ms: 4000 });
+
+    // Verify state
+    let info = tm.get_time_info();
+    assert!(info.elapsed_ms < 100); // Should be quick in test
+}
+
+#[test]
+fn test_time_state_enum_is_accessible() {
+    // Verify all TimeState variants are accessible
+    let _main_state = TimeState::Main { main_left_ms: 1000 };
+    let _byoyomi_state = TimeState::Byoyomi { main_left_ms: 0 };
+    let _non_byoyomi_state = TimeState::NonByoyomi;
+}
+
+#[test]
+fn test_byoyomi_transition_with_new_api() {
+    let limits = SearchLimits {
+        time_control: TimeControl::Byoyomi {
+            main_time_ms: 1000,
+            byoyomi_ms: 1000,
+            periods: 3,
+        },
+        ..Default::default()
+    };
+
+    let tm = TimeManager::new(&limits, Color::Black, 0, GamePhase::MiddleGame);
+
+    // Transition to byoyomi
+    tm.update_after_move(1500, TimeState::Main { main_left_ms: 1000 });
+
+    let info = tm.get_time_info();
+    assert!(info.byoyomi_info.is_some());
+    let byoyomi_info = info.byoyomi_info.unwrap();
+    assert!(byoyomi_info.in_byoyomi);
+}
+
+// The following would fail to compile if uncommented, proving finish_move is not public:
+// #[test]
+// fn test_finish_move_not_accessible() {
+//     let limits = SearchLimits {
+//         time_control: TimeControl::Byoyomi {
+//             main_time_ms: 5000,
+//             byoyomi_ms: 1000,
+//             periods: 3,
+//         },
+//         ..Default::default()
+//     };
+//     
+//     let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
+//     
+//     // This should NOT compile - finish_move is not public
+//     tm.finish_move(1000, Some(4000));
+// }


### PR DESCRIPTION
# 将棋エンジン時間管理モジュール実装計画

## 概要

本ドキュメントは、rust-core将棋エンジンに実装する時間管理モジュール（`time_management`）の詳細な実装計画を示します。レビューフィードバックを反映し、実装上の詳細仕様と段階的な開発計画を定義します。

## 1. 要件定義

### 1.1 時間制御モード

| モード | 説明 | 実装優先度 |
|-------|------|-----------|
| **Fischer** | 残り時間＋増分 (`remain + inc`) | 高 |
| **FixedTime** | 1手あたり固定時間 | 高 |
| **FixedNodes** | 指定ノード数で停止 | 中 |
| **Byoyomi** | 基本時間＋秒読み（期管理あり） | 中 |
| **Infinite** | ユーザー停止まで探索 | 低 |
| **Ponder** | 相手番思考（ponderhitで即停止） | 高 |

> **用語統一**: "Fixed time per move"、"MoveTime" → **FixedTime**に統一

### 1.2 時間割り当てポリシー

#### Move-over-Move方式
```
base_time = (remain_ms / moves_left) + increment_ms * 0.8
```

#### 局面係数
- **開始局面（Opening）**: 1.2倍
- **中盤（MiddleGame）**: 1.0倍
- **終盤（EndGame）**: 0.8倍

#### 動的オーバーヘッド
```rust
dynamic_overhead = max(50, rtt_estimate / 2)  // ネットワーク遅延対応
```

### 1.3 検索停止条件

1. **ハードリミット到達**: `elapsed >= hard_limit`（必ず停止）
2. **ソフトリミット＋PV安定**: `elapsed >= soft_limit && pv_stable`
3. **ノードリミット**: `nodes >= node_limit`（FixedNodesモード）
4. **ユーザー/GUI信号**: `force_stop()` / `ponderhit`
5. **緊急停止**: 時間切迫時の安全フェイル

### 1.4 緊急停止条件（時間制御種別ごと）

| 時間制御 | 緊急停止条件 |
|---------|-----------|
| Fischer | `remain_ms < 300 && increment_ms == 0` |
| Byoyomi（基本時間） | `main_remain_ms < 300` |
| Byoyomi（秒読み） | `remain_in_period_ms < 80` |
| FixedTime | `elapsed > hard_limit * 1.1` |
| その他 | なし |

### 1.5 技術要件

- **チェック周期**: 15ms または 2048ノードごと（早い方）
- **スレッド安全性**: エンジンごとに1インスタンス、ロックレス設計
- **Atomic Ordering**:
  - 書き込み: `Relaxed`
  - 読み取り: `Acquire`（メモリ可視性保証）
- **Instant管理**: `parking_lot::Mutex<Instant>`使用（AtomicU64変換によるUB回避）

## 2. API設計

### 2.1 コア構造体

```rust
// src/time_management/mod.rs
use parking_lot::Mutex;
use std::sync::{
    atomic::{AtomicBool, AtomicU64, Ordering},
    Arc,
};
use std::time::{Duration, Instant};

/// 時間管理の中核
pub struct TimeManager {
    inner: Arc<TimeManagerInner>,
}

/// 時間制御設定
#[derive(Debug, Clone)]
pub enum TimeControl {
    /// Fischer制御: 基本時間＋増分
    Fischer { 
        white_ms: u64, 
        black_ms: u64, 
        increment_ms: u64 
    },
    /// 固定時間/手
    FixedTime { 
        ms_per_move: u64 
    },
    /// 固定ノード数
    FixedNodes { 
        nodes: u64 
    },
    /// 秒読み（日本式）
    /// 
    /// 注：このenumは初期設定のみを保持する。
    /// 実際の残り期数などのランタイム状態はTimeManager内部の
    /// ByoyomiStateで別途管理される。
    Byoyomi { 
        main_time_ms: u64,      // 基本持ち時間（初期値）
        byoyomi_ms: u64,        // 1期あたりの秒読み時間
        periods: u32,           // 秒読み期数（初期値）
    },
    /// 無限思考
    Infinite,
    /// 先読み（相手番思考）
    Ponder,
}

/// 検索制限パラメータ
#[derive(Debug, Clone)]
pub struct SearchLimits {
    pub time_control: TimeControl,
    pub moves_to_go: Option<u32>,    // 次の時間制御までの手数
    pub depth: Option<u32>,          // 最大深さ
    pub nodes: Option<u64>,          // 最大ノード数
}

/// 内部状態（スレッド間共有）
struct TimeManagerInner {
    // === 初期化後不変 ===
    time_control: TimeControl,
    side_to_move: Color,
    start_ply: u32,
    
    // === 可変状態（Atomic/Mutex） ===
    // 時刻管理（Mutex使用）
    start_time: Mutex<Instant>,
    
    // 制限値（Atomic）
    soft_limit_ms: AtomicU64,
    hard_limit_ms: AtomicU64,
    overhead_ms: AtomicU64,
    
    // 検索状態
    nodes_searched: AtomicU64,
    stop_flag: AtomicBool,
    
    // PV安定性追跡
    last_pv_change_ms: AtomicU64,     // 開始からの経過ミリ秒
    pv_threshold_ms: AtomicU64,       // 安定判定閾値
    
    // Byoyomi専用状態
    byoyomi_state: Mutex<ByoyomiState>,
}

/// 秒読み状態管理
/// 
/// TimeControl::Byoyomiとは別に、実際のランタイム状態を追跡する。
/// これにより設定（immutable）と状態（mutable）を明確に分離。
#[derive(Debug, Clone)]
struct ByoyomiState {
    periods_left: u32,      // 残り期数
    current_period_ms: u64, // 現在期の残り時間
    in_byoyomi: bool,       // 基本時間を使い切って秒読みに入ったか
}
```

### 2.2 公開API

```rust
impl TimeManager {
    /// 新規時間管理インスタンス作成
    pub fn new(
        limits: &SearchLimits, 
        side: Color, 
        ply: u32, 
        game_phase: GamePhase
    ) -> Self;
    
    /// 検索停止判定（検索ループから高頻度呼び出し）
    pub fn should_stop(&self, current_nodes: u64) -> bool;
    
    /// PV変更通知（安定性ベース時間延長用）
    pub fn on_pv_change(&self, depth: u32);
    
    /// 強制停止（ユーザー割り込み）
    pub fn force_stop(&self);
    
    /// 経過時間取得
    pub fn elapsed_ms(&self) -> u64;
    
    /// 手番終了後の時間更新
    /// 
    /// Byoyomiの場合、期の消費を管理：
    /// - time_spent_ms > byoyomi_ms の場合、1期消費
    /// - 全期消費で時間切れフラグ設定
    /// 
    /// 注：TimeControl設定は変更されず、内部のByoyomiStateのみ更新
    pub fn finish_move(&self, color: Color, time_spent_ms: u64);
    
    /// 秒読み状態取得（GUI向けAPI）
    /// 
    /// 返り値: Some((periods_left, current_period_ms, in_byoyomi)) または None
    pub fn get_byoyomi_state(&self) -> Option<(u32, u64, bool)>;
    
    /// 現在の時間情報取得（USI/ログ用）
    pub fn get_time_info(&self) -> TimeInfo;
    
    /// Ponderヒット処理
    pub fn ponder_hit(&self);
}

/// 時間情報（読み取り専用）
#[derive(Debug, Clone)]
pub struct TimeInfo {
    pub elapsed_ms: u64,
    pub soft_limit_ms: u64,
    pub hard_limit_ms: u64,
    pub nodes_searched: u64,
    pub time_pressure: f32,      // 0.0=余裕あり、1.0=切迫
    pub byoyomi_info: Option<ByoyomiInfo>,
}

/// 秒読み情報（TimeInfo経由で公開）
/// 
/// TimeManager内部のByoyomiStateから生成される読み取り専用の情報。
/// GUIなどへの状態通知に使用。
#[derive(Debug, Clone)]
pub struct ByoyomiInfo {
    pub in_byoyomi: bool,       // 秒読み中かどうか
    pub periods_left: u32,      // 残り期数
    pub current_period_ms: u64, // 現在期の残り時間
}
```

### 2.3 TimeManager初期化

```rust
impl TimeManager {
    pub fn new(limits: &SearchLimits, side: Color, ply: u32, game_phase: GamePhase) -> Self {
        // ... パラメータ取得と時間割り当て計算 ...
        
        // 秒読み状態の初期化
        let byoyomi_state = match &limits.time_control {
            TimeControl::Byoyomi { periods, byoyomi_ms, main_time_ms } => {
                ByoyomiState {
                    periods_left: *periods,
                    current_period_ms: *byoyomi_ms,
                    in_byoyomi: *main_time_ms == 0,  // 基本時間0なら即秒読み開始
                }
            }
            _ => ByoyomiState::default(),
        };
        
        // ... TimeManagerInner作成 ...
    }
}
```

## 3. アルゴリズム詳細

### 3.1 時間割り当て計算

```rust
fn calculate_time_allocation(
    time_control: &TimeControl,
    side: Color,
    ply: u32,
    moves_to_go: Option<u32>,
    game_phase: GamePhase,
    params: &TimeParameters,
) -> (u64, u64) {  // (soft_limit_ms, hard_limit_ms)
    match time_control {
        TimeControl::Fischer { white_ms, black_ms, increment_ms } => {
            let remain_ms = if side == Color::White { *white_ms } else { *black_ms };
            
            // 安全フェイル：残り時間不足
            if remain_ms < params.critical_fischer_ms && *increment_ms == 0 {
                return (50, 100);  // 最小時間で即座に手を返す
            }
            
            let moves_left = moves_to_go.unwrap_or_else(|| estimate_moves_remaining(ply));
            let base_ms = (remain_ms / moves_left as u64) + (increment_ms * params.inc_usage as u64 / 10);
            
            // 局面係数適用
            let phase_factor = match game_phase {
                GamePhase::Opening => params.opening_factor,
                GamePhase::MiddleGame => 1.0,
                GamePhase::EndGame => params.endgame_factor,
            };
            
            let soft_ms = ((base_ms as f64) * phase_factor * params.soft_multiplier) as u64;
            let hard_ms = ((soft_ms as f64) * params.hard_multiplier) as u64
                .min(remain_ms * 8 / 10);
            
            let overhead = params.overhead_ms;
            (
                soft_ms.saturating_sub(overhead),
                hard_ms.saturating_sub(overhead),
            )
        }
        
        TimeControl::FixedTime { ms_per_move } => {
            let soft = ((*ms_per_move as f64) * 0.9) as u64;
            (soft, *ms_per_move)
        }
        
        TimeControl::Byoyomi { main_time_ms, byoyomi_ms, .. } => {
            // Byoyomi実装は3.4参照
            calculate_byoyomi_time(main_time_ms, byoyomi_ms, params)
        }
        
        TimeControl::FixedNodes { .. } => (u64::MAX, u64::MAX),
        TimeControl::Infinite => (u64::MAX, u64::MAX),
        TimeControl::Ponder => (u64::MAX, u64::MAX),
    }
}
```

### 3.2 残り手数推定

```rust
fn estimate_moves_remaining(ply: u32) -> u32 {
    const AVERAGE_GAME_LENGTH: u32 = 120;
    let moves_played = ply / 2;
    
    // 標準的なゲーム進行曲線に基づく推定
    if moves_played < 30 {
        60  // 序盤は長めに見積もる
    } else if moves_played < 80 {
        40  // 中盤
    } else {
        20  // 終盤は最低20手を確保
    }
}
```

### 3.3 PV安定性による動的調整

```rust
impl TimeManager {
    pub fn on_pv_change(&self, depth: u32) {
        let now_ms = self.elapsed_ms();
        self.inner.last_pv_change_ms.store(now_ms, Ordering::Relaxed);
        
        // 深さに応じた閾値調整
        let params = self.get_params();
        let threshold = params.pv_base_threshold_ms + 
                       (depth as u64 * params.pv_depth_slope_ms);
        self.inner.pv_threshold_ms.store(threshold, Ordering::Relaxed);
    }
    
    fn is_pv_stable(&self) -> bool {
        let now_ms = self.elapsed_ms();
        let last_change = self.inner.last_pv_change_ms.load(Ordering::Acquire);
        let threshold = self.inner.pv_threshold_ms.load(Ordering::Acquire);
        
        now_ms.saturating_sub(last_change) > threshold
    }
}
```

### 3.4 秒読み（Byoyomi）実装

```rust
fn calculate_byoyomi_time(
    main_time_ms: u64,
    byoyomi_ms: u64,
    params: &TimeParameters,
) -> (u64, u64) {
    if main_time_ms > 0 {
        // まだ基本時間内 - Fischer同様に保守的割り当て
        // 基本時間の20%をソフトリミット、50%をハードリミットとして使用
        let soft = main_time_ms / 5;  // 20% = 1/5
        let hard = main_time_ms / 2;  // 50% = 1/2
        (soft, hard)
    } else {
        // 秒読み中 - 期内時間の80%をソフトリミットとして使用
        let soft = (byoyomi_ms * 4) / 5;  // 80% = 4/5
        let hard = byoyomi_ms;
        let overhead = params.overhead_ms;
        (soft.saturating_sub(overhead), hard.saturating_sub(overhead))
    }
}

impl TimeManager {
    pub fn finish_move(&self, color: Color, time_spent_ms: u64) {
        match &self.inner.time_control {
            TimeControl::Byoyomi { main_time_ms, byoyomi_ms, periods } => {
                let mut state = self.inner.byoyomi_state.lock();
                
                if !state.in_byoyomi {
                    // まだ基本時間内
                    // 注：実際の基本時間追跡はGUI側で管理
                    // ここでは基本時間を0になった場合の秒読み移行を処理
                    if *main_time_ms == 0 {
                        state.in_byoyomi = true;
                    }
                } else {
                    // 秒読み中
                    if time_spent_ms > *byoyomi_ms {
                        // 期を1つ消費
                        state.periods_left = state.periods_left.saturating_sub(1);
                        
                        if state.periods_left == 0 {
                            // 時間切れ - 強制停止フラグを立てる
                            self.inner.stop_flag.store(true, Ordering::Release);
                        } else {
                            // 次の期にリセット
                            state.current_period_ms = *byoyomi_ms;
                        }
                    } else {
                        // 期内に指した - 次の手で使える時間
                        state.current_period_ms = byoyomi_ms.saturating_sub(time_spent_ms);
                    }
                }
            }
            _ => {}
        }
    }
}
```

### 3.5 停止判定実装

```rust
impl TimeManager {
    pub fn should_stop(&self, current_nodes: u64) -> bool {
        // 強制停止フラグ（最も高速なチェック）
        if self.inner.stop_flag.load(Ordering::Acquire) {
            return true;
        }
        
        // ノード数更新（fetch_addで競合回避）
        let prev_nodes = self.inner.nodes_searched.fetch_add(
            current_nodes.saturating_sub(self.inner.nodes_searched.load(Ordering::Relaxed)),
            Ordering::Relaxed
        );
        
        // ノード制限チェック
        if let TimeControl::FixedNodes { nodes } = &self.inner.time_control {
            if current_nodes >= *nodes {
                return true;
            }
        }
        
        // 時間ベースのチェック
        let elapsed = self.elapsed_ms();
        
        // ハードリミット
        let hard_limit = self.inner.hard_limit_ms.load(Ordering::Acquire);
        if elapsed >= hard_limit {
            return true;
        }
        
        // ソフトリミット＋PV安定性
        let soft_limit = self.inner.soft_limit_ms.load(Ordering::Acquire);
        if elapsed >= soft_limit && self.is_pv_stable() {
            return true;
        }
        
        // 緊急停止チェック
        if self.is_time_critical() {
            return true;
        }
        
        false
    }
    
    fn is_time_critical(&self) -> bool {
        match &self.inner.time_control {
            TimeControl::Fischer { white_ms, black_ms, increment_ms } => {
                let remain = if self.inner.side_to_move == Color::White {
                    *white_ms
                } else {
                    *black_ms
                };
                remain < CRITICAL_FISCHER_MS && *increment_ms == 0
            }
            TimeControl::Byoyomi { .. } => {
                let state = self.inner.byoyomi_state.lock();
                // 秒読み中で期内時間が少ない場合に危険
                state.in_byoyomi && state.current_period_ms < CRITICAL_BYOYOMI_MS
            }
            TimeControl::FixedTime { .. } => {
                // オーバーラン防止
                let elapsed = self.elapsed_ms();
                let hard = self.inner.hard_limit_ms.load(Ordering::Acquire);
                elapsed > hard * 11 / 10  // 110%超過
            }
            _ => false,
        }
    }
}
```

## 4. 既存コードへの統合

### 4.1 SearchContext修正

```rust
// search_enhanced.rs
pub struct SearchContext<'a> {
    // ... 既存フィールド ...
    pub time_manager: Option<TimeManager>,
}

impl<'a> SearchContext<'a> {
    fn should_stop(&self) -> bool {
        // 既存の停止フラグ
        if self.stop_flag.load(Ordering::Relaxed) {
            return true;
        }
        
        // 時間管理による停止判定
        if let Some(ref tm) = self.time_manager {
            if tm.should_stop(self.stats.nodes) {
                return true;
            }
        }
        
        // 既存のノード/深さチェック
        // ...
    }
}
```

### 4.2 アルファベータ探索への統合

```rust
fn alpha_beta<E: Evaluator>(
    ctx: &mut SearchContext,
    // ... パラメータ ...
) -> i32 {
    // ... 既存コード ...
    
    // PV更新時の通知
    if score > alpha && score < beta {
        // PVが変わった
        if let Some(ref tm) = ctx.time_manager {
            tm.on_pv_change(depth);
        }
        
        // ... トランスポジションテーブル更新など ...
    }
    
    // ... 残りの処理 ...
}
```

### 4.3 Engineコントローラ統合

```rust
// engine/controller.rs
impl Engine {
    pub fn search(&mut self, limits: SearchLimits) -> SearchResult {
        // ゲームフェーズ判定
        let game_phase = estimate_game_phase(&self.position);
        
        // 時間管理作成
        let time_manager = TimeManager::new(
            &limits,
            self.position.side_to_move(),
            self.position.game_ply(),
            game_phase,
        );
        
        // 検索コンテキスト作成
        let mut context = SearchContext::new(
            &self.position,
            self.transposition_table.as_mut(),
            Some(time_manager),
        );
        
        // 探索実行
        let result = search_enhanced(&mut context);
        
        // 時間消費を記録
        if let Some(tm) = context.time_manager {
            tm.finish_move(
                self.position.side_to_move(),
                tm.elapsed_ms(),
            );
        }
        
        result
    }
}
```

## 5. テスト戦略

### 5.1 単体テスト（MockClock使用）

```rust
#[cfg(test)]
mod tests {
    use super::*;
    use instant::MockClock;
    
    #[test]
    fn test_fischer_time_allocation() {
        MockClock::set_time(0);
        
        let limits = SearchLimits {
            time_control: TimeControl::Fischer {
                white_ms: 60000,
                black_ms: 60000,
                increment_ms: 1000,
            },
            ..Default::default()
        };
        
        let tm = TimeManager::new(&limits, Color::White, 0, GamePhase::Opening);
        let info = tm.get_time_info();
        
        // 開始局面は1.2倍の時間
        assert!(info.soft_limit_ms > 1200);
        assert!(info.hard_limit_ms > info.soft_limit_ms);
        assert!(info.hard_limit_ms <= 48000); // 60秒の80%
    }
    
    #[test]
    fn test_byoyomi_period_consumption() {
        MockClock::set_time(0);
        
        let limits = SearchLimits {
            time_control: TimeControl::Byoyomi {
                main_time_ms: 0,  // 既に秒読み
                byoyomi_ms: 30000,
                periods: 3,
            },
            ..Default::default()
        };
        
        let tm = TimeManager::new(&limits, Color::Black, 80, GamePhase::EndGame);
        
        // 35秒消費（期オーバー）
        tm.finish_move(Color::Black, 35000);
        
        let info = tm.get_time_info();
        assert_eq!(info.byoyomi_info.unwrap().periods_left, 2);
    }
    
    #[test]
    fn test_pv_stability_with_depth() {
        MockClock::set_time(0);
        let tm = create_test_manager();
        
        // 深さ10でPV変更
        tm.on_pv_change(10);
        MockClock::advance(50);
        assert!(!tm.is_pv_stable()); // 50ms < 80+10*5=130ms
        
        MockClock::advance(100);
        assert!(tm.is_pv_stable());  // 150ms > 130ms
    }
}
```

### 5.2 並行性テスト（loom使用）

```rust
#[cfg(loom)]
#[test]
fn test_concurrent_stop_check() {
    use loom::thread;
    
    loom::model(|| {
        let tm = Arc::new(create_test_manager());
        let tm1 = tm.clone();
        let tm2 = tm.clone();
        
        let t1 = thread::spawn(move || {
            for i in 0..1000 {
                tm1.should_stop(i);
            }
        });
        
        let t2 = thread::spawn(move || {
            thread::yield_now();
            tm2.force_stop();
        });
        
        t1.join().unwrap();
        t2.join().unwrap();
        
        assert!(tm.should_stop(0));
    });
}
```

### 5.3 統合テスト

```rust
#[test]
fn test_search_respects_time_limit() {
    let mut engine = Engine::new();
    let position = Position::from_sfen(INITIAL_SFEN).unwrap();
    engine.set_position(position);
    
    let limits = SearchLimits {
        time_control: TimeControl::FixedTime { ms_per_move: 1000 },
        ..Default::default()
    };
    
    let start = Instant::now();
    let result = engine.search(limits);
    let elapsed = start.elapsed();
    
    // 時間制限を守っているか
    assert!(elapsed.as_millis() <= 1100); // 100msのバッファ
    assert!(result.best_move.is_some());
    assert!(result.pv.len() > 0);
}
```

### 5.4 ベンチマークテスト

```rust
// benches/time_management.rs
use criterion::{black_box, criterion_group, criterion_main, Criterion};

fn benchmark_should_stop(c: &mut Criterion) {
    let tm = create_bench_time_manager();
    
    c.bench_function("should_stop", |b| {
        let mut nodes = 0u64;
        b.iter(|| {
            nodes += 1;
            black_box(tm.should_stop(nodes))
        });
    });
}

fn benchmark_time_allocation(c: &mut Criterion) {
    c.bench_function("calculate_allocation_fischer", |b| {
        b.iter(|| {
            calculate_time_allocation(
                &TimeControl::Fischer {
                    white_ms: 300000,
                    black_ms: 300000,
                    increment_ms: 5000,
                },
                Color::White,
                40,
                None,
                GamePhase::MiddleGame,
                &TimeParameters::default(),
            )
        });
    });
}

criterion_group!(benches, benchmark_should_stop, benchmark_time_allocation);
criterion_main!(benches);
```

## 6. チューニングパラメータ

```rust
/// 時間管理の調整可能パラメータ
#[derive(Debug, Clone, serde::Deserialize)]
pub struct TimeParameters {
    // オーバーヘッド
    pub overhead_ms: u64,              // デフォルト: 50
    pub network_overhead_factor: f64,   // デフォルト: 0.5
    
    // PV安定性
    pub pv_base_threshold_ms: u64,     // デフォルト: 80
    pub pv_depth_slope_ms: u64,        // デフォルト: 5
    
    // 緊急停止閾値
    pub critical_fischer_ms: u64,      // デフォルト: 300
    pub critical_byoyomi_ms: u64,      // デフォルト: 80
    
    // 時間配分係数
    pub soft_multiplier: f64,          // デフォルト: 1.0
    pub hard_multiplier: f64,          // デフォルト: 4.0
    pub increment_usage: f64,          // デフォルト: 0.8
    
    // 局面係数
    pub opening_factor: f64,           // デフォルト: 1.2
    pub endgame_factor: f64,           // デフォルト: 0.8
}

impl Default for TimeParameters {
    fn default() -> Self {
        Self {
            overhead_ms: 50,
            network_overhead_factor: 0.5,
            pv_base_threshold_ms: 80,
            pv_depth_slope_ms: 5,
            critical_fischer_ms: 300,
            critical_byoyomi_ms: 80,
            soft_multiplier: 1.0,
            hard_multiplier: 4.0,
            increment_usage: 0.8,
            opening_factor: 1.2,
            endgame_factor: 0.8,
        }
    }
}
```

## 7. 実装フェーズ

### Phase 1: 基礎実装（第1週）
- [ ] `time_management`モジュール作成
- [ ] `TimeManager`、`TimeControl`、`SearchLimits`実装
- [ ] Fischer/FixedTime時間割り当てアルゴリズム
- [ ] 基本的な単体テスト（MockClock使用）

### Phase 2: 検索統合（第2週）
- [ ] `SearchContext`へのTimeManager統合
- [ ] `should_stop()`の時間ベース判定追加
- [ ] PV変更追跡とon_pv_change実装
- [ ] loomによる並行性テスト

### Phase 3: 高度な機能（第3週）
- [ ] Byoyomi期管理実装
- [ ] Ponder機能とponderhit処理
- [ ] 緊急時間管理と安全フェイル
- [ ] WASM環境でのテスト

### Phase 4: 最適化とチューニング（第4週）
- [ ] ベンチマークテストと性能最適化
- [ ] 自己対局によるパラメータチューニング
- [ ] ドキュメント完成
- [ ] リリース準備

## 8. リスクと対策

| リスク | 対策 |
|-------|------|
| WASM環境でのタイマー精度不足 | `performance.now()`使用、フォールバックでノードベース停止 |
| Instant→AtomicU64変換のUB | `parking_lot::Mutex<Instant>`で安全に管理 |
| 並行アクセスによる競合状態 | 適切なAtomic Ordering（write:Relaxed, read:Acquire） |
| 秒読み期0での時間切れ | 強制停止＋最善手即座返却の実装 |
| ネットワーク遅延の影響 | 動的オーバーヘッド調整機能 |

## 9. パフォーマンス目標

- 時間割り当て計算: < 0.1ms/回
- should_stop()呼び出し: < 0.01ms/回
- メモリ使用量: < 1KB/TimeManagerインスタンス
- ホットパスでのメモリアロケーション: 0
- 検索中のミューテックスロック: 0（ロックフリー設計）

## 10. 将来の拡張

1. **機械学習統合**: ゲームデータベースから時間配分パターンを学習
2. **局面複雑度分析**: 複雑な局面により多くの時間を配分
3. **対戦相手モデリング**: 相手の時間管理パターンに基づく調整
4. **Multi-PV時間管理**: 複数の主要変化に時間を分配
5. **クラスタ探索**: 分散環境での総時間管理

---

本実装計画は、プロフェッショナルグレードの時間管理システムを段階的に構築し、既存のコードベースとシームレスに統合することを目的としています。各フェーズでの明確な成果物とテスト戦略により、高品質な実装を保証します。
