### PR TITLE
feat(search): Ply スケーリング eval (B-6)

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -66,8 +66,14 @@ pub(super) fn draw_jitter(nodes: u64, tune_params: &SearchTuneParams) -> i32 {
 
 #[inline]
 /// 補正履歴を適用した静的評価に変換（詰みスコア領域に入り込まないようにクリップ）
-pub(super) fn to_corrected_static_eval(unadjusted: Value, correction_value: i32) -> Value {
-    let corrected = unadjusted.raw() + correction_value / 131_072;
+/// ply スケーリング: 深い探索ほど評価値を微増させ、千日手回避バイアスをかける（stoat 由来）
+pub(super) fn to_corrected_static_eval(
+    unadjusted: Value,
+    correction_value: i32,
+    ply: i32,
+) -> Value {
+    let scaled = unadjusted.raw() as i64 * (1024 + ply as i64) / 1024;
+    let corrected = scaled as i32 + correction_value / 131_072;
     Value::new(corrected.clamp(Value::MATED_IN_MAX_PLY.raw() + 1, Value::MATE_IN_MAX_PLY.raw() - 1))
 }
 
@@ -610,7 +616,7 @@ impl SearchWorker {
             #[cfg(not(feature = "search-no-pass-rules"))]
             let pass_rights_eval = evaluate_pass_rights(pos, pos.game_ply() as u16);
 
-            to_corrected_static_eval(unadjusted_static_eval, corr) + pass_rights_eval
+            to_corrected_static_eval(unadjusted_static_eval, corr, 0) + pass_rights_eval
         };
         self.state.stack[0].static_eval = static_eval;
         (unadjusted_static_eval, corr)

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -66,7 +66,12 @@ pub(super) fn draw_jitter(nodes: u64, tune_params: &SearchTuneParams) -> i32 {
 
 #[inline]
 /// 補正履歴を適用した静的評価に変換（詰みスコア領域に入り込まないようにクリップ）
-/// ply スケーリング: 深い探索ほど評価値を微増させ、千日手回避バイアスをかける（stoat 由来）
+///
+/// ply スケーリング（stoat 由来）: `rawEval * (1024 + ply) / 1024`
+/// negamax の手番側視点で符号に関わらず絶対値を拡大する。
+/// 正の評価値（有利）がより大きくなることで千日手回避の動機を生み、
+/// 負の評価値（不利）がより小さくなることで相手にも打開動機を与える。
+/// ply=0（root）では無変化。
 pub(super) fn to_corrected_static_eval(
     unadjusted: Value,
     correction_value: i32,

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -512,7 +512,7 @@ pub(super) fn compute_eval_context(
     };
 
     if !in_check && unadjusted_static_eval != Value::NONE {
-        static_eval = to_corrected_static_eval(unadjusted_static_eval, corr_value);
+        static_eval = to_corrected_static_eval(unadjusted_static_eval, corr_value, ply);
         // パス権評価を動的に追加（TTには保存されないので手数依存でもOK）
         let pass_rights_eval = {
             #[cfg(feature = "search-no-pass-rules")]

--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -250,7 +250,7 @@ pub(super) fn qsearch<const NT: u8>(
     };
 
     if !in_check && unadjusted_static_eval != Value::NONE {
-        static_eval = to_corrected_static_eval(unadjusted_static_eval, corr_value);
+        static_eval = to_corrected_static_eval(unadjusted_static_eval, corr_value, ply);
         // パス権評価を動的に追加（TTには保存されないので手数依存でもOK）
         #[cfg(not(feature = "search-no-pass-rules"))]
         {


### PR DESCRIPTION
## Summary
- stoat 由来の ply スケーリングを実装
- `scaled = rawEval * (1024 + ply) / 1024` で深い探索ほど微増
- 千日手回避バイアスとして機能

## 施策
`docs/improvement_plan_202604.md` B-6

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)