### PR TITLE
perf(tools): rescore_psv ONNX 推論のゼロコピー化 + IoBinding 導入

### DIFF
--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1584,6 +1584,7 @@ where
     F: Fn(&Position, &mut [f32], &mut [f32], &PackedSfenValue) + Send + Sync,
 {
     use ort::ep::ExecutionProvider;
+    use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
     use ort::session::Session;
     use ort::value::TensorRef;
 
@@ -1813,7 +1814,8 @@ where
 
         error_count += batch_errors.load(Ordering::Relaxed);
 
-        // ゼロコピーでテンソル参照を作成し推論（CPU→ORT のメモリコピーを排除）
+        // IoBinding で推論（Python の run_with_iobinding に対応）
+        // session.run() より ORT 内部のメモリ管理が効率的
         let shape1: [usize; 4] = [actual_batch, input1_channels, 9, 9];
         let input1 = TensorRef::<f32>::from_array_view((shape1, &f1_buf[..actual_batch * f1_size]))
             .map_err(onnx_ort_err)?;
@@ -1822,12 +1824,20 @@ where
         let input2 = TensorRef::<f32>::from_array_view((shape2, &f2_buf[..actual_batch * f2_size]))
             .map_err(onnx_ort_err)?;
 
-        let outputs = session
-            .run(ort::inputs![
-                "input1" => input1,
-                "input2" => input2,
-            ])
+        let mut binding = session.create_binding().map_err(onnx_ort_err)?;
+        binding.bind_input("input1", &input1).map_err(onnx_ort_err)?;
+        binding.bind_input("input2", &input2).map_err(onnx_ort_err)?;
+        let output_mem =
+            MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
+                .map_err(onnx_ort_err)?;
+        binding
+            .bind_output_to_device("output_policy", &output_mem)
             .map_err(onnx_ort_err)?;
+        binding
+            .bind_output_to_device("output_value", &output_mem)
+            .map_err(onnx_ort_err)?;
+
+        let outputs = session.run_binding(&binding).map_err(onnx_ort_err)?;
 
         let (_, values) =
             outputs["output_value"].try_extract_tensor::<f32>().map_err(onnx_ort_err)?;

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1556,15 +1556,7 @@ fn onnx_ort_err(e: ort::Error) -> anyhow::Error {
     anyhow::anyhow!("ONNX Runtime error: {e}")
 }
 
-/// GPU パイプラインに送信するバッチデータ
-#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
-struct OnnxBatch {
-    f1_data: Vec<f32>,
-    f2_data: Vec<f32>,
-    actual_batch: usize,
-}
-
-/// ストリーミング読み込み + rayon 並列特徴量構築 + GPU パイプライン推論
+/// ストリーミング読み込み + rayon 並列特徴量構築 + ゼロコピー GPU 推論
 ///
 /// AobaZero / 標準 dlshogi の両方で共通のパイプライン処理。
 /// `build_features` クロージャで特徴量構築の差異を吸収する。
@@ -1593,7 +1585,7 @@ where
 {
     use ort::ep::ExecutionProvider;
     use ort::session::Session;
-    use ort::value::Tensor;
+    use ort::value::TensorRef;
 
     // ORT_DYLIB_PATH 事前検証（load-dynamic feature）
     //
@@ -1702,41 +1694,6 @@ where
     );
     progress.set_message("Processing...");
 
-    // GPU 推論スレッドとのパイプライン (ダブルバッファリング)
-    // バッチ N の GPU 推論中にバッチ N+1 の特徴量構築を並行実行
-    // work チャネル容量 2: メインスレッドが次バッチの特徴量構築を GPU 推論と並行して実行可能に
-    let (tx_work, rx_work) = mpsc::sync_channel::<OnnxBatch>(2);
-    let (tx_result, rx_result) = mpsc::sync_channel::<Result<Vec<f32>>>(1);
-
-    let gpu_handle = thread::spawn(move || -> Session {
-        while let Ok(batch) = rx_work.recv() {
-            let result = (|| -> Result<Vec<f32>> {
-                let shape1: [usize; 4] = [batch.actual_batch, input1_channels, 9, 9];
-                let input1 =
-                    Tensor::<f32>::from_array((shape1, batch.f1_data)).map_err(onnx_ort_err)?;
-
-                let shape2: [usize; 4] = [batch.actual_batch, input2_channels, 9, 9];
-                let input2 =
-                    Tensor::<f32>::from_array((shape2, batch.f2_data)).map_err(onnx_ort_err)?;
-
-                let outputs = session
-                    .run(ort::inputs![
-                        "input1" => input1,
-                        "input2" => input2,
-                    ])
-                    .map_err(onnx_ort_err)?;
-
-                let (_, values) =
-                    outputs["output_value"].try_extract_tensor::<f32>().map_err(onnx_ort_err)?;
-                Ok(values.to_vec())
-            })();
-            if tx_result.send(result).is_err() {
-                break;
-            }
-        }
-        session
-    });
-
     // ストリーミング読み込み + バッチ処理
     let in_file = File::open(input_path)
         .with_context(|| format!("Failed to open {}", input_path.display()))?;
@@ -1786,9 +1743,6 @@ where
     let mut clipped_count: u64 = 0;
     let mut total_processed: u64 = 0;
 
-    let mut prev_batch: Vec<(PackedSfenValue, String)> = Vec::new();
-    let mut gpu_pending = false;
-
     loop {
         // バッチ分のレコードをストリーム読み込み
         let mut batch_records: Vec<(PackedSfenValue, String)> = Vec::with_capacity(batch_size);
@@ -1832,78 +1786,76 @@ where
         }
 
         let actual_batch = batch_records.len();
-        if actual_batch > 0 {
-            f1_buf[..actual_batch * f1_size].fill(0.0);
-            f2_buf[..actual_batch * f2_size].fill(0.0);
-
-            let batch_errors = AtomicU64::new(0);
-            let f1_slices: Vec<&mut [f32]> =
-                f1_buf[..actual_batch * f1_size].chunks_mut(f1_size).collect();
-            let f2_slices: Vec<&mut [f32]> =
-                f2_buf[..actual_batch * f2_size].chunks_mut(f2_size).collect();
-
-            f1_slices.into_par_iter().zip(f2_slices).zip(batch_records.par_iter()).for_each(
-                |((f1, f2), (psv, sfen))| {
-                    let mut pos = Position::new();
-                    if pos.set_sfen(sfen).is_err() {
-                        batch_errors.fetch_add(1, Ordering::Relaxed);
-                        return;
-                    }
-                    build_features(&pos, f1, f2, psv);
-                },
-            );
-
-            error_count += batch_errors.load(Ordering::Relaxed);
-        }
-
-        // 前回の GPU 結果を受信 + 書き出し
-        if gpu_pending {
-            let values = rx_result
-                .recv()
-                .map_err(|_| anyhow::anyhow!("GPU thread terminated unexpectedly"))??;
-            for (i, (psv, _)) in prev_batch.iter().enumerate() {
-                let winrate = values[i];
-                let clamped = winrate.clamp(0.001, 0.999);
-                let logit = (clamped / (1.0 - clamped)).ln();
-                let raw_score = (logit * eval_scale) as i32;
-                let clipped = raw_score.abs() > score_clip as i32;
-                let new_score = raw_score.clamp(-(score_clip as i32), score_clip as i32) as i16;
-                if clipped {
-                    clipped_count += 1;
-                }
-                let new_psv = PackedSfenValue {
-                    sfen: psv.sfen,
-                    score: new_score,
-                    move16: 0,
-                    game_ply: psv.game_ply,
-                    game_result: psv.game_result,
-                    padding: 0,
-                };
-                writer.write_all(&new_psv.to_bytes())?;
-            }
-            total_processed += prev_batch.len() as u64;
-            progress.inc(prev_batch.len() as u64);
-        }
-
         if actual_batch == 0 {
             break;
         }
 
-        // 現在のバッチを GPU に送信
-        tx_work
-            .send(OnnxBatch {
-                f1_data: f1_buf[..actual_batch * f1_size].to_vec(),
-                f2_data: f2_buf[..actual_batch * f2_size].to_vec(),
-                actual_batch,
-            })
-            .map_err(|_| anyhow::anyhow!("GPU thread terminated unexpectedly"))?;
-        gpu_pending = true;
-        prev_batch = batch_records;
-    }
+        // rayon 並列で特徴量構築
+        f1_buf[..actual_batch * f1_size].fill(0.0);
+        f2_buf[..actual_batch * f2_size].fill(0.0);
 
-    // GPU スレッド終了
-    drop(tx_work);
-    let mut session = gpu_handle.join().map_err(|_| anyhow::anyhow!("GPU thread panicked"))?;
+        let batch_errors = AtomicU64::new(0);
+        let f1_slices: Vec<&mut [f32]> =
+            f1_buf[..actual_batch * f1_size].chunks_mut(f1_size).collect();
+        let f2_slices: Vec<&mut [f32]> =
+            f2_buf[..actual_batch * f2_size].chunks_mut(f2_size).collect();
+
+        f1_slices.into_par_iter().zip(f2_slices).zip(batch_records.par_iter()).for_each(
+            |((f1, f2), (psv, sfen))| {
+                let mut pos = Position::new();
+                if pos.set_sfen(sfen).is_err() {
+                    batch_errors.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+                build_features(&pos, f1, f2, psv);
+            },
+        );
+
+        error_count += batch_errors.load(Ordering::Relaxed);
+
+        // ゼロコピーでテンソル参照を作成し推論（CPU→ORT のメモリコピーを排除）
+        let shape1: [usize; 4] = [actual_batch, input1_channels, 9, 9];
+        let input1 = TensorRef::<f32>::from_array_view((shape1, &f1_buf[..actual_batch * f1_size]))
+            .map_err(onnx_ort_err)?;
+
+        let shape2: [usize; 4] = [actual_batch, input2_channels, 9, 9];
+        let input2 = TensorRef::<f32>::from_array_view((shape2, &f2_buf[..actual_batch * f2_size]))
+            .map_err(onnx_ort_err)?;
+
+        let outputs = session
+            .run(ort::inputs![
+                "input1" => input1,
+                "input2" => input2,
+            ])
+            .map_err(onnx_ort_err)?;
+
+        let (_, values) =
+            outputs["output_value"].try_extract_tensor::<f32>().map_err(onnx_ort_err)?;
+
+        // 結果を書き出し（テンソルから直接読み取り、to_vec() コピーを排除）
+        for (i, (psv, _)) in batch_records.iter().enumerate() {
+            let winrate = values[i];
+            let clamped = winrate.clamp(0.001, 0.999);
+            let logit = (clamped / (1.0 - clamped)).ln();
+            let raw_score = (logit * eval_scale) as i32;
+            let clipped = raw_score.abs() > score_clip as i32;
+            let new_score = raw_score.clamp(-(score_clip as i32), score_clip as i32) as i16;
+            if clipped {
+                clipped_count += 1;
+            }
+            let new_psv = PackedSfenValue {
+                sfen: psv.sfen,
+                score: new_score,
+                move16: 0,
+                game_ply: psv.game_ply,
+                game_result: psv.game_result,
+                padding: 0,
+            };
+            writer.write_all(&new_psv.to_bytes())?;
+        }
+        total_processed += actual_batch as u64;
+        progress.inc(actual_batch as u64);
+    }
 
     if profile_path.is_some() {
         match session.end_profiling() {

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1744,6 +1744,11 @@ where
     let mut clipped_count: u64 = 0;
     let mut total_processed: u64 = 0;
 
+    // MemoryInfo はバッチサイズに依存しないのでループ外で1回だけ作成
+    let output_mem =
+        MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
+            .map_err(onnx_ort_err)?;
+
     loop {
         // バッチ分のレコードをストリーム読み込み
         let mut batch_records: Vec<(PackedSfenValue, String)> = Vec::with_capacity(batch_size);
@@ -1827,9 +1832,8 @@ where
         let mut binding = session.create_binding().map_err(onnx_ort_err)?;
         binding.bind_input("input1", &input1).map_err(onnx_ort_err)?;
         binding.bind_input("input2", &input2).map_err(onnx_ort_err)?;
-        let output_mem =
-            MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
-                .map_err(onnx_ort_err)?;
+        // output_policy: スコアリングには不使用だが、省略すると ORT 内部処理で
+        // オーバーヘッドが増加するため全出力をバインドする
         binding
             .bind_output_to_device("output_policy", &output_mem)
             .map_err(onnx_ort_err)?;

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1821,6 +1821,15 @@ where
 
         // IoBinding で推論（Python の run_with_iobinding に対応）
         // session.run() より ORT 内部のメモリ管理が効率的
+        //
+        // 最適化の検証ログ (PR #451):
+        // - create_binding() のループ外化（再利用）は逆効果（4.6〜36% 悪化）。
+        //   rebind 時に ORT 内部で前回バインドのクリーンアップコストが発生するため、
+        //   毎回新規作成の方が速い。
+        // - output_policy のバインド省略も逆効果（10% 悪化）。
+        //   ORT が未バインド出力の処理にオーバーヘッドを生じる。
+        // - ボトルネックは cudaMemcpyAsync（CPU→GPU 転送）で全体の 96.1%（nsys 計測）。
+        //   転送量削減（FP16 化等）以外での大幅改善は困難。
         let shape1: [usize; 4] = [actual_batch, input1_channels, 9, 9];
         let input1 = TensorRef::<f32>::from_array_view((shape1, &f1_buf[..actual_batch * f1_size]))
             .map_err(onnx_ort_err)?;


### PR DESCRIPTION
## Summary

- `Tensor::from_array` (Vec 所有権移動) → `TensorRef::from_array_view` (スライス参照) でゼロコピー化
- `session.run()` → `run_binding()` (IoBinding) で ORT 内部のメモリ管理効率を改善
- GPU スレッド + mpsc チャネルを廃止し、メインスレッドで直接推論するシンプルな構造に変更
- `OnnxBatch` 構造体と `to_vec()` コピーを排除

## ベンチマーク

### 計測環境

- GPU: NVIDIA GeForce RTX 2070 Super (8GB VRAM)
- CUDA: 12.9 / cuDNN: 9.8.0
- ONNX Runtime: 1.24.2 GPU (ort 2.0.0-rc.12)
- モデル: DL_suisho.onnx (dlshogi 標準形式, 55MB)
- バッチサイズ: 1024
- CPU スレッド: 4 (rayon 並列特徴量構築)

### 再現手順

```bash
# 1. ベンチマーク用 PSV を作成（10000 対局 = 1,051,780 局面）
cargo run --release -p tools --bin pack_to_psv -- \
  --input data/kif20251113-1000000.pack \
  --output data/bench_rescore_large.psv \
  --max-games 10000

# 2. Rust (この PR) の計測
ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so \
LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64 \
/usr/bin/time -v cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
  --input data/bench_rescore_large.psv \
  --output-dir /tmp/bench_rust/ \
  --dlshogi-onnx-model DL_suisho.onnx \
  --onnx-batch-size 1024 \
  --onnx-gpu-id 0 \
  --onnx-eval-scale 600 \
  --threads 4

# 3. Python psv-utils の計測（比較用）
cd /tmp/psv-utils && uv venv .venv && uv pip install onnxruntime-gpu cshogi numpy tqdm
LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64 \
/usr/bin/time -v /tmp/psv-utils/.venv/bin/python /tmp/psv-utils/bench_wallclock.py \
  data/bench_rescore_large.psv \
  DL_suisho.onnx \
  1024

# 4. nsys プロファイル（ボトルネック分析）
ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so \
LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64 \
nsys profile --trace=cuda --stats=true --output=/tmp/report --force-overwrite=true \
  cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
  --input data/bench_rescore_large.psv \
  --output-dir /tmp/bench_nsys/ \
  --dlshogi-onnx-model DL_suisho.onnx \
  --onnx-batch-size 1024 \
  --onnx-gpu-id 0 \
  --onnx-eval-scale 600 \
  --threads 4
```

### Wall clock 結果（1,051,780 records、プロファイルなし）

| 実装 | Wall clock | Throughput | CPU% |
|---|---|---|---|
| Rust (IoBinding, この PR) | 5:53 | 2,980 rec/s | 129% |
| Python [psv-utils](https://github.com/KazApps/psv-utils) (参考) | 6:06 | 2,885 rec/s | 100% |

同一データ・同一モデル・同一 GPU・同一 BS での比較。

### ORT プロファイル（90,724 records）

| 実装 | OH/batch | SeqExec/batch | rec/s | 比率 |
|---|---|---|---|---|
| Baseline (`session.run` + `Tensor`) | 362 ms | 7.3 ms | 2,739 | 1.0x |
| Zero-copy (`session.run` + `TensorRef`) | 280 ms | 7.0 ms | 3,484 | 1.27x |
| IoBinding (`run_binding` + `TensorRef`) | 268 ms | 7.3 ms | 3,662 | 1.34x |

推論カーネル (SeqExec) は全実装で ~7ms/batch で同一。

### バッチサイズ別（90,724 records, IoBinding 版）

| BS | rec/s | OH/batch | 備考 |
|---|---|---|---|
| 256 | 3,522 | 67 ms | |
| 2048 | 3,870 | 647 ms | 本環境の最速 |
| 4096 | 176 | 22,000 ms | VRAM 不足で崩壊 |

## ボトルネック分析（nsys プロファイル）

NVIDIA Nsight Systems で CUDA API レベルのプロファイルを取得し、残りのオーバーヘッドの原因を特定した。

| CUDA API | 時間 | 割合 |
|---|---|---|
| `cudaMemcpyAsync` | 27.1 s | **96.1%** |
| `cudaLaunchKernel` | 0.73 s | 2.6% |
| `cudaMalloc` | 0.29 s | 1.0% |
| その他 | 0.1 s | 0.3% |

**全処理時間の 96.1% が `cudaMemcpyAsync`（CPU メインメモリ → GPU VRAM のデータ転送）**。
バッチあたり約 39MB (f1: 5022x1024x4B + f2: 4617x1024x4B) を PCIe 経由で転送しており、これは ORT 内部の処理で Rust/Python 共通の物理的制約。
GPU 上の推論カーネル自体は 2.6% でボトルネックではない。

## 今後の改善候補

| 施策 | 期待効果 | 備考 |
|---|---|---|
| FP16 入力 (TensorRT EP) | ~2x | 転送量半減。精度検証必要 |
| Pinned Memory (`cudaHostAlloc`) | 1.2~1.5x | PCIe DMA 転送効率の改善。ort API の対応要調査 |
| PackedSfen → Position 直接変換 | 小 | CPU 側処理の改善（現在は GPU 転送が支配的） |

## Test plan

- [x] 出力の完全一致確認（baseline vs zero-copy vs IoBinding, xxd diff）
- [x] cargo clippy / cargo test パス
- [x] Wall clock ベンチマーク（105万レコード）で Python psv-utils と同等以上を確認

Generated with [Claude Code](https://claude.com/claude-code)
