### PR TITLE
Fix test error

### DIFF
--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/error.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/error.rs
@@ -18,6 +18,9 @@ pub enum EngineError {
     /// Operation timed out
     Timeout,
 
+    /// Position was corrupted during search
+    PositionCorrupted,
+
     /// Other errors
     Other(anyhow::Error),
 }
@@ -28,6 +31,7 @@ impl fmt::Display for EngineError {
             EngineError::NoLegalMoves => write!(f, "No legal moves available"),
             EngineError::EngineNotAvailable(msg) => write!(f, "Engine not available: {msg}"),
             EngineError::Timeout => write!(f, "Operation timed out"),
+            EngineError::PositionCorrupted => write!(f, "Position was corrupted during search"),
             EngineError::Other(e) => write!(f, "Other error: {e}"),
         }
     }

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/mod.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/mod.rs
@@ -117,4 +117,16 @@ impl EngineAdapter {
     pub fn byoyomi_safety_ms(&self) -> u64 {
         self.byoyomi_safety_ms
     }
+
+    /// Set byoyomi safety ms for testing
+    #[cfg(test)]
+    pub fn set_byoyomi_safety_ms_for_test(&mut self, ms: u64) {
+        self.byoyomi_safety_ms = ms;
+    }
+
+    /// Set last search is byoyomi for testing
+    #[cfg(test)]
+    pub fn set_last_search_is_byoyomi(&mut self, is_byoyomi: bool) {
+        self.last_search_is_byoyomi = is_byoyomi;
+    }
 }

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
@@ -247,7 +247,14 @@ impl EngineAdapter {
         let slice = legal_moves.as_slice();
 
         // Common opening moves that are generally good
-        let common_opening_moves = ["7g7f", "2g2f", "6i7h", "5i6h", "8h7g", "2h7h"];
+        // For black (sente): pawn advances, king safety moves
+        // For white (gote): similar defensive/developing moves
+        let common_opening_moves = [
+            // Black (sente) common moves
+            "7g7f", "2g2f", "6i7h", "5i6h", "8h7g", "2h7h",
+            // White (gote) common moves
+            "3c3d", "7c7d", "6a7b", "5a6b", "2b7b", "8c8d",
+        ];
 
         let best_move = slice
             .iter()
@@ -525,8 +532,11 @@ mod tests {
         adapter.set_position(true, None, &[]).unwrap();
         let emergency_move = adapter.generate_emergency_move().unwrap();
 
-        // Should be one of the common opening moves
-        let common_moves = ["7g7f", "2g2f", "6i7h", "5i6h", "8h7g", "2h7h"];
+        // Should be one of the common opening moves (either sente or gote)
+        let common_moves = [
+            "7g7f", "2g2f", "6i7h", "5i6h", "8h7g", "2h7h", "3c3d", "7c7d", "6a7b", "5a6b", "2b7b",
+            "8c8d",
+        ];
         assert!(
             common_moves.contains(&emergency_move.as_str()),
             "Emergency move {} should be a common opening move",

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
@@ -233,8 +233,10 @@ impl EngineAdapter {
 
     /// Force reset engine state
     pub fn force_reset_state(&mut self) {
-        // Clear position
-        self.position = None;
+        // NOTE: We do NOT clear position here anymore.
+        // The position should remain valid across engine resets since it represents
+        // the game state from the GUI. Only the GUI should control position state
+        // via position commands.
 
         // Clear ponder state
         self.clear_ponder_state();
@@ -253,7 +255,7 @@ impl EngineAdapter {
             }
         }
 
-        info!("Engine state forcefully reset");
+        info!("Engine state forcefully reset (position preserved)");
     }
 
     /// Check if the last search was using byoyomi time control

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/search.rs
@@ -209,6 +209,25 @@ impl EngineAdapter {
         }
     }
 
+    /// Check if the current position has any legal moves
+    pub fn has_legal_moves(&self) -> Result<bool> {
+        let position = self.get_position().ok_or_else(|| anyhow!("Position not set"))?;
+
+        // Generate legal moves
+        let mut movegen = MoveGen::new();
+        let mut legal_moves = MoveList::new();
+        movegen.generate_all(position, &mut legal_moves);
+
+        Ok(!legal_moves.is_empty())
+    }
+
+    /// Check if the current position is in check
+    pub fn is_in_check(&self) -> Result<bool> {
+        let position = self.get_position().ok_or_else(|| anyhow!("Position not set"))?;
+
+        Ok(position.is_in_check())
+    }
+
     /// Generate an emergency move using simple heuristics
     pub fn generate_emergency_move(&self) -> Result<String, EngineError> {
         let position = self

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
@@ -149,9 +149,9 @@ impl EngineAdapter {
             || position.ply != original_ply
         {
             error!(
-                "Position was modified during search! Original: hash={:016x}, side={:?}, ply={} -> Current: hash={:016x}, side={:?}, ply={}",
+                "Position was modified during search! Original: hash={:#016x}, side={:?}, ply={} -> Current: hash={:#016x}, side={:?}, ply={}",
                 original_hash, original_side, original_ply,
-                position.hash, position.side_to_move, position.ply
+                position.zobrist_hash(), position.side_to_move, position.ply
             );
         }
 

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
@@ -75,9 +75,6 @@ impl EngineAdapter {
         limits: SearchLimits,
         info_callback: Box<dyn Fn(SearchInfo) + Send + Sync>,
     ) -> Result<ExtendedSearchResult, EngineError> {
-        info!("execute_search_static called");
-        info!("Search starting...");
-
         // Save original position state for verification
         let original_hash = position.zobrist_hash();
         let original_side = position.side_to_move;

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
@@ -153,6 +153,7 @@ impl EngineAdapter {
                 original_hash, original_side, original_ply,
                 position.zobrist_hash(), position.side_to_move, position.ply
             );
+            return Err(EngineError::PositionCorrupted);
         }
 
         // Convert to extended result

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
@@ -2,8 +2,6 @@
 //!
 //! This module contains helper functions for debugging, state management,
 //! and static search execution.
-
-use anyhow::Result;
 use engine_core::{
     engine::controller::Engine, search::limits::SearchLimits, search::SearchResult,
     shogi::Position, usi::move_to_usi,

--- a/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
+++ b/packages/rust-core/crates/engine-cli/src/engine_adapter/utils.rs
@@ -81,7 +81,7 @@ impl EngineAdapter {
         info!("Search starting...");
 
         // Save original position state for verification
-        let original_hash = position.hash;
+        let original_hash = position.zobrist_hash();
         let original_side = position.side_to_move;
         let original_ply = position.ply;
 
@@ -144,7 +144,7 @@ impl EngineAdapter {
         };
 
         // Verify position wasn't modified
-        if position.hash != original_hash
+        if position.zobrist_hash() != original_hash
             || position.side_to_move != original_side
             || position.ply != original_ply
         {

--- a/packages/rust-core/crates/engine-cli/src/lib.rs
+++ b/packages/rust-core/crates/engine-cli/src/lib.rs
@@ -6,3 +6,6 @@ pub mod search_session;
 pub mod types;
 pub mod usi;
 pub mod utils;
+
+#[cfg(test)]
+mod test_helpers;

--- a/packages/rust-core/crates/engine-cli/src/main.rs
+++ b/packages/rust-core/crates/engine-cli/src/main.rs
@@ -100,6 +100,7 @@ fn run_engine(allow_null_move: bool) -> Result<()> {
     let mut current_session: Option<SearchSession> = None; // Current search session
     let mut current_bestmove_emitter: Option<BestmoveEmitter> = None; // Current search's emitter
     let mut current_stop_flag: Option<Arc<AtomicBool>> = None; // Per-search stop flag
+    let mut last_position_cmd: Option<String> = None; // Last position command for recovery
 
     // Main event loop - process USI commands and worker messages concurrently
     loop {
@@ -136,6 +137,7 @@ fn run_engine(allow_null_move: bool) -> Result<()> {
                             current_bestmove_emitter: &mut current_bestmove_emitter,
                             current_stop_flag: &mut current_stop_flag,
                             allow_null_move,
+                            last_position_cmd: &mut last_position_cmd,
                         };
                         handle_command(cmd, &mut ctx)?;
                     }
@@ -164,6 +166,7 @@ fn run_engine(allow_null_move: bool) -> Result<()> {
                             current_bestmove_emitter: &mut current_bestmove_emitter,
                             current_stop_flag: &mut current_stop_flag,
                             allow_null_move,
+                            last_position_cmd: &mut last_position_cmd,
                         };
                         handle_worker_message(msg, &mut ctx)?;
                     }

--- a/packages/rust-core/crates/engine-cli/src/main.rs
+++ b/packages/rust-core/crates/engine-cli/src/main.rs
@@ -678,6 +678,7 @@ mod tests {
         let mut current_session: Option<SearchSession> = None;
         let mut current_bestmove_emitter = None;
         let mut current_stop_flag = None;
+        let mut last_position_cmd = None;
 
         let mut ctx = CommandContext {
             engine: &engine,
@@ -693,6 +694,7 @@ mod tests {
             current_bestmove_emitter: &mut current_bestmove_emitter,
             current_stop_flag: &mut current_stop_flag,
             allow_null_move: false,
+            last_position_cmd: &mut last_position_cmd,
         };
 
         // Note: In a full test, we would mock send_response to capture sent Info messages

--- a/packages/rust-core/crates/engine-cli/src/main.rs
+++ b/packages/rust-core/crates/engine-cli/src/main.rs
@@ -331,7 +331,7 @@ fn handle_worker_message(msg: WorkerMessage, ctx: &mut CommandContext) -> Result
 
                         // Fallback if session validation failed
                         match generate_fallback_move(ctx.engine, None, ctx.allow_null_move) {
-                            Ok(fallback_move) => {
+                            Ok((fallback_move, _used_partial)) => {
                                 let meta = build_meta(
                                     BestmoveSource::EmergencyFallback,
                                     0,         // depth
@@ -385,7 +385,7 @@ fn handle_worker_message(msg: WorkerMessage, ctx: &mut CommandContext) -> Result
 
                         // Fallback
                         match generate_fallback_move(ctx.engine, None, ctx.allow_null_move) {
-                            Ok(fallback_move) => {
+                            Ok((fallback_move, _used_partial)) => {
                                 send_response(UsiResponse::BestMove {
                                     best_move: fallback_move,
                                     ponder: None,

--- a/packages/rust-core/crates/engine-cli/src/position.rs
+++ b/packages/rust-core/crates/engine-cli/src/position.rs
@@ -56,12 +56,12 @@ impl EngineAdapter {
         if let (Some(start_hash), Some(start_side)) =
             (self.search_start_position_hash, self.search_start_side_to_move)
         {
-            if start_hash != position.hash || start_side != position.side_to_move {
+            if start_hash != position.zobrist_hash() || start_side != position.side_to_move {
                 log::warn!(
-                    "Position inconsistency detected during validation! Search start: hash={:016x}, side={:?} -> Current: hash={:016x}, side={:?}",
+                    "Position inconsistency detected during validation! Search start: hash={:#016x}, side={:?} -> Current: hash={:#016x}, side={:?}",
                     start_hash,
                     start_side,
-                    position.hash,
+                    position.zobrist_hash(),
                     position.side_to_move
                 );
             }
@@ -94,7 +94,7 @@ impl EngineAdapter {
         // Log detailed information for debugging
         log::warn!("Move '{usi_move}' is not legal in current position");
         log::warn!("Current position SFEN: {}", usi::position_to_sfen(position));
-        log::warn!("Position hash: {:016x}, ply: {}", position.hash, position.ply);
+        log::warn!("Position hash: {:#016x}, ply: {}", position.zobrist_hash(), position.ply);
         log::warn!("Side to move: {:?}", position.side_to_move);
         log::warn!("Legal moves count: {}", legal_moves.len());
 

--- a/packages/rust-core/crates/engine-cli/src/test_helpers.rs
+++ b/packages/rust-core/crates/engine-cli/src/test_helpers.rs
@@ -1,0 +1,70 @@
+//! Test helper functions for engine-cli tests
+
+#[cfg(test)]
+pub mod test_utils {
+    use crate::types::ResignReason;
+    use crate::usi::output::SearchInfo;
+    use engine_core::shogi::Position;
+
+    /// Check if ResignReason matches expected checkmate/no-legal-moves conditions
+    pub fn verify_resign_reason(
+        _position: &Position,
+        has_legal_moves: bool,
+        is_in_check: bool,
+    ) -> ResignReason {
+        if !has_legal_moves {
+            if is_in_check {
+                ResignReason::Checkmate
+            } else {
+                ResignReason::NoLegalMovesButNotInCheck
+            }
+        } else {
+            panic!("Position has legal moves, should not resign");
+        }
+    }
+
+    /// Create a test SearchInfo with minimal fields
+    pub fn make_test_search_info(depth: u8) -> SearchInfo {
+        SearchInfo {
+            depth: Some(depth as u32),
+            time: Some(0),
+            nodes: Some(0),
+            string: Some("test".to_string()),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_utils::*;
+    use crate::types::ResignReason;
+
+    #[test]
+    fn test_verify_resign_reason_checkmate() {
+        // Dummy position (not actually used in test helper)
+        let pos = engine_core::shogi::Position::startpos();
+
+        // Checkmate: no legal moves and in check
+        let reason = verify_resign_reason(&pos, false, true);
+        assert_eq!(reason, ResignReason::Checkmate);
+    }
+
+    #[test]
+    fn test_verify_resign_reason_no_legal_moves() {
+        let pos = engine_core::shogi::Position::startpos();
+
+        // No legal moves but not in check (error condition)
+        let reason = verify_resign_reason(&pos, false, false);
+        assert_eq!(reason, ResignReason::NoLegalMovesButNotInCheck);
+    }
+
+    #[test]
+    #[should_panic(expected = "Position has legal moves")]
+    fn test_verify_resign_reason_panic() {
+        let pos = engine_core::shogi::Position::startpos();
+
+        // Should panic when there are legal moves
+        verify_resign_reason(&pos, true, false);
+    }
+}

--- a/packages/rust-core/crates/engine-cli/src/types.rs
+++ b/packages/rust-core/crates/engine-cli/src/types.rs
@@ -90,3 +90,60 @@ impl fmt::Display for BestmoveSource {
         write!(f, "{s}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resign_reason_display() {
+        // Test each variant's display format
+        assert_eq!(ResignReason::NoPositionSet.to_string(), "no_position_set");
+        assert_eq!(
+            ResignReason::PositionRebuildFailed {
+                error: "test error"
+            }
+            .to_string(),
+            "position_rebuild_failed error=test error"
+        );
+        assert_eq!(
+            ResignReason::InvalidStoredPositionCmd.to_string(),
+            "invalid_stored_position_cmd"
+        );
+        assert_eq!(ResignReason::Checkmate.to_string(), "checkmate");
+        assert_eq!(
+            ResignReason::NoLegalMovesButNotInCheck.to_string(),
+            "no_legal_moves_but_not_in_check"
+        );
+        assert_eq!(
+            ResignReason::OtherError {
+                error: "custom error"
+            }
+            .to_string(),
+            "error=custom error"
+        );
+    }
+
+    #[test]
+    fn test_resign_reason_equality() {
+        assert_eq!(ResignReason::Checkmate, ResignReason::Checkmate);
+        assert_ne!(ResignReason::Checkmate, ResignReason::NoPositionSet);
+
+        // Test that same error messages are equal
+        let reason1 = ResignReason::PositionRebuildFailed { error: "same" };
+        let reason2 = ResignReason::PositionRebuildFailed { error: "same" };
+        assert_eq!(reason1, reason2);
+    }
+
+    #[test]
+    fn test_bestmove_source_display() {
+        // Test a few important variants
+        assert_eq!(BestmoveSource::EmergencyFallback.to_string(), "emergency_fallback");
+        assert_eq!(BestmoveSource::Resign.to_string(), "resign");
+        assert_eq!(BestmoveSource::SessionOnStop.to_string(), "session_on_stop");
+        assert_eq!(
+            BestmoveSource::SessionInSearchFinished.to_string(),
+            "session_in_search_finished"
+        );
+    }
+}

--- a/packages/rust-core/crates/engine-cli/src/types.rs
+++ b/packages/rust-core/crates/engine-cli/src/types.rs
@@ -5,6 +5,39 @@
 
 use std::fmt;
 
+/// Reason for resignation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResignReason {
+    /// Position not set
+    NoPositionSet,
+    /// Position rebuild failed
+    PositionRebuildFailed { error: &'static str },
+    /// Invalid stored position command
+    InvalidStoredPositionCmd,
+    /// Checkmate (no legal moves and in check)
+    Checkmate,
+    /// No legal moves but not in check (likely error)
+    NoLegalMovesButNotInCheck,
+    /// Other error
+    OtherError { error: &'static str },
+}
+
+impl fmt::Display for ResignReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoPositionSet => write!(f, "no_position_set"),
+            Self::PositionRebuildFailed { error } => {
+                write!(f, "position_rebuild_failed error={error}")
+            }
+            Self::InvalidStoredPositionCmd => write!(f, "invalid_stored_position_cmd"),
+            Self::Checkmate => write!(f, "checkmate"),
+            Self::NoLegalMovesButNotInCheck => write!(f, "no_legal_moves_but_not_in_check"),
+            Self::OtherError { error } => write!(f, "error={error}"),
+        }
+    }
+}
+
 /// Source of bestmove emission
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]

--- a/packages/rust-core/crates/engine-cli/src/worker.rs
+++ b/packages/rust-core/crates/engine-cli/src/worker.rs
@@ -283,7 +283,8 @@ pub fn search_worker(
                         // Try to generate emergency move before resigning (only if not pondering)
                         if !params.ponder {
                             // Get position hash for session
-                            let position_hash = adapter.get_position().map(|p| p.hash).unwrap_or(0);
+                            let position_hash =
+                                adapter.get_position().map(|p| p.zobrist_hash()).unwrap_or(0);
 
                             match adapter.generate_emergency_move() {
                                 Ok(emergency_move) => {
@@ -489,7 +490,7 @@ pub fn search_worker(
     drop(ponder_hit_flag);
 
     // Create search session
-    let mut session = SearchSession::new(search_id, position.hash);
+    let mut session = SearchSession::new(search_id, position.zobrist_hash());
 
     // Wrap session in Arc<Mutex<>> for shared access in callback
     let session_arc = Arc::new(Mutex::new(session.clone()));

--- a/packages/rust-core/crates/engine-cli/src/worker.rs
+++ b/packages/rust-core/crates/engine-cli/src/worker.rs
@@ -166,9 +166,7 @@ pub fn lock_or_recover_adapter(mutex: &Mutex<EngineAdapter>) -> MutexGuard<'_, E
             guard.force_reset_state();
 
             // Try to notify GUI about the reset
-            let _ = send_info_string(
-                "Engine state reset due to error recovery. Please send 'isready' to reinitialize.",
-            );
+            let _ = send_info_string("Engine state reset due to error recovery.");
 
             guard
         }

--- a/packages/rust-core/crates/engine-cli/src/worker.rs
+++ b/packages/rust-core/crates/engine-cli/src/worker.rs
@@ -743,7 +743,7 @@ pub fn search_worker(
                             // Create emergency session
                             let emergency_session = create_emergency_session(
                                 search_id,
-                                position.hash,
+                                position.zobrist_hash(),
                                 emergency_move,
                                 false,
                             );
@@ -776,7 +776,7 @@ pub fn search_worker(
                             // Only resign if no legal moves
                             let resign_session = create_emergency_session(
                                 search_id,
-                                position.hash,
+                                position.zobrist_hash(),
                                 "resign".to_string(),
                                 true,
                             );
@@ -838,7 +838,7 @@ pub fn search_worker(
                             // Create emergency session
                             let emergency_session = create_emergency_session(
                                 search_id,
-                                position.hash,
+                                position.zobrist_hash(),
                                 emergency_move,
                                 false,
                             );
@@ -871,7 +871,7 @@ pub fn search_worker(
                             // Only resign if no legal moves
                             let resign_session = create_emergency_session(
                                 search_id,
-                                position.hash,
+                                position.zobrist_hash(),
                                 "resign".to_string(),
                                 true,
                             );


### PR DESCRIPTION
● 実装した修正内容のまとめ

  1. 問題の原因

  - force_reset_stateが呼ばれた際にpositionがクリアされていた
  - しかし、何らかの理由でpositionが失われた場合の対策が不十分だった

  2. 実装した修正

  A. Position コマンドの保存と復元機能

  - CommandContextにlast_position_cmdフィールドを追加
  - positionコマンド受信時に、完全なコマンド文字列を保存
  - goコマンド時にpositionが設定されていない場合、保存したコマンドから自動復元

  B. Go コマンドのプリフライトチェック強化

  1. positionが設定されているかチェック
  2. 設定されていない場合は、保存したlast_position_cmdから復元を試みる
  3. 復元後、合法手生成テストを実行してサニティチェック
  4. すべての段階で詳細なResignReasonをログ出力

  C. 探索前のresign禁止ポリシー

  - resignする前に必ず理由をログ出力（ResignReason）
  - 以下の場合のみresignを許可：
    - position復元失敗
    - 合法手が本当に存在しない（チェックメイト）
  - ワーカースレッド起動前の即座のresignを防止

  D. デバッグログの強化

  - positionコマンド完了時：SFEN、Zobristハッシュ、手番、手数をログ出力
  - goコマンド受信時：復元試行の詳細をログ出力
  - resign時：必ず理由（ResignReason）を明示

  3. 期待される効果

  - エンジン内部状態が一時的に不整合になっても、自動復元により対局継続可能
  - 不当なresignの防止
  - 問題発生時の原因特定が容易に

  4. 追加の推奨事項

  将来的には以下の対策も検討することをお勧めします：
  - 増分適用の実装時は、分岐検出とフル再構築へのフォールバック機能を必須とする
  - PVテーブルの所有権管理の見直し（PV owner mismatchesの警告への対処）


● 改修作業サマリ

  背景

  将棋エンジンが勝てる局面で早期にリザイン（投了）してしまうバグの修正作業を行いました。このバグ
  は、エンジンの状態リセット時に局面情報が失われ、次の探索で「局面が設定されていない」と判断して
  投了してしまうことが原因でした。

  実施した改修内容

  Phase 1: 緊急対応（すべて完了）

  1. finalize_search保証の実装
    - emit_and_finalizeヘルパー関数を追加
    - BestmoveEmitter::emit()でエラーが発生しても必ずfinalize_searchが呼ばれるように修正
    - 6箇所のemit呼び出しをすべて修正
  2. emergency moveの後手対応
    - 定番手配列に後手の一般的な初手を追加（"3c3d", "7c7d", "6a7b", "5a6b", "2b7b", "8c8d"）
    - 先手・後手どちらでも適切な緊急手が選択できるように改善
  3. ログレベルの整理
    - 過剰なinfo!ログをdebug!に変更
    - ユーザー影響のある重要な情報のみinfo!レベルに維持
    - ノイズを減らして運用時の可読性を向上

  Phase 2: 優先度高（一部完了）

  1. BestmoveMeta生成の重複排除（完了）
    - build_metaヘルパー関数を作成
    - 各所に散在していたBestmoveMeta構築ロジックを統一
    - コードの保守性とDRY原則の向上

  未着手（優先度：中）

  1. PositionState構造体の導入
    - 局面情報の二重保存による堅牢性向上
  2. ResignReasonの拡張
    - より詳細な診断情報の提供
  3. SearchSession内での継続的position検証
    - 探索中の局面一貫性チェック
  4. テストの後始末
    - リソースリークの防止

  改修の成果

  - エラー発生時でも確実にリソースがクリーンアップされるように
  - 先手・後手どちらでも適切な緊急手が生成できるように
  - ログの可読性が向上し、デバッグが容易に
  - コードの重複が削減され、保守性が向上
