### PR TITLE
fix(tools): rescore_psv の ORT_DYLIB_PATH 事前検証とドキュメント追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,9 +1340,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -22,7 +22,8 @@ wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxrunt
 tar xzf onnxruntime-linux-x64-gpu-1.24.2.tgz -C ~/lib/
 ```
 
-> ort 2.0.0-rc.12 は ONNX Runtime 1.24.2 向け。バージョンを合わせること。
+> ort 2.0.0-rc.12（Release Candidate）は ONNX Runtime 1.24.2 向け。バージョンを合わせること。
+> ort の安定版リリース後はバージョン対応表を要確認。
 
 ### 2. cuDNN 9
 
@@ -39,7 +40,7 @@ tar xf cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz -C ~/lib/
 
 ```bash
 export ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so
-export LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda-12.9/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ```
 
 | 環境変数 | 役割 |

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -1,0 +1,148 @@
+# rescore_psv — PSV 評価値の再スコアリング
+
+PSV（PackedSfenValue）ファイルの評価値を ONNX モデルで再スコアリングするツール。
+GPU 推論による高速処理に対応。
+
+## 前提条件
+
+- NVIDIA GPU + CUDA Toolkit（12.x 以上）
+- ONNX Runtime 1.24.2 GPU 版
+- cuDNN 9
+
+## セットアップ
+
+### 1. ONNX Runtime GPU 版
+
+[ONNX Runtime Releases](https://github.com/microsoft/onnxruntime/releases) から
+`onnxruntime-linux-x64-gpu-1.24.2.tgz`（Linux）または
+`onnxruntime-win-x64-gpu-1.24.2.zip`（Windows）をダウンロード。
+
+```bash
+wget https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-gpu-1.24.2.tgz
+tar xzf onnxruntime-linux-x64-gpu-1.24.2.tgz -C ~/lib/
+```
+
+> ort 2.0.0-rc.12 は ONNX Runtime 1.24.2 向け。バージョンを合わせること。
+
+### 2. cuDNN 9
+
+ONNX Runtime GPU 版は cuDNN 9 に依存する。
+
+```bash
+wget https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz
+tar xf cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz -C ~/lib/
+```
+
+### 3. 環境変数
+
+以下を `.bashrc` 等に追加する。
+
+```bash
+export ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so
+export LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda-12.9/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+```
+
+| 環境変数 | 役割 |
+|---|---|
+| `ORT_DYLIB_PATH` | ONNX Runtime ライブラリ本体のパス（必須） |
+| `LD_LIBRARY_PATH` | cuDNN・CUDA 等の依存ライブラリの検索パス |
+
+**Windows の場合**: `LD_LIBRARY_PATH` の代わりにシステムの `PATH` を使う。
+
+```powershell
+$env:ORT_DYLIB_PATH = "C:\path\to\onnxruntime-win-x64-gpu-1.24.2\lib\onnxruntime.dll"
+$env:PATH = "C:\path\to\onnxruntime-win-x64-gpu-1.24.2\lib;C:\path\to\cudnn\bin;" + $env:PATH
+```
+
+## 使い方
+
+### ビルド
+
+モデル形式に応じた feature フラグを指定する。
+
+| feature | 対象モデル |
+|---|---|
+| `aobazero-onnx` | AobaZero 系 ONNX モデル |
+| `dlshogi-onnx` | 標準 dlshogi 系 ONNX モデル（DL水匠等） |
+
+```bash
+cargo build --release -p tools --features aobazero-onnx --bin rescore_psv
+# または
+cargo build --release -p tools --features dlshogi-onnx --bin rescore_psv
+```
+
+### 実行例
+
+```bash
+# AobaZero ONNX モデル（GPU）
+cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
+  --input data/train.psv \
+  --output-dir data/rescored/ \
+  --onnx-model model.onnx \
+  --onnx-batch-size 1024 \
+  --onnx-gpu-id 0 \
+  --onnx-eval-scale 600 \
+  --threads 12
+
+# 標準 dlshogi ONNX モデル（GPU）
+cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
+  --input data/train.psv \
+  --output-dir data/rescored/ \
+  --dlshogi-onnx-model DL_suisho.onnx \
+  --onnx-batch-size 1024 \
+  --onnx-gpu-id 0 \
+  --onnx-eval-scale 600 \
+  --threads 12
+
+# CPU 推論
+cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
+  --input data/train.psv \
+  --output-dir data/rescored/ \
+  --onnx-model model.onnx \
+  --onnx-gpu-id=-1 \
+  --threads 12
+```
+
+### 主要オプション
+
+| オプション | デフォルト | 説明 |
+|---|---|---|
+| `--input` | （必須） | 入力 PSV ファイル（カンマ区切りで複数可） |
+| `--output-dir` | （必須） | 出力ディレクトリ |
+| `--onnx-model` | — | AobaZero ONNX モデルパス（`aobazero-onnx` feature 時） |
+| `--dlshogi-onnx-model` | — | dlshogi ONNX モデルパス（`dlshogi-onnx` feature 時） |
+| `--onnx-batch-size` | 256 | 推論バッチサイズ |
+| `--onnx-gpu-id` | 0 | GPU ID（`-1` で CPU 推論） |
+| `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール |
+| `--threads` | 1 | 処理スレッド数 |
+
+## 動作確認
+
+正常時の出力:
+
+```
+ORT_DYLIB_PATH: /home/user/lib/.../libonnxruntime.so
+Loading AobaZero ONNX model: model.onnx
+Using CUDA GPU 0
+CUDA execution provider: available
+AobaZero ONNX model loaded. Batch size: 1024
+[00:00:05] ████████████████████ 6693/6693 (1234 rec/s) Processing...
+```
+
+## トラブルシューティング
+
+| エラーメッセージ | 原因 | 対処 |
+|---|---|---|
+| `ORT_DYLIB_PATH environment variable is not set` | 環境変数未設定 | `ORT_DYLIB_PATH` に `libonnxruntime.so` のパスを設定 |
+| `ORT_DYLIB_PATH is set to '...' but the file does not exist` | パスが間違っている | ファイルパスを確認 |
+| `CUDAExecutionProvider is NOT available` | CPU 版ランタイムを使っている | GPU 版ランタイムをダウンロードして `ORT_DYLIB_PATH` を修正 |
+| `libcudnn.so.9: cannot open shared object file` | cuDNN が見つからない | cuDNN 9 をインストールし `LD_LIBRARY_PATH` に追加 |
+| `CUDA EP registration failed` | CUDA/cuDNN のバージョン不一致等 | CUDA Toolkit・cuDNN のバージョンを確認 |
+
+## 技術的背景
+
+本ツールは ONNX Runtime をバイナリに同梱せず、実行時に外部ライブラリとして読み込む。
+このため `ORT_DYLIB_PATH` でライブラリの場所を明示的に指定する必要がある。
+
+- `ORT_DYLIB_PATH` 未設定時はエラーを返す（未設定のまま実行するとハングするため）
+- GPU モードでは起動時に CUDA が利用可能かチェックし、CPU への暗黙フォールバックを防止する

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1595,6 +1595,48 @@ where
     use ort::session::Session;
     use ort::value::Tensor;
 
+    // ORT_DYLIB_PATH 事前検証（load-dynamic feature）
+    //
+    // ort クレートは load-dynamic feature 有効時、ORT_DYLIB_PATH 環境変数で指定された
+    // ライブラリを dlopen する。未設定時はシステムパスから "libonnxruntime.so" を探すが、
+    // 見つからない場合にハングする（エラーではなくブロックする）。
+    //
+    // ort の default features には download-binaries（ビルド時に CPU 版ランタイムを
+    // 自動ダウンロード）が含まれるが、load-dynamic とは #[cfg] で排他のため共存不可。
+    // また download-binaries で取得されるのは CPU 版のみで GPU 版は提供されない。
+    //
+    // したがって load-dynamic を使い、ランタイムはユーザーが自前で用意する設計とする。
+    // GPU 推論がデフォルト。暗黙の CPU フォールバックは CUDA EP チェックで防止する。
+    //
+    // ORT_DYLIB_PATH は GPU/CPU どちらのモードでも必須。
+    // 未設定時に ort がシステムパスから探すとハングするため。
+    match std::env::var("ORT_DYLIB_PATH") {
+        Ok(path) if !path.is_empty() => {
+            if !std::path::Path::new(&path).exists() {
+                anyhow::bail!(
+                    "ORT_DYLIB_PATH is set to '{path}' but the file does not exist.\n\
+                     Download ONNX Runtime from:\n  \
+                     https://github.com/microsoft/onnxruntime/releases"
+                );
+            }
+            eprintln!("ORT_DYLIB_PATH: {path}");
+        }
+        _ => {
+            let mode_hint = if gpu_id >= 0 {
+                "GPU inference requires a GPU-enabled ONNX Runtime (onnxruntime-linux-x64-gpu-*)."
+            } else {
+                "CPU inference requires an ONNX Runtime library (GPU or CPU build)."
+            };
+            anyhow::bail!(
+                "ORT_DYLIB_PATH environment variable is not set.\n\
+                 {mode_hint}\n\
+                 Download from: https://github.com/microsoft/onnxruntime/releases\n\
+                 Example:\n  \
+                 ORT_DYLIB_PATH=/path/to/libonnxruntime.so cargo run ..."
+            );
+        }
+    }
+
     // ONNX Runtime セッション初期化
     eprintln!("Loading {model_name} ONNX model: {}", onnx_path.display());
 

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1612,9 +1612,10 @@ where
     // 未設定時に ort がシステムパスから探すとハングするため。
     match std::env::var("ORT_DYLIB_PATH") {
         Ok(path) if !path.is_empty() => {
-            if !std::path::Path::new(&path).exists() {
+            if !std::path::Path::new(&path).is_file() {
                 anyhow::bail!(
-                    "ORT_DYLIB_PATH is set to '{path}' but the file does not exist.\n\
+                    "ORT_DYLIB_PATH is set to '{path}' but the file does not exist \
+                     (or is not a regular file).\n\
                      Download ONNX Runtime from:\n  \
                      https://github.com/microsoft/onnxruntime/releases"
                 );


### PR DESCRIPTION
## Summary

- `rescore_psv` の ONNX 推論で `ORT_DYLIB_PATH` 未設定時にハングする問題を防止
- `Session::builder()` 呼び出し前に環境変数・ファイル存在を検証し、未設定・ファイル不在時は即座にエラーを返す
- エンドユーザー向けセットアップガイド（`crates/tools/docs/rescore_psv.md`）を追加

## 背景

ort クレートの `load-dynamic` feature は `ORT_DYLIB_PATH` 未設定時にシステムパスから `libonnxruntime.so` を探すが、見つからない場合にエラーではなくハング（無限ブロック）する。GPU 版ランタイムは自動ダウンロードされないため、ユーザーが自前で用意する必要がある。

## 変更内容

### ORT_DYLIB_PATH 事前検証 (`rescore_psv.rs`)
- GPU/CPU 両モードで `ORT_DYLIB_PATH` 必須化
- ファイル不在時は即エラー（ダウンロード先 URL を案内）
- GPU モードでは既存の CUDA EP 可用性チェックと合わせて二重防護

### ドキュメント (`crates/tools/docs/rescore_psv.md`)
- 前提条件（CUDA, ONNX Runtime GPU, cuDNN）
- セットアップ手順（Linux / Windows）
- 使い方（AobaZero / dlshogi / CPU 推論）
- トラブルシューティング表

## Test plan

- [x] GPU モード + `ORT_DYLIB_PATH` 未設定 → 即エラー
- [x] CPU モード + `ORT_DYLIB_PATH` 未設定 → 即エラー
- [x] `ORT_DYLIB_PATH` ファイル不在 → 即エラー
- [x] 正常パス: AobaZero ONNX GPU 推論成功（RTX 2070 SUPER）
- [x] 正常パス: dlshogi ONNX GPU 推論成功
- [x] `cargo clippy` / `cargo test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)