### PR TITLE
update_accumulatorの処理を改善し、視点ごとのreset判定を追加。YaneuraOu classicに準拠した差分更新を実装。

### DIFF
--- a/packages/rust-core/crates/engine-core/src/nnue/network.rs
+++ b/packages/rust-core/crates/engine-core/src/nnue/network.rs
@@ -186,6 +186,8 @@ pub fn evaluate(pos: &Position, stack: &mut AccumulatorStack) -> Value {
                 let mut updated = false;
 
                 // 1. 直前局面で差分更新を試行
+                // YaneuraOu classic と同様に、update_accumulator は視点ごとに reset を判定し、
+                // 常に成功する（玉移動した視点は再構築、それ以外は差分更新）。
                 if let Some(prev_idx) = current_entry.previous {
                     let prev_computed = stack.entry_at(prev_idx).accumulator.computed_accumulation;
                     if prev_computed {
@@ -196,15 +198,16 @@ pub fn evaluate(pos: &Position, stack: &mut AccumulatorStack) -> Value {
                         // （値コピー + std::memcpy）を使用している。
                         let prev_acc = stack.entry_at(prev_idx).accumulator.clone();
                         let current_acc = &mut stack.current_mut().accumulator;
-                        updated = network.feature_transformer.update_accumulator(
+                        network.feature_transformer.update_accumulator(
                             pos,
                             &dirty_piece,
                             current_acc,
                             &prev_acc,
                         );
+                        updated = true;
                         #[cfg(feature = "diagnostics")]
                         {
-                            diff_update_result = if updated { 1 } else { 4 };
+                            diff_update_result = 1; // diff_success
                         }
                     } else {
                         #[cfg(feature = "diagnostics")]


### PR DESCRIPTION
# PR: Classic NNUE 更新ロジックの YO パリティ化

## 概要

YaneuraOu classic の `refresh_accumulator` / `update_accumulator` と同等の更新手法に寄せ、差分更新のメモリアクセスと分岐を最小化しました。

## 変更内容

### 1. 飽和演算を非飽和演算に変更

`feature_transformer.rs` の `add_weights` / `sub_weights` で使用していた飽和演算を、YaneuraOu classic と同様の非飽和演算に変更しました。

| アーキテクチャ | 変更前 | 変更後 |
|---------------|--------|--------|
| AVX2 | `_mm256_adds_epi16` / `_mm256_subs_epi16` | `_mm256_add_epi16` / `_mm256_sub_epi16` |
| SSE2 | `_mm_adds_epi16` / `_mm_subs_epi16` | `_mm_add_epi16` / `_mm_sub_epi16` |
| WASM SIMD | `i16x8_add_sat` / `i16x8_sub_sat` | `i16x8_add` / `i16x8_sub` |
| スカラー | `saturating_add` / `saturating_sub` | `wrapping_add` / `wrapping_sub` |

### 2. update_accumulator のリセット対応

YaneuraOu classic と同様に、視点ごとに `reset` 判定を行うよう変更しました。

**変更前:**
- 玉移動時は `false` を返して呼び出し元で全計算にフォールバック
- 両視点とも全計算が必要

**変更後:**
- 視点ごとに `reset` を判定
- `reset` が必要な視点は `biases` から再構築してアクティブ特徴量を加算
- `reset` 不要な視点は従来通り差分更新を継続
- 戻り値を `bool` から `()` に変更（常に成功するため）

これにより、片方の玉だけ移動した場合でも、他方の視点は差分更新が継続可能になりました。

### 3. 呼び出し元の修正

`network.rs` の `update_accumulator` 呼び出し箇所を新しいシグネチャに合わせて修正しました。

## 変更ファイル

- `crates/engine-core/src/nnue/feature_transformer.rs`
  - `add_weights`: 飽和演算→非飽和演算
  - `sub_weights`: 飽和演算→非飽和演算
  - `update_accumulator`: 視点ごとのreset対応、戻り値変更
- `crates/engine-core/src/nnue/network.rs`
  - `update_accumulator` 呼び出し箇所の修正

## テスト結果

```
test result: ok. 414 passed; 0 failed; 0 ignored
```

## ベンチマーク結果

### 計測条件

- CPU: AMD Ryzen 9 5950X 16-Core Processor
- Threads: 1
- TT: 1024MB
- 探索時間: 10秒/局面
- NNUE: nn.bin (MaterialLevel 9)
- RUSTFLAGS: `-C target-cpu=native`

### NNUE評価 局面別NPS比較

| 局面 | SFEN | 変更前 NPS | 変更後 NPS | 変化 |
|------|------|-----------|-----------|------|
| 1 | 序盤（9手目） | 871,170 | 884,408 | **+1.5%** |
| 2 | 詰将棋局面 | 491,103 | 506,254 | **+3.1%** |
| 3 | 中終盤 | 527,288 | 529,251 | **+0.4%** |
| 4 | 詰将棋局面2 | 504,406 | 507,442 | **+0.6%** |

### NNUE評価 総合結果

| 指標 | 変更前 | 変更後 | 変化 |
|------|--------|--------|------|
| 総ノード数 | 22,592,513 | 22,895,616 | +1.3% |
| 総時間 | 37,751 ms | 37,739 ms | -0.0% |
| **総合NPS** | **598,437** | **606,683** | **+1.4%** |

### ベンチマーク結果ファイル

- 変更前: `benchmark_results/20251220235128_internal_1.json`
- 変更後: `benchmark_results/20251221181636_internal_1.json`

## 技術的ポイント

1. **非飽和演算**: YaneuraOu classic と同一の挙動。Transform レイヤーの出力時に ClippedReLU（0-127クランプ）が適用されるため、最終的な評価値には影響なし。

2. **視点ごとのreset判定**: 片方の玉だけ移動した場合でも他方は差分更新が継続可能になり、効率が向上。

3. **パフォーマンス**: 全局面でNPSが微増し、総合で約+1.4%の改善。

## 関連ドキュメント

- 設計ドキュメント: `memo/nps_optimization_plan/25_nnue_classic_update_parity.md`
- 前提タスク: `23_nnue_classic_feature_set_port.md`, `24_nnue_classic_accumulator_triggers.md`
