### PR TITLE
秒読み機能の時間管理修正2

### DIFF
--- a/packages/rust-core/crates/engine-cli/src/main.rs
+++ b/packages/rust-core/crates/engine-cli/src/main.rs
@@ -1093,12 +1093,12 @@ fn handle_command(command: UsiCommand, ctx: &mut CommandContext) -> Result<()> {
                 };
 
                 // Use longer timeouts for byoyomi mode
-                let stage1_timeout = if overhead_ms >= engine_adapter::BYOYOMI_OVERHEAD_MS {
+                let stage1_timeout = if overhead_ms >= usi::DEFAULT_BYOYOMI_OVERHEAD_MS {
                     Duration::from_millis(500) // Byoyomi mode: wait longer for in-flight messages
                 } else {
                     Duration::from_millis(100) // Normal mode: quick wait
                 };
-                let total_timeout = if overhead_ms >= engine_adapter::BYOYOMI_OVERHEAD_MS {
+                let total_timeout = if overhead_ms >= usi::DEFAULT_BYOYOMI_OVERHEAD_MS {
                     Duration::from_millis(1000) // Byoyomi mode: up to 1 second total
                 } else {
                     Duration::from_millis(150) // Normal mode: quick fallback

--- a/packages/rust-core/crates/engine-cli/src/usi/mod.rs
+++ b/packages/rust-core/crates/engine-cli/src/usi/mod.rs
@@ -21,6 +21,20 @@ pub const OPT_USI_BYOYOMI_PERIODS: &str = "USI_ByoyomiPeriods"; // Alias for com
 pub const MAX_BYOYOMI_PERIODS: u32 = 10;
 pub const MIN_BYOYOMI_PERIODS: u32 = 1;
 
+/// Time management option names
+pub const OPT_OVERHEAD_MS: &str = "OverheadMs";
+pub const OPT_BYOYOMI_OVERHEAD_MS: &str = "ByoyomiOverheadMs";
+pub const OPT_BYOYOMI_SAFETY_MS: &str = "ByoyomiSafetyMs";
+
+/// Time management default values
+pub const DEFAULT_OVERHEAD_MS: u64 = 50;
+pub const DEFAULT_BYOYOMI_OVERHEAD_MS: u64 = 1000; // Conservative for GUI compatibility
+pub const DEFAULT_BYOYOMI_SAFETY_MS: u64 = 500;
+
+/// Time management limits
+pub const MIN_OVERHEAD_MS: u64 = 0;
+pub const MAX_OVERHEAD_MS: u64 = 5000;
+
 /// Clamp periods value to valid range with optional warning
 pub fn clamp_periods(periods: u32, warn_on_clamp: bool) -> u32 {
     let clamped = periods.clamp(MIN_BYOYOMI_PERIODS, MAX_BYOYOMI_PERIODS);


### PR DESCRIPTION
実装内容

1. USIオプション定数の追加（/src/usi/mod.rs）

以下の定数を追加しました：
- OPT_OVERHEAD_MS = "OverheadMs" - 通常時の時間管理オーバーヘッド
- OPT_BYOYOMI_OVERHEAD_MS = "ByoyomiOverheadMs" - 秒読み専用オーバーヘッド
- OPT_BYOYOMI_SAFETY_MS = "ByoyomiSafetyMs" - 秒読みハードリミット追加安全マージン

デフォルト値：
- DEFAULT_OVERHEAD_MS = 50 (通常時50ms)
- DEFAULT_BYOYOMI_OVERHEAD_MS = 1000 (秒読み時1秒、GUI互換性のため保守的)
- DEFAULT_BYOYOMI_SAFETY_MS = 500 (追加安全マージン500ms)

2. EngineAdapterの更新（/src/engine_adapter.rs）

構造体への追加フィールド：
overhead_ms: u64,           // 時間管理の一般的なオーバーヘッド
byoyomi_overhead_ms: u64,   // 秒読み専用のオーバーヘッド
byoyomi_safety_ms: u64,     // 秒読みハードリミットの追加安全マージン

主な変更点：
- コンストラクタでデフォルト値を設定
- init_options()に3つの新しいSpinオプションを追加
- set_option()で新オプションの処理を実装（適切なバリデーション付き）
- prepare_search()でハードコード値の代わりに設定可能な値を使用

3. 動的停止ハンドラタイムアウト

- last_overhead_msフィールドは既に存在し、prepare_search()で適切に更新
- get_last_overhead_ms()メソッドが利用可能で、停止ハンドラから参照可能

4. テストの追加

- test_time_management_options: 新オプションの設定と検証をテスト
- test_time_parameters_creation_with_custom_overhead:
カスタムオーバーヘッド値が異なる時間制御モードで適切に使用されることをテスト

実装の利点

1. GUI互換性: 異なるGUIで異なるオーバーヘッド値を使用可能
2. ネットワーク遅延補償: オンライン対局では遅延を考慮してオーバーヘッドを増加可能
3. ハードウェア適応: 遅いシステムではより大きな安全マージンを使用可能
4. テスト柔軟性: 異なるタイミング設定を簡単にテスト可能
