### PR TITLE
feat(tools/rescore_psv): policy ベースの局面展開を ONNX 推論 1 パスで統合

### DIFF
--- a/crates/tools/docs/pack_tools.md
+++ b/crates/tools/docs/pack_tools.md
@@ -133,7 +133,7 @@ AobaZero (`--onnx-model`) と標準 dlshogi (`--dlshogi-onnx-model`, DL水匠等
 > **Tip**: スコア付け (rescore) と局面展開 (expand) を同じモデルで両方行う場合は、
 > `rescore_psv --expand-output-dir ...` を使うと **推論 1 パス** で両方を同時に実行できる
 > （value 出力で rescore、policy 出力で expand）。詳細は
-> [rescore_psv.md](rescore_psv.md#ポリシー展開expand-output-dirについて) を参照。
+> [rescore_psv.md](rescore_psv.md#ポリシー展開--expand-output-dirについて) を参照。
 
 **前提条件**: ONNX Runtime のセットアップが必要。詳細は [rescore_psv.md](rescore_psv.md) を参照。
 

--- a/crates/tools/docs/pack_tools.md
+++ b/crates/tools/docs/pack_tools.md
@@ -130,6 +130,11 @@ dlshogi 系 ONNX モデルのポリシー出力を使い、各局面の合法手
 
 AobaZero (`--onnx-model`) と標準 dlshogi (`--dlshogi-onnx-model`, DL水匠等) の両方に対応。
 
+> **Tip**: スコア付け (rescore) と局面展開 (expand) を同じモデルで両方行う場合は、
+> `rescore_psv --expand-output-dir ...` を使うと **推論 1 パス** で両方を同時に実行できる
+> （value 出力で rescore、policy 出力で expand）。詳細は
+> [rescore_psv.md](rescore_psv.md#ポリシー展開expand-output-dirについて) を参照。
+
 **前提条件**: ONNX Runtime のセットアップが必要。詳細は [rescore_psv.md](rescore_psv.md) を参照。
 
 ```bash
@@ -229,15 +234,40 @@ cargo run -p tools --release --bin preprocess_psv -- \
 
 ### ポリシーネットワークで局面を拡張する場合
 
-dlshogi モデルの有力手から次局面を生成し、学習データを増やす：
+dlshogi モデルの有力手から次局面を生成し、学習データを増やす。
+**同じ ONNX モデルで rescore と expand を両方行うなら `rescore_psv` の
+`--expand-output-dir` で 1 パス実行** が推奨（GPU 推論が 1 回で済み、I/O も減る）。
+
+```bash
+# 1 パス版: rescore + expand を同一推論で同時に実行
+cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
+  --input data.psv --output-dir rescored/ \
+  --expand-output-dir expanded/ \
+  --expand-threshold 10.0 \
+  --dlshogi-onnx-model model.onnx \
+  --onnx-tensorrt --onnx-tensorrt-cache /tmp/trt_cache
+
+# expanded/data.psv は score=0 で書き出されるため、NNUE で再スコア
+cargo run -p tools --release --bin rescore_psv -- \
+  --input expanded/data.psv --output-dir rescored_expanded/ \
+  --nnue model.nnue --use-qsearch
+
+# 元データと結合してシャッフル
+cat rescored/data.psv rescored_expanded/data.psv > combined.psv
+cargo run -p tools --release --bin shuffle_psv -- \
+  --input combined.psv --output training_shuffled.psv
+```
+
+rescore と expand で異なるモデルを使いたい場合、または既存スコア付き PSV から
+policy 展開だけ追加したい場合は `expand_psv_from_policy` を単独で使う：
 
 ```bash
 # 1. ポリシーで局面拡張（確率 10% 超の手の次局面を生成）
 cargo run --release -p tools --features dlshogi-onnx --bin expand_psv_from_policy -- \
   --input data.psv --output expanded.psv \
-  --onnx-model model.onnx --threshold 10.0
+  --dlshogi-onnx-model policy_model.onnx --threshold 10.0
 
-# 2. 拡張局面にスコアを付与
+# 2. 拡張局面にスコアを付与（rescore 用モデル）
 cargo run -p tools --release --bin rescore_psv -- \
   --input expanded.psv --output-dir rescored/ \
   --nnue model.nnue --use-qsearch

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -254,6 +254,92 @@ CPU 側の特徴量構築を並列化しても全体時間は短縮されない*
 > 注: GPU のサーマルスロットリングが計測に大きく影響するため、
 > 連続計測時は GPU 温度を 60℃ 以下に冷却してから実行すること。
 
+## ユースケース別の使い分け
+
+DL 系 ONNX モード（`--dlshogi-onnx-model` / `--onnx-model`）での代表的な
+運用パターン。各フラグは独立に組み合わせ可能。
+
+### 1. 王手局面を教師データから除外する
+
+王手親局面は評価が不安定になりやすい（詰み・詰めろ・王手放置などが混在）ため、
+学習ノイズを減らしたい場合に使う:
+
+```bash
+rescore_psv --input "data/*.bin" --output-dir rescored/ \
+  --dlshogi-onnx-model model.onnx \
+  --skip-in-check
+```
+
+rescore 出力から王手親レコードが除外される（推論は実行され、書き出しだけ抑制）。
+出力サイズは「入力 - 王手局面数」。
+
+### 2. 親と子の王手フィルタを別々に制御する（expand 併用）
+
+expand 側と rescore 側で独立に王手除外を制御したい場合:
+
+```bash
+# 例 A: rescore には王手親も含める、expand 側は王手親から展開しない
+rescore_psv --input data.bin --output-dir rescored/ \
+  --expand-output-dir expanded/ \
+  --dlshogi-onnx-model model.onnx \
+  --expand-skip-parent-in-check
+
+# 例 B: 展開した子局面が王手状態になるものを除外（"王手に追い込んだ手" を学習対象から外す）
+rescore_psv --input data.bin --output-dir rescored/ \
+  --expand-output-dir expanded/ \
+  --dlshogi-onnx-model model.onnx \
+  --expand-skip-child-in-check
+```
+
+`--skip-in-check` / `--expand-skip-parent-in-check` / `--expand-skip-child-in-check`
+の 3 フラグは独立。全部同時 ON で「王手が関係する局面を全排除」にもできる。
+
+### 3. 大規模 shard を段階的に処理する（glob + レジューム）
+
+数十〜数百 shard を逐次処理し、中断・設定変更があっても再開できる:
+
+```bash
+rescore_psv --input "data/shard_*.bin" --output-dir rescored/ \
+  --expand-output-dir expanded/ \
+  --dlshogi-onnx-model model.onnx \
+  --onnx-tensorrt --onnx-tensorrt-cache /tmp/trt_cache \
+  --expand-threshold 10.0
+```
+
+各 shard 完了時に `rescored/shard_XXX.bin.done` マーカーが書き出される。
+次回実行時の挙動:
+
+- 設定変更なし + 全 shard 完了済み → 全 skip
+- 一部 shard のみ完了 → 未完了 shard だけ処理（完了分はマーカーで skip）
+- `--onnx-eval-scale` やモデルを変更 → marker 不一致で対象 shard を自動再生成
+
+`nohup` / `tmux` で流しっぱなしにしておき、GPU 温度で止めた後の再開や、
+モデル差し替え時の一括再スコアに使える。
+
+### 4. 段階的パイプライン（多段 expand + rescore）
+
+policy で得た子局面をさらに展開、のようにカバレッジを段階的に広げる:
+
+```bash
+# ステップ 1: 元データを rescore + 1 次展開
+rescore_psv --input "data/*.bin" --output-dir rescored/ \
+  --expand-output-dir expanded1/ \
+  --dlshogi-onnx-model model.onnx
+
+# ステップ 2: 1 次展開の子局面を入力にして、さらに rescore + 2 次展開
+rescore_psv --input "expanded1/*.bin" --output-dir rescored_expanded1/ \
+  --expand-output-dir expanded2/ \
+  --dlshogi-onnx-model model.onnx
+```
+
+**運用上の注意**:
+
+- 各段で `--output-dir` と `--expand-output-dir` は **別ディレクトリ**を指定
+- 入力ディレクトリ（例 `expanded1/`）と新しい `--expand-output-dir`（例
+  `expanded2/`）も **別ディレクトリ**を指定
+- 旧段の expand 出力が次段の入力と同じファイル実体になる誤設定は起動時に検出
+  してエラー（安全装置、PR #463 で追加）
+
 ## 動作確認
 
 正常時の出力:

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -1,7 +1,11 @@
-# rescore_psv — PSV 評価値の再スコアリング
+# rescore_psv — PSV 評価値の再スコアリング + ポリシー展開
 
 PSV（PackedSfenValue）ファイルの評価値を ONNX モデルで再スコアリングするツール。
 GPU 推論による高速処理に対応。
+
+`--expand-output-dir` を指定すると、**同一の ONNX 推論結果から value と policy を
+両方取り出して、rescore と局面展開を 1 パスで実行** できる（`expand_psv_from_policy`
+相当の処理を統合）。
 
 ## 前提条件
 
@@ -128,6 +132,20 @@ cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
   --onnx-model model.onnx \
   --onnx-gpu-id=-1 \
   --threads 12
+
+# rescore + ポリシー展開を 1 パスで実行（--expand-output-dir）
+# 同一推論で value → rescore 出力、policy → 子局面出力
+cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
+  --input data/train.psv \
+  --output-dir data/rescored/ \
+  --expand-output-dir data/expanded/ \
+  --expand-threshold 10.0 \
+  --dlshogi-onnx-model DL_suisho.onnx \
+  --onnx-batch-size 1024 \
+  --onnx-gpu-id 0 \
+  --onnx-tensorrt \
+  --onnx-tensorrt-cache /tmp/trt_cache \
+  --onnx-eval-scale 600
 ```
 
 ### 主要オプション
@@ -142,8 +160,82 @@ cargo run --release -p tools --features aobazero-onnx --bin rescore_psv -- \
 | `--onnx-gpu-id` | 0 | GPU ID（`-1` で CPU 推論） |
 | `--onnx-tensorrt` | false | TensorRT EP を使用（FP16 推論） |
 | `--onnx-tensorrt-cache` | — | TensorRT エンジンキャッシュの保存先 |
-| `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール |
+| `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール（有限値・正値必須） |
+| `--skip-in-check` | false | 王手親局面の rescore 出力を抑制（後述） |
 | `--threads` | 1 | 処理スレッド数（rayon による特徴量構築の並列化） |
+
+### ポリシー展開オプション（`--expand-output-dir` 指定時）
+
+| オプション | デフォルト | 説明 |
+|---|---|---|
+| `--expand-output-dir` | — | 展開された子局面の出力ディレクトリ。**指定時のみ expand 有効。ONNX モード必須** |
+| `--expand-threshold` | 10.0 | 合法手 softmax 確率がこの値（%）を超えた手を子局面として出力。`(0.0, 100.0]` の有限値 |
+| `--expand-skip-parent-in-check` | false | 親が王手なら expand をスキップ（`--skip-in-check` と独立） |
+| `--expand-skip-child-in-check` | false | 展開した子局面が王手なら expand 出力をスキップ |
+
+出力ファイル名は入力ファイル名と同じ。`--output-dir` と `--expand-output-dir` は
+別ディレクトリを指定する必要がある（同一指定は起動時エラー）。
+
+### `--skip-in-check` の挙動
+
+王手局面を rescore 出力から除外するフラグ。**ONNX モードでは 2026-04 以降、
+挙動が変更されている**:
+
+- 旧挙動: 推論バッチに入れる前にドロップ（推論もスキップ）
+- 新挙動: **推論は実行し、rescore の書き出しだけ抑制**（expand 機能と独立動作させるため）
+
+出力 PSV のバイト列は変わらない。推論コストは王手親局面の割合分わずかに増加する
+（教師データ中の王手局面は通常 1 桁 %）。
+`--expand-skip-parent-in-check` と `--expand-skip-child-in-check` で expand 側の
+王手フィルタを独立に制御できる。
+
+### ポリシー展開（`--expand-output-dir`）について
+
+`--expand-output-dir` を指定すると、同じ ONNX 推論の policy 出力を使って
+合法手の softmax 確率を計算し、閾値を超えた手の子局面を PSV として書き出す。
+`expand_psv_from_policy` を別パスで走らせるのと同等の結果を、**推論 1 パス**で
+得られる。
+
+子局面 PSV の `score` / `move16` / `game_result` は 0 で初期化される。子局面に
+スコアを付与したい場合は、出力した expand 結果を改めて `rescore_psv` に通す
+（そのときは `--expand-output-dir` なしで value rescore のみ）。
+
+### 完了マーカー（`<rescore_output>.done`）
+
+ONNX モードでは、各入力ファイルの処理完了時に rescore 出力の隣に
+`<ファイル名>.done` という sidecar テキストを atomic rename で書き出す。
+次回同じ入力に対して実行すると:
+
+- **marker の設定 fingerprint が現在の CLI と完全一致 + 出力サイズが記録と一致** → ファイル skip
+- **fingerprint 不一致（モデル差し替え・`--onnx-eval-scale` 変更・expand 設定変更など）** →
+  rescore/expand 両出力を truncate して再生成
+- **marker が無い（従来互換）+ expand 無効** → 既存のレコード数ベース resume にフォールバック
+- **marker が無い + expand 有効** → 両出力を truncate して最初から処理
+
+fingerprint に含まれる項目:
+
+- モデルパス（canonicalize 済み）、モデルサイズ、モデル mtime（ns）
+- 入力パス、入力サイズ、入力 mtime（ns）
+- `process_count`（`--limit` 適用後）
+- `--skip-in-check`、`--score-clip`、`--onnx-eval-scale`（`f32::to_bits()` の hex で保存）
+- AobaZero モデル時のみ `--onnx-draw-ply`
+- expand 有効時: `--expand-threshold`（to_bits hex）、`--expand-skip-parent-in-check`、
+  `--expand-skip-child-in-check`、`--expand-output-dir` の canonicalize 済みパス
+
+`Ctrl-C` で中断した場合は marker を書き出さない（中途半端に処理したファイルを
+完了扱いにしない）。プロセス kill / panic には atomic rename + `sync_all()` で
+対応。電源断・カーネルパニックは非目標。
+
+### パス安全チェック（ONNX モード）
+
+ONNX モードでは以下を起動時 / ファイルごとに検証し、データ破壊を防止する:
+
+- `--output-dir` と `--expand-output-dir` が同一ディレクトリ → エラー
+- 入力ファイル = 予定出力パス（未作成でも parent canonicalize で検出）→ エラー
+- 既存出力が symlink → エラー（symlink 越しの truncate で入力を破壊しないため）
+- Unix のみ: 既存出力が入力と同じ inode（hardlink）→ エラー
+- marker 不一致で旧 expand artifact を削除する前に、旧 artifact が現在の入力と
+  同一実体でないことを検証 → 同一なら削除せずエラー（段階的パイプライン対策）
 
 ### `--threads` について
 
@@ -186,6 +278,13 @@ AobaZero ONNX model loaded. Batch size: 1024
 | `CUDA EP registration failed` | CUDA/cuDNN のバージョン不一致等 | CUDA Toolkit・cuDNN のバージョンを確認 |
 | `TensorRTExecutionProvider is NOT available` | TensorRT が見つからない | `libnvinfer.so.10` を `LD_LIBRARY_PATH` に追加 |
 | `--onnx-tensorrt requires a GPU` | TensorRT と CPU モードの併用 | `--onnx-gpu-id` を 0 以上に設定 |
+| `--expand-output-dir requires ONNX mode` | NNUE/USI モードで expand 指定 | ONNX モード（`--onnx-model` / `--dlshogi-onnx-model`）を使う |
+| `--expand-threshold must be a finite value in (0.0, 100.0]` | 範囲外 / NaN / inf | 有限値かつ `0 < v <= 100` を指定 |
+| `--onnx-eval-scale must be a positive finite value` | 0 以下 / NaN / inf | 正の有限値（通常 600.0）を指定 |
+| `--output-dir and --expand-output-dir must point to different directories` | 同一ディレクトリ指定 | 別ディレクトリを指定 |
+| `Output path is a symlink (refusing to truncate a symlink)` | 出力予定パスが symlink | symlink を削除するか別ディレクトリを使う |
+| `Output path is a hardlink to the input file` | 出力予定が入力の hardlink（Unix） | 別ディレクトリを指定 |
+| `Stale expand artifact ... resolves to the current input file` | 旧 expand 出力と現在 input が同一（段階的パイプライン） | 入力を移動するか `--expand-output-dir` を変更 |
 
 ## 技術的背景
 

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -226,6 +226,19 @@ fingerprint に含まれる項目:
 完了扱いにしない）。プロセス kill / panic には atomic rename + `sync_all()` で
 対応。電源断・カーネルパニックは非目標。
 
+#### パスに使える文字の制約
+
+マーカーは単純な `key=value\n` テキスト形式で保存される。round-trip を保証する
+ため、**model / input / expand_output_dir のパスに以下の文字を含めると起動時
+エラーで弾かれる**:
+
+- `=` (key/value セパレータと衝突、例: `v1.0=alpha/model.onnx`)
+- `\n` / `\r` (レコードセパレータと衝突)
+- 非 UTF-8 バイト列（Windows では実質発生しない、Linux の古い / 非 UTF-8 FS 由来）
+
+エラーが出た場合はパスをリネームして回避する。これらの文字を path に含める
+ユースケースは稀なので通常は気にする必要はない。
+
 ### パス安全チェック（ONNX モード）
 
 ONNX モードでは以下を起動時 / ファイルごとに検証し、データ破壊を防止する:
@@ -371,6 +384,8 @@ AobaZero ONNX model loaded. Batch size: 1024
 | `Output path is a symlink (refusing to truncate a symlink)` | 出力予定パスが symlink | symlink を削除するか別ディレクトリを使う |
 | `Output path is a hardlink to the input file` | 出力予定が入力の hardlink（Unix） | 別ディレクトリを指定 |
 | `Stale expand artifact ... resolves to the current input file` | 旧 expand 出力と現在 input が同一（段階的パイプライン） | 入力を移動するか `--expand-output-dir` を変更 |
+| `... path contains '=' which is not supported by the completion marker` | モデル/入力/expand 出力パスに `=` が含まれる | パスをリネーム（`v1.0=alpha` → `v1.0-alpha` など） |
+| `... path contains non-UTF-8 characters` | パスに非 UTF-8 バイト列 | パスを UTF-8 に揃える |
 
 ## 技術的背景
 

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -2199,16 +2199,42 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
     })
 }
 
-/// マーカーを atomic に書き出す（tmp に書く → sync_all → rename）
+/// マーカーを atomic に書き出す（tmp に書く → sync_all → rename）。
+/// 他の出力パスと同様、tmp / final が symlink の場合は拒否する
+/// （symlink を follow して任意ファイルを上書きするのを防ぐ、PR #463 review）。
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) -> Result<()> {
     let final_path = marker_path_for(rescore_output);
     let mut tmp_os = final_path.as_os_str().to_owned();
     tmp_os.push(".tmp");
     let tmp_path = PathBuf::from(tmp_os);
+
+    // symlink 拒否: final / tmp どちらも symlink 経由の書き込みをブロック。
+    // tmp に前回クラッシュの残骸 (通常ファイル) があれば事前削除する。
+    for p in [&final_path, &tmp_path] {
+        if let Ok(meta) = fs::symlink_metadata(p)
+            && meta.file_type().is_symlink()
+        {
+            anyhow::bail!(
+                "Marker path is a symlink (refusing to write): {}. \
+                 Remove the symlink or choose a different directory.",
+                p.display()
+            );
+        }
+    }
+    if tmp_path.exists() {
+        fs::remove_file(&tmp_path)
+            .with_context(|| format!("Failed to remove stale marker tmp {}", tmp_path.display()))?;
+    }
+
     let body = serialize_marker(marker);
     {
-        let mut f = File::create(&tmp_path)
+        // `create_new(true)` により、競合で tmp を別プロセスが作っていた場合は
+        // 失敗させる（上の symlink チェックと TOCTOU 窓を狭める）。
+        let mut f = File::options()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
             .with_context(|| format!("Failed to create marker tmp {}", tmp_path.display()))?;
         f.write_all(body.as_bytes())?;
         f.sync_all()?;
@@ -2598,9 +2624,10 @@ where
                     continue;
                 }
             };
-            // 王手判定はバッチ読み込み時に 1 回だけ。失敗時は in_check=false
-            // 扱いとし、書き出しループで Position::set_sfen が再度失敗すれば
-            // error_count に計上される。
+            // 王手判定はバッチ読み込み時に 1 回だけ行う。ここで
+            // Position::set_sfen に失敗した場合は in_check=false 扱いとする
+            // （後段の特徴量構築で同じ局面を再パースしたときに失敗すれば
+            //  batch_errors → error_count に計上される）。
             let mut probe = Position::new();
             let in_check = match probe.set_sfen(&sfen) {
                 Ok(()) => probe.in_check(),

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -2245,6 +2245,41 @@ fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) ->
     Ok(())
 }
 
+/// マーカーの `key=value\n` テキスト形式で安全に round-trip できないパスを拒否する。
+///
+/// 具体的には以下のいずれかを含むパスを起動時にエラーにする:
+/// - 非 UTF-8 バイト列（`Path::to_str` が `None`、`Path::display` が lossy になる）
+/// - `=`（key/value セパレータと衝突）
+/// - `\n` / `\r`（レコードセパレータと衝突）
+///
+/// 現実的には `=` を含むパスだけが稀に発生する（例:
+/// `v1.0=alpha/model.onnx`）。非 UTF-8 と改行はほぼ起こらないが、同じ
+/// 検証枠で拾っておく。遭遇時はパスをリネームすることで回避可能。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn ensure_marker_safe_path(kind: &str, path: &std::path::Path) -> Result<()> {
+    let s = path.to_str().ok_or_else(|| {
+        anyhow::anyhow!(
+            "{kind} path contains non-UTF-8 characters which cannot be recorded in the \
+             completion marker: {}. Rename the path to ASCII / UTF-8 only characters.",
+            path.display()
+        )
+    })?;
+    if let Some(bad) = s.chars().find(|c| *c == '=' || *c == '\n' || *c == '\r') {
+        let name = match bad {
+            '=' => "'='",
+            '\n' => "LF (newline)",
+            '\r' => "CR",
+            _ => unreachable!(),
+        };
+        anyhow::bail!(
+            "{kind} path contains {name} which is not supported by the completion marker \
+             format (key=value text): {}. Rename the path to avoid these characters.",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// `OnnxPipelineConfig` から `RunFingerprint` を構築
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerprint> {
@@ -2252,18 +2287,22 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         .onnx_path
         .canonicalize()
         .with_context(|| format!("Failed to canonicalize {}", config.onnx_path.display()))?;
+    ensure_marker_safe_path("--onnx-model / --dlshogi-onnx-model", &model_path)?;
     let (model_size, model_mtime_ns) = file_size_mtime_ns(&model_path)?;
     let input_path = config
         .input_path
         .canonicalize()
         .with_context(|| format!("Failed to canonicalize {}", config.input_path.display()))?;
+    ensure_marker_safe_path("input", &input_path)?;
     let (input_size, input_mtime_ns) = file_size_mtime_ns(&input_path)?;
     let expand_output_path = match config.expand {
-        Some(e) => Some(
+        Some(e) => {
             // 出力ファイルが未作成でも canonical_dir + file_name で予定パスを構築する
             // ため、parent dir のみ canonicalize する
-            canonicalize_predicted_path(e.output_path)?,
-        ),
+            let p = canonicalize_predicted_path(e.output_path)?;
+            ensure_marker_safe_path("--expand-output-dir (entry)", &p)?;
+            Some(p)
+        }
         None => None,
     };
     Ok(RunFingerprint {

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -263,6 +263,36 @@ enum OnnxMarkerDecision {
     LegacyResume,
 }
 
+/// 2 つのパスが同じファイル実体を指すかを判定する。
+/// パス文字列一致、canonicalize 一致、Unix の `dev + ino` 一致のいずれかで true を返す。
+/// I/O エラーや非 Unix プラットフォームで dev/ino が取れないケースでは false
+/// に倒れる（= 「同一と判定できなかった」。呼び出し側の文脈で追加の安全策が
+/// 必要な場面ではパス一致検証と併用する）。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn is_same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
+    if a == b {
+        return true;
+    }
+    if let (Ok(ca), Ok(cb)) = (a.canonicalize(), b.canonicalize())
+        && ca == cb
+    {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if a.exists()
+            && b.exists()
+            && let (Ok(ma), Ok(mb)) = (fs::metadata(a), fs::metadata(b))
+            && ma.dev() == mb.dev()
+            && ma.ino() == mb.ino()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// 既存出力パスが symlink でないこと、未作成・既存どちらでも入力パスと衝突
 /// しないことを検証する。既存ファイルが入力の hardlink である場合も検出する
 /// （Unix のみ、`MetadataExt::dev/ino` で同一 inode を判定）。
@@ -394,27 +424,50 @@ fn onnx_marker_decide(
             return Ok(OnnxMarkerDecision::Skip);
         }
 
-        // 不一致: 現在 run の出力を truncate
-        if rescore_output_path.exists() {
-            File::options().write(true).open(rescore_output_path)?.set_len(0)?;
-        }
-        if let Some(p) = expand_output_path
-            && p.exists()
-        {
-            File::options().write(true).open(p)?.set_len(0)?;
-        }
-        // 過去 marker が指す expand 出力パスが現在と異なれば旧 artifact を削除
+        // 不一致時の再生成手順。
+        // 破壊操作の順序は意図的:
+        //   1. 旧 expand artifact 削除（失敗しうる、入力衝突も事前検証）
+        //   2. 現 rescore 出力 truncate
+        //   3. 現 expand 出力 truncate
+        //   4. marker 削除（最後）
+        // この順なら、どの段階で失敗しても次回実行時に marker 不一致判定が
+        // 働き、続きからやり直せる。旧設計の "truncate してから remove_file"
+        // だと、後段失敗時に truncate 済み出力 + 古い marker が残ってデータ
+        // 損失になり得たため修正 (PR #463 review P1)。
+
+        // 1. 旧 expand artifact 削除
         if let Some(old) = &marker.fingerprint.expand_output_path {
-            let same =
-                expand_output_path.map(|p| canonicalize_predicted_path(p).ok()).unwrap_or(None);
-            let differ = same.as_ref() != Some(old);
-            if differ && old.exists() {
+            // 段階的パイプライン（前回 expand 出力を次回入力に使う）対策。
+            // 旧 artifact が現在 run の入力と同一ファイルなら絶対に削除しない。
+            if is_same_file(old, &canonical_input) {
+                anyhow::bail!(
+                    "Stale expand artifact {} resolves to the current input file {}. \
+                     Refusing to delete to prevent input data loss. \
+                     Move the input or change --expand-output-dir.",
+                    old.display(),
+                    canonical_input.display()
+                );
+            }
+            // 現在 run の expand 出力と同一なら truncate ステップで処理されるのでスキップ
+            let same_as_current = expand_output_path.is_some_and(|p| is_same_file(p, old));
+            if !same_as_current && old.exists() {
                 fs::remove_file(old).with_context(|| {
                     format!("Failed to remove stale expand artifact {}", old.display())
                 })?;
             }
         }
-        // marker 自体も削除（次回完了時に新しい marker を作成）
+
+        // 2. 現 rescore 出力 truncate
+        if rescore_output_path.exists() {
+            File::options().write(true).open(rescore_output_path)?.set_len(0)?;
+        }
+        // 3. 現 expand 出力 truncate
+        if let Some(p) = expand_output_path
+            && p.exists()
+        {
+            File::options().write(true).open(p)?.set_len(0)?;
+        }
+        // 4. marker 削除（最後）
         fs::remove_file(&marker_path)
             .with_context(|| format!("Failed to remove stale marker {}", marker_path.display()))?;
         return Ok(OnnxMarkerDecision::TruncateAndProcess);

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1568,22 +1568,23 @@ fn onnx_ort_err(e: ort::Error) -> anyhow::Error {
     anyhow::anyhow!("ONNX Runtime error: {e}")
 }
 
-/// ストリーミング読み込み + rayon 並列特徴量構築 + ゼロコピー GPU 推論
+/// ONNX 直接推論パイプラインの共通設定
 ///
-/// AobaZero / 標準 dlshogi の両方で共通のパイプライン処理。
-/// `build_features` クロージャで特徴量構築の差異を吸収する。
+/// 全フィールドが `Copy` のため、関数内で destructure して既存ローカル変数名と
+/// 互換に展開できる。引数 17 個の関数シグネチャを単一引数に集約することで、
+/// 後続コミットでフィールド追加（expand 機能）を容易にする。
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
-#[allow(clippy::too_many_arguments)]
-fn process_file_with_onnx_pipeline<F>(
-    model_name: &str,
-    onnx_path: &std::path::Path,
-    input_path: &std::path::Path,
-    output_path: &std::path::Path,
+#[derive(Clone, Copy)]
+struct OnnxPipelineConfig<'a> {
+    model_name: &'a str,
+    onnx_path: &'a std::path::Path,
+    input_path: &'a std::path::Path,
+    output_path: &'a std::path::Path,
     process_count: u64,
     batch_size: usize,
     gpu_id: i32,
     use_tensorrt: bool,
-    tensorrt_cache: Option<&std::path::Path>,
+    tensorrt_cache: Option<&'a std::path::Path>,
     score_clip: i16,
     eval_scale: f32,
     skip_in_check: bool,
@@ -1591,12 +1592,40 @@ fn process_file_with_onnx_pipeline<F>(
     f2_size: usize,
     input1_channels: usize,
     input2_channels: usize,
-    profile_path: Option<&std::path::Path>,
+    profile_path: Option<&'a std::path::Path>,
+}
+
+/// ストリーミング読み込み + rayon 並列特徴量構築 + ゼロコピー GPU 推論
+///
+/// AobaZero / 標準 dlshogi の両方で共通のパイプライン処理。
+/// `build_features` クロージャで特徴量構築の差異を吸収する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn process_file_with_onnx_pipeline<F>(
+    config: &OnnxPipelineConfig<'_>,
     build_features: F,
 ) -> Result<()>
 where
     F: Fn(&Position, &mut [f32], &mut [f32], &PackedSfenValue) + Send + Sync,
 {
+    let OnnxPipelineConfig {
+        model_name,
+        onnx_path,
+        input_path,
+        output_path,
+        process_count,
+        batch_size,
+        gpu_id,
+        use_tensorrt,
+        tensorrt_cache,
+        score_clip,
+        eval_scale,
+        skip_in_check,
+        f1_size,
+        f2_size,
+        input1_channels,
+        input2_channels,
+        profile_path,
+    } = *config;
     use ort::ep::ExecutionProvider;
     use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
     use ort::session::Session;
@@ -1992,28 +2021,28 @@ fn process_file_with_onnx(
     };
 
     let draw_ply = cli.onnx_draw_ply;
-    process_file_with_onnx_pipeline(
-        "AobaZero",
-        cli.onnx_model.as_ref().unwrap(),
+    let config = OnnxPipelineConfig {
+        model_name: "AobaZero",
+        onnx_path: cli.onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
         process_count,
-        cli.onnx_batch_size,
-        cli.onnx_gpu_id,
-        cli.onnx_tensorrt,
-        cli.onnx_tensorrt_cache.as_deref(),
-        cli.score_clip,
-        cli.onnx_eval_scale,
-        cli.skip_in_check,
-        FEATURES1_SIZE,
-        FEATURES2_SIZE,
-        INPUT1_CHANNELS,
-        INPUT2_CHANNELS,
-        cli.ort_profile.as_deref(),
-        move |pos, f1, f2, psv| {
-            make_input_features(pos, f1, f2, psv.game_ply as i32, draw_ply);
-        },
-    )
+        batch_size: cli.onnx_batch_size,
+        gpu_id: cli.onnx_gpu_id,
+        use_tensorrt: cli.onnx_tensorrt,
+        tensorrt_cache: cli.onnx_tensorrt_cache.as_deref(),
+        score_clip: cli.score_clip,
+        eval_scale: cli.onnx_eval_scale,
+        skip_in_check: cli.skip_in_check,
+        f1_size: FEATURES1_SIZE,
+        f2_size: FEATURES2_SIZE,
+        input1_channels: INPUT1_CHANNELS,
+        input2_channels: INPUT2_CHANNELS,
+        profile_path: cli.ort_profile.as_deref(),
+    };
+    process_file_with_onnx_pipeline(&config, move |pos, f1, f2, psv| {
+        make_input_features(pos, f1, f2, psv.game_ply as i32, draw_ply);
+    })
 }
 
 // ============================================================
@@ -2031,26 +2060,26 @@ fn process_file_with_dlshogi_onnx(
         FEATURES1_SIZE, FEATURES2_SIZE, INPUT1_CHANNELS, INPUT2_CHANNELS, make_input_features,
     };
 
-    process_file_with_onnx_pipeline(
-        "dlshogi",
-        cli.dlshogi_onnx_model.as_ref().unwrap(),
+    let config = OnnxPipelineConfig {
+        model_name: "dlshogi",
+        onnx_path: cli.dlshogi_onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
         process_count,
-        cli.onnx_batch_size,
-        cli.onnx_gpu_id,
-        cli.onnx_tensorrt,
-        cli.onnx_tensorrt_cache.as_deref(),
-        cli.score_clip,
-        cli.onnx_eval_scale,
-        cli.skip_in_check,
-        FEATURES1_SIZE,
-        FEATURES2_SIZE,
-        INPUT1_CHANNELS,
-        INPUT2_CHANNELS,
-        cli.ort_profile.as_deref(),
-        |pos, f1, f2, _psv| {
-            make_input_features(pos, f1, f2);
-        },
-    )
+        batch_size: cli.onnx_batch_size,
+        gpu_id: cli.onnx_gpu_id,
+        use_tensorrt: cli.onnx_tensorrt,
+        tensorrt_cache: cli.onnx_tensorrt_cache.as_deref(),
+        score_clip: cli.score_clip,
+        eval_scale: cli.onnx_eval_scale,
+        skip_in_check: cli.skip_in_check,
+        f1_size: FEATURES1_SIZE,
+        f2_size: FEATURES2_SIZE,
+        input1_channels: INPUT1_CHANNELS,
+        input2_channels: INPUT2_CHANNELS,
+        profile_path: cli.ort_profile.as_deref(),
+    };
+    process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
+        make_input_features(pos, f1, f2);
+    })
 }

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -222,6 +222,26 @@ struct Cli {
     /// ORT profiling出力先ディレクトリ（指定するとsession.run()の内訳をJSONで出力）
     #[arg(long)]
     ort_profile: Option<PathBuf>,
+
+    // --- ポリシー展開モード（ONNX 推論で value と同時に policy も使う） ---
+    /// 展開された子局面の出力ディレクトリ（指定時のみ expand 機能が有効）
+    /// ONNX モード（--onnx-model または --dlshogi-onnx-model）必須。
+    /// 入力ファイル名と同名で出力（rescore 出力とは別ディレクトリに置くこと）。
+    #[arg(long)]
+    expand_output_dir: Option<PathBuf>,
+
+    /// 合法手 softmax 確率がこの値（%）を超えた手を子局面として書き出す
+    /// `0.0 < v <= 100.0` の有限値が必要。expand 無効時は無視。
+    #[arg(long, default_value_t = 10.0)]
+    expand_threshold: f32,
+
+    /// 親局面が王手のとき expand をスキップ（rescore 側は --skip-in-check で別制御）
+    #[arg(long)]
+    expand_skip_parent_in_check: bool,
+
+    /// 展開した子局面が王手のとき expand 出力をスキップ
+    #[arg(long)]
+    expand_skip_child_in_check: bool,
 }
 
 /// 処理中にCtrl-Cが押されたかを追跡
@@ -231,6 +251,191 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 const QSEARCH_ALPHA_INIT: i32 = -30000;
 /// qsearchの初期beta値
 const QSEARCH_BETA_INIT: i32 = 30000;
+
+/// ONNX モードの marker 判定結果
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+enum OnnxMarkerDecision {
+    /// 完了済み（marker 一致 + bodies_match）。ファイル全体を skip
+    Skip,
+    /// rescore + expand 出力を truncate して最初から処理
+    TruncateAndProcess,
+    /// marker 不存在 + expand 無効 → 既存の record-count resume にフォールバック
+    LegacyResume,
+}
+
+/// 既存出力パスが symlink でないこと、未作成・既存どちらでも入力パスと衝突
+/// しないことを検証する。既存ファイルが入力の hardlink である場合も検出する
+/// （Unix のみ、`MetadataExt::dev/ino` で同一 inode を判定）。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn ensure_safe_output_path(
+    predicted: &std::path::Path,
+    canonical_input: &std::path::Path,
+) -> Result<()> {
+    // 既存ファイルなら symlink を拒否（truncate/append が symlink を辿ると
+    // 入力破壊につながる）
+    if let Ok(meta) = fs::symlink_metadata(predicted)
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!(
+            "Output path is a symlink (refusing to truncate a symlink): {}. \
+             Remove the symlink or choose a different directory.",
+            predicted.display()
+        );
+    }
+    // 出力ファイル未作成でも parent を canonicalize して予定 canonical パスを構築
+    // し、入力パスと一致したらエラー
+    let predicted_canonical = canonicalize_predicted_path(predicted)?;
+    if predicted_canonical == canonical_input {
+        anyhow::bail!(
+            "Output path resolves to input file: {} -> {}",
+            predicted.display(),
+            canonical_input.display()
+        );
+    }
+    // 既存出力ファイルが入力と同じ inode を指す（hardlink）ケースを検出。
+    // `canonicalize` はパス解決のみで hardlink を検出できないため、Unix では
+    // `MetadataExt::{dev, ino}` で同一 inode 判定する。
+    #[cfg(unix)]
+    if predicted.exists() {
+        use std::os::unix::fs::MetadataExt;
+        let pred_meta = fs::metadata(predicted)
+            .with_context(|| format!("Failed to stat predicted output {}", predicted.display()))?;
+        let in_meta = fs::metadata(canonical_input)
+            .with_context(|| format!("Failed to stat input {}", canonical_input.display()))?;
+        if pred_meta.dev() == in_meta.dev() && pred_meta.ino() == in_meta.ino() {
+            anyhow::bail!(
+                "Output path is a hardlink to the input file ({} ↔ {}). \
+                 Refusing to truncate; choose a different directory.",
+                predicted.display(),
+                canonical_input.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// ONNX モードの marker チェック + 必要な truncate を行い、判定結果を返す
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[allow(clippy::too_many_arguments)]
+fn onnx_marker_decide(
+    cli: &Cli,
+    model_kind: &str,
+    onnx_path: &std::path::Path,
+    input_path: &std::path::Path,
+    rescore_output_path: &std::path::Path,
+    expand_output_path: Option<&std::path::Path>,
+    process_count: u64,
+) -> Result<OnnxMarkerDecision> {
+    // 現在 run の OnnxPipelineConfig を組み立てて fingerprint を作る
+    // （f1/f2 サイズや input1/input2 channels は fingerprint に含まれないが、
+    //  Config を共通化するために設定する。任意値で OK）
+    let expand_cfg = expand_output_path.map(|p| ExpandConfig {
+        output_path: p,
+        threshold: cli.expand_threshold / 100.0,
+        skip_parent_in_check: cli.expand_skip_parent_in_check,
+        skip_child_in_check: cli.expand_skip_child_in_check,
+    });
+    // dlshogi モデルは `onnx_draw_ply` を使わないため fingerprint からも 0 固定にする
+    // （AobaZero 専用パラメータの誤った invalidation を避ける）
+    let onnx_draw_ply_for_fp = if model_kind == "aobazero" {
+        cli.onnx_draw_ply
+    } else {
+        0
+    };
+    let cfg = OnnxPipelineConfig {
+        model_name: "",
+        model_kind,
+        onnx_path,
+        input_path,
+        output_path: rescore_output_path,
+        process_count,
+        batch_size: cli.onnx_batch_size,
+        gpu_id: cli.onnx_gpu_id,
+        use_tensorrt: cli.onnx_tensorrt,
+        tensorrt_cache: cli.onnx_tensorrt_cache.as_deref(),
+        score_clip: cli.score_clip,
+        eval_scale: cli.onnx_eval_scale,
+        skip_in_check: cli.skip_in_check,
+        onnx_draw_ply: onnx_draw_ply_for_fp,
+        f1_size: 0,
+        f2_size: 0,
+        input1_channels: 0,
+        input2_channels: 0,
+        profile_path: None,
+        expand: expand_cfg,
+    };
+    let current = build_run_fingerprint(&cfg)?;
+
+    // 入出力 symlink / 重複チェック
+    let canonical_input = current.input_path.clone();
+    ensure_safe_output_path(rescore_output_path, &canonical_input)?;
+    if let Some(p) = expand_output_path {
+        ensure_safe_output_path(p, &canonical_input)?;
+    }
+
+    let marker_path = marker_path_for(rescore_output_path);
+    if marker_path.exists() {
+        let marker = parse_marker(&marker_path)?;
+        let bodies_match = rescore_output_path.exists()
+            && fs::metadata(rescore_output_path)?.len() == marker.output_sizes.rescore_output_size
+            && match (
+                marker.fingerprint.expand,
+                marker.output_sizes.expand_output_size,
+                marker.fingerprint.expand_output_path.as_ref(),
+            ) {
+                (true, Some(size), Some(path)) => {
+                    path.exists() && fs::metadata(path)?.len() == size
+                }
+                (false, None, None) => true,
+                _ => false,
+            };
+
+        if marker.fingerprint == current && bodies_match {
+            return Ok(OnnxMarkerDecision::Skip);
+        }
+
+        // 不一致: 現在 run の出力を truncate
+        if rescore_output_path.exists() {
+            File::options().write(true).open(rescore_output_path)?.set_len(0)?;
+        }
+        if let Some(p) = expand_output_path
+            && p.exists()
+        {
+            File::options().write(true).open(p)?.set_len(0)?;
+        }
+        // 過去 marker が指す expand 出力パスが現在と異なれば旧 artifact を削除
+        if let Some(old) = &marker.fingerprint.expand_output_path {
+            let same =
+                expand_output_path.map(|p| canonicalize_predicted_path(p).ok()).unwrap_or(None);
+            let differ = same.as_ref() != Some(old);
+            if differ && old.exists() {
+                fs::remove_file(old).with_context(|| {
+                    format!("Failed to remove stale expand artifact {}", old.display())
+                })?;
+            }
+        }
+        // marker 自体も削除（次回完了時に新しい marker を作成）
+        fs::remove_file(&marker_path)
+            .with_context(|| format!("Failed to remove stale marker {}", marker_path.display()))?;
+        return Ok(OnnxMarkerDecision::TruncateAndProcess);
+    }
+
+    // marker 不存在
+    if expand_output_path.is_some() {
+        // expand 有効時は marker 必須。truncate して最初から
+        if rescore_output_path.exists() {
+            File::options().write(true).open(rescore_output_path)?.set_len(0)?;
+        }
+        if let Some(p) = expand_output_path
+            && p.exists()
+        {
+            File::options().write(true).open(p)?.set_len(0)?;
+        }
+        Ok(OnnxMarkerDecision::TruncateAndProcess)
+    } else {
+        Ok(OnnxMarkerDecision::LegacyResume)
+    }
+}
 
 /// 入力パターンをglobで展開してファイルリストを取得
 fn expand_input_patterns(patterns: &[String]) -> Result<Vec<PathBuf>> {
@@ -300,6 +505,28 @@ fn main() -> Result<()> {
             "--nnue is required when --engine/--onnx-model/--dlshogi-onnx-model is not specified"
         );
     }
+
+    // --expand-output-dir は ONNX モード必須
+    if cli.expand_output_dir.is_some() && !(use_onnx || use_dlshogi_onnx) {
+        anyhow::bail!(
+            "--expand-output-dir requires ONNX mode (--onnx-model or --dlshogi-onnx-model). \
+             policy 出力は ONNX 推論経路でのみ取得できます。"
+        );
+    }
+    // expand 機能の数値検証
+    if cli.expand_output_dir.is_some() {
+        let t = cli.expand_threshold;
+        if !(t.is_finite() && 0.0 < t && t <= 100.0) {
+            anyhow::bail!("--expand-threshold must be a finite value in (0.0, 100.0], got {t}");
+        }
+    }
+    // ONNX 系の eval_scale 妥当性
+    if use_onnx || use_dlshogi_onnx {
+        let s = cli.onnx_eval_scale;
+        if !s.is_finite() || s <= 0.0 {
+            anyhow::bail!("--onnx-eval-scale must be a positive finite value, got {s}");
+        }
+    }
     #[cfg(not(feature = "aobazero-onnx"))]
     if use_onnx {
         anyhow::bail!(
@@ -333,6 +560,29 @@ fn main() -> Result<()> {
         fs::create_dir_all(&cli.output_dir).with_context(|| {
             format!("Failed to create output directory: {}", cli.output_dir.display())
         })?;
+    }
+    // expand 出力ディレクトリの作成
+    if let Some(d) = &cli.expand_output_dir
+        && !d.exists()
+    {
+        fs::create_dir_all(d).with_context(|| {
+            format!("Failed to create expand output directory: {}", d.display())
+        })?;
+    }
+    // 両 dir を canonicalize して衝突を検出
+    let canonical_rescore_dir = cli.output_dir.canonicalize().with_context(|| {
+        format!("Failed to canonicalize --output-dir {}", cli.output_dir.display())
+    })?;
+    let canonical_expand_dir = match &cli.expand_output_dir {
+        Some(d) => Some(d.canonicalize().with_context(|| {
+            format!("Failed to canonicalize --expand-output-dir {}", d.display())
+        })?),
+        None => None,
+    };
+    if let Some(ed) = &canonical_expand_dir
+        && &canonical_rescore_dir == ed
+    {
+        anyhow::bail!("--output-dir and --expand-output-dir must point to different directories");
     }
 
     // NNUEモデルのロード（NNUE内部評価モードのみ）
@@ -434,6 +684,15 @@ fn main() -> Result<()> {
         cli.source_fv_scale as f64 / cli.target_fv_scale as f64
     );
     eprintln!("Output directory: {}", cli.output_dir.display());
+    if let Some(d) = &cli.expand_output_dir {
+        eprintln!(
+            "Expand output directory: {} (threshold={:.2}%, skip_parent={}, skip_child={})",
+            d.display(),
+            cli.expand_threshold,
+            cli.expand_skip_parent_in_check,
+            cli.expand_skip_child_in_check,
+        );
+    }
     if cli.delete_input {
         eprintln!("Delete input after processing: yes");
     }
@@ -448,44 +707,100 @@ fn main() -> Result<()> {
         }
 
         // 出力ファイルパスを生成
-        let output_path =
-            cli.output_dir.join(input_path.file_name().ok_or_else(|| {
-                anyhow::anyhow!("Invalid input file name: {}", input_path.display())
-            })?);
+        let file_name = input_path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Invalid input file name: {}", input_path.display()))?;
+        let output_path = cli.output_dir.join(file_name);
+        #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+        let expand_output_path = canonical_expand_dir.as_ref().map(|d| d.join(file_name));
 
-        // 入力と出力が同じパスの場合はエラー（--delete-input でデータ消失を防ぐ）
-        if input_path.canonicalize().ok() == output_path.canonicalize().ok() {
-            anyhow::bail!(
-                "Input and output paths are the same: {}. Use a different --output-dir.",
-                input_path.display()
-            );
-        }
-
-        // 出力ファイルが既に存在し、入力と同じレコード数ならスキップ（完了済み）
+        // 入力ファイルサイズと process_count を最初に確定（marker 判定の前提）
         let input_file_size = fs::metadata(input_path)?.len();
         let input_record_count = input_file_size / PackedSfenValue::SIZE as u64;
-        if output_path.exists() {
-            let out_size = fs::metadata(&output_path)?.len();
-            let out_records = out_size / PackedSfenValue::SIZE as u64;
-            if out_records >= input_record_count && out_size % PackedSfenValue::SIZE as u64 == 0 {
-                eprintln!(
-                    "=== [{}/{}] Skipping (complete: {} records): {} ===",
-                    file_idx + 1,
-                    total_files,
-                    out_records,
-                    output_path.display()
-                );
-                continue;
+        let process_count = if cli.limit > 0 && cli.limit < input_record_count {
+            cli.limit
+        } else {
+            input_record_count
+        };
+
+        // ONNX モードでは marker ベースで skip / truncate 判定
+        #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+        let mut use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx);
+        #[cfg(not(any(feature = "aobazero-onnx", feature = "dlshogi-onnx")))]
+        let use_legacy_resume_check = !(use_onnx || use_dlshogi_onnx);
+        #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+        if use_onnx || use_dlshogi_onnx {
+            let (model_kind, onnx_path): (&str, &std::path::Path) = if use_onnx {
+                ("aobazero", cli.onnx_model.as_ref().unwrap().as_path())
+            } else {
+                ("dlshogi", cli.dlshogi_onnx_model.as_ref().unwrap().as_path())
+            };
+            let decision = onnx_marker_decide(
+                &cli,
+                model_kind,
+                onnx_path,
+                input_path,
+                &output_path,
+                expand_output_path.as_deref(),
+                process_count,
+            )?;
+            match decision {
+                OnnxMarkerDecision::Skip => {
+                    eprintln!(
+                        "=== [{}/{}] Skipping (marker matches): {} ===",
+                        file_idx + 1,
+                        total_files,
+                        output_path.display()
+                    );
+                    continue;
+                }
+                OnnxMarkerDecision::TruncateAndProcess => {
+                    eprintln!(
+                        "=== [{}/{}] Truncated stale outputs, regenerating: {} ===",
+                        file_idx + 1,
+                        total_files,
+                        input_path.display()
+                    );
+                }
+                OnnxMarkerDecision::LegacyResume => {
+                    use_legacy_resume_check = true;
+                }
             }
-            if out_records > 0 {
-                eprintln!(
-                    "=== [{}/{}] Resuming ({}/{} records): {} ===",
-                    file_idx + 1,
-                    total_files,
-                    out_records,
-                    input_record_count,
+        }
+
+        // legacy resume / skip 判定（NNUE/USI 全モード、または ONNX 無 marker + expand 無効）
+        if use_legacy_resume_check {
+            // 入力と出力が同じパスの場合はエラー（--delete-input でデータ消失を防ぐ）
+            if input_path.canonicalize().ok() == output_path.canonicalize().ok() {
+                anyhow::bail!(
+                    "Input and output paths are the same: {}. Use a different --output-dir.",
                     input_path.display()
                 );
+            }
+            if output_path.exists() {
+                let out_size = fs::metadata(&output_path)?.len();
+                let out_records = out_size / PackedSfenValue::SIZE as u64;
+                if out_records >= input_record_count && out_size % PackedSfenValue::SIZE as u64 == 0
+                {
+                    eprintln!(
+                        "=== [{}/{}] Skipping (complete: {} records): {} ===",
+                        file_idx + 1,
+                        total_files,
+                        out_records,
+                        output_path.display()
+                    );
+                    continue;
+                }
+                if out_records > 0 {
+                    eprintln!(
+                        "=== [{}/{}] Resuming ({}/{} records): {} ===",
+                        file_idx + 1,
+                        total_files,
+                        out_records,
+                        input_record_count,
+                        input_path.display()
+                    );
+                }
             }
         }
 
@@ -506,12 +821,6 @@ fn main() -> Result<()> {
             );
         }
 
-        let process_count = if cli.limit > 0 && cli.limit < record_count {
-            cli.limit
-        } else {
-            record_count
-        };
-
         eprintln!("Records: {record_count}, Processing: {process_count}");
 
         // 必要メモリの概算と警告（入力バッファ + 出力バッファ）
@@ -527,11 +836,23 @@ fn main() -> Result<()> {
         // 処理実行
         #[cfg(feature = "aobazero-onnx")]
         if use_onnx {
-            process_file_with_onnx(&cli, input_path, &output_path, process_count)?;
+            process_file_with_onnx(
+                &cli,
+                input_path,
+                &output_path,
+                expand_output_path.as_deref(),
+                process_count,
+            )?;
         }
         #[cfg(feature = "dlshogi-onnx")]
         if use_dlshogi_onnx {
-            process_file_with_dlshogi_onnx(&cli, input_path, &output_path, process_count)?;
+            process_file_with_dlshogi_onnx(
+                &cli,
+                input_path,
+                &output_path,
+                expand_output_path.as_deref(),
+                process_count,
+            )?;
         }
         if !use_onnx && !use_dlshogi_onnx {
             if !engines.is_empty() {
@@ -1571,12 +1892,12 @@ fn onnx_ort_err(e: ort::Error) -> anyhow::Error {
 /// ONNX 直接推論パイプラインの共通設定
 ///
 /// 全フィールドが `Copy` のため、関数内で destructure して既存ローカル変数名と
-/// 互換に展開できる。引数 17 個の関数シグネチャを単一引数に集約することで、
-/// 後続コミットでフィールド追加（expand 機能）を容易にする。
+/// 互換に展開できる。
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 #[derive(Clone, Copy)]
 struct OnnxPipelineConfig<'a> {
     model_name: &'a str,
+    model_kind: &'a str,
     onnx_path: &'a std::path::Path,
     input_path: &'a std::path::Path,
     output_path: &'a std::path::Path,
@@ -1588,11 +1909,321 @@ struct OnnxPipelineConfig<'a> {
     score_clip: i16,
     eval_scale: f32,
     skip_in_check: bool,
+    onnx_draw_ply: i32,
     f1_size: usize,
     f2_size: usize,
     input1_channels: usize,
     input2_channels: usize,
     profile_path: Option<&'a std::path::Path>,
+    expand: Option<ExpandConfig<'a>>,
+}
+
+/// ポリシー展開機能の設定（`OnnxPipelineConfig::expand` が `Some` のときのみ動作）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[derive(Clone, Copy)]
+struct ExpandConfig<'a> {
+    /// 展開した子局面の出力ファイルパス（入力ファイル名を `--expand-output-dir` に置いたもの）
+    output_path: &'a std::path::Path,
+    /// 合法手 softmax 確率の閾値（割合: `0.0 < v <= 1.0`、CLI の `%` から内部変換済み）
+    threshold: f32,
+    /// 親局面が王手なら expand 出力をスキップ
+    skip_parent_in_check: bool,
+    /// 展開した子局面が王手なら expand 出力をスキップ
+    skip_child_in_check: bool,
+}
+
+/// 完了マーカーのフォーマットバージョン
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+const MARKER_VERSION: u32 = 1;
+
+/// 完了マーカーの fingerprint 部（出力内容を一意に決める実行設定）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunFingerprint {
+    version: u32,
+    mode: String,
+    model_kind: String,
+    model_path: PathBuf,
+    model_size: u64,
+    model_mtime_ns: u128,
+    input_path: PathBuf,
+    input_size: u64,
+    input_mtime_ns: u128,
+    process_count: u64,
+    skip_in_check: bool,
+    score_clip: i16,
+    eval_scale_bits: u32,
+    onnx_draw_ply: i32,
+    expand: bool,
+    expand_threshold_bits: Option<u32>,
+    expand_skip_parent_in_check: Option<bool>,
+    expand_skip_child_in_check: Option<bool>,
+    expand_output_path: Option<PathBuf>,
+}
+
+/// 完了マーカーの出力サイズ情報（fingerprint とは分離）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OutputSizes {
+    rescore_output_size: u64,
+    expand_output_size: Option<u64>,
+}
+
+/// 完了マーカー全体（fingerprint + output sizes）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoneMarker {
+    fingerprint: RunFingerprint,
+    output_sizes: OutputSizes,
+}
+
+/// `<rescore_output>.done` を返す
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
+    let mut s = rescore_output.as_os_str().to_owned();
+    s.push(".done");
+    PathBuf::from(s)
+}
+
+/// ファイルの `(len, modified_unix_ns)` を取得
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn file_size_mtime_ns(path: &std::path::Path) -> Result<(u64, u128)> {
+    let m = fs::metadata(path).with_context(|| format!("Failed to stat {}", path.display()))?;
+    let mtime = m
+        .modified()
+        .with_context(|| format!("Failed to read mtime: {}", path.display()))?;
+    let dur = mtime
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .with_context(|| format!("Invalid mtime (before UNIX epoch): {}", path.display()))?;
+    Ok((m.len(), dur.as_nanos()))
+}
+
+/// `DoneMarker` をテキスト key=value 形式にシリアライズ
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn serialize_marker(marker: &DoneMarker) -> String {
+    let f = &marker.fingerprint;
+    let mut out = String::new();
+    use std::fmt::Write;
+    let _ = writeln!(out, "version={}", f.version);
+    let _ = writeln!(out, "mode={}", f.mode);
+    let _ = writeln!(out, "model_kind={}", f.model_kind);
+    let _ = writeln!(out, "model_path={}", f.model_path.display());
+    let _ = writeln!(out, "model_size={}", f.model_size);
+    let _ = writeln!(out, "model_mtime_ns={}", f.model_mtime_ns);
+    let _ = writeln!(out, "input_path={}", f.input_path.display());
+    let _ = writeln!(out, "input_size={}", f.input_size);
+    let _ = writeln!(out, "input_mtime_ns={}", f.input_mtime_ns);
+    let _ = writeln!(out, "process_count={}", f.process_count);
+    let _ = writeln!(out, "skip_in_check={}", f.skip_in_check);
+    let _ = writeln!(out, "score_clip={}", f.score_clip);
+    let _ = writeln!(out, "eval_scale_bits=0x{:08x}", f.eval_scale_bits);
+    let _ = writeln!(out, "onnx_draw_ply={}", f.onnx_draw_ply);
+    let _ = writeln!(out, "expand={}", f.expand);
+    if f.expand {
+        let _ = writeln!(
+            out,
+            "expand_threshold_bits=0x{:08x}",
+            f.expand_threshold_bits.expect("expand=true requires threshold")
+        );
+        let _ = writeln!(
+            out,
+            "expand_skip_parent_in_check={}",
+            f.expand_skip_parent_in_check.expect("expand=true requires skip_parent")
+        );
+        let _ = writeln!(
+            out,
+            "expand_skip_child_in_check={}",
+            f.expand_skip_child_in_check.expect("expand=true requires skip_child")
+        );
+        let _ = writeln!(
+            out,
+            "expand_output_path={}",
+            f.expand_output_path.as_ref().expect("expand=true requires path").display()
+        );
+    }
+    let _ = writeln!(out, "rescore_output_size={}", marker.output_sizes.rescore_output_size);
+    if f.expand {
+        let _ = writeln!(
+            out,
+            "expand_output_size={}",
+            marker
+                .output_sizes
+                .expand_output_size
+                .expect("expand=true requires expand_output_size")
+        );
+    }
+    out
+}
+
+/// マーカーファイルをパース（key=value テキスト形式、行頭空白・コメントは未対応）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read marker {}", path.display()))?;
+    let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for (lineno, raw) in text.lines().enumerate() {
+        if raw.is_empty() {
+            continue;
+        }
+        let (k, v) = raw.split_once('=').ok_or_else(|| {
+            anyhow::anyhow!("Marker {} line {}: missing '='", path.display(), lineno + 1)
+        })?;
+        map.insert(k.to_string(), v.to_string());
+    }
+    let get = |k: &str| -> Result<&String> {
+        map.get(k)
+            .ok_or_else(|| anyhow::anyhow!("Marker {} missing key {k}", path.display()))
+    };
+    let parse_hex_u32 = |s: &str| -> Result<u32> {
+        let stripped = s
+            .strip_prefix("0x")
+            .ok_or_else(|| anyhow::anyhow!("expected '0x' prefix, got: {s}"))?;
+        u32::from_str_radix(stripped, 16).context("invalid hex u32")
+    };
+    let parse_bool = |s: &str| -> Result<bool> {
+        match s {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            other => anyhow::bail!("invalid bool: {other}"),
+        }
+    };
+
+    let version: u32 = get("version")?.parse().context("invalid version")?;
+    if version != MARKER_VERSION {
+        anyhow::bail!("Unsupported marker version: {version} (expected {MARKER_VERSION})");
+    }
+    let expand = parse_bool(get("expand")?)?;
+    let fingerprint = RunFingerprint {
+        version,
+        mode: get("mode")?.clone(),
+        model_kind: get("model_kind")?.clone(),
+        model_path: PathBuf::from(get("model_path")?),
+        model_size: get("model_size")?.parse().context("invalid model_size")?,
+        model_mtime_ns: get("model_mtime_ns")?.parse().context("invalid model_mtime_ns")?,
+        input_path: PathBuf::from(get("input_path")?),
+        input_size: get("input_size")?.parse().context("invalid input_size")?,
+        input_mtime_ns: get("input_mtime_ns")?.parse().context("invalid input_mtime_ns")?,
+        process_count: get("process_count")?.parse().context("invalid process_count")?,
+        skip_in_check: parse_bool(get("skip_in_check")?)?,
+        score_clip: get("score_clip")?.parse().context("invalid score_clip")?,
+        eval_scale_bits: parse_hex_u32(get("eval_scale_bits")?)?,
+        onnx_draw_ply: get("onnx_draw_ply")?.parse().context("invalid onnx_draw_ply")?,
+        expand,
+        expand_threshold_bits: if expand {
+            Some(parse_hex_u32(get("expand_threshold_bits")?)?)
+        } else {
+            None
+        },
+        expand_skip_parent_in_check: if expand {
+            Some(parse_bool(get("expand_skip_parent_in_check")?)?)
+        } else {
+            None
+        },
+        expand_skip_child_in_check: if expand {
+            Some(parse_bool(get("expand_skip_child_in_check")?)?)
+        } else {
+            None
+        },
+        expand_output_path: if expand {
+            Some(PathBuf::from(get("expand_output_path")?))
+        } else {
+            None
+        },
+    };
+    let output_sizes = OutputSizes {
+        rescore_output_size: get("rescore_output_size")?
+            .parse()
+            .context("invalid rescore_output_size")?,
+        expand_output_size: if expand {
+            Some(get("expand_output_size")?.parse().context("invalid expand_output_size")?)
+        } else {
+            None
+        },
+    };
+    Ok(DoneMarker {
+        fingerprint,
+        output_sizes,
+    })
+}
+
+/// マーカーを atomic に書き出す（tmp に書く → sync_all → rename）
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) -> Result<()> {
+    let final_path = marker_path_for(rescore_output);
+    let mut tmp_os = final_path.as_os_str().to_owned();
+    tmp_os.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_os);
+    let body = serialize_marker(marker);
+    {
+        let mut f = File::create(&tmp_path)
+            .with_context(|| format!("Failed to create marker tmp {}", tmp_path.display()))?;
+        f.write_all(body.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_path, &final_path).with_context(|| {
+        format!("Failed to rename marker {} → {}", tmp_path.display(), final_path.display())
+    })?;
+    Ok(())
+}
+
+/// `OnnxPipelineConfig` から `RunFingerprint` を構築
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerprint> {
+    let model_path = config
+        .onnx_path
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", config.onnx_path.display()))?;
+    let (model_size, model_mtime_ns) = file_size_mtime_ns(&model_path)?;
+    let input_path = config
+        .input_path
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize {}", config.input_path.display()))?;
+    let (input_size, input_mtime_ns) = file_size_mtime_ns(&input_path)?;
+    let expand_output_path = match config.expand {
+        Some(e) => Some(
+            // 出力ファイルが未作成でも canonical_dir + file_name で予定パスを構築する
+            // ため、parent dir のみ canonicalize する
+            canonicalize_predicted_path(e.output_path)?,
+        ),
+        None => None,
+    };
+    Ok(RunFingerprint {
+        version: MARKER_VERSION,
+        mode: "onnx".to_string(),
+        model_kind: config.model_kind.to_string(),
+        model_path,
+        model_size,
+        model_mtime_ns,
+        input_path,
+        input_size,
+        input_mtime_ns,
+        process_count: config.process_count,
+        skip_in_check: config.skip_in_check,
+        score_clip: config.score_clip,
+        eval_scale_bits: config.eval_scale.to_bits(),
+        onnx_draw_ply: config.onnx_draw_ply,
+        expand: config.expand.is_some(),
+        expand_threshold_bits: config.expand.map(|e| e.threshold.to_bits()),
+        expand_skip_parent_in_check: config.expand.map(|e| e.skip_parent_in_check),
+        expand_skip_child_in_check: config.expand.map(|e| e.skip_child_in_check),
+        expand_output_path,
+    })
+}
+
+/// 未作成出力ファイルの予定 canonical パスを構築する。
+/// parent dir を canonicalize して file_name と join する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn canonicalize_predicted_path(path: &std::path::Path) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Path has no parent directory: {}", path.display()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Path has no file name: {}", path.display()))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize parent {}", parent.display()))?;
+    Ok(canonical_parent.join(file_name))
 }
 
 /// ストリーミング読み込み + rayon 並列特徴量構築 + ゼロコピー GPU 推論
@@ -1609,6 +2240,7 @@ where
 {
     let OnnxPipelineConfig {
         model_name,
+        model_kind: _,
         onnx_path,
         input_path,
         output_path,
@@ -1620,16 +2252,35 @@ where
         score_clip,
         eval_scale,
         skip_in_check,
+        onnx_draw_ply: _,
         f1_size,
         f2_size,
         input1_channels,
         input2_channels,
         profile_path,
+        expand,
     } = *config;
     use ort::ep::ExecutionProvider;
     use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
     use ort::session::Session;
     use ort::value::TensorRef;
+    use rshogi_core::movegen::{MoveList, generate_legal};
+    use tools::dlshogi_features::{MAX_MOVE_LABEL_NUM, make_move_label};
+
+    /// 合法手のロジットを softmax 正規化して `out` に書き込む
+    fn softmax_normalize(logits: &[f32], out: &mut [f32]) {
+        debug_assert_eq!(logits.len(), out.len());
+        let max = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for (o, &l) in out.iter_mut().zip(logits.iter()) {
+            *o = (l - max).exp();
+            sum += *o;
+        }
+        let inv = if sum > 0.0 { 1.0 / sum } else { 0.0 };
+        for o in out.iter_mut() {
+            *o *= inv;
+        }
+    }
 
     // ORT_DYLIB_PATH 事前検証（load-dynamic feature）
     //
@@ -1815,7 +2466,20 @@ where
         .with_context(|| format!("Failed to open {}", output_path.display()))?;
     let mut writer = BufWriter::new(out_file);
 
-    // 既存レコード分の入力をスキップ
+    // expand 出力 writer（expand 有効時のみ）。main 側で truncate(0) 済みなので
+    // append open で常に先頭から書く。
+    let mut expand_writer: Option<BufWriter<File>> = if let Some(e) = expand {
+        let f =
+            File::options().create(true).append(true).open(e.output_path).with_context(|| {
+                format!("Failed to open expand output {}", e.output_path.display())
+            })?;
+        Some(BufWriter::new(f))
+    } else {
+        None
+    };
+
+    // 既存レコード分の入力をスキップ（expand 無効 + marker 不存在の legacy
+    // resume パス。main 側で truncate(0) 済みなら resume_count == 0 になり no-op）
     let mut remaining = process_count;
     if resume_count > 0 {
         let skip = resume_count.min(remaining);
@@ -1836,6 +2500,10 @@ where
     let mut error_count: u64 = 0;
     let mut clipped_count: u64 = 0;
     let mut total_processed: u64 = 0;
+    let mut total_expanded: u64 = 0;
+    // expand 用 softmax バッファ（バッチ・局面間で再利用）
+    let mut logits_buf: Vec<f32> = Vec::with_capacity(600);
+    let mut probs_buf: Vec<f32> = Vec::with_capacity(600);
 
     // MemoryInfo はバッチサイズに依存しないのでループ外で1回だけ作成
     let output_mem =
@@ -1843,8 +2511,12 @@ where
             .map_err(onnx_ort_err)?;
 
     loop {
-        // バッチ分のレコードをストリーム読み込み
-        let mut batch_records: Vec<(PackedSfenValue, String)> = Vec::with_capacity(batch_size);
+        // バッチ分のレコードをストリーム読み込み。
+        // 注: 旧実装は `--skip-in-check` でこの段階で親をドロップしていたが、
+        // expand 機能（ポリシー推論）と独立に動かすため、推論は常に実行し、
+        // 王手フラグだけを記録して rescore 書き出し / expand 書き出しの個別判定に使う。
+        let mut batch_records: Vec<(PackedSfenValue, String, bool)> =
+            Vec::with_capacity(batch_size);
         while batch_records.len() < batch_size && remaining > 0 {
             if INTERRUPTED.load(Ordering::SeqCst) {
                 remaining = 0;
@@ -1873,15 +2545,15 @@ where
                     continue;
                 }
             };
-            if skip_in_check {
-                let mut pos = Position::new();
-                if pos.set_sfen(&sfen).is_ok() && pos.in_check() {
-                    skipped_count += 1;
-                    progress.inc(1);
-                    continue;
-                }
-            }
-            batch_records.push((psv, sfen));
+            // 王手判定はバッチ読み込み時に 1 回だけ。失敗時は in_check=false
+            // 扱いとし、書き出しループで Position::set_sfen が再度失敗すれば
+            // error_count に計上される。
+            let mut probe = Position::new();
+            let in_check = match probe.set_sfen(&sfen) {
+                Ok(()) => probe.in_check(),
+                Err(_) => false,
+            };
+            batch_records.push((psv, sfen, in_check));
         }
 
         let actual_batch = batch_records.len();
@@ -1900,7 +2572,7 @@ where
             f2_buf[..actual_batch * f2_size].chunks_mut(f2_size).collect();
 
         f1_slices.into_par_iter().zip(f2_slices).zip(batch_records.par_iter()).for_each(
-            |((f1, f2), (psv, sfen))| {
+            |((f1, f2), (psv, sfen, _in_check))| {
                 let mut pos = Position::new();
                 if pos.set_sfen(sfen).is_err() {
                     batch_errors.fetch_add(1, Ordering::Relaxed);
@@ -1948,8 +2620,13 @@ where
         let (_, values) =
             outputs["output_value"].try_extract_tensor::<f32>().map_err(onnx_ort_err)?;
 
-        // 結果を書き出し（テンソルから直接読み取り、to_vec() コピーを排除）
-        for (i, (psv, _)) in batch_records.iter().enumerate() {
+        // rescore 書き出し（テンソルから直接読み取り、to_vec() コピーを排除）
+        // skip_in_check が真かつ親が王手の場合は書き出しを抑制（推論結果は破棄）。
+        for (i, (psv, _sfen, in_check)) in batch_records.iter().enumerate() {
+            if skip_in_check && *in_check {
+                skipped_count += 1;
+                continue;
+            }
             let winrate = values[i];
             let clamped = winrate.clamp(0.001, 0.999);
             let logit = (clamped / (1.0 - clamped)).ln();
@@ -1969,6 +2646,75 @@ where
             };
             writer.write_all(&new_psv.to_bytes())?;
         }
+
+        // expand 機能（policy ベースの子局面生成）
+        if let (Some(expand_cfg), Some(ew)) = (expand, expand_writer.as_mut()) {
+            let (policy_shape, policy_data) =
+                outputs["output_policy"].try_extract_tensor::<f32>().map_err(onnx_ort_err)?;
+            let expected_len = actual_batch * MAX_MOVE_LABEL_NUM;
+            if policy_data.len() != expected_len {
+                anyhow::bail!(
+                    "Policy output shape mismatch: expected [{actual_batch}, \
+                     {MAX_MOVE_LABEL_NUM}] ({expected_len} elements), got shape {:?} \
+                     ({} elements). Is the ONNX model a compatible policy network?",
+                    policy_shape,
+                    policy_data.len()
+                );
+            }
+
+            for (i, (psv, sfen, parent_in_check)) in batch_records.iter().enumerate() {
+                if expand_cfg.skip_parent_in_check && *parent_in_check {
+                    continue;
+                }
+
+                let mut pos = Position::new();
+                if pos.set_sfen(sfen).is_err() {
+                    continue;
+                }
+                let color = pos.side_to_move();
+
+                let mut list = MoveList::new();
+                generate_legal(&pos, &mut list);
+                if list.is_empty() {
+                    continue;
+                }
+
+                let policy_row = &policy_data[i * MAX_MOVE_LABEL_NUM..(i + 1) * MAX_MOVE_LABEL_NUM];
+
+                logits_buf.clear();
+                for mv in list.iter() {
+                    let label = make_move_label(*mv, color);
+                    logits_buf.push(policy_row[label]);
+                }
+                probs_buf.resize(logits_buf.len(), 0.0);
+                softmax_normalize(&logits_buf, &mut probs_buf);
+
+                for (j, mv) in list.iter().enumerate() {
+                    if probs_buf[j] > expand_cfg.threshold {
+                        let gives_check = pos.gives_check(*mv);
+                        pos.do_move(*mv, gives_check);
+
+                        let child_in_check = pos.in_check();
+                        if !(expand_cfg.skip_child_in_check && child_in_check) {
+                            let packed = pack_position(&pos);
+                            let child = PackedSfenValue {
+                                sfen: packed,
+                                score: 0,
+                                move16: 0,
+                                game_ply: psv.game_ply.saturating_add(1),
+                                game_result: 0,
+                                padding: 0,
+                            };
+                            ew.write_all(&child.to_bytes())?;
+                            total_expanded += 1;
+                        }
+
+                        pos.undo_move(*mv);
+                    }
+                }
+            }
+        }
+
         total_processed += actual_batch as u64;
         progress.inc(actual_batch as u64);
     }
@@ -1980,11 +2726,29 @@ where
         }
     }
 
+    // 出力ファイル本体を flush + sync して、マーカー書き出し前にクラッシュしても
+    // 書き出し済みバイト列が確実にディスクに着地している状態を作る。
+    // sync_all() は内部の File に対して実行（BufWriter::flush + into_inner で取り出し）。
     writer.flush()?;
+    let rescore_inner = writer
+        .into_inner()
+        .map_err(|e| anyhow::anyhow!("rescore writer into_inner error: {}", e.error()))?;
+    rescore_inner.sync_all()?;
+    drop(rescore_inner);
+
+    if let Some(mut ew) = expand_writer.take() {
+        ew.flush()?;
+        let inner = ew
+            .into_inner()
+            .map_err(|e| anyhow::anyhow!("expand writer into_inner error: {}", e.error()))?;
+        inner.sync_all()?;
+    }
+
     progress.finish_with_message("Done");
 
     // 統計情報
-    let total = total_processed + skipped_count + error_count;
+    let rescore_written = total_processed.saturating_sub(skipped_count);
+    let total = total_processed + error_count;
     if error_count > 0 {
         eprintln!("Note: {error_count} positions had errors");
     }
@@ -1994,13 +2758,46 @@ where
             skipped_count as f64 / total as f64 * 100.0
         );
     }
-    if total > 0 {
+    if rescore_written > 0 {
         eprintln!(
             "Clipped scores: {clipped_count} ({:.2}%)",
-            clipped_count as f64 / total as f64 * 100.0
+            clipped_count as f64 / rescore_written as f64 * 100.0
         );
     }
-    eprintln!("Wrote {total_processed} records");
+    eprintln!("Rescored: {rescore_written} positions");
+    if let Some(e) = expand {
+        let avg = if rescore_written > 0 {
+            total_expanded as f64 / rescore_written as f64
+        } else {
+            0.0
+        };
+        eprintln!(
+            "Expanded: {total_expanded} positions (threshold={:.2}%, avg {:.2} per parent)",
+            e.threshold * 100.0,
+            avg
+        );
+    }
+
+    // 完了マーカー書き出し（atomic rename）。
+    // INTERRUPTED が立っている場合（Ctrl-C で残ファイル分を打ち切った場合）も
+    // 書き出した分は完了扱いとはせず、marker を作らない。
+    if !INTERRUPTED.load(Ordering::SeqCst) {
+        let fingerprint = build_run_fingerprint(config)?;
+        let rescore_size = fs::metadata(output_path)?.len();
+        let expand_size = match expand {
+            Some(e) => Some(fs::metadata(e.output_path)?.len()),
+            None => None,
+        };
+        let marker = DoneMarker {
+            fingerprint,
+            output_sizes: OutputSizes {
+                rescore_output_size: rescore_size,
+                expand_output_size: expand_size,
+            },
+        };
+        write_marker_atomic(output_path, &marker)?;
+        eprintln!("Marker written: {}", marker_path_for(output_path).display());
+    }
 
     Ok(())
 }
@@ -2014,6 +2811,7 @@ fn process_file_with_onnx(
     cli: &Cli,
     input_path: &std::path::Path,
     output_path: &std::path::Path,
+    expand_output_path: Option<&std::path::Path>,
     process_count: u64,
 ) -> Result<()> {
     use tools::aobazero_features::{
@@ -2021,8 +2819,15 @@ fn process_file_with_onnx(
     };
 
     let draw_ply = cli.onnx_draw_ply;
+    let expand = expand_output_path.map(|p| ExpandConfig {
+        output_path: p,
+        threshold: cli.expand_threshold / 100.0,
+        skip_parent_in_check: cli.expand_skip_parent_in_check,
+        skip_child_in_check: cli.expand_skip_child_in_check,
+    });
     let config = OnnxPipelineConfig {
         model_name: "AobaZero",
+        model_kind: "aobazero",
         onnx_path: cli.onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
@@ -2034,11 +2839,13 @@ fn process_file_with_onnx(
         score_clip: cli.score_clip,
         eval_scale: cli.onnx_eval_scale,
         skip_in_check: cli.skip_in_check,
+        onnx_draw_ply: cli.onnx_draw_ply,
         f1_size: FEATURES1_SIZE,
         f2_size: FEATURES2_SIZE,
         input1_channels: INPUT1_CHANNELS,
         input2_channels: INPUT2_CHANNELS,
         profile_path: cli.ort_profile.as_deref(),
+        expand,
     };
     process_file_with_onnx_pipeline(&config, move |pos, f1, f2, psv| {
         make_input_features(pos, f1, f2, psv.game_ply as i32, draw_ply);
@@ -2054,14 +2861,22 @@ fn process_file_with_dlshogi_onnx(
     cli: &Cli,
     input_path: &std::path::Path,
     output_path: &std::path::Path,
+    expand_output_path: Option<&std::path::Path>,
     process_count: u64,
 ) -> Result<()> {
     use tools::dlshogi_features::{
         FEATURES1_SIZE, FEATURES2_SIZE, INPUT1_CHANNELS, INPUT2_CHANNELS, make_input_features,
     };
 
+    let expand = expand_output_path.map(|p| ExpandConfig {
+        output_path: p,
+        threshold: cli.expand_threshold / 100.0,
+        skip_parent_in_check: cli.expand_skip_parent_in_check,
+        skip_child_in_check: cli.expand_skip_child_in_check,
+    });
     let config = OnnxPipelineConfig {
         model_name: "dlshogi",
+        model_kind: "dlshogi",
         onnx_path: cli.dlshogi_onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
@@ -2073,11 +2888,15 @@ fn process_file_with_dlshogi_onnx(
         score_clip: cli.score_clip,
         eval_scale: cli.onnx_eval_scale,
         skip_in_check: cli.skip_in_check,
+        // dlshogi モデルでは `onnx_draw_ply` を使わない。fingerprint の過剰
+        // invalidation を避けるため 0 固定（`onnx_marker_decide` 側でも同じ扱い）。
+        onnx_draw_ply: 0,
         f1_size: FEATURES1_SIZE,
         f2_size: FEATURES2_SIZE,
         input1_channels: INPUT1_CHANNELS,
         input2_channels: INPUT2_CHANNELS,
         profile_path: cli.ort_profile.as_deref(),
+        expand,
     };
     process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
         make_input_features(pos, f1, f2);


### PR DESCRIPTION
## Summary

教師局面の評価値付け (rescore) と policy 出力による子局面生成 (expand) を、
同一 ONNX 推論結果から両方取り出して 1 パスで実行できるようにした。
従来は `crates/tools/src/bin/expand_psv_from_policy.rs` が同じモデルに対して
別パスで推論を走らせており、value/policy のどちらかを毎回捨てていた。

ユーザーからの提案:
> その評価値をつける際に、どうせその局面をネットワークに通すなら、value で
> 評価値をつけることに追加して、同時に policy で更に新たな局面を生成できる
> のではないかと考えました。

## コミット構成

1. **refactor**: `process_file_with_onnx_pipeline` の引数 17 個を
   `OnnxPipelineConfig` struct に集約（挙動変更なし）
2. **feat**: expand 機能本体（CLI 4 フラグ + 完了マーカー + パス安全チェック）

## 追加 CLI

| フラグ | デフォルト | 説明 |
|---|---|---|
| `--expand-output-dir <DIR>` | — | 子局面出力先（指定時のみ expand 有効、ONNX モード必須） |
| `--expand-threshold <PERCENT>` | 10.0 | softmax 確率閾値、`(0.0, 100.0]` の有限値 |
| `--expand-skip-parent-in-check` | false | 親が王手なら expand スキップ |
| `--expand-skip-child-in-check` | false | 子が王手なら expand スキップ |

`--onnx-eval-scale` の有限値・正値検証も追加。

## 主な実装

- `OnnxPipelineConfig` に `expand: Option<ExpandConfig>` と `model_kind` /
  `onnx_draw_ply` を追加
- ONNX pipeline 内で `--skip-in-check` を「推論バッチから除外」→「推論はする、
  rescore 書き出しのみ抑制」に変更し、expand の policy 推論と独立化
- expand 有効時は policy を `try_extract_tensor` してから合法手 softmax を
  計算し、閾値超え手の子局面を pack して expand 出力に書き出す

### 完了マーカー (`<rescore_output>.done`)

- `RunFingerprint` (model path/size/mtime, input path/size/mtime, score_clip,
  eval_scale_bits, onnx_draw_ply, expand 設定, expand_output_path) +
  `OutputSizes` (rescore_output_size, optional expand_output_size) を
  key=value テキストで保存。float は `to_bits()` の hex
- `writer.flush() → into_inner() → sync_all() → marker tmp 書き出し →
  fsync → rename` の atomic 配置
- `onnx_marker_decide` で fingerprint 一致 + bodies_match なら skip、
  不一致なら現出力 truncate + 旧 expand_output_path 削除 + marker 削除して再生成
- marker 不存在 + expand 無効は既存の record-count resume にフォールバック
- INTERRUPTED 時は marker を作らない（中断を完了扱いしない）
- dlshogi モードでは `onnx_draw_ply` を 0 固定にして過剰 invalidation を回避

### パス安全チェック

- `--output-dir` と `--expand-output-dir` の dir 衝突
- 各入力ファイルの予定出力パスが入力を指すケース（未作成パスでも検出）
- 既存出力が symlink のときは拒否
- Unix では `MetadataExt::{dev, ino}` で hardlink も検出

## 既存挙動への影響

- `--expand-output-dir` 未指定時の出力 PSV のバイト列は変わらない
- `--skip-in-check` の意味変更で推論コストが王手親割合分わずかに増える
  可能性あり（出力バイト列は同じ）

## レビュー履歴

設計レビュー (Codex 6 ラウンド: v1→v6) を経て OK 判定後に実装、
コード review (Codex 2 ラウンド) を経て OK 判定。

## Test plan

- [x] cargo build (no-feature, aobazero-onnx, dlshogi-onnx, 全 features) 通過
- [x] cargo fmt 通過
- [x] cargo clippy --tests -D warnings (全 feature 組み合わせ) 通過
- [x] cargo test -p tools 通過
- [x] CLI `--help` で expand フラグ表示確認
- [ ] 実 GPU/PSV を使った rescore + expand の動作確認 (要 GPU 環境)
- [ ] marker レジューム挙動: 完了→再実行で skip、threshold 変更で truncate
- [ ] expand 出力が `expand_psv_from_policy` 単独実行と一致することの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)