### PR TITLE
feat(search): Check Extension 復活 (B-2)

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2690,6 +2690,11 @@ impl SearchWorker {
                 }
             }
 
+            // Check Extension: SE で延長されなかった王手手に +1 延長（stoat 由来）
+            if extension == 0 && gives_check {
+                extension = 1;
+            }
+
             // 指し手を実行
             st.stack[ply as usize].current_move = mv;
             do_move_and_push(st, pos, mv, gives_check, ctx.tt);

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2691,6 +2691,10 @@ impl SearchWorker {
             }
 
             // Check Extension: SE で延長されなかった王手手に +1 延長（stoat 由来）
+            // root ノードでも適用（stoat と同様）。SE は !root_node で発動するため
+            // root では extension は常に 0 であり、gives_check なら延長される。
+            // Negative Extension が 0 の場合にも check extension が適用されるが、
+            // これは意図的（SE で特別でないと判定された手でも王手なら延長する）。
             if extension == 0 && gives_check {
                 extension = 1;
             }


### PR DESCRIPTION
## Summary
- stoat 由来の check extension を実装
- SE で延長されなかった王手手に extension=1 を付与
- Stockfish/YO では削除済み、将棋での有効性を SPRT で検証

## 施策
`docs/improvement_plan_202604.md` B-2

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)