### PR TITLE
feat: 探索後に置換表をprefetchする機能を追加し、メモリ待ちを隠蔽

### DIFF
--- a/packages/rust-core/crates/engine-core/src/search/alpha_beta.rs
+++ b/packages/rust-core/crates/engine-core/src/search/alpha_beta.rs
@@ -791,6 +791,7 @@ impl<'a> SearchWorker<'a> {
 
             pos.do_move(mv, pos.gives_check(mv));
             self.nodes += 1;
+            self.tt.prefetch(pos.key(), pos.side_to_move());
             let mut value = -self.qsearch::<{ NodeType::NonPV as u8 }>(
                 pos,
                 DEPTH_QS,
@@ -1119,6 +1120,7 @@ impl<'a> SearchWorker<'a> {
             // 探索
             pos.do_move(mv, gives_check);
             self.nodes += 1;
+            self.tt.prefetch(pos.key(), pos.side_to_move());
 
             // PVS
             let value = if rm_idx == 0 {
@@ -1248,6 +1250,7 @@ impl<'a> SearchWorker<'a> {
             // 探索
             pos.do_move(mv, gives_check);
             self.nodes += 1;
+            self.tt.prefetch(pos.key(), pos.side_to_move());
 
             // PVS: 最初の手（このPVラインの候補）はPV探索
             let value = if rm_idx == pv_idx {
@@ -1607,6 +1610,10 @@ impl<'a> SearchWorker<'a> {
 
             pos.do_move(mv, gives_check);
             self.nodes += 1;
+
+            // do_move直後に置換表をprefetch（YaneuraOu準拠）
+            // 評価計算などの間にメモリ待ちを隠蔽する
+            self.tt.prefetch(pos.key(), pos.side_to_move());
 
             // YaneuraOu方式: ContHistKeyを設定
             // ⚠ in_checkは親ノードの王手状態を使用（gives_checkではない）
@@ -2396,6 +2403,7 @@ impl<'a> SearchWorker<'a> {
 
             pos.do_move(mv, gives_check);
             self.nodes += 1;
+            self.tt.prefetch(pos.key(), pos.side_to_move());
 
             self.stack[ply as usize].cont_hist_key =
                 Some(ContHistKey::new(in_check, capture, cont_hist_pc, cont_hist_to));


### PR DESCRIPTION
変更内容

  crates/engine-core/src/search/alpha_beta.rs で、すべての do_move 呼び出し直後に self.tt.prefetch(pos.key(), pos.side_to_move()) を追加しました（5箇所）：

  1. L792-794: probcut探索のdo_move後
  2. L1120-1122: root探索（単一PV）のdo_move後
  3. L1250-1252: root探索（マルチPV）のdo_move後
  4. L1608-1613: メイン探索ループ（search_node）のdo_move後
  5. L2404-2406: qsearch のdo_move後

  ベンチマーク結果

  | 状態            | NPS     | 変化  |
  |-----------------|---------|-------|
  | 変更前          | 421,538 | -     |
  | 変更後（1回目） | 432,012 | +2.5% |
  | 変更後（2回目） | 433,281 | +2.8% |