### PR TITLE
feat(csa-server): TCP 観戦購読 %%MONITOR2ON/OFF + %%CHAT を配線

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/broadcaster.rs
+++ b/crates/rshogi-csa-server-tcp/src/broadcaster.rs
@@ -5,8 +5,18 @@
 //! を必ず 1 回以上呼ぶので、呼び先が空の実装でも例外にならない契約にしている。
 //!
 //! 設計上、各ルームの観戦者集合は `Mutex<HashMap<RoomId, Vec<Subscriber>>>` で保持する。
-//! 1 subscriber あたり `tokio::sync::mpsc::UnboundedSender<CsaLine>` を持たせ、
+//! 1 subscriber あたり [`tokio::sync::mpsc::Sender<CsaLine>`] (**bounded**) を持たせ、
 //! 実際の送信は受信側タスクが担う（I/O をロック内で行わないようにするため）。
+//!
+//! # Bounded channel
+//! 旧実装は `UnboundedSender` を採用していたが、Codex review (PR #469 P2) で
+//! 指摘のとおり slow-but-not-dead な observer が無制限にキューを溜め込む
+//! メモリ肥大経路になり得る。`%%CHAT` はユーザー駆動で rate-limit が無く、
+//! 1 観戦者あたりの buffer を緩和しないと DoS リスクになる。本版では容量
+//! [`SUBSCRIBER_CHANNEL_CAPACITY`] の bounded channel を使い、`try_send` が
+//! 失敗した subscriber は「配信不能」とみなして broadcaster 側の retain で
+//! 即 prune する (disconnect と同等の扱い)。これによりプロセス全体の
+//! buffer 上限が `room 数 × subscriber 数 × capacity × 1 行最大サイズ` に収まる。
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,18 +25,26 @@ use rshogi_csa_server::TransportError;
 use rshogi_csa_server::port::{BroadcastTag, Broadcaster};
 use rshogi_csa_server::types::{CsaLine, RoomId};
 use tokio::sync::Mutex;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
+
+/// 1 subscriber あたりの broadcast キュー容量（行数）。
+///
+/// 通常の対局では 1 手に 1 行、チャットを含めても 1 秒あたり数行が上限。
+/// 256 行は数分〜数十分の受信遅延を吸収できる余裕で、かつ 1 観戦者あたりの
+/// メモリ最大値を `256 * sizeof(CsaLine)` に抑える。
+pub const SUBSCRIBER_CHANNEL_CAPACITY: usize = 256;
 
 /// 1 人分の観戦者ハンドル。
 #[derive(Clone)]
 pub struct Subscriber {
-    /// 受信側タスクへ 1 行を送る送信口。エラー（受信タスク停止）は `retain` で掃除される。
-    tx: UnboundedSender<CsaLine>,
+    /// 受信側タスクへ 1 行を送る送信口 (bounded)。送信失敗 (受信タスク停止 /
+    /// キューあふれ) は `retain` で掃除される。
+    tx: Sender<CsaLine>,
 }
 
 impl Subscriber {
     /// 与えられた送信口で Subscriber を作る。
-    pub fn new(tx: UnboundedSender<CsaLine>) -> Self {
+    pub fn new(tx: Sender<CsaLine>) -> Self {
         Self { tx }
     }
 }
@@ -81,8 +99,12 @@ impl Broadcaster for InMemoryBroadcaster {
         let Some(subs) = guard.get_mut(room_id) else {
             return Ok(());
         };
-        // 受信側が停止している subscriber は `send` に失敗するので、ここで掃除する。
-        subs.retain(|s| s.tx.send(line.clone()).is_ok());
+        // `try_send` は (a) 受信側停止、(b) キューあふれ のどちらでも Err を返す。
+        // どちらも「配信不能」とみなし、retain で即 prune する。これにより slow
+        // consumer が全体 memory を溜め込む経路を遮断する (broadcast loss の責務は
+        // subscriber 側が draw back する設計: observer 側で一時的に受信が止まれば
+        // broadcaster から切断される)。
+        subs.retain(|s| s.tx.try_send(line.clone()).is_ok());
         Ok(())
     }
 }
@@ -90,12 +112,12 @@ impl Broadcaster for InMemoryBroadcaster {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::sync::mpsc::unbounded_channel;
+    use tokio::sync::mpsc::channel;
 
     #[tokio::test(flavor = "current_thread")]
     async fn broadcast_tag_spectator_reaches_registered_subscriber() {
         let bcast = InMemoryBroadcaster::new();
-        let (tx, mut rx) = unbounded_channel();
+        let (tx, mut rx) = channel(SUBSCRIBER_CHANNEL_CAPACITY);
         bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
 
         bcast
@@ -110,7 +132,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn broadcast_tag_non_spectator_is_no_op() {
         let bcast = InMemoryBroadcaster::new();
-        let (tx, mut rx) = unbounded_channel();
+        let (tx, mut rx) = channel(SUBSCRIBER_CHANNEL_CAPACITY);
         bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
         bcast
             .broadcast_tag(&RoomId::new("g1"), BroadcastTag::Player, &CsaLine::new("X"))
@@ -123,7 +145,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn broadcast_tag_prunes_dead_subscribers() {
         let bcast = InMemoryBroadcaster::new();
-        let (tx, rx) = unbounded_channel::<CsaLine>();
+        let (tx, rx) = channel::<CsaLine>(SUBSCRIBER_CHANNEL_CAPACITY);
         bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
         drop(rx); // 受信側を先に捨てる → 送信は以降ずっと Err
         bcast
@@ -133,6 +155,29 @@ mod tests {
         // dead subscriber は掃除されているので、内部 Vec は空になっている。
         let guard = bcast.inner.lock().await;
         assert!(guard.get(&RoomId::new("g1")).unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn broadcast_tag_prunes_full_subscribers() {
+        // Codex review (PR #469 P2) の回帰: slow consumer がキューをあふれさせた
+        // subscriber は try_send が WouldBlock で失敗し、即 prune されることを
+        // 確認する。bounded channel の capacity を 1 にして、1 通目までは受理、
+        // 2 通目で overflow → prune。
+        let bcast = InMemoryBroadcaster::new();
+        let (tx, _keep_rx) = channel::<CsaLine>(1);
+        bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
+        // 1 通目は受理されキューに積まれる。subscriber はまだ生存。
+        bcast
+            .broadcast_tag(&RoomId::new("g1"), BroadcastTag::Spectator, &CsaLine::new("1"))
+            .await
+            .unwrap();
+        assert_eq!(bcast.inner.lock().await.get(&RoomId::new("g1")).unwrap().len(), 1);
+        // 2 通目は try_send が Full で失敗 → subscriber が prune される。
+        bcast
+            .broadcast_tag(&RoomId::new("g1"), BroadcastTag::Spectator, &CsaLine::new("2"))
+            .await
+            .unwrap();
+        assert_eq!(bcast.inner.lock().await.get(&RoomId::new("g1")).unwrap().len(), 0);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -147,7 +192,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn clear_room_removes_all_subscribers() {
         let bcast = InMemoryBroadcaster::new();
-        let (tx, mut rx) = unbounded_channel();
+        let (tx, mut rx) = channel(SUBSCRIBER_CHANNEL_CAPACITY);
         bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
         bcast.clear_room(&RoomId::new("g1")).await;
         bcast

--- a/crates/rshogi-csa-server-tcp/src/broadcaster.rs
+++ b/crates/rshogi-csa-server-tcp/src/broadcaster.rs
@@ -65,10 +65,29 @@ impl InMemoryBroadcaster {
     }
 
     /// ルームに観戦者を登録する（`%%MONITOR2ON` 相当の拡張経路から呼ばれる想定）。
-    /// 現状のバイナリ構成では呼び出し経路のみ用意し、本体コードからは未使用。
+    ///
+    /// 登録の前に既存 subscriber の中で `tx.is_closed()` が true (= receiver が
+    /// drop 済み) のものを retain で prune する。`%%MONITOR2OFF` や購読先切替で
+    /// 行き場の無くなった Sender が `clear_room` まで残らないようにするため
+    /// (Codex review PR #469 P2)。broadcast が発生しない idle な room でも
+    /// 登録時に毎回掃除されるので、dead entry の蓄積は O(同時購読者数) に抑えられる。
     pub async fn subscribe(&self, room_id: RoomId, subscriber: Subscriber) {
         let mut guard = self.inner.lock().await;
-        guard.entry(room_id).or_default().push(subscriber);
+        let entry = guard.entry(room_id).or_default();
+        entry.retain(|s| !s.tx.is_closed());
+        entry.push(subscriber);
+    }
+
+    /// 指定ルームに紐づく dead subscriber (receiver drop 済み) を prune する。
+    ///
+    /// `%%MONITOR2OFF` など「subscribe は呼ばないが掃除はしたい」経路で使う。
+    /// broadcast 経路と違い `retain` は `is_closed` のみを基準にするため、
+    /// 生存中の subscriber への送信は発生しない。
+    pub async fn prune_closed(&self, room_id: &RoomId) {
+        let mut guard = self.inner.lock().await;
+        if let Some(subs) = guard.get_mut(room_id) {
+            subs.retain(|s| !s.tx.is_closed());
+        }
     }
 
     /// ルームに紐づく観戦者集合を丸ごと削除する。対局終了時などに呼ぶ。
@@ -200,5 +219,44 @@ mod tests {
             .await
             .unwrap();
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn subscribe_prunes_closed_subscribers_before_inserting() {
+        // Codex review (PR #469 再 review P2) の回帰: 観戦者が MONITOR2OFF / 切替で
+        // rx を drop しても、broadcast が発火するまで死んだ Sender が残る。subscribe
+        // が次の購読登録の直前に dead entry を prune することで、反復トグルによる
+        // 蓄積を O(同時生存購読者数) に抑える。
+        let bcast = InMemoryBroadcaster::new();
+        let (tx1, rx1) = channel::<CsaLine>(SUBSCRIBER_CHANNEL_CAPACITY);
+        bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx1)).await;
+        drop(rx1); // 1 つ目の subscriber を dead 化
+        // broadcast 無しで 2 つ目を subscribe。1 つ目は prune されるはず。
+        let (tx2, _rx2) = channel::<CsaLine>(SUBSCRIBER_CHANNEL_CAPACITY);
+        bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx2)).await;
+        let guard = bcast.inner.lock().await;
+        let subs = guard.get(&RoomId::new("g1")).unwrap();
+        assert_eq!(subs.len(), 1, "subscribe should have pruned dead entry first");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn prune_closed_removes_dead_entries_on_demand() {
+        // MONITOR2OFF 経路では subscribe は呼ばれないため、専用の prune_closed で
+        // 明示的に dead entry を掃除する。broadcast 無しで直接 prune が走って
+        // いることを確認。
+        let bcast = InMemoryBroadcaster::new();
+        let (tx, rx) = channel::<CsaLine>(SUBSCRIBER_CHANNEL_CAPACITY);
+        bcast.subscribe(RoomId::new("g1"), Subscriber::new(tx)).await;
+        drop(rx);
+        assert_eq!(bcast.inner.lock().await.get(&RoomId::new("g1")).unwrap().len(), 1);
+        bcast.prune_closed(&RoomId::new("g1")).await;
+        assert_eq!(bcast.inner.lock().await.get(&RoomId::new("g1")).unwrap().len(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn prune_closed_on_unknown_room_is_noop() {
+        // 存在しない room_id に対する prune は no-op (エラーにならない)。
+        let bcast = InMemoryBroadcaster::new();
+        bcast.prune_closed(&RoomId::new("never-subscribed")).await;
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -46,7 +46,7 @@ use tokio::sync::{Mutex, Notify, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::auth::{AuthOutcome, PasswordHasher, authenticate};
-use crate::broadcaster::InMemoryBroadcaster;
+use crate::broadcaster::{InMemoryBroadcaster, Subscriber};
 use crate::rate_limit::IpLoginRateLimiter;
 use crate::transport::TcpTransport;
 
@@ -469,10 +469,16 @@ where
         );
     }
 
-    // マッチ確定 / 受信 の 2 経路を監視する。x1 waiter のみ受信行を `%%` 系
-    // コマンドとして解釈し応答を返すため、recv ブランチは loop で回す。`recv_line` は
-    // cancel-safe（`TcpTransport::recv_line`）なので、マッチが先に到着した場合は
-    // バッファを保ったまま drive 側へ transport を渡せる。
+    // `%%MONITOR2ON <game_id>` で購読中の対局があれば、その broadcast 受信口を
+    // `(game_id, UnboundedReceiver<CsaLine>)` として保持する。単一購読モデル:
+    // 後続の `%%MONITOR2ON` は既存 rx を drop して差し替える。CSA x1 仕様上
+    // 複数同時観戦は稀なので、複雑なキュー/セット管理を避ける。
+    let mut monitor_rx: Option<(GameId, tokio::sync::mpsc::UnboundedReceiver<CsaLine>)> = None;
+
+    // マッチ確定 / 受信 / 観戦 broadcast 中継 の 3 経路を監視する。x1 waiter のみ
+    // 受信行を `%%` 系コマンドとして解釈し応答を返すため、recv ブランチは loop で
+    // 回す。`recv_line` は cancel-safe（`TcpTransport::recv_line`）なので、マッチが
+    // 先に到着した場合はバッファを保ったまま drive 側へ transport を渡せる。
     let waiter_outcome: WaiterOutcome = 'outer: loop {
         let recv = tokio::select! {
             req_res = &mut match_req_rx => {
@@ -486,6 +492,39 @@ where
                     Err(_) => {
                         // pool 側が破棄された。league だけクリーンアップ。
                         break 'outer WaiterOutcome::Aborted;
+                    }
+                }
+            }
+            // 観戦購読中のみ有効になる broadcast 中継経路。`monitor_rx` が `None` なら
+            // `pending()` で永久に await し、実質このブランチは無効化される。
+            forwarded = async {
+                match &mut monitor_rx {
+                    Some((_, rx)) => rx.recv().await,
+                    None => std::future::pending::<Option<CsaLine>>().await,
+                }
+            } => {
+                match forwarded {
+                    Some(line) => {
+                        // 観戦者向け broadcast を transport に中継。書き込み失敗・
+                        // タイムアウトは切断扱い（既存の返信経路と同じ `x1_reply_write_timeout`
+                        // を共用し、観戦中継がハングしてマッチメイクを止めないようにする）。
+                        let write_timeout = state.config.x1_reply_write_timeout;
+                        match tokio::time::timeout(write_timeout, transport.send_line(&line)).await
+                        {
+                            Ok(Ok(())) => continue 'outer,
+                            _ => {
+                                let mut pool = state.waiting.lock().await;
+                                let _ = pool.remove_by_handle(&game_name, &handle);
+                                break 'outer WaiterOutcome::DisconnectedFromPool;
+                            }
+                        }
+                    }
+                    None => {
+                        // 送信側 (broadcaster 側の Subscriber tx) が drop された。
+                        // 対局終了による `clear_room` 経由が典型。購読状態をクリアして
+                        // 次の `%%MONITOR2ON` を待つ。
+                        monitor_rx = None;
+                        continue 'outer;
                     }
                 }
             }
@@ -544,11 +583,87 @@ where
                 };
                 Some(rshogi_csa_server::protocol::info::show_lines(&game_id, listing.as_ref()))
             }
+            ClientCommand::Monitor2On { game_id } => {
+                // 対局が GameRegistry に存在しているときのみ購読を許可する。
+                // 存在しない game_id への購読要求は `NOT_FOUND` を返して購読状態を
+                // 変更しない（無効な subscribe でも broadcaster には登録するが、
+                // clear_room まで残ることを避ける方針）。
+                let exists = {
+                    let games = state.games.lock().await;
+                    games.get(&game_id).is_some()
+                };
+                if !exists {
+                    Some(vec![
+                        CsaLine::new(format!("##[MONITOR2] NOT_FOUND {game_id}")),
+                        CsaLine::new("##[MONITOR2] END"),
+                    ])
+                } else {
+                    // 既存の購読があれば rx を drop (broadcaster 側 subscriber は次回の
+                    // broadcast で prune される) して新しい rx に差し替える。単一観戦
+                    // モデルの方針を踏襲。
+                    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                    state
+                        .broadcaster
+                        .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
+                        .await;
+                    monitor_rx = Some((game_id.clone(), rx));
+                    Some(vec![
+                        CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
+                        CsaLine::new("##[MONITOR2] END"),
+                    ])
+                }
+            }
+            ClientCommand::Monitor2Off { game_id } => {
+                // 現在購読中かつ game_id が一致する場合のみ解除する。別 game_id
+                // を指定された場合は no-op で OK を返す（CSA 仕様の寛容性を優先）。
+                if let Some((active_id, _)) = &monitor_rx
+                    && *active_id == game_id
+                {
+                    monitor_rx = None;
+                }
+                Some(vec![
+                    CsaLine::new(format!("##[MONITOR2OFF] {game_id}")),
+                    CsaLine::new("##[MONITOR2OFF] END"),
+                ])
+            }
+            ClientCommand::Chat { message } => {
+                // 現在観戦中のルーム（`monitor_rx` が握っている game_id）に対し、
+                // `##[CHAT] <handle>: <message>` 形式で同ルームの全観戦者へ broadcast
+                // する。対局者 (drive 側 transport) は本 broadcaster では購読しない
+                // 構成なので現時点では受信しない (制約)。対局者側への配信は後続タスク
+                // で `broadcast_room` の配線を見直す際に追加する。
+                //
+                // 観戦中でない CHAT は NOT_MONITORING で弾く。対局参加前の x1 クライアント
+                // が部屋未指定で CHAT を投げた場合のフォールバック経路。
+                if let Some((active_id, _)) = &monitor_rx {
+                    let line = CsaLine::new(format!("##[CHAT] {handle}: {message}"));
+                    // CHAT broadcast 自体は送信側 (本クライアント) 自身にも echo
+                    // として届く (broadcaster に自身が subscribe している)。これは
+                    // CSA 仕様の通例で、送信確認を兼ねる。
+                    let _ = state
+                        .broadcaster
+                        .broadcast_tag(
+                            &RoomId::new(active_id.as_str()),
+                            BroadcastTag::Spectator,
+                            &line,
+                        )
+                        .await;
+                    Some(vec![
+                        CsaLine::new(format!("##[CHAT] OK {active_id}")),
+                        CsaLine::new("##[CHAT] END"),
+                    ])
+                } else {
+                    Some(vec![
+                        CsaLine::new("##[CHAT] NOT_MONITORING"),
+                        CsaLine::new("##[CHAT] END"),
+                    ])
+                }
+            }
             _ => None,
         };
         let Some(lines) = replies else {
             // 未サポートの x1 コマンド / 対局中コマンドは切断扱い（未配線の
-            // `%%MONITOR2ON` / `%%CHAT` / `%%SETBUOY` 等は後続コミットで追加する）。
+            // `%%SETBUOY` / `%%DELETEBUOY` / `%%GETBUOYCOUNT` / `%%FORK` 等は後続タスクで追加する）。
             let mut pool = state.waiting.lock().await;
             let _removed = pool.remove_by_handle(&game_name, &handle);
             break 'outer WaiterOutcome::DisconnectedFromPool;

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -677,6 +677,35 @@ where
                         if !still_exists {
                             drop(rx);
                             state.broadcaster.prune_closed(&RoomId::new(game_id.as_str())).await;
+                            // 状態巻き戻し: pool から抜けた + League を Connected に
+                            // 遷移した + observer_mode を立てた 3 点を元に戻す。
+                            // 新しい oneshot ペアを作って slot を再登録し、次の
+                            // tokio::select! で match_req_rx を再び監視できる状態に
+                            // 戻す (Codex review PR #469 4th round P2)。
+                            let (new_tx, new_rx) = oneshot::channel::<MatchRequest>();
+                            {
+                                let mut pool = state.waiting.lock().await;
+                                pool.push(
+                                    game_name.clone(),
+                                    WaitingSlot {
+                                        handle: handle.clone(),
+                                        color,
+                                        match_request_tx: new_tx,
+                                    },
+                                );
+                            }
+                            {
+                                let mut league = state.league.lock().await;
+                                let _ = league.transition(
+                                    &handle_player,
+                                    PlayerStatus::GameWaiting {
+                                        game_name: game_name.clone(),
+                                        preferred_color: Some(color),
+                                    },
+                                );
+                            }
+                            match_req_rx = new_rx;
+                            observer_mode = false;
                             Some(vec![
                                 CsaLine::new(format!("##[MONITOR2] NOT_FOUND {game_id}")),
                                 CsaLine::new("##[MONITOR2] END"),

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -555,9 +555,19 @@ where
         let line = match recv {
             Ok(l) => l,
             Err(_) => {
-                // 切断 or I/O エラー → pool を抜けて終了。
+                // 切断 or I/O エラー → pool を抜けて終了。observer モードで
+                // MONITOR2OFF を呼ばずに切断した接続は `monitor_rx` を drop する
+                // ことで tx が `is_closed` になるが、`broadcaster.inner` の entry
+                // は次の broadcast / subscribe / clear_room まで掃除されない。
+                // broadcast が発生しない idle room で再接続を繰り返されると
+                // dead sender が蓄積するため、切断時にも明示的に prune する
+                // (Codex review PR #469 3rd round P2)。
                 let mut pool = state.waiting.lock().await;
                 let _removed = pool.remove_by_handle(&game_name, &handle);
+                drop(pool);
+                if let Some((room, _)) = monitor_rx.take() {
+                    state.broadcaster.prune_closed(&RoomId::new(room.as_str())).await;
+                }
                 break 'outer WaiterOutcome::DisconnectedFromPool;
             }
         };
@@ -657,11 +667,27 @@ where
                             .broadcaster
                             .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
                             .await;
-                        monitor_rx = Some((game_id.clone(), rx));
-                        Some(vec![
-                            CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
-                            CsaLine::new("##[MONITOR2] END"),
-                        ])
+                        // TOCTOU 回避: 初回 exists 確認から subscribe までの間に
+                        // drive が終局して `unregister + clear_room` を完了している
+                        // 可能性がある。その場合は broadcaster に stale room が残り、
+                        // 観戦者は二度と broadcast を受け取れない。subscribe 後に
+                        // もう一度存在確認し、消えていれば rx を drop + prune して
+                        // NOT_FOUND を返す (Codex review PR #469 3rd round P2)。
+                        let still_exists = subscribe_still_registered(&state, &game_id).await;
+                        if !still_exists {
+                            drop(rx);
+                            state.broadcaster.prune_closed(&RoomId::new(game_id.as_str())).await;
+                            Some(vec![
+                                CsaLine::new(format!("##[MONITOR2] NOT_FOUND {game_id}")),
+                                CsaLine::new("##[MONITOR2] END"),
+                            ])
+                        } else {
+                            monitor_rx = Some((game_id.clone(), rx));
+                            Some(vec![
+                                CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
+                                CsaLine::new("##[MONITOR2] END"),
+                            ])
+                        }
                     }
                 } else {
                     // 既に observer モード。旧 rx を drop して差し替える。
@@ -676,11 +702,22 @@ where
                         .broadcaster
                         .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
                         .await;
-                    monitor_rx = Some((game_id.clone(), rx));
-                    Some(vec![
-                        CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
-                        CsaLine::new("##[MONITOR2] END"),
-                    ])
+                    // 同じく subscribe 後に TOCTOU 再確認。
+                    let still_exists = subscribe_still_registered(&state, &game_id).await;
+                    if !still_exists {
+                        drop(rx);
+                        state.broadcaster.prune_closed(&RoomId::new(game_id.as_str())).await;
+                        Some(vec![
+                            CsaLine::new(format!("##[MONITOR2] NOT_FOUND {game_id}")),
+                            CsaLine::new("##[MONITOR2] END"),
+                        ])
+                    } else {
+                        monitor_rx = Some((game_id.clone(), rx));
+                        Some(vec![
+                            CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
+                            CsaLine::new("##[MONITOR2] END"),
+                        ])
+                    }
                 }
             }
             ClientCommand::Monitor2Off { game_id } => {
@@ -793,6 +830,23 @@ enum WaiterOutcome {
     Aborted,
     /// 対局前に切断を検知した（pool + league から除去する）。
     DisconnectedFromPool,
+}
+
+/// `%%MONITOR2ON` の TOCTOU 再確認用ヘルパ。`subscribe` 完了後に game_id が
+/// まだ `GameRegistry` に存在するかを確認する。
+///
+/// `subscribe` の前後は drive 側の `unregister + clear_room` に対して非原子的で、
+/// subscribe 完了時点でゲームが既に終局している可能性がある。その場合 stale
+/// なエントリを broadcaster に残さないよう、呼び出し側で drop + prune して
+/// NOT_FOUND を返す (Codex review PR #469 3rd round P2)。
+async fn subscribe_still_registered<R, K, P>(state: &SharedState<R, K, P>, game_id: &GameId) -> bool
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let games = state.games.lock().await;
+    games.get(game_id).is_some()
 }
 
 /// drive 側タスクのメインループ。両 transport を所有して 1 対局を完了まで運ぶ。

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -470,10 +470,20 @@ where
     }
 
     // `%%MONITOR2ON <game_id>` で購読中の対局があれば、その broadcast 受信口を
-    // `(game_id, UnboundedReceiver<CsaLine>)` として保持する。単一購読モデル:
+    // `(game_id, Receiver<CsaLine>)` (bounded) として保持する。単一購読モデル:
     // 後続の `%%MONITOR2ON` は既存 rx を drop して差し替える。CSA x1 仕様上
     // 複数同時観戦は稀なので、複雑なキュー/セット管理を避ける。
-    let mut monitor_rx: Option<(GameId, tokio::sync::mpsc::UnboundedReceiver<CsaLine>)> = None;
+    //
+    // キュー容量は `crate::broadcaster::SUBSCRIBER_CHANNEL_CAPACITY`。slow
+    // consumer がキューを溜め込んだ時点で broadcaster 側が prune するため、
+    // 無制限 memory 溜め込み経路 (Codex review PR #469 P2) を遮断する。
+    let mut monitor_rx: Option<(GameId, tokio::sync::mpsc::Receiver<CsaLine>)> = None;
+
+    // `%%MONITOR2ON` が成立したら観戦者扱いとなるため、waiting pool から除外する
+    // 必要がある (Codex review PR #469 P1: 観戦者が同一 game_name + 相補色で
+    // 後続 LOGIN とマッチさせられる経路を塞ぐ)。`pool.remove_by_handle` は
+    // 冪等 (未登録なら何もしない) なので、複数回呼んでも害が無い。
+    let mut observer_mode = false;
 
     // マッチ確定 / 受信 / 観戦 broadcast 中継 の 3 経路を監視する。x1 waiter のみ
     // 受信行を `%%` 系コマンドとして解釈し応答を返すため、recv ブランチは loop で
@@ -481,7 +491,18 @@ where
     // 先に到着した場合はバッファを保ったまま drive 側へ transport を渡せる。
     let waiter_outcome: WaiterOutcome = 'outer: loop {
         let recv = tokio::select! {
-            req_res = &mut match_req_rx => {
+            // observer_mode 時は `match_req_rx` の Err は自分が pool から自主的に
+            // 外れたことが原因。`recv_line` / `forwarded` ブランチを使い続けられるよう、
+            // pending() に切り替えて本ブランチを実質無効化する。`match_req_rx` を
+            // `Option` 化すると `tokio::select!` 内部の pin 要件が面倒になるため、
+            // ブランチ側で observer_mode 判定をする。
+            req_res = async {
+                if observer_mode {
+                    std::future::pending::<Result<MatchRequest, oneshot::error::RecvError>>().await
+                } else {
+                    (&mut match_req_rx).await
+                }
+            } => {
                 match req_res {
                     Ok(req) => {
                         // transport を drive 側へ渡し、終局通知を待つ。
@@ -600,13 +621,33 @@ where
                 } else {
                     // 既存の購読があれば rx を drop (broadcaster 側 subscriber は次回の
                     // broadcast で prune される) して新しい rx に差し替える。単一観戦
-                    // モデルの方針を踏襲。
-                    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                    // モデルの方針を踏襲。容量制限付き channel を使うことで slow
+                    // consumer による unbounded buffer 蓄積を防ぐ。
+                    let (tx, rx) =
+                        tokio::sync::mpsc::channel(crate::broadcaster::SUBSCRIBER_CHANNEL_CAPACITY);
                     state
                         .broadcaster
                         .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
                         .await;
                     monitor_rx = Some((game_id.clone(), rx));
+                    // 観戦者モードに入ったら waiting pool から自分のスロットを除外する。
+                    // さらに League 側の PlayerStatus も `GameWaiting` から `Connected`
+                    // へ戻して、`%%WHO` で `waiting:<game_name>` と出ないようにする。
+                    // これにより、同一 game_name + 相補色で後続プレイヤが LOGIN しても
+                    // 観戦者を対局者として選ばれなくなる (Codex review PR #469 P1)。
+                    // 観戦者のループは `match_req_rx` が drop されても observer_mode
+                    // フラグで本ブランチを pending 化しているのでループを抜けない。
+                    if !observer_mode {
+                        let mut pool = state.waiting.lock().await;
+                        let _ = pool.remove_by_handle(&game_name, &handle);
+                        drop(pool);
+                        let mut league = state.league.lock().await;
+                        // `transition` が Err を返すのは「未ログイン」「Finished」の 2 ケース
+                        // のみ。observer 化の時点で両者どちらでもないはずなので結果は
+                        // 無視してログ用途に留める。
+                        let _ = league.transition(&handle_player, PlayerStatus::Connected);
+                        observer_mode = true;
+                    }
                     Some(vec![
                         CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
                         CsaLine::new("##[MONITOR2] END"),

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -606,9 +606,6 @@ where
             }
             ClientCommand::Monitor2On { game_id } => {
                 // 対局が GameRegistry に存在しているときのみ購読を許可する。
-                // 存在しない game_id への購読要求は `NOT_FOUND` を返して購読状態を
-                // 変更しない（無効な subscribe でも broadcaster には登録するが、
-                // clear_room まで残ることを避ける方針）。
                 let exists = {
                     let games = state.games.lock().await;
                     games.get(&game_id).is_some()
@@ -618,11 +615,61 @@ where
                         CsaLine::new(format!("##[MONITOR2] NOT_FOUND {game_id}")),
                         CsaLine::new("##[MONITOR2] END"),
                     ])
+                } else if !observer_mode {
+                    // 初回の observer 転換。subscribe().await の前に waiting pool
+                    // から自分を除外する必要がある。そうしないと drive 側の
+                    // `take_complement` と subscribe() の await の間にレースが発生し、
+                    // drive が slot を掴んだ後で我々が observer_mode に入ると
+                    // match_request が監視外に流れて相手が永久 hang する
+                    // (Codex review PR #469 P1)。
+                    //
+                    // 競合の結果は pool の Mutex で直列化されるので、`remove_by_handle`
+                    // の戻り値で「先に drive が slot を掴んだか」を確実に判別できる:
+                    // - true: 我々が先に取り除いた。drive は以後 slot を見つけない。
+                    //         安全に observer へ遷移。
+                    // - false: drive が先に slot を取っていった。match_request が
+                    //         間もなく match_req_rx に届く。observer にはならず、
+                    //         client に BUSY を返して通常 waiter として match_req_rx
+                    //         を次のループで受けさせる。
+                    let mut pool = state.waiting.lock().await;
+                    let removed = pool.remove_by_handle(&game_name, &handle);
+                    drop(pool);
+                    if !removed {
+                        Some(vec![
+                            CsaLine::new(format!("##[MONITOR2] BUSY {game_id}")),
+                            CsaLine::new("##[MONITOR2] END"),
+                        ])
+                    } else {
+                        // League も `GameWaiting` → `Connected` へ戻して `%%WHO` から
+                        // `waiting:<game_name>` を消す。`transition` は「未ログイン」
+                        // 「Finished」でのみ Err を返すが、ここではどちらでもない。
+                        let mut league = state.league.lock().await;
+                        let _ = league.transition(&handle_player, PlayerStatus::Connected);
+                        drop(league);
+                        observer_mode = true;
+                        // subscriber 登録。subscribe は内部で dead entry を prune する
+                        // ため、切替や MONITOR2OFF の蓄積は O(生存購読者数) に抑えられる
+                        // (Codex review PR #469 P2)。
+                        let (tx, rx) = tokio::sync::mpsc::channel(
+                            crate::broadcaster::SUBSCRIBER_CHANNEL_CAPACITY,
+                        );
+                        state
+                            .broadcaster
+                            .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
+                            .await;
+                        monitor_rx = Some((game_id.clone(), rx));
+                        Some(vec![
+                            CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
+                            CsaLine::new("##[MONITOR2] END"),
+                        ])
+                    }
                 } else {
-                    // 既存の購読があれば rx を drop (broadcaster 側 subscriber は次回の
-                    // broadcast で prune される) して新しい rx に差し替える。単一観戦
-                    // モデルの方針を踏襲。容量制限付き channel を使うことで slow
-                    // consumer による unbounded buffer 蓄積を防ぐ。
+                    // 既に observer モード。旧 rx を drop して差し替える。
+                    // 差し替え前に旧 room の dead entry を明示的に prune する
+                    // (subscribe 内の prune は新 room に対してのみ行われるため)。
+                    if let Some((old_id, _)) = monitor_rx.take() {
+                        state.broadcaster.prune_closed(&RoomId::new(old_id.as_str())).await;
+                    }
                     let (tx, rx) =
                         tokio::sync::mpsc::channel(crate::broadcaster::SUBSCRIBER_CHANNEL_CAPACITY);
                     state
@@ -630,24 +677,6 @@ where
                         .subscribe(RoomId::new(game_id.as_str()), Subscriber::new(tx))
                         .await;
                     monitor_rx = Some((game_id.clone(), rx));
-                    // 観戦者モードに入ったら waiting pool から自分のスロットを除外する。
-                    // さらに League 側の PlayerStatus も `GameWaiting` から `Connected`
-                    // へ戻して、`%%WHO` で `waiting:<game_name>` と出ないようにする。
-                    // これにより、同一 game_name + 相補色で後続プレイヤが LOGIN しても
-                    // 観戦者を対局者として選ばれなくなる (Codex review PR #469 P1)。
-                    // 観戦者のループは `match_req_rx` が drop されても observer_mode
-                    // フラグで本ブランチを pending 化しているのでループを抜けない。
-                    if !observer_mode {
-                        let mut pool = state.waiting.lock().await;
-                        let _ = pool.remove_by_handle(&game_name, &handle);
-                        drop(pool);
-                        let mut league = state.league.lock().await;
-                        // `transition` が Err を返すのは「未ログイン」「Finished」の 2 ケース
-                        // のみ。observer 化の時点で両者どちらでもないはずなので結果は
-                        // 無視してログ用途に留める。
-                        let _ = league.transition(&handle_player, PlayerStatus::Connected);
-                        observer_mode = true;
-                    }
                     Some(vec![
                         CsaLine::new(format!("##[MONITOR2] BEGIN {game_id}")),
                         CsaLine::new("##[MONITOR2] END"),
@@ -661,6 +690,10 @@ where
                     && *active_id == game_id
                 {
                     monitor_rx = None;
+                    // 旧 rx が drop された時点で tx は is_closed になる。broadcast
+                    // が起きない idle room でも tx が貯まらないよう、ここで明示的に
+                    // prune する (Codex review PR #469 P2)。
+                    state.broadcaster.prune_closed(&RoomId::new(game_id.as_str())).await;
                 }
                 Some(vec![
                     CsaLine::new(format!("##[MONITOR2OFF] {game_id}")),

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -881,6 +881,52 @@ fn monitor2_subscribes_and_receives_moves_and_chat() {
 }
 
 #[test]
+fn monitor2_removes_subscriber_from_matchmaking_pool() {
+    // Codex review (PR #469 P1) の回帰: x1 waiter は LOGIN で一旦 WaitingPool に
+    // 入るが、`%%MONITOR2ON` が成立した時点で観戦者扱いになるため pool から
+    // 除外しなければならない。除外しないと、同一 game_name + 相補色で後続
+    // プレイヤが LOGIN したとき観戦者が対局者として選ばれてしまう。
+    //
+    // このテストでは alice/bob 対局進行中に carol が同じ `g1`+`black` で x1
+    // LOGIN (alice と同色 = bob と相補)。`%%MONITOR2ON` で observer 化した後、
+    // carol が `%%WHO` で自分の status を確認し `waiting:g1` が出ないことを
+    // 確認する (= pool から正しく抜けている)。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("monitor2_no_match").await;
+
+        // alice vs bob のメイン対局。
+        let (_rb, _wb, _rw, _ww, game_id) = login_match_agree(addr).await;
+
+        // carol が相補色候補として pool に入る (現時点では `waiting:g1`)。
+        let (mut rc, mut wc) = connect(addr).await;
+        send_line(&mut wc, "LOGIN carol+g1+black pw x1").await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:carol OK");
+
+        // observer 化。pool から外れる。
+        send_line(&mut wc, &format!("%%MONITOR2ON {game_id}")).await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), format!("##[MONITOR2] BEGIN {game_id}"));
+        let _ = read_line_raw(&mut rc).await.unwrap(); // END
+
+        // %%WHO で carol の status を確認。observer 化済みなら `waiting:g1` は
+        // 出ないはず (pool から抜けているので League の GameWaiting 状態ではない)。
+        send_line(&mut wc, "%%WHO").await;
+        let mut lines = Vec::new();
+        for _ in 0..20 {
+            let l = read_line_raw(&mut rc).await.unwrap();
+            let end = l == "##[WHO] END";
+            lines.push(l);
+            if end {
+                break;
+            }
+        }
+        let has_waiting_carol = lines.iter().any(|l| l == "##[WHO] carol waiting:g1");
+        assert!(!has_waiting_carol, "observer carol must not appear as waiting: {lines:?}");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
 fn chat_without_active_monitor_returns_not_monitoring() {
     // x1 waiter が `%%MONITOR2ON` 前に `%%CHAT` を投げると `NOT_MONITORING` で
     // 弾かれる。購読前の chat 経路を誤って開放していないことの回帰防止。

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -802,3 +802,121 @@ fn sennichite_broadcasts_draw_on_12_ply_gold_dance() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+#[test]
+fn monitor2_subscribes_and_receives_moves_and_chat() {
+    // x1 クライアント carol が `%%MONITOR2ON <game_id>` で対局に購読し、
+    // (a) 指し手 broadcast (`+7776FU,T0` 等) を受信する
+    // (b) `%%CHAT <msg>` で自身が送ったメッセージが自身に echo される
+    // (c) `%%MONITOR2OFF` で購読を解除する (以降の broadcast は届かない)
+    // を end-to-end で検証する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("monitor2").await;
+
+        // 対局セットアップ (alice vs bob)。white は対局中に指さないので writer は使わない。
+        let (mut rb, mut wb, mut rw, _ww, game_id) = login_match_agree(addr).await;
+
+        // 観戦者 carol は x1 で login。game_name は対局と同じにする必要は無い
+        // (異なる game_name なので直接マッチは成立せず、x1 waiter として留まる)。
+        let (mut rc, mut wc) = connect(addr).await;
+        send_line(&mut wc, "LOGIN carol+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:carol OK");
+
+        // `%%MONITOR2ON <game_id>` → `##[MONITOR2] BEGIN <game_id>` + END。
+        send_line(&mut wc, &format!("%%MONITOR2ON {game_id}")).await;
+        let begin = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(begin, format!("##[MONITOR2] BEGIN {game_id}"));
+        let end = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(end, "##[MONITOR2] END");
+
+        // 対局者が着手すると、broadcast (Spectators 宛て) で observer にも届く。
+        send_line(&mut wb, "+7776FU").await;
+        let _ = read_until(&mut rb, "+7776FU,T0").await;
+        let _ = read_until(&mut rw, "+7776FU,T0").await;
+        // observer は `+7776FU,T0` を受信する。
+        let observed = read_until(&mut rc, "+7776FU,T0").await;
+        assert!(observed.iter().any(|l| l == "+7776FU,T0"));
+
+        // `%%CHAT` → `##[CHAT] carol: hello` を observer 自身が echo 受信する
+        // (subscriber に自身が含まれる contract)。
+        send_line(&mut wc, "%%CHAT hello").await;
+        let mut saw_chat = false;
+        for _ in 0..10 {
+            let line = read_line_raw(&mut rc).await.unwrap();
+            if line == "##[CHAT] carol: hello" {
+                saw_chat = true;
+                break;
+            }
+            if line == format!("##[CHAT] OK {game_id}") {
+                // OK 応答自体はあり得る順序。続きを読む。
+                continue;
+            }
+            if line == "##[CHAT] END" {
+                continue;
+            }
+        }
+        assert!(saw_chat, "did not observe CHAT echo");
+
+        // `%%MONITOR2OFF <game_id>` → `##[MONITOR2OFF] <game_id>` + END。
+        send_line(&mut wc, &format!("%%MONITOR2OFF {game_id}")).await;
+        let off = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(off, format!("##[MONITOR2OFF] {game_id}"));
+        let off_end = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(off_end, "##[MONITOR2OFF] END");
+
+        // observer を降りた後、対局者の次着手は broadcaster 経由では届かない
+        // (subscriber は drop されて prune される)。厳密な「届かない」検証は
+        // タイミング依存なので、後続手を送って observer の recv_line が短時間
+        // (100ms) 以内に何も届かない (あるいは subscriber が落ちて何か別行が
+        // 届く) ことで妥協する。本テストでは購読解除 reply の最終行まで
+        // 完了した時点を off 済みとみなし、以降は検証しない (スケジューラ
+        // タイミングで broadcaster の retain (prune) が未実行のまま 1 通だけ
+        // 取りこぼす可能性がある)。
+
+        // 対局を投了で畳んでテスト clean-up する。
+        send_line(&mut wb, "%TORYO").await;
+        let _ = read_until(&mut rb, "#LOSE").await;
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn chat_without_active_monitor_returns_not_monitoring() {
+    // x1 waiter が `%%MONITOR2ON` 前に `%%CHAT` を投げると `NOT_MONITORING` で
+    // 弾かれる。購読前の chat 経路を誤って開放していないことの回帰防止。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("chat_no_sub").await;
+        let (mut rc, mut wc) = connect(addr).await;
+        send_line(&mut wc, "LOGIN carol+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:carol OK");
+        send_line(&mut wc, "%%CHAT no-subscription-yet").await;
+        let resp = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(resp, "##[CHAT] NOT_MONITORING");
+        let end = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(end, "##[CHAT] END");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn monitor2_on_unknown_game_returns_not_found() {
+    // 存在しない game_id への `%%MONITOR2ON` は `NOT_FOUND` を返し、購読状態を
+    // 変更しない (broadcaster にも登録しない)。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server("mon_unknown").await;
+        let (mut rc, mut wc) = connect(addr).await;
+        send_line(&mut wc, "LOGIN carol+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:carol OK");
+        send_line(&mut wc, "%%MONITOR2ON unknown-game").await;
+        let resp = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(resp, "##[MONITOR2] NOT_FOUND unknown-game");
+        let end = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(end, "##[MONITOR2] END");
+        // 購読していないので CHAT は弾かれるはず。
+        send_line(&mut wc, "%%CHAT hello").await;
+        let chat = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(chat, "##[CHAT] NOT_MONITORING");
+        let _ = read_line_raw(&mut rc).await.unwrap(); // END
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -54,9 +54,12 @@ impl Role {
 /// - [`WsAttachment::Pending`]: LOGIN 到着前の匿名接続。`websocket_message`
 ///   ハンドラは最初に受信した行を LOGIN として解釈しようとする。
 /// - [`WsAttachment::Player`]: 認証済みプレイヤ。色・ハンドル・game_name を保持する。
+/// - [`WsAttachment::Spectator`]: 観戦者。`game_id` で観戦対象の対局を特定する。
+///   観戦系メッセージ (`%%MONITOR2ON/OFF`, `%%CHAT`) の経路判定と broadcast
+///   fanout の対象判定に使う。
 ///
-/// serde タグ付き形式を使い、将来 `Spectator` などを追加しても既存
-/// attachment を読み壊さない前方互換性を確保する。
+/// serde タグ付き形式を使い、新 variant を追加しても既存 attachment を
+/// 読み壊さない前方互換性を確保する。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum WsAttachment {
@@ -71,6 +74,15 @@ pub enum WsAttachment {
         /// CSA LOGIN の `<game_name>` 部分。マッチング時の同名性チェックに使う。
         game_name: String,
     },
+    /// 観戦者。`/ws/<room_id>/spectate` から接続したセッションに付与する。
+    ///
+    /// Player との違いは「盤面を動かす権限を持たず、broadcast を一方向受信する」点。
+    /// `game_id` は観戦対象の対局 ID で、`GameRoom` DO が broadcast fanout 時に
+    /// `WsAttachment::Spectator` 持ちセッション全てへ配信する判定で使う。
+    Spectator {
+        /// 観戦対象の対局 ID。
+        game_id: String,
+    },
 }
 
 impl WsAttachment {
@@ -80,6 +92,13 @@ impl WsAttachment {
             role,
             handle: handle.into(),
             game_name: game_name.into(),
+        }
+    }
+
+    /// 観戦者 attachment を構築する補助関数。
+    pub fn spectator(game_id: impl Into<String>) -> Self {
+        Self::Spectator {
+            game_id: game_id.into(),
         }
     }
 }
@@ -174,5 +193,30 @@ mod tests {
         assert!(parse_login_handle("+game1+black").is_none());
         assert!(parse_login_handle("alice++black").is_none());
         assert!(parse_login_handle("alice+game1+black+extra").is_none());
+    }
+
+    #[test]
+    fn spectator_roundtrips_via_json() {
+        let att = WsAttachment::spectator("room-20260101-0001");
+        let s = serde_json::to_string(&att).unwrap();
+        let back: WsAttachment = serde_json::from_str(&s).unwrap();
+        assert_eq!(att, back);
+    }
+
+    #[test]
+    fn spectator_json_has_expected_shape() {
+        let att = WsAttachment::spectator("room-xyz");
+        let s = serde_json::to_string(&att).unwrap();
+        // `#[serde(tag = "type")]` の下では variant 名が `type` 値に入る。
+        assert!(s.contains("\"type\":\"Spectator\""));
+        assert!(s.contains("\"game_id\":\"room-xyz\""));
+    }
+
+    #[test]
+    fn player_and_spectator_are_distinct_types() {
+        // 同一ハンドル / ID でも Player と Spectator は別 variant として比較される。
+        let player = WsAttachment::player(Role::Black, "alice", "room-1");
+        let spec = WsAttachment::spectator("room-1");
+        assert_ne!(player, spec);
     }
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -187,6 +187,14 @@ impl DurableObject for GameRoom {
             WsAttachment::Player { role, handle, .. } => {
                 self.handle_game_line(role, &handle, &line).await
             }
+            // 観戦者の受付ルート (`/ws/<room_id>/spectate`) と observer 系コマンドは
+            // 後続 PR で `router::handle_fetch` / `GameRoom` DO へ配線する。現時点では
+            // `WsAttachment::Spectator` 付きセッションは enum 互換性のためだけに存在し、
+            // 受信行は黙って破棄する (Player 経路への誤入を防ぐ)。
+            WsAttachment::Spectator { .. } => {
+                console_log!("[GameRoom] spectator message ignored (route not wired yet)");
+                Ok(())
+            }
         }
     }
 

--- a/crates/rshogi-csa-server/src/protocol/info.rs
+++ b/crates/rshogi-csa-server/src/protocol/info.rs
@@ -137,8 +137,10 @@ pub fn help_lines() -> Vec<CsaLine> {
         "%%WHO - list logged-in players",
         "%%LIST - list active games",
         "%%SHOW <game_id> - show a game summary",
-        "%%MONITOR2ON <game_id> - subscribe to a game as a spectator",
-        "%%MONITOR2OFF <game_id> - unsubscribe from a game",
+        "%%MONITOR2ON <game_id> - subscribe to a game as a spectator \
+(the session leaves matchmaking; re-LOGIN to resume)",
+        "%%MONITOR2OFF <game_id> - unsubscribe from a game (stays observer-only; \
+re-LOGIN to return to matchmaking)",
         "%%CHAT <message> - broadcast a chat message to spectators of the monitored game",
     ];
     let mut out: Vec<CsaLine> =

--- a/crates/rshogi-csa-server/src/protocol/info.rs
+++ b/crates/rshogi-csa-server/src/protocol/info.rs
@@ -124,8 +124,8 @@ pub fn show_lines(game_id: &GameId, listing: Option<&GameListing>) -> Vec<CsaLin
 /// 応答は CSA 拡張 `##[HELP]` プレフィックス付きの行列 + 末尾に終端行
 /// `##[HELP] END` を必ず付ける。**このリストは実際に受け付けるコマンドだけを
 /// 含める** (advertise ≠ accept の乖離を防ぐため)。未配線の
-/// `%%MONITOR2ON/OFF` / `%%CHAT` / `%%SETBUOY` 系は、各コマンドの配線コミットで
-/// 順次追加する。
+/// `%%SETBUOY` / `%%DELETEBUOY` / `%%GETBUOYCOUNT` / `%%FORK` 系は、各コマンドの
+/// 配線コミットで順次追加する。
 ///
 /// 終端行があることで、persistent socket 上でクライアントは「HELP 応答が何行
 /// 続くか」を事前に知らずに次コマンド送信に進める（`%%WHO` / `%%LIST` /
@@ -137,6 +137,9 @@ pub fn help_lines() -> Vec<CsaLine> {
         "%%WHO - list logged-in players",
         "%%LIST - list active games",
         "%%SHOW <game_id> - show a game summary",
+        "%%MONITOR2ON <game_id> - subscribe to a game as a spectator",
+        "%%MONITOR2OFF <game_id> - unsubscribe from a game",
+        "%%CHAT <message> - broadcast a chat message to spectators of the monitored game",
     ];
     let mut out: Vec<CsaLine> =
         entries.iter().map(|e| CsaLine::new(format!("##[HELP] {e}"))).collect();
@@ -166,10 +169,19 @@ mod tests {
         let lines = help_lines();
         let joined: String =
             lines.iter().map(|l| l.as_str().to_owned()).collect::<Vec<_>>().join("\n");
-        for cmd in ["%%VERSION", "%%HELP", "%%WHO", "%%LIST", "%%SHOW"] {
+        for cmd in [
+            "%%VERSION",
+            "%%HELP",
+            "%%WHO",
+            "%%LIST",
+            "%%SHOW",
+            "%%MONITOR2ON",
+            "%%MONITOR2OFF",
+            "%%CHAT",
+        ] {
             assert!(joined.contains(cmd), "help missing {cmd}: {joined}");
         }
-        for unwired in ["%%MONITOR2ON", "%%CHAT", "%%SETBUOY", "%%FORK"] {
+        for unwired in ["%%SETBUOY", "%%DELETEBUOY", "%%GETBUOYCOUNT", "%%FORK"] {
             assert!(
                 !joined.contains(unwired),
                 "help advertises unwired command {unwired}: {joined}"


### PR DESCRIPTION
## Summary

tasks.md §11.3 の観戦購読・発言中継を **TCP フロントエンド側で end-to-end** に実装。x1 クライアントが進行中の対局を購読し、指し手 broadcast を受信できるようにする。

本 PR は `csa-extended-clocks` (PR #468) にネスト。最終的には main までスタック (csa-extended-endings #467 → csa-extended-clocks #468 → csa-observers-chat 本 PR)。

## TCP 実装 (`rshogi-csa-server-tcp`)

`run_waiter` の x1 分岐に 3 命令を追加:
- `%%MONITOR2ON <game_id>`: `GameRegistry` 存在確認 → `InMemoryBroadcaster::subscribe` で登録、対応 `UnboundedReceiver<CsaLine>` を waiter loop 内で単一購読スロットとして保持。
- `%%MONITOR2OFF <game_id>`: rx を drop → broadcaster の retain(prune) で回収。
- `%%CHAT <msg>`: 現在観戦中のルームに `##[CHAT] <handle>: <msg>` を `BroadcastTag::Spectator` で broadcast。未購読時は `NOT_MONITORING` で弾く。

`tokio::select!` を 3 branch に拡張: マッチ確定 / 購読 broadcast 中継 / クライアント入力。中継書き込みも `x1_reply_write_timeout` 共用でハング防止。

`protocol::info::help_lines` に `%%MONITOR2ON/OFF/CHAT` を追加、回帰テストを同期更新。

## Workers 側 (先行スコープのみ)

- `WsAttachment::Spectator { game_id }` variant を追加 (前方互換 JSON roundtrip テスト付き)。
- `game_room.rs` の match 完全性のため Spectator 分岐 (stub) を追加。
- **`/ws/<room_id>/spectate` endpoint と DO 側 observer fanout は本 PR では未実装**。後続 PR で router + DO を一括配線する。

## テスト

TCP E2E:
- `monitor2_subscribes_and_receives_moves_and_chat` — alice vs bob 対局中に carol が購読→着手受信→CHAT echo→解除。
- `chat_without_active_monitor_returns_not_monitoring` — 未購読 CHAT の回帰。
- `monitor2_on_unknown_game_returns_not_found` — 未知 game_id の回帰。

Workers 単体:
- `spectator_roundtrips_via_json` / `spectator_json_has_expected_shape` / `player_and_spectator_are_distinct_types`。

## 既知の制約

- CHAT は **観戦者のみ** に届く。対局者 (drive 側 transport) は broadcaster に subscribe しておらず受信しない。`run_loop` 改修で Player-tag subscription を追加するか chat 専用チャネルを通すかは本 PR スコープ外。
- Workers 側 `/ws/<room_id>/spectate` endpoint と DO observer fanout は未実装 (enum 互換性のみ確保)。

## 品質ゲート

- `cargo fmt --all`
- `cargo clippy --workspace --tests -- -D warnings` 警告ゼロ
- `RUSTFLAGS=\"-C target-cpu=x86-64-v2\" cargo clippy --workspace --all-targets -- -D warnings` 警告ゼロ
- `cargo test --workspace` 全緑
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 通過

## Test plan

- [x] TCP 16 テスト全緑 (新規 3 本含む)
- [x] Workers attachment 9 テスト全緑 (新規 3 本含む)
- [x] workspace fmt/clippy/test/wasm32 check
- [ ] Workers `/ws/<room>/spectate` endpoint 配線は後続 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)