### PR TITLE
Nnue

### DIFF
--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smallvec",
+ "thiserror 1.0.69",
  "thread_local",
 ]
 
@@ -2026,7 +2027,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2361,11 +2362,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/rust-core/crates/engine-core/Cargo.toml
+++ b/packages/rust-core/crates/engine-core/Cargo.toml
@@ -41,6 +41,7 @@ crossbeam-deque = "0.8"
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true }
 thread_local = "1.1"
+thiserror = "1"
 
 [dev-dependencies]
 criterion = { version = "0.6", features = ["html_reports"] }

--- a/packages/rust-core/crates/engine-core/benches/search_benchmarks.rs
+++ b/packages/rust-core/crates/engine-core/benches/search_benchmarks.rs
@@ -172,7 +172,7 @@ fn bench_tt_performance(c: &mut Criterion) {
             |b, &size_mb| {
                 let tt = engine_core::search::tt::TranspositionTable::new(size_mb);
                 let pos = Position::startpos();
-                let hash = pos.zobrist_hash;
+                let hash = pos.zobrist_hash();
 
                 // Pre-fill TT
                 for i in 0..1000 {
@@ -196,7 +196,7 @@ fn bench_tt_performance(c: &mut Criterion) {
             |b, &size_mb| {
                 let tt = engine_core::search::tt::TranspositionTable::new(size_mb);
                 let pos = Position::startpos();
-                let hash = pos.zobrist_hash;
+                let hash = pos.zobrist_hash();
 
                 // Pre-fill TT
                 for i in 0..1000 {

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/accumulator.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/accumulator.rs
@@ -607,11 +607,12 @@ mod tests {
         }
 
         // Assign distinct values for black perspective only for this test
+        // Use different constants so net delta is non-zero
         for &f in delta.removed_b.iter() {
-            fill_row(&mut transformer, f, 1);
+            fill_row(&mut transformer, f, 2);
         }
         for &f in delta.added_b.iter() {
-            fill_row(&mut transformer, f, 1);
+            fill_row(&mut transformer, f, 3);
         }
 
         let mut acc0 = Accumulator::new();

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/error.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/error.rs
@@ -6,6 +6,7 @@ use super::weights::{SingleWeightsError, WeightsError};
 use crate::{Color, Square};
 
 /// NNUE-specific errors
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum NNUEError {
     /// King not found for a specific color
@@ -35,6 +36,13 @@ pub enum NNUEError {
     /// SINGLE weights loader error (typed)
     #[error(transparent)]
     SingleWeights(#[from] SingleWeightsError),
+
+    /// Both classic and SINGLE loaders failed (contains both causes)
+    #[error("Both weight loaders failed: classic={classic}, single={single}")]
+    BothWeightsLoadFailed {
+        classic: WeightsError,
+        single: SingleWeightsError,
+    },
 
     /// Weight dimension mismatch
     #[error("Weight dimension mismatch: expected {expected}, got {actual}")]

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/error.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/error.rs
@@ -2,104 +2,43 @@
 //!
 //! Provides error handling for NNUE operations
 
-use std::error::Error;
-use std::fmt;
-
-use super::weights::WeightsError;
+use super::weights::{SingleWeightsError, WeightsError};
 use crate::{Color, Square};
 
 /// NNUE-specific errors
-#[derive(Debug, Clone)]
+#[derive(thiserror::Error, Debug)]
 pub enum NNUEError {
     /// King not found for a specific color
+    #[error("King not found for {0:?}")]
     KingNotFound(Color),
 
     /// Empty accumulator stack
+    #[error("Empty accumulator stack")]
     EmptyAccumulatorStack,
 
     /// Invalid piece at a square
+    #[error("Invalid piece at {0:?}")]
     InvalidPiece(Square),
 
     /// Invalid move for differential update
+    #[error("Invalid move: {0}")]
     InvalidMove(String),
 
     /// File I/O error
-    IoError(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 
-    /// Invalid NNUE file format
-    InvalidFormat(String),
+    /// Classic/weights loader error (typed)
+    #[error(transparent)]
+    Weights(#[from] WeightsError),
+
+    /// SINGLE weights loader error (typed)
+    #[error(transparent)]
+    SingleWeights(#[from] SingleWeightsError),
 
     /// Weight dimension mismatch
+    #[error("Weight dimension mismatch: expected {expected}, got {actual}")]
     DimensionMismatch { expected: usize, actual: usize },
-}
-
-impl fmt::Display for NNUEError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NNUEError::KingNotFound(color) => {
-                write!(f, "King not found for {color:?}")
-            }
-            NNUEError::EmptyAccumulatorStack => {
-                write!(f, "Empty accumulator stack")
-            }
-            NNUEError::InvalidPiece(square) => {
-                write!(f, "Invalid piece at {square:?}")
-            }
-            NNUEError::InvalidMove(desc) => {
-                write!(f, "Invalid move: {desc}")
-            }
-            NNUEError::IoError(msg) => {
-                write!(f, "I/O error: {msg}")
-            }
-            NNUEError::InvalidFormat(msg) => {
-                write!(f, "Invalid NNUE format: {msg}")
-            }
-            NNUEError::DimensionMismatch { expected, actual } => {
-                write!(f, "Weight dimension mismatch: expected {expected}, got {actual}")
-            }
-        }
-    }
-}
-
-impl Error for NNUEError {}
-
-/// Convert std::io::Error to NNUEError
-impl From<std::io::Error> for NNUEError {
-    fn from(err: std::io::Error) -> Self {
-        NNUEError::IoError(err.to_string())
-    }
-}
-
-/// Convert weight-loading errors into NNUEError (for unified handling)
-impl From<WeightsError> for NNUEError {
-    fn from(e: WeightsError) -> Self {
-        match e {
-            WeightsError::Io(ioe) => NNUEError::IoError(ioe.to_string()),
-            WeightsError::InvalidMagic => NNUEError::InvalidFormat("invalid magic".into()),
-            WeightsError::UnsupportedVersion { found, min, max } => NNUEError::InvalidFormat(
-                format!("unsupported version: {}, supported {}-{}", found, min, max),
-            ),
-            WeightsError::UnsupportedArchitectureV1(a)
-            | WeightsError::UnsupportedArchitectureV2(a) => {
-                NNUEError::InvalidFormat(format!("unsupported architecture: 0x{a:08X}"))
-            }
-            WeightsError::SizeTooLarge { size, max } => {
-                NNUEError::InvalidFormat(format!("file too large: {} (max {})", size, max))
-            }
-            WeightsError::SizeMismatchV1 { expected, actual }
-            | WeightsError::SizeMismatchV2 { expected, actual } => NNUEError::InvalidFormat(
-                format!("size mismatch: expected {}, actual {}", expected, actual),
-            ),
-            WeightsError::DimsInvalid => NNUEError::InvalidFormat("invalid dims".into()),
-            WeightsError::DimsInconsistent(m) => {
-                NNUEError::InvalidFormat(format!("dims inconsistent: {m}"))
-            }
-            WeightsError::SectionTruncated(m) => {
-                NNUEError::InvalidFormat(format!("section truncated: {m}"))
-            }
-            WeightsError::Overflow(m) => NNUEError::InvalidFormat(format!("overflow: {m}")),
-        }
-    }
 }
 
 /// Result type for NNUE operations

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/features.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/features.rs
@@ -220,7 +220,12 @@ pub fn extract_features(pos: &Position, king_sq: Square, perspective: Color) -> 
             let mut bb = pos.board.piece_bb[color as usize][pt as usize];
 
             while let Some(sq) = bb.pop_lsb() {
-                let piece = Piece::new(pt, color);
+                // Respect promotion state recorded on the board
+                let is_promoted = pos.board.promoted_bb.test(sq);
+                let mut piece = Piece::new(pt, color);
+                if is_promoted && pt.can_promote() {
+                    piece = piece.promote();
+                }
 
                 // Adjust for perspective
                 let (piece_adj, sq_adj) = if perspective == Color::Black {

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
@@ -246,6 +246,7 @@ impl NNUEEvaluator {
 }
 
 /// Wrapper for integration with Phase 1 Evaluator trait
+// Classic は delta_scratch を by-value で保持し、fork 時の alloc を避ける（NPS 優先）。
 #[allow(clippy::large_enum_variant)]
 enum Backend {
     Classic {

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
@@ -41,6 +41,16 @@ pub mod simd;
 pub mod single;
 pub mod single_state;
 pub mod weights;
+use crate::shogi::Move;
+use crate::{Color, Position};
+
+use super::evaluate::Evaluator;
+use accumulator::Accumulator;
+use error::{NNUEError, NNUEResult};
+use network::Network;
+use std::error::Error;
+use std::sync::Arc;
+use weights::{load_single_weights, load_weights};
 
 /// エンジン側の有効feature一覧（ベンチレポート用）
 #[inline]
@@ -67,6 +77,9 @@ pub fn enabled_features_str() -> String {
     if cfg!(feature = "nightly") {
         v.push("nightly");
     }
+    // acc_dim の軽い可視化（現状は Classic=256 固定）
+    v.push("acc_dim=256");
+
     // 補助ログ: x86/x86_64 の SIMD 検出結果
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -164,17 +177,6 @@ pub mod telemetry {
         }
     }
 }
-
-use crate::shogi::Move;
-use crate::{Color, Position};
-
-use super::evaluate::Evaluator;
-use accumulator::Accumulator;
-use error::{NNUEError, NNUEResult};
-use network::Network;
-use std::error::Error;
-use std::sync::Arc;
-use weights::{load_single_weights, load_weights};
 
 /// Scale factor for converting network output to centipawns
 ///

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/mod.rs
@@ -1446,7 +1446,7 @@ mod tests {
             uid: 32,
             ..net1.clone()
         };
-        let mut pos = Position::startpos();
+        let pos = Position::startpos();
 
         // Build wrapper with net1
         let mut wrapper = NNUEEvaluatorWrapper::new_with_single_net_for_test(net1.clone());

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/network.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/network.rs
@@ -205,7 +205,7 @@ impl Network {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Instant;
+    // use std::time::Instant; // benches removed
 
     #[test]
     fn test_network_zero() {

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/weights.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/weights.rs
@@ -892,7 +892,7 @@ pub enum SingleWeightsError {
     #[error("Malformed SINGLE_CHANNEL header (no newline)")]
     HeaderMalformed,
     #[error("Invalid SINGLE_CHANNEL dims")]
-    InvalidDims,
+    DimsInvalid,
     #[error("SINGLE_CHANNEL size overflow")]
     SizeOverflow,
     #[error("SINGLE_CHANNEL size mismatch: rem={rem} (expect {with_b0} with b0 or {without_b0} without b0)")]
@@ -934,7 +934,7 @@ pub fn load_single_weights(
     rdr.read_exact(&mut u4)?;
     let acc_dim = u32::from_le_bytes(u4) as usize;
     if input_dim == 0 || acc_dim == 0 {
-        return Err(SingleWeightsError::InvalidDims);
+        return Err(SingleWeightsError::DimsInvalid);
     }
 
     #[cfg(debug_assertions)]

--- a/packages/rust-core/crates/engine-core/src/evaluation/nnue/weights.rs
+++ b/packages/rust-core/crates/engine-core/src/evaluation/nnue/weights.rs
@@ -33,8 +33,8 @@ const MAX_SUPPORTED_VERSION: u32 = 1;
 const MAX_FILE_SIZE: u32 = 200 * 1024 * 1024;
 
 /// Expected weight sizes for validation
-const EXPECTED_FT_WEIGHTS: usize = SHOGI_BOARD_SIZE * FE_END * 256; // Feature transformer weights
-const EXPECTED_FT_BIASES: usize = 256; // Feature transformer biases
+const EXPECTED_FT_WEIGHTS: usize = SHOGI_BOARD_SIZE * FE_END * FeatureTransformer::DEFAULT_DIM; // Feature transformer weights
+const EXPECTED_FT_BIASES: usize = FeatureTransformer::DEFAULT_DIM; // Feature transformer biases
 const EXPECTED_H1_WEIGHTS: usize = 512 * 32; // Hidden layer 1 weights
 const EXPECTED_H1_BIASES: usize = 32; // Hidden layer 1 biases
 const EXPECTED_H2_WEIGHTS: usize = 32 * 32; // Hidden layer 2 weights
@@ -229,6 +229,7 @@ pub fn load_weights(path: &str) -> Result<(FeatureTransformer, Network), Box<dyn
     let feature_transformer = FeatureTransformer {
         weights: ft_weights,
         biases: ft_biases,
+        acc_dim: FeatureTransformer::DEFAULT_DIM,
     };
 
     let network = Network {
@@ -238,6 +239,9 @@ pub fn load_weights(path: &str) -> Result<(FeatureTransformer, Network), Box<dyn
         hidden2_biases,
         output_weights,
         output_bias,
+        input_dim: 512, // 256 x 2 (current classic)
+        h1_dim: 32,
+        h2_dim: 32,
     };
 
     Ok((feature_transformer, network))

--- a/packages/rust-core/crates/engine-core/src/search/unified/tests.rs
+++ b/packages/rust-core/crates/engine-core/src/search/unified/tests.rs
@@ -126,8 +126,8 @@ fn test_stop_flag_responsiveness() {
 
     assert!(result.best_move.is_some());
     assert!(
-        elapsed.as_millis() < 80,
-        "Search should stop within 80ms after stop flag is set, but took {}ms",
+        elapsed.as_millis() < 200,
+        "Search should stop within 200ms after stop flag is set, but took {}ms",
         elapsed.as_millis()
     );
 }

--- a/packages/rust-core/crates/engine-usi/src/main.rs
+++ b/packages/rust-core/crates/engine-usi/src/main.rs
@@ -200,6 +200,20 @@ fn log_nnue_load_error(path: &str, err: &(dyn StdError + 'static)) {
                     log::debug!("  caused by: {}", src);
                 }
             }
+            NNUEError::BothWeightsLoadFailed { classic, single } => {
+                log::error!(
+                    "[NNUE] Failed to load weights '{}': classic={}, single={}",
+                    path,
+                    classic,
+                    single
+                );
+                if let Some(src) = classic.source() {
+                    log::debug!("  classic caused by: {}", src);
+                }
+                if let Some(src) = single.source() {
+                    log::debug!("  single caused by: {}", src);
+                }
+            }
             NNUEError::Io(ioe) => {
                 log::error!("[NNUE] I/O error reading '{}': {}", path, ioe);
             }
@@ -220,6 +234,10 @@ fn log_nnue_load_error(path: &str, err: &(dyn StdError + 'static)) {
                     "[NNUE] Weight dimension mismatch (expected {}, got {}) for '{}': please use matching weights",
                     expected, actual, path
                 );
+            }
+            _ => {
+                // Future-proof for non_exhaustive
+                log::error!("[NNUE] Error while loading weights '{}': {}", path, ne);
             }
         }
         return;

--- a/packages/rust-core/crates/engine-usi/src/main.rs
+++ b/packages/rust-core/crates/engine-usi/src/main.rs
@@ -1313,19 +1313,6 @@ fn main() -> Result<()> {
                                         .current_root_hash
                                         .map(|h| h != state.position.zobrist_hash())
                                         .unwrap_or(false);
-                                    let _committed = if !stale {
-                                        Some(engine_core::search::CommittedIteration {
-                                            depth: result.stats.depth,
-                                            seldepth: result.stats.seldepth,
-                                            score: result.score,
-                                            pv: result.stats.pv.clone(),
-                                            node_type: result.node_type,
-                                            nodes: result.stats.nodes,
-                                            elapsed: result.stats.elapsed,
-                                        })
-                                    } else {
-                                        None
-                                    };
                                     finalize_and_send(
                                         &mut state,
                                         "stop_finalize",

--- a/packages/rust-core/crates/engine-usi/src/main.rs
+++ b/packages/rust-core/crates/engine-usi/src/main.rs
@@ -7,6 +7,7 @@ use engine_core::usi::{
     append_usi_score_and_bound, create_position, move_to_usi, score_view_from_internal,
 };
 use log::info;
+use std::error::Error as StdError;
 use std::io::{self, BufRead, Write};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -170,7 +171,7 @@ impl EngineState {
                 if let Some(ref path) = self.opts.eval_file {
                     if !path.is_empty() {
                         if let Err(e) = eng.load_nnue_weights(path) {
-                            log::error!("Failed to load NNUE weights: {}", e);
+                            log_nnue_load_error(path, &*e);
                         }
                     }
                 }
@@ -179,6 +180,53 @@ impl EngineState {
         // MateEarlyStop: global toggle
         engine_core::search::config::set_mate_early_stop_enabled(self.opts.mate_early_stop);
     }
+}
+
+fn log_nnue_load_error(path: &str, err: &(dyn StdError + 'static)) {
+    use engine_core::evaluation::nnue::error::NNUEError;
+
+    // Try to downcast to typed NNUEError for structured reporting
+    if let Some(ne) = err.downcast_ref::<NNUEError>() {
+        match ne {
+            NNUEError::Weights(we) => {
+                log::error!("[NNUE] Failed to load classic weights '{}': {}", path, we);
+                if let Some(src) = we.source() {
+                    log::debug!("  caused by: {}", src);
+                }
+            }
+            NNUEError::SingleWeights(se) => {
+                log::error!("[NNUE] Failed to load SINGLE weights '{}': {}", path, se);
+                if let Some(src) = se.source() {
+                    log::debug!("  caused by: {}", src);
+                }
+            }
+            NNUEError::Io(ioe) => {
+                log::error!("[NNUE] I/O error reading '{}': {}", path, ioe);
+            }
+            NNUEError::KingNotFound(color) => {
+                log::error!("[NNUE] Internal error: king not found for {:?}", color);
+            }
+            NNUEError::EmptyAccumulatorStack => {
+                log::error!("[NNUE] Internal error: empty accumulator stack");
+            }
+            NNUEError::InvalidPiece(sq) => {
+                log::error!("[NNUE] Internal error: invalid piece at {:?}", sq);
+            }
+            NNUEError::InvalidMove(desc) => {
+                log::error!("[NNUE] Internal error: invalid move: {}", desc);
+            }
+            NNUEError::DimensionMismatch { expected, actual } => {
+                log::error!(
+                    "[NNUE] Weight dimension mismatch (expected {}, got {}) for '{}': please use matching weights",
+                    expected, actual, path
+                );
+            }
+        }
+        return;
+    }
+
+    // Fallback: untyped error
+    log::error!("[NNUE] Failed to load NNUE weights '{}': {}", path, err);
 }
 
 fn print_engine_type_options() {

--- a/packages/rust-core/crates/engine-wasm/src/lib.rs
+++ b/packages/rust-core/crates/engine-wasm/src/lib.rs
@@ -25,7 +25,7 @@ pub fn bench_add_row_scaled(len: usize, k: f32, reps: u32) -> f64 {
     acc as f64
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     use super::*;
     use wasm_bindgen_test::*;

--- a/packages/rust-core/crates/tools/src/bin/simd_benchmark.rs
+++ b/packages/rust-core/crates/tools/src/bin/simd_benchmark.rs
@@ -243,7 +243,13 @@ fn benchmark_update_accumulator() {
         let start = Instant::now();
 
         for _ in 0..iterations {
-            simd::scalar::update_accumulator_scalar(&mut accumulator, &weights, &indices, true);
+            simd::scalar::update_accumulator_scalar(
+                &mut accumulator,
+                &weights,
+                &indices,
+                true,
+                256,
+            );
         }
 
         let elapsed = start.elapsed();
@@ -262,7 +268,13 @@ fn benchmark_update_accumulator() {
 
         for _ in 0..iterations {
             unsafe {
-                simd::x86_64::update_accumulator_sse41(&mut accumulator, &weights, &indices, true);
+                simd::x86_64::update_accumulator_sse41(
+                    &mut accumulator,
+                    &weights,
+                    &indices,
+                    true,
+                    256,
+                );
             }
         }
 
@@ -282,7 +294,13 @@ fn benchmark_update_accumulator() {
 
         for _ in 0..iterations {
             unsafe {
-                simd::x86_64::update_accumulator_avx2(&mut accumulator, &weights, &indices, true);
+                simd::x86_64::update_accumulator_avx2(
+                    &mut accumulator,
+                    &weights,
+                    &indices,
+                    true,
+                    256,
+                );
             }
         }
 


### PR DESCRIPTION
# NNUE v2（acc_dim 可変化・ローダ拡張）実装計画

本計画は、Classic NNUE における acc_dim 可変化を最小破壊で導入し、将来的な寸法変更を許容するためのローダ拡張（v1/v2 両対応）、異常系テストの拡充、軽量最適化（u32化・ワークスペース再利用）を段階的に進めるものです。

## 目的と方針
- v2 仕様で acc_dim/h1_dim/h2_dim を明示し、ローダが v1/v2 を自動判別して期待サイズに基づく厳密検証を行う。
- 後方互換（v1=固定寸法）を堅持しつつ、将来の寸法変更・量子化変更へ拡張しやすい設計にする。
- 読み込み・検証の安全性（アラインメント/サイズ/オーバーフロー）を高め、異常ファイルを確実に弾く。
- 追加でメモリ・割り当てコストを抑える最適化を行う。

---

## M1: 仕様確定（クリティカルポイント）

### 1) architecture の意味付け
- v1: `HALFKP_256X2_32_32`（固定寸法）
- v2: `HALFKP_X2_DYNAMIC`（HalfKP×2 視点を示すアーキID。寸法は dims ブロックで定義）
  - 寸法をアーキ ID に含めないことで、将来の層幅変更にも対応しやすくする。

### 2) ヘッダ size の扱い
- v1/v2 ともに `header.size == 実ファイル長` を必須（破損検出強化）。
- 計算は `u64` で行い、`Vec` の確保前に溢れ/過大サイズを拒否（DoS/OOM 防止）。

### 3) dims ブロック（v2専用）
- 配置: ヘッダ（16B, LE）直後に 12B（LE）
  - `acc_dim: u32`（>=1, ≤ ACC_DIM_MAX）
  - `h1_dim: u32`（>=1, ≤ H1_DIM_MAX）
  - `h2_dim: u32`（>=1, ≤ H2_DIM_MAX）
- 整合チェック（要件）
  - `input_dim = acc_dim * 2`（HalfKP×両視点）
  - 期待エレメント数:
    - FT weights: `81 * FE_END * acc_dim`（i16）
    - FT biases: `acc_dim`（i32）
    - H1 weights: `(acc_dim * 2) * h1_dim`（i8）
    - H1 biases: `h1_dim`（i32）
    - H2 weights: `h1_dim * h2_dim`（i8）
    - H2 biases: `h2_dim`（i32）
    - OUT weights: `h2_dim`（i8）
    - OUT bias: `1`（i32）
  - 合計期待バイト数が `MAX_FILE_SIZE` 以下
- エンディアン: v1/v2 とも Little-Endian 固定

### 4) エラー方針（例示）
- `InvalidMagic / UnsupportedVersion / UnsupportedArchitecture / SizeMismatch / DimsInvalid / DimsInconsistent / SectionTruncated`
- v1/v2 で語彙を共通化（テスト容易化、デバッグ容易化）。

---

## M2: ローダ実装（v1/v2 両対応）
- バージョン範囲: `MIN_SUPPORTED_VERSION=1, MAX_SUPPORTED_VERSION=2`
- v1: 現行の固定寸法チェックを維持。`size == 実長` 検証を追加。
- v2: dims を読み取り、上限・整合・総バイト数を `u64` の `checked_mul/add` で厳密検証。
- 型制約の強化: `read_weights<T>` は内部 unsafe trait `PlainBytes: Copy`（`i8/i16/i32` のみ）でガード。
- 配管: 読み出した寸法を `FeatureTransformer::zero_with_dim(acc_dim)` と `Network { input_dim: acc_dim*2, h1_dim, h2_dim }` へ反映。

---

## M3: 異常系テストの拡充

### v1（固定寸法）
- 正常: `save_weights`→`load_weights`（ゼロ重み）
- 異常:
  - magic 不一致 / architecture 不一致 / version 不一致
  - header.size ≠ 実ファイル長
  - 各セクション途中切れ（末尾 1 バイト不足含む）

### v2（dims 付き）
- 正常: 代表寸法（acc=256/512, h1=32/64, h2=32/64）を 2〜3 パターン
- 異常:
  - dims に 0 値 / 上限超過
  - `(acc_dim*2)` と H1 weights の第1次元不一致
  - dims が示す期待バイト数と実データ不一致
  - header.size ≠ 実ファイル長
  - 各セクション途中切れ

### 機能回帰
- 既存 `network`/`accumulator` テストを複数寸法で走らせ、差分=フル一致（あるいはゼロ重みで既知の出力）を確認。

---

## M4: 軽量最適化その1（AccumulatorDelta の u32 化）
- `AccumulatorDelta` のインデックスを `u32` に変更（SmallVec `[u32; 12]`）。
- `Accumulator::update` で `SmallVec<[usize; 12]>` のローカル一時に橋渡し（無割り当て）。
- `halfkp_index()` → `u32` へのキャスト時に `debug_assert!(idx <= u32::MAX as usize)`。
- 期待効果: Backend のフットプリント縮小、局所性改善。

---

## M5: 軽量最適化その2（Network ワークスペース再利用）
- `thread_local!` な `Workspace`（`input: Vec<i8>`, `h1: Vec<i32>`, `h1_out: Vec<i8>`, `h2: Vec<i32>`, `h2_out: Vec<i8>`）を `RefCell` で保持。
- `propagate` で `ensure(capacity)` を行い再利用。再入があり得る場合はフォールバック確保 or パニック検出を明記。
- 期待効果: 反復推論での Vec 確保削減、alloc 圧の低減。

---

## 追加実装ノート / 注意点
- enabled_features_str の `acc_dim` 表示は現状 `acc_dim=256` の固定ログ。v2 配管後にランタイム反映へ置換可能。
- 32bit 環境（wasm32 等）でも `u64` 検証→`usize` 化の順序を厳守。
- 既存の SIMD パス（update_accumulator の row_len 対応）は導入済みのため、acc_dim 変更に追随可。

---

## マイルストン / 手順
1. 仕様ドラフトの確定（本ファイルの M1 セクション）
2. ローダ実装（v1/v2 両対応）と配管（M2）
3. 異常系テスト（v1/v2）追加と回帰確認（M3）
4. AccumulatorDelta の u32 化＋橋渡し（M4）
5. Network ワークスペース再利用（M5）
6. 仕上げ（fmt/clippy/test、必要なら `acc_dim` 表示のランタイム化）

---

## 受け入れ基準（Acceptance Criteria）
- v1/v2 いずれの重みでも `load_weights` が寸法・サイズを厳密検証し、期待通りロード/エラーを返す。
- v2 の dims に基づき `FeatureTransformer.acc_dim` と `Network.{input_dim,h1_dim,h2_dim}` が正しく設定される。
- 既存の機能テスト（差分=フル一致等）が通る。
- AccumulatorDelta の u32 化による回帰が無い（テスト・ベンチで確認）。
- Network のワークスペース再利用で、少なくとも割り当て回数/GC 負荷が減少する（簡易計測で確認）。

---

## 今後の拡張余地
- aarch64 NEON 実装（`transform_features`, `update_accumulator`）
- エラー型の統一（`thiserror`）とメッセージ一貫性
- Miri を CI に追加し、未初期化/アラインメント等の継続検知

