### PR TITLE
Normalize usi score

### DIFF
--- a/packages/rust-core/crates/engine-core/src/engine/controller.rs
+++ b/packages/rust-core/crates/engine-core/src/engine/controller.rs
@@ -1608,10 +1608,7 @@ mod tests {
 
         // Inspect the underlying searcher directly to verify MultiPV persistence
         {
-            let guard = engine
-                .material_searcher
-                .lock()
-                .expect("lock material searcher");
+            let guard = engine.material_searcher.lock().expect("lock material searcher");
             let s = guard.as_ref().expect("material searcher should exist");
             assert_eq!(s.multi_pv(), 3);
         }
@@ -1626,10 +1623,7 @@ mod tests {
 
         // Inspect the recreated searcher
         {
-            let guard = engine
-                .material_searcher
-                .lock()
-                .expect("lock material searcher");
+            let guard = engine.material_searcher.lock().expect("lock material searcher");
             let s = guard.as_ref().expect("material searcher should exist");
             assert_eq!(s.multi_pv(), 4);
         }
@@ -1643,10 +1637,7 @@ mod tests {
 
         // Inspect the enhanced searcher
         {
-            let guard = engine
-                .material_enhanced_searcher
-                .lock()
-                .expect("lock enhanced searcher");
+            let guard = engine.material_enhanced_searcher.lock().expect("lock enhanced searcher");
             let s = guard.as_ref().expect("enhanced searcher should exist");
             assert_eq!(s.multi_pv(), 2);
         }

--- a/packages/rust-core/crates/engine-core/src/engine/controller.rs
+++ b/packages/rust-core/crates/engine-core/src/engine/controller.rs
@@ -210,6 +210,7 @@ impl Engine {
 
     /// Get current hashfull estimate of the transposition table (permille: 0-1000)
     /// - Uses shared TT in parallel mode; otherwise queries the active searcher's TT when available
+    /// - Falls back to shared TT when the active searcher is not yet initialized
     pub fn tt_hashfull_permille(&self) -> u16 {
         if self.use_parallel {
             return self.shared_tt.hashfull();
@@ -479,7 +480,8 @@ impl Engine {
     ) -> Option<crate::shogi::Move> {
         // Apply best move to reach child position
         let mut child = pos.clone();
-        let _undo = child.do_move(best_move);
+        // We don't need the undo handle here
+        let _ = child.do_move(best_move);
         let child_hash = child.zobrist_hash;
 
         // Choose TT source
@@ -881,6 +883,8 @@ impl Engine {
                 }
             }
         }
+        // Ensure new or existing searchers reflect the desired MultiPV setting
+        self.set_multipv(self.desired_multi_pv);
     }
 
     /// Clear the transposition table

--- a/packages/rust-core/crates/engine-core/src/usi/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/usi/mod.rs
@@ -7,6 +7,7 @@ pub use notation::{
     move_to_usi, parse_sfen, parse_usi_move, parse_usi_square, position_to_sfen, UsiParseError,
 };
 pub use utils::{
-    canonicalize_position_cmd, create_position, rebuild_and_verify, rebuild_then_snapshot_fallback,
-    restore_snapshot_and_verify, RestoreSource,
+    append_usi_score_and_bound, canonicalize_position_cmd, create_position, rebuild_and_verify,
+    rebuild_then_snapshot_fallback, restore_snapshot_and_verify, score_view_from_internal,
+    RestoreSource, ScoreView,
 };

--- a/packages/rust-core/crates/engine-core/src/usi/utils.rs
+++ b/packages/rust-core/crates/engine-core/src/usi/utils.rs
@@ -325,6 +325,13 @@ mod tests {
     }
 
     #[test]
+    fn test_append_usi_score_mate_negative() {
+        let mut s = String::from("info");
+        append_usi_score_and_bound(&mut s, ScoreView::Mate(-3), NodeType::Exact);
+        assert!(s.contains(" score mate -3"));
+    }
+
+    #[test]
     fn test_mate_detection_helpers() {
         let win2 = mate_score(2, true);
         assert!(is_mate_score(win2));

--- a/packages/rust-core/crates/engine-core/src/usi/utils.rs
+++ b/packages/rust-core/crates/engine-core/src/usi/utils.rs
@@ -334,6 +334,14 @@ mod tests {
     }
 
     #[test]
+    fn test_append_usi_score_mate_zero_normalization() {
+        let mut s = String::from("info");
+        append_usi_score_and_bound(&mut s, ScoreView::Mate(0), NodeType::Exact);
+        assert!(s.contains(" score mate 0"));
+        assert!(!s.contains(" score mate -0"));
+    }
+
+    #[test]
     fn test_mate_detection_helpers() {
         let win2 = mate_score(2, true);
         assert!(is_mate_score(win2));

--- a/packages/rust-core/crates/engine-core/src/usi/utils.rs
+++ b/packages/rust-core/crates/engine-core/src/usi/utils.rs
@@ -234,7 +234,9 @@ pub fn append_usi_score_and_bound(out: &mut String, view: ScoreView, bound: Node
             out.push_str(&format!(" score cp {}", cp));
         }
         ScoreView::Mate(d) => {
-            out.push_str(&format!(" score mate {}", d));
+            // Normalize -0 to 0 to avoid "-0"
+            let dz = if d == 0 { 0 } else { d };
+            out.push_str(&format!(" score mate {}", dz));
         }
     }
 


### PR DESCRIPTION
Summary

  - Normalize USI score output (mate/bound/sign) and centralize formatting in core. Harden USI
  behavior around ponder and stale results. Improve diagnostics (seldepth, nps, hashfull) and make
  position parsing more robust.

  Key Changes

  - USI score formatting to core
      - Added ScoreView, append_usi_score_and_bound, score_view_from_internal in crates/engine-core/
  src/usi/utils.rs and re-exported in usi/mod.rs.
      - engine-usi now uses these helpers for both live info and finalize/MultiPV lines.
  - Ponder and stale behavior
      - Ponder: set current_is_ponder at search start; on stop during ponder, suppress bestmove
  (silent) and clear current_root_hash.
      - Guard: when USI_Ponder=false, force go ponder → normal search; log info string
  ponder_disabled_guard=1.
      - Stale finalize: if stale, do not call choose_final_bestmove; immediately emit bestmove resign
  and return (consistent logs and output).
  - Output enhancements
      - Add seldepth to finalize-time MultiPV lines.
      - Add nps to live info lines (minimal overhead).
      - Add nps and hashfull (permille) to finalize-time MultiPV lines; obtain hashfull via
  Engine::tt_hashfull_permille() (lightweight).
  - Position parsing robustness
      - parse_position now only extracts tokens; final position built via
  engine_core::usi::create_position (single source of truth for legality and promotion handling).
      - Early error on empty SFEN (position sfen  moves ...) with info string invalid_sfen_empty.
  - Mate zero normalization
      - Prevent -0: score mate 0 always.

  Behavior

  - Mate is always printed as score mate ±N; cp remains side-to-move perspective.
  - Bound tags (upperbound/lowerbound) appear immediately after score.
  - During ponder:
      - stop → no bestmove (silent).
      - ponderhit → normal search (results emitted).
  - Stale results: MultiPV suppressed; bestmove is always resign.
  - go ponder when USI_Ponder=false is treated as normal go.

  Performance

  - Live info nps: computed from local counters; no locks.
  - Finalize hashfull: read once via atomic; no runtime penalty in live info.
  - No hot-path locking added; string building overhead only.

  Tests

  - Core unit tests extended:
      - cp/mate/bound formatting, negative mate, and mate 0 normalization.
  - All existing tests pass:
      - cargo test -p engine-core (622 passed, 11 ignored)
      - cargo test -p engine-usi (ok)
  - Manual smoke (optional):
      - position startpos → go depth 2: info ... score cp ... nps ...
      - Known mate SFEN → go depth 1: info ... score mate N ...

  Files Touched

  - crates/engine-core/src/usi/utils.rs (+ScoreView, +append_usi_score_and_bound,
  +score_view_from_internal, tests)
  - crates/engine-core/src/usi/mod.rs (re-exports)
  - crates/engine-core/src/engine/controller.rs (+tt_hashfull_permille)
  - crates/engine-usi/src/main.rs
      - Use core helpers; add seldepth/nps/hashfull (finalize only) to info lines
      - Ponder silent stop; guard go ponder when option disabled
      - finalize_and_send: stale early-return (bestmove resign)
      - parse_position delegates to create_position; empty SFEN early error

  Notes

  - Aligns with docs/tasks/engine_improvement_plan.md A-1 (mate/bound/sign normalization).
  - No option changes required; behavior is safer defaults.
  - If desired later: add integration tests for ponder-silent and stale-finalize paths, and document
  the new info fields for GUIs.
