### PR TITLE
feat(tools): rescore_psv に TensorRT EP + FP16 推論を追加 — 2.45x 高速化

### DIFF
--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -8,6 +8,7 @@ GPU 推論による高速処理に対応。
 - NVIDIA GPU + CUDA Toolkit（12.x 以上）
 - ONNX Runtime 1.24.2 GPU 版
 - cuDNN 9
+- TensorRT 10（`--onnx-tensorrt` 使用時のみ、オプション）
 
 ## セットアップ
 
@@ -34,25 +35,38 @@ wget https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_
 tar xf cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz -C ~/lib/
 ```
 
-### 3. 環境変数
+### 3. TensorRT（オプション、`--onnx-tensorrt` 使用時のみ）
+
+TensorRT EP を使うと FP16 推論により約 2.5 倍高速化される。
+
+```bash
+wget https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.11.0/tars/TensorRT-10.11.0.33.Linux.x86_64-gnu.cuda-12.9.tar.gz
+tar xzf TensorRT-10.11.0.33.Linux.x86_64-gnu.cuda-12.9.tar.gz -C ~/lib/
+```
+
+> ORT 1.24.2 は `libnvinfer.so.10` を要求するため TensorRT 10.x が必要。
+
+### 4. 環境変数
 
 以下を `.bashrc` 等に追加する。
 
 ```bash
 export ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so
-export LD_LIBRARY_PATH=~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=~/lib/TensorRT-10.11.0.33/lib:~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ```
+
+TensorRT を使わない場合は `LD_LIBRARY_PATH` から TensorRT のパスを省略可。
 
 | 環境変数 | 役割 |
 |---|---|
 | `ORT_DYLIB_PATH` | ONNX Runtime ライブラリ本体のパス（必須） |
-| `LD_LIBRARY_PATH` | cuDNN・CUDA 等の依存ライブラリの検索パス |
+| `LD_LIBRARY_PATH` | TensorRT・cuDNN・CUDA 等の依存ライブラリの検索パス |
 
 **Windows の場合**: `LD_LIBRARY_PATH` の代わりにシステムの `PATH` を使う。
 
 ```powershell
 $env:ORT_DYLIB_PATH = "C:\path\to\onnxruntime-win-x64-gpu-1.24.2\lib\onnxruntime.dll"
-$env:PATH = "C:\path\to\onnxruntime-win-x64-gpu-1.24.2\lib;C:\path\to\cudnn\bin;" + $env:PATH
+$env:PATH = "C:\path\to\TensorRT\lib;C:\path\to\onnxruntime-win-x64-gpu-1.24.2\lib;C:\path\to\cudnn\bin;" + $env:PATH
 ```
 
 ## 使い方
@@ -95,6 +109,18 @@ cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
   --onnx-eval-scale 600 \
   --threads 12
 
+# TensorRT + FP16（約 2.5 倍高速、初回はエンジンコンパイルに時間がかかる）
+cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
+  --input data/train.psv \
+  --output-dir data/rescored/ \
+  --dlshogi-onnx-model DL_suisho.onnx \
+  --onnx-batch-size 1024 \
+  --onnx-gpu-id 0 \
+  --onnx-tensorrt \
+  --onnx-tensorrt-cache /tmp/trt_cache \
+  --onnx-eval-scale 600 \
+  --threads 12
+
 # CPU 推論
 cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
   --input data/train.psv \
@@ -114,6 +140,8 @@ cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
 | `--dlshogi-onnx-model` | — | dlshogi ONNX モデルパス（`dlshogi-onnx` feature 時） |
 | `--onnx-batch-size` | 256 | 推論バッチサイズ |
 | `--onnx-gpu-id` | 0 | GPU ID（`-1` で CPU 推論） |
+| `--onnx-tensorrt` | false | TensorRT EP を使用（FP16 推論） |
+| `--onnx-tensorrt-cache` | — | TensorRT エンジンキャッシュの保存先 |
 | `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール |
 | `--threads` | 1 | 処理スレッド数 |
 
@@ -139,6 +167,8 @@ AobaZero ONNX model loaded. Batch size: 1024
 | `CUDAExecutionProvider is NOT available` | CPU 版ランタイムを使っている | GPU 版ランタイムをダウンロードして `ORT_DYLIB_PATH` を修正 |
 | `libcudnn.so.9: cannot open shared object file` | cuDNN が見つからない | cuDNN 9 をインストールし `LD_LIBRARY_PATH` に追加 |
 | `CUDA EP registration failed` | CUDA/cuDNN のバージョン不一致等 | CUDA Toolkit・cuDNN のバージョンを確認 |
+| `TensorRTExecutionProvider is NOT available` | TensorRT が見つからない | `libnvinfer.so.10` を `LD_LIBRARY_PATH` に追加 |
+| `--onnx-tensorrt requires a GPU` | TensorRT と CPU モードの併用 | `--onnx-gpu-id` を 0 以上に設定 |
 
 ## 技術的背景
 
@@ -147,3 +177,7 @@ AobaZero ONNX model loaded. Batch size: 1024
 
 - `ORT_DYLIB_PATH` 未設定時はエラーを返す（未設定のまま実行するとハングするため）
 - GPU モードでは起動時に CUDA が利用可能かチェックし、CPU への暗黙フォールバックを防止する
+- `--onnx-tensorrt` で TensorRT ExecutionProvider を使用可能。FP16 推論により約 2.5 倍高速化されるが、
+  評価値に平均 12cp 程度の差が出る（FP16 の方が系統的にやや高く出る傾向）
+- TensorRT は初回実行時にモデルを GPU 固有にコンパイルする（数十秒〜数分）。
+  `--onnx-tensorrt-cache` でキャッシュを保存すると 2 回目以降は高速起動する

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -177,7 +177,12 @@ AobaZero ONNX model loaded. Batch size: 1024
 
 - `ORT_DYLIB_PATH` 未設定時はエラーを返す（未設定のまま実行するとハングするため）
 - GPU モードでは起動時に CUDA が利用可能かチェックし、CPU への暗黙フォールバックを防止する
-- `--onnx-tensorrt` で TensorRT ExecutionProvider を使用可能。FP16 推論により約 2.5 倍高速化されるが、
+- `--onnx-tensorrt` で TensorRT ExecutionProvider (FP16) を使用可能
+- TensorRT は常に FP16 で推論する。FP32 モード（`--onnx-tensorrt` なし）と比較して約 2.8 倍高速化されるが、
   評価値に平均 12cp 程度の差が出る（FP16 の方が系統的にやや高く出る傾向）
+- TensorRT FP32 は計測の結果 CUDA EP より遅いため（カーネル最適化の効果よりセッション初期化コストが大きい）、
+  FP32 で推論する場合は `--onnx-tensorrt` を指定せず CUDA EP を使うこと
 - TensorRT は初回実行時にモデルを GPU 固有にコンパイルする（数十秒〜数分）。
   `--onnx-tensorrt-cache` でキャッシュを保存すると 2 回目以降は高速起動する
+- このツールのボトルネックは CPU→GPU のデータ転送（全処理時間の 96%、nsys 計測）であり、
+  FP16 による高速化は主に転送量の半減と Tensor Core 活用に起因する

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -203,6 +203,14 @@ struct Cli {
     #[arg(long, default_value_t = 0)]
     onnx_gpu_id: i32,
 
+    /// TensorRT ExecutionProvider を使用（FP16推論、初回はエンジンコンパイルに時間がかかる）
+    #[arg(long)]
+    onnx_tensorrt: bool,
+
+    /// TensorRT エンジンキャッシュの保存先ディレクトリ
+    #[arg(long)]
+    onnx_tensorrt_cache: Option<PathBuf>,
+
     /// 引き分け手数（--onnx-model使用時の手数特徴量調整、0=調整なし）
     #[arg(long, default_value_t = 0)]
     onnx_draw_ply: i32,
@@ -371,14 +379,24 @@ fn main() -> Result<()> {
     eprintln!(
         "Mode: {}",
         if use_onnx {
+            let ep = if cli.onnx_tensorrt {
+                "TensorRT+FP16"
+            } else {
+                "CUDA"
+            };
             format!(
-                "AobaZero ONNX direct inference (batch={}, gpu={})",
-                cli.onnx_batch_size, cli.onnx_gpu_id
+                "AobaZero ONNX direct inference (batch={}, gpu={}, ep={})",
+                cli.onnx_batch_size, cli.onnx_gpu_id, ep
             )
         } else if use_dlshogi_onnx {
+            let ep = if cli.onnx_tensorrt {
+                "TensorRT+FP16"
+            } else {
+                "CUDA"
+            };
             format!(
-                "dlshogi ONNX direct inference (batch={}, gpu={})",
-                cli.onnx_batch_size, cli.onnx_gpu_id
+                "dlshogi ONNX direct inference (batch={}, gpu={}, ep={})",
+                cli.onnx_batch_size, cli.onnx_gpu_id, ep
             )
         } else if use_engine {
             format!("external USI engine (nodes={}, threads={})", cli.engine_nodes, engine_threads)
@@ -1570,6 +1588,8 @@ fn process_file_with_onnx_pipeline<F>(
     process_count: u64,
     batch_size: usize,
     gpu_id: i32,
+    use_tensorrt: bool,
+    tensorrt_cache: Option<&std::path::Path>,
     score_clip: i16,
     eval_scale: f32,
     skip_in_check: bool,
@@ -1651,34 +1671,77 @@ where
     };
 
     let mut session = if gpu_id >= 0 {
-        eprintln!("Using CUDA GPU {gpu_id}");
+        if use_tensorrt {
+            eprintln!("Using TensorRT (FP16) on GPU {gpu_id}");
 
-        // CUDA EP が ORT ライブラリに含まれているか事前チェック（サイレント CPU フォールバック防止）
-        let cuda_ep =
-            ort::execution_providers::CUDAExecutionProvider::default().with_device_id(gpu_id);
-        match cuda_ep.is_available() {
-            Ok(true) => eprintln!("CUDA execution provider: available"),
-            Ok(false) => {
-                anyhow::bail!(
-                    "CUDAExecutionProvider is NOT available in the loaded ONNX Runtime library.\n\
-                     The library may be a CPU-only build.\n\
-                     Check ORT_DYLIB_PATH points to a GPU-enabled onnxruntime.\n\
-                     To use CPU inference instead, omit --onnx-gpu-id."
-                );
+            let trt_ep = ort::execution_providers::TensorRTExecutionProvider::default()
+                .with_device_id(gpu_id)
+                .with_fp16(true)
+                .with_engine_cache(true);
+            let trt_ep = if let Some(cache_path) = tensorrt_cache {
+                eprintln!("TensorRT engine cache: {}", cache_path.display());
+                trt_ep.with_engine_cache_path(cache_path.to_string_lossy())
+            } else {
+                trt_ep
+            };
+
+            match trt_ep.is_available() {
+                Ok(true) => eprintln!("TensorRT execution provider: available"),
+                Ok(false) => {
+                    anyhow::bail!(
+                        "TensorRTExecutionProvider is NOT available.\n\
+                         Ensure TensorRT (libnvinfer.so.10) is in LD_LIBRARY_PATH.\n\
+                         To use CUDA EP instead, omit --onnx-tensorrt."
+                    );
+                }
+                Err(e) => {
+                    eprintln!("WARNING: Failed to check TensorRT EP availability: {e}");
+                }
             }
-            Err(e) => {
-                eprintln!("WARNING: Failed to check CUDA EP availability: {e}");
+
+            // TensorRT EP + CUDA EP をフォールバックとして登録
+            let cuda_ep = ort::execution_providers::CUDAExecutionProvider::default()
+                .with_device_id(gpu_id)
+                .build()
+                .error_on_failure();
+            let trt_ep = trt_ep.build().error_on_failure();
+
+            builder
+                .with_execution_providers([trt_ep, cuda_ep])
+                .map_err(|e| anyhow::anyhow!("TensorRT/CUDA EP registration failed: {e}"))?
+                .commit_from_file(onnx_path)
+                .map_err(onnx_ort_err)?
+        } else {
+            eprintln!("Using CUDA GPU {gpu_id}");
+
+            let cuda_ep =
+                ort::execution_providers::CUDAExecutionProvider::default().with_device_id(gpu_id);
+            match cuda_ep.is_available() {
+                Ok(true) => eprintln!("CUDA execution provider: available"),
+                Ok(false) => {
+                    anyhow::bail!(
+                        "CUDAExecutionProvider is NOT available in the loaded ONNX Runtime library.\n\
+                         The library may be a CPU-only build.\n\
+                         Check ORT_DYLIB_PATH points to a GPU-enabled onnxruntime.\n\
+                         To use CPU inference instead, omit --onnx-gpu-id."
+                    );
+                }
+                Err(e) => {
+                    eprintln!("WARNING: Failed to check CUDA EP availability: {e}");
+                }
             }
+
+            let ep = cuda_ep.build().error_on_failure();
+            builder
+                .with_execution_providers([ep])
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "CUDA EP registration failed (is onnxruntime-gpu installed?): {e}"
+                    )
+                })?
+                .commit_from_file(onnx_path)
+                .map_err(onnx_ort_err)?
         }
-
-        let ep = cuda_ep.build().error_on_failure();
-        builder
-            .with_execution_providers([ep])
-            .map_err(|e| {
-                anyhow::anyhow!("CUDA EP registration failed (is onnxruntime-gpu installed?): {e}")
-            })?
-            .commit_from_file(onnx_path)
-            .map_err(onnx_ort_err)?
     } else {
         eprintln!("Using CPU");
         builder.commit_from_file(onnx_path).map_err(onnx_ort_err)?
@@ -1936,6 +1999,8 @@ fn process_file_with_onnx(
         process_count,
         cli.onnx_batch_size,
         cli.onnx_gpu_id,
+        cli.onnx_tensorrt,
+        cli.onnx_tensorrt_cache.as_deref(),
         cli.score_clip,
         cli.onnx_eval_scale,
         cli.skip_in_check,
@@ -1973,6 +2038,8 @@ fn process_file_with_dlshogi_onnx(
         process_count,
         cli.onnx_batch_size,
         cli.onnx_gpu_id,
+        cli.onnx_tensorrt,
+        cli.onnx_tensorrt_cache.as_deref(),
         cli.score_clip,
         cli.onnx_eval_scale,
         cli.skip_in_check,

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -286,6 +286,9 @@ fn main() -> Result<()> {
             "--dlshogi-onnx-model is mutually exclusive with --engine, --use-qsearch, --search-depth"
         );
     }
+    if cli.onnx_tensorrt && cli.onnx_gpu_id < 0 {
+        anyhow::bail!("--onnx-tensorrt requires a GPU (--onnx-gpu-id >= 0)");
+    }
     if use_engine && (cli.use_qsearch || cli.search_depth.is_some()) {
         anyhow::bail!("--engine is mutually exclusive with --use-qsearch and --search-depth");
     }
@@ -378,25 +381,16 @@ fn main() -> Result<()> {
     // 処理設定の表示
     eprintln!(
         "Mode: {}",
-        if use_onnx {
+        if use_onnx || use_dlshogi_onnx {
             let ep = if cli.onnx_tensorrt {
                 "TensorRT+FP16"
             } else {
                 "CUDA"
             };
+            let model = if use_onnx { "AobaZero" } else { "dlshogi" };
             format!(
-                "AobaZero ONNX direct inference (batch={}, gpu={}, ep={})",
-                cli.onnx_batch_size, cli.onnx_gpu_id, ep
-            )
-        } else if use_dlshogi_onnx {
-            let ep = if cli.onnx_tensorrt {
-                "TensorRT+FP16"
-            } else {
-                "CUDA"
-            };
-            format!(
-                "dlshogi ONNX direct inference (batch={}, gpu={}, ep={})",
-                cli.onnx_batch_size, cli.onnx_gpu_id, ep
+                "{model} ONNX direct inference (batch={}, gpu={}, ep={ep})",
+                cli.onnx_batch_size, cli.onnx_gpu_id
             )
         } else if use_engine {
             format!("external USI engine (nodes={}, threads={})", cli.engine_nodes, engine_threads)
@@ -1677,11 +1671,18 @@ where
             let trt_ep = ort::execution_providers::TensorRTExecutionProvider::default()
                 .with_device_id(gpu_id)
                 .with_fp16(true)
-                .with_engine_cache(true);
+                .with_engine_cache(tensorrt_cache.is_some());
             let trt_ep = if let Some(cache_path) = tensorrt_cache {
+                let cache_str = cache_path.to_str().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "TensorRT cache path contains non-UTF-8 characters: {}",
+                        cache_path.display()
+                    )
+                })?;
                 eprintln!("TensorRT engine cache: {}", cache_path.display());
-                trt_ep.with_engine_cache_path(cache_path.to_string_lossy())
+                trt_ep.with_engine_cache_path(cache_str)
             } else {
+                eprintln!("TensorRT engine cache: disabled (use --onnx-tensorrt-cache to enable)");
                 trt_ep
             };
 


### PR DESCRIPTION
## Summary

`--onnx-tensorrt` フラグで TensorRT ExecutionProvider (FP16) を使用可能に。
`--onnx-tensorrt-cache` でエンジンキャッシュの保存先を指定可能。
初回実行時はモデルのコンパイルに時間がかかるが、2回目以降はキャッシュから高速起動する。

TensorRT は常に FP16 で推論する。TensorRT FP32 は計測の結果 CUDA EP より遅いため、
FP32 推論には `--onnx-tensorrt` を指定せず CUDA EP を使うこと。

## 計測環境

- GPU: NVIDIA GeForce RTX 2070 Super (8GB VRAM)
- CUDA: 12.9 / cuDNN: 9.8.0 / TensorRT: 10.11.0
- ONNX Runtime: 1.24.2 GPU (ort 2.0.0-rc.12)
- モデル: DL_suisho.onnx (dlshogi 標準形式, 55MB)
- バッチサイズ: 1024

## 使い方

```bash
ORT_DYLIB_PATH=~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib/libonnxruntime.so \
LD_LIBRARY_PATH=~/lib/TensorRT-10.11.0.33/lib:~/lib/cudnn-linux-x86_64-9.8.0.87_cuda12-archive/lib:~/lib/onnxruntime-linux-x64-gpu-1.24.2/lib:/usr/local/cuda/lib64 \
cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
  --input data/input.psv \
  --output-dir /tmp/output/ \
  --dlshogi-onnx-model DL_suisho.onnx \
  --onnx-batch-size 1024 \
  --onnx-gpu-id 0 \
  --onnx-tensorrt \
  --onnx-tensorrt-cache /tmp/trt_cache \
  --onnx-eval-scale 600
```

## ベンチマーク

### CUDA EP vs TensorRT EP — 90,724 records, 各3回平均

| EP | 平均 | rec/s | 比率 |
|---|---|---|---|
| CUDA (FP32) | 32.4 s | 2,800 | 1.0x |
| TensorRT (FP32) | 48.1 s | 1,886 | 0.67x |
| **TensorRT (FP16)** | **11.6 s** | **7,821** | **2.79x** |

TensorRT FP32 は CUDA EP より 33% 遅い。TensorRT の価値は FP16 にある。
ボトルネックが CPU→GPU 転送 (96%, PR #451 で計測済み) のため、
推論カーネルの最適化 (TensorRT FP32) は効果がなく、
転送量半減 (FP16) のみが効果を発揮する。

### 1,051,780 records, GPU 温度管理付き (60℃ 以下まで待機), 各2回平均

| 構成 | run1 | run2 | 平均 | rec/s | 比率 |
|---|---|---|---|---|---|
| Rust CUDA FP32, --threads 4 | 372.4 s | 357.6 s | 365.0 s | 2,881 | 1.0x |
| **Rust TensorRT FP16, --threads 4** | 94.9 s | 99.6 s | **97.2 s** | **10,821** | **3.76x** |
| Rust TensorRT FP16, --threads 1 | 94.5 s | 99.3 s | 96.9 s | 10,854 | 3.76x |
| Python psv-utils TensorRT FP16 | 103.4 s | 109.9 s | 106.7 s | 9,858 | 3.42x |

**Rust TensorRT FP16 は Python psv-utils より約 9% 速い**。

### --threads の影響

| 構成 | --threads 4 | --threads 1 | 差 |
|---|---|---|---|
| CUDA FP32 (90,724) | 31.7 s | 33.4 s | -5% |
| TensorRT FP16 (90,724) | 11.6 s | 11.4 s | +2% |
| TensorRT FP16 (1,051,780) | 97.2 s | 96.9 s | +0.3% |

TensorRT FP16 では GPU 推論が速すぎて、CPU 側並列化（特徴量構築）の効果がほぼない。
CUDA FP32 では並列化が有効（GPU 待ち時間に CPU 処理を重ねられるため）。

### 調査経緯のメモ

初期の計測で「`--threads 1` が `--threads 4` より 63 秒速い」という結果が出たが、
温度管理付きで再計測したところ差は消えた（**GPU サーマルスロットリングによる偶発的な差**だった）。
連続計測では GPU 温度が 80℃ 以上になり、次の実行のクロック周波数が低下する現象が観測された。
正確な比較には GPU 温度を 60℃ 以下まで冷却してから計測する必要がある。

## Rust vs Python psv-utils の差分調査

ort クレートと onnxruntime Python バインディングのコード比較を行った結果:

- TensorRT EP オプションは両者とも `device_id=0`, `trt_fp16_enable=1`, `trt_engine_cache_enable=1`, `trt_engine_cache_path` のみで、残りは C++ 側のデフォルト値（完全一致）
- IoBinding API は両者とも `RunWithBinding` C API を呼ぶ
- Rust 版が 9% 速い原因は明確に特定できていないが、rayon による特徴量構築の並列化と推論のオーバーラップ、
  Python インタプリタのオーバーヘッドの差の累積が寄与していると推定

## FP16 精度検証（1,051,780 records）

### cp 差の分布

| 差 | 局面数 | 割合 |
|---|---|---|
| 完全一致 | 175,376 | 16.7% |
| <= 10cp | 571,422 | 54.3% |
| <= 20cp | 866,470 | 82.4% |
| <= 50cp | 1,036,657 | 98.6% |
| > 100cp | 1,857 | 0.2% |

### cp 比率（|diff| / |FP32 score|）の分布

| 比率 | 局面数 | 割合 |
|---|---|---|
| <= 1% | 516,821 | 49.2% |
| <= 5% | 872,366 | 83.0% |
| <= 10% | 958,449 | 91.2% |
| > 10% | 92,359 | 8.8% |

### 統計

| 指標 | 絶対差 (cp) | 比率 (%) |
|---|---|---|
| 平均 | 11.86 | 6.35 |
| 中央値 | 9 | 1.04 |
| 最大 | 159 | — |

FP16 は系統的に +9.14 cp 高く出る傾向（70.8% の局面で FP16 の方が高い）。

## 前提条件

TensorRT ランタイム (libnvinfer.so.10) が `LD_LIBRARY_PATH` に必要。
ORT GPU 版に `libonnxruntime_providers_tensorrt.so` が含まれている必要がある（1.24.2 GPU 版には同梱）。

## Test plan

- [x] TensorRT EP (FP16) 動作確認
- [x] TensorRT EP (FP32) vs CUDA EP (FP32) 速度比較
- [x] FP32 vs FP16 精度比較（105万局面）
- [x] Rust vs Python psv-utils 比較（105万局面、温度管理付き）
- [x] --threads 1 vs --threads 4 比較（90万 + 105万）
- [x] cargo clippy / cargo test パス

Generated with [Claude Code](https://claude.com/claude-code)
