### PR TITLE
chore(deps): rustls-webpki を 0.103.12 に更新 (RUSTSEC-2026-0098/0099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

`cargo audit --deny warnings` CI が 2 件の RustSec 脆弱性を検出していたため、`rustls-webpki` を 0.103.10 → 0.103.12 にパッチ更新します（`Cargo.lock` のみ変更）。

## Advisories

- **RUSTSEC-2026-0098**: Name constraints for URI names were incorrectly accepted  
  <https://rustsec.org/advisories/RUSTSEC-2026-0098>
- **RUSTSEC-2026-0099**: Name constraints were accepted for certificates asserting a wildcard name  
  <https://rustsec.org/advisories/RUSTSEC-2026-0099>

Solution: `>=0.103.12, <0.104.0-alpha.1`

## 依存経路

```
tools 0.1.0
└── reqwest 0.12.28
    └── hyper-rustls 0.27.7
        └── rustls 0.23.35
            └── rustls-webpki 0.103.10  (→ 0.103.12)
```

`tools` クレートが Floodgate 棋譜取得で `reqwest` を経由して間接依存している箇所。
プロジェクトコードの変更は不要で、`cargo update -p rustls-webpki` によるパッチ取得のみで解消します。

## Test plan

- [x] `cargo update -p rustls-webpki` で 0.103.10 → 0.103.12 を確認
- [x] `cargo check --workspace` ビルド通過
- [x] `cargo audit --deny warnings` ローカルで **exit 0** を確認（脆弱性ゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)