### PR TITLE
枝刈りの強化

### DIFF
--- a/packages/rust-core/crates/engine-cli/tests/thread_safety_test.rs
+++ b/packages/rust-core/crates/engine-cli/tests/thread_safety_test.rs
@@ -198,7 +198,7 @@ fn test_stop_ponderhit_simultaneous() {
     ponderhit_thread.join().expect("Ponderhit thread panicked");
 
     // Should get bestmove without deadlock
-    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(10));
     assert!(result.is_ok(), "Failed to get bestmove after simultaneous stop/ponderhit");
 
     // Cleanup
@@ -351,7 +351,7 @@ fn test_position_update_during_stop() {
     stop_thread.join().expect("Stop thread panicked");
 
     // Should get bestmove
-    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(10));
     assert!(
         result.is_ok(),
         "Failed to get bestmove after position/stop race - {:?}",
@@ -428,8 +428,8 @@ fn test_memory_ordering_visibility() {
     // Verify ordering was maintained
     assert!(response_received.load(Ordering::Acquire), "Memory ordering not maintained");
 
-    // Get bestmove
-    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(5));
+    // Get bestmove (allow more time for CI environments where search might take longer)
+    let result = read_until_pattern(&rx, "bestmove", Duration::from_secs(10));
     assert!(result.is_ok(), "Failed to get bestmove");
 
     // Cleanup

--- a/packages/rust-core/crates/engine-core/src/search/unified/pruning/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/pruning/mod.rs
@@ -208,3 +208,217 @@ pub fn can_do_static_null_move(depth: u8, in_check: bool, beta: i32, static_eval
         && can_prune_beta(in_check, beta)
         && static_eval - STATIC_NULL_MOVE_DEPTH_FACTOR * depth as i32 >= beta
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mate_score_detection() {
+        assert!(is_mate_score(30001));
+        assert!(is_mate_score(-30001));
+        assert!(is_mate_score(40000));
+        assert!(!is_mate_score(30000));
+        assert!(!is_mate_score(-30000));
+        assert!(!is_mate_score(0));
+        assert!(!is_mate_score(100));
+    }
+
+    #[test]
+    fn test_common_pruning_helpers() {
+        // Test can_prune
+        assert!(can_prune(false, 100, 200));
+        assert!(!can_prune(true, 100, 200)); // in check
+        assert!(!can_prune(false, 31000, 200)); // mate score alpha
+        assert!(!can_prune(false, 100, -31000)); // mate score beta
+
+        // Test can_prune_alpha
+        assert!(can_prune_alpha(false, 100));
+        assert!(!can_prune_alpha(true, 100)); // in check
+        assert!(!can_prune_alpha(false, 31000)); // mate score
+
+        // Test can_prune_beta
+        assert!(can_prune_beta(false, 200));
+        assert!(!can_prune_beta(true, 200)); // in check
+        assert!(!can_prune_beta(false, -31000)); // mate score
+    }
+
+    #[test]
+    fn test_null_move_pruning_conditions() {
+        // Valid conditions
+        let pos = Position::startpos();
+        assert!(can_do_null_move(&pos, 3, false, 100, 50));
+        assert!(can_do_null_move(&pos, 5, false, 100, 50));
+
+        // Invalid: in check
+        assert!(!can_do_null_move(&pos, 3, true, 100, 50));
+
+        // Invalid: too shallow
+        assert!(!can_do_null_move(&pos, 2, false, 100, 50));
+
+        // Test reduction calculation
+        assert_eq!(null_move_reduction(3), 2);
+        assert_eq!(null_move_reduction(4), 3);
+        assert_eq!(null_move_reduction(8), 4);
+        assert_eq!(null_move_reduction(12), 5);
+    }
+
+    #[test]
+    fn test_futility_pruning_boundary_conditions() {
+        // Valid conditions
+        assert!(can_do_futility_pruning(3, false, 100, 200, 150));
+        assert!(can_do_futility_pruning(7, false, 100, 200, 150));
+
+        // Invalid: too deep
+        assert!(!can_do_futility_pruning(8, false, 100, 200, 150));
+
+        // Invalid: in check
+        assert!(!can_do_futility_pruning(3, true, 100, 200, 150));
+
+        // Invalid: mate scores
+        assert!(!can_do_futility_pruning(3, false, 31000, 200, 150));
+        assert!(!can_do_futility_pruning(3, false, 100, -31000, 150));
+
+        // Test margin values
+        assert_eq!(futility_margin(0), 0);
+        assert_eq!(futility_margin(1), 100);
+        assert_eq!(futility_margin(2), 200);
+        assert_eq!(futility_margin(7), 700);
+        assert_eq!(futility_margin(10), 700); // capped at 700
+    }
+
+    #[test]
+    fn test_razoring_boundary_conditions() {
+        // Valid razoring at depth 1
+        assert!(can_do_razoring(1, false, 0, -500)); // static_eval + 400 < alpha
+        assert!(can_do_razoring(2, false, 100, -350)); // static_eval + 400 < alpha
+
+        // Invalid: static eval too high
+        assert!(!can_do_razoring(1, false, 0, -300)); // -300 + 400 = 100 >= 0
+
+        // Invalid: too deep
+        assert!(!can_do_razoring(3, false, 0, -500));
+
+        // Invalid: in check
+        assert!(!can_do_razoring(1, true, 0, -500));
+
+        // Invalid: mate score
+        assert!(!can_do_razoring(1, false, 31000, -500));
+
+        // Test margin values
+        assert_eq!(razoring_margin(1), RAZORING_MARGIN_DEPTH_1);
+        assert_eq!(razoring_margin(2), RAZORING_MARGIN_DEPTH_2);
+        assert_eq!(razoring_margin(3), 0);
+    }
+
+    #[test]
+    fn test_lmr_conditions_and_reductions() {
+        use crate::shogi::{Move, Square};
+
+        // Create test moves
+        let normal_move = Move::normal(Square::new(7, 7), Square::new(7, 6), false);
+        let capture_move = Move::normal_with_piece(
+            Square::new(7, 7),
+            Square::new(7, 6),
+            false,
+            crate::shogi::PieceType::Pawn,
+            Some(crate::shogi::PieceType::Pawn),
+        );
+        let promote_move = Move::normal(Square::new(7, 7), Square::new(7, 3), true);
+
+        // Valid LMR conditions
+        assert!(can_do_lmr(3, 4, false, false, normal_move));
+        assert!(can_do_lmr(5, 10, false, false, normal_move));
+
+        // Invalid: too few moves searched
+        assert!(!can_do_lmr(3, 3, false, false, normal_move));
+
+        // Invalid: too shallow
+        assert!(!can_do_lmr(2, 5, false, false, normal_move));
+
+        // Invalid: in check or gives check
+        assert!(!can_do_lmr(3, 5, true, false, normal_move));
+        assert!(!can_do_lmr(3, 5, false, true, normal_move));
+
+        // Invalid: capture or promotion
+        assert!(!can_do_lmr(3, 5, false, false, capture_move));
+        assert!(!can_do_lmr(3, 5, false, false, promote_move));
+    }
+
+    #[test]
+    fn test_lmr_reduction_table() {
+        // Test the new aggressive reduction table
+
+        // No reduction for early moves or shallow depths
+        assert_eq!(lmr_reduction(2, 5), 0);
+        assert_eq!(lmr_reduction(3, 3), 0);
+
+        // Shallow depth reductions
+        assert_eq!(lmr_reduction(3, 4), 1);
+        assert_eq!(lmr_reduction(3, 6), 2);
+
+        // Medium depth reductions
+        assert_eq!(lmr_reduction(4, 4), 2);
+        assert_eq!(lmr_reduction(4, 8), 3);
+        assert_eq!(lmr_reduction(5, 6), 3);
+        assert_eq!(lmr_reduction(5, 10), 3);
+
+        // Deep reductions
+        assert_eq!(lmr_reduction(6, 8), 3);
+        assert_eq!(lmr_reduction(6, 12), 4);
+        assert_eq!(lmr_reduction(7, 14), 4);
+        assert_eq!(lmr_reduction(8, 16), 5);
+
+        // Very deep reductions
+        assert_eq!(lmr_reduction(9, 18), 5);
+        assert_eq!(lmr_reduction(10, 20), 6);
+        assert_eq!(lmr_reduction(12, 25), 6); // max reduction
+    }
+
+    #[test]
+    fn test_lmr_reduction_formula() {
+        // Test logarithmic formula
+        assert_eq!(lmr_reduction_formula(2, 5), 0);
+        assert_eq!(lmr_reduction_formula(3, 3), 0);
+
+        // Should produce reasonable reductions
+        let r1 = lmr_reduction_formula(5, 10);
+        assert!(r1 > 0 && r1 <= 4);
+
+        let r2 = lmr_reduction_formula(8, 20);
+        assert!(r2 > r1); // deeper/later moves get more reduction
+        assert!(r2 <= 7); // capped at depth-1
+
+        let r3 = lmr_reduction_formula(10, 30);
+        assert!(r3 <= 9); // capped at depth-1
+    }
+
+    #[test]
+    fn test_static_null_move_pruning() {
+        // Valid conditions
+        assert!(can_do_static_null_move(3, false, 100, 500)); // 500 - 120*3 = 140 >= 100
+        assert!(can_do_static_null_move(2, false, 0, 250)); // 250 - 120*2 = 10 >= 0
+
+        // Invalid: static eval too low
+        assert!(!can_do_static_null_move(3, false, 100, 400)); // 400 - 120*3 = 40 < 100
+
+        // Invalid: too deep
+        assert!(!can_do_static_null_move(7, false, 100, 1000));
+
+        // Invalid: in check
+        assert!(!can_do_static_null_move(3, true, 100, 500));
+
+        // Invalid: mate score
+        assert!(!can_do_static_null_move(3, false, 31000, 500));
+
+        // Boundary test at exact threshold
+        assert!(can_do_static_null_move(1, false, 100, 220)); // 220 - 120*1 = 100 >= 100
+        assert!(!can_do_static_null_move(1, false, 100, 219)); // 219 - 120*1 = 99 < 100
+    }
+
+    #[test]
+    fn test_delta_pruning_margin() {
+        assert_eq!(delta_pruning_margin(), DELTA_PRUNING_MARGIN);
+        assert_eq!(delta_pruning_margin(), 200); // verify constant value
+    }
+}

--- a/packages/rust-core/crates/engine-core/src/search/unified/pruning/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/pruning/mod.rs
@@ -88,6 +88,20 @@ pub fn can_do_lmr(
         && !mv.is_promote()
 }
 
+/// Check if we can do razoring (extreme futility pruning at low depths)
+pub fn can_do_razoring(depth: u8, in_check: bool, alpha: i32, static_eval: i32) -> bool {
+    !in_check && depth <= 2 && !is_mate_score(alpha) && static_eval + 400 < alpha
+}
+
+/// Get razoring margin
+pub fn razoring_margin(depth: u8) -> i32 {
+    match depth {
+        1 => 200,
+        2 => 400,
+        _ => 0,
+    }
+}
+
 /// Calculate LMR reduction
 pub fn lmr_reduction(depth: u8, moves_searched: u32) -> u8 {
     // More sophisticated reduction table based on depth and move count
@@ -119,6 +133,16 @@ pub fn lmr_reduction_formula(depth: u8, moves_searched: u32) -> u8 {
 }
 
 /// Check if score is a mate score
-fn is_mate_score(score: i32) -> bool {
+pub fn is_mate_score(score: i32) -> bool {
     score.abs() > 30000
+}
+
+/// Get delta pruning margin for quiescence search
+pub fn delta_pruning_margin() -> i32 {
+    200 // Conservative margin to avoid missing tactics
+}
+
+/// Check if static null move (reverse futility) pruning is applicable
+pub fn can_do_static_null_move(depth: u8, in_check: bool, beta: i32, static_eval: i32) -> bool {
+    !in_check && depth <= 6 && !is_mate_score(beta) && static_eval - 120 * depth as i32 >= beta
 }


### PR DESCRIPTION
https://github.com/SH11235/shogi/issues/82

エンジンタイプがEnhanced / NNUEEnhanced の場合に適用されるので、Materialには効かない。

Move Ordering改善の実装計画
                                                                                        
現状の分析                                                                              
                                                                                        
1. Killer movesは既にSearchStackに実装されており、beta cutoff時に更新される仕組みがある 
2. History heuristicのmutex取得失敗時は単に0スコアを返すだけで、代替処理がない          
3. Move orderingは以下の優先順位：                                                      
  - TT move: 1,000,000                                                                  
  - Captures (MVV-LVA): 100,000 +                                                       
  - Killer moves: 90,000                                                                
  - History: 10,000 + history_score                                                     
                                                                                        
実装計画                                                                                
                                                                                        
1. History heuristicのmutex失敗時の代替処理を実装                                       
                                                                                        
ファイル: /packages/rust-core/crates/engine-core/src/search/unified/ordering/mod.rs     
                                                                                        
変更内容:                                                                               
- score_move関数内で、mutex取得失敗時に静的評価値ベースのスコアリングを実装             
- 手の種類（capture, promotion等）に基づく静的スコアリングを追加                        
                                                                                        
// History heuristic部分の改善                                                          
let history_score = match self.history.lock() {                                         
    Ok(history) => history.get_score(pos.side_to_move, mv, None),                       
    Err(e) => {                                                                         
        log::error!("Failed to acquire history lock in move ordering: {e}");            
        // 代替処理：静的評価に基づくスコアリング                                       
        self.get_static_move_score(pos, mv)                                             
    }                                                                                   
};                                                                                      
                                                                                        
新しいメソッドを追加：                                                                  
fn get_static_move_score(&self, pos: &Position, mv: Move) -> i32 {                      
    let mut score = 0;                                                                  
                                                                                        
    // Promotions get bonus                                                             
    if mv.is_promote() {                                                                
        score += 1000;                                                                  
    }                                                                                   
                                                                                        
    // Moves to/from center get bonus                                                   
    let to_sq = mv.to();                                                                
    let from_sq = mv.from();                                                            
                                                                                        
    // Center control bonus (5th rank and center files)                                 
    if to_sq.rank() == 5 {                                                              
        score += 100;                                                                   
    }                                                                                   
    if to_sq.file() >= 3 && to_sq.file() <= 7 {                                         
        score += 50;                                                                    
    }                                                                                   
                                                                                        
    // Piece type based scoring                                                         
    match mv.piece_type() {                                                             
        Some(PieceType::Rook) | Some(PieceType::Bishop) => score += 200,                
        Some(PieceType::Gold) | Some(PieceType::Silver) => score += 150,                
        _ => {}                                                                         
    }                                                                                   
                                                                                        
    score                                                                               
}                                                                                       
                                                                                        
2. Killer movesの強化                                                                   
                                                                                        
現状: 既に実装済みだが、以下の最適化を追加                                              
                                                                                        
ファイル: /packages/rust-core/crates/engine-core/src/search/unified/core/node.rs        
                                                                                        
改善内容:                                                                               
- Killer moveの更新時に、より効果的な手を優先的に保存                                   
- History scoreも参考にして、より良いkiller moveを選択                                  
                                                                                        
3. Move orderingのデバッグ情報追加                                                      
                                                                                        
ファイル: /packages/rust-core/crates/engine-core/src/search/unified/ordering/mod.rs     
                                                                                        
追加内容:                                                                               
- デバッグビルドで手順序の統計情報を出力                                                
- TT move hit率、killer move効果などを測定                                              
                                                                                        
検証計画                                                                                
                                                                                        
1. 単体テスト:                                                                          
  - mutex失敗時の代替処理が正しく動作することを確認                                     
  - 静的スコアリングが適切な順序を生成することを確認                                    
2. 性能テスト:                                                                          
  - 問題のある局面でのノード数削減効果を測定                                            
cargo run --release --bin debug_position -- \                                           
  --sfen "l5g1l/2s1k1s2/2npp1n1p/p4p1p1/1p2P4/P1P2PPP1/1PN1S1N1P/1B1GKG3/L6RL w BPrb2p  
1" \                                                                                    
  --depth 6 --time 5000                                                                 
3. 比較テスト:                                                                          
  - 改善前後でのノード数比較                                                            
  - 探索時間の改善率測定                                                                
                                                                                        
期待される効果                                                                          
                                                                                        
- Mutex取得失敗時でも適切な手順序を維持                                                 
- 探索ノード数を30-50%削減                                                              
- 深さ5-6での探索時間を大幅改善                                                         
- より安定した探索性能                                                                  
                                                                                        
実装順序                                                                                
                                                                                        
1. 静的評価ベースのスコアリング関数を実装                                               
2. score_move関数を修正してmutex失敗時の代替処理を追加                                  
3. テストを実行して動作確認                                                             
4. 性能測定とチューニング                                                               
