### PR TITLE
fix(csa-server): 終局判定 (%KACHI / 千日手 / 連続王手千日手 / 打ち歩詰) を駆動系まで接続

### DIFF
--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -708,3 +708,97 @@ fn waiter_disconnect_is_cleaned_up_and_allows_relogin() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+/// alice / bob をマッチ成立させて AGREE まで進め、(reader_black, writer_black,
+/// reader_white, writer_white, game_id) を返すテストハーネス。
+/// 終局系 E2E テストで共通のセットアップを削減するため。
+async fn login_match_agree(
+    addr: std::net::SocketAddr,
+) -> (
+    BufReader<OwnedReadHalf>,
+    OwnedWriteHalf,
+    BufReader<OwnedReadHalf>,
+    OwnedWriteHalf,
+    String,
+) {
+    let (mut rb, mut wb) = connect(addr).await;
+    send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+    assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+    let (mut rw, mut ww) = connect(addr).await;
+    send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+    assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+    let _ = drain_game_summary(&mut rb).await;
+    let _ = drain_game_summary(&mut rw).await;
+    send_line(&mut wb, "AGREE").await;
+    send_line(&mut ww, "AGREE").await;
+    let start_b = read_line_raw(&mut rb).await.unwrap();
+    let _ = read_line_raw(&mut rw).await.unwrap();
+    let game_id = start_b.trim_start_matches("START:").to_owned();
+    (rb, wb, rw, ww, game_id)
+}
+
+#[test]
+fn kachi_on_initial_position_ends_as_illegal_kachi() {
+    // 平手初期局面で %KACHI を投げると 24 点不成立で `#ILLEGAL_MOVE` 終局。
+    // TCP 駆動系を通った終局メッセージが対局者双方に届くことを確認する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("kachi_rejected").await;
+        let (mut rb, mut wb, mut rw, _ww, _game_id) = login_match_agree(addr).await;
+        send_line(&mut wb, "%KACHI").await;
+        // 黒 (敗者側) は #ILLEGAL_MOVE + #LOSE。白 (勝者側) は #ILLEGAL_MOVE + #WIN。
+        let b_lines = read_until(&mut rb, "#LOSE").await;
+        assert!(b_lines.iter().any(|l| l == "#ILLEGAL_MOVE"));
+        let w_lines = read_until(&mut rw, "#WIN").await;
+        assert!(w_lines.iter().any(|l| l == "#ILLEGAL_MOVE"));
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn sennichite_broadcasts_draw_on_12_ply_gold_dance() {
+    // 平手から両者の左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて 3 サイクル (12 手)
+    // 経過で初期局面 4 回目の出現 → `#SENNICHITE` + `#DRAW` が双方の対局者に届く。
+    // TCP 層で千日手の通知が正しく fanout されることを E2E で検証する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("sennichite").await;
+        let (mut rb, mut wb, mut rw, mut ww, _game_id) = login_match_agree(addr).await;
+        // 3 サイクル (12 手) を淡々と送り出す。最終手以外は `,T0` broadcast が流れる。
+        let moves: &[(&str, bool)] = &[
+            ("+4948KI", true), // (token, is_black)
+            ("-4142KI", false),
+            ("+4849KI", true),
+            ("-4241KI", false),
+        ];
+        for _ in 0..2 {
+            for (tok, is_black) in moves {
+                if *is_black {
+                    send_line(&mut wb, tok).await;
+                } else {
+                    send_line(&mut ww, tok).await;
+                }
+                let expect = format!("{tok},T0");
+                let _ = read_until(&mut rb, &expect).await;
+                let _ = read_until(&mut rw, &expect).await;
+            }
+        }
+        // 3 サイクル目: 最終 (-4241KI) で千日手が確定する。最終手の放送と `#SENNICHITE`
+        // / `#DRAW` の両方を対局者双方で確認する。
+        for (tok, is_black) in moves.iter().take(3) {
+            if *is_black {
+                send_line(&mut wb, tok).await;
+            } else {
+                send_line(&mut ww, tok).await;
+            }
+            let expect = format!("{tok},T0");
+            let _ = read_until(&mut rb, &expect).await;
+            let _ = read_until(&mut rw, &expect).await;
+        }
+        send_line(&mut ww, "-4241KI").await;
+        let b_end = read_until(&mut rb, "#DRAW").await;
+        assert!(b_end.iter().any(|l| l == "#SENNICHITE"));
+        assert!(b_end.iter().any(|l| l == "-4241KI,T0"));
+        let w_end = read_until(&mut rw, "#DRAW").await;
+        assert!(w_end.iter().any(|l| l == "#SENNICHITE"));
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server-workers/tests/core_contract_smoke.rs
+++ b/crates/rshogi-csa-server-workers/tests/core_contract_smoke.rs
@@ -1,0 +1,72 @@
+//! Workers フロントエンドが依存する core 契約の smoke テスト。
+//!
+//! `GameRoom` Durable Object (wasm32 target only) の `finalize_if_ended` は
+//! 対局終局時に [`primary_result_code`] を呼び出し、`FinishedState::result_code`
+//! と R2 棋譜の `kifu_result_code` metadata を 1 つの文字列で固定する。
+//! DO 本体はホスト target ではコンパイルされないが、同じ関数は core crate に
+//! 単一 source of truth として存在するため、全 `GameResult` variant に対する
+//! マッピングをホスト target 上で網羅テストして回帰検知する。
+//!
+//! 完全な DO 統合テストは `wrangler dev` (Miniflare) 下の外部ハーネスで別途
+//! 実施する (task A (`csa-observers-chat`) で WebSocket ハーネスを整備する時に
+//! 合流する)。
+
+use rshogi_csa_server::game::result::{GameResult, IllegalReason};
+use rshogi_csa_server::record::kifu::primary_result_code;
+use rshogi_csa_server::types::Color;
+
+/// 全 `GameResult` variant の `primary_result_code` マッピングを網羅して固定する。
+///
+/// Workers DO の `finalize_if_ended` が書き出す `result_code` は本関数が唯一の
+/// 情報源。variant 追加時はこの網羅テストが落ちることで、R2 に書き出される
+/// コードの更新忘れを検知できる。
+#[test]
+fn primary_result_code_maps_every_game_result_variant() {
+    assert_eq!(
+        primary_result_code(&GameResult::Toryo {
+            winner: Color::Black
+        }),
+        "#RESIGN"
+    );
+    assert_eq!(
+        primary_result_code(&GameResult::TimeUp {
+            loser: Color::White
+        }),
+        "#TIME_UP"
+    );
+    for reason in [
+        IllegalReason::Generic,
+        IllegalReason::Uchifuzume,
+        IllegalReason::IllegalKachi,
+    ] {
+        assert_eq!(
+            primary_result_code(&GameResult::IllegalMove {
+                loser: Color::Black,
+                reason,
+            }),
+            "#ILLEGAL_MOVE",
+            "IllegalReason::{reason:?} should map to #ILLEGAL_MOVE"
+        );
+    }
+    assert_eq!(
+        primary_result_code(&GameResult::Kachi {
+            winner: Color::Black
+        }),
+        "#JISHOGI"
+    );
+    assert_eq!(
+        primary_result_code(&GameResult::OuteSennichite {
+            loser: Color::Black
+        }),
+        "#OUTE_SENNICHITE"
+    );
+    assert_eq!(primary_result_code(&GameResult::Sennichite), "#SENNICHITE");
+    assert_eq!(primary_result_code(&GameResult::MaxMoves), "#MAX_MOVES");
+    assert_eq!(primary_result_code(&GameResult::Abnormal { winner: None }), "#ABNORMAL");
+    assert_eq!(
+        primary_result_code(&GameResult::Abnormal {
+            winner: Some(Color::Black)
+        }),
+        "#ABNORMAL"
+    );
+}

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -455,8 +455,14 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteLose => {
-                // 連続王手していた側（=直前の手番=from）が反則負け。
-                let mut result = self.finish(GameResult::OuteSennichite { loser: from });
+                // `OuteSennichiteLose` ⇔ `Position::repetition_state` の `Lose` で、
+                // 「手番側 (= side-to-move after the last move = from.opposite()) が
+                // 連続王手していた側で反則負け」を意味する。循環の最終手 (from) が
+                // 非王手 (=受け手の escape) で閉じ、from.opposite() がサイクル中ずっと
+                // 王手を連続して掛けていた場合に発火する。従って敗者は from.opposite()。
+                let mut result = self.finish(GameResult::OuteSennichite {
+                    loser: from.opposite(),
+                });
                 broadcasts.append(&mut result.broadcasts);
                 return Ok(HandleResult {
                     outcome: result.outcome,
@@ -464,10 +470,10 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteWin => {
-                // 連続王手されていた側（直前の手番）が勝ち＝相手（手番外）の反則負け。
-                let mut result = self.finish(GameResult::OuteSennichite {
-                    loser: from.opposite(),
-                });
+                // `OuteSennichiteWin` ⇔ `Position::repetition_state` の `Win` で、
+                // 「手番側 (from.opposite()) が勝ち」= 直前に指した from が連続王手
+                // していた側で反則負け。循環の最終手が from による王手で閉じた場合に発火。
+                let mut result = self.finish(GameResult::OuteSennichite { loser: from });
                 broadcasts.append(&mut result.broadcasts);
                 return Ok(HandleResult {
                     outcome: result.outcome,
@@ -619,6 +625,28 @@ mod tests {
         };
         let clock = Box::new(SecondsCountdownClock::new(60, 5));
         GameRoom::new(config, clock)
+    }
+
+    /// 任意 SFEN から対局を開始するためのテスト専用 helper。
+    ///
+    /// 本番 API (`GameRoom::new`) は入玉対局・千日手・打ち歩詰など
+    /// 「局面起点」の終局シナリオを試験できるように拡張されていない
+    /// （Game_Summary / 棋譜の初期局面契約まで一括で導入するタスクが別にある）。
+    /// テストモジュール内で private フィールド `pos` を直接差し替えて、
+    /// 本番 API を増やさずに位置を注入する。
+    fn room_with_sfen(rule: EnteringKingRule, sfen: &str) -> GameRoom {
+        let config = GameRoomConfig {
+            game_id: GameId::new("20140101120000"),
+            black: PlayerName::new("alice"),
+            white: PlayerName::new("bob"),
+            max_moves: 256,
+            time_margin_ms: 0,
+            entering_king_rule: rule,
+        };
+        let clock = Box::new(SecondsCountdownClock::new(60, 5));
+        let mut room = GameRoom::new(config, clock);
+        room.pos.set_sfen(sfen).expect("valid sfen for test");
+        room
     }
 
     fn line(s: &str) -> CsaLine {
@@ -1019,5 +1047,131 @@ mod tests {
         assert_eq!(r.broadcasts[0].line.as_str(), "-3334FU,T0");
         assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#MAX_MOVES"));
         assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#CENSORED"));
+    }
+
+    #[test]
+    fn kachi_accepted_from_point27_sfen_ends_with_jishogi() {
+        // Validator の `evaluate_kachi_accepted_for_27pt_position` と同じ入玉局面を流用。
+        // 先手が 28 点を満たしており、両者 AGREE → 先手 %KACHI → `GameResult::Kachi` 確定。
+        let mut room =
+            room_with_sfen(EnteringKingRule::Point27, "LNSGKGSNL/4BR3/9/9/9/9/9/9/4k4 b RB 1");
+        agree_both(&mut room);
+        let r = room.handle_line(Color::Black, &line("%KACHI"), 0).unwrap();
+        match &r.outcome {
+            HandleOutcome::GameEnded(GameResult::Kachi {
+                winner: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        // `#JISHOGI` + `#WIN/#LOSE` の 3 宛先 × 2 行 = 6 行。
+        assert_eq!(r.broadcasts.len(), 6);
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#JISHOGI"));
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#WIN"));
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#LOSE"));
+    }
+
+    #[test]
+    fn uchifuzume_pawn_drop_ends_with_illegal_move_reason_uchifuzume() {
+        // Validator の `validate_move_detects_uchifuzume` と同じ盤面:
+        // 後手玉 1 一、先手 と 1 三、先手金 3 二、先手玉 5 九、手駒に歩。
+        // 先手 +0012FU で打ち歩詰 → `IllegalMove{reason: Uchifuzume}` が確定する。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "8k/6G2/8+P/9/9/9/9/9/4K4 b P 1");
+        agree_both(&mut room);
+        let r = room.handle_line(Color::Black, &line("+0012FU"), 0).unwrap();
+        match &r.outcome {
+            HandleOutcome::GameEnded(GameResult::IllegalMove {
+                loser: Color::Black,
+                reason: IllegalReason::Uchifuzume,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#ILLEGAL_MOVE"));
+    }
+
+    #[test]
+    fn sennichite_ends_game_after_12_ply_gold_dance() {
+        // 平手初期局面で左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて 3 サイクル
+        // (12 手) 経過 → 初期局面 4 回目の到達 → `GameResult::Sennichite`。
+        let mut room = make_room();
+        agree_both(&mut room);
+        let cycle = [
+            (Color::Black, "+4948KI"),
+            (Color::White, "-4142KI"),
+            (Color::Black, "+4849KI"),
+            (Color::White, "-4241KI"),
+        ];
+        for _ in 0..2 {
+            for (c, tok) in &cycle {
+                let r = room.handle_line(*c, &line(tok), 0).unwrap();
+                assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+            }
+        }
+        for (c, tok) in cycle.iter().take(3) {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        // 3 サイクル目の最終手 (-4241KI) で 4 回目の初期局面到達 → Sennichite。
+        let last = room.handle_line(Color::White, &line("-4241KI"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::Sennichite) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#SENNICHITE"));
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#DRAW"));
+    }
+
+    #[test]
+    fn oute_sennichite_win_variant_loses_the_last_checker() {
+        // Win variant: 開始 SFEN で白が既に黒飛の王手下にある (side=W)。
+        // 4 手 1 サイクル (白退避 → 黒再王手 → 白退避 → 黒再王手) で開始 SFEN に復帰。
+        // 連続王手は反則行為なので 1 サイクルで反則確定 (競技将棋ルール準拠)。
+        // 循環最終手 (+4838HI) は黒の王手手なので from=Black、連続王手側の黒が敗者。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "9/6k2/9/9/9/9/9/6R2/K8 w - 1");
+        agree_both(&mut room);
+        let prefix = [
+            (Color::White, "-3242OU"),
+            (Color::Black, "+3848HI"),
+            (Color::White, "-4232OU"),
+        ];
+        for (c, tok) in &prefix {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        let last = room.handle_line(Color::Black, &line("+4838HI"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::OuteSennichite {
+                loser: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#OUTE_SENNICHITE"));
+    }
+
+    #[test]
+    fn oute_sennichite_lose_variant_loses_the_perpetual_checker() {
+        // Lose variant: Win variant と駒群は同じだが、開始 SFEN を「白玉 4 二 退避済、
+        // 黒番で次の黒の手が王手」に寄せる (黒飛 3 八, 白玉 4 二, side=B, 非王手)。
+        // 4 手 1 サイクルで初期 SFEN 復帰。連続王手側 (Black = from.opposite()) が敗者。
+        // 最終手 (-3242OU) は白の退避手で非王手のため from=White、連続王手していた
+        // 黒が from.opposite()。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "9/5k3/9/9/9/9/9/6R2/K8 b - 1");
+        agree_both(&mut room);
+        let prefix = [
+            (Color::Black, "+3848HI"),
+            (Color::White, "-4232OU"),
+            (Color::Black, "+4838HI"),
+        ];
+        for (c, tok) in &prefix {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        let last = room.handle_line(Color::White, &line("-3242OU"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::OuteSennichite {
+                loser: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#OUTE_SENNICHITE"));
     }
 }

--- a/crates/rshogi-csa-server/src/game/validator.rs
+++ b/crates/rshogi-csa-server/src/game/validator.rs
@@ -128,12 +128,27 @@ impl Validator {
     ///
     /// `Position::repetition_state` 内部で連続王手判定も行われるため、
     /// 千日手成立時の勝敗側もここで切り分ける。
+    ///
+    /// **発火タイミング:**
+    /// - 通常千日手 (Draw): 同一局面 4 回目の到達で発火する。`state.repetition < 0`
+    ///   (= `times >= 3` = 4 回目以降の出現) を必須条件としており、それ以前の非決定的
+    ///   な再来では `None` を返す。これは競技将棋の「同一局面 4 回で引き分け」ルール
+    ///   に一致する。
+    /// - 連続王手千日手 (Win/Lose): 1 サイクル目の再来で発火する。連続王手は
+    ///   反則行為であり、1 循環で反則確定すればそれ以降は続行する意味がないため、
+    ///   非決定的な (`rep > 0` の) 再来でも Verdict を返す。
     pub fn classify_repetition(&self, pos: &Position) -> RepetitionVerdict {
-        match pos.repetition_state(i32::MAX) {
+        let state = pos.state();
+        if state.repetition == 0 {
+            return RepetitionVerdict::None;
+        }
+        match state.repetition_type {
             RepetitionState::None | RepetitionState::Superior | RepetitionState::Inferior => {
                 RepetitionVerdict::None
             }
-            RepetitionState::Draw => RepetitionVerdict::Sennichite,
+            // 非決定的な再来 (rep > 0) では発火せず対局続行。決定的 (rep < 0) でのみ発火。
+            RepetitionState::Draw if state.repetition < 0 => RepetitionVerdict::Sennichite,
+            RepetitionState::Draw => RepetitionVerdict::None,
             RepetitionState::Lose => RepetitionVerdict::OuteSennichiteLose,
             RepetitionState::Win => RepetitionVerdict::OuteSennichiteWin,
         }
@@ -735,5 +750,78 @@ mod tests {
         let pos = pos_from_sfen(rshogi_core::position::SFEN_HIRATE);
         assert!(!v.is_sennichite(&pos));
         assert!(!v.is_oute_sennichite(&pos));
+    }
+
+    /// CSA トークン列を順次 `do_move` で適用する検証用ヘルパ。
+    ///
+    /// 千日手系テストは CSA トークンで棋譜を記述した方が読みやすい。`validate_move`
+    /// で Move を取り出し `Position::gives_check` を渡して `do_move` する、という
+    /// 3 ステップを 1 つにまとめる。
+    fn apply_moves(pos: &mut Position, rule: EnteringKingRule, tokens: &[&str]) {
+        let v = Validator::new(rule);
+        for t in tokens {
+            let tok = token(t);
+            let mv = v
+                .validate_move(pos, &tok)
+                .unwrap_or_else(|e| panic!("validate_move failed for {t}: {e:?}"));
+            let gc = pos.gives_check(mv);
+            pos.do_move(mv, gc);
+        }
+    }
+
+    #[test]
+    fn classify_repetition_returns_sennichite_after_12_ply_gold_dance() {
+        // 平手初期局面から両者の左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて
+        // 3 サイクル (= 12 手) で初期局面 4 回目の到達 → 通常千日手。
+        //
+        // どの手も相手玉には利かないため連続王手は発生せず、RepetitionState::Draw
+        // として分類される想定。
+        let mut pos = pos_from_sfen(rshogi_core::position::SFEN_HIRATE);
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["+4948KI", "-4142KI", "+4849KI", "-4241KI"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        // 3 周目の最終手でちょうど初期局面 4 回目の出現。
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::Sennichite);
+    }
+
+    #[test]
+    fn classify_repetition_returns_oute_sennichite_win_for_perpetual_checker() {
+        // 黒玉 9 九、黒飛 3 八、白玉 3 二、side = White（=白が王手されている局面から開始）。
+        // 4 手 1 サイクルで「白王が 3 二 ↔ 4 二 を往復し、黒飛が 3 八 ↔ 4 八 を往復して
+        // そのたびに王手をかけ直す」連続王手の千日手を作る。3 サイクル (= 12 手) 経過で
+        // 初期 SFEN 局面が 4 回目の出現となり、RepetitionState::Win が分類される。
+        //
+        // `RepetitionState::Win` は「手番側 = 連続王手されていた側が勝つ」を意味するので
+        // Verdict は `OuteSennichiteWin`。側面: 黒が perpetual checker。
+        let mut pos = pos_from_sfen("9/6k2/9/9/9/9/9/6R2/K8 w - 1");
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["-3242OU", "+3848HI", "-4232OU", "+4838HI"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteWin);
+        // `is_oute_sennichite` は勝敗を区別しない薄いラッパなので両 variant で true。
+        assert!(v.is_oute_sennichite(&pos));
+    }
+
+    #[test]
+    fn classify_repetition_returns_oute_sennichite_lose_when_cycle_ends_on_non_checking_move() {
+        // Win variant と同じ駒配置・同じ連続王手循環だが、開始 SFEN を「サイクル中間
+        // (白玉 4 二 退避済み、黒番で黒飛が次に王手を掛け直す直前)」に寄せると、
+        // 検出発火 M12 は **白の退避手** で閉じる。
+        //
+        // 結果として side-to-move after M12 = Black（＝連続王手していた側）で、
+        // `cc_side = cc[Black]` が高い値を持つため `RepetitionState::Lose` が選ばれる。
+        // Verdict は `OuteSennichiteLose`。Lose は「手番側が負け = 連続王手していた側が負け」
+        // であり、このケースでは Black（= from.opposite() = 次手番）が敗者となる。
+        let mut pos = pos_from_sfen("9/5k3/9/9/9/9/9/6R2/K8 b - 1");
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["+3848HI", "-4232OU", "+4838HI", "-3242OU"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteLose);
     }
 }


### PR DESCRIPTION
## Summary

tasks.md §13.1 の実装。`Validator::evaluate_kachi` / `classify_repetition` / `Uchifuzume` 判定はコアに揃っていたが、`GameRoom` と駆動系 (TCP / Workers) で end-to-end に検証されておらず、動作時に **2 件の既存バグ** を温存していた。E2E テスト追加に合わせて両バグを修正。

## 既存バグの修正

- **Validator::classify_repetition**: `repetition_state(i32::MAX)` を使っていたため 1 回目の同一局面再来で通常千日手を発火させていた (競技将棋ルール「4 回目で引き分け」と乖離)。`Position::StateInfo` を直接読む方式に書き換え、Draw は `repetition < 0` (= 決定的 / 4 回目以降) のみ発火。連続王手千日手 (Win/Lose) は perpetual check が反則行為で 1 循環確定なので従来どおり非決定的でも発火させる。
- **GameRoom の `OuteSennichite` loser 指定の polarity 反転**: `OuteSennichiteWin => loser: from` / `OuteSennichiteLose => loser: from.opposite()` が正。`continuous_check[us]` の更新規約 (do_move 直後に `us = side_to_move` before flip + is_check で +2) と `RepetitionState::{Win,Lose}` の「手番側 (= side-to-move after move) の勝敗」セマンティクスから見て、PR 前のコードは両 variant で敗者を取り違えていた。

## 追加したテスト

- **Validator** (polarity 固定):
  - `classify_repetition_returns_sennichite_after_12_ply_gold_dance` — 12 手の金循環で決定的 Sennichite。
  - `classify_repetition_returns_oute_sennichite_win_for_perpetual_checker` — 黒飛が perpetual checker。
  - `classify_repetition_returns_oute_sennichite_lose_when_cycle_ends_on_non_checking_move` — 循環最終手が非王手で閉じる Lose variant。
- **GameRoom** (`room_with_sfen` helper で任意 SFEN から対局開始):
  - `kachi_accepted_from_point27_sfen_ends_with_jishogi`
  - `uchifuzume_pawn_drop_ends_with_illegal_move_reason_uchifuzume`
  - `sennichite_ends_game_after_12_ply_gold_dance`
  - `oute_sennichite_win_variant_loses_the_last_checker`
  - `oute_sennichite_lose_variant_loses_the_perpetual_checker`
- **TCP E2E** (実 TCP ソケット経由、`login_match_agree` helper 追加):
  - `kachi_on_initial_position_ends_as_illegal_kachi` — 平手 %KACHI → `#ILLEGAL_MOVE` + `#WIN/#LOSE`。
  - `sennichite_broadcasts_draw_on_12_ply_gold_dance` — 12 手金循環 → `#SENNICHITE` + `#DRAW`。
- **Workers smoke** (`tests/core_contract_smoke.rs` 新設):
  - `primary_result_code_maps_every_game_result_variant` — DO の `finalize_if_ended` が書く `result_code` 契約を全 `GameResult` variant で網羅 (DO 本体は wasm32 only でホストテストできないため、唯一の真実である core 関数をホスト側でゲートして回帰検知)。

## 今 PR で deferral した項目

- TCP E2E の uchifuzume / kachi-accepted / oute-sennichite は初期 SFEN 注入が必要で、後続の `csa-buoy-fork` ブランチで `GameRoomConfig::initial_sfen` を Game_Summary / 棋譜と一括統合する契約に合わせて追加する (PR #465 milestone 1 P1 で「initial_sfen 単体追加禁止」と指摘された経緯による)。
- Workers の DO 統合テストは後続の `csa-observers-chat` ブランチで WebSocket ハーネスを整備する際に合流。

## 事前・事後レビュー

- **事前レビュー**: Codex CLI にブランチ切り出し前の実装方針を相談し、以下の助言を反映済み:
  - `room_with_sfen` test-only helper に寄せる → 採用。
  - oute-sennichite の SFEN polarity を `Validator` レベルで先行固定 → 採用。既存バグ発見につながった。
  - Workers smoke 1 本入れる → 採用 (`primary_result_code` 網羅)。
- **事後レビュー**: Codex CLI で commit 後にレビュー実行。`Lose/Win` の極性反転修正が `continuous_check` 更新規約と整合することを検証し、追加テスト群を再実行 (TCP のみ codex sandbox の socket 不許可で skip)。P1 / P2 指摘なし。

## 品質ゲート

- `cargo fmt --all`
- `cargo clippy --workspace --tests -- -D warnings` 警告ゼロ
- `RUSTFLAGS="-C target-cpu=x86-64-v2" cargo clippy --workspace --all-targets -- -D warnings` 警告ゼロ
- `cargo test --workspace` 全緑
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 通過

## Test plan

- [x] `cargo test -p rshogi-csa-server --lib` (162 passed)
- [x] `cargo test -p rshogi-csa-server-tcp --test tcp_session` (14 passed)
- [x] `cargo test -p rshogi-csa-server-workers` (33 unit + 1 integration passed)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- [x] `RUSTFLAGS="-C target-cpu=x86-64-v2" cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)