### PR TITLE
USI engineのスレッドセーフティ改善

### DIFF
--- a/packages/rust-core/crates/engine-cli/tests/thread_safety_test.rs
+++ b/packages/rust-core/crates/engine-cli/tests/thread_safety_test.rs
@@ -1,0 +1,479 @@
+//! Thread safety tests for USI engine
+//! Tests race conditions and concurrent command handling
+
+use crossbeam_channel::{unbounded, Receiver};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Helper to spawn engine process
+fn spawn_engine() -> std::process::Child {
+    Command::new(env!("CARGO_BIN_EXE_engine-cli"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit()) // Show any panics or errors
+        .spawn()
+        .expect("Failed to spawn engine")
+}
+
+/// Helper to send command to engine
+fn send_command<W: Write + ?Sized>(stdin: &mut W, command: &str) {
+    writeln!(stdin, "{command}").expect("Failed to write command");
+    stdin.flush().expect("Failed to flush stdin");
+}
+
+/// Spawn a thread that continuously reads engine output
+fn spawn_output_reader(
+    mut reader: BufReader<std::process::ChildStdout>,
+) -> (Receiver<String>, thread::JoinHandle<()>) {
+    let (tx, rx) = unbounded::<String>();
+
+    let handle = thread::spawn(move || {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    let trimmed = line.trim_end().to_string();
+                    if !trimmed.is_empty() {
+                        println!("[ENGINE] {trimmed}");
+                        if tx.send(trimmed).is_err() {
+                            break; // Receiver dropped
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    (rx, handle)
+}
+
+/// Helper to read lines until a specific pattern or timeout
+fn read_until_pattern(
+    rx: &Receiver<String>,
+    pattern: &str,
+    timeout: Duration,
+) -> Result<Vec<String>, String> {
+    let deadline = Instant::now() + timeout;
+    let mut lines = Vec::new();
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("Timeout waiting for pattern: {pattern}"));
+        }
+
+        match rx.recv_timeout(remaining) {
+            Ok(line) => {
+                lines.push(line.clone());
+                if line.starts_with(pattern) {
+                    return Ok(lines);
+                }
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                return Err(format!("Timeout waiting for pattern: {pattern}"));
+            }
+            Err(_) => return Err("Output channel closed".into()),
+        }
+    }
+}
+
+/// Cleanup helper to properly shutdown engine
+fn cleanup_engine(
+    mut engine: std::process::Child,
+    stdin: std::process::ChildStdin,
+    reader_handle: thread::JoinHandle<()>,
+) {
+    // Close stdin to send EOF
+    drop(stdin);
+
+    // Wait for engine to exit
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match engine.try_wait() {
+            Ok(Some(status)) => {
+                println!("Engine exited with status: {status:?}");
+                break;
+            }
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) | Err(_) => {
+                println!("Engine didn't exit in time, killing it");
+                let _ = engine.kill();
+                let _ = engine.wait();
+                break;
+            }
+        }
+    }
+
+    // Wait for reader thread to finish
+    let _ = reader_handle.join();
+}
+
+/// Initialize engine and return handles
+fn init_engine() -> (
+    std::process::Child,
+    std::process::ChildStdin,
+    Receiver<String>,
+    thread::JoinHandle<()>,
+) {
+    let mut engine = spawn_engine();
+    let mut stdin = engine.stdin.take().expect("Failed to get stdin");
+    let stdout = engine.stdout.take().expect("Failed to get stdout");
+    let reader = BufReader::new(stdout);
+
+    // Start output reader thread
+    let (rx, reader_handle) = spawn_output_reader(reader);
+
+    // Initialize
+    send_command(&mut stdin, "usi");
+    let _ = read_until_pattern(&rx, "usiok", Duration::from_secs(2)).expect("Failed to get usiok");
+    send_command(&mut stdin, "isready");
+    let _ =
+        read_until_pattern(&rx, "readyok", Duration::from_secs(2)).expect("Failed to get readyok");
+
+    (engine, stdin, rx, reader_handle)
+}
+
+#[test]
+fn test_stop_ponderhit_simultaneous() {
+    let (mut engine, stdin, rx, _reader_handle) = init_engine();
+    let stdin = Arc::new(std::sync::Mutex::new(stdin));
+
+    // Set position
+    {
+        let mut stdin = stdin.lock().unwrap();
+        send_command(&mut *stdin, "position startpos moves 2c2d 8g8f");
+    }
+
+    // Start ponder search
+    {
+        let mut stdin = stdin.lock().unwrap();
+        send_command(&mut *stdin, "go ponder btime 60000 wtime 60000");
+    }
+
+    // Give time for ponder to start
+    thread::sleep(Duration::from_millis(50));
+
+    // Create barrier for simultaneous execution
+    let barrier = Arc::new(Barrier::new(2));
+    let stdin_clone = stdin.clone();
+    let barrier_clone = barrier.clone();
+    let stdin_clone2 = stdin.clone();
+
+    // Thread 1: Send stop
+    let stop_thread = thread::spawn(move || {
+        barrier_clone.wait();
+        let mut stdin = stdin_clone.lock().unwrap();
+        send_command(&mut *stdin, "stop");
+    });
+
+    // Thread 2: Send ponderhit
+    let ponderhit_thread = thread::spawn(move || {
+        barrier.wait();
+        let mut stdin = stdin_clone2.lock().unwrap();
+        send_command(&mut *stdin, "ponderhit");
+    });
+
+    // Wait for threads
+    stop_thread.join().expect("Stop thread panicked");
+    ponderhit_thread.join().expect("Ponderhit thread panicked");
+
+    // Should get bestmove without deadlock
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    assert!(result.is_ok(), "Failed to get bestmove after simultaneous stop/ponderhit");
+
+    // Cleanup
+    {
+        let mut stdin = Arc::try_unwrap(stdin)
+            .unwrap_or_else(|_| panic!("Failed to unwrap stdin"))
+            .into_inner()
+            .unwrap();
+        send_command(&mut stdin, "quit");
+    }
+    let _ = engine.wait();
+}
+
+#[test]
+fn test_multiple_go_commands_concurrent() {
+    let (mut engine, stdin, rx, _reader_handle) = init_engine();
+    let stdin = Arc::new(std::sync::Mutex::new(stdin));
+
+    // Set position
+    {
+        let mut stdin = stdin.lock().unwrap();
+        send_command(&mut *stdin, "position startpos");
+    }
+
+    // Track which thread succeeded
+    let success_count = Arc::new(AtomicU32::new(0));
+    let barrier = Arc::new(Barrier::new(3));
+
+    // Spawn 3 threads trying to start search simultaneously
+    let mut handles = vec![];
+    for i in 0..3 {
+        let stdin = stdin.clone();
+        let barrier = barrier.clone();
+        let success_count = success_count.clone();
+
+        let handle = thread::spawn(move || {
+            barrier.wait();
+            let mut stdin = stdin.lock().unwrap();
+            send_command(&mut *stdin, &format!("go movetime {}", 1000 + i * 100));
+            drop(stdin); // Release lock immediately
+            success_count.fetch_add(1, Ordering::SeqCst);
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all threads
+    for handle in handles {
+        handle.join().expect("Thread panicked");
+    }
+
+    // Should get exactly one bestmove (engine should handle concurrent go gracefully)
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(3));
+    assert!(result.is_ok(), "Failed to get bestmove after concurrent go commands");
+
+    // Verify we sent 3 commands
+    assert_eq!(success_count.load(Ordering::SeqCst), 3, "Not all go commands were sent");
+
+    // Cleanup
+    {
+        let mut stdin = Arc::try_unwrap(stdin)
+            .unwrap_or_else(|_| panic!("Failed to unwrap stdin"))
+            .into_inner()
+            .unwrap();
+        send_command(&mut stdin, "quit");
+    }
+    let _ = engine.wait();
+}
+
+#[test]
+fn test_position_update_during_stop() {
+    let (engine, stdin, rx, reader_handle) = init_engine();
+    let stdin = Arc::new(std::sync::Mutex::new(stdin));
+
+    // Start search
+    {
+        let mut stdin = stdin.lock().unwrap();
+        send_command(&mut *stdin, "position startpos");
+        send_command(&mut *stdin, "go infinite");
+    }
+
+    // Wait for search to actually start by looking for info output
+    match read_until_pattern(&rx, "info", Duration::from_millis(500)) {
+        Ok(_) => println!("Search confirmed started (info received)"),
+        Err(e) => {
+            println!("Warning: No info line for infinite search: {e}");
+            // Try to continue anyway
+        }
+    }
+
+    // Create threads for concurrent position and stop
+    let barrier = Arc::new(Barrier::new(2));
+    let stdin_clone = stdin.clone();
+    let stdin_clone2 = stdin.clone();
+    let barrier_clone = barrier.clone();
+
+    // Thread 1: Update position
+    let position_thread = thread::spawn(move || {
+        barrier_clone.wait();
+        let mut stdin = stdin_clone.lock().unwrap();
+        send_command(&mut *stdin, "position startpos moves 2c2d");
+    });
+
+    // Thread 2: Send stop
+    let stop_thread = thread::spawn(move || {
+        barrier.wait();
+        let mut stdin = stdin_clone2.lock().unwrap();
+        send_command(&mut *stdin, "stop");
+    });
+
+    // Wait for threads
+    position_thread.join().expect("Position thread panicked");
+    stop_thread.join().expect("Stop thread panicked");
+
+    // Should get bestmove
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    assert!(
+        result.is_ok(),
+        "Failed to get bestmove after position/stop race - {:?}",
+        result.err()
+    );
+
+    // Verify we can start a new search with the updated position
+    let mut stdin = Arc::try_unwrap(stdin)
+        .unwrap_or_else(|_| panic!("Failed to unwrap stdin"))
+        .into_inner()
+        .unwrap();
+    send_command(&mut stdin, "go movetime 300");
+
+    // Wait for this search to complete
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(2));
+    assert!(
+        result.is_ok(),
+        "Failed to start new search after position update - {:?}",
+        result.err()
+    );
+
+    // Cleanup
+    send_command(&mut stdin, "quit");
+    cleanup_engine(engine, stdin, reader_handle);
+}
+
+#[test]
+fn test_memory_ordering_visibility() {
+    // This test verifies that atomic operations have proper visibility across threads
+    let (mut engine, stdin, rx, _reader_handle) = init_engine();
+    let stdin = Arc::new(std::sync::Mutex::new(stdin));
+
+    // Track command timing
+    let command_sent = Arc::new(AtomicBool::new(false));
+    let response_received = Arc::new(AtomicBool::new(false));
+
+    let command_sent_clone = command_sent.clone();
+    let response_received_clone = response_received.clone();
+    let stdin_clone = stdin.clone();
+
+    // Thread 1: Send commands and mark timing
+    let sender_thread = thread::spawn(move || {
+        let mut stdin = stdin_clone.lock().unwrap();
+        send_command(&mut *stdin, "position startpos");
+        send_command(&mut *stdin, "go ponder");
+        command_sent_clone.store(true, Ordering::Release);
+
+        // Wait a bit then send ponderhit
+        thread::sleep(Duration::from_millis(50));
+        send_command(&mut *stdin, "ponderhit");
+    });
+
+    // Thread 2: Monitor for proper ordering
+    let monitor_thread = thread::spawn(move || {
+        // Wait for command to be sent
+        while !command_sent.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+
+        // At this point, commands should be visible to engine
+        response_received_clone.store(true, Ordering::Release);
+    });
+
+    // Wait for threads
+    sender_thread.join().expect("Sender thread panicked");
+    monitor_thread.join().expect("Monitor thread panicked");
+
+    // Verify ordering was maintained
+    assert!(response_received.load(Ordering::Acquire), "Memory ordering not maintained");
+
+    // Get bestmove
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    assert!(result.is_ok(), "Failed to get bestmove");
+
+    // Cleanup
+    {
+        let mut stdin = Arc::try_unwrap(stdin)
+            .unwrap_or_else(|_| panic!("Failed to unwrap stdin"))
+            .into_inner()
+            .unwrap();
+        send_command(&mut stdin, "quit");
+    }
+    let _ = engine.wait();
+}
+
+#[test]
+fn test_rapid_go_stop_cycles() {
+    let (engine, mut stdin, rx, reader_handle) = init_engine();
+
+    // Set position once
+    send_command(&mut stdin, "position startpos");
+
+    // Rapid go/stop cycles - reduced iterations for stability
+    for i in 0..5 {
+        println!("Starting rapid cycle {}", i + 1);
+
+        // Start search with longer time to ensure it starts
+        send_command(&mut stdin, "go movetime 500");
+
+        // Wait for "info" line to confirm search actually started
+        match read_until_pattern(&rx, "info", Duration::from_millis(500)) {
+            Ok(_) => {
+                println!("Search started (info received), sending stop");
+            }
+            Err(e) => {
+                println!("Warning: No info line received: {e}");
+                // Continue anyway - some engines might not send info immediately
+            }
+        }
+
+        // Stop after confirming search started
+        send_command(&mut stdin, "stop");
+
+        // Should get bestmove
+        let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(3));
+        assert!(
+            result.is_ok(),
+            "Failed to get bestmove in rapid cycle {} - {:?}",
+            i + 1,
+            result.err()
+        );
+
+        // Small delay between cycles
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    // Cleanup
+    send_command(&mut stdin, "quit");
+    cleanup_engine(engine, stdin, reader_handle);
+}
+
+#[test]
+fn test_concurrent_setoption_and_go() {
+    let (mut engine, stdin, rx, _reader_handle) = init_engine();
+    let stdin = Arc::new(std::sync::Mutex::new(stdin));
+
+    let barrier = Arc::new(Barrier::new(2));
+    let stdin_clone = stdin.clone();
+    let barrier_clone = barrier.clone();
+    let stdin_clone2 = stdin.clone();
+
+    // Thread 1: Set option
+    let option_thread = thread::spawn(move || {
+        barrier_clone.wait();
+        let mut stdin = stdin_clone.lock().unwrap();
+        send_command(&mut *stdin, "setoption name Threads value 2");
+    });
+
+    // Thread 2: Start search
+    let search_thread = thread::spawn(move || {
+        barrier.wait();
+        let mut stdin = stdin_clone2.lock().unwrap();
+        send_command(&mut *stdin, "position startpos");
+        send_command(&mut *stdin, "go movetime 500");
+    });
+
+    // Wait for threads
+    option_thread.join().expect("Option thread panicked");
+    search_thread.join().expect("Search thread panicked");
+
+    // Should complete search successfully
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(2));
+    assert!(result.is_ok(), "Failed to complete search after concurrent setoption");
+
+    // Cleanup
+    {
+        let mut stdin = Arc::try_unwrap(stdin)
+            .unwrap_or_else(|_| panic!("Failed to unwrap stdin"))
+            .into_inner()
+            .unwrap();
+        send_command(&mut stdin, "quit");
+    }
+    let _ = engine.wait();
+}


### PR DESCRIPTION

## 1. 概要と目的

USIエンジンのスレッドセーフティを強化し、並行処理における競合状態やデッドロックを防止する。特に`stop`、`ponderhit`、`go`、`position`コマンドの並行実行時の安定性を向上させる。

## 2. 現状分析

### 2.1 既存のテスト
- `ponder_hit_stress_test.rs`: 5つのストレステスト実装済み
  - rapid ponder_hit
  - concurrent commands
  - stop/ponderhit組み合わせ
  - 基本的なレース条件はカバー

### 2.2 Atomic Ordering
- `stop_flag`: Release/Acquire（現状）
- `ponder_hit_flag`: Release（現状）
- 潜在的な問題: 複数スレッド間での可視性保証が不完全な可能性

### 2.3 Mutex使用パターン
- `EngineAdapter`: Arc<Mutex<_>>で保護
- `engine`: ownership転送による排他制御
- `active_ponder_hit_flag`: Option<Arc<AtomicBool>>で状態共有

## 3. 実装計画

### 3.1 レース条件テスト追加（tests/thread_safety_test.rs）

#### 実装内容
```rust
// 新規テストケース
1. stop/ponderhit同時送信テスト
   - 10ms以内に両コマンドを送信
   - 状態整合性を検証

2. 複数goコマンドの並行実行テスト
   - 別スレッドから同時にgo送信
   - 一つだけが実行されることを確認

3. position更新中のstopテスト
   - position処理中にstop送信
   - デッドロックしないことを確認

4. メモリオーダリング検証テスト
   - フラグの可視性タイミング検証
```

### 3.2 Ordering改善（段階的アプローチ）

#### Step 1: パフォーマンス測定基準の確立
```rust
// ベンチマーク作成
- 現在のRelease/Acquireでの基準値測定
- stop_flag/ponder_hit_flagのアクセス頻度計測
- criterionによる定量評価
```

#### Step 2: 必要に応じてSeqCst化
```rust
// 判断基準
- アクセス頻度が100Hz未満: SeqCst化を検討
- パフォーマンス劣化5%以内: 実装続行
- それ以外: Acquire/Release + 明示的コメント
```

### 3.3 デッドロック対策

#### Mutex取得ルール
```rust
// 常にこの順序でlock取得
1. engine_adapter (外側)
2. ponder_state (内側)
3. その他
```

#### try_lock_for実装
```rust
// タイムアウト付きlock
- 初期タイムアウト: 100ms
- 失敗時: error!ログ + graceful degradation
- panic禁止
```

### 3.4 ストレステスト拡張

#### 既存テストの強化
```rust
// ponder_hit_stress_test.rsに追加
1. 長時間ストレステスト
   - 環境変数STRESS_TEST_ITERATIONS（デフォルト100、CI: 1000）
   - ランダム遅延（0-10ms）

2. 並行度テスト
   - CPU数×2スレッドで同時実行
   - 統計的な成功率測定
```

### 3.5 CI統合

#### Stage 1: 基本強化
```yaml
# .github/workflows/rust.yml
env:
  RUST_TEST_THREADS: 1
  
test:
  run: cargo test --package engine-cli -- --test-threads=1
```

#### Stage 2: Miri（別ジョブ）
```yaml
miri-test:
  runs-on: ubuntu-latest
  continue-on-error: true
  steps:
    - uses: actions/checkout@v4
    - uses: dtolnay/rust-toolchain@nightly
      with:
        components: miri
    - run: cargo miri test --package engine-cli
```

## 4. 実装チェックリスト

### Day 1
- [ ] thread_safety_test.rs作成
  - [ ] stop/ponderhit同時送信テスト
  - [ ] 複数go並行実行テスト
  - [ ] position/stop競合テスト
- [ ] パフォーマンスベンチマーク基盤
  - [ ] criterion設定
  - [ ] 基準値測定

### Day 2
- [ ] Ordering改善
  - [ ] アクセス頻度測定
  - [ ] 改善判断
  - [ ] 実装（必要な場合）
- [ ] デッドロック対策
  - [ ] Mutex取得順序文書化
  - [ ] try_lock_for実装

### Day 3
- [ ] ストレステスト拡張
  - [ ] 長時間テスト追加
  - [ ] 並行度テスト追加
- [ ] CI統合
  - [ ] 基本設定更新
  - [ ] Miriジョブ追加

## 5. 成功基準とリスク管理

### 成功基準
1. 全テストがDebug/Releaseで通過
2. パフォーマンス劣化5%以内
3. CI実行時間増加20%以内
4. Miri実行でデータレースゼロ（best effort）

### リスクと対策

| リスク | 影響度 | 対策 |
|--------|--------|------|
| SeqCstによる性能劣化 | 中 | 段階的適用、測定重視 |
| CI時間増加 | 低 | 並列実行、キャッシュ活用 |
| false positive | 低 | suppressionリスト作成 |
| macOSでのTSan制限 | 低 | Linux環境でのみ実行 |

## 6. 将来的な拡張（Phase 3.5）

- **loom導入**: deterministic concurrency testing
- **ThreadSanitizer**: より詳細なデータレース検出
- **formal verification**: TLA+等による並行性の形式検証