### PR TITLE
feat(search): Correction History complexity factor (B-5)

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1589,7 +1589,7 @@ impl SearchWorker {
                     reductions: &self.reductions,
                     draw_value_table: self.draw_value_table,
                 };
-                update_correction_history(&self.state, &ctx, pos, 0, bonus);
+                update_correction_history(&self.state, &ctx, pos, 0, bonus, 0);
             }
         }
 
@@ -3669,7 +3669,23 @@ impl SearchWorker {
             let divisor = if best_move.is_some() { 10 } else { 8 };
             let bonus = ((best_value.raw() - static_eval.raw()) * depth / divisor)
                 .clamp(-CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
-            update_correction_history(st, ctx, pos, ply, bonus);
+            // complexity: TT スコアと静的評価の乖離度（stoat 由来）
+            let complexity = if tt_hit && static_eval != Value::NONE && tt_value != Value::NONE {
+                let se = static_eval.raw();
+                let tv = tt_value.raw();
+                let bound = tt_data.bound;
+                if bound == Bound::Exact
+                    || (bound == Bound::Upper && tv <= se)
+                    || (bound == Bound::Lower && tv >= se)
+                {
+                    (se - tv).unsigned_abs() as i32
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+            update_correction_history(st, ctx, pos, ply, bonus, complexity);
         }
 
         best_value

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1589,6 +1589,7 @@ impl SearchWorker {
                     reductions: &self.reductions,
                     draw_value_table: self.draw_value_table,
                 };
+                // complexity=0: root では TT データ未参照のためスケールなし
                 update_correction_history(&self.state, &ctx, pos, 0, bonus, 0);
             }
         }

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -10,7 +10,7 @@ use crate::types::{Bound, Color, DEPTH_UNSEARCHED, Depth, MAX_PLY, Move, Value};
 use super::alpha_beta::{
     EvalContext, ProbeOutcome, SearchContext, SearchState, TTContext, to_corrected_static_eval,
 };
-use super::history::CORRECTION_HISTORY_SIZE;
+use super::history::{CORRECTION_HISTORY_LIMIT, CORRECTION_HISTORY_SIZE};
 #[cfg(feature = "use-lazy-evaluate")]
 use super::search_helpers::ensure_nnue_accumulator;
 use super::search_helpers::nnue_evaluate;
@@ -128,7 +128,8 @@ pub(super) fn update_correction_history(
     bonus: i32,
     complexity: i32,
 ) {
-    // complexity factor: 1.0 + log2(complexity + 1) / 10.0 を整数近似
+    // complexity factor: 1.0 + log2(complexity + 1) / 10.0 を整数近似（stoat 由来）
+    // ilog2 による離散近似は意図的。連続 log2 との微差は棋力に影響しない。
     // 1024 スケール: factor = 1024 + ilog2(complexity + 1) * 102
     let log2_val = if complexity > 0 {
         (complexity as u32 + 1).ilog2() as i32
@@ -136,7 +137,9 @@ pub(super) fn update_correction_history(
         0
     };
     let factor = 1024 + log2_val * 102;
-    let bonus = bonus * factor / 1024;
+    // stoat 準拠: factor 適用後に再クランプ（factor でスケール後に上限を超えないようにする）
+    let bonus =
+        (bonus * factor / 1024).clamp(-CORRECTION_HISTORY_LIMIT / 4, CORRECTION_HISTORY_LIMIT / 4);
     let us = pos.side_to_move();
     let pawn_idx = (pos.pawn_key() as usize) & (CORRECTION_HISTORY_SIZE - 1);
     let minor_idx = (pos.minor_piece_key() as usize) & (CORRECTION_HISTORY_SIZE - 1);

--- a/crates/rshogi-core/src/search/eval_helpers.rs
+++ b/crates/rshogi-core/src/search/eval_helpers.rs
@@ -118,6 +118,7 @@ pub(super) fn correction_value(
 }
 
 /// 補正履歴の更新
+/// complexity: TT スコアと静的評価の乖離度。大きいほど bonus を強く更新する（stoat 由来）。
 #[inline]
 pub(super) fn update_correction_history(
     st: &SearchState,
@@ -125,7 +126,17 @@ pub(super) fn update_correction_history(
     pos: &Position,
     ply: i32,
     bonus: i32,
+    complexity: i32,
 ) {
+    // complexity factor: 1.0 + log2(complexity + 1) / 10.0 を整数近似
+    // 1024 スケール: factor = 1024 + ilog2(complexity + 1) * 102
+    let log2_val = if complexity > 0 {
+        (complexity as u32 + 1).ilog2() as i32
+    } else {
+        0
+    };
+    let factor = 1024 + log2_val * 102;
+    let bonus = bonus * factor / 1024;
     let us = pos.side_to_move();
     let pawn_idx = (pos.pawn_key() as usize) & (CORRECTION_HISTORY_SIZE - 1);
     let minor_idx = (pos.minor_piece_key() as usize) & (CORRECTION_HISTORY_SIZE - 1);


### PR DESCRIPTION
## Summary
- stoat 由来の correction history complexity factor を実装
- `factor = 1 + log2(complexity + 1) / 10` で bonus をスケール
- TT スコアと静的評価の乖離が大きい局面ほど補正を強く学習

## 施策
`docs/improvement_plan_202604.md` B-5

## Test plan
- [x] cargo test 通過
- [ ] 500局 nodes=300K tournament で評価予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)