### PR TITLE
feat(search): QSearch 合法手数制限 (B-7)

### DIFF
--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -401,6 +401,7 @@ pub(super) fn qsearch<const NT: u8>(
     }
 
     let mut move_count = 0;
+    let mut searched_moves = 0;
 
     for mv in ordered_moves.iter() {
         // 静止探索では PASS は対象外（TT手として来る可能性があるため明示的にスキップ）
@@ -456,6 +457,12 @@ pub(super) fn qsearch<const NT: u8>(
                 inc_stat!(st, qs_see_margin_pruned);
                 continue;
             }
+        }
+
+        // QSearch 合法手数制限（stoat 由来）: 探索する手を 2 手までに制限
+        searched_moves += 1;
+        if searched_moves > 2 {
+            break;
         }
 
         // SAFETY: ply < MAX_PLY < STACK_SIZE。

--- a/crates/rshogi-core/src/search/qsearch.rs
+++ b/crates/rshogi-core/src/search/qsearch.rs
@@ -459,10 +459,13 @@ pub(super) fn qsearch<const NT: u8>(
             }
         }
 
-        // QSearch 合法手数制限（stoat 由来）: 探索する手を 2 手までに制限
-        searched_moves += 1;
-        if searched_moves > 2 {
-            break;
+        // QSearch 合法手数制限（stoat 由来）: 非王手局面で探索する手を 2 手までに制限
+        // in_check 時は全回避手を探索する必要があるため制限しない
+        if !in_check {
+            searched_moves += 1;
+            if searched_moves > 2 {
+                break;
+            }
         }
 
         // SAFETY: ply < MAX_PLY < STACK_SIZE。


### PR DESCRIPTION
## Summary
- stoat 由来の qsearch 手数制限を実装
- 探索する手を 2 手までに制限
- NPS 改善期待、棋力影響は要 SPRT 検証

## 施策
`docs/improvement_plan_202604.md` B-7

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)