### PR TITLE
学習ダッシュボードの最小化

### DIFF
--- a/.github/workflows/train_dashboard.yml
+++ b/.github/workflows/train_dashboard.yml
@@ -1,0 +1,103 @@
+name: train-dashboard
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/rust-core/**'
+      - '!packages/rust-core/docs/**'
+      - '!packages/rust-core/runs/**'
+      - '!packages/rust-core/converted_openings/**'
+      - '!packages/rust-core/memo/**'
+      - '!packages/rust-core/target/**'
+      - '!**/*.md'
+      - '!**/*.mdx'
+      - '.github/workflows/train_dashboard.yml'
+  pull_request:
+    paths:
+      - 'packages/rust-core/**'
+      - '!packages/rust-core/docs/**'
+      - '!packages/rust-core/runs/**'
+      - '!packages/rust-core/converted_openings/**'
+      - '!packages/rust-core/memo/**'
+      - '!packages/rust-core/target/**'
+      - '!**/*.md'
+      - '!**/*.mdx'
+      - '.github/workflows/train_dashboard.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -C link-arg=-fuse-ld=mold
+
+defaults:
+  run:
+    working-directory: packages/rust-core
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mold linker
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y mold clang
+          mold --version || true
+          clang --version || true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "packages/rust-core -> target"
+
+      - name: Build tools (with plots)
+        run: |
+          set -euo pipefail
+          cargo build -p tools --features plots --release
+
+      - name: Prepare tiny JSONL data
+        run: |
+          set -euo pipefail
+          mkdir -p sample_data
+          cat > sample_data/train.jsonl << 'EOF'
+          {"sfen":"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1","eval":0,"depth":20,"seldepth":30,"bound1":"Exact","bound2":"Exact","best2_gap_cp":50}
+          {"sfen":"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1","eval":150,"depth":20,"seldepth":30,"bound1":"Exact","bound2":"Exact","best2_gap_cp":30}
+          EOF
+          cp sample_data/train.jsonl sample_data/val.jsonl
+
+      - name: Run baseline trainer
+        run: |
+          set -euo pipefail
+          ./target/release/train_wdl_baseline \
+            --input sample_data/train.jsonl \
+            --validation sample_data/val.jsonl \
+            --epochs 2 --batch-size 64 \
+            --metrics --calibration-bins 10 --plots \
+            --gate-val-loss-non-increase --gate-mode fail --seed 1 \
+            --out runs/wdl_ci
+
+      - name: Run NNUE trainer
+        run: |
+          set -euo pipefail
+          ./target/release/train_nnue \
+            --input sample_data/train.jsonl \
+            --validation sample_data/val.jsonl \
+            --epochs 2 --batch-size 128 \
+            --metrics --calibration-bins 10 --plots \
+            --gate-val-loss-non-increase --gate-mode fail --seed 1 \
+            --out runs/nnue_ci
+
+      - name: Upload baseline dashboard
+        uses: actions/upload-artifact@v4
+        with:
+          name: wdl_dashboard
+          path: packages/rust-core/runs/wdl_ci/**
+
+      - name: Upload NNUE dashboard
+        uses: actions/upload-artifact@v4
+        with:
+          name: nnue_dashboard
+          path: packages/rust-core/runs/nnue_ci/**

--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -124,6 +124,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -159,6 +165,12 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -272,16 +284,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -454,10 +518,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dwrote"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c93d234bac0cdd0e2ac08bc8a5133f8df2169e95b262dfcea5e5cb7855672f"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
 
 [[package]]
 name = "either"
@@ -548,6 +654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +679,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "font-kit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "core-foundation",
+ "core-graphics",
+ "core-text",
+ "dirs",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -667,6 +851,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -674,7 +869,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -727,6 +932,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -799,9 +1018,15 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -824,6 +1049,26 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -860,6 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -868,7 +1114,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -908,6 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +1180,25 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -954,9 +1225,16 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
+ "chrono",
+ "font-kit",
+ "image",
+ "lazy_static",
  "num-traits",
+ "pathfinder_geometry",
  "plotters-backend",
+ "plotters-bitmap",
  "plotters-svg",
+ "ttf-parser",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -968,12 +1246,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
+name = "plotters-bitmap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
+dependencies = [
+ "gif",
+ "image",
+ "plotters-backend",
+]
+
+[[package]]
 name = "plotters-svg"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1080,7 +1382,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1118,7 +1420,18 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1151,12 +1464,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1189,6 +1511,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1253,6 +1581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -1299,6 +1633,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -1327,6 +1681,7 @@ dependencies = [
  "flate2",
  "hex",
  "log",
+ "plotters",
  "predicates",
  "rand",
  "rand_xoshiro",
@@ -1339,6 +1694,12 @@ dependencies = [
  "tempfile",
  "zstd",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "typenum"
@@ -1388,6 +1749,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1495,6 +1862,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1891,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1710,12 +2105,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]

--- a/packages/rust-core/README.md
+++ b/packages/rust-core/README.md
@@ -198,6 +198,10 @@ Machine learning tools for NNUE evaluation function:
 - **train_nnue**: Full NNUE trainer with HalfKP features and row-sparse updates
   - Performance metrics: loader_ratio and examples/sec monitoring
   - Cache support for faster data loading
+  - Minimal training dashboard: per-epoch metrics, phase metrics, calibration (CP-binned ECE)
+
+See tools README for usage, options, and outputs:
+- crates/tools/README.md (Minimal Training Dashboard: baseline and NNUE)
 
 #### 手動ベンチ（GitHub Actions）: NNUE Stream Loader Bench
 - 目的: stream-cache ローダとプリフェッチの効果検証（sps / loader_ratio を比較）。

--- a/packages/rust-core/crates/tools/Cargo.toml
+++ b/packages/rust-core/crates/tools/Cargo.toml
@@ -26,9 +26,11 @@ sha2 = "0.10"
 hex = "0.4"
 smallvec = { workspace = true }
 csv = "1.3"
+plotters = { version = "0.3", optional = true }
 
 [features]
 zstd = ["dep:zstd"]
+plots = ["dep:plotters"]
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
+++ b/packages/rust-core/crates/tools/src/bin/build_feature_cache.rs
@@ -609,8 +609,9 @@ fn read_linux_rss_kb() -> Option<(u64, u64)> {
 mod tests {
     use super::*;
     use std::io::{Read, Seek, SeekFrom, Write};
+    use std::path::Path;
 
-    fn write_minimal_jsonl(dir: &PathBuf) -> PathBuf {
+    fn write_minimal_jsonl(dir: &Path) -> PathBuf {
         let jsonl_path = dir.join("input.jsonl");
         let mut f = File::create(&jsonl_path).unwrap();
         // stm = Black, cp=+100
@@ -628,7 +629,7 @@ mod tests {
         jsonl_path
     }
 
-    fn parse_cache_labels(path: &PathBuf) -> (u64, Vec<(usize, f32)>) {
+    fn parse_cache_labels(path: &Path) -> (u64, Vec<(usize, f32)>) {
         let mut f = File::open(path).unwrap();
         let mut magic = [0u8; 4];
         f.read_exact(&mut magic).unwrap();
@@ -725,7 +726,7 @@ mod tests {
             payload_encoding: PayloadEncodingKind::None,
             compress_level: None,
             dedup_features: false,
-            io_buf_bytes: 1 * 1024 * 1024,
+            io_buf_bytes: 1024 * 1024,
             metrics_interval: 10_000,
             report_rss: false,
         };
@@ -767,7 +768,7 @@ mod tests {
             payload_encoding: PayloadEncodingKind::Gzip,
             compress_level: Some(6),
             dedup_features: false,
-            io_buf_bytes: 1 * 1024 * 1024,
+            io_buf_bytes: 1024 * 1024,
             metrics_interval: 10_000,
             report_rss: false,
         };
@@ -804,7 +805,7 @@ mod tests {
             payload_encoding: PayloadEncodingKind::None,
             compress_level: None,
             dedup_features: false,
-            io_buf_bytes: 1 * 1024 * 1024,
+            io_buf_bytes: 1024 * 1024,
             metrics_interval: 10_000,
             report_rss: false,
         };
@@ -839,7 +840,7 @@ mod tests {
                 payload_encoding: PayloadEncodingKind::Gzip,
                 compress_level: Some(lvl),
                 dedup_features: false,
-                io_buf_bytes: 1 * 1024 * 1024,
+                io_buf_bytes: 1024 * 1024,
                 metrics_interval: 10_000,
                 report_rss: false,
             };
@@ -870,7 +871,7 @@ mod tests {
             payload_encoding: PayloadEncodingKind::Gzip,
             compress_level: Some(6),
             dedup_features: false,
-            io_buf_bytes: 1 * 1024 * 1024,
+            io_buf_bytes: 1024 * 1024,
             metrics_interval: 10_000,
             report_rss: false,
         };
@@ -901,7 +902,7 @@ mod tests {
                 payload_encoding: PayloadEncodingKind::Zstd,
                 compress_level: Some(lvl),
                 dedup_features: false,
-                io_buf_bytes: 1 * 1024 * 1024,
+                io_buf_bytes: 1024 * 1024,
                 metrics_interval: 10_000,
                 report_rss: false,
             };
@@ -934,7 +935,7 @@ mod tests {
             payload_encoding: PayloadEncodingKind::None,
             compress_level: None,
             dedup_features: false,
-            io_buf_bytes: 1 * 1024 * 1024,
+            io_buf_bytes: 1024 * 1024,
             metrics_interval: 10_000,
             report_rss: false,
         };

--- a/packages/rust-core/crates/tools/src/bin/orchestrate_ambiguous.rs
+++ b/packages/rust-core/crates/tools/src/bin/orchestrate_ambiguous.rs
@@ -495,7 +495,7 @@ mod tests {
             "output_sha256": sha,
         });
         std::fs::write(&man, serde_json::to_string(&manifest).unwrap()).unwrap();
-        let (by_src, total) = compute_pass1_totals(&[pass1.clone()]).unwrap();
+        let (by_src, total) = compute_pass1_totals(std::slice::from_ref(&pass1)).unwrap();
         assert_eq!(by_src, vec![5]);
         assert_eq!(total, 5);
     }
@@ -512,7 +512,7 @@ mod tests {
         enc.write_all(b"b\n").unwrap();
         enc.write_all(b"c\n").unwrap();
         enc.finish().unwrap();
-        let (by_src, total) = compute_pass1_totals(&[pass1.clone()]).unwrap();
+        let (by_src, total) = compute_pass1_totals(std::slice::from_ref(&pass1)).unwrap();
         assert_eq!(by_src, vec![3]);
         assert_eq!(total, 3);
     }
@@ -523,7 +523,7 @@ mod tests {
         let pass1 = dir.path().join("p1.jsonl");
         // two lines, second without trailing newline
         std::fs::write(&pass1, b"x\ny").unwrap();
-        let (by_src, total) = compute_pass1_totals(&[pass1.clone()]).unwrap();
+        let (by_src, total) = compute_pass1_totals(std::slice::from_ref(&pass1)).unwrap();
         assert_eq!(by_src, vec![2]);
         assert_eq!(total, 2);
     }

--- a/packages/rust-core/crates/tools/src/bin/train_nnue.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_nnue.rs
@@ -276,7 +276,12 @@ impl BatchLoader {
             indices.shuffle(rng);
         }
 
-        BatchLoader { indices, batch_size, position: 0, epoch: 0 }
+        BatchLoader {
+            indices,
+            batch_size,
+            position: 0,
+            epoch: 0,
+        }
     }
 
     fn next_batch(&mut self) -> Option<Vec<usize>> {

--- a/packages/rust-core/crates/tools/src/bin/train_wdl_baseline.rs
+++ b/packages/rust-core/crates/tools/src/bin/train_wdl_baseline.rs
@@ -86,7 +86,6 @@ struct Sample {
     label: f32,
     weight: f32,
     cp: i32,
-    #[allow(dead_code)]
     phase: GamePhase,
 }
 

--- a/packages/rust-core/crates/tools/src/lib.rs
+++ b/packages/rust-core/crates/tools/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod common;
 pub mod io_detect;
 pub mod nnfc_v1;
+pub mod plot;
 pub mod stats;

--- a/packages/rust-core/crates/tools/src/plot.rs
+++ b/packages/rust-core/crates/tools/src/plot.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "plots")]
+pub fn plot_calibration_png<P: AsRef<std::path::Path>>(
+    path: P,
+    bins: &[(i32, i32, f32, f64, f64)], // (left, right, center, mean_pred, mean_label)
+) -> Result<(), Box<dyn std::error::Error>> {
+    use plotters::prelude::*;
+    let root = BitMapBackend::new(path.as_ref(), (640, 480)).into_drawing_area();
+    root.fill(&WHITE)?;
+    let x_min = bins.first().map(|b| b.0).unwrap_or(-1200) as f32;
+    let x_max = bins.last().map(|b| b.1).unwrap_or(1200) as f32;
+    let mut chart = ChartBuilder::on(&root)
+        .margin(20)
+        .caption("Calibration", ("sans-serif", 22))
+        .x_label_area_size(40)
+        .y_label_area_size(40)
+        .build_cartesian_2d(x_min..x_max, 0.0f32..1.0f32)?;
+    chart.configure_mesh().draw()?;
+    // diagonal y=x scaled to [0,1] over x range; use cp normalized to 0..1 reference line is not meaningful.
+    // Instead draw y=0..1 reference lines.
+    let pred_series: Vec<(f32, f32)> = bins.iter().map(|b| (b.2, b.3 as f32)).collect();
+    let label_series: Vec<(f32, f32)> = bins.iter().map(|b| (b.2, b.4 as f32)).collect();
+    chart
+        .draw_series(LineSeries::new(pred_series, &BLUE))?
+        .label("mean_pred")
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE.filled()));
+    chart
+        .draw_series(LineSeries::new(label_series, &RED))?
+        .label("mean_label")
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED.filled()));
+    chart.configure_series_labels().background_style(&WHITE.mix(0.8)).draw()?;
+    root.present()?;
+    Ok(())
+}
+
+#[cfg(not(feature = "plots"))]
+pub fn plot_calibration_png<P: AsRef<std::path::Path>>(
+    _path: P,
+    _bins: &[(i32, i32, f32, f64, f64)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("plots feature is not enabled".into())
+}

--- a/packages/rust-core/crates/tools/src/plot.rs
+++ b/packages/rust-core/crates/tools/src/plot.rs
@@ -11,10 +11,10 @@ pub fn plot_calibration_png<P: AsRef<std::path::Path>>(
     let mut chart = ChartBuilder::on(&root)
         .margin(20)
         .caption("Calibration", ("sans-serif", 22))
-        .x_label_area_size(40)
-        .y_label_area_size(40)
+        .x_label_area_size(45)
+        .y_label_area_size(45)
         .build_cartesian_2d(x_min..x_max, 0.0f32..1.0f32)?;
-    chart.configure_mesh().draw()?;
+    chart.configure_mesh().x_desc("CP (clipped)").y_desc("Probability").draw()?;
     // diagonal y=x scaled to [0,1] over x range; use cp normalized to 0..1 reference line is not meaningful.
     // Instead draw y=0..1 reference lines.
     let pred_series: Vec<(f32, f32)> = bins.iter().map(|b| (b.2, b.3 as f32)).collect();
@@ -27,7 +27,11 @@ pub fn plot_calibration_png<P: AsRef<std::path::Path>>(
         .draw_series(LineSeries::new(label_series, &RED))?
         .label("mean_label")
         .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED.filled()));
-    chart.configure_series_labels().background_style(&WHITE.mix(0.8)).draw()?;
+    chart
+        .configure_series_labels()
+        .background_style(&WHITE.mix(0.8))
+        .border_style(&BLACK)
+        .draw()?;
     root.present()?;
     Ok(())
 }

--- a/packages/rust-core/crates/tools/src/stats.rs
+++ b/packages/rust-core/crates/tools/src/stats.rs
@@ -558,6 +558,20 @@ pub fn calibration_bins(
     bins
 }
 
+/// Compute Expected Calibration Error (ECE) from calibration bins.
+/// Uses weighted L1 distance between mean_pred and mean_label.
+pub fn ece_from_bins(bins: &[CalibBin]) -> Option<f64> {
+    let wsum: f64 = bins.iter().map(|b| b.weighted_count).sum();
+    if wsum <= 0.0 {
+        return None;
+    }
+    let mut acc = 0.0f64;
+    for b in bins {
+        acc += b.weighted_count * (b.mean_pred - b.mean_label).abs();
+    }
+    Some(acc / wsum)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust-core/crates/tools/src/stats.rs
+++ b/packages/rust-core/crates/tools/src/stats.rs
@@ -546,7 +546,8 @@ pub fn calibration_bins(
         bins[idx].count += 1;
         bins[idx].weighted_count += w;
         bins[idx].mean_pred += w * (probs[i] as f64);
-        bins[idx].mean_label += w * if labels[i] >= 0.5 { 1.0 } else { 0.0 };
+        // Use soft mean (average of provided labels) for calibration target
+        bins[idx].mean_label += w * (labels[i] as f64);
     }
     for b in &mut bins {
         if b.weighted_count > 0.0 {

--- a/packages/rust-core/crates/tools/src/stats.rs
+++ b/packages/rust-core/crates/tools/src/stats.rs
@@ -34,31 +34,17 @@ pub fn compute_stats_exact(values: &[i64]) -> Option<StatsI64> {
     }
     let mean = sum as f64 / count as f64;
     let mut v = values.to_vec();
-    let n = v.len();
-    // nearest-rank-ish index (consistent with existing quantile_sorted)
-    let idx = |q: f64| -> usize { (((n - 1) as f64 * q).round() as usize).min(n - 1) };
-    let i50 = idx(0.5);
-    let i90 = idx(0.9);
-    let i95 = idx(0.95);
-    let i99 = idx(0.99);
-    // Sort indices descending and deduplicate while preserving need
-    let mut idxs = vec![i99, i95, i90, i50];
-    idxs.sort_unstable_by(|a, b| b.cmp(a));
-    idxs.dedup();
-    // Use select_nth_unstable for each index from largest to smallest
-    for &i in &idxs {
-        let (_less, _nth, _greater) = v.select_nth_unstable(i);
-        // no-op; positions are now correct up to i
-    }
+    v.sort_unstable();
+    let idx = |q: f64| -> usize { (((count - 1) as f64 * q).round() as usize).min(count - 1) };
     Some(StatsI64 {
         count,
         min: min_v,
         max: max_v,
         mean,
-        p50: v[i50],
-        p90: v[i90],
-        p95: v[i95],
-        p99: v[i99],
+        p50: v[idx(0.5)],
+        p90: v[idx(0.9)],
+        p95: v[idx(0.95)],
+        p99: v[idx(0.99)],
     })
 }
 
@@ -384,6 +370,191 @@ impl OnlineTDigest {
     pub fn q(&mut self, q: f64) -> i64 {
         self.td.quantile(q).round() as i64
     }
+}
+
+// ------------------------
+// Additional metrics utils
+// ------------------------
+
+/// Weighted ROC-AUC for binary labels (labels >= 0.5 treated as positive).
+/// Returns None if there are no positive or no negative examples.
+pub fn roc_auc_weighted(scores: &[f32], labels: &[f32], weights: &[f32]) -> Option<f64> {
+    use std::cmp::Ordering;
+    let n = scores.len();
+    if n == 0 || labels.len() != n || weights.len() != n {
+        return None;
+    }
+    let mut items: Vec<(f32, f32, f32)> =
+        (0..n).map(|i| (scores[i], labels[i], weights[i])).collect();
+    items.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
+
+    let mut wpos = 0.0f64;
+    let mut wneg = 0.0f64;
+    for &(_, y, w) in &items {
+        if y >= 0.5 {
+            wpos += w as f64;
+        } else {
+            wneg += w as f64;
+        }
+    }
+    if wpos == 0.0 || wneg == 0.0 {
+        return None;
+    }
+
+    let mut auc_num = 0.0f64;
+    let mut neg_cum = 0.0f64;
+    let mut i = 0;
+    while i < n {
+        let s = items[i].0;
+        let mut j = i;
+        let mut pos_sum = 0.0f64;
+        let mut neg_sum = 0.0f64;
+        while j < n && items[j].0 == s {
+            if items[j].1 >= 0.5 {
+                pos_sum += items[j].2 as f64;
+            } else {
+                neg_sum += items[j].2 as f64;
+            }
+            j += 1;
+        }
+        auc_num += pos_sum * neg_cum + 0.5 * pos_sum * neg_sum;
+        neg_cum += neg_sum;
+        i = j;
+    }
+    Some(auc_num / (wpos * wneg))
+}
+
+/// Binary classification metrics for WDL probability predictions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BinaryMetrics {
+    pub logloss: f64,
+    pub brier: f64,
+    pub accuracy: f64,
+}
+
+pub fn binary_metrics(probs: &[f32], labels: &[f32], weights: &[f32]) -> Option<BinaryMetrics> {
+    let n = probs.len();
+    if n == 0 || labels.len() != n || weights.len() != n {
+        return None;
+    }
+    let mut wsum = 0.0f64;
+    let mut logloss = 0.0f64;
+    let mut brier = 0.0f64;
+    let mut correct = 0.0f64;
+    for i in 0..n {
+        let p = probs[i].clamp(1e-7, 1.0 - 1e-7) as f64;
+        let y = if labels[i] >= 0.5 { 1.0 } else { 0.0 };
+        let w = weights[i] as f64;
+        logloss += -w * (y * p.ln() + (1.0 - y) * (1.0 - p).ln());
+        brier += w * (p - y) * (p - y);
+        correct += w * if (p >= 0.5) as i32 as f64 == y {
+            1.0
+        } else {
+            0.0
+        };
+        wsum += w;
+    }
+    if wsum == 0.0 {
+        return None;
+    }
+    Some(BinaryMetrics {
+        logloss: logloss / wsum,
+        brier: brier / wsum,
+        accuracy: correct / wsum,
+    })
+}
+
+/// Regression metrics (CP prediction) with weights.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RegMetrics {
+    pub mse: f64,
+    pub mae: f64,
+}
+
+pub fn regression_metrics(pred: &[f32], label: &[f32], weights: &[f32]) -> Option<RegMetrics> {
+    let n = pred.len();
+    if n == 0 || label.len() != n || weights.len() != n {
+        return None;
+    }
+    let mut wsum = 0.0f64;
+    let mut mse = 0.0f64;
+    let mut mae = 0.0f64;
+    for i in 0..n {
+        let e = (pred[i] - label[i]) as f64;
+        let w = weights[i] as f64;
+        mse += w * e * e;
+        mae += w * e.abs();
+        wsum += w;
+    }
+    if wsum == 0.0 {
+        return None;
+    }
+    Some(RegMetrics {
+        mse: mse / wsum,
+        mae: mae / wsum,
+    })
+}
+
+/// Calibration bin summary for cp↔wdl calibration plotting.
+#[derive(Clone, Debug)]
+pub struct CalibBin {
+    pub left: i32,
+    pub right: i32,
+    pub center: f32,
+    pub count: usize,
+    pub weighted_count: f64,
+    pub mean_pred: f64,
+    pub mean_label: f64,
+}
+
+/// Build equal-width calibration bins across [-clip, clip].
+pub fn calibration_bins(
+    cps: &[i32],
+    probs: &[f32],
+    labels: &[f32],
+    weights: &[f32],
+    clip: i32,
+    nbins: usize,
+) -> Vec<CalibBin> {
+    let n = cps.len().min(probs.len()).min(labels.len()).min(weights.len());
+    let nb = nbins.max(1);
+    let width = (2 * clip).max(1) as f32 / nb as f32;
+    let mut bins: Vec<CalibBin> = (0..nb)
+        .map(|b| {
+            let l = (-clip as f32 + b as f32 * width).round() as i32;
+            let r = (-clip as f32 + (b as f32 + 1.0) * width).round() as i32;
+            let c = (l + r) as f32 / 2.0;
+            CalibBin {
+                left: l,
+                right: r,
+                center: c,
+                count: 0,
+                weighted_count: 0.0,
+                mean_pred: 0.0,
+                mean_label: 0.0,
+            }
+        })
+        .collect();
+    if n == 0 {
+        return bins;
+    }
+    for i in 0..n {
+        let cp = cps[i].clamp(-clip, clip);
+        let idx = (((cp + clip) as f32) / width).floor() as usize;
+        let idx = idx.min(nb - 1);
+        let w = weights[i] as f64;
+        bins[idx].count += 1;
+        bins[idx].weighted_count += w;
+        bins[idx].mean_pred += w * (probs[i] as f64);
+        bins[idx].mean_label += w * if labels[i] >= 0.5 { 1.0 } else { 0.0 };
+    }
+    for b in &mut bins {
+        if b.weighted_count > 0.0 {
+            b.mean_pred /= b.weighted_count;
+            b.mean_label /= b.weighted_count;
+        }
+    }
+    bins
 }
 
 #[cfg(test)]

--- a/packages/rust-core/crates/tools/tests/generate_seed_stability_test.rs
+++ b/packages/rust-core/crates/tools/tests/generate_seed_stability_test.rs
@@ -18,7 +18,7 @@ fn stable_seed_from_args(args: &[&str]) -> u64 {
     let mut hasher = Sha256::new();
     for a in args.iter() {
         hasher.update(a.as_bytes());
-        hasher.update(&[0]);
+        hasher.update([0]);
     }
     let d = hasher.finalize();
     u64::from_le_bytes(d[0..8].try_into().unwrap())

--- a/packages/rust-core/crates/tools/tests/move_encoder_test.rs
+++ b/packages/rust-core/crates/tools/tests/move_encoder_test.rs
@@ -142,9 +142,8 @@ mod move_encoder_tests {
         for encoding in invalid_encodings {
             let result = MoveEncoder::decode_move(encoding);
             // Should either succeed with a valid move or fail gracefully
-            if result.is_ok() {
+            if let Ok(decoded) = result {
                 // If it succeeds, re-encoding should give the same result
-                let decoded = result.unwrap();
                 let re_encoded = MoveEncoder::encode_move(&decoded);
                 assert!(re_encoded.is_ok());
             }


### PR DESCRIPTION
概要

- NNUE トレーナーに「最小学習ダッシュボード」を移植/拡張し、baseline との整合を取りました。
- メトリクス（CSV）、フェーズ別、校正（CSV/PNG）、ECE、AUC、ゲート、ベスト重み保存（fp32+meta）を実装。
- 圧縮 NNFC 判定バグの修正や AUC の 0.5 ラベル扱い改善など、レビュー指摘にも対応。
- ドキュメントと CI を更新し、ローカル/CI の両方で成果物を確認しやすくしました。

主な変更点

- train_nnue（新規/拡張）
    - 追加フラグ: --metrics, --calibration-bins, --plots, --gate-val-loss-non-increase, --gate-min-auc, --gate-mode {warn|fail}, --save-every, --stream-cache, --prefetch-*
    - 出力:
    - per-epoch `metrics.csv`: `epoch, train_loss, val_loss, val_auc, val_ece, time_sec, train_weight_sum, val_weight_sum, is_best`
    - `phase_metrics.csv`: WDL=logloss/brier/accuracy, CP=mae/mse（JSONL 検証時のみ）
    - `calibration_epoch_k.csv/.png`: CP 等幅ビン、`mean_pred`/`mean_label(soft)`（WDL+JSONL 検証時のみ）
    - `nn_best.fp32.bin` + `nn_best.meta.json`
    - 最終モデル `nn.fp32.bin`（必要に応じ `nn.i8.bin`）
- ベスト保存: nn_best.meta.json に再現性情報を追記
    - `seed, optimizer, lr, l2, acc_dim, relu_clip, label_type, scale, cp_clip` + `best_epoch, best_val_loss, best_val_auc, best_val_ece`
- AUC 計算をロバスト化
    - `label==0.5` は境界として AUC 試料からスキップ（`>0.5=正`, `<0.5=負`）
- 圧縮 NNFC 判定の修正（ブロッカー対応）
    - `is_cache_file` を `nnfc_v1::open_payload_reader` ベースへ切替（raw/gzip/zstd を正しく判定）
- ストリーミング/プリフェッチ
    - 同期/非同期/インメモリの 3 経路に対応。`loader_ratio`, `sps` などスループットログ出力
- L2 正則化の方針をコメントで明示
    - w0 は行疎即時更新で逐次 L2、w2 はバッチ平均 + L2（性能と再現性上の設計）
- clippy/引数整理
    - `TrainContext` 導入で `too_many_arguments` を解消
    - 未使用フィールドを削除（`BatchLoader.samples` を削除し index 供給に統一）

- baseline（train_wdl_baseline）
    - metrics.csv に is_best 列追加、ベスト保存ログ、ゼロ重みバッチのログなどを整備（整合化）
    - metrics.csv に is_best 列追加、ベスト保存ログ、ゼロ重みバッチのログなどを整備（整合化）
-
共通ユーティリティ（stats）
    - calibration_bins のビン境界安定化（floor 使用）
    - ECE の定義を明記（CP 等幅ビン = cp-binned ECE）
    - ユニットテスト
    - ECE が 0 になるケース
    - ROC AUC の同点グループ 0.5
    - 追加: AUC の境界 0.5 ラベルをスキップする新テスト

- ドキュメント/CI
    - crates/tools/README.md
    - train_nnue の使い方、出力一覧、`val_ece` の定義、ローカル検証（サンプル生成→CSV/PNG確認）を追記
    - `量子化フォーマット（VERSION 3 概要）` を追加（`scale`/`zero_point` 順、LE、配列順、復元式）
- ルート README
    - NNUE ダッシュボードの簡易案内を追記（tools README 参照）
- CI（.github/workflows/train_dashboard.yml）
    - baseline に加え `train_nnue` も 2 epoch 実行して artifact 化（plots 有効）
    - それぞれ `wdl_dashboard` と `nnue_dashboard` をアップロード

バグ修正・レビュー対応の要点

- 圧縮 NNFC 誤判定（ブロッカー）を修正
- AUC の「0.5」ラベル扱いを改善（境界スキップ）
- ベストメタに再現性情報を追加（seed/optimizer/lr/l2 等）
- clippy を tools クレートで完全クリア（ベンチ/別クレートは対象外）

互換性・影響

- CSV 列構成は baseline と一致（is_best 含む）
- AUC の境界ラベルスキップにより、従来より AUC がわずかに変わる可能性あり（よりロバストな定義）
- is_cache_file の挙動は堅牢化（圧縮キャッシュを正しく cache 判定）
- 量子化保存は仕様を README に明記（互換性向上）

パフォーマンス

- w0 行疎即時更新とプリフェッチで大規模データに配慮
- 検証系の forward バッファは現状関数内確保（必要なら共有化の微最適化を別PRで検討可能）

テスト

- tools クレート内ユニットテスト拡充（AUC/ECE、NNFC ヘッダ異常系、gzip ラウンドトリップ他）全グリーン
- ローカルの最小 JSONL で CSV 出力およびベスト保存（meta 含む）を確認

動作確認（ローカル最小サンプル）

- baseline/nnue ともに 2 エポックで metrics.csv, phase_metrics.csv, calibration_epoch_k.csv を出力（PNG はplots 有効時）
- nnue: nn_best.fp32.bin と nn_best.meta.json が保存され、meta に seed 等が入ることを確認

今後の任意改善

- 検証バッファの共有化（alloc 減）
- CI に zstd feature の分岐追加（必要な場合）
