### PR TITLE
PV安定性判定の改善

### DIFF
--- a/packages/rust-core/crates/engine-core/src/search/unified/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/mod.rs
@@ -243,6 +243,8 @@ where
 
                 // Check for timeout during re-search
                 if self.context.should_stop() {
+                    // Note: final_node_type is already set based on the last search result
+                    // This ensures we use the evaluation from the interrupted search
                     break;
                 }
             }

--- a/packages/rust-core/crates/engine-core/src/search/unified/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/mod.rs
@@ -259,7 +259,7 @@ where
                 self.stats.pv = pv.clone();
 
                 // Update score history for volatility calculation
-                self.aspiration_window.update_score(score);
+                self.aspiration_window.update_score(score, best_node_type);
 
                 // Try to reconstruct PV from TT if we have TT enabled
                 if USE_TT {


### PR DESCRIPTION
実装内容

1. AspirationWindow::update_scoreメソッドの修正
  - NodeTypeパラメータを追加
  - EXACTノードのスコアのみを履歴に追加するフィルタリング実装
2. 変更したファイル
  - src/search/unified/aspiration.rs:
      - NodeTypeのインポート追加
    - update_scoreメソッドにNodeTypeパラメータを追加
    - EXACTノードのみ履歴に追加する条件分岐
  - src/search/unified/mod.rs:
      - update_scoreの呼び出しにbest_node_typeを渡すよう修正
3. テストの追加
  - test_boundary_node_type_filtering: 境界値（LOWERBOUND/UPPERBOUND）が除外されることを確認
  - test_volatility_with_only_boundary_nodes: 境界値のみの場合、volatilityが0になることを確認

結果

- PV安定性の計算がより正確になり、境界値（不確定なスコア）の影響を受けなくなりました
- すべてのテストが成功し、既存の機能への影響はありません