### PR TITLE
line_bb()の動的計算を避け、direct_of()による方向一致判定に置き換え

### DIFF
--- a/packages/rust-core/crates/engine-core/src/position/pos.rs
+++ b/packages/rust-core/crates/engine-core/src/position/pos.rs
@@ -1007,6 +1007,11 @@ impl Position {
             // fromが王との直線上にある場合、toも同じ直線上にないと開き王手
             // line_bb()の動的計算を避け、direct_of()による方向一致判定に置き換え
             let dir_from = crate::bitboard::direct_of(ksq, from);
+            // blockerは必ず玉との直線上にある（blockers_for_kingの仕様保証）
+            debug_assert!(
+                dir_from.is_some(),
+                "blocker at {from:?} must be on line with king at {ksq:?}"
+            );
             let dir_to = crate::bitboard::direct_of(ksq, to);
             if dir_from != dir_to {
                 return true;


### PR DESCRIPTION
**gives_check line_bb最適化後（現行ベースライン）:**

| 局面 | 最適化前 NPS | 最適化後 NPS | 変化 |
|------|-------------|-------------|------|
| 1 | 1,293,373 | 1,313,202 | +1.5% |
| 2 | 623,244 | 627,261 | +0.6% |
| 3 | 643,023 | 651,870 | +1.4% |
| 4 | 703,005 | 706,608 | +0.5% |
| **総合** | **815,533** | **824,506** | **+1.1%** |

変更内容:
- `gives_check()` の開き王手判定で `line_bb()` を `direct_of()` による方向一致判定に置き換え
- テーブル参照による O(1) 判定で微コスト削減

計測ファイル:
- 最適化前: `20251219234403_internal_1.json`
- 最適化後: `20251219234607_internal_1.json`

**YaneuraOu比較（Material Lv1）:**
- 本エンジン: 824,506 NPS
- YaneuraOu: 1,545,172 NPS
- 差: 約53%

**YaneuraOu比較（NNUE）:**
- 本エンジン: 575,247 NPS
- YaneuraOu: 1,118,219 NPS
- 差: 約51%