### PR TITLE
perf(bitboard): attackers_to_occ near を inline asm (SSE2) で実装（不採用、記録用）

### DIFF
--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -501,13 +501,9 @@ impl Position {
         self.attackers_to_occ(sq, self.occupied())
     }
 
-    /// 指定マスに利いている駒（占有指定）
-    ///
-    /// Apery/YaneuraOu式: silverEffect で HDK の斜め近接利き、
-    /// goldEffect で HDK の直線近接利きを捕捉し、
-    /// 個別の king_effect / horse近接 / dragon近接 を不要にする。
-    /// また rook_effect を再利用して lance_effect の個別スライド計算を省略。
-    pub fn attackers_to_occ(&self, sq: Square, occupied: Bitboard) -> Bitboard {
+    #[cfg(any(test, not(target_arch = "x86_64")))]
+    #[inline]
+    fn attackers_to_occ_near_rust(&self, sq: Square) -> Bitboard {
         let silver_hdk = self.pieces_pt(PieceType::Silver) | self.hdk_bb;
         let golds_hdk = self.golds_bb | self.hdk_bb;
 
@@ -525,6 +521,112 @@ impl Position {
             | (gold_effect(Color::Black, sq) & golds_hdk))
             & self.pieces_c(Color::White);
 
+        black_attackers | white_attackers
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(test)))]
+    #[inline(always)]
+    fn attackers_to_occ_near_asm(&self, sq: Square) -> Bitboard {
+        use crate::bitboard::{GOLD_EFFECT, KNIGHT_EFFECT, PAWN_EFFECT, SILVER_EFFECT};
+        use core::arch::asm;
+
+        let mut out = Bitboard::EMPTY;
+        const BB_SIZE: usize = core::mem::size_of::<Bitboard>();
+        const EFFECT_STRIDE: usize = Square::NUM * BB_SIZE;
+        const PT_PAWN_OFFSET: usize = PieceType::Pawn as usize * BB_SIZE;
+        const PT_KNIGHT_OFFSET: usize = PieceType::Knight as usize * BB_SIZE;
+        const PT_SILVER_OFFSET: usize = PieceType::Silver as usize * BB_SIZE;
+        const BLACK_OFFSET: usize = Color::Black as usize * BB_SIZE;
+        const WHITE_OFFSET: usize = Color::White as usize * BB_SIZE;
+        let effect_black_offset = sq.index() * BB_SIZE;
+        let effect_white_offset = EFFECT_STRIDE + effect_black_offset;
+
+        // SAFETY:
+        // - x86_64 では SSE2 がベースラインであり、`movdqa/pand/por` は常に使用可能
+        // - Bitboard は `#[repr(C, align(16))]` で、static table・局面内フィールド・ローカル `out` は
+        //   16 バイト境界に整列しているため `movdqa` のアラインメント要件を満たす
+        // - 参照するメモリはすべて読み取り専用で、書き込み先はローカル `out` のみ
+        // - `sq.index()` は Square の不変条件により 0..80
+        // - asm ブロックはスタックを変更せず、xmm0..xmm7 以外のレジスタ状態を壊さない
+        unsafe {
+            asm!(
+                "movdqa xmm5, xmmword ptr [{by_type} + {pt_pawn_off}]",
+                "movdqa xmm6, xmmword ptr [{by_type} + {pt_knight_off}]",
+                "movdqa xmm7, xmmword ptr [{hdk}]",
+                "movdqa xmm3, xmmword ptr [{by_type} + {pt_silver_off}]",
+                "por xmm3, xmm7",
+                "movdqa xmm4, xmmword ptr [{golds}]",
+                "por xmm4, xmm7",
+                "movdqa xmm0, xmmword ptr [{pawn_base} + {eff_white_off}]",
+                "pand xmm0, xmm5",
+                "movdqa xmm1, xmmword ptr [{knight_base} + {eff_white_off}]",
+                "pand xmm1, xmm6",
+                "por xmm0, xmm1",
+                "movdqa xmm1, xmmword ptr [{silver_base} + {eff_white_off}]",
+                "pand xmm1, xmm3",
+                "por xmm0, xmm1",
+                "movdqa xmm1, xmmword ptr [{gold_base} + {eff_white_off}]",
+                "pand xmm1, xmm4",
+                "por xmm0, xmm1",
+                "pand xmm0, xmmword ptr [{by_color} + {black_off}]",
+                "movdqa xmm1, xmmword ptr [{pawn_base} + {eff_black_off}]",
+                "pand xmm1, xmm5",
+                "movdqa xmm2, xmmword ptr [{knight_base} + {eff_black_off}]",
+                "pand xmm2, xmm6",
+                "por xmm1, xmm2",
+                "movdqa xmm2, xmmword ptr [{silver_base} + {eff_black_off}]",
+                "pand xmm2, xmm3",
+                "por xmm1, xmm2",
+                "movdqa xmm2, xmmword ptr [{gold_base} + {eff_black_off}]",
+                "pand xmm2, xmm4",
+                "por xmm1, xmm2",
+                "pand xmm1, xmmword ptr [{by_color} + {white_off}]",
+                "por xmm0, xmm1",
+                "movdqa xmmword ptr [{out}], xmm0",
+                pawn_base = in(reg) PAWN_EFFECT.as_ptr(),
+                knight_base = in(reg) KNIGHT_EFFECT.as_ptr(),
+                silver_base = in(reg) SILVER_EFFECT.as_ptr(),
+                gold_base = in(reg) GOLD_EFFECT.as_ptr(),
+                by_type = in(reg) self.by_type.as_ptr(),
+                by_color = in(reg) self.by_color.as_ptr(),
+                hdk = in(reg) &self.hdk_bb,
+                golds = in(reg) &self.golds_bb,
+                eff_white_off = in(reg) effect_white_offset,
+                eff_black_off = in(reg) effect_black_offset,
+                pt_pawn_off = const PT_PAWN_OFFSET,
+                pt_knight_off = const PT_KNIGHT_OFFSET,
+                pt_silver_off = const PT_SILVER_OFFSET,
+                black_off = const BLACK_OFFSET,
+                white_off = const WHITE_OFFSET,
+                out = in(reg) &mut out,
+                lateout("xmm0") _,
+                lateout("xmm1") _,
+                lateout("xmm2") _,
+                lateout("xmm3") _,
+                lateout("xmm4") _,
+                lateout("xmm5") _,
+                lateout("xmm6") _,
+                lateout("xmm7") _,
+                options(nostack, preserves_flags),
+            );
+        }
+
+        out
+    }
+
+    /// 指定マスに利いている駒（占有指定）
+    ///
+    /// Apery/YaneuraOu式: silverEffect で HDK の斜め近接利き、
+    /// goldEffect で HDK の直線近接利きを捕捉し、
+    /// 個別の king_effect / horse近接 / dragon近接 を不要にする。
+    /// また rook_effect を再利用して lance_effect の個別スライド計算を省略。
+    pub fn attackers_to_occ(&self, sq: Square, occupied: Bitboard) -> Bitboard {
+        #[cfg(all(target_arch = "x86_64", not(test)))]
+        let near = self.attackers_to_occ_near_asm(sq);
+
+        #[cfg(any(test, not(target_arch = "x86_64")))]
+        let near = self.attackers_to_occ_near_rust(sq);
+
         // 角・馬のスライド利き
         let bishop = bishop_effect(sq, occupied) & self.bishop_horse_bb;
 
@@ -537,7 +639,7 @@ impl Position {
                 | (lance_step_effect(Color::Black, sq)
                     & self.pieces(Color::White, PieceType::Lance)));
 
-        black_attackers | white_attackers | bishop | rook_lance
+        near | bishop | rook_lance
     }
 
     /// 指定マスに利いている指定手番の駒
@@ -1834,6 +1936,7 @@ mod tests {
         assert!(attackers.contains(sq55));
     }
 
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_do_move_drop() {
         let mut pos = Position::new();


### PR DESCRIPTION
## Summary

`attackers_to_occ` の近接駒部分を `asm!` インラインアセンブリで hand-written SSE2 に置き換える試み。**不採用。記録として残す。**

## 背景（一連の試行の最終段）

PR #404 の C kernel アプローチでは FFI オーバーヘッド (+0.8% instructions) が SSE2 化の改善を相殺した。`asm!` なら call/ret + ctx 構築が不要になり FFI 問題を解消できるか検証。

### これまでの試行結果

| 施策 | NPS | instructions/node | 問題 |
|------|-----|-------------------|------|
| Rust `__m128i` intrinsics | - | - | LLVM が AVX に自動昇格、無効 |
| C kernel Phase 2 (no-AVX) | +/-1% | +0.8% | FFI オーバーヘッドが相殺 |
| C kernel + see_ge 吸収 | -2.38% | +2.06% | kernel 肥大化 |
| static/dynamic ctx 分割 | -2.25% | +0.54% | global load コスト |
| **asm! inline（本 PR）** | **-4%** | **-0.3%** | **GPR 圧迫** |

## 実装

- `attackers_to_occ_near_asm()`: `asm!` ブロックで SSE2 (movdqa/pand/por) のみ使用
- `in(reg)` x 10 + `const` x 5 でテーブルポインタとオフセットを渡す
- xmm0-7 の 8 レジスタを使用、clobber 宣言済み
- test 時は Rust 実装にフォールバック（linker 問題回避）

## 計測結果

| 計測 | NPS | cycles/node | instructions/node |
|------|-----|-------------|-------------------|
| 1 回目 | -4.58% | +4.98% | -0.31% |
| 2 回目 | -3.98% | +4.25% | -0.39% |

- instructions はわずかに減少 → FFI 排除の効果あり
- **cycles は大幅悪化** → `in(reg)` x 10 が x86_64 の汎用レジスタ 15 本中 10 本を占有し、周辺コードのレジスタ圧迫 → spill 増加
- tree-safe: 4/4 局面 depth 20 完全一致

## 結論

**attackers_to_occ の AVX spill 問題に対する全試行を打ち切り。**

near 部分だけの asm 化では、LLVM に 10 本のポインタレジスタを予約させるコストが SSE2 化によるメリットを上回る。根本的に、attackers_to_occ が多数の lookup table と Position フィールドを参照する構造上、どの手段（intrinsics, C kernel, inline asm）でもレジスタ/メモリアクセスのコストが SSE2 化の改善を相殺する。

**この PR は main にマージしない。** 記録として残す。

## Test plan

- [x] `cargo fmt && cargo clippy --fix --allow-dirty --tests` 通過
- [x] `cargo test` 全テスト通過（test 時は Rust fallback）
- [x] `compare_nodes` depth 20, 4 局面完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
