### PR TITLE
perf(search): quiet scoring の SEE 除去 (A-16)

### DIFF
--- a/crates/rshogi-core/src/search/movepicker.rs
+++ b/crates/rshogi-core/src/search/movepicker.rs
@@ -644,7 +644,7 @@ impl MovePicker {
                 value += ch3.get(pc, to) as i32;
                 value += ch5.get(pc, to) as i32;
 
-                if pos.check_squares(pt).contains(to) && pos.see_ge(m, Value::new(-75)) {
+                if pos.check_squares(pt).contains(to) {
                     value += 16384;
                 }
 
@@ -669,7 +669,7 @@ impl MovePicker {
                 value += ch3.get(pc, to) as i32;
                 value += ch5.get(pc, to) as i32;
 
-                if pos.check_squares(pt).contains(to) && pos.see_ge(m, Value::new(-75)) {
+                if pos.check_squares(pt).contains(to) {
                     value += 16384;
                 }
 


### PR DESCRIPTION
## Summary
- quiet 手のスコアリングで `check_squares(pt).contains(to) && see_ge(m, -75)` の SEE 呼び出しを除去
- `check_squares(pt).contains(to)` のみでボーナス判定
- Reckless は quiet scoring で SEE を呼ばない

## 種別
BOTH（NPS + 棋力）— NPS 改善が期待されるが、棋力への影響を SPRT で検証する。

## 施策
docs/improvement_plan_202604.md A-16

## Test plan
- [x] cargo test 通過
- [ ] search_only_ab (NPS)
- [ ] 250局 nodes=300K tournament (棋力)
