### PR TITLE
Streaming optimization

### DIFF
--- a/.github/workflows/tools-bench.yml
+++ b/.github/workflows/tools-bench.yml
@@ -34,8 +34,6 @@ jobs:
         working-directory: packages/rust-core
         run: |
           cargo build -p tools --features zstd --release
-          cargo build -p tools --bin parse_bench_metrics --release
-          cargo build -p tools --bin compare_bench_metrics --release
       - name: Generate mini JSONL
         run: |
           python3 - <<'PY'
@@ -69,8 +67,6 @@ jobs:
         run: |
           cd base/packages/rust-core
           cargo build -p tools --features zstd --release
-          cargo build -p tools --bin parse_bench_metrics --release
-          cargo build -p tools --bin compare_bench_metrics --release
       - name: Bench base (gzip, chunked)
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/tools-bench.yml
+++ b/.github/workflows/tools-bench.yml
@@ -1,0 +1,98 @@
+name: Tools Bench
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/rust-core/crates/tools/**'
+      - '.github/workflows/tools-bench.yml'
+  pull_request:
+    paths:
+      - 'packages/rust-core/crates/tools/**'
+      - '.github/workflows/tools-bench.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -C link-arg=-fuse-ld=mold
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mold linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold clang
+          mold --version || true
+          clang --version || true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "packages/rust-core -> target"
+      - name: Build tools (with zstd)
+        working-directory: packages/rust-core
+        run: |
+          cargo build -p tools --features zstd --release
+          cargo build -p tools --bin parse_bench_metrics --release
+          cargo build -p tools --bin compare_bench_metrics --release
+      - name: Generate mini JSONL
+        run: |
+          python3 - <<'PY'
+          import json
+          sfen_b="lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+          sfen_w="lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+          with open('/tmp/in.jsonl','w') as f:
+            for i in range(2000):
+              d={"sfen": sfen_b if i%2==0 else sfen_w, "eval": (i%5)*50, "depth": 12, "seldepth": 16, "bound1":"Exact","bound2":"Exact","best2_gap_cp":30}
+              f.write(json.dumps(d)+'\n')
+          PY
+          gzip -c /tmp/in.jsonl > /tmp/in.jsonl.gz
+          zstd -q -f -3 /tmp/in.jsonl -o /tmp/in.jsonl.zst
+      - name: Bench (gzip, chunked)
+        working-directory: packages/rust-core
+        run: |
+          /usr/bin/time -v target/release/build_feature_cache \
+            -i /tmp/in.jsonl.gz -o /tmp/out.cache \
+            --compress --compressor gz --chunk-size 8192 --io-buf-mb 8 --metrics-interval 5000 --report-rss \
+            2>&1 | tee /tmp/bench.log
+      - name: Parse metrics (head)
+        run: packages/rust-core/target/release/parse_bench_metrics /tmp/bench.log > /tmp/head.json
+      - name: Checkout base
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      - name: Build tools at base (with zstd)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          cd base/packages/rust-core
+          cargo build -p tools --features zstd --release
+          cargo build -p tools --bin parse_bench_metrics --release
+          cargo build -p tools --bin compare_bench_metrics --release
+      - name: Bench base (gzip, chunked)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          /usr/bin/time -v base/packages/rust-core/target/release/build_feature_cache \
+            -i /tmp/in.jsonl.gz -o /tmp/out_base.cache \
+            --compress --compressor gz --chunk-size 8192 --io-buf-mb 8 --metrics-interval 5000 --report-rss \
+            2>&1 | tee /tmp/bench_base.log
+      - name: Parse metrics (base)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: packages/rust-core/target/release/parse_bench_metrics /tmp/bench_base.log > /tmp/base.json
+      - name: Compare metrics (WARN only)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: packages/rust-core/target/release/compare_bench_metrics /tmp/head.json /tmp/base.json
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tools-bench
+          path: |
+            /tmp/bench.log
+            /tmp/out.cache
+            /tmp/head.json
+            /tmp/bench_base.log
+            /tmp/out_base.cache
+            /tmp/base.json

--- a/.github/workflows/tools-bench.yml
+++ b/.github/workflows/tools-bench.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install mold linker
         run: |
           sudo apt-get update
-          sudo apt-get install -y mold clang
+          sudo apt-get install -y mold clang zstd
           mold --version || true
           clang --version || true
       - uses: dtolnay/rust-toolchain@stable
@@ -96,3 +96,4 @@ jobs:
             /tmp/bench_base.log
             /tmp/out_base.cache
             /tmp/base.json
+          if-no-files-found: ignore

--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -1331,6 +1331,7 @@ dependencies = [
  "rand",
  "rand_xoshiro",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/packages/rust-core/crates/tools/Cargo.toml
+++ b/packages/rust-core/crates/tools/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
 env_logger = { workspace = true }
+regex = { workspace = true }
 flate2 = "1.0"
 chrono = "0.4"
 criterion = { version = "0.6", features = ["html_reports"] }

--- a/packages/rust-core/crates/tools/README.md
+++ b/packages/rust-core/crates/tools/README.md
@@ -41,7 +41,7 @@ cargo run --release -p tools --bin build_feature_cache --features zstd -- \
   - v1 フォーマット（既定）では 2 サンプル/局面（先手視点・後手視点）に分割し、ラベルは黒基準で整合化します。
   - `--dedup-features` で特徴の重複を除去（デフォルトOFF）。統計に dedup の有無を表示。
   - 圧縮はヘッダ非圧縮＋ペイロード部のみ圧縮（gzip/zstd）。トレーナはヘッダの `payload_encoding` を自動判別して読込。
-  - 圧縮時は `chunk_size` 件ごとにメンバー/フレームを区切る（マルチメンバー gzip / 連結 zstd）。メモリピークの安定化に有効。
+  - 圧縮時は `chunk_size` 件（= サンプル単位。1局面=先手/後手の2サンプル）ごとにメンバー/フレームを区切る（マルチメンバー gzip / 連結 zstd）。メモリピークの安定化に有効。
   - 入力 JSONL は `.jsonl`/`.jsonl.gz`/`.jsonl.zst`（zstdは feature 有効時）を自動判別。
 
 3) NNUE 学習（キャッシュ入力推奨）

--- a/packages/rust-core/crates/tools/README.md
+++ b/packages/rust-core/crates/tools/README.md
@@ -26,7 +26,8 @@ cargo run --release -p tools --bin generate_nnue_training_data -- \
 ```bash
 cargo run --release -p tools --bin build_feature_cache -- \
   -i runs/out_pass1.jsonl -o runs/out_pass1.cache \
-  -l wdl --scale 600 --exclude-no-legal-move --exclude-fallback
+  -l wdl --scale 600 --exclude-no-legal-move --exclude-fallback \
+  --io-buf-mb 8 --metrics-interval 20000 --report-rss
 
 # 圧縮付き（ペイロードのみ圧縮。ヘッダは非圧縮）
 cargo run --release -p tools --bin build_feature_cache -- \
@@ -40,6 +41,8 @@ cargo run --release -p tools --bin build_feature_cache --features zstd -- \
   - v1 フォーマット（既定）では 2 サンプル/局面（先手視点・後手視点）に分割し、ラベルは黒基準で整合化します。
   - `--dedup-features` で特徴の重複を除去（デフォルトOFF）。統計に dedup の有無を表示。
   - 圧縮はヘッダ非圧縮＋ペイロード部のみ圧縮（gzip/zstd）。トレーナはヘッダの `payload_encoding` を自動判別して読込。
+  - 圧縮時は `chunk_size` 件ごとにメンバー/フレームを区切る（マルチメンバー gzip / 連結 zstd）。メモリピークの安定化に有効。
+  - 入力 JSONL は `.jsonl`/`.jsonl.gz`/`.jsonl.zst`（zstdは feature 有効時）を自動判別。
 
 3) NNUE 学習（キャッシュ入力推奨）
 ```bash

--- a/packages/rust-core/crates/tools/docs/nnue-training-data-generation.md
+++ b/packages/rust-core/crates/tools/docs/nnue-training-data-generation.md
@@ -18,6 +18,9 @@
 - **スキップ局面の保存**: タイムアウト局面を別ファイルに保存し後で再処理
 - **進捗追跡**: `.progress` で実試行数を管理（スキップ含む）
 - **並列処理**: Rayonで全CPUコアを活用
+- **構造化ログ（JSONL）**: `--structured-log <PATH|->` でバッチ/最終サマリを機械可読に記録
+- **manifest 要約（summary）**: 実行のサマリ（throughput/rates/曖昧率/深さヒスト/件数）を manifest v2 に埋め込み
+- **分割出力**: `--split <N>` / `--compress <gz|zst>` に対応（各 part manifest + 親の集約 manifest を自動出力）
 
 ### エンジン選択の指針
 
@@ -64,6 +67,25 @@ cd packages/rust-core
 - `--hybrid-ply-cutoff`: `ply <= cutoff` でWDL、それ以降CP（デフォルト: 100）
 - `--time-limit-ms`: 深度ごとの既定値を上書き
 - `--hash-mb`: TTサイズ（MB、デフォルト: 16）
+
+#### 追加オプション（抜粋）
+
+- 出力形式/分割/圧縮:
+  - `--output-format text|jsonl`（既定: text）
+  - `--split <N>`（N行ごとに `<stem>.part-0001.*` などへローテーション）
+  - `--compress gz|zst`（分割出力時に圧縮。`zst`は `--features zstd` が必要）
+  - `--structured-log <PATH|->` 構造化ログ（JSONL）をファイル or STDOUT（`-`）へ出力
+- 予算/下限/並列:
+  - `--nodes <N>`（ノード固定。指定時は `--time-limit-ms` 無効）
+  - `--min-depth <d>`（位置引数 `depth` と `max` を取る）
+  - `--jobs <n>`（外側並列。各エンジンは単スレッド）
+- キャリブレーション（ノード自動化）:
+  - `--nodes-autocalibrate-ms <ms>` / `--calibrate-sample <k>`
+  - `--no-recalib` / `--force-recalib`
+- 曖昧/K=3:
+  - `--amb-gap2-threshold <cp>`（既定 25）
+  - `--amb-allow-inexact`（既定はExactのみを曖昧条件に採用）
+  - `--entropy-mate-mode exclude|saturate`（K=3エントロピーの詰みスコア扱い）
 
 ### 段階的なデータ生成（推奨）
 
@@ -139,6 +161,34 @@ sfen l1s1k2nl/1r1g2g2/2npppsp1/ppp3p1p/9/P1P2P1PP/1PSPPSP2/2G4R1/LN2KG1NL w Bb 2
 50
 ```
 
+### 構造化ログ（JSONL, 任意）
+
+`--structured-log <PATH|->` を指定すると、バッチ終了ごとに `kind="batch"`、終了時に `kind="final"` の JSON が1行ずつ出力されます。
+
+例（抜粋）:
+```
+{"kind":"batch","batch_index":3,"size":4,"success":3,
+ "elapsed_sec":1.21,"sps":3.30,"attempted_sps":3.30,
+ "processed_total":12,"attempted_total":16,"percent":40.0}
+{"kind":"final","summary":{ ... manifest summary と同内容 ... }}
+```
+
+### Manifest と Summary（v2）
+
+非分割時は `<stem>.manifest.json`、分割時は各 part に `*.part-0001.manifest.json` を出力し、さらに親 `<stem>.manifest.json` を集約版として出力します。
+
+- 親 manifest には `summary` を含みます（part manifest は省略）。
+- `summary` には以下が含まれます（要約）:
+  - `elapsed_sec`: 実行時間（秒）
+  - `throughput { attempted_sps, success_sps }`
+  - `rates { timeout, top1_exact, both_exact }`
+  - `ambiguous { threshold_cp, require_exact, count, denom, rate }`
+  - `depth { histogram, min, max, p50, p90 }`
+  - `counts { attempted, success, skipped_timeout, errors{parse, nonexact_top1, empty_or_missing_pv} }`
+- 分割出力時:
+  - 各 part manifest の `count` は当該 part の成功件数（`count_in_part` と同値）
+  - 親 manifest の `count` は全体の成功件数、`part_count` に総パート数を含む
+
 ## パフォーマンス
 
 ### 探索深度別の時間制限
@@ -154,6 +204,12 @@ sfen l1s1k2nl/1r1g2g2/2npppsp1/ppp3p1p/9/P1P2P1PP/1PSPPSP2/2G4R1/LN2KG1NL w Bb 2
 - 深度2: 約50-100局面/秒
 - 深度3: 約20-50局面/秒
 - 深度4: 約10-20局面/秒
+
+ヒント:
+- 本番・検証いずれも **`--release` ビルドを推奨**（デバッグは 5〜20× 遅い）
+- **`material` + 深度1** は PV/Exact が得られないことが多く、フィルタ（top1=Exact）により**全ドロップ**になりがちです。
+  - 初回の動作確認・本番生成には **`--engine enhanced` + `--min-depth 2`** を推奨
+  - 時間/ノード予算を適度に増やす（例: `--time-limit-ms 200` か `--nodes 150000`）
 
 ## トラブルシューティング
 
@@ -176,6 +232,11 @@ sfen l1s1k2nl/1r1g2g2/2npppsp1/ppp3p1p/9/P1P2P1PP/1PSPPSP2/2G4R1/LN2KG1NL w Bb 2
 # スレッド数を4に制限
 RAYON_NUM_THREADS=4 ./target/release/generate_nnue_training_data input.sfen output.txt
 ```
+
+4. **成功行が0件のとき**
+
+- `errors.empty_or_missing_pv` が多い: **PVが出ていない**可能性。`--engine enhanced`、`--min-depth 2+`、時間/ノード増。
+- `errors.nonexact_top1` が多い: **Exactに届いていない**可能性。時間/ノード増、`--teacher-profile safe` も検討。
 
 ### レジューム時の注意点
 

--- a/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
+++ b/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
@@ -274,7 +274,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn cp_to_wdl(cp: i32, scale: f32) -> f32 {
-    1.0 / (1.0 + (-cp as f32 / scale).exp())
+    let x = (cp as f32 / scale).clamp(-20.0, 20.0);
+    1.0 / (1.0 + (-x).exp())
 }
 
 fn write_samples_stream<R: BufRead, W: Write>(

--- a/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
+++ b/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
@@ -581,7 +581,7 @@ fn write_cache_file_streaming(
         #[cfg(feature = "zstd")]
         PayloadEncodingKind::Zstd => {
             let level = config.compress_level.unwrap_or(0);
-            let mut sink = BufWriter::with_capacity(config.io_buf_bytes, file);
+            let sink = BufWriter::with_capacity(config.io_buf_bytes, file);
 
             let mut r = reader; // BufRead
             let mut line_buf: Vec<u8> = Vec::with_capacity(64 * 1024);
@@ -636,7 +636,7 @@ fn write_cache_file_streaming(
                 }
                 num_samples += written as u64;
                 total_features += feats as u64;
-                in_chunk += (written as u32);
+                in_chunk += written as u32;
                 if in_chunk >= config.chunk_size {
                     // close current frame and start a new one
                     let finished_sink = enc.finish()?; // returns BufWriter<File>

--- a/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
+++ b/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
@@ -23,12 +23,8 @@ use tools::nnfc_v1::{
 
 // Cache header constants are provided by nnfc_v1
 
-// Flags (shared across versions)
-const FLAG_BOTH_EXACT: u8 = 1 << 0;
-const FLAG_MATE_BOUNDARY: u8 = 1 << 1;
-// Additional flags (reader may ignore unknown bits):
-const FLAG_PERSPECTIVE_BLACK: u8 = 1 << 2;
-const FLAG_STM_BLACK: u8 = 1 << 3;
+// Use shared flag definitions
+use tools::nnfc_v1::flags as fc_flags;
 
 #[inline]
 fn is_exact_opt(s: &Option<String>) -> bool {
@@ -376,11 +372,11 @@ fn write_samples_stream<R: BufRead, W: Write>(
         // both_exact (robust to case/whitespace)
         let both_exact = is_exact_opt(&pos_data.bound1) && is_exact_opt(&pos_data.bound2);
         if both_exact {
-            base_flags |= FLAG_BOTH_EXACT;
+            base_flags |= fc_flags::BOTH_EXACT;
         }
         // mate boundary
         if pos_data.mate_boundary.unwrap_or(false) {
-            base_flags |= FLAG_MATE_BOUNDARY;
+            base_flags |= fc_flags::MATE_BOUNDARY;
         }
 
         // Side to move (for label orientation and flags)
@@ -423,10 +419,10 @@ fn write_samples_stream<R: BufRead, W: Write>(
 
             let mut flags = base_flags;
             if perspective == Color::Black {
-                flags |= FLAG_PERSPECTIVE_BLACK;
+                flags |= fc_flags::PERSPECTIVE_BLACK;
             }
             if stm == Color::Black {
-                flags |= FLAG_STM_BLACK;
+                flags |= fc_flags::STM_BLACK;
             }
 
             // Write sample (no padding; meta layout fixed)
@@ -664,10 +660,10 @@ fn write_cache_file_streaming(
         #[cfg(feature = "zstd")]
         PayloadEncodingKind::Zstd => PayloadEncoding::Zstd,
     };
-    let sample_flags_mask: u32 = (FLAG_BOTH_EXACT as u32)
-        | (FLAG_MATE_BOUNDARY as u32)
-        | (FLAG_PERSPECTIVE_BLACK as u32)
-        | (FLAG_STM_BLACK as u32);
+    let sample_flags_mask: u32 = (fc_flags::BOTH_EXACT as u32)
+        | (fc_flags::MATE_BOUNDARY as u32)
+        | (fc_flags::PERSPECTIVE_BLACK as u32)
+        | (fc_flags::STM_BLACK as u32);
     let header = HeaderV1 {
         version: CACHE_VERSION_V1,
         feature_set_id: FEATURE_SET_ID_HALF,
@@ -719,10 +715,10 @@ fn write_position_samples<W: Write>(
     let mut base_flags = 0u8;
     let both_exact = is_exact_opt(&pos_data.bound1) && is_exact_opt(&pos_data.bound2);
     if both_exact {
-        base_flags |= FLAG_BOTH_EXACT;
+        base_flags |= fc_flags::BOTH_EXACT;
     }
     if pos_data.mate_boundary.unwrap_or(false) {
-        base_flags |= FLAG_MATE_BOUNDARY;
+        base_flags |= fc_flags::MATE_BOUNDARY;
     }
     let stm = position.side_to_move;
     let cp_black = if stm == Color::Black { cp } else { -cp };
@@ -762,10 +758,10 @@ fn write_position_samples<W: Write>(
         };
         let mut flags = base_flags;
         if perspective == Color::Black {
-            flags |= FLAG_PERSPECTIVE_BLACK;
+            flags |= fc_flags::PERSPECTIVE_BLACK;
         }
         if stm == Color::Black {
-            flags |= FLAG_STM_BLACK;
+            flags |= fc_flags::STM_BLACK;
         }
 
         let n_features = features_buf.len() as u32;

--- a/packages/rust-core/crates/tools/src/bin/compare_bench_metrics.rs
+++ b/packages/rust-core/crates/tools/src/bin/compare_bench_metrics.rs
@@ -1,0 +1,199 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde_json::{json, Value};
+use std::fs;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Compare benchmark metrics between head and base"
+)]
+struct Args {
+    /// Path to the head metrics JSON file
+    head_json: String,
+
+    /// Path to the base metrics JSON file
+    base_json: String,
+}
+
+fn calculate_percent_delta(new_val: f64, base_val: f64) -> Option<f64> {
+    if base_val == 0.0 {
+        None
+    } else {
+        Some(100.0 * (new_val - base_val) / base_val)
+    }
+}
+
+fn compare_metrics(head: &Value, base: &Value) -> (Vec<String>, Value) {
+    let mut warnings = Vec::new();
+
+    // Thresholds for warnings
+    const SAMPLES_PER_SEC_NEG_THRESHOLD: f64 = -15.0; // head slower than base by >15%
+    const HWM_POS_THRESHOLD: f64 = 20.0; // head HWM higher than base by >20%
+    const TIME_POS_THRESHOLD: f64 = 20.0; // head seconds higher than base by >20%
+
+    // Compare samples_per_sec (lower is bad)
+    if let (Some(head_sps), Some(base_sps)) = (
+        head.get("samples_per_sec").and_then(Value::as_f64),
+        base.get("samples_per_sec").and_then(Value::as_f64),
+    ) {
+        if let Some(delta) = calculate_percent_delta(head_sps, base_sps) {
+            if delta < SAMPLES_PER_SEC_NEG_THRESHOLD {
+                warnings.push(format!(
+                    "samples_per_sec regression: {:.1}% (head={}, base={})",
+                    delta, head_sps, base_sps
+                ));
+            }
+        }
+    }
+
+    // Compare hwm_mb_last (higher is bad)
+    if let (Some(head_hwm), Some(base_hwm)) = (
+        head.get("hwm_mb_last").and_then(Value::as_u64),
+        base.get("hwm_mb_last").and_then(Value::as_u64),
+    ) {
+        if let Some(delta) = calculate_percent_delta(head_hwm as f64, base_hwm as f64) {
+            if delta > HWM_POS_THRESHOLD {
+                warnings.push(format!(
+                    "peak RSS increase: +{:.1}% (head={}MB, base={}MB)",
+                    delta, head_hwm, base_hwm
+                ));
+            }
+        }
+    }
+
+    // Compare seconds (higher is bad)
+    if let (Some(head_seconds), Some(base_seconds)) = (
+        head.get("seconds").and_then(Value::as_f64),
+        base.get("seconds").and_then(Value::as_f64),
+    ) {
+        if let Some(delta) = calculate_percent_delta(head_seconds, base_seconds) {
+            if delta > TIME_POS_THRESHOLD {
+                warnings.push(format!(
+                    "elapsed time increase: +{:.1}% (head={:.3}s, base={:.3}s)",
+                    delta, head_seconds, base_seconds
+                ));
+            }
+        }
+    }
+
+    let result = json!({
+        "head": head,
+        "base": base,
+        "warns": warnings
+    });
+
+    (warnings, result)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Read JSON files
+    let head_content = fs::read_to_string(&args.head_json)
+        .with_context(|| format!("Failed to read head file: {}", args.head_json))?;
+    let base_content = fs::read_to_string(&args.base_json)
+        .with_context(|| format!("Failed to read base file: {}", args.base_json))?;
+
+    let head: Value =
+        serde_json::from_str(&head_content).with_context(|| "Failed to parse head JSON")?;
+    let base: Value =
+        serde_json::from_str(&base_content).with_context(|| "Failed to parse base JSON")?;
+
+    let (warnings, result) = compare_metrics(&head, &base);
+
+    // Output JSON result
+    println!("{}", serde_json::to_string(&result)?);
+
+    // Output warnings if any
+    if !warnings.is_empty() {
+        println!("WARN: performance regressions detected:");
+        for warning in &warnings {
+            println!("- {}", warning);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_no_regression() {
+        let head = json!({
+            "samples_per_sec": 100.0,
+            "hwm_mb_last": 500,
+            "seconds": 10.0
+        });
+        let base = json!({
+            "samples_per_sec": 95.0,
+            "hwm_mb_last": 490,
+            "seconds": 10.5
+        });
+
+        let (warnings, _) = compare_metrics(&head, &base);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_samples_per_sec_regression() {
+        let head = json!({
+            "samples_per_sec": 80.0
+        });
+        let base = json!({
+            "samples_per_sec": 100.0
+        });
+
+        let (warnings, _) = compare_metrics(&head, &base);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("samples_per_sec regression"));
+        assert!(warnings[0].contains("-20.0%"));
+    }
+
+    #[test]
+    fn test_hwm_increase() {
+        let head = json!({
+            "hwm_mb_last": 625
+        });
+        let base = json!({
+            "hwm_mb_last": 500
+        });
+
+        let (warnings, _) = compare_metrics(&head, &base);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("peak RSS increase"));
+        assert!(warnings[0].contains("+25.0%"));
+    }
+
+    #[test]
+    fn test_time_increase() {
+        let head = json!({
+            "seconds": 13.0
+        });
+        let base = json!({
+            "seconds": 10.0
+        });
+
+        let (warnings, _) = compare_metrics(&head, &base);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("elapsed time increase"));
+        assert!(warnings[0].contains("+30.0%"));
+    }
+
+    #[test]
+    fn test_division_by_zero() {
+        let head = json!({
+            "samples_per_sec": 100.0
+        });
+        let base = json!({
+            "samples_per_sec": 0.0
+        });
+
+        let (warnings, _) = compare_metrics(&head, &base);
+        assert!(warnings.is_empty()); // Should not crash, just skip comparison
+    }
+}

--- a/packages/rust-core/crates/tools/src/bin/parse_bench_metrics.rs
+++ b/packages/rust-core/crates/tools/src/bin/parse_bench_metrics.rs
@@ -1,0 +1,131 @@
+use anyhow::Result;
+use clap::Parser;
+use regex::Regex;
+use serde_json::json;
+use std::fs;
+use std::io::{self, Read};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Parse benchmark metrics from log file")]
+struct Args {
+    /// Path to the benchmark log file (use "-" for stdin)
+    log_file: String,
+}
+
+fn parse_log_content(content: &str) -> serde_json::Value {
+    let mut result = json!({});
+
+    // Pattern: "Processed {samples} samples in {seconds}s"
+    let processed_re = Regex::new(r"Processed\s+(\d+)\s+samples\s+in\s+([0-9.]+)s").unwrap();
+    if let Some(caps) = processed_re.captures(content) {
+        let samples = caps[1].parse::<u64>().unwrap_or(0);
+        let seconds = caps[2].parse::<f64>().unwrap_or(0.0);
+
+        result["samples"] = json!(samples);
+        result["seconds"] = json!(seconds);
+
+        if seconds > 0.0 {
+            let samples_per_sec = (samples as f64) / seconds;
+            result["samples_per_sec"] = json!((samples_per_sec * 100.0).round() / 100.0);
+        }
+    }
+
+    // Pattern: "Cache file size: {size} MB"
+    let cache_size_re = Regex::new(r"Cache file size:\s+(\d+) MB").unwrap();
+    if let Some(caps) = cache_size_re.captures(content) {
+        result["cache_mb"] = json!(caps[1].parse::<u64>().unwrap_or(0));
+    }
+
+    // Pattern: "RSS={value}MB"
+    let rss_re = Regex::new(r"RSS=(\d+)MB").unwrap();
+    let rss_values: Vec<u64> = rss_re
+        .captures_iter(content)
+        .filter_map(|caps| caps[1].parse::<u64>().ok())
+        .collect();
+    if let Some(&last_rss) = rss_values.last() {
+        result["rss_mb_last"] = json!(last_rss);
+    }
+
+    // Pattern: "HWM={value}MB"
+    let hwm_re = Regex::new(r"HWM=(\d+)MB").unwrap();
+    let hwm_values: Vec<u64> = hwm_re
+        .captures_iter(content)
+        .filter_map(|caps| caps[1].parse::<u64>().ok())
+        .collect();
+    if let Some(&last_hwm) = hwm_values.last() {
+        result["hwm_mb_last"] = json!(last_hwm);
+    }
+
+    result
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let content = if args.log_file == "-" {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        buffer
+    } else {
+        fs::read_to_string(&args.log_file)?
+    };
+
+    let result = parse_log_content(&content);
+    println!("{}", serde_json::to_string(&result)?);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_complete_log() {
+        let log_content = r#"
+Starting processing...
+Processed 2000 samples in 15.25s
+Cache file size: 128 MB
+RSS=256MB
+RSS=512MB
+HWM=300MB
+HWM=450MB
+Done.
+"#;
+
+        let result = parse_log_content(log_content);
+
+        assert_eq!(result["samples"], 2000);
+        assert_eq!(result["seconds"], 15.25);
+        assert_eq!(result["samples_per_sec"], 131.15);
+        assert_eq!(result["cache_mb"], 128);
+        assert_eq!(result["rss_mb_last"], 512);
+        assert_eq!(result["hwm_mb_last"], 450);
+    }
+
+    #[test]
+    fn test_parse_partial_log() {
+        let log_content = r#"
+Processed 1000 samples in 10.0s
+RSS=256MB
+"#;
+
+        let result = parse_log_content(log_content);
+
+        assert_eq!(result["samples"], 1000);
+        assert_eq!(result["seconds"], 10.0);
+        assert_eq!(result["samples_per_sec"], 100.0);
+        assert_eq!(result["rss_mb_last"], 256);
+        assert!(result.get("cache_mb").is_none());
+        assert!(result.get("hwm_mb_last").is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_log() {
+        let log_content = "";
+        let result = parse_log_content(log_content);
+
+        assert!(result.get("samples").is_none());
+        assert!(result.get("seconds").is_none());
+    }
+}

--- a/packages/rust-core/crates/tools/src/bin/train_nnue.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_nnue.rs
@@ -51,6 +51,7 @@ use engine_core::{
 use rand::rngs::StdRng;
 use rand::{seq::SliceRandom, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
+use tools::nnfc_v1::flags as fc_flags;
 
 #[derive(Debug, Deserialize)]
 struct TrainingPosition {
@@ -581,9 +582,9 @@ impl StreamCacheLoader {
                 // weight policy
                 let mut weight = 1.0f32;
                 weight *= (gap as f32 / 50.0).min(1.0);
-                let both_exact = (flags & 1) != 0;
+                let both_exact = (flags & fc_flags::BOTH_EXACT) != 0;
                 weight *= if both_exact { 1.0 } else { 0.7 };
-                if (flags & 2) != 0 {
+                if (flags & fc_flags::MATE_BOUNDARY) != 0 {
                     weight *= 0.5;
                 }
                 if seldepth < depth.saturating_add(6) {

--- a/packages/rust-core/crates/tools/src/bin/train_nnue.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_nnue.rs
@@ -1044,7 +1044,8 @@ fn load_samples(path: &str, config: &Config) -> Result<Vec<Sample>, Box<dyn std:
 }
 
 fn cp_to_wdl(cp: i32, scale: f32) -> f32 {
-    1.0 / (1.0 + (-cp as f32 / scale).exp())
+    let x = (cp as f32 / scale).clamp(-20.0, 20.0);
+    1.0 / (1.0 + (-x).exp())
 }
 
 #[inline]
@@ -1182,11 +1183,11 @@ fn load_samples_from_cache(path: &str) -> Result<Vec<Sample>, Box<dyn std::error
         weight *= (gap as f32 / 50.0).min(1.0);
 
         // Exact bound weight
-        let both_exact = (flags & 1) != 0;
+        let both_exact = (flags & fc_flags::BOTH_EXACT) != 0;
         weight *= if both_exact { 1.0 } else { 0.7 };
 
         // Mate boundary weight
-        if (flags & 2) != 0 {
+        if (flags & fc_flags::MATE_BOUNDARY) != 0 {
             weight *= 0.5;
         }
 
@@ -1421,9 +1422,9 @@ fn train_model_stream_cache(
                     let _unknown = (flags as u32) & !flags_mask; // ignore warn in sync path
                     let mut weight = 1.0f32;
                     weight *= (gap as f32 / 50.0).min(1.0);
-                    let both_exact = (flags & 1) != 0;
+                    let both_exact = (flags & fc_flags::BOTH_EXACT) != 0;
                     weight *= if both_exact { 1.0 } else { 0.7 };
-                    if (flags & 2) != 0 {
+                    if (flags & fc_flags::MATE_BOUNDARY) != 0 {
                         weight *= 0.5;
                     }
                     if seldepth < depth.saturating_add(6) {

--- a/packages/rust-core/crates/tools/src/bin/train_nnue.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_nnue.rs
@@ -611,8 +611,8 @@ impl StreamCacheLoader {
             let inner_reader: Box<dyn Read> = match payload_encoding {
                 0 => Box::new(f),
                 1 => {
-                    use flate2::read::GzDecoder;
-                    Box::new(GzDecoder::new(f))
+                    use flate2::read::MultiGzDecoder;
+                    Box::new(MultiGzDecoder::new(f))
                 }
                 2 => {
                     #[cfg(feature = "zstd")]
@@ -1319,8 +1319,8 @@ fn open_cache_payload_reader(path: &str) -> Result<CachePayload, Box<dyn std::er
     let reader: Box<dyn Read> = match payload_encoding {
         0 => Box::new(f),
         1 => {
-            use flate2::read::GzDecoder;
-            Box::new(GzDecoder::new(f))
+            use flate2::read::MultiGzDecoder;
+            Box::new(MultiGzDecoder::new(f))
         }
         2 => {
             #[cfg(feature = "zstd")]

--- a/packages/rust-core/crates/tools/src/bin/train_nnue.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_nnue.rs
@@ -32,12 +32,15 @@
 //! speed for sparse feature sets like HalfKP.
 
 use std::fs::{create_dir_all, File};
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{sync_channel, Receiver};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Instant, SystemTime};
+use tools::nnfc_v1::{
+    open_payload_reader as open_cache_payload_reader_shared, FEATURE_SET_ID_HALF,
+};
 
 use clap::{arg, Command};
 use engine_core::{
@@ -458,186 +461,24 @@ impl StreamCacheLoader {
         let (tx, rx) = sync_channel::<BatchMsg>(self.prefetch_batches.max(1));
 
         let handle = std::thread::spawn(move || {
-            // Open cache and parse header (v1)
-            let file = match File::open(&path) {
-                Ok(f) => f,
+            // Use shared nnfc_v1 reader
+            let (reader, header) = match tools::nnfc_v1::open_payload_reader(&path) {
+                Ok(v) => v,
                 Err(e) => {
                     let _ = tx.send(BatchMsg::Err(format!("Failed to open cache {}: {}", path, e)));
                     return;
                 }
             };
-            let mut f = BufReader::new(file);
-
-            let mut magic = [0u8; 4];
-            if let Err(e) = f.read_exact(&mut magic) {
-                let _ =
-                    tx.send(BatchMsg::Err(format!("Failed to read magic from {}: {}", path, e)));
-                return;
-            }
-            if &magic != b"NNFC" {
-                let _ = tx
-                    .send(BatchMsg::Err(format!("Invalid cache file: bad magic (file {})", path)));
-                return;
-            }
-
-            let mut u32b = [0u8; 4];
-            let mut u64b = [0u8; 8];
-
-            // Version
-            if let Err(e) = f.read_exact(&mut u32b) {
-                let _ =
-                    tx.send(BatchMsg::Err(format!("Failed to read version from {}: {}", path, e)));
-                return;
-            }
-            let version = u32::from_le_bytes(u32b);
-            if version != 1 {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Unsupported cache version: {} (file {})",
-                    version, path
-                )));
-                return;
-            }
-
-            // feature_set_id
-            if let Err(e) = f.read_exact(&mut u32b) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Failed to read feature_set_id from {}: {}",
-                    path, e
-                )));
-                return;
-            }
-            let feature_set_id = u32::from_le_bytes(u32b);
-            if feature_set_id != FEATURE_SET_ID_HALF {
+            if header.feature_set_id != tools::nnfc_v1::FEATURE_SET_ID_HALF {
                 let _ = tx.send(BatchMsg::Err(format!(
                     "Unsupported feature_set_id: 0x{:08x} (file {})",
-                    feature_set_id, path
+                    header.feature_set_id, path
                 )));
                 return;
             }
-
-            if let Err(e) = f.read_exact(&mut u64b) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Failed to read num_samples from {}: {}",
-                    path, e
-                )));
-                return;
-            }
-            let num_samples = u64::from_le_bytes(u64b);
-
-            if let Err(e) = f.read_exact(&mut u32b) {
-                let _ = tx
-                    .send(BatchMsg::Err(format!("Failed to read chunk_size from {}: {}", path, e)));
-                return;
-            }
-            let _chunk_size = u32::from_le_bytes(u32b);
-
-            if let Err(e) = f.read_exact(&mut u32b) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Failed to read header_size from {}: {}",
-                    path, e
-                )));
-                return;
-            }
-            let header_size = u32::from_le_bytes(u32b);
-            if !(40..=4096).contains(&header_size) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Unreasonable header_size: {} (file {})",
-                    header_size, path
-                )));
-                return;
-            }
-
-            let mut b = [0u8; 1];
-            if let Err(e) = f.read_exact(&mut b) {
-                let _ = tx
-                    .send(BatchMsg::Err(format!("Failed to read endianness from {}: {}", path, e)));
-                return;
-            }
-            if b[0] != 0 {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Unsupported endianness (expected LE) for {}",
-                    path
-                )));
-                return;
-            }
-
-            if let Err(e) = f.read_exact(&mut b) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Failed to read payload_encoding from {}: {}",
-                    path, e
-                )));
-                return;
-            }
-            let payload_encoding = b[0];
-            // reserved16
-            let mut _r16 = [0u8; 2];
-            if let Err(e) = f.read_exact(&mut _r16) {
-                let _ = tx
-                    .send(BatchMsg::Err(format!("Failed to read reserved16 from {}: {}", path, e)));
-                return;
-            }
-            if let Err(e) = f.read_exact(&mut u64b) {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "Failed to read payload_offset from {}: {}",
-                    path, e
-                )));
-                return;
-            }
-            let payload_offset = u64::from_le_bytes(u64b);
-            // sample_flags_mask
-            if let Err(e) = f.read_exact(&mut u32b) {
-                let _ = tx
-                    .send(BatchMsg::Err(format!("Failed to read flags_mask from {}: {}", path, e)));
-                return;
-            }
-            let flags_mask = u32::from_le_bytes(u32b);
-
-            // Seek to payload
-            let header_end = 4u64 + header_size as u64;
-            if payload_offset < header_end {
-                let _ = tx.send(BatchMsg::Err(format!(
-                    "payload_offset ({}) < header_end ({}) for {}",
-                    payload_offset, header_end, path
-                )));
-                return;
-            }
-            if let Err(e) = f.seek(SeekFrom::Start(payload_offset)) {
-                let _ =
-                    tx.send(BatchMsg::Err(format!("Failed to seek to payload in {}: {}", path, e)));
-                return;
-            }
-
-            // Wrap payload reader if needed
-            let inner_reader: Box<dyn Read> = match payload_encoding {
-                0 => Box::new(f),
-                1 => {
-                    use flate2::read::MultiGzDecoder;
-                    Box::new(MultiGzDecoder::new(f))
-                }
-                2 => {
-                    #[cfg(feature = "zstd")]
-                    {
-                        Box::new(zstd::Decoder::new(f).expect("zstd decoder"))
-                    }
-                    #[cfg(not(feature = "zstd"))]
-                    {
-                        let _ = tx.send(BatchMsg::Err(format!(
-                            "zstd payload requires building with 'zstd' feature (file {})",
-                            path
-                        )));
-                        return;
-                    }
-                }
-                other => {
-                    let _ = tx.send(BatchMsg::Err(format!(
-                        "Unknown payload encoding: {} (file {})",
-                        other, path
-                    )));
-                    return;
-                }
-            };
-
-            let mut r = BufReader::new(inner_reader);
+            let num_samples = header.num_samples;
+            let flags_mask = header.flags_mask;
+            let mut r = reader; // BufReader<Box<dyn Read>>
 
             let mut loaded: u64 = 0;
             let mut batch = Vec::with_capacity(batch_size);
@@ -1019,13 +860,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize RNG with seed if provided
     let mut rng: StdRng = if let Some(seed_str) = app.get_one::<String>("seed") {
-        let seed: u64 = seed_str.parse().expect("Invalid seed value");
-        println!("Using random seed: {}", seed);
+        let seed: u64 = seed_str.parse().expect("Invalid seed value (expected u64)");
+        println!("Using random seed (u64): {}", seed);
         StdRng::seed_from_u64(seed)
     } else {
         let seed_bytes: [u8; 32] = rand::rng().random();
-        let seed_str = seed_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>();
-        println!("Generated random seed: {}", seed_str);
+        let seed_hex = seed_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+        let u64_proj = u64::from_le_bytes(seed_bytes[0..8].try_into().unwrap());
+        println!("Generated random seed (32B hex): {} | (u64 proj): {}", seed_hex, u64_proj);
         StdRng::from_seed(seed_bytes)
     };
 
@@ -1086,19 +928,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn open_jsonl_reader(path: &str) -> Result<Box<dyn BufRead>, Box<dyn std::error::Error>> {
+    const BUF_MB: usize = 4;
+    tools::io_detect::open_maybe_compressed_reader(path, BUF_MB * 1024 * 1024)
+}
+
 fn load_samples(path: &str, config: &Config) -> Result<Vec<Sample>, Box<dyn std::error::Error>> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = open_jsonl_reader(path)?;
     let mut samples = Vec::new();
     let mut skipped = 0;
+    let mut line_buf: Vec<u8> = Vec::with_capacity(64 * 1024);
 
-    for line in reader.lines() {
-        let line = line?;
-        if line.trim().is_empty() {
+    loop {
+        line_buf.clear();
+        let n = reader.read_until(b'\n', &mut line_buf)?;
+        if n == 0 {
+            break;
+        }
+        if line_buf.iter().all(|b| b.is_ascii_whitespace()) {
             continue;
         }
 
-        let pos_data: TrainingPosition = match serde_json::from_str(&line) {
+        let pos_data: TrainingPosition = match serde_json::from_slice(&line_buf) {
             Ok(data) => data,
             Err(_) => {
                 skipped += 1;
@@ -1185,7 +1036,7 @@ fn load_samples(path: &str, config: &Config) -> Result<Vec<Sample>, Box<dyn std:
     }
 
     if skipped > 0 {
-        println!("Skipped {} positions", skipped);
+        eprintln!("Skipped {} positions (invalid/filtered)", skipped);
     }
 
     Ok(samples)
@@ -1232,116 +1083,19 @@ fn calculate_weight(pos_data: &TrainingPosition, _config: &Config) -> f32 {
 
 // Type alias to keep function signatures simple
 type CachePayload = (BufReader<Box<dyn Read>>, u64, u32);
-// Feature set id for HALF (HalfKP) cache
-const FEATURE_SET_ID_HALF: u32 = 0x48414C46; // "HALF"
 
 // Common helper: open a v1 cache file and return a BufReader over the payload,
 // along with (num_samples, flags_mask). Handles raw/gzip/zstd based on header.
 fn open_cache_payload_reader(path: &str) -> Result<CachePayload, Box<dyn std::error::Error>> {
-    let mut f = File::open(path)?;
-
-    let mut magic = [0u8; 4];
-    f.read_exact(&mut magic)?;
-    if &magic != b"NNFC" {
-        return Err(format!("Invalid cache file: bad magic (file {})", path).into());
-    }
-
-    let mut u32b = [0u8; 4];
-    let mut u64b = [0u8; 8];
-
-    // version
-    f.read_exact(&mut u32b)?;
-    let version = u32::from_le_bytes(u32b);
-    if version != 1 {
-        return Err(format!(
-            "Unsupported cache version: {} (v1 required) for file {}",
-            version, path
-        )
-        .into());
-    }
-    // feature_set_id
-    f.read_exact(&mut u32b)?;
-    let feature_set_id = u32::from_le_bytes(u32b);
-    if feature_set_id != FEATURE_SET_ID_HALF {
+    let (r, header) = open_cache_payload_reader_shared(path)?;
+    if header.feature_set_id != FEATURE_SET_ID_HALF {
         return Err(format!(
             "Unsupported feature_set_id: 0x{:08x} for file {}",
-            feature_set_id, path
+            header.feature_set_id, path
         )
         .into());
     }
-    // num_samples, chunk_size, header_size
-    f.read_exact(&mut u64b)?;
-    let num_samples = u64::from_le_bytes(u64b);
-    f.read_exact(&mut u32b)?; // chunk_size (unused)
-    f.read_exact(&mut u32b)?; // header_size
-    let header_size = u32::from_le_bytes(u32b);
-    if !(40..=4096).contains(&header_size) {
-        return Err(format!("Unreasonable header_size: {} for file {}", header_size, path).into());
-    }
-    // endianness
-    let mut b = [0u8; 1];
-    f.read_exact(&mut b)?;
-    if b[0] != 0 {
-        return Err(format!(
-            "Unsupported endianness in cache header (expected LE=0) for file {}",
-            path
-        )
-        .into());
-    }
-    // payload_encoding
-    f.read_exact(&mut b)?;
-    let payload_encoding = b[0];
-    // reserved16
-    let mut _r16 = [0u8; 2];
-    f.read_exact(&mut _r16)?;
-    // payload_offset
-    f.read_exact(&mut u64b)?;
-    let payload_offset = u64::from_le_bytes(u64b);
-    let header_end = 4u64 + header_size as u64;
-    if payload_offset < header_end {
-        return Err(format!(
-            "payload_offset ({}) is smaller than header end ({}); file {} may be corrupted",
-            payload_offset, header_end, path
-        )
-        .into());
-    }
-    // flags_mask
-    f.read_exact(&mut u32b)?;
-    let flags_mask = u32::from_le_bytes(u32b);
-
-    // seek to payload
-    let current = f.stream_position()?;
-    if current < payload_offset {
-        f.seek(SeekFrom::Start(payload_offset))?;
-    }
-
-    // wrap reader
-    let reader: Box<dyn Read> = match payload_encoding {
-        0 => Box::new(f),
-        1 => {
-            use flate2::read::MultiGzDecoder;
-            Box::new(MultiGzDecoder::new(f))
-        }
-        2 => {
-            #[cfg(feature = "zstd")]
-            {
-                Box::new(zstd::Decoder::new(f)?)
-            }
-            #[cfg(not(feature = "zstd"))]
-            {
-                return Err(format!(
-                    "zstd payload requires building with 'zstd' feature (file {})",
-                    path
-                )
-                .into());
-            }
-        }
-        other => {
-            return Err(format!("Unknown payload encoding: {} for file {}", other, path).into())
-        }
-    };
-
-    Ok((BufReader::new(reader), num_samples, flags_mask))
+    Ok((r, header.num_samples, header.flags_mask))
 }
 
 fn load_samples_from_cache(path: &str) -> Result<Vec<Sample>, Box<dyn std::error::Error>> {

--- a/packages/rust-core/crates/tools/src/common/mod.rs
+++ b/packages/rust-core/crates/tools/src/common/mod.rs
@@ -1,0 +1,3 @@
+pub mod io;
+pub mod manifest;
+pub mod sfen;

--- a/packages/rust-core/crates/tools/src/io_detect.rs
+++ b/packages/rust-core/crates/tools/src/io_detect.rs
@@ -1,0 +1,57 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextCompressionKind {
+    Plain,
+    Gzip,
+    Zstd,
+}
+
+fn sniff_magic(path: &str) -> io::Result<TextCompressionKind> {
+    // Read first 4 bytes
+    let mut f = File::open(path)?;
+    let mut magic = [0u8; 4];
+    let n = f.read(&mut magic)?;
+    if n >= 2 && magic[0] == 0x1F && magic[1] == 0x8B {
+        return Ok(TextCompressionKind::Gzip);
+    }
+    if n >= 4 && magic == [0x28, 0xB5, 0x2F, 0xFD] {
+        return Ok(TextCompressionKind::Zstd);
+    }
+    Ok(TextCompressionKind::Plain)
+}
+
+pub fn open_maybe_compressed_reader(
+    path: &str,
+    buf_bytes: usize,
+) -> Result<Box<dyn BufRead>, Box<dyn std::error::Error>> {
+    // Prefer extension, fall back to magic
+    let kind = if path.ends_with(".gz") {
+        TextCompressionKind::Gzip
+    } else if path.ends_with(".zst") {
+        TextCompressionKind::Zstd
+    } else {
+        sniff_magic(path)?
+    };
+
+    let file = File::open(path)?;
+    let reader: Box<dyn Read> = match kind {
+        TextCompressionKind::Plain => Box::new(file),
+        TextCompressionKind::Gzip => {
+            use flate2::read::MultiGzDecoder;
+            Box::new(MultiGzDecoder::new(file))
+        }
+        TextCompressionKind::Zstd => {
+            #[cfg(feature = "zstd")]
+            {
+                Box::new(zstd::Decoder::new(file)?)
+            }
+            #[cfg(not(feature = "zstd"))]
+            {
+                return Err("zst input requires building 'tools' with feature 'zstd'".into());
+            }
+        }
+    };
+    Ok(Box::new(BufReader::with_capacity(buf_bytes, reader)))
+}

--- a/packages/rust-core/crates/tools/src/io_detect.rs
+++ b/packages/rust-core/crates/tools/src/io_detect.rs
@@ -55,7 +55,7 @@ pub fn open_maybe_compressed_reader(
             }
             #[cfg(not(feature = "zstd"))]
             {
-                return Err("zst input requires building 'tools' with feature 'zstd'".into());
+                return Err("input looks like zstd (magic 28 B5 2F FD), but this binary was built without 'zstd' feature".into());
             }
         }
     };

--- a/packages/rust-core/crates/tools/src/lib.rs
+++ b/packages/rust-core/crates/tools/src/lib.rs
@@ -1,6 +1,4 @@
+pub mod common;
+pub mod io_detect;
+pub mod nnfc_v1;
 pub mod stats;
-pub mod common {
-    pub mod io;
-    pub mod manifest;
-    pub mod sfen;
-}

--- a/packages/rust-core/crates/tools/src/nnfc_v1.rs
+++ b/packages/rust-core/crates/tools/src/nnfc_v1.rs
@@ -6,6 +6,14 @@ pub const CACHE_VERSION_V1: u32 = 1;
 pub const HEADER_SIZE_V1: u32 = 48;
 pub const FEATURE_SET_ID_HALF: u32 = 0x4841_4C46; // "HALF"
 
+/// Sample flag bits used in payload samples
+pub mod flags {
+    pub const BOTH_EXACT: u8 = 1 << 0;
+    pub const MATE_BOUNDARY: u8 = 1 << 1;
+    pub const PERSPECTIVE_BLACK: u8 = 1 << 2;
+    pub const STM_BLACK: u8 = 1 << 3;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PayloadEncoding {
     None = 0,
@@ -29,14 +37,21 @@ impl PayloadEncoding {
 
 #[derive(Debug, Clone)]
 pub struct HeaderV1 {
+    /// Cache version. Currently must be 1.
     pub version: u32,
+    /// Feature set identifier. HALF (HalfKP) = 0x48414C46.
     pub feature_set_id: u32,
+    /// Number of samples in payload (after perspective split).
     pub num_samples: u64,
+    /// Chunk size hint (samples per chunk).
     pub chunk_size: u32,
+    /// Header size in bytes (after magic). Minimum 40. Payload starts at 4 + header_size.
     pub header_size: u32,
+    /// Endianness for payload. 0 = little-endian.
     pub endianness: u8,
     pub payload_encoding: PayloadEncoding,
     pub payload_offset: u64,
+    /// Bitmask of known sample flag bits.
     pub flags_mask: u32,
 }
 

--- a/packages/rust-core/crates/tools/src/nnfc_v1.rs
+++ b/packages/rust-core/crates/tools/src/nnfc_v1.rs
@@ -1,0 +1,188 @@
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom, Write};
+
+pub const MAGIC: &[u8; 4] = b"NNFC";
+pub const CACHE_VERSION_V1: u32 = 1;
+pub const HEADER_SIZE_V1: u32 = 48;
+pub const FEATURE_SET_ID_HALF: u32 = 0x4841_4C46; // "HALF"
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadEncoding {
+    None = 0,
+    Gzip = 1,
+    Zstd = 2,
+}
+
+impl PayloadEncoding {
+    pub fn code(self) -> u8 {
+        self as u8
+    }
+    pub fn from_code(b: u8) -> Option<Self> {
+        match b {
+            0 => Some(PayloadEncoding::None),
+            1 => Some(PayloadEncoding::Gzip),
+            2 => Some(PayloadEncoding::Zstd),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HeaderV1 {
+    pub version: u32,
+    pub feature_set_id: u32,
+    pub num_samples: u64,
+    pub chunk_size: u32,
+    pub header_size: u32,
+    pub endianness: u8,
+    pub payload_encoding: PayloadEncoding,
+    pub payload_offset: u64,
+    pub flags_mask: u32,
+}
+
+pub fn write_header_v1_at(f: &mut File, header_pos: u64, h: &HeaderV1) -> io::Result<()> {
+    f.seek(SeekFrom::Start(header_pos))?;
+    f.write_all(&h.version.to_le_bytes())?;
+    f.write_all(&h.feature_set_id.to_le_bytes())?;
+    f.write_all(&h.num_samples.to_le_bytes())?;
+    f.write_all(&h.chunk_size.to_le_bytes())?;
+    f.write_all(&h.header_size.to_le_bytes())?;
+    f.write_all(&[h.endianness])?;
+    f.write_all(&[h.payload_encoding.code()])?;
+    f.write_all(&[0u8; 2])?; // reserved16
+    f.write_all(&h.payload_offset.to_le_bytes())?;
+    f.write_all(&h.flags_mask.to_le_bytes())?;
+    // pad to HEADER_SIZE_V1
+    let written = 40usize; // bytes after magic
+    let tail = (h.header_size as usize).saturating_sub(written);
+    if tail > 0 {
+        f.write_all(&vec![0u8; tail])?;
+    }
+    Ok(())
+}
+
+pub fn read_header_v1(f: &mut File) -> io::Result<HeaderV1> {
+    // read magic
+    let mut magic = [0u8; 4];
+    f.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid cache file: bad magic"));
+    }
+    let mut u32b = [0u8; 4];
+    let mut u64b = [0u8; 8];
+
+    // version
+    f.read_exact(&mut u32b)?;
+    let version = u32::from_le_bytes(u32b);
+    if version != CACHE_VERSION_V1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Unsupported cache version: {} (v1 required)", version),
+        ));
+    }
+
+    // feature_set_id
+    f.read_exact(&mut u32b)?;
+    let feature_set_id = u32::from_le_bytes(u32b);
+
+    // num_samples, chunk_size, header_size
+    f.read_exact(&mut u64b)?;
+    let num_samples = u64::from_le_bytes(u64b);
+    f.read_exact(&mut u32b)?;
+    let chunk_size = u32::from_le_bytes(u32b);
+    f.read_exact(&mut u32b)?;
+    let header_size = u32::from_le_bytes(u32b);
+    if !(40..=4096).contains(&header_size) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Unreasonable header_size: {}", header_size),
+        ));
+    }
+    // endianness
+    let mut b = [0u8; 1];
+    f.read_exact(&mut b)?;
+    if b[0] != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Unsupported endianness (expected LE)",
+        ));
+    }
+    let endianness = b[0];
+
+    // payload_encoding
+    f.read_exact(&mut b)?;
+    let payload_encoding = PayloadEncoding::from_code(b[0])
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Unknown payload encoding"))?;
+    // reserved16
+    let mut _r16 = [0u8; 2];
+    f.read_exact(&mut _r16)?;
+
+    // payload_offset
+    f.read_exact(&mut u64b)?;
+    let payload_offset = u64::from_le_bytes(u64b);
+    let header_end = 4u64 + header_size as u64;
+    if payload_offset < header_end {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "payload_offset ({}) is smaller than header end ({})",
+                payload_offset, header_end
+            ),
+        ));
+    }
+
+    // flags mask
+    f.read_exact(&mut u32b)?;
+    let flags_mask = u32::from_le_bytes(u32b);
+
+    Ok(HeaderV1 {
+        version,
+        feature_set_id,
+        num_samples,
+        chunk_size,
+        header_size,
+        endianness,
+        payload_encoding,
+        payload_offset,
+        flags_mask,
+    })
+}
+
+pub type PayloadReader = (BufReader<Box<dyn Read>>, HeaderV1);
+
+#[allow(clippy::type_complexity)]
+pub fn open_payload_reader(path: &str) -> Result<PayloadReader, Box<dyn std::error::Error>> {
+    let mut f = File::open(path)?;
+    let header = read_header_v1(&mut f)?;
+    if header.feature_set_id != FEATURE_SET_ID_HALF {
+        return Err(format!(
+            "Unsupported feature_set_id: 0x{:08x} for file {}",
+            header.feature_set_id, path
+        )
+        .into());
+    }
+    // seek to payload
+    let current = f.stream_position()?;
+    if current < header.payload_offset {
+        f.seek(SeekFrom::Start(header.payload_offset))?;
+    }
+    // wrap reader by encoding
+    let inner: Box<dyn Read> = match header.payload_encoding {
+        PayloadEncoding::None => Box::new(f),
+        PayloadEncoding::Gzip => {
+            use flate2::read::MultiGzDecoder;
+            Box::new(MultiGzDecoder::new(f))
+        }
+        PayloadEncoding::Zstd => {
+            #[cfg(feature = "zstd")]
+            {
+                Box::new(zstd::Decoder::new(f)?)
+            }
+            #[cfg(not(feature = "zstd"))]
+            {
+                return Err("zstd payload requires building with 'zstd' feature".into());
+            }
+        }
+    };
+    Ok((BufReader::new(inner), header))
+}

--- a/packages/rust-core/docs/README.md
+++ b/packages/rust-core/docs/README.md
@@ -29,12 +29,14 @@ Shogi AIエンジン (rust-core) の技術ドキュメント集です。
 
 ### 🛠️ Tools
 - [**Opening Book ツール**](tools/opening-book-tools-guide.md) - 定跡データ変換・検証ツール
+- [**NNUE 教師データ生成**](tools/nnue-training-data-guide.md) - generate_nnue_training_data の運用ガイド（構造化ログ/manifest v2）
 
 ### 📝 Implementation Notes
 - [**Rustプリプロセッシング計画**](implementation/rust-preprocessing-scripts-plan.md) - Rust実装の計画文書
 
 ### 📖 Reference
 - [**YaneuraOu SFEN形式**](reference/yaneuraou-sfen-format.md) - SFEN形式の仕様
+- [**Manifest v2（NNUE教師生成）**](reference/manifest_v2.md) - 親/partの責務、summaryのrunスコープ、K=3メトリクス
 
 ### 🔬 Performance Analysis
 - [**NNUE性能分析**](performance/analysis/nnue-performance.md) - NNUE評価関数の性能分析

--- a/packages/rust-core/docs/reference/manifest_v2.md
+++ b/packages/rust-core/docs/reference/manifest_v2.md
@@ -1,0 +1,62 @@
+# Manifest v2 リファレンス（NNUE 教師データ生成）
+
+本書は `generate_nnue_training_data` が出力する `manifest.json`（v2）の仕様と解釈を定義します。後方互換性を重視し、将来の拡張は Optional フィールドで行います。
+
+## スコープと基本方針
+- `manifest_version`: 文字列 `"2"`。
+- **run スコープ**: `summary` は「今回の実行（run）での増分」を要約します。
+- **累積スコープ**: manifest トップレベルの `attempted/skipped_timeout/errors` は累積（既存＋今回）。
+- **part/親の責務分離**: 分割出力時は part と親で意味が異なります（後述）。
+
+## 代表フィールド
+- `generated_at`: 生成時刻（UTC ISO8601）。
+- `engine`: 教師エンジン名（例: `material`/`enhanced`/`nnue`/`enhanced-nnue`）。
+- `teacher_engine {name,version,commit,usi_opts{hash_mb,multipv,threads,teacher_profile,min_depth}}`: プロビナンス。
+- `generation_command`: 生成に使用したコマンド（再現性のため）。
+- `seed`: 生成時の安定化用シード（引数から決定）。
+- `input {path,sha256,bytes}`: 入力の出自情報。
+- `nnue_weights_sha256/nnue_weights`: NNUE 重み（使用時）。
+- `preset/overrides`: プリセットと、CLI 明示値（time/nodes/hash/multipv/min_depth）の上書き有無。
+- `teacher_profile/multipv/budget{mode,time_ms,nodes}/min_depth/hash_mb/threads_per_engine/jobs`: 実行構成。
+- `count`: 出力件数（親では全体、part では `count_in_part`）。
+- `calibration`: 自動キャリブの結果（存在時）。
+- `attempted/skipped_timeout/errors`: 累積統計（トップレベル）。
+- `manifest_scope`: `"aggregate" | "part"`（後述）。
+- `compression`: `"gz" | "zst" | null`（part/親ともに）。
+- `summary`: run 増分の要約（親のみ信頼）。
+
+## manifest_scope と part/親の運用
+- `manifest_scope="part"`（part manifest）
+  - `count = count_in_part`。`summary=null`。
+  - `attempted/skipped_timeout/errors` などの集計値は**参照非推奨**（親を参照）。
+- `manifest_scope="aggregate"`（親 manifest）
+  - 集約 `summary` を保持。`count` は全パート合計。
+
+## summary（run 増分）
+- `elapsed_sec`: 今回 run の経過秒。
+- `throughput {attempted_sps,success_sps}`
+  - `attempted_sps = attempted_run / elapsed_sec`
+  - `success_sps = success_run / elapsed_sec`
+- `rates {timeout,top1_exact,both_exact}`（クランプ 0..1）
+  - `timeout = skipped_timeout / attempted_run`（skip_overrun のみを対象）
+  - `top1_exact = success_run / attempted_run`
+  - `both_exact = both_exact_count / lines_ge2`（採用ライン基準: K=3 差替え済みならそれ）
+- `counts {attempted,success,skipped_timeout,errors{parse,nonexact_top1,empty_or_missing_pv}}`
+  - `attempted/success` は run 増分、`skipped_timeout/errors` は今回分。
+- `ambiguous {threshold_cp,require_exact,count,denom,rate,reran?,with_entropy?}`
+  - `reran`: K=3 を実行した件数（Option）。
+  - `with_entropy`: エントロピーを算出できた件数（Option）。
+
+## JSONL（学習データ）との対応（抜粋）
+- `lines_origin = "k2" | "k3"`（採用ラインの由来）。
+- K=3 コスト内訳: `time_ms_k2/time_ms_k3/search_time_ms_total`、`nodes_k2/nodes_k3/nodes_total`。
+- `softmax_entropy_k3`: K=3 の 3手候補に基づくエントロピー。
+
+## K=3 実行ポリシー（参考）
+- 判定条件: `gap2 <= threshold_cp`。`require_exact=false` で非Exactも許容。
+- time モードでは K=3 追加予算を `min(rem, limit/4)` とし、**下限 20ms** を適用。
+
+## 後方互換性
+- スキーマ拡張は Optional フィールドで行い、既存解析は破壊しません。
+- `manifest_version=2` は据え置き。`summary` の run スコープは本ドキュメントで定義。
+

--- a/packages/rust-core/docs/tools/nnue-training-data-guide.md
+++ b/packages/rust-core/docs/tools/nnue-training-data-guide.md
@@ -1,0 +1,101 @@
+# NNUE 教師データ生成ツールガイド（generate_nnue_training_data）
+
+本書は `crates/tools` の `generate_nnue_training_data` の運用ガイドです。実行オプション、出力（JSONL/manifest v2）、分割/圧縮、構造化ログ、K=3 再探索指標をまとめます。
+
+## 概要
+- 入力: SFEN を含むテキスト（1行に1局面）。
+- 出力: 学習用 JSONL（またはテキスト）と `manifest.json`（v2）。
+- 目的: NNUE 学習に用いる教師データの安定生成・再現性確保・実行状況の可視化。
+
+## 主要オプション
+- 予算: `--time-limit-ms <ms>` もしくは `--nodes <n>` のいずれか（同時指定は nodes 優先）。
+- エンジン: `--engine {material|enhanced|nnue|enhanced-nnue}`、`--teacher-profile {safe|balanced|aggressive}`。
+- 並列: `--jobs <n>`（外側並列、エンジンスレッドは常に1）。
+- 出力形式: `--output-format {jsonl|text}`（既定: text）。
+- 分割/圧縮: `--split <N>`、`--compress {gz|zst}`（zst は `--features zstd` 必須）。
+- 構造化ログ: `--structured-log <PATH|->`（`-` 指定で STDOUT へ JSONL）
+- 再探索/K=3: `--amb-gap2-threshold <cp>`、`--amb-allow-inexact`、`--entropy-mate-mode {exclude|saturate}`、`--entropy-scale <f64>`。
+- レジューム: `[resume_from]`（位置指定）+ 自動 `*.progress` の両輪で重複防止。
+
+## 推奨コマンド例
+- Time モード（最小動作確認）
+  ```bash
+  cargo run -p tools --bin generate_nnue_training_data -- \
+    start_sfens_ply24.txt runs/out_time.jsonl 2 30 0 \
+    --engine enhanced --min-depth 2 --time-limit-ms 300 \
+    --output-format jsonl --jobs 1 --structured-log runs/logs/out_time.jsonl
+  ```
+- Nodes モード
+  ```bash
+  cargo run -p tools --bin generate_nnue_training_data -- \
+    start_sfens_ply24.txt runs/out_nodes.jsonl 2 30 0 \
+    --engine enhanced --min-depth 2 --nodes 200000 \
+    --output-format jsonl --jobs 1 --structured-log runs/logs/out_nodes.jsonl
+  ```
+- 構造化ログを STDOUT、人間可読ログを STDERR（分離）
+  ```bash
+  cargo run -p tools --bin generate_nnue_training_data -- \
+    start_sfens_ply24.txt runs/out_stdout.jsonl 2 20 0 \
+    --engine enhanced --min-depth 1 --time-limit-ms 200 \
+    --output-format jsonl --structured-log - \
+    1> runs/logs/structured.jsonl 2> runs/logs/human.log
+  ```
+- 分割/圧縮（part manifest と親 manifest）
+  ```bash
+  cargo run -p tools --bin generate_nnue_training_data -- \
+    start_sfens_ply24.txt runs/out_parts.jsonl 2 100 0 \
+    --engine enhanced --min-depth 2 --time-limit-ms 300 \
+    --output-format jsonl --split 200 --compress gz \
+    --structured-log runs/logs/out_parts.jsonl
+  ```
+
+## 構造化ログ（JSONL）
+- レコードには `version: 1` を付与。
+- `--structured-log -` のとき、JSON は STDOUT に、人間可読ログは STDERR に出力（混在しない）。
+- 代表スキーマ（抜粋）
+  - `{ "kind":"batch", "version":1, "batch_index":N, "size":M, "success":K, "elapsed_sec":... }`
+  - `{ "kind":"final", "version":1, "summary":{...} }`
+- `percent` は「成功 / 全入力」の進捗率。将来 `attempted_percent` を追加予定（任意）。
+
+## JSONL（学習データ）出力項目（抜粋）
+- 共通: `sfen`, `eval`, `label`, `lines[] {move,score_cp,bound,depth,seldepth,pv,...}`
+- K=3 関連（新規）
+  - `lines_origin`: `"k2" | "k3"`（採用ラインの由来）
+  - `softmax_entropy_k3`: K=3 の3手候補に基づくエントロピー
+  - コスト内訳: `time_ms_k2`, `time_ms_k3`, `search_time_ms_total`（合計）
+  - ノード内訳: `nodes_k2`, `nodes_k3`, `nodes_total`（合計）
+
+## manifest v2（集約情報）
+- 仕様の詳細は [reference/manifest_v2.md](../reference/manifest_v2.md) を参照。
+- 重要な運用上の前提
+  - `summary` は**今回 run（増分）**の要約。
+  - `manifest_scope`: `"part" | "aggregate"`（part は `summary=null`、親に集約 `summary`）。
+  - part では `count=count_in_part` のみ信頼。`attempted/skipped/errors` などの集計は親 manifest を参照。
+
+## summary の意味（重要）
+- `summary.throughput`
+  - `attempted_sps = attempted_run / elapsed_sec`
+  - `success_sps = success_run / elapsed_sec`
+- `summary.rates`（0..1 でクランプ）
+  - `timeout` は**スキップ対象のオーバーラン**（skip_overrun）の比率（`skipped_timeout / attempted_run`）。
+  - `top1_exact = success_run / attempted_run`
+  - `both_exact = both_exact_count / lines_ge2`
+- `summary.counts`
+  - `attempted` と `success` は run 増分。`skipped_timeout` と `errors` は今回分のカウント。
+- 補足: 累積統計が必要な場合は、manifest トップレベルの `attempted/skipped_timeout/errors` を参照。
+
+## K=3 再探索
+- 条件: `gap2 <= --amb-gap2-threshold`（既定25cp）。`--amb-allow-inexact` で非Exactも対象。
+- time モードの K=3 追加予算: `min(rem, limit/4)` に **下限20ms** を適用。
+- 追加の要約指標
+  - `summary.ambiguous.reran`: K=3 を実際に走らせた件数
+  - `summary.ambiguous.with_entropy`: エントロピーを算出できた件数（3本揃い・mate処理方針に依存）
+
+## レジューム（重複ゼロ）
+- `resume_from` と `*.progress`（試行件数）を見て自動スキップ。
+- `.progress` の方が大きければ「既に試行したが失敗/スキップ」分として差分を通知。
+- 単一ファイル追記時は改行末尾の整合性を自動補正。
+
+## 互換性
+- スキーマは後方互換: 新規項目は Optional。`manifest_version=2` のまま拡張。
+


### PR DESCRIPTION
概要

  - 対象: crates/tools/src/bin/generate_nnue_training_data.rs
  - 目的: 実運用での計測/集計の整合性とログ運用性を改善（summary の run 正規化、構造化ログの分離、K=3 メトリクス
  拡充、part/親 manifest の責務明確化）

  変更点（要約）

  - summary を「今回 run（増分）」に正規化
      - throughput: attempted_run/success_run を elapsed_sec で割る
      - rates: attempted_run を母数（timeout/top1_exact/both_exact は 0..1 にクランプ）
      - counts: attempted/success は run 増分、skipped_timeout/errors は今回分
      - 注: manifest トップレベルの attempted/skipped/errors は従来通り累積
      - 注: manifest トップレベルの attempted/skipped/errors は従来通り累積
  -  構造化ログの STDOUT 汚染防止
      - --structured-log - の場合、人間可読ログは STDERR（構造化 JSON は STDOUT）
      - 簡易マクロ human_log! 導入で既存の println! を置換
  -  both_exact/lines_ge2 の母集団を「採用ライン（K=3 で差替え済みならそれ）」で集計
  -  K=3 関連メトリクスの拡充
      - JSONL に time_ms_k2/time_ms_k3/search_time_ms_total、nodes_k2/nodes_k3/nodes_total
      - 走行カウンタ: k3_reran（K=3 実行件数）、k3_entropy（entropy 算出件数）
      - summary.ambiguous に reran/with_entropy（Option）を追加
  -  K=3 の time cap に下限を導入
      - cap = rem.min(limit/4).max(20)（ms）で安定性向上
  -  構造化ログの堅牢化
      - JSONL に version: 1 を付与（kind=batch/final）
      - ファイル出力時は親ディレクトリがなければ create_dir_all で作成
  -  part/親 manifest の責務明確化
      - manifest_scope: "part" | "aggregate" を追加
      - part manifest: count=count_in_part、summary=null（他の統計は「親のみ信頼」）
      - 親 manifest: 集約 summary を保持
  -  微修正
      - 浮動小数の丸め誤差で rate が 1.0 超しないようクランプ
      - 未使用の共有カウンタ top1_exact を削除（機能影響なし）

  スキーマ互換性

  - 追加フィールドは Option で後方互換（解析側は無視可能）
      - manifest: manifest_scope（Optional）
      - summary.ambiguous: reran/with_entropy（Optional）
      - JSONL: K=2/K=3 関連の追加キー（既存フィールド不変）
  - 仕様変更（明示）
      - manifest v2 の summary.* は「run（今回実行分）」の統計
      - 累積統計は manifest トップレベルの attempted/skipped/errors を参照

  動作確認（実行コマンド）

  - Time モード（基本）
      - cargo run -p tools --bin generate_nnue_training_data -- runs/small24_20.txt runs/out_time2.jsonl 1 10 0
  --engine enhanced --min-depth 1 --time-limit-ms 600 --multipv 2 --teacher-profile safe --output-format jsonl
  --jobs 1 --structured-log runs/logs/out_time2.jsonl
      - 確認: summary.counts.attempted=20, success=20、throughput/rates が run 増分
      - 確認: summary.counts.attempted=20, success=20、throughput/rates が run 増分
  -  構造化ログの STDOUT 分離
      - cargo run ... --structured-log - 1> runs/logs/structured.jsonl 2> runs/logs/human.log
      - 確認: structured.jsonl は純 JSONL（kind=batch/final に version:1）、人間可読ログは human.log のみ
  -  分割/圧縮（part/親 manifest）
      - cargo run ... -- runs/small24.txt runs/out_parts.jsonl 1 20 0 --engine enhanced --min-depth 1 --time-
  limit-ms 300 --multipv 2 --output-format jsonl --split 20 --compress gz --structured-log runs/logs/
  out_parts.jsonl
      - 確認:
      - `out_parts.part-XXXX.manifest.json`: `manifest_scope="part"`, `summary=null`, `count=そのpartの件数`
      - `out_parts.manifest.json`: `manifest_scope="aggregate"`, 集約 `summary` あり

  - K=3 メトリクス
      - cargo run ... -- runs/small24_15.txt runs/out_k3.jsonl 2 15 0 --engine enhanced --min-depth 2 --time-
  limit-ms 500 --multipv 2 --amb-allow-inexact --amb-gap2-threshold 200 --output-format jsonl --structured-log
  runs/logs/out_k3.jsonl
      - 確認:
      - JSONL: `time_ms_k2/time_ms_k3/search_time_ms_total`、`nodes_k2/nodes_k3/nodes_total`、
  `lines_origin="k3"` 行あり、`softmax_entropy_k3` 出力を確認
      - 親 manifest: `summary.ambiguous.reran/with_entropy` が増加

  - 再実行（resume）による run 増分確認
      - 同じ出力に再実行 → summary.counts.attempted/success=0（今回分 0）
      - 同じ出力に再実行 → summary.counts.attempted/success=0（今回分 0）
  -  Nodes モード
      - cargo run -p tools --bin generate_nnue_training_data -- runs/small24_20.txt runs/out_nodes.jsonl 1 10 0
  --engine enhanced --min-depth 1 --nodes 200000 --multipv 2 --teacher-profile safe --output-format jsonl --jobs
  1 --structured-log runs/logs/out_nodes.jsonl
      - 確認: budget.mode="nodes"、summary は run 増分
  -  Nodes 自動キャリブレーション（任意）
      - 1回目（校正）: --nodes-autocalibrate-ms 100 --calibrate-sample 10
      - 2回目（再利用）: --no-recalib（calibration 持続を確認）

  確認結果（抜粋）

  - run 増分の正規化
      - summary.counts.attempted/success が今回実行分のみ（例: 20/20、再実行後は 0/0）
      - summary.throughput/rates も run 増分で一貫（clamp 済み）
      - summary.throughput/rates も run 増分で一貫（clamp 済み）
  -  構造化ログ
      - --structured-log - で STDOUT が JSONL 専用、人間可読ログは STDERR へ分離
      - JSON レコードに version:1 を付与
  -  K=3
      - JSONL に K=2/K=3 の内訳と合計が出力
      - summary.ambiguous に reran/with_entropy（Option）を追加
  -  part/親 manifest
      - part: manifest_scope="part", summary=null, count=count_in_part
      - 親: manifest_scope="aggregate", summary あり


  - 解析側（ダッシュボード等）が manifest の summary を run 増分として扱えるようにする必要あり（集計ロジックでの
  加算 or 既存のトップレベル累積値を使用）
  - JSONL にフィールド追加（解析側が未知キー無視なら互換）

  既知の除外/今後の改善

  - 入力のストリーミング化（巨大入力でのメモリ削減）はこの PR では未対応（必要になれば後続で対応可能）