### PR TITLE
fix(tools): ONNX CUDA EP のサイレント CPU フォールバックを検出・防止

### DIFF
--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -375,6 +375,11 @@ fn main() -> Result<()> {
                 "AobaZero ONNX direct inference (batch={}, gpu={})",
                 cli.onnx_batch_size, cli.onnx_gpu_id
             )
+        } else if use_dlshogi_onnx {
+            format!(
+                "dlshogi ONNX direct inference (batch={}, gpu={})",
+                cli.onnx_batch_size, cli.onnx_gpu_id
+            )
         } else if use_engine {
             format!("external USI engine (nodes={}, threads={})", cli.engine_nodes, engine_threads)
         } else if let Some(depth) = cli.search_depth {
@@ -1610,11 +1615,32 @@ where
 
     let mut session = if gpu_id >= 0 {
         eprintln!("Using CUDA GPU {gpu_id}");
+
+        // CUDA EP が ORT ライブラリに含まれているか事前チェック
+        use ort::ep::ExecutionProvider;
+        let cuda_ep = ort::execution_providers::CUDAExecutionProvider::default();
+        match cuda_ep.is_available() {
+            Ok(true) => eprintln!("CUDA execution provider: available"),
+            Ok(false) => {
+                eprintln!("WARNING: CUDAExecutionProvider is NOT available in the loaded ONNX Runtime library.");
+                eprintln!("  The library may be a CPU-only build.");
+                eprintln!("  Check ORT_DYLIB_PATH points to a GPU-enabled onnxruntime.");
+                eprintln!("  Falling back to CPU inference (this will be extremely slow).");
+            }
+            Err(e) => {
+                eprintln!("WARNING: Failed to check CUDA EP availability: {e}");
+            }
+        }
+
+        // error_on_failure() により CUDA EP 登録失敗時はエラーを返す（サイレント CPU フォールバック防止）
+        let ep = ort::execution_providers::CUDAExecutionProvider::default()
+            .with_device_id(gpu_id)
+            .build()
+            .error_on_failure();
+
         builder
-            .with_execution_providers([ort::execution_providers::CUDAExecutionProvider::default()
-                .with_device_id(gpu_id)
-                .build()])
-            .map_err(|e| anyhow::anyhow!("ORT builder error: {e}"))?
+            .with_execution_providers([ep])
+            .map_err(|e| anyhow::anyhow!("ORT builder error (CUDA EP registration failed — is onnxruntime-gpu installed?): {e}"))?
             .commit_from_file(onnx_path)
             .map_err(onnx_ort_err)?
     } else {

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1591,6 +1591,7 @@ fn process_file_with_onnx_pipeline<F>(
 where
     F: Fn(&Position, &mut [f32], &mut [f32], &PackedSfenValue) + Send + Sync,
 {
+    use ort::ep::ExecutionProvider;
     use ort::session::Session;
     use ort::value::Tensor;
 
@@ -1616,31 +1617,30 @@ where
     let mut session = if gpu_id >= 0 {
         eprintln!("Using CUDA GPU {gpu_id}");
 
-        // CUDA EP が ORT ライブラリに含まれているか事前チェック
-        use ort::ep::ExecutionProvider;
-        let cuda_ep = ort::execution_providers::CUDAExecutionProvider::default();
+        // CUDA EP が ORT ライブラリに含まれているか事前チェック（サイレント CPU フォールバック防止）
+        let cuda_ep =
+            ort::execution_providers::CUDAExecutionProvider::default().with_device_id(gpu_id);
         match cuda_ep.is_available() {
             Ok(true) => eprintln!("CUDA execution provider: available"),
             Ok(false) => {
-                eprintln!("WARNING: CUDAExecutionProvider is NOT available in the loaded ONNX Runtime library.");
-                eprintln!("  The library may be a CPU-only build.");
-                eprintln!("  Check ORT_DYLIB_PATH points to a GPU-enabled onnxruntime.");
-                eprintln!("  Falling back to CPU inference (this will be extremely slow).");
+                anyhow::bail!(
+                    "CUDAExecutionProvider is NOT available in the loaded ONNX Runtime library.\n\
+                     The library may be a CPU-only build.\n\
+                     Check ORT_DYLIB_PATH points to a GPU-enabled onnxruntime.\n\
+                     To use CPU inference instead, omit --onnx-gpu-id."
+                );
             }
             Err(e) => {
                 eprintln!("WARNING: Failed to check CUDA EP availability: {e}");
             }
         }
 
-        // error_on_failure() により CUDA EP 登録失敗時はエラーを返す（サイレント CPU フォールバック防止）
-        let ep = ort::execution_providers::CUDAExecutionProvider::default()
-            .with_device_id(gpu_id)
-            .build()
-            .error_on_failure();
-
+        let ep = cuda_ep.build().error_on_failure();
         builder
             .with_execution_providers([ep])
-            .map_err(|e| anyhow::anyhow!("ORT builder error (CUDA EP registration failed — is onnxruntime-gpu installed?): {e}"))?
+            .map_err(|e| {
+                anyhow::anyhow!("CUDA EP registration failed (is onnxruntime-gpu installed?): {e}")
+            })?
             .commit_from_file(onnx_path)
             .map_err(onnx_ort_err)?
     } else {


### PR DESCRIPTION
## Summary
- `rescore_psv` で `--onnx-gpu-id` 指定時、ort の `with_execution_providers()` が CUDA EP 登録失敗をサイレントに CPU フォールバックする問題を検出・防止
- `is_available()` による事前チェック + `error_on_failure()` でサイレント劣化を防止
- Mode 表示で `--dlshogi-onnx-model` 指定時に `"static NNUE evaluation"` と誤表示されていた問題を修正

## 背景
GPU 指定で rescore を実行しても、onnxruntime が CPU 版だと CUDA EP がサイレントに失敗し `intra_threads(1)` の CPU 推論にフォールバックする。結果として ~124 nps と極端に遅くなるが、エラーメッセージが出ないため原因特定が困難だった。

## Test plan
- [x] `cargo clippy --features dlshogi-onnx` 警告なし
- [x] `cargo clippy --features aobazero-onnx` 警告なし
- [x] `cargo test -p tools` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)