### PR TITLE
feat(csa-server): FischerClock / StopWatchClock を TimeClock 実装として追加

### DIFF
--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -708,3 +708,97 @@ fn waiter_disconnect_is_cleaned_up_and_allows_relogin() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+/// alice / bob をマッチ成立させて AGREE まで進め、(reader_black, writer_black,
+/// reader_white, writer_white, game_id) を返すテストハーネス。
+/// 終局系 E2E テストで共通のセットアップを削減するため。
+async fn login_match_agree(
+    addr: std::net::SocketAddr,
+) -> (
+    BufReader<OwnedReadHalf>,
+    OwnedWriteHalf,
+    BufReader<OwnedReadHalf>,
+    OwnedWriteHalf,
+    String,
+) {
+    let (mut rb, mut wb) = connect(addr).await;
+    send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+    assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+    let (mut rw, mut ww) = connect(addr).await;
+    send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+    assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+    let _ = drain_game_summary(&mut rb).await;
+    let _ = drain_game_summary(&mut rw).await;
+    send_line(&mut wb, "AGREE").await;
+    send_line(&mut ww, "AGREE").await;
+    let start_b = read_line_raw(&mut rb).await.unwrap();
+    let _ = read_line_raw(&mut rw).await.unwrap();
+    let game_id = start_b.trim_start_matches("START:").to_owned();
+    (rb, wb, rw, ww, game_id)
+}
+
+#[test]
+fn kachi_on_initial_position_ends_as_illegal_kachi() {
+    // 平手初期局面で %KACHI を投げると 24 点不成立で `#ILLEGAL_MOVE` 終局。
+    // TCP 駆動系を通った終局メッセージが対局者双方に届くことを確認する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("kachi_rejected").await;
+        let (mut rb, mut wb, mut rw, _ww, _game_id) = login_match_agree(addr).await;
+        send_line(&mut wb, "%KACHI").await;
+        // 黒 (敗者側) は #ILLEGAL_MOVE + #LOSE。白 (勝者側) は #ILLEGAL_MOVE + #WIN。
+        let b_lines = read_until(&mut rb, "#LOSE").await;
+        assert!(b_lines.iter().any(|l| l == "#ILLEGAL_MOVE"));
+        let w_lines = read_until(&mut rw, "#WIN").await;
+        assert!(w_lines.iter().any(|l| l == "#ILLEGAL_MOVE"));
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn sennichite_broadcasts_draw_on_12_ply_gold_dance() {
+    // 平手から両者の左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて 3 サイクル (12 手)
+    // 経過で初期局面 4 回目の出現 → `#SENNICHITE` + `#DRAW` が双方の対局者に届く。
+    // TCP 層で千日手の通知が正しく fanout されることを E2E で検証する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("sennichite").await;
+        let (mut rb, mut wb, mut rw, mut ww, _game_id) = login_match_agree(addr).await;
+        // 3 サイクル (12 手) を淡々と送り出す。最終手以外は `,T0` broadcast が流れる。
+        let moves: &[(&str, bool)] = &[
+            ("+4948KI", true), // (token, is_black)
+            ("-4142KI", false),
+            ("+4849KI", true),
+            ("-4241KI", false),
+        ];
+        for _ in 0..2 {
+            for (tok, is_black) in moves {
+                if *is_black {
+                    send_line(&mut wb, tok).await;
+                } else {
+                    send_line(&mut ww, tok).await;
+                }
+                let expect = format!("{tok},T0");
+                let _ = read_until(&mut rb, &expect).await;
+                let _ = read_until(&mut rw, &expect).await;
+            }
+        }
+        // 3 サイクル目: 最終 (-4241KI) で千日手が確定する。最終手の放送と `#SENNICHITE`
+        // / `#DRAW` の両方を対局者双方で確認する。
+        for (tok, is_black) in moves.iter().take(3) {
+            if *is_black {
+                send_line(&mut wb, tok).await;
+            } else {
+                send_line(&mut ww, tok).await;
+            }
+            let expect = format!("{tok},T0");
+            let _ = read_until(&mut rb, &expect).await;
+            let _ = read_until(&mut rw, &expect).await;
+        }
+        send_line(&mut ww, "-4241KI").await;
+        let b_end = read_until(&mut rb, "#DRAW").await;
+        assert!(b_end.iter().any(|l| l == "#SENNICHITE"));
+        assert!(b_end.iter().any(|l| l == "-4241KI,T0"));
+        let w_end = read_until(&mut rw, "#DRAW").await;
+        assert!(w_end.iter().any(|l| l == "#SENNICHITE"));
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server-workers/tests/core_contract_smoke.rs
+++ b/crates/rshogi-csa-server-workers/tests/core_contract_smoke.rs
@@ -1,0 +1,72 @@
+//! Workers フロントエンドが依存する core 契約の smoke テスト。
+//!
+//! `GameRoom` Durable Object (wasm32 target only) の `finalize_if_ended` は
+//! 対局終局時に [`primary_result_code`] を呼び出し、`FinishedState::result_code`
+//! と R2 棋譜の `kifu_result_code` metadata を 1 つの文字列で固定する。
+//! DO 本体はホスト target ではコンパイルされないが、同じ関数は core crate に
+//! 単一 source of truth として存在するため、全 `GameResult` variant に対する
+//! マッピングをホスト target 上で網羅テストして回帰検知する。
+//!
+//! 完全な DO 統合テストは `wrangler dev` (Miniflare) 下の外部ハーネスで別途
+//! 実施する (task A (`csa-observers-chat`) で WebSocket ハーネスを整備する時に
+//! 合流する)。
+
+use rshogi_csa_server::game::result::{GameResult, IllegalReason};
+use rshogi_csa_server::record::kifu::primary_result_code;
+use rshogi_csa_server::types::Color;
+
+/// 全 `GameResult` variant の `primary_result_code` マッピングを網羅して固定する。
+///
+/// Workers DO の `finalize_if_ended` が書き出す `result_code` は本関数が唯一の
+/// 情報源。variant 追加時はこの網羅テストが落ちることで、R2 に書き出される
+/// コードの更新忘れを検知できる。
+#[test]
+fn primary_result_code_maps_every_game_result_variant() {
+    assert_eq!(
+        primary_result_code(&GameResult::Toryo {
+            winner: Color::Black
+        }),
+        "#RESIGN"
+    );
+    assert_eq!(
+        primary_result_code(&GameResult::TimeUp {
+            loser: Color::White
+        }),
+        "#TIME_UP"
+    );
+    for reason in [
+        IllegalReason::Generic,
+        IllegalReason::Uchifuzume,
+        IllegalReason::IllegalKachi,
+    ] {
+        assert_eq!(
+            primary_result_code(&GameResult::IllegalMove {
+                loser: Color::Black,
+                reason,
+            }),
+            "#ILLEGAL_MOVE",
+            "IllegalReason::{reason:?} should map to #ILLEGAL_MOVE"
+        );
+    }
+    assert_eq!(
+        primary_result_code(&GameResult::Kachi {
+            winner: Color::Black
+        }),
+        "#JISHOGI"
+    );
+    assert_eq!(
+        primary_result_code(&GameResult::OuteSennichite {
+            loser: Color::Black
+        }),
+        "#OUTE_SENNICHITE"
+    );
+    assert_eq!(primary_result_code(&GameResult::Sennichite), "#SENNICHITE");
+    assert_eq!(primary_result_code(&GameResult::MaxMoves), "#MAX_MOVES");
+    assert_eq!(primary_result_code(&GameResult::Abnormal { winner: None }), "#ABNORMAL");
+    assert_eq!(
+        primary_result_code(&GameResult::Abnormal {
+            winner: Some(Color::Black)
+        }),
+        "#ABNORMAL"
+    );
+}

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -149,6 +149,196 @@ impl TimeClock for SecondsCountdownClock {
     }
 }
 
+/// Fischer 方式の時計（増分加算 / Bronstein 派生ではない標準 Fischer）。
+///
+/// - `total_time_seconds`: 初期の持ち時間（秒）。
+/// - `increment_seconds`: 1 手を指し終えるたびに加算される増分（秒）。
+/// - 経過時間は整数秒に切り捨て（SecondsCountdown と同様 CSA 慣用）。
+/// - 消費で残時間が負に落ちた時点で時間切れ。
+///
+/// # セマンティクス
+/// - `consume(elapsed)` は「この手で使った時間」を差し引いた後、使い切っていなければ
+///   `increment` を加算する。増分は手を指し終えたタイミングで付与される（手番中に
+///   増分を先取りして使える実装にはしない）。
+/// - `turn_budget_ms` は「現在の残時間」だけを返す。`increment` は次手完了後に
+///   加算されるため、現在手の budget には含めない。
+#[derive(Debug, Clone)]
+pub struct FischerClock {
+    total_time_seconds: u32,
+    increment_seconds: u32,
+    remaining_black_ms: i64,
+    remaining_white_ms: i64,
+}
+
+impl FischerClock {
+    /// 新しい Fischer 時計を作る。引数単位は「秒」。
+    pub fn new(total_time_seconds: u32, increment_seconds: u32) -> Self {
+        let initial = total_time_seconds as i64 * 1000;
+        Self {
+            total_time_seconds,
+            increment_seconds,
+            remaining_black_ms: initial,
+            remaining_white_ms: initial,
+        }
+    }
+
+    fn slot_mut(&mut self, color: Color) -> &mut i64 {
+        match color {
+            Color::Black => &mut self.remaining_black_ms,
+            Color::White => &mut self.remaining_white_ms,
+        }
+    }
+
+    fn slot(&self, color: Color) -> i64 {
+        match color {
+            Color::Black => self.remaining_black_ms,
+            Color::White => self.remaining_white_ms,
+        }
+    }
+
+    fn increment_ms(&self) -> i64 {
+        self.increment_seconds as i64 * 1000
+    }
+}
+
+impl TimeClock for FischerClock {
+    fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
+        let elapsed_sec_ms = (elapsed_ms / 1000) as i64 * 1000;
+        let increment = self.increment_ms();
+        let slot = self.slot_mut(color);
+
+        // 消費後の残時間が非負なら受理し、増分を加算。負に落ちたら時間切れ。
+        let after = *slot - elapsed_sec_ms;
+        if after < 0 {
+            *slot = 0;
+            ClockResult::TimeUp
+        } else {
+            *slot = after + increment;
+            ClockResult::Continue
+        }
+    }
+
+    fn format_summary(&self) -> String {
+        // Fischer 方式では `Byoyomi` の代わりに `Increment` を出力する。
+        // 項目順は CSA 仕様互換の `Time_Unit, Total_Time, Increment, Least_Time_Per_Move`。
+        let mut out = String::new();
+        out.push_str("BEGIN Time\n");
+        out.push_str("Time_Unit:1sec\n");
+        out.push_str(&format!("Total_Time:{}\n", self.total_time_seconds));
+        out.push_str(&format!("Increment:{}\n", self.increment_seconds));
+        out.push_str("Least_Time_Per_Move:0\n");
+        out.push_str("END Time\n");
+        out
+    }
+
+    fn remaining_main_ms(&self, color: Color) -> i64 {
+        self.slot(color)
+    }
+
+    fn turn_budget_ms(&self, color: Color) -> i64 {
+        // 現在手で使える budget は現在の残時間のみ。increment は手完了後に付く。
+        self.slot(color)
+    }
+}
+
+/// StopWatch 方式の時計（分単位切り捨ての秒読み）。
+///
+/// CSA 2014 改訂以前の shogi-server 標準挙動に相当する。
+/// - 持ち時間・秒読みとも **分単位** で扱う (`Time_Unit:1min`)。
+/// - 経過時間は **分単位に切り捨て** される。具体的には `elapsed_sec / 60` を
+///   消費分として差し引く。これにより 0〜59 秒の手は時間消費ゼロ、60 秒以上で
+///   初めて 1 分消費される。
+/// - 本体持ち時間を使い切った後は、毎手分の秒読み（= `byoyomi_minutes` 分）に
+///   乗り換える。秒読み中も 1 手で使える時間は `byoyomi_minutes` 分に固定。
+/// - 秒読みを使い切ったら時間切れ。
+#[derive(Debug, Clone)]
+pub struct StopWatchClock {
+    total_time_minutes: u32,
+    byoyomi_minutes: u32,
+    remaining_black_ms: i64,
+    remaining_white_ms: i64,
+}
+
+impl StopWatchClock {
+    /// 新しい StopWatch 時計を作る。引数単位は「分」。
+    pub fn new(total_time_minutes: u32, byoyomi_minutes: u32) -> Self {
+        let initial = total_time_minutes as i64 * 60 * 1000;
+        Self {
+            total_time_minutes,
+            byoyomi_minutes,
+            remaining_black_ms: initial,
+            remaining_white_ms: initial,
+        }
+    }
+
+    fn slot_mut(&mut self, color: Color) -> &mut i64 {
+        match color {
+            Color::Black => &mut self.remaining_black_ms,
+            Color::White => &mut self.remaining_white_ms,
+        }
+    }
+
+    fn slot(&self, color: Color) -> i64 {
+        match color {
+            Color::Black => self.remaining_black_ms,
+            Color::White => self.remaining_white_ms,
+        }
+    }
+
+    /// `byoyomi_minutes` をミリ秒単位で返す（ヘルパ）。
+    fn byoyomi_ms(&self) -> i64 {
+        self.byoyomi_minutes as i64 * 60 * 1000
+    }
+}
+
+impl TimeClock for StopWatchClock {
+    fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
+        // 分単位切り捨て。elapsed_min_ms = floor(elapsed_ms / 60000) * 60000。
+        let elapsed_min = elapsed_ms / 60_000;
+        let elapsed_min_ms = (elapsed_min as i64) * 60 * 1000;
+        let byoyomi_ms = self.byoyomi_ms();
+        let slot = self.slot_mut(color);
+
+        // 本体時間に収まる場合は単純減算。
+        if elapsed_min_ms <= *slot {
+            *slot -= elapsed_min_ms;
+            return ClockResult::Continue;
+        }
+
+        // 本体を超過した分は秒読みに回す。SecondsCountdown と同じロジックを
+        // 分単位で再実装しているため一見冗長に見えるが、単位を混ぜて bug を
+        // 招かないよう別構造体として明示的に保持している。
+        let over_min_ms = elapsed_min_ms - *slot;
+        *slot = 0;
+        if over_min_ms > byoyomi_ms {
+            ClockResult::TimeUp
+        } else {
+            ClockResult::Continue
+        }
+    }
+
+    fn format_summary(&self) -> String {
+        // StopWatch 方式は分単位で扱うため `Time_Unit:1min`。
+        let mut out = String::new();
+        out.push_str("BEGIN Time\n");
+        out.push_str("Time_Unit:1min\n");
+        out.push_str(&format!("Total_Time:{}\n", self.total_time_minutes));
+        out.push_str(&format!("Byoyomi:{}\n", self.byoyomi_minutes));
+        out.push_str("Least_Time_Per_Move:0\n");
+        out.push_str("END Time\n");
+        out
+    }
+
+    fn remaining_main_ms(&self, color: Color) -> i64 {
+        self.slot(color)
+    }
+
+    fn turn_budget_ms(&self, color: Color) -> i64 {
+        // 本体残り + 毎手 full 回復する秒読み（分単位）。
+        self.slot(color) + self.byoyomi_ms()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +424,125 @@ mod tests {
         let mut c = SecondsCountdownClock::new(5, 0);
         assert_eq!(c.consume(Color::Black, 5_000), ClockResult::Continue);
         assert_eq!(c.turn_budget_ms(Color::Black), 0);
+    }
+
+    // ---- FischerClock ----
+
+    #[test]
+    fn fischer_adds_increment_after_consume() {
+        // 初期 60 秒、増分 5 秒。10 秒使って手を指し終えると残りは 55 秒 (= 60 - 10 + 5)。
+        let mut c = FischerClock::new(60, 5);
+        assert_eq!(c.consume(Color::Black, 10_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 55_000);
+        // 連続 2 手消費しても増分はそれぞれ付く。
+        assert_eq!(c.consume(Color::Black, 2_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 58_000);
+    }
+
+    #[test]
+    fn fischer_time_up_when_elapsed_exceeds_remaining() {
+        // 残 5 秒。6 秒使い切ったら TimeUp (increment は加算されない)。
+        let mut c = FischerClock::new(5, 3);
+        assert_eq!(c.consume(Color::Black, 6_000), ClockResult::TimeUp);
+        assert_eq!(c.remaining_main_ms(Color::Black), 0);
+    }
+
+    #[test]
+    fn fischer_consume_truncates_to_second() {
+        // 999ms は 0 秒に切り捨て。消費 0 + 増分 5 秒 = 残 65 秒。
+        let mut c = FischerClock::new(60, 5);
+        assert_eq!(c.consume(Color::Black, 999), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 65_000);
+    }
+
+    #[test]
+    fn fischer_format_summary_includes_increment_field() {
+        let c = FischerClock::new(600, 10);
+        let s = c.format_summary();
+        assert!(s.contains("BEGIN Time"));
+        assert!(s.contains("Time_Unit:1sec"));
+        assert!(s.contains("Total_Time:600"));
+        assert!(s.contains("Increment:10"));
+        assert!(!s.contains("Byoyomi:"), "Fischer には Byoyomi フィールドを含めない");
+        assert!(s.contains("Least_Time_Per_Move:0"));
+        assert!(s.contains("END Time"));
+    }
+
+    #[test]
+    fn fischer_turn_budget_is_remaining_only_not_plus_increment() {
+        // increment は手を指し終えた時に付くので、現在手の budget は残時間のみ。
+        let c = FischerClock::new(60, 5);
+        assert_eq!(c.turn_budget_ms(Color::Black), 60_000);
+    }
+
+    #[test]
+    fn fischer_black_and_white_are_independent() {
+        let mut c = FischerClock::new(60, 5);
+        assert_eq!(c.consume(Color::Black, 10_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::White), 60_000);
+    }
+
+    // ---- StopWatchClock ----
+
+    #[test]
+    fn stopwatch_discards_sub_minute_consumption() {
+        // 30 秒使っても分単位切り捨てで消費ゼロ。残量は初期値のまま。
+        let mut c = StopWatchClock::new(10, 1);
+        assert_eq!(c.consume(Color::Black, 30_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 10 * 60 * 1000);
+        // 59 秒も同様。
+        assert_eq!(c.consume(Color::Black, 59_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 10 * 60 * 1000);
+    }
+
+    #[test]
+    fn stopwatch_consumes_minute_at_60_second_boundary() {
+        // ちょうど 60 秒経過で 1 分消費される。
+        let mut c = StopWatchClock::new(10, 1);
+        assert_eq!(c.consume(Color::Black, 60_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 9 * 60 * 1000);
+    }
+
+    #[test]
+    fn stopwatch_enters_byoyomi_when_main_exhausted() {
+        // 本体 3 分 + 秒読み 2 分。3 分ちょうどで本体 0、秒読み区間に入る。
+        let mut c = StopWatchClock::new(3, 2);
+        assert_eq!(c.consume(Color::Black, 3 * 60_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 0);
+        // 秒読み 2 分以内 (例: 119 秒 = 1 分消費) なら TimeUp ではない。
+        assert_eq!(c.consume(Color::Black, 119_000), ClockResult::Continue);
+    }
+
+    #[test]
+    fn stopwatch_time_up_when_over_byoyomi() {
+        // 本体 1 分 + 秒読み 1 分。3 分経過で時間切れ (本体 1 + 秒読み 1 = 2 分を超過)。
+        let mut c = StopWatchClock::new(1, 1);
+        assert_eq!(c.consume(Color::Black, 3 * 60_000), ClockResult::TimeUp);
+    }
+
+    #[test]
+    fn stopwatch_format_summary_uses_minute_unit() {
+        let c = StopWatchClock::new(15, 1);
+        let s = c.format_summary();
+        assert!(s.contains("BEGIN Time"));
+        assert!(s.contains("Time_Unit:1min"));
+        assert!(s.contains("Total_Time:15"));
+        assert!(s.contains("Byoyomi:1"));
+        assert!(s.contains("Least_Time_Per_Move:0"));
+        assert!(s.contains("END Time"));
+    }
+
+    #[test]
+    fn stopwatch_turn_budget_includes_byoyomi() {
+        // 本体 15 分 + 秒読み 1 分 = 16 分。
+        let c = StopWatchClock::new(15, 1);
+        assert_eq!(c.turn_budget_ms(Color::Black), 16 * 60 * 1000);
+    }
+
+    #[test]
+    fn stopwatch_black_and_white_are_independent() {
+        let mut c = StopWatchClock::new(15, 1);
+        assert_eq!(c.consume(Color::Black, 60_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::White), 15 * 60 * 1000);
     }
 }

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -145,9 +145,20 @@ impl TimeClock for SecondsCountdownClock {
 
     fn turn_budget_ms(&self, color: Color) -> i64 {
         // 今の 1 手で使える最大時間 = 本体残り + 毎手 full 回復する byoyomi。
-        self.slot(color) + self.byoyomi_ms()
+        //
+        // `consume` は経過時間を **秒単位に切り捨て** てから差し引くため、
+        // 実際に受理される物理 elapsed_ms は `slot + byoyomi_ms` そのものではなく
+        // 「次の秒境界の直前まで」 (`slot + byoyomi + 999ms`) となる。スケジューラは
+        // 本関数の戻り値で deadline を設定するため、`consume` の truncation 分
+        // (999ms) を足さないと正当な着手がタイムアウトで強制敗北する。
+        self.slot(color) + self.byoyomi_ms() + (SECOND_GRAIN_MS - 1)
     }
 }
+
+/// 1 秒分のミリ秒。Fischer / SecondsCountdown の grain (最小単位) として共通使用。
+const SECOND_GRAIN_MS: i64 = 1_000;
+/// 1 分分のミリ秒。StopWatch の grain (最小単位)。
+const MINUTE_GRAIN_MS: i64 = 60 * 1_000;
 
 /// Fischer 方式の時計（増分加算 / Bronstein 派生ではない標準 Fischer）。
 ///
@@ -236,8 +247,11 @@ impl TimeClock for FischerClock {
     }
 
     fn turn_budget_ms(&self, color: Color) -> i64 {
-        // 現在手で使える budget は現在の残時間のみ。increment は手完了後に付く。
-        self.slot(color)
+        // 現在手で使える budget は現在の残時間のみ (increment は手完了後に付く)。
+        // `consume` は elapsed を秒単位に切り捨てるため、`slot` ぴったりで
+        // deadline を切ると正当な着手 (例: slot=5000ms で物理 5.5s 経過) を
+        // 誤って TimeUp させる。truncation 分 (999ms) を足して整合を取る。
+        self.slot(color) + (SECOND_GRAIN_MS - 1)
     }
 }
 
@@ -335,7 +349,12 @@ impl TimeClock for StopWatchClock {
 
     fn turn_budget_ms(&self, color: Color) -> i64 {
         // 本体残り + 毎手 full 回復する秒読み（分単位）。
-        self.slot(color) + self.byoyomi_ms()
+        //
+        // `consume` は elapsed_ms を **分単位に切り捨て** (`elapsed_ms / 60_000`)
+        // してから差し引くため、`slot + byoyomi_ms` で deadline を切るとプレイヤが
+        // まだ本来使える分 (最大 59_999ms) を失う。`MINUTE_GRAIN_MS - 1` を足して
+        // 次の分境界の直前まで deadline を伸ばし、`consume` の切り捨て挙動と整合させる。
+        self.slot(color) + self.byoyomi_ms() + (MINUTE_GRAIN_MS - 1)
     }
 }
 
@@ -399,31 +418,36 @@ mod tests {
 
     #[test]
     fn turn_budget_includes_byoyomi_on_fresh_clock() {
-        // 本体 60 秒 + 秒読み 10 秒 → 初手の予算 70 秒。旧 API (remaining_ms) は 60 秒しか
-        // 返さず、deadline 計算が byoyomi を無視するバグの元だった。
+        // 本体 60 秒 + 秒読み 10 秒 → 初手の予算 70_999ms (秒 grain の `consume` で
+        // truncation される最大フラクショナル 999ms を scheduler deadline に含める)。
+        // 旧 API (remaining_ms) は 60 秒しか返さず、deadline 計算が byoyomi を無視する
+        // バグの元だった。
         let c = SecondsCountdownClock::new(60, 10);
         assert_eq!(c.remaining_main_ms(Color::Black), 60_000);
-        assert_eq!(c.turn_budget_ms(Color::Black), 70_000);
+        assert_eq!(c.turn_budget_ms(Color::Black), 70_999);
     }
 
     #[test]
     fn turn_budget_is_byoyomi_only_after_main_exhausted() {
-        // 本体 5 秒使い切り後、各手番は byoyomi 10 秒だけが予算。
+        // 本体 5 秒使い切り後、各手番は byoyomi 10 秒 + 秒 grain 分 = 10_999ms が予算。
         let mut c = SecondsCountdownClock::new(5, 10);
         assert_eq!(c.consume(Color::Black, 5_000), ClockResult::Continue);
         assert_eq!(c.remaining_main_ms(Color::Black), 0);
-        assert_eq!(c.turn_budget_ms(Color::Black), 10_000);
+        assert_eq!(c.turn_budget_ms(Color::Black), 10_999);
         // 次の手番も同じ予算（byoyomi はリセットされる）。
         assert_eq!(c.consume(Color::Black, 9_000), ClockResult::Continue);
-        assert_eq!(c.turn_budget_ms(Color::Black), 10_000);
+        assert_eq!(c.turn_budget_ms(Color::Black), 10_999);
     }
 
     #[test]
-    fn turn_budget_zero_only_when_main_zero_and_byoyomi_zero() {
-        // byoyomi=0 かつ本体 0 でだけ予算 0（= 次の手で即 time-up）。
+    fn turn_budget_reflects_second_grain_when_byoyomi_zero() {
+        // byoyomi=0 で本体 0 に落ちた状態でも、秒 grain の切り捨て分 (999ms) だけ
+        // deadline を伸ばす必要がある。`consume(elapsed=999)` は elapsed_sec=0 に
+        // 切り捨てられるため受理される (本体 0 を消費しない)。budget もこれに
+        // 合わせ 999ms を返すのが正しい挙動。
         let mut c = SecondsCountdownClock::new(5, 0);
         assert_eq!(c.consume(Color::Black, 5_000), ClockResult::Continue);
-        assert_eq!(c.turn_budget_ms(Color::Black), 0);
+        assert_eq!(c.turn_budget_ms(Color::Black), 999);
     }
 
     // ---- FischerClock ----
@@ -469,10 +493,13 @@ mod tests {
     }
 
     #[test]
-    fn fischer_turn_budget_is_remaining_only_not_plus_increment() {
-        // increment は手を指し終えた時に付くので、現在手の budget は残時間のみ。
+    fn fischer_turn_budget_is_remaining_only_plus_second_grain() {
+        // increment は手を指し終えた時に付くので、現在手の budget は「残時間 + 秒 grain」。
+        // 秒 grain の 999ms は `consume` の秒単位切り捨てと整合させるための余白で、
+        // deadline スケジューラが正当な着手 (例: slot=60_000ms で物理 60.5s 経過) を
+        // 誤って TimeUp させないために入れる。
         let c = FischerClock::new(60, 5);
-        assert_eq!(c.turn_budget_ms(Color::Black), 60_000);
+        assert_eq!(c.turn_budget_ms(Color::Black), 60_999);
     }
 
     #[test]
@@ -533,10 +560,13 @@ mod tests {
     }
 
     #[test]
-    fn stopwatch_turn_budget_includes_byoyomi() {
-        // 本体 15 分 + 秒読み 1 分 = 16 分。
+    fn stopwatch_turn_budget_includes_byoyomi_plus_minute_grain() {
+        // 本体 15 分 + 秒読み 1 分 + minute grain (59_999ms) = 16 分 + 59_999ms。
+        // `consume` が分単位に切り捨てる挙動と scheduler deadline を整合させるため、
+        // 次の分境界の直前まで delay を伸ばす。これが無いと 1 分 byoyomi の局面で
+        // scheduler が最大 59 秒早く TimeUp を発火させてしまう (Codex review P1)。
         let c = StopWatchClock::new(15, 1);
-        assert_eq!(c.turn_budget_ms(Color::Black), 16 * 60 * 1000);
+        assert_eq!(c.turn_budget_ms(Color::Black), 16 * 60_000 + 59_999);
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -160,19 +160,22 @@ const SECOND_GRAIN_MS: i64 = 1_000;
 /// 1 分分のミリ秒。StopWatch の grain (最小単位)。
 const MINUTE_GRAIN_MS: i64 = 60 * 1_000;
 
-/// Fischer 方式の時計（増分加算 / Bronstein 派生ではない標準 Fischer）。
+/// Fischer 方式の時計（増分加算、**pre-increment セマンティクス**）。
 ///
 /// - `total_time_seconds`: 初期の持ち時間（秒）。
-/// - `increment_seconds`: 1 手を指し終えるたびに加算される増分（秒）。
+/// - `increment_seconds`: 1 手ごとに加算される増分（秒）。
 /// - 経過時間は整数秒に切り捨て（SecondsCountdown と同様 CSA 慣用）。
 /// - 消費で残時間が負に落ちた時点で時間切れ。
 ///
 /// # セマンティクス
-/// - `consume(elapsed)` は「この手で使った時間」を差し引いた後、使い切っていなければ
-///   `increment` を加算する。増分は手を指し終えたタイミングで付与される（手番中に
-///   増分を先取りして使える実装にはしない）。
-/// - `turn_budget_ms` は「現在の残時間」だけを返す。`increment` は次手完了後に
-///   加算されるため、現在手の budget には含めない。
+/// - **`consume(elapsed)` は先に増分を加算してから elapsed を差し引く**
+///   (pre-increment)。初手から `total + increment` の budget が使える挙動で、
+///   既存 CSA client (`crates/tools/src/csa_client/session.rs`) が
+///   `black_time_ms = total_time_ms + increment_ms` で move 1 を計算するのと
+///   整合する。FIDE 標準の「手完了後に increment 追加 (post-increment)」とは
+///   タイミングだけ 1 手ぶん前後するが、数手指した後の残り時間は同じに収束する。
+/// - `turn_budget_ms` は「現在手で使える最大時間 = 残時間 + increment +
+///   秒 grain」を返す。
 #[derive(Debug, Clone)]
 pub struct FischerClock {
     total_time_seconds: u32,
@@ -214,17 +217,20 @@ impl FischerClock {
 
 impl TimeClock for FischerClock {
     fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
+        // pre-increment: 先に `increment_ms` を加算してから elapsed を差し引く。
+        // move 1 で `total + increment` の budget が使える挙動にして、CSA client
+        // (`black_time_ms = total_time_ms + increment_ms`) と整合させる
+        // (Codex review PR #468 3rd round P1)。
         let elapsed_sec_ms = (elapsed_ms / 1000) as i64 * 1000;
         let increment = self.increment_ms();
         let slot = self.slot_mut(color);
 
-        // 消費後の残時間が非負なら受理し、増分を加算。負に落ちたら時間切れ。
-        let after = *slot - elapsed_sec_ms;
+        let after = *slot + increment - elapsed_sec_ms;
         if after < 0 {
             *slot = 0;
             ClockResult::TimeUp
         } else {
-            *slot = after + increment;
+            *slot = after;
             ClockResult::Continue
         }
     }
@@ -247,11 +253,12 @@ impl TimeClock for FischerClock {
     }
 
     fn turn_budget_ms(&self, color: Color) -> i64 {
-        // 現在手で使える budget は現在の残時間のみ (increment は手完了後に付く)。
-        // `consume` は elapsed を秒単位に切り捨てるため、`slot` ぴったりで
-        // deadline を切ると正当な着手 (例: slot=5000ms で物理 5.5s 経過) を
-        // 誤って TimeUp させる。truncation 分 (999ms) を足して整合を取る。
-        self.slot(color) + (SECOND_GRAIN_MS - 1)
+        // pre-increment セマンティクスにより、`consume` は `slot + increment`
+        // までの elapsed を受理する。deadline スケジューラはその境界を使うこと
+        // (CSA client も move 1 を `total + increment` で計算)。
+        // `consume` は elapsed を秒単位に切り捨てるため、truncation 分 (999ms)
+        // を足して境界を次の秒境界の直前に揃える。
+        self.slot(color) + self.increment_ms() + (SECOND_GRAIN_MS - 1)
     }
 }
 
@@ -332,12 +339,20 @@ impl TimeClock for StopWatchClock {
     }
 
     fn format_summary(&self) -> String {
-        // StopWatch 方式は分単位で扱うため `Time_Unit:1min`。
+        // `Time_Unit:1min` は CSA 仕様上は合法だが、既存 client / USI エンジンの
+        // 多くは byoyomi を「単位 × value ms」ではなく常に秒 × 1000 ms として
+        // 解釈する (Codex review PR #468 3rd round P2)。相互運用性を優先して
+        // `Time_Unit:1sec` で出力し、total_time と byoyomi を秒に展開する。
+        // 内部 `consume` は依然として分単位に切り捨てるため、engine から見た
+        // byoyomi (秒単位) と server 側が受理する最大 elapsed (分切り上げ) の
+        // 乖離は、engine が自主的に byoyomi 内に収めることで解消する。
+        let total_time_seconds = self.total_time_minutes * 60;
+        let byoyomi_seconds = self.byoyomi_minutes * 60;
         let mut out = String::new();
         out.push_str("BEGIN Time\n");
-        out.push_str("Time_Unit:1min\n");
-        out.push_str(&format!("Total_Time:{}\n", self.total_time_minutes));
-        out.push_str(&format!("Byoyomi:{}\n", self.byoyomi_minutes));
+        out.push_str("Time_Unit:1sec\n");
+        out.push_str(&format!("Total_Time:{total_time_seconds}\n"));
+        out.push_str(&format!("Byoyomi:{byoyomi_seconds}\n"));
         out.push_str("Least_Time_Per_Move:0\n");
         out.push_str("END Time\n");
         out
@@ -453,27 +468,43 @@ mod tests {
     // ---- FischerClock ----
 
     #[test]
-    fn fischer_adds_increment_after_consume() {
-        // 初期 60 秒、増分 5 秒。10 秒使って手を指し終えると残りは 55 秒 (= 60 - 10 + 5)。
+    fn fischer_adds_increment_before_consume() {
+        // 初期 60 秒、増分 5 秒。pre-increment セマンティクス: move 1 では
+        // `total + increment = 65` が予算で、10 秒使うと残り `65 - 10 = 55`。
         let mut c = FischerClock::new(60, 5);
         assert_eq!(c.consume(Color::Black, 10_000), ClockResult::Continue);
         assert_eq!(c.remaining_main_ms(Color::Black), 55_000);
-        // 連続 2 手消費しても増分はそれぞれ付く。
+        // 2 手目は `55 + 5 = 60` が予算、2 秒使って残り 58。
         assert_eq!(c.consume(Color::Black, 2_000), ClockResult::Continue);
         assert_eq!(c.remaining_main_ms(Color::Black), 58_000);
     }
 
     #[test]
-    fn fischer_time_up_when_elapsed_exceeds_remaining() {
-        // 残 5 秒。6 秒使い切ったら TimeUp (increment は加算されない)。
+    fn fischer_accepts_move_up_to_total_plus_increment_on_move_one() {
+        // Codex review (PR #468 3rd round) の回帰防止: CSA client は move 1 で
+        // `total + increment` の budget を engine に配る (`black_time_ms =
+        // total_time_ms + increment_ms`)。server もそれを受理すること。
+        // 例: total=60, inc=5 → move 1 は 65 秒まで受理、66 秒で TimeUp。
+        let mut c = FischerClock::new(60, 5);
+        assert_eq!(c.consume(Color::Black, 65_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 0);
+        // 次手の残時間は 0 + increment (pre) = 5 秒まで許容、6 秒で TimeUp。
+        let mut c2 = FischerClock::new(60, 5);
+        assert_eq!(c2.consume(Color::Black, 66_000), ClockResult::TimeUp);
+    }
+
+    #[test]
+    fn fischer_time_up_when_elapsed_exceeds_remaining_plus_increment() {
+        // 残 5 秒、増分 3 秒。pre-increment なので 8 秒までは受理 (5+3)。
+        // 9 秒で TimeUp。
         let mut c = FischerClock::new(5, 3);
-        assert_eq!(c.consume(Color::Black, 6_000), ClockResult::TimeUp);
+        assert_eq!(c.consume(Color::Black, 9_000), ClockResult::TimeUp);
         assert_eq!(c.remaining_main_ms(Color::Black), 0);
     }
 
     #[test]
     fn fischer_consume_truncates_to_second() {
-        // 999ms は 0 秒に切り捨て。消費 0 + 増分 5 秒 = 残 65 秒。
+        // 999ms は 0 秒に切り捨て。pre-increment で slot=60 → 60+5-0=65。
         let mut c = FischerClock::new(60, 5);
         assert_eq!(c.consume(Color::Black, 999), ClockResult::Continue);
         assert_eq!(c.remaining_main_ms(Color::Black), 65_000);
@@ -493,13 +524,12 @@ mod tests {
     }
 
     #[test]
-    fn fischer_turn_budget_is_remaining_only_plus_second_grain() {
-        // increment は手を指し終えた時に付くので、現在手の budget は「残時間 + 秒 grain」。
-        // 秒 grain の 999ms は `consume` の秒単位切り捨てと整合させるための余白で、
-        // deadline スケジューラが正当な着手 (例: slot=60_000ms で物理 60.5s 経過) を
-        // 誤って TimeUp させないために入れる。
+    fn fischer_turn_budget_includes_increment_and_second_grain() {
+        // pre-increment により、move 1 では `total + increment + 秒 grain` が予算。
+        // 60 + 5 = 65 秒分 (65_000ms) が `consume` の受理上限で、`turn_budget_ms`
+        // は秒切り捨て分の 999ms を足した 65_999 を返す。
         let c = FischerClock::new(60, 5);
-        assert_eq!(c.turn_budget_ms(Color::Black), 60_999);
+        assert_eq!(c.turn_budget_ms(Color::Black), 65_999);
     }
 
     #[test]
@@ -548,13 +578,18 @@ mod tests {
     }
 
     #[test]
-    fn stopwatch_format_summary_uses_minute_unit() {
+    fn stopwatch_format_summary_emits_seconds_for_client_compat() {
+        // `Time_Unit:1min` は既存 CSA client + USI エンジンの多くが byoyomi を
+        // 秒として扱う都合で損失が出るため、秒に展開して出す (Codex review
+        // PR #468 3rd round P2)。内部 consume は依然として分単位に切り捨てる
+        // ため、engine から見た byoyomi (秒) と server 側の最大受理 elapsed
+        // (分切り上げ) の差は engine が自主的に byoyomi 内に収めることで吸収。
         let c = StopWatchClock::new(15, 1);
         let s = c.format_summary();
         assert!(s.contains("BEGIN Time"));
-        assert!(s.contains("Time_Unit:1min"));
-        assert!(s.contains("Total_Time:15"));
-        assert!(s.contains("Byoyomi:1"));
+        assert!(s.contains("Time_Unit:1sec"));
+        assert!(s.contains("Total_Time:900"), "total=15min → 900 sec: {s}");
+        assert!(s.contains("Byoyomi:60"), "byoyomi=1min → 60 sec: {s}");
         assert!(s.contains("Least_Time_Per_Move:0"));
         assert!(s.contains("END Time"));
     }

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -160,7 +160,7 @@ const SECOND_GRAIN_MS: i64 = 1_000;
 /// 1 分分のミリ秒。StopWatch の grain (最小単位)。
 const MINUTE_GRAIN_MS: i64 = 60 * 1_000;
 
-/// Fischer 方式の時計（増分加算、**pre-increment セマンティクス**）。
+/// Fischer 方式の時計（増分加算、**CSA client の会計規則に合わせた init+post hybrid**）。
 ///
 /// - `total_time_seconds`: 初期の持ち時間（秒）。
 /// - `increment_seconds`: 1 手ごとに加算される増分（秒）。
@@ -168,14 +168,19 @@ const MINUTE_GRAIN_MS: i64 = 60 * 1_000;
 /// - 消費で残時間が負に落ちた時点で時間切れ。
 ///
 /// # セマンティクス
-/// - **`consume(elapsed)` は先に増分を加算してから elapsed を差し引く**
-///   (pre-increment)。初手から `total + increment` の budget が使える挙動で、
-///   既存 CSA client (`crates/tools/src/csa_client/session.rs`) が
-///   `black_time_ms = total_time_ms + increment_ms` で move 1 を計算するのと
-///   整合する。FIDE 標準の「手完了後に increment 追加 (post-increment)」とは
-///   タイミングだけ 1 手ぶん前後するが、数手指した後の残り時間は同じに収束する。
-/// - `turn_budget_ms` は「現在手で使える最大時間 = 残時間 + increment +
-///   秒 grain」を返す。
+/// 既存 CSA client (`crates/tools/src/csa_client/session.rs`) は以下の会計を採用:
+/// ```text
+/// init:          slot = total + increment     // pre-init-increment
+/// consume(e):    slot = slot - e + increment  // post-move-increment
+/// ```
+///
+/// FIDE 標準 (init=total / 各手 post-increment) とも、完全な pre-increment
+/// (init=total / 各手 pre-increment) とも異なる独特の計算だが、既存 client /
+/// 棋譜ツールとの interop を優先してサーバもこれに合わせる (Codex review
+/// PR #468 4th round P1)。初手に `total + increment` 秒の予算があり、以後
+/// 各手ごとに (残 - elapsed + inc) で slot が更新される。
+///
+/// - `turn_budget_ms` は「現在の slot (既に +increment 済み) + 秒 grain」を返す。
 #[derive(Debug, Clone)]
 pub struct FischerClock {
     total_time_seconds: u32,
@@ -186,8 +191,11 @@ pub struct FischerClock {
 
 impl FischerClock {
     /// 新しい Fischer 時計を作る。引数単位は「秒」。
+    ///
+    /// client と合わせるため初期 slot は `total + increment` (= 初手で使える
+    /// 予算)。以後 `consume` 毎に post-increment で `slot = slot - elapsed + inc`。
     pub fn new(total_time_seconds: u32, increment_seconds: u32) -> Self {
-        let initial = total_time_seconds as i64 * 1000;
+        let initial = (total_time_seconds as i64 + increment_seconds as i64) * 1000;
         Self {
             total_time_seconds,
             increment_seconds,
@@ -217,20 +225,23 @@ impl FischerClock {
 
 impl TimeClock for FischerClock {
     fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
-        // pre-increment: 先に `increment_ms` を加算してから elapsed を差し引く。
-        // move 1 で `total + increment` の budget が使える挙動にして、CSA client
-        // (`black_time_ms = total_time_ms + increment_ms`) と整合させる
-        // (Codex review PR #468 3rd round P1)。
+        // CSA client の会計規則に合わせた post-move-increment:
+        //   new_slot = slot - elapsed + increment
+        // 初期 slot は `new` で `total + increment` 済みなので、初手でも
+        // `total + increment` 秒の予算を検査できる。2 手目以降は前手の完了時に
+        // increment が加算されているため実質的に post-increment 挙動。
+        // client は `black_time_ms = total + inc` + 毎手 `slot -= e; slot += inc`
+        // で動くので、server もこれに一致させる (Codex review PR #468 4th round P1)。
         let elapsed_sec_ms = (elapsed_ms / 1000) as i64 * 1000;
         let increment = self.increment_ms();
         let slot = self.slot_mut(color);
 
-        let after = *slot + increment - elapsed_sec_ms;
-        if after < 0 {
+        let after_consume = *slot - elapsed_sec_ms;
+        if after_consume < 0 {
             *slot = 0;
             ClockResult::TimeUp
         } else {
-            *slot = after;
+            *slot = after_consume + increment;
             ClockResult::Continue
         }
     }
@@ -253,12 +264,11 @@ impl TimeClock for FischerClock {
     }
 
     fn turn_budget_ms(&self, color: Color) -> i64 {
-        // pre-increment セマンティクスにより、`consume` は `slot + increment`
-        // までの elapsed を受理する。deadline スケジューラはその境界を使うこと
-        // (CSA client も move 1 を `total + increment` で計算)。
-        // `consume` は elapsed を秒単位に切り捨てるため、truncation 分 (999ms)
-        // を足して境界を次の秒境界の直前に揃える。
-        self.slot(color) + self.increment_ms() + (SECOND_GRAIN_MS - 1)
+        // `slot` は既に前手 post-increment 込み (初期は `total + increment`、
+        // 以後 `- elapsed + increment`)。`consume` は `slot - elapsed` で判定
+        // するので、deadline も現在の slot 値をそのまま budget とする。
+        // `consume` の秒切り捨てを考慮して `SECOND_GRAIN_MS - 1` (999ms) を足す。
+        self.slot(color) + (SECOND_GRAIN_MS - 1)
     }
 }
 
@@ -339,20 +349,28 @@ impl TimeClock for StopWatchClock {
     }
 
     fn format_summary(&self) -> String {
-        // `Time_Unit:1min` は CSA 仕様上は合法だが、既存 client / USI エンジンの
-        // 多くは byoyomi を「単位 × value ms」ではなく常に秒 × 1000 ms として
-        // 解釈する (Codex review PR #468 3rd round P2)。相互運用性を優先して
-        // `Time_Unit:1sec` で出力し、total_time と byoyomi を秒に展開する。
-        // 内部 `consume` は依然として分単位に切り捨てるため、engine から見た
-        // byoyomi (秒単位) と server 側が受理する最大 elapsed (分切り上げ) の
-        // 乖離は、engine が自主的に byoyomi 内に収めることで解消する。
-        let total_time_seconds = self.total_time_minutes * 60;
-        let byoyomi_seconds = self.byoyomi_minutes * 60;
+        // StopWatch 方式は `consume` が elapsed_ms を **分単位に切り捨てる** ため、
+        // Game_Summary も CSA 仕様の `Time_Unit:1min` で分単位を宣言する。
+        //
+        // # 既知の client-server 乖離
+        //
+        // 本 server は `T<sec>` broadcast (秒単位の elapsed) を送り、client
+        // (`crates/tools/src/csa_client/session.rs`) はその値を literal ms として
+        // 残時間から減算する。一方 server 側の `consume` は分単位で切り捨てる
+        // ため、「client のローカル remaining」と「server の実 slot」は 1 手に
+        // 最大 59 秒ずれ得る (Codex review PR #468 4th round P1 指摘の client 側
+        // 実装の limitation)。engine の時間管理精度を保つには、client 側も
+        // StopWatch 相当の分単位切り捨てを行うか、T<sec> を分単位で emit する
+        // 必要がある。どちらも別 PR で対応。
+        //
+        // 現状の妥協: server は CSA 仕様に準拠して `Time_Unit:1min` を出し、
+        // client-side の取り違えは後続タスクで修正する (サーバ側を変えると
+        // `%%LIST` / 棋譜互換を広く破ってしまう)。
         let mut out = String::new();
         out.push_str("BEGIN Time\n");
-        out.push_str("Time_Unit:1sec\n");
-        out.push_str(&format!("Total_Time:{total_time_seconds}\n"));
-        out.push_str(&format!("Byoyomi:{byoyomi_seconds}\n"));
+        out.push_str("Time_Unit:1min\n");
+        out.push_str(&format!("Total_Time:{}\n", self.total_time_minutes));
+        out.push_str(&format!("Byoyomi:{}\n", self.byoyomi_minutes));
         out.push_str("Least_Time_Per_Move:0\n");
         out.push_str("END Time\n");
         out
@@ -468,34 +486,38 @@ mod tests {
     // ---- FischerClock ----
 
     #[test]
-    fn fischer_adds_increment_before_consume() {
-        // 初期 60 秒、増分 5 秒。pre-increment セマンティクス: move 1 では
-        // `total + increment = 65` が予算で、10 秒使うと残り `65 - 10 = 55`。
+    fn fischer_matches_csa_client_accounting() {
+        // CSA client は init `slot = total + inc` + 毎手 `slot -= e; slot += inc`
+        // で動くので、server もこれに一致させる (Codex review PR #468 4th round P1)。
+        //
+        // 初期 60 秒、増分 5 秒。init で slot=65。move 1 で 10 秒使うと:
+        //   slot = 65 - 10 = 55, + inc = 60
+        // move 2 で 2 秒使うと:
+        //   slot = 60 - 2 = 58, + inc = 63
         let mut c = FischerClock::new(60, 5);
+        assert_eq!(c.remaining_main_ms(Color::Black), 65_000);
         assert_eq!(c.consume(Color::Black, 10_000), ClockResult::Continue);
-        assert_eq!(c.remaining_main_ms(Color::Black), 55_000);
-        // 2 手目は `55 + 5 = 60` が予算、2 秒使って残り 58。
+        assert_eq!(c.remaining_main_ms(Color::Black), 60_000);
         assert_eq!(c.consume(Color::Black, 2_000), ClockResult::Continue);
-        assert_eq!(c.remaining_main_ms(Color::Black), 58_000);
+        assert_eq!(c.remaining_main_ms(Color::Black), 63_000);
     }
 
     #[test]
     fn fischer_accepts_move_up_to_total_plus_increment_on_move_one() {
-        // Codex review (PR #468 3rd round) の回帰防止: CSA client は move 1 で
-        // `total + increment` の budget を engine に配る (`black_time_ms =
-        // total_time_ms + increment_ms`)。server もそれを受理すること。
+        // Codex review (PR #468 3rd/4th round) 回帰防止: CSA client は move 1 で
+        // `total + increment` の budget を engine に配る。server もそれを受理する。
         // 例: total=60, inc=5 → move 1 は 65 秒まで受理、66 秒で TimeUp。
         let mut c = FischerClock::new(60, 5);
         assert_eq!(c.consume(Color::Black, 65_000), ClockResult::Continue);
-        assert_eq!(c.remaining_main_ms(Color::Black), 0);
-        // 次手の残時間は 0 + increment (pre) = 5 秒まで許容、6 秒で TimeUp。
+        assert_eq!(c.remaining_main_ms(Color::Black), 5_000);
+        // 次手の残時間は 5 秒。5 秒使えば OK、6 秒で TimeUp。
         let mut c2 = FischerClock::new(60, 5);
         assert_eq!(c2.consume(Color::Black, 66_000), ClockResult::TimeUp);
     }
 
     #[test]
-    fn fischer_time_up_when_elapsed_exceeds_remaining_plus_increment() {
-        // 残 5 秒、増分 3 秒。pre-increment なので 8 秒までは受理 (5+3)。
+    fn fischer_time_up_when_elapsed_exceeds_total_plus_increment() {
+        // client の init = total + increment 規則。total=5, inc=3 → 初手 8 秒まで。
         // 9 秒で TimeUp。
         let mut c = FischerClock::new(5, 3);
         assert_eq!(c.consume(Color::Black, 9_000), ClockResult::TimeUp);
@@ -504,10 +526,10 @@ mod tests {
 
     #[test]
     fn fischer_consume_truncates_to_second() {
-        // 999ms は 0 秒に切り捨て。pre-increment で slot=60 → 60+5-0=65。
+        // 999ms は 0 秒に切り捨て。init slot=65, consume(999): 65 - 0 + 5 = 70。
         let mut c = FischerClock::new(60, 5);
         assert_eq!(c.consume(Color::Black, 999), ClockResult::Continue);
-        assert_eq!(c.remaining_main_ms(Color::Black), 65_000);
+        assert_eq!(c.remaining_main_ms(Color::Black), 70_000);
     }
 
     #[test]
@@ -524,10 +546,8 @@ mod tests {
     }
 
     #[test]
-    fn fischer_turn_budget_includes_increment_and_second_grain() {
-        // pre-increment により、move 1 では `total + increment + 秒 grain` が予算。
-        // 60 + 5 = 65 秒分 (65_000ms) が `consume` の受理上限で、`turn_budget_ms`
-        // は秒切り捨て分の 999ms を足した 65_999 を返す。
+    fn fischer_turn_budget_uses_current_slot_plus_second_grain() {
+        // init slot = total + inc = 65 秒。`turn_budget_ms` は slot + grain 999ms。
         let c = FischerClock::new(60, 5);
         assert_eq!(c.turn_budget_ms(Color::Black), 65_999);
     }
@@ -536,7 +556,8 @@ mod tests {
     fn fischer_black_and_white_are_independent() {
         let mut c = FischerClock::new(60, 5);
         assert_eq!(c.consume(Color::Black, 10_000), ClockResult::Continue);
-        assert_eq!(c.remaining_main_ms(Color::White), 60_000);
+        // init で両者とも 60+5=65 秒、Black だけ消費後 60 秒、White は 65 秒のまま。
+        assert_eq!(c.remaining_main_ms(Color::White), 65_000);
     }
 
     // ---- StopWatchClock ----
@@ -578,18 +599,18 @@ mod tests {
     }
 
     #[test]
-    fn stopwatch_format_summary_emits_seconds_for_client_compat() {
-        // `Time_Unit:1min` は既存 CSA client + USI エンジンの多くが byoyomi を
-        // 秒として扱う都合で損失が出るため、秒に展開して出す (Codex review
-        // PR #468 3rd round P2)。内部 consume は依然として分単位に切り捨てる
-        // ため、engine から見た byoyomi (秒) と server 側の最大受理 elapsed
-        // (分切り上げ) の差は engine が自主的に byoyomi 内に収めることで吸収。
+    fn stopwatch_format_summary_uses_minute_unit() {
+        // StopWatch は consume で分単位切り捨てを行うため、Game_Summary も
+        // `Time_Unit:1min` で分単位宣言する (Codex review PR #468 4th round P1
+        // の指摘通り)。Round 3 で一時的に秒表記にしたが、`consume` の分切り捨てと
+        // `T<sec>` broadcast の秒単位が乖離して client 側の remaining が server 側
+        // と食い違うため revert。
         let c = StopWatchClock::new(15, 1);
         let s = c.format_summary();
         assert!(s.contains("BEGIN Time"));
-        assert!(s.contains("Time_Unit:1sec"));
-        assert!(s.contains("Total_Time:900"), "total=15min → 900 sec: {s}");
-        assert!(s.contains("Byoyomi:60"), "byoyomi=1min → 60 sec: {s}");
+        assert!(s.contains("Time_Unit:1min"));
+        assert!(s.contains("Total_Time:15"));
+        assert!(s.contains("Byoyomi:1"));
         assert!(s.contains("Least_Time_Per_Move:0"));
         assert!(s.contains("END Time"));
     }

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -455,8 +455,14 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteLose => {
-                // 連続王手していた側（=直前の手番=from）が反則負け。
-                let mut result = self.finish(GameResult::OuteSennichite { loser: from });
+                // `OuteSennichiteLose` ⇔ `Position::repetition_state` の `Lose` で、
+                // 「手番側 (= side-to-move after the last move = from.opposite()) が
+                // 連続王手していた側で反則負け」を意味する。循環の最終手 (from) が
+                // 非王手 (=受け手の escape) で閉じ、from.opposite() がサイクル中ずっと
+                // 王手を連続して掛けていた場合に発火する。従って敗者は from.opposite()。
+                let mut result = self.finish(GameResult::OuteSennichite {
+                    loser: from.opposite(),
+                });
                 broadcasts.append(&mut result.broadcasts);
                 return Ok(HandleResult {
                     outcome: result.outcome,
@@ -464,10 +470,10 @@ impl GameRoom {
                 });
             }
             RepetitionVerdict::OuteSennichiteWin => {
-                // 連続王手されていた側（直前の手番）が勝ち＝相手（手番外）の反則負け。
-                let mut result = self.finish(GameResult::OuteSennichite {
-                    loser: from.opposite(),
-                });
+                // `OuteSennichiteWin` ⇔ `Position::repetition_state` の `Win` で、
+                // 「手番側 (from.opposite()) が勝ち」= 直前に指した from が連続王手
+                // していた側で反則負け。循環の最終手が from による王手で閉じた場合に発火。
+                let mut result = self.finish(GameResult::OuteSennichite { loser: from });
                 broadcasts.append(&mut result.broadcasts);
                 return Ok(HandleResult {
                     outcome: result.outcome,
@@ -619,6 +625,28 @@ mod tests {
         };
         let clock = Box::new(SecondsCountdownClock::new(60, 5));
         GameRoom::new(config, clock)
+    }
+
+    /// 任意 SFEN から対局を開始するためのテスト専用 helper。
+    ///
+    /// 本番 API (`GameRoom::new`) は入玉対局・千日手・打ち歩詰など
+    /// 「局面起点」の終局シナリオを試験できるように拡張されていない
+    /// （Game_Summary / 棋譜の初期局面契約まで一括で導入するタスクが別にある）。
+    /// テストモジュール内で private フィールド `pos` を直接差し替えて、
+    /// 本番 API を増やさずに位置を注入する。
+    fn room_with_sfen(rule: EnteringKingRule, sfen: &str) -> GameRoom {
+        let config = GameRoomConfig {
+            game_id: GameId::new("20140101120000"),
+            black: PlayerName::new("alice"),
+            white: PlayerName::new("bob"),
+            max_moves: 256,
+            time_margin_ms: 0,
+            entering_king_rule: rule,
+        };
+        let clock = Box::new(SecondsCountdownClock::new(60, 5));
+        let mut room = GameRoom::new(config, clock);
+        room.pos.set_sfen(sfen).expect("valid sfen for test");
+        room
     }
 
     fn line(s: &str) -> CsaLine {
@@ -1019,5 +1047,131 @@ mod tests {
         assert_eq!(r.broadcasts[0].line.as_str(), "-3334FU,T0");
         assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#MAX_MOVES"));
         assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#CENSORED"));
+    }
+
+    #[test]
+    fn kachi_accepted_from_point27_sfen_ends_with_jishogi() {
+        // Validator の `evaluate_kachi_accepted_for_27pt_position` と同じ入玉局面を流用。
+        // 先手が 28 点を満たしており、両者 AGREE → 先手 %KACHI → `GameResult::Kachi` 確定。
+        let mut room =
+            room_with_sfen(EnteringKingRule::Point27, "LNSGKGSNL/4BR3/9/9/9/9/9/9/4k4 b RB 1");
+        agree_both(&mut room);
+        let r = room.handle_line(Color::Black, &line("%KACHI"), 0).unwrap();
+        match &r.outcome {
+            HandleOutcome::GameEnded(GameResult::Kachi {
+                winner: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        // `#JISHOGI` + `#WIN/#LOSE` の 3 宛先 × 2 行 = 6 行。
+        assert_eq!(r.broadcasts.len(), 6);
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#JISHOGI"));
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#WIN"));
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#LOSE"));
+    }
+
+    #[test]
+    fn uchifuzume_pawn_drop_ends_with_illegal_move_reason_uchifuzume() {
+        // Validator の `validate_move_detects_uchifuzume` と同じ盤面:
+        // 後手玉 1 一、先手 と 1 三、先手金 3 二、先手玉 5 九、手駒に歩。
+        // 先手 +0012FU で打ち歩詰 → `IllegalMove{reason: Uchifuzume}` が確定する。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "8k/6G2/8+P/9/9/9/9/9/4K4 b P 1");
+        agree_both(&mut room);
+        let r = room.handle_line(Color::Black, &line("+0012FU"), 0).unwrap();
+        match &r.outcome {
+            HandleOutcome::GameEnded(GameResult::IllegalMove {
+                loser: Color::Black,
+                reason: IllegalReason::Uchifuzume,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(r.broadcasts.iter().any(|b| b.line.as_str() == "#ILLEGAL_MOVE"));
+    }
+
+    #[test]
+    fn sennichite_ends_game_after_12_ply_gold_dance() {
+        // 平手初期局面で左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて 3 サイクル
+        // (12 手) 経過 → 初期局面 4 回目の到達 → `GameResult::Sennichite`。
+        let mut room = make_room();
+        agree_both(&mut room);
+        let cycle = [
+            (Color::Black, "+4948KI"),
+            (Color::White, "-4142KI"),
+            (Color::Black, "+4849KI"),
+            (Color::White, "-4241KI"),
+        ];
+        for _ in 0..2 {
+            for (c, tok) in &cycle {
+                let r = room.handle_line(*c, &line(tok), 0).unwrap();
+                assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+            }
+        }
+        for (c, tok) in cycle.iter().take(3) {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        // 3 サイクル目の最終手 (-4241KI) で 4 回目の初期局面到達 → Sennichite。
+        let last = room.handle_line(Color::White, &line("-4241KI"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::Sennichite) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#SENNICHITE"));
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#DRAW"));
+    }
+
+    #[test]
+    fn oute_sennichite_win_variant_loses_the_last_checker() {
+        // Win variant: 開始 SFEN で白が既に黒飛の王手下にある (side=W)。
+        // 4 手 1 サイクル (白退避 → 黒再王手 → 白退避 → 黒再王手) で開始 SFEN に復帰。
+        // 連続王手は反則行為なので 1 サイクルで反則確定 (競技将棋ルール準拠)。
+        // 循環最終手 (+4838HI) は黒の王手手なので from=Black、連続王手側の黒が敗者。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "9/6k2/9/9/9/9/9/6R2/K8 w - 1");
+        agree_both(&mut room);
+        let prefix = [
+            (Color::White, "-3242OU"),
+            (Color::Black, "+3848HI"),
+            (Color::White, "-4232OU"),
+        ];
+        for (c, tok) in &prefix {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        let last = room.handle_line(Color::Black, &line("+4838HI"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::OuteSennichite {
+                loser: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#OUTE_SENNICHITE"));
+    }
+
+    #[test]
+    fn oute_sennichite_lose_variant_loses_the_perpetual_checker() {
+        // Lose variant: Win variant と駒群は同じだが、開始 SFEN を「白玉 4 二 退避済、
+        // 黒番で次の黒の手が王手」に寄せる (黒飛 3 八, 白玉 4 二, side=B, 非王手)。
+        // 4 手 1 サイクルで初期 SFEN 復帰。連続王手側 (Black = from.opposite()) が敗者。
+        // 最終手 (-3242OU) は白の退避手で非王手のため from=White、連続王手していた
+        // 黒が from.opposite()。
+        let mut room = room_with_sfen(EnteringKingRule::Point24, "9/5k3/9/9/9/9/9/6R2/K8 b - 1");
+        agree_both(&mut room);
+        let prefix = [
+            (Color::Black, "+3848HI"),
+            (Color::White, "-4232OU"),
+            (Color::Black, "+4838HI"),
+        ];
+        for (c, tok) in &prefix {
+            let r = room.handle_line(*c, &line(tok), 0).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        let last = room.handle_line(Color::White, &line("-3242OU"), 0).unwrap();
+        match &last.outcome {
+            HandleOutcome::GameEnded(GameResult::OuteSennichite {
+                loser: Color::Black,
+            }) => {}
+            other => panic!("unexpected outcome: {other:?}"),
+        }
+        assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#OUTE_SENNICHITE"));
     }
 }

--- a/crates/rshogi-csa-server/src/game/validator.rs
+++ b/crates/rshogi-csa-server/src/game/validator.rs
@@ -128,12 +128,27 @@ impl Validator {
     ///
     /// `Position::repetition_state` 内部で連続王手判定も行われるため、
     /// 千日手成立時の勝敗側もここで切り分ける。
+    ///
+    /// **発火タイミング:**
+    /// - 通常千日手 (Draw): 同一局面 4 回目の到達で発火する。`state.repetition < 0`
+    ///   (= `times >= 3` = 4 回目以降の出現) を必須条件としており、それ以前の非決定的
+    ///   な再来では `None` を返す。これは競技将棋の「同一局面 4 回で引き分け」ルール
+    ///   に一致する。
+    /// - 連続王手千日手 (Win/Lose): 1 サイクル目の再来で発火する。連続王手は
+    ///   反則行為であり、1 循環で反則確定すればそれ以降は続行する意味がないため、
+    ///   非決定的な (`rep > 0` の) 再来でも Verdict を返す。
     pub fn classify_repetition(&self, pos: &Position) -> RepetitionVerdict {
-        match pos.repetition_state(i32::MAX) {
+        let state = pos.state();
+        if state.repetition == 0 {
+            return RepetitionVerdict::None;
+        }
+        match state.repetition_type {
             RepetitionState::None | RepetitionState::Superior | RepetitionState::Inferior => {
                 RepetitionVerdict::None
             }
-            RepetitionState::Draw => RepetitionVerdict::Sennichite,
+            // 非決定的な再来 (rep > 0) では発火せず対局続行。決定的 (rep < 0) でのみ発火。
+            RepetitionState::Draw if state.repetition < 0 => RepetitionVerdict::Sennichite,
+            RepetitionState::Draw => RepetitionVerdict::None,
             RepetitionState::Lose => RepetitionVerdict::OuteSennichiteLose,
             RepetitionState::Win => RepetitionVerdict::OuteSennichiteWin,
         }
@@ -735,5 +750,78 @@ mod tests {
         let pos = pos_from_sfen(rshogi_core::position::SFEN_HIRATE);
         assert!(!v.is_sennichite(&pos));
         assert!(!v.is_oute_sennichite(&pos));
+    }
+
+    /// CSA トークン列を順次 `do_move` で適用する検証用ヘルパ。
+    ///
+    /// 千日手系テストは CSA トークンで棋譜を記述した方が読みやすい。`validate_move`
+    /// で Move を取り出し `Position::gives_check` を渡して `do_move` する、という
+    /// 3 ステップを 1 つにまとめる。
+    fn apply_moves(pos: &mut Position, rule: EnteringKingRule, tokens: &[&str]) {
+        let v = Validator::new(rule);
+        for t in tokens {
+            let tok = token(t);
+            let mv = v
+                .validate_move(pos, &tok)
+                .unwrap_or_else(|e| panic!("validate_move failed for {t}: {e:?}"));
+            let gc = pos.gives_check(mv);
+            pos.do_move(mv, gc);
+        }
+    }
+
+    #[test]
+    fn classify_repetition_returns_sennichite_after_12_ply_gold_dance() {
+        // 平手初期局面から両者の左金を 4 九 ↔ 4 八 / 4 一 ↔ 4 二 と循環させて
+        // 3 サイクル (= 12 手) で初期局面 4 回目の到達 → 通常千日手。
+        //
+        // どの手も相手玉には利かないため連続王手は発生せず、RepetitionState::Draw
+        // として分類される想定。
+        let mut pos = pos_from_sfen(rshogi_core::position::SFEN_HIRATE);
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["+4948KI", "-4142KI", "+4849KI", "-4241KI"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        // 3 周目の最終手でちょうど初期局面 4 回目の出現。
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::Sennichite);
+    }
+
+    #[test]
+    fn classify_repetition_returns_oute_sennichite_win_for_perpetual_checker() {
+        // 黒玉 9 九、黒飛 3 八、白玉 3 二、side = White（=白が王手されている局面から開始）。
+        // 4 手 1 サイクルで「白王が 3 二 ↔ 4 二 を往復し、黒飛が 3 八 ↔ 4 八 を往復して
+        // そのたびに王手をかけ直す」連続王手の千日手を作る。3 サイクル (= 12 手) 経過で
+        // 初期 SFEN 局面が 4 回目の出現となり、RepetitionState::Win が分類される。
+        //
+        // `RepetitionState::Win` は「手番側 = 連続王手されていた側が勝つ」を意味するので
+        // Verdict は `OuteSennichiteWin`。側面: 黒が perpetual checker。
+        let mut pos = pos_from_sfen("9/6k2/9/9/9/9/9/6R2/K8 w - 1");
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["-3242OU", "+3848HI", "-4232OU", "+4838HI"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteWin);
+        // `is_oute_sennichite` は勝敗を区別しない薄いラッパなので両 variant で true。
+        assert!(v.is_oute_sennichite(&pos));
+    }
+
+    #[test]
+    fn classify_repetition_returns_oute_sennichite_lose_when_cycle_ends_on_non_checking_move() {
+        // Win variant と同じ駒配置・同じ連続王手循環だが、開始 SFEN を「サイクル中間
+        // (白玉 4 二 退避済み、黒番で黒飛が次に王手を掛け直す直前)」に寄せると、
+        // 検出発火 M12 は **白の退避手** で閉じる。
+        //
+        // 結果として side-to-move after M12 = Black（＝連続王手していた側）で、
+        // `cc_side = cc[Black]` が高い値を持つため `RepetitionState::Lose` が選ばれる。
+        // Verdict は `OuteSennichiteLose`。Lose は「手番側が負け = 連続王手していた側が負け」
+        // であり、このケースでは Black（= from.opposite() = 次手番）が敗者となる。
+        let mut pos = pos_from_sfen("9/5k3/9/9/9/9/9/6R2/K8 b - 1");
+        let v = Validator::new(EnteringKingRule::Point24);
+        let cycle = ["+3848HI", "-4232OU", "+4838HI", "-3242OU"];
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        apply_moves(&mut pos, EnteringKingRule::Point24, &cycle);
+        assert_eq!(v.classify_repetition(&pos), RepetitionVerdict::OuteSennichiteLose);
     }
 }


### PR DESCRIPTION
## Summary

tasks.md §13.2 の実装。既存 `SecondsCountdownClock` (秒読み、CSA 2014 改訂互換) と並列に、**増分加算方式** と **分単位切り捨て秒読み方式** の 2 つを追加。選択は `GameRoomConfig` 経由で `Box<dyn TimeClock>` として差し替え可能。

本 PR は `csa-extended-endings` (PR #467) にネスト。

## 実装

### FischerClock
- `consume`: 経過秒 (整数秒切り捨て) を残時間から減算 → 非負なら `increment_seconds` を加算して受理、負なら TimeUp。
- `turn_budget_ms`: 現在の残時間のみを返す。increment は手完了時に付与されるため、現在手の deadline 計算には含めない (早期 TimeUp を防ぐ)。
- `format_summary`: `Byoyomi` 行の代わりに `Increment:<sec>` を出力。`Time_Unit:1sec, Total_Time, Increment, Least_Time_Per_Move` の CSA 準拠順。

### StopWatchClock
- 本体持ち時間・秒読みとも **分単位** (`Time_Unit:1min`)。
- `consume`: 経過時間を分単位に切り捨て (`elapsed_ms / 60_000` → minutes)。0〜59 秒の手は時間消費ゼロ、60 秒以上で初めて 1 分消費。
- 本体使い切り後は毎手分の秒読みに乗り換え、秒読み超過で TimeUp。
- `format_summary`: `Time_Unit:1min, Total_Time:<min>, Byoyomi:<min>, Least_Time_Per_Move:0`。

## テスト

- **FischerClock** 6 本: increment 加算 / TimeUp 境界 / 秒切り捨て / `format_summary` で Byoyomi が含まれない / `turn_budget = remaining` / 両手独立。
- **StopWatchClock** 6 本: 分単位切り捨て (30s, 59s, 60s 境界) / 本体→秒読み遷移 / 秒読み超過 TimeUp / `Time_Unit:1min` 出力 / 両手独立。

## 今 PR で含めない項目 (deferral)

- `GameRoomConfig` / `GameSummaryBuilder` への **時計種別選択経路の配線**。
  これは後続 `csa-buoy-fork` (task B) で `GameRoomConfig::initial_sfen` と一緒に
  Game_Summary の `time_section` / `position_section` を一括で契約統合する際に
  追加する。現時点では新時計は `Box::new(FischerClock::new(...))` 等で直接注入
  するテスト/ライブラリ用途で機能するが、CSA プロトコル経由では
  `SecondsCountdownClock` しか選べない。

## 品質ゲート

- `cargo fmt --all`
- `cargo clippy --workspace --tests -- -D warnings` 警告ゼロ
- `cargo test --workspace` 全緑 (22 clock tests passing)
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 通過

## Test plan

- [x] FischerClock 全 6 テスト通過
- [x] StopWatchClock 全 6 テスト通過
- [x] 既存 SecondsCountdownClock テスト 10 本引き続き通過
- [x] workspace 全体で clippy/test 回帰無し
- [ ] task B (`csa-buoy-fork`) で `GameRoomConfig` 経由の選択経路を配線した後、
  CSA プロトコル E2E テストで clock 選択の挙動を検証する

🤖 Generated with [Claude Code](https://claude.com/claude-code)