### PR TITLE
feat(search): allNode LMR r スケールアップ (B-1)

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2789,9 +2789,11 @@ impl SearchWorker {
             st.stack[ply as usize].stat_score = stat_score;
             r -= stat_score * ctx.tune_params.lmr_step16_stat_score_scale_num / 8192;
 
-            // allNode スケーリング（Stockfish 由来）
-            // allNode では r を depth 依存の比率でスケールアップ。
-            // 浅い depth ほど効果が大きい。
+            // allNode スケーリング（Stockfish search.cpp:1247-1248 由来）
+            // allNode（PV でも cutNode でもないノード）では r を depth 依存の比率で
+            // スケールアップ。浅い depth ほど効果が大きい。
+            // r が負の場合は更に負方向に補正されるが、後続の max(1, ...) で
+            // 最終的な探索深度は 1 以上に保証される。
             if all_node {
                 r += r * 273 / (256 * depth + 260);
             }

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2789,6 +2789,13 @@ impl SearchWorker {
             st.stack[ply as usize].stat_score = stat_score;
             r -= stat_score * ctx.tune_params.lmr_step16_stat_score_scale_num / 8192;
 
+            // allNode スケーリング（Stockfish 由来）
+            // allNode では r を depth 依存の比率でスケールアップ。
+            // 浅い depth ほど効果が大きい。
+            if all_node {
+                r += r * 273 / (256 * depth + 260);
+            }
+
             // =============================================================
             // 探索
             // =============================================================


### PR DESCRIPTION
## Summary
- Stockfish 由来の allNode LMR scaling を実装
- allNode で `r += r * 273 / (256 * depth + 260)` を追加
- 浅い depth ほど効果が大きく、allNode での無駄な探索を削減

## 施策
`docs/improvement_plan_202604.md` B-1

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価中

🤖 Generated with [Claude Code](https://claude.com/claude-code)