### PR TITLE
feat(search): mainHistory イテレーション間 decay (A-3)

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1442,6 +1442,11 @@ where
 
         // メインのみ: if (!mainThread) continue; に対応する部分はループ末尾で処理
 
+        // mainHistory のイテレーション間 decay（Stockfish 由来）
+        // 古い history 値の蓄積を防ぎ move ordering の鮮度を保つ
+        // SAFETY: 単一スレッド内で使用、探索ループ外なので排他保証
+        unsafe { worker.history.as_mut_unchecked() }.main_history.decay(820, 1024);
+
         let search_depth = depth;
         worker.state.root_depth = search_depth;
         worker.state.sel_depth = 0;

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1442,10 +1442,15 @@ where
 
         // メインのみ: if (!mainThread) continue; に対応する部分はループ末尾で処理
 
-        // mainHistory のイテレーション間 decay（Stockfish 由来）
-        // 古い history 値の蓄積を防ぎ move ordering の鮮度を保つ
+        // mainHistory のイテレーション間 decay（Stockfish 由来: search.cpp:316-318）
+        // 古い history 値の蓄積を防ぎ move ordering の鮮度を保つ。
+        // 未更新エントリ（MAIN_HISTORY_INIT=68）も decay されるが影響は微小。
         // SAFETY: 単一スレッド内で使用、探索ループ外なので排他保証
-        unsafe { worker.history.as_mut_unchecked() }.main_history.decay(820, 1024);
+        const HISTORY_DECAY_NUM: i32 = 820;
+        const HISTORY_DECAY_DEN: i32 = 1024;
+        unsafe { worker.history.as_mut_unchecked() }
+            .main_history
+            .decay(HISTORY_DECAY_NUM, HISTORY_DECAY_DEN);
 
         let search_depth = depth;
         worker.state.root_depth = search_depth;

--- a/crates/rshogi-core/src/search/history.rs
+++ b/crates/rshogi-core/src/search/history.rs
@@ -211,6 +211,17 @@ impl ButterflyHistory {
         }
     }
 
+    /// イテレーション間 decay（Stockfish 由来）
+    /// 全エントリを numerator/denominator にスケールダウンする。
+    pub fn decay(&mut self, numerator: i32, denominator: i32) {
+        for color_table in &mut self.table {
+            for entry in color_table.iter_mut() {
+                let v = entry.get() as i32;
+                entry.set((v * numerator / denominator) as i16);
+            }
+        }
+    }
+
     /// 指定初期値でクリア
     pub fn clear_with_init(&mut self, init_val: i16) {
         for color_table in &mut self.table {

--- a/crates/rshogi-core/src/search/history.rs
+++ b/crates/rshogi-core/src/search/history.rs
@@ -213,7 +213,9 @@ impl ButterflyHistory {
 
     /// イテレーション間 decay（Stockfish 由来）
     /// 全エントリを numerator/denominator にスケールダウンする。
+    /// StatsEntry<7183> の値域 (-7183..7183) × 820/1024 は i16 範囲内。
     pub fn decay(&mut self, numerator: i32, denominator: i32) {
+        debug_assert!(denominator > 0, "denominator must be positive");
         for color_table in &mut self.table {
             for entry in color_table.iter_mut() {
                 let v = entry.get() as i32;


### PR DESCRIPTION
## Summary
- Stockfish 由来の mainHistory iteration decay を実装
- 各イテレーション開始時に mainHistory を 820/1024 (~80%) にスケール
- 古い history 値の蓄積を防ぎ move ordering の鮮度を保つ

## 施策
`docs/improvement_plan_202604.md` A-3

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)