### PR TITLE
TT, PVの検証強化

### DIFF
--- a/packages/rust-core/crates/engine-core/src/search/unified/ordering/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/ordering/mod.rs
@@ -73,6 +73,10 @@ impl MoveOrdering {
     ) -> i32 {
         // TT move gets highest priority
         if Some(mv) == tt_move {
+            #[cfg(debug_assertions)]
+            {
+                eprintln!("[DEBUG] TT move {} gets highest priority", crate::usi::move_to_usi(&mv));
+            }
             return 1_000_000;
         }
 
@@ -283,7 +287,6 @@ impl MoveOrdering {
         use crate::Color;
 
         let to_sq = mv.to();
-        let _enemy_color = pos.side_to_move.flip();
 
         // Check if the destination square is near enemy pieces
         // This is a simplified heuristic - proper attack detection would require


### PR DESCRIPTION
## TTムーブ合法性検証の問題を修正

### 実施した修正内容

1. node.rs: TTムーブの合法性フィルタ追加 (line 148-165)
  - TTから取得した手が合法手リストに含まれるか確認
  - 含まれない場合は無視してNoneを返す
2. node.rs: 二重防御の軽量チェック追加 (line 189-202)
  - 通常手の送手の駒が自分のものか確認
  - 相手の駒や空マスの場合はスキップ
3. node.rs: is_pseudo_legalチェック追加 (line 241-252)
  - do_move実行前に擬似合法性を確認
4. core/mod.rs: pv_local_sanityに合法性チェック追加 (line 132-138)
  - PV検証時にもis_pseudo_legalチェックを実施


## PV検証の局面不整合問題を修正

### 実施内容

- searcher.pv_table.get_line(0) → searcher.pv_table.get_line(ply as usize)
- ルートPVではなく、現在のplyからの局所PVを検証するように変更


## TTエントリのキー一致チェックを追加

### 実施内容

1. node.rs: ABDADAの早期リターン (line 136)
- entry.matches(hash) チェックを追加
- 異なる局面のスコアを使用するリスクを排除
2. node.rs: TTムーブ取得 (line 149-151)
- .filter(|e| e.matches(hash)) でキー一致フィルタを追加
- 合法手チェックと二重の保護
3. mod.rs: TTスコア使用 (line 424)
- if tt_entry.matches(hash) で全体をラップ
- キー不一致時は「TTヒットなし」として処理