### PR TITLE
feat: send_response関数にエラープロパゲーションを追加し、BrokenPipeエラーを処理するロジックを強化

### DIFF
--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "engine-core",
  "env_logger",
  "log",
+ "thiserror",
 ]
 
 [[package]]
@@ -1042,6 +1043,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/rust-core/crates/engine-cli/Cargo.toml
+++ b/packages/rust-core/crates/engine-cli/Cargo.toml
@@ -14,3 +14,4 @@ log = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
 crossbeam-channel = "0.5"
+thiserror = "1.0"

--- a/packages/rust-core/crates/engine-cli/src/usi/mod.rs
+++ b/packages/rust-core/crates/engine-cli/src/usi/mod.rs
@@ -7,7 +7,7 @@ pub mod parser;
 
 pub use commands::{EngineOption, GameResult, GoParams, UsiCommand};
 pub use conversion::create_position;
-pub use output::{send_info_string, send_response, UsiResponse};
+pub use output::{send_info_string, send_response, send_response_or_exit, UsiResponse};
 pub use parser::parse_usi_command;
 
 /// USI option name constants


### PR DESCRIPTION
  1. ✅ thiserror依存の確認 - Cargo.tomlに追加済み
  2. ✅ io::Error::other → ErrorKind::Other - MSRV対応のため変更
  3. ✅ Poisoned対応の一貫性 - すべてlock_or_recoverヘルパーに統一
  4. ✅ 不要なimportの削除と再追加 - Writeトレイトは実際に必要だったため再追加
  5. ✅ APIガイドラインの追加 - send_response/send_response_or_exitの使い分けをコメントで明示
  6. ✅ BrokenPipe判定の最適化 - リトライ前にBrokenPipeを判定して無駄なリトライを回避