### PR TITLE
feat(tools): psv_dedup_partition — ディスクパーティション方式の exact PSV dedup

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -23,6 +23,7 @@
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
 | `psv_to_jsonl` | PSV 形式 → JSONL 変換（デバッグ・確認用） |
 | `fix_scores` | スコアの補正 |
+| `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
 
 ### ベンチマーク・分析
 

--- a/crates/tools/docs/pack_tools.md
+++ b/crates/tools/docs/pack_tools.md
@@ -189,6 +189,39 @@ GPU 推論が律速のため、バッチサイズ 1024〜2048 が推奨。
 
 スコアの補正処理。
 
+## 重複除去ツールの選び方
+
+PSV 重複除去には 3 種類のツールを用意している。入力規模・利用可能メモリ・一時ディスクの有無で選ぶ。重複キーはいずれも先頭 32 バイトの PackedSfen（first-wins）。
+
+| ツール | 方式 | 正確性 | メモリ | 一時ディスク | I/O パス | 想定規模 |
+|---|---|---|---|---|---|---|
+| [`psv_dedup`](../src/bin/psv_dedup.rs) | 全件 `HashSet<u64>` | ほぼ exact (64bit hash 衝突のみ) | ユニーク局面数 × ~16 B | 不要 | 1 | 数億〜数十億 |
+| [`psv_dedup_bloom`](psv_dedup_bloom.md) | Blocked Bloom Filter | 近似 (`--fpr` で制御、偽陽性あり) | 固定 (入力規模と `fpr` で決定) | 不要 | 1 | 数百億 (メモリ潤沢) |
+| [`psv_dedup_partition`](psv_dedup_partition.md) | ディスクパーティション + `HashSet<[u8;32]>` | **完全 exact** | 最大パーティションのユニーク局面ぶん | 入力と同等 | 2 | 数十億〜数百億 (メモリ限定) |
+
+### 選び方フロー
+
+```
+入力 < 数十億件？
+├─ Yes → psv_dedup（シンプル・速い）
+└─ No
+    ├─ メモリに余裕あり（数十 GiB 以上）
+    │   ├─ 偽陽性が許容できる → psv_dedup_bloom（1 パス・最速）
+    │   └─ exact が必須         → psv_dedup_partition
+    └─ メモリが限られている
+        └─ 一時ディスクに余裕あり → psv_dedup_partition（exact・低メモリ）
+```
+
+### reference モードが必要な場合
+
+既存 dedup 済みファイルとの **差分だけ** を抽出したい場合は `psv_dedup_bloom --reference` または `psv_dedup_partition --reference` が対応（`psv_dedup` は非対応）。近似で良いなら bloom、exact が必須なら partition を選ぶ。
+
+### 重複率の事前調査
+
+本番 dedup の前に重複率を把握したい場合は [`psv_dedup_check`](../src/bin/psv_dedup_check.rs) を使う。
+- `--table-size 4G` 等で direct-mapped テーブルを指定すれば固定メモリの近似チェック
+- 指定しない場合は `HashMap` で正確カウント (重複度合いの分布も出る)
+
 ## 典型的なワークフロー
 
 ### engine_selfplay で生成した場合

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -1,0 +1,217 @@
+# psv_dedup_partition
+
+`psv_dedup_partition` は、大規模な PSV データから PackedSfen 重複を **完全一致 (exact)** で除去する低メモリ向けツールです。
+
+- 入力: PackedSfenValue 40 バイト固定長ファイル
+- 重複キー: 先頭 32 バイトの PackedSfen（`psv_dedup` と同じ方針）
+- 出力: 最初に出現した局面のみを残した単一ファイル
+- 方式: ディスクパーティショニング → パーティションごとに `HashSet<[u8; 32]>`
+- 特徴: **偽陽性・偽陰性なし**、メモリは「最大パーティション分」に抑えられる
+
+巨大データでも exact に dedup したいが、`psv_dedup`（全件 HashSet 保持）ではメモリが足りないケース向けです。
+
+## 仕組み
+
+### Phase 1: Partitioning
+
+入力を順次ストリーミングで読み、PackedSfen (32 B) の 64 bit FNV-1a ハッシュを計算して `--partitions` 個の一時ファイルに振り分ける。
+
+```
+入力 .bin → hash_packed_sfen(sfen) % P → partition_NNNNN.bin
+```
+
+同じ局面は必ず同じパーティションに入るため、後段で「1 パーティション内で HashSet 判定」すれば全体の dedup と等価になる。
+
+### Phase 2: Deduplication
+
+各パーティションファイルを 1 つずつ読み込み、`HashSet<[u8; 32]>` で first-wins の重複判定を行い、出力ファイルに追記する。処理済みパーティションは `HashSet` ごと解放してから次へ進むため、ピークメモリは「最大パーティション 1 つぶんのユニーク局面」で決まる。
+
+`--keep-temp` を指定しない限り、処理済みパーティションは逐次削除される。
+
+### 一時ディレクトリ構造
+
+```
+<temp-dir>/
+├── input/
+│   ├── partition_00000.bin
+│   ├── partition_00001.bin
+│   └── ...
+└── ref/              # --reference 指定時のみ
+    ├── partition_00000.bin
+    └── ...
+```
+
+## reference モード
+
+既存の dedup 済みファイルがあり、新規データから「その既存ファイルに含まれない局面」だけを抽出したい場合に `--reference` を使う。参照ファイルは出力に含まれず、HashSet 登録のみ行われる。
+
+Phase 2 の流れ (パーティションごと):
+
+1. `ref/partition_{i}.bin` を HashSet に全件ロード（出力しない）
+2. `input/partition_{i}.bin` を streaming し、HashSet に未登録なら出力 + 挿入
+3. HashSet を解放して次パーティションへ
+
+これにより、既存ファイルと新規ファイルを結合してから dedup するよりも I/O が少なく、かつ reference 側の重複は出力に回らない。`psv_dedup_bloom --reference` の完全一致版に相当。
+
+`--phase2-only` で再開する際は `<temp-dir>/ref/` の存在を自動検出し、reference モードとして処理する（`--reference` 再指定は不要）。
+
+## 事前見積りと不足チェック
+
+起動時に Phase 1 / Phase 2 のメモリとディスク要件を見積もり、不足時は実行前に停止する。
+
+```
+=== Resource Estimate ===
+Total input records:  17000000000 (680000000000 bytes / 40)
+Phase 1 temp disk:    633.2 GiB (cleaned up on success)
+Phase 1 memory:       0.5 GiB (fixed: partitions × buffer)
+Phase 2 peak memory:  1.3 GiB (HashSet of largest partition, ~1.20x variance)
+Memory available:     64.0 GiB (threshold 80% = 51.2 GiB)
+Temp disk available:  8.0 TiB (/fast/ssd/tmp)
+Output disk:          same filesystem as temp (/fast/ssd). ...
+```
+
+チェック内容:
+
+- **メモリ**: `Phase1 mem` と `Phase2 peak mem` のうち大きい方が `MemAvailable × 80%` を超えたら Err
+- **temp ディスク**: 入力合計 × 1.05 が `--temp-dir` の空きを超えたら Err
+- **output ディスク**: 出力上限 = 入力合計（dedup しない最悪ケース）× 1.05 が出力親ディレクトリの空きを超えたら Err。ただし temp と同一ファイルシステムなら、temp は Phase 2 で削除されながら出力が書き込まれるため重複要件とみなさずスキップする
+- 不足時は停止。`--force` を付けると Warning を出して続行する（swap 多用・途中失敗のリスクを許容する場合のみ）
+
+## 一時ディスクの寿命
+
+- **Phase 1 実行中〜Phase 2 開始時点**: peak 使用量 ≈ 入力合計サイズ
+- **Phase 2 実行中**: partition ごとに処理→削除するので、temp 使用量は徐々に減る
+- **完走時**: 一時ファイルと一時ディレクトリを全て削除（`--keep-temp` 時のみ保持）
+- **出力ファイル**: 別途 `--output` に書き出され、完走後も残る
+
+## メモリ見積り
+
+Phase 2 のピークメモリはおおよそ次の式で決まる:
+
+```
+peak_memory ≈ (total_records / partitions) × entry_overhead
+```
+
+`entry_overhead` は `HashSet<[u8; 32]>` で 1 エントリあたり 50〜70 B 程度（バケット + エントリ + load factor）。
+
+### 参考値（均等分布を仮定）
+
+| 総レコード数 | `--partitions 1024` | `--partitions 4096` |
+|---:|---:|---:|
+| 10 億      | ~60 MiB       | ~15 MiB       |
+| 100 億     | ~600 MiB      | ~150 MiB      |
+| 250 億     | ~1.5 GiB      | ~370 MiB      |
+
+Phase 1 の固定コストは `partitions × partition_buffer_kb`。デフォルト (`1024 × 64 KiB = 64 MiB`) で十分で、メモリが更に厳しい場合は `--partition-buffer-kb 16` 等に縮小できる。
+
+## 一時ディスク
+
+Phase 1 は入力と **ほぼ同サイズ** のデータを一時ディレクトリに書き出す。`--temp-dir` は入力と同等以上の空き容量がある場所を指定すること（デフォルト: `./psv_dedup_partition_tmp`）。
+
+Phase 2 の進行に合わせて一時ファイルは削除されるので、ピーク使用量は入力サイズ程度。`--keep-temp` 指定時は残る。
+
+## I/O
+
+合計 I/O は通常 dedup の約 2 倍（Phase 1 で write once、Phase 2 で read once）。一方 `psv_dedup_bloom` は 1 パスなので、「メモリ vs ディスク I/O」のトレードオフになる。
+
+## FD 上限
+
+`--partitions 1024` 指定時は ulimit の soft limit が 1024 以上必要。起動時にチェックして不足なら警告する。Linux のデフォルトは 1024 なので、多くの環境で次の指定が必要:
+
+```bash
+ulimit -n 4096
+```
+
+## 使用例
+
+### 基本: ディレクトリ内の全ファイルを exact dedup
+
+```bash
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --input-dir ../bullet-shogi/data/DLSuisho15b \
+  --pattern "*.bin" \
+  --output /path/to/deduped.bin \
+  --temp-dir /fast/ssd/psv_tmp
+```
+
+### メモリをさらに絞る
+
+```bash
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --input-dir /path/to/dir \
+  --output deduped.bin \
+  --temp-dir /fast/ssd/psv_tmp \
+  --partitions 4096 \
+  --partition-buffer-kb 16
+```
+
+### 既存 dedup 済みファイルとの差分だけ抽出 (reference モード)
+
+```bash
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --reference existing_deduped.bin \
+  --input new_data.bin \
+  --output unique_new.bin \
+  --temp-dir /fast/ssd/psv_tmp
+```
+
+複数の reference を指定する場合はカンマ区切り:
+
+```bash
+  --reference old1.bin,old2.bin,old3.bin \
+```
+
+### Phase 1 だけ先に済ませて後日 Phase 2
+
+`--keep-temp` で一時ファイルを保持し、別セッションで `--phase2-only` から再開できる。
+
+```bash
+# セッション1: 振り分けだけ
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --input-dir /path/to/dir \
+  --output deduped.bin \
+  --temp-dir ./psv_tmp \
+  --keep-temp
+
+# セッション2: 後日 Phase 2 のみ
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --output deduped.bin \
+  --temp-dir ./psv_tmp \
+  --phase2-only
+```
+
+## オプション一覧
+
+| オプション | 説明 | デフォルト |
+|---|---|---|
+| `--reference` | 参照ファイル（カンマ区切り）。HashSet に登録するが出力しない | — |
+| `--input` | 入力ファイル（カンマ区切り）。`--input-dir` と排他 | — |
+| `--input-dir` | 入力ディレクトリ。`--pattern` と組み合わせ | — |
+| `--pattern` | `--input-dir` 使用時の glob パターン | `*.bin` |
+| `--output` | 出力ファイルパス | — |
+| `--temp-dir` | パーティション一時ファイルの置き場 | `./psv_dedup_partition_tmp` |
+| `--partitions` | パーティション数 | `1024` |
+| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB) | `64` |
+| `--max-positions` | 処理する入力レコードの最大件数（0 = 全件、試走用）。参照は常に全件 | `0` |
+| `--phase2-only` | Phase 1 をスキップして既存一時ファイルから再開（ref/ は自動検出） | off |
+| `--keep-temp` | 完了後も一時ファイル・ディレクトリを削除しない | off |
+| `--force` | メモリ/ディスク不足でも警告のみで続行する | off |
+
+## `psv_dedup` / `psv_dedup_bloom` との比較
+
+| 項目 | `psv_dedup` | `psv_dedup_bloom` | `psv_dedup_partition` |
+|---|---|---|---|
+| 方式 | 全件 `HashSet<u64>` | Blocked Bloom Filter | ディスクパーティション + `HashSet<[u8;32]>` |
+| 正確性 | ほぼ exact (64bit hash 衝突のみ) | 近似 (`--fpr` で制御、偽陽性あり) | **完全 exact** |
+| メモリ | ユニーク局面数 × 約 16 B | 固定 (入力規模と `fpr` から決定) | 最大パーティションのユニーク局面ぶん |
+| 一時ディスク | 不要 | 不要 | 入力と同等 |
+| I/O パス数 | 1 パス | 1 パス | 2 パス (write + read) |
+| 向いている規模 | 数億〜数十億 | 数百億 (メモリ潤沢) | 数十億〜数百億 (メモリ限定) |
+
+選び方は [pack_tools.md の「重複除去ツールの選び方」](pack_tools.md#重複除去ツールの選び方) を参照。
+
+## 注意
+
+- 入力と出力が同一ファイルの場合はエラー
+- キーは PackedSfen のみ。同一局面に対する複数の教師手がある場合は `psv_dedup` と同様、最初の出現だけ残す
+- パーティション出力の順序は保存されない（ハッシュ順）。順序を保ちたい場合は後段で `shuffle_psv` 等を使う

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -67,14 +67,14 @@ Phase 1 memory:       0.5 GiB (fixed: partitions × buffer)
 Phase 2 peak memory:  1.3 GiB (HashSet of largest partition, ~1.20x variance)
 Memory available:     64.0 GiB (threshold 80% = 51.2 GiB)
 Temp disk available:  8.0 TiB (/fast/ssd/tmp)
-Output disk:          same filesystem as temp (/fast/ssd). ...
+Output disk:          same filesystem as temp (/fast/ssd). 追加 headroom ...
 ```
 
 チェック内容:
 
 - **メモリ**: `Phase1 mem` と `Phase2 peak mem` のうち大きい方が `MemAvailable × 80%` を超えたら Err
 - **temp ディスク**: 入力合計 × 1.05 が `--temp-dir` の空きを超えたら Err
-- **output ディスク**: 出力上限 = 入力合計（dedup しない最悪ケース）× 1.05 が出力親ディレクトリの空きを超えたら Err。ただし temp と同一ファイルシステムなら、temp は Phase 2 で削除されながら出力が書き込まれるため重複要件とみなさずスキップする
+- **output ディスク**: 出力上限 = 入力合計（dedup しない最悪ケース）× 1.05 が出力親ディレクトリの空きを超えたら Err。temp と同一ファイルシステムの場合もチェックは省略しない。`--keep-temp` なしでは「処理中の最大 input partition」ぶんの追加 headroom、`--keep-temp` ありでは output 全量ぶんの追加空き容量を要求する
 - 不足時は停止。`--force` を付けると Warning を出して続行する（swap 多用・途中失敗のリスクを許容する場合のみ）
 
 ## 一時ディスクの寿命
@@ -163,7 +163,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 
 ### Phase 1 だけ先に済ませて後日 Phase 2
 
-`--keep-temp` で一時ファイルを保持し、別セッションで `--phase2-only` から再開できる。
+`--keep-temp` で一時ファイルを保持し、別セッションで `--phase2-only` から再開できる。途中で partition ファイルが欠けた temp ディレクトリは破損扱いとなり、`--phase2-only` は即エラーで停止する。
 
 ```bash
 # セッション1: 振り分けだけ

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # rshogi tools リファレンス
 
-crates/tools/src/bin/ 配下の全31バイナリの一覧と解説。
+crates/tools/src/bin/ 配下の全32バイナリの一覧と解説。
 
 ## 対局・トーナメント
 
@@ -46,8 +46,9 @@ crates/tools/src/bin/ 配下の全31バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `psv_dedup` | PSV ファイルの局面重複削除（HashSet 方式） |
-| `psv_dedup_bloom` | 大規模 PSV ファイルのブルームフィルタ重複除去（数百億レコード対応） |
+| `psv_dedup` | PSV ファイルの局面重複削除（HashSet 方式、中規模向け） |
+| `psv_dedup_bloom` | 大規模 PSV ファイルのブルームフィルタ重複除去（数百億レコード対応、近似） |
+| `psv_dedup_partition` | ディスクパーティション方式の exact 重複除去（低メモリ・大規模向け） |
 | `psv_dedup_check` | PSV ファイルの重複率を統計出力（近似モード・正確モード対応） |
 | `validate_sfens` | SFEN テキストの不正局面を検出・除去（文法・玉の存在・駒数超過・二歩など） |
 

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -128,7 +128,10 @@ const MEM_THRESHOLD_FACTOR: f64 = 0.8;
 
 struct ResourceEstimate {
     total_records: u64,
+    /// Phase 1 が一時ディレクトリに書き出すバイト数 (= ref + input)
     phase1_temp_bytes: u64,
+    /// 出力の上限バイト数。reference モードでは input 側だけが出力対象。
+    output_upper_bound_bytes: u64,
     phase1_memory_bytes: u64,
     phase2_peak_memory_bytes: u64,
 }
@@ -149,6 +152,7 @@ fn estimate_resources(
     ResourceEstimate {
         total_records,
         phase1_temp_bytes: total_bytes,
+        output_upper_bound_bytes: input_size_bytes,
         phase1_memory_bytes: phase1_mem,
         phase2_peak_memory_bytes: phase2_peak_mem,
     }
@@ -252,7 +256,8 @@ fn preflight_check(
     } else {
         same_filesystem(temp_dir, output_parent)
     };
-    let output_required = (estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
+    // 出力上限は input 側のみ（reference は出力対象外なので除外する）
+    let output_required = (estimate.output_upper_bound_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
     if let Some(avail) = get_disk_available(output_parent) {
         if same_fs == Some(true) {
             eprintln!(
@@ -304,6 +309,53 @@ fn sum_existing_partition_bytes(dir: &Path) -> io::Result<u64> {
         }
     }
     Ok(total)
+}
+
+/// `--phase2-only` 時、既存 temp ディレクトリから partition 数を推定する。
+///
+/// `partition_NNNNN.bin` 形式のファイルを列挙し、最大 index + 1 を返す。
+/// Phase 1 は 0..N-1 のすべての partition ファイルを空でも作成するため、
+/// ファイル数ではなく最大 index を使うことで途中削除された場合も正しく
+/// Phase 1 時点の N を取得できる。
+fn detect_partition_count(dir: &Path) -> io::Result<usize> {
+    if !dir.is_dir() {
+        return Ok(0);
+    }
+    let mut max_idx: Option<usize> = None;
+    let mut count = 0usize;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Some(stripped) = name.strip_prefix("partition_").and_then(|s| s.strip_suffix(".bin"))
+        else {
+            continue;
+        };
+        let Ok(idx) = stripped.parse::<usize>() else {
+            continue;
+        };
+        max_idx = Some(max_idx.map_or(idx, |m| m.max(idx)));
+        count += 1;
+    }
+    match max_idx {
+        Some(m) => {
+            let detected = m + 1;
+            if count < detected {
+                eprintln!(
+                    "Warning: temp {} に {} 個の partition ファイルしか見つかりません \
+                     (Phase 1 時の N={})。欠損 partition は skip されます。",
+                    dir.display(),
+                    count,
+                    detected,
+                );
+            }
+            Ok(detected)
+        }
+        None => Ok(0),
+    }
 }
 
 fn partition_filename(partition: usize) -> String {
@@ -577,11 +629,13 @@ fn main() -> io::Result<()> {
         ));
     }
 
-    warn_fd_limit(args.partitions);
-
     let partition_buffer_bytes = args.partition_buffer_kb * 1024;
     let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
     let ref_subdir = args.temp_dir.join(REF_SUBDIR);
+
+    // Phase 2 で使う partition 数。--phase2-only 時は既存 temp dir から自動検出して
+    // Phase 1 時の N と一致させる (データ欠損を防ぐ)。
+    let partitions: usize;
 
     let (phase1_ref_records, phase1_input_records) = if args.phase2_only {
         eprintln!("=== Phase 1 skipped (--phase2-only) ===");
@@ -600,7 +654,40 @@ fn main() -> io::Result<()> {
                 ),
             ));
         }
+
+        let detected = detect_partition_count(&input_subdir)?;
+        if detected == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "partition ファイルが見つかりません: {} (ファイル名形式 partition_NNNNN.bin)",
+                    input_subdir.display(),
+                ),
+            ));
+        }
+        if detected != args.partitions {
+            eprintln!(
+                "Info: --phase2-only で {} から {} 個の partition を検出しました \
+                 (CLI の --partitions={} は上書きされます)。",
+                input_subdir.display(),
+                detected,
+                args.partitions,
+            );
+        }
+        partitions = detected;
+        warn_fd_limit(partitions);
+
         if ref_subdir.is_dir() {
+            let ref_detected = detect_partition_count(&ref_subdir)?;
+            if ref_detected != 0 && ref_detected != partitions {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "partition 数の不一致: input={partitions}, ref={ref_detected}. \
+                         temp ディレクトリが壊れている可能性があります。",
+                    ),
+                ));
+            }
             eprintln!("  reference パーティション検出: {}", ref_subdir.display());
         }
 
@@ -609,7 +696,7 @@ fn main() -> io::Result<()> {
         let estimate = estimate_resources(
             existing_ref_bytes,
             existing_input_bytes,
-            args.partitions,
+            partitions,
             partition_buffer_bytes,
         );
         preflight_check(
@@ -622,6 +709,9 @@ fn main() -> io::Result<()> {
 
         (0u64, 0u64)
     } else {
+        partitions = args.partitions;
+        warn_fd_limit(partitions);
+
         let ref_paths = match args.reference.as_deref() {
             Some(r) => parse_reference_paths(r)?,
             None => Vec::new(),
@@ -643,12 +733,8 @@ fn main() -> io::Result<()> {
         } else {
             input_size
         };
-        let estimate = estimate_resources(
-            ref_size,
-            capped_input_size,
-            args.partitions,
-            partition_buffer_bytes,
-        );
+        let estimate =
+            estimate_resources(ref_size, capped_input_size, partitions, partition_buffer_bytes);
         preflight_check(
             &estimate,
             &args.temp_dir,
@@ -657,11 +743,11 @@ fn main() -> io::Result<()> {
             args.force,
         )?;
 
-        eprintln!("=== Phase 1: Partitioning ({} partitions) ===", args.partitions);
+        eprintln!("=== Phase 1: Partitioning ({partitions} partitions) ===");
         eprintln!(
             "  partition buffer: {} KiB/partition (total ~{:.1} MiB)",
             args.partition_buffer_kb,
-            (args.partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
+            (partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
         );
 
         let ref_records = if ref_paths.is_empty() {
@@ -675,7 +761,7 @@ fn main() -> io::Result<()> {
                 "reference",
                 &ref_paths,
                 &ref_subdir,
-                args.partitions,
+                partitions,
                 partition_buffer_bytes,
                 0, // reference は常に全件
             )?
@@ -685,7 +771,7 @@ fn main() -> io::Result<()> {
             "input",
             &inputs,
             &input_subdir,
-            args.partitions,
+            partitions,
             partition_buffer_bytes,
             args.max_positions,
         )?;
@@ -710,7 +796,7 @@ fn main() -> io::Result<()> {
     let (ref_seen, input_seen, unique) = deduplicate_partitions(
         &input_subdir,
         ref_dir_opt,
-        args.partitions,
+        partitions,
         &args.output,
         args.keep_temp,
     )?;

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -132,6 +132,10 @@ struct ResourceEstimate {
     phase1_temp_bytes: u64,
     /// 出力の上限バイト数。reference モードでは input 側だけが出力対象。
     output_upper_bound_bytes: u64,
+    /// same filesystem 上で Phase 2 に一時的に必要になる追加空き容量の見積り。
+    /// `--keep-temp` なしでは「現在処理中の最大 input partition ぶん」、
+    /// `--keep-temp` ありでは使わない。
+    phase2_peak_partition_input_bytes: u64,
     phase1_memory_bytes: u64,
     phase2_peak_memory_bytes: u64,
 }
@@ -145,16 +149,32 @@ fn estimate_resources(
     let total_bytes = ref_size_bytes + input_size_bytes;
     let total_records = total_bytes / PSV_SIZE as u64;
     let avg_records_per_partition = total_records as f64 / num_partitions.max(1) as f64;
-    let peak_records_per_partition = (avg_records_per_partition * HASH_VARIANCE_FACTOR) as u64;
+    let peak_records_per_partition =
+        (avg_records_per_partition * HASH_VARIANCE_FACTOR).ceil() as u64;
     let phase2_peak_mem = peak_records_per_partition.saturating_mul(HASHSET_ENTRY_BYTES);
     let phase1_mem = (num_partitions as u64).saturating_mul(partition_buffer_bytes as u64);
+    let input_records = input_size_bytes / PSV_SIZE as u64;
+    let avg_input_records_per_partition = input_records as f64 / num_partitions.max(1) as f64;
+    let peak_input_records_per_partition =
+        (avg_input_records_per_partition * HASH_VARIANCE_FACTOR).ceil() as u64;
+    let phase2_peak_partition_input_bytes =
+        peak_input_records_per_partition.saturating_mul(PSV_SIZE as u64);
 
     ResourceEstimate {
         total_records,
         phase1_temp_bytes: total_bytes,
         output_upper_bound_bytes: input_size_bytes,
+        phase2_peak_partition_input_bytes,
         phase1_memory_bytes: phase1_mem,
         phase2_peak_memory_bytes: phase2_peak_mem,
+    }
+}
+
+fn same_fs_output_headroom_bytes(estimate: &ResourceEstimate, keep_temp: bool) -> u64 {
+    if keep_temp {
+        estimate.output_upper_bound_bytes
+    } else {
+        estimate.phase2_peak_partition_input_bytes
     }
 }
 
@@ -164,6 +184,7 @@ fn preflight_check(
     temp_dir: &Path,
     output_path: &Path,
     skip_temp_check: bool,
+    keep_temp: bool,
     force: bool,
 ) -> io::Result<()> {
     eprintln!("=== Resource Estimate ===");
@@ -250,7 +271,7 @@ fn preflight_check(
         }
     }
 
-    // 出力ディスクチェック（temp と同一 fs なら重複メッセージを避けてまとめる）
+    // 出力ディスクチェック（temp と同一 fs の場合は Phase 2 の一時的な headroom を見る）
     let same_fs = if skip_temp_check {
         Some(false)
     } else {
@@ -260,11 +281,58 @@ fn preflight_check(
     let output_required = (estimate.output_upper_bound_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
     if let Some(avail) = get_disk_available(output_parent) {
         if same_fs == Some(true) {
+            let same_fs_headroom = (same_fs_output_headroom_bytes(estimate, keep_temp) as f64
+                * DISK_SAFETY_FACTOR) as u64;
             eprintln!(
-                "Output disk:          same filesystem as temp ({}). 出力は temp と交互に入れ替わるため \
-                 追加空き容量は不要。",
+                "Output disk:          same filesystem as temp ({}). Phase 2 では temp を削除しながら \
+                 出力するため、追加で必要な空き容量は最悪 {}{}。",
                 output_parent.display(),
+                format_gib(same_fs_headroom),
+                if keep_temp {
+                    "（--keep-temp のため output 全量ぶん）"
+                } else {
+                    "（処理中の最大 input partition 想定）"
+                }
             );
+            let same_fs_required = if skip_temp_check {
+                same_fs_headroom
+            } else {
+                ((estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64)
+                    .saturating_add(same_fs_headroom)
+            };
+            if same_fs_required > avail {
+                let msg = if skip_temp_check {
+                    format!(
+                        "出力ディスク不足: same filesystem 上で Phase 2 に追加 headroom {} 必要ですが \
+                         {} しか空きがありません ({})。\n\
+                         対処法:\n\
+                         - temp/output を別ファイルシステムに分ける\n\
+                         - 一時ファイルを整理してから --phase2-only を再実行\n\
+                         - --force で強制続行",
+                        format_gib(same_fs_headroom),
+                        format_gib(avail),
+                        output_parent.display(),
+                    )
+                } else {
+                    format!(
+                        "ディスク不足: same filesystem 上で Phase 1 temp {} と Phase 2 headroom {} の合計が \
+                         必要ですが {} しか空きがありません ({})。\n\
+                         対処法:\n\
+                         - temp/output を別ファイルシステムに分ける\n\
+                         - --partitions を増やして最大 partition を小さくする\n\
+                         - --force で強制続行",
+                        format_gib((estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64),
+                        format_gib(same_fs_headroom),
+                        format_gib(avail),
+                        output_parent.display(),
+                    )
+                };
+                if force {
+                    eprintln!("Warning (--force): {msg}");
+                } else {
+                    return Err(io::Error::other(msg));
+                }
+            }
         } else {
             eprintln!(
                 "Output disk available:{} ({}, 出力上限 {})",
@@ -344,13 +412,16 @@ fn detect_partition_count(dir: &Path) -> io::Result<usize> {
         Some(m) => {
             let detected = m + 1;
             if count < detected {
-                eprintln!(
-                    "Warning: temp {} に {} 個の partition ファイルしか見つかりません \
-                     (Phase 1 時の N={})。欠損 partition は skip されます。",
-                    dir.display(),
-                    count,
-                    detected,
-                );
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "temp {} の partition が欠損しています: {} 個しか見つからず \
+                         Phase 1 時の N={} を満たしません。`--phase2-only` は不完全な temp では再開できません。",
+                        dir.display(),
+                        count,
+                        detected,
+                    ),
+                ));
             }
             Ok(detected)
         }
@@ -525,22 +596,35 @@ fn deduplicate_partitions(
         // --- Phase 2a: reference partition を HashSet にロード（出力しない） ---
         if let Some(ref_dir) = ref_subdir {
             let ref_path = ref_dir.join(partition_filename(partition));
-            if ref_path.exists() {
-                let ref_records = read_partition_records(&ref_path, |_rec, sfen| {
-                    seen.insert(*sfen);
-                    Ok(())
-                })?;
-                total_ref += ref_records;
-                if !keep_temp {
-                    let _ = std::fs::remove_file(&ref_path);
-                }
+            if !ref_path.exists() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "reference partition が見つかりません: {} (temp ディレクトリ破損の可能性)",
+                        ref_path.display()
+                    ),
+                ));
+            }
+            let ref_records = read_partition_records(&ref_path, |_rec, sfen| {
+                seen.insert(*sfen);
+                Ok(())
+            })?;
+            total_ref += ref_records;
+            if !keep_temp {
+                let _ = std::fs::remove_file(&ref_path);
             }
         }
 
         // --- Phase 2b: input partition を streaming し、未登録なら出力 ---
         let input_path = input_subdir.join(partition_filename(partition));
         if !input_path.exists() {
-            continue;
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "input partition が見つかりません: {} (temp ディレクトリ破損の可能性)",
+                    input_path.display()
+                ),
+            ));
         }
 
         let mut unique_in_partition = 0u64;
@@ -637,6 +721,8 @@ fn main() -> io::Result<()> {
     // Phase 1 時の N と一致させる (データ欠損を防ぐ)。
     let partitions: usize;
 
+    let has_reference_partitions: bool;
+
     let (phase1_ref_records, phase1_input_records) = if args.phase2_only {
         eprintln!("=== Phase 1 skipped (--phase2-only) ===");
         if !args.temp_dir.is_dir() {
@@ -688,7 +774,12 @@ fn main() -> io::Result<()> {
                     ),
                 ));
             }
-            eprintln!("  reference パーティション検出: {}", ref_subdir.display());
+            has_reference_partitions = ref_detected != 0;
+            if has_reference_partitions {
+                eprintln!("  reference パーティション検出: {}", ref_subdir.display());
+            }
+        } else {
+            has_reference_partitions = false;
         }
 
         let existing_input_bytes = sum_existing_partition_bytes(&input_subdir)?;
@@ -704,6 +795,7 @@ fn main() -> io::Result<()> {
             &args.temp_dir,
             &args.output,
             /* skip_temp_check = */ true,
+            args.keep_temp,
             args.force,
         )?;
 
@@ -740,6 +832,7 @@ fn main() -> io::Result<()> {
             &args.temp_dir,
             &args.output,
             /* skip_temp_check = */ false,
+            args.keep_temp,
             args.force,
         )?;
 
@@ -755,8 +848,10 @@ fn main() -> io::Result<()> {
             if ref_subdir.is_dir() {
                 std::fs::remove_dir_all(&ref_subdir)?;
             }
+            has_reference_partitions = false;
             0
         } else {
+            has_reference_partitions = true;
             partition_files_into(
                 "reference",
                 &ref_paths,
@@ -779,7 +874,7 @@ fn main() -> io::Result<()> {
         (ref_records, input_records)
     };
 
-    let ref_dir_opt = if ref_subdir.is_dir() {
+    let ref_dir_opt = if has_reference_partitions && ref_subdir.is_dir() {
         Some(ref_subdir.as_path())
     } else {
         None
@@ -834,4 +929,35 @@ fn main() -> io::Result<()> {
     println!("Output file:       {}", args.output.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn same_fs_headroom_without_keep_temp_is_peak_partition_only() {
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+
+        assert_eq!(same_fs_output_headroom_bytes(&estimate, false), 1_200);
+    }
+
+    #[test]
+    fn same_fs_headroom_with_keep_temp_is_full_output() {
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+
+        assert_eq!(same_fs_output_headroom_bytes(&estimate, true), 4_000);
+    }
+
+    #[test]
+    fn detect_partition_count_rejects_missing_partition() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join(partition_filename(0)), []).unwrap();
+        std::fs::write(dir.path().join(partition_filename(2)), []).unwrap();
+
+        let err = detect_partition_count(dir.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("欠損"));
+    }
 }

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -1,0 +1,751 @@
+/// PSV ファイルの局面重複削除ツール（ディスクパーティション方式）
+///
+/// 重複キー: 先頭 32 バイトの PackedSfen（`psv_dedup` と同じ方針）
+/// 方式: 完全一致 (exact dedup)。偽陽性・偽陰性なし。
+///
+/// ## 仕組み
+///
+/// 1. **Phase 1 (partitioning)**: 入力を順次読み、PackedSfen の 64bit FNV-1a
+///    ハッシュで `--partitions` 個の一時ファイルに振り分ける。`--reference`
+///    指定時は参照ファイル群も同じハッシュで別サブディレクトリに振り分ける。
+/// 2. **Phase 2 (deduplication)**: 各パーティションを 1 つずつ `HashSet<[u8;32]>`
+///    にロードし、first-wins で出力ファイルへ追記する。参照パーティションが
+///    あれば先に HashSet に入れ（出力はしない）、続けて入力パーティションを
+///    照合して新規局面だけ出力する。
+///
+/// ピークメモリは「全ユニーク局面」ではなく「最大パーティションのユニーク局面」に
+/// 抑えられるため、`psv_dedup` では載らない規模でも exact dedup が可能。
+/// 代償として、一時ディスクが入力と同等サイズ必要で、I/O は約 2 倍になる。
+///
+/// Usage:
+///   cargo run --release --bin psv_dedup_partition -- \
+///     --input-dir /path/to/dir \
+///     --pattern "*.bin" \
+///     --output /path/to/deduped.bin \
+///     --temp-dir /path/to/tmp
+///
+///   # reference モード: 既存 dedup 済みファイルとの差分だけ抽出
+///   cargo run --release --bin psv_dedup_partition -- \
+///     --reference existing_deduped.bin \
+///     --input new_data.bin \
+///     --output unique_new.bin \
+///     --temp-dir /path/to/tmp
+///
+///   # 既存の一時ファイルから Phase 2 のみ再実行
+///   cargo run --release --bin psv_dedup_partition -- \
+///     --output /path/to/deduped.bin \
+///     --temp-dir /path/to/tmp \
+///     --phase2-only
+use std::{
+    collections::HashSet,
+    fs::{File, OpenOptions},
+    io::{self, BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use tools::common::dedup::{
+    PSV_SIZE, SFEN_SIZE, check_output_not_in_inputs, collect_input_paths, format_gib,
+    get_disk_available, get_mem_available, hash_packed_sfen, same_filesystem, sum_file_sizes,
+};
+
+const INPUT_SUBDIR: &str = "input";
+const REF_SUBDIR: &str = "ref";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "psv_dedup_partition",
+    about = "ディスクパーティションによる exact PSV 重複除去 (低メモリ)"
+)]
+struct Args {
+    /// 参照ファイル（カンマ区切り）。HashSet に登録するが出力しない。
+    /// 既存 dedup 済みファイルとの差分だけ出力したいときに使う。
+    #[arg(long)]
+    reference: Option<String>,
+
+    /// 入力 PSV ファイル（カンマ区切り）。--input-dir と排他
+    #[arg(long)]
+    input: Option<String>,
+
+    /// 入力ディレクトリ。--pattern と組み合わせ。--input と排他
+    #[arg(long)]
+    input_dir: Option<PathBuf>,
+
+    /// --input-dir 使用時の glob パターン
+    #[arg(long, default_value = "*.bin")]
+    pattern: String,
+
+    /// 出力ファイルパス
+    #[arg(long)]
+    output: PathBuf,
+
+    /// 一時ディレクトリ（パーティションファイルの置き場）
+    #[arg(long, default_value = "./psv_dedup_partition_tmp")]
+    temp_dir: PathBuf,
+
+    /// パーティション数。多いほど Phase 2 の 1 パーティションあたりメモリが減るが
+    /// file descriptor と出力バッファの総量が増える。
+    #[arg(long, default_value = "1024")]
+    partitions: usize,
+
+    /// Phase 1 でパーティションごとに確保する BufWriter のバッファサイズ (KiB)
+    #[arg(long, default_value = "64")]
+    partition_buffer_kb: usize,
+
+    /// 処理する入力レコードの最大件数（0 = 全件、試走向け）。
+    /// 参照ファイルは常に全件読み込まれる。
+    #[arg(long, default_value = "0")]
+    max_positions: u64,
+
+    /// Phase 1 をスキップして既存の一時ファイルから Phase 2 のみ実行。
+    /// temp_dir/ref/ が存在すれば自動で reference モードになる。
+    #[arg(long)]
+    phase2_only: bool,
+
+    /// 完了後も一時ディレクトリを削除しない
+    #[arg(long)]
+    keep_temp: bool,
+
+    /// メモリ/ディスクの事前見積りチェックをスキップして強制実行する。
+    /// swap 多用・途中失敗のリスクを許容する場合のみ使う。
+    #[arg(long)]
+    force: bool,
+}
+
+/// `HashSet<[u8; SFEN_SIZE]>` 1 エントリあたりの推定メモリ使用量（バイト）。
+/// hashbrown の RawTable は key(32B) + 制御バイト(1B) + load factor 7/8 + ヘッダ等を
+/// 含めて実測で 40-48B 前後だが、余裕を見て 56B をカウントする。
+const HASHSET_ENTRY_BYTES: u64 = 56;
+
+/// ハッシュ分布のばらつきによる最大パーティションの余剰係数。
+const HASH_VARIANCE_FACTOR: f64 = 1.2;
+
+/// ディスクチェックの安全マージン (5%)。
+const DISK_SAFETY_FACTOR: f64 = 1.05;
+
+/// メモリ不足判定のしきい値 (MemAvailable の 80%)。
+const MEM_THRESHOLD_FACTOR: f64 = 0.8;
+
+struct ResourceEstimate {
+    total_records: u64,
+    phase1_temp_bytes: u64,
+    phase1_memory_bytes: u64,
+    phase2_peak_memory_bytes: u64,
+}
+
+fn estimate_resources(
+    ref_size_bytes: u64,
+    input_size_bytes: u64,
+    num_partitions: usize,
+    partition_buffer_bytes: usize,
+) -> ResourceEstimate {
+    let total_bytes = ref_size_bytes + input_size_bytes;
+    let total_records = total_bytes / PSV_SIZE as u64;
+    let avg_records_per_partition = total_records as f64 / num_partitions.max(1) as f64;
+    let peak_records_per_partition = (avg_records_per_partition * HASH_VARIANCE_FACTOR) as u64;
+    let phase2_peak_mem = peak_records_per_partition.saturating_mul(HASHSET_ENTRY_BYTES);
+    let phase1_mem = (num_partitions as u64).saturating_mul(partition_buffer_bytes as u64);
+
+    ResourceEstimate {
+        total_records,
+        phase1_temp_bytes: total_bytes,
+        phase1_memory_bytes: phase1_mem,
+        phase2_peak_memory_bytes: phase2_peak_mem,
+    }
+}
+
+/// 不足チェック結果を INFO 出力し、不足時は Err（`force` なら Warning）。
+fn preflight_check(
+    estimate: &ResourceEstimate,
+    temp_dir: &Path,
+    output_path: &Path,
+    skip_temp_check: bool,
+    force: bool,
+) -> io::Result<()> {
+    eprintln!("=== Resource Estimate ===");
+    eprintln!(
+        "Total input records:  {} ({} bytes / {})",
+        estimate.total_records, estimate.phase1_temp_bytes, PSV_SIZE
+    );
+    if !skip_temp_check {
+        eprintln!(
+            "Phase 1 temp disk:    {} (cleaned up on success)",
+            format_gib(estimate.phase1_temp_bytes),
+        );
+        eprintln!(
+            "Phase 1 memory:       {} (fixed: partitions × buffer)",
+            format_gib(estimate.phase1_memory_bytes),
+        );
+    }
+    eprintln!(
+        "Phase 2 peak memory:  {} (HashSet of largest partition, ~{:.2}x variance)",
+        format_gib(estimate.phase2_peak_memory_bytes),
+        HASH_VARIANCE_FACTOR,
+    );
+
+    let peak_mem = estimate.phase1_memory_bytes.max(estimate.phase2_peak_memory_bytes);
+
+    // --- メモリチェック ---
+    if let Some(avail) = get_mem_available() {
+        let threshold = (avail as f64 * MEM_THRESHOLD_FACTOR) as u64;
+        eprintln!(
+            "Memory available:     {} (threshold {:.0}% = {})",
+            format_gib(avail),
+            MEM_THRESHOLD_FACTOR * 100.0,
+            format_gib(threshold),
+        );
+        if peak_mem > threshold {
+            let msg = format!(
+                "メモリ不足: 推定ピーク {} が threshold {} を超えます。\n\
+                 対処法:\n\
+                 - --partitions を大きくする（1 パーティションのメモリが減る）\n\
+                 - --force で強制続行（swap 使用の可能性）",
+                format_gib(peak_mem),
+                format_gib(threshold),
+            );
+            if force {
+                eprintln!("Warning (--force): {msg}");
+            } else {
+                return Err(io::Error::other(msg));
+            }
+        }
+    } else {
+        eprintln!("Memory available:     (取得不可、メモリチェックをスキップ)");
+    }
+
+    // --- ディスクチェック ---
+    let output_parent = {
+        let p = output_path.parent().unwrap_or(Path::new("."));
+        if p.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            p
+        }
+    };
+
+    if !skip_temp_check {
+        let temp_required = (estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
+        if let Some(avail) = get_disk_available(temp_dir) {
+            eprintln!("Temp disk available:  {} ({})", format_gib(avail), temp_dir.display());
+            if temp_required > avail {
+                let msg = format!(
+                    "一時ディスク不足: 約 {} 必要ですが {} しか空きがありません ({})。\n\
+                     対処法:\n\
+                     - --temp-dir で容量のあるファイルシステムを指定\n\
+                     - --force で強制続行",
+                    format_gib(temp_required),
+                    format_gib(avail),
+                    temp_dir.display(),
+                );
+                if force {
+                    eprintln!("Warning (--force): {msg}");
+                } else {
+                    return Err(io::Error::other(msg));
+                }
+            }
+        }
+    }
+
+    // 出力ディスクチェック（temp と同一 fs なら重複メッセージを避けてまとめる）
+    let same_fs = if skip_temp_check {
+        Some(false)
+    } else {
+        same_filesystem(temp_dir, output_parent)
+    };
+    let output_required = (estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
+    if let Some(avail) = get_disk_available(output_parent) {
+        if same_fs == Some(true) {
+            eprintln!(
+                "Output disk:          same filesystem as temp ({}). 出力は temp と交互に入れ替わるため \
+                 追加空き容量は不要。",
+                output_parent.display(),
+            );
+        } else {
+            eprintln!(
+                "Output disk available:{} ({}, 出力上限 {})",
+                format_gib(avail),
+                output_parent.display(),
+                format_gib(output_required),
+            );
+            if output_required > avail {
+                let msg = format!(
+                    "出力ディスク不足: 上限 {} 必要ですが {} しか空きがありません ({})。\n\
+                     対処法:\n\
+                     - 別ファイルシステムの --output を指定\n\
+                     - --force で強制続行",
+                    format_gib(output_required),
+                    format_gib(avail),
+                    output_parent.display(),
+                );
+                if force {
+                    eprintln!("Warning (--force): {msg}");
+                } else {
+                    return Err(io::Error::other(msg));
+                }
+            }
+        }
+    }
+
+    eprintln!();
+    Ok(())
+}
+
+/// `--phase2-only` 時、既存 temp ディレクトリのパーティションファイルサイズを
+/// 合計して total bytes を得る。
+fn sum_existing_partition_bytes(dir: &Path) -> io::Result<u64> {
+    if !dir.is_dir() {
+        return Ok(0);
+    }
+    let mut total = 0u64;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            total += entry.metadata()?.len();
+        }
+    }
+    Ok(total)
+}
+
+fn partition_filename(partition: usize) -> String {
+    format!("partition_{partition:05}.bin")
+}
+
+/// reference 引数をパスのベクタにパースする。
+fn parse_reference_paths(reference: &str) -> io::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for s in reference.split(',') {
+        let p = PathBuf::from(s.trim());
+        if !p.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("reference ファイルが見つかりません: {}", p.display()),
+            ));
+        }
+        paths.push(p);
+    }
+    Ok(paths)
+}
+
+/// 入力ファイル群を 1 つのサブディレクトリ下のパーティションに振り分ける。
+///
+/// `max_positions > 0` の場合は `total_records` がその値に達した時点で
+/// 途中終了する。`max_positions == 0` なら全件処理する。
+fn partition_files_into(
+    label: &str,
+    inputs: &[PathBuf],
+    subdir: &Path,
+    num_partitions: usize,
+    partition_buffer_bytes: usize,
+    max_positions: u64,
+) -> io::Result<u64> {
+    std::fs::create_dir_all(subdir)?;
+
+    let mut writers: Vec<BufWriter<File>> = (0..num_partitions)
+        .map(|i| {
+            let path = subdir.join(partition_filename(i));
+            let file = OpenOptions::new().create(true).write(true).truncate(true).open(&path)?;
+            Ok::<_, io::Error>(BufWriter::with_capacity(partition_buffer_bytes, file))
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+
+    let mut total_records = 0u64;
+    let mut buf = [0u8; PSV_SIZE];
+    let start = std::time::Instant::now();
+
+    'outer: for input in inputs {
+        eprintln!("  [{label}] {}", input.display());
+        let file = File::open(input)?;
+        let meta = file.metadata()?;
+        let size = meta.len();
+        if !size.is_multiple_of(PSV_SIZE as u64) {
+            eprintln!("Warning: {} size {size} is not a multiple of {PSV_SIZE}", input.display());
+        }
+        let mut reader = BufReader::with_capacity(8 << 20, file);
+
+        loop {
+            if max_positions > 0 && total_records >= max_positions {
+                break 'outer;
+            }
+
+            match reader.read_exact(&mut buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e),
+            }
+
+            let sfen: &[u8; SFEN_SIZE] = buf[..SFEN_SIZE].try_into().unwrap();
+            let h = hash_packed_sfen(sfen);
+            let partition = (h as usize) % num_partitions;
+            writers[partition].write_all(&buf)?;
+
+            total_records += 1;
+            if total_records.is_multiple_of(100_000_000) {
+                let elapsed = start.elapsed().as_secs_f64();
+                let speed = total_records as f64 / elapsed / 1e6;
+                eprintln!(
+                    "    {:.0}M partitioned, {:.1}s ({:.1}M rec/s)",
+                    total_records as f64 / 1e6,
+                    elapsed,
+                    speed,
+                );
+            }
+        }
+    }
+
+    for w in &mut writers {
+        w.flush()?;
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    eprintln!("  [{label}] done: {total_records} records, {elapsed:.1}s");
+
+    Ok(total_records)
+}
+
+/// パーティションファイルを読み、各レコードのコールバックを呼ぶ。
+fn read_partition_records(
+    path: &Path,
+    mut on_record: impl FnMut(&[u8; PSV_SIZE], &[u8; SFEN_SIZE]) -> io::Result<()>,
+) -> io::Result<u64> {
+    let file = File::open(path)?;
+    let meta = file.metadata()?;
+    let size = meta.len();
+    if size == 0 {
+        return Ok(0);
+    }
+    if !size.is_multiple_of(PSV_SIZE as u64) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "partition {} size {size} is not a multiple of {PSV_SIZE} (破損の可能性)",
+                path.display(),
+            ),
+        ));
+    }
+
+    let mut reader = BufReader::with_capacity(8 << 20, file);
+    let mut buf = [0u8; PSV_SIZE];
+    let mut count = 0u64;
+    loop {
+        match reader.read_exact(&mut buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+        let sfen: [u8; SFEN_SIZE] = buf[..SFEN_SIZE].try_into().unwrap();
+        on_record(&buf, &sfen)?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Phase 2: 各パーティションを HashSet で exact dedup し、出力に追記する。
+///
+/// `ref_subdir` が `Some` ならパーティション先頭で reference を HashSet に
+/// ロードし（出力はしない）、続けて input パーティションを照合する。
+///
+/// 戻り値は `(reference_records, input_records_seen, unique_output_records)`。
+fn deduplicate_partitions(
+    input_subdir: &Path,
+    ref_subdir: Option<&Path>,
+    num_partitions: usize,
+    output_path: &Path,
+    keep_temp: bool,
+) -> io::Result<(u64, u64, u64)> {
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+        && !parent.is_dir()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let out_file = File::create(output_path)?;
+    let mut writer = BufWriter::with_capacity(16 << 20, out_file);
+
+    let mut total_ref = 0u64;
+    let mut total_seen = 0u64;
+    let mut total_unique = 0u64;
+    let start = std::time::Instant::now();
+
+    for partition in 0..num_partitions {
+        let mut seen: HashSet<[u8; SFEN_SIZE]> = HashSet::new();
+
+        // --- Phase 2a: reference partition を HashSet にロード（出力しない） ---
+        if let Some(ref_dir) = ref_subdir {
+            let ref_path = ref_dir.join(partition_filename(partition));
+            if ref_path.exists() {
+                let ref_records = read_partition_records(&ref_path, |_rec, sfen| {
+                    seen.insert(*sfen);
+                    Ok(())
+                })?;
+                total_ref += ref_records;
+                if !keep_temp {
+                    let _ = std::fs::remove_file(&ref_path);
+                }
+            }
+        }
+
+        // --- Phase 2b: input partition を streaming し、未登録なら出力 ---
+        let input_path = input_subdir.join(partition_filename(partition));
+        if !input_path.exists() {
+            continue;
+        }
+
+        let mut unique_in_partition = 0u64;
+        let input_records = read_partition_records(&input_path, |rec, sfen| {
+            if seen.insert(*sfen) {
+                writer.write_all(rec)?;
+                unique_in_partition += 1;
+            }
+            Ok(())
+        })?;
+
+        total_seen += input_records;
+        total_unique += unique_in_partition;
+
+        drop(seen);
+        if !keep_temp {
+            let _ = std::fs::remove_file(&input_path);
+        }
+
+        if partition.is_multiple_of(64) || partition + 1 == num_partitions {
+            let elapsed = start.elapsed().as_secs_f64();
+            eprintln!(
+                "  partition {}/{}  ref={:.1}M seen={:.1}M unique={:.1}M  {:.1}s",
+                partition + 1,
+                num_partitions,
+                total_ref as f64 / 1e6,
+                total_seen as f64 / 1e6,
+                total_unique as f64 / 1e6,
+                elapsed,
+            );
+        }
+    }
+
+    writer.flush()?;
+    let elapsed = start.elapsed().as_secs_f64();
+    eprintln!(
+        "Phase 2 done: {total_unique} unique / {total_seen} input records (ref loaded: {total_ref}), {elapsed:.1}s",
+    );
+
+    Ok((total_ref, total_seen, total_unique))
+}
+
+fn warn_fd_limit(num_partitions: usize) {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit は POSIX 標準で、rlimit 構造体への書き込みのみ行う。
+    // 失敗時は戻り値が -1 になるだけで副作用はない。
+    let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) };
+    if rc != 0 {
+        return;
+    }
+    let soft = limit.rlim_cur as usize;
+    // Phase 1 で同時に開く fd ≈ num_partitions + 入力 1 + stderr/stdout など余裕 16
+    let required = num_partitions + 32;
+    if soft < required {
+        eprintln!(
+            "Warning: RLIMIT_NOFILE soft limit = {soft}, but {required} fd needed for {num_partitions} partitions. \
+            `ulimit -n {required}` で引き上げてから再実行してください。",
+        );
+    }
+}
+
+/// temp_dir を掃除する（空ディレクトリなら削除）。
+fn cleanup_if_empty(dir: &Path) -> io::Result<()> {
+    if dir.is_dir() && std::fs::read_dir(dir)?.next().is_none() {
+        std::fs::remove_dir(dir)?;
+    }
+    Ok(())
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    if args.partitions == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--partitions は 1 以上を指定してください",
+        ));
+    }
+    if args.partition_buffer_kb == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--partition-buffer-kb は 1 以上を指定してください",
+        ));
+    }
+
+    warn_fd_limit(args.partitions);
+
+    let partition_buffer_bytes = args.partition_buffer_kb * 1024;
+    let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
+    let ref_subdir = args.temp_dir.join(REF_SUBDIR);
+
+    let (phase1_ref_records, phase1_input_records) = if args.phase2_only {
+        eprintln!("=== Phase 1 skipped (--phase2-only) ===");
+        if !args.temp_dir.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("一時ディレクトリが存在しません: {}", args.temp_dir.display()),
+            ));
+        }
+        if !input_subdir.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "入力パーティションが見つかりません: {} (Phase 1 を先に実行してください)",
+                    input_subdir.display(),
+                ),
+            ));
+        }
+        if ref_subdir.is_dir() {
+            eprintln!("  reference パーティション検出: {}", ref_subdir.display());
+        }
+
+        let existing_input_bytes = sum_existing_partition_bytes(&input_subdir)?;
+        let existing_ref_bytes = sum_existing_partition_bytes(&ref_subdir)?;
+        let estimate = estimate_resources(
+            existing_ref_bytes,
+            existing_input_bytes,
+            args.partitions,
+            partition_buffer_bytes,
+        );
+        preflight_check(
+            &estimate,
+            &args.temp_dir,
+            &args.output,
+            /* skip_temp_check = */ true,
+            args.force,
+        )?;
+
+        (0u64, 0u64)
+    } else {
+        let ref_paths = match args.reference.as_deref() {
+            Some(r) => parse_reference_paths(r)?,
+            None => Vec::new(),
+        };
+
+        let inputs =
+            collect_input_paths(args.input.as_deref(), args.input_dir.as_ref(), &args.pattern)?;
+        if inputs.is_empty() {
+            eprintln!("入力ファイルが見つかりません");
+            return Ok(());
+        }
+        check_output_not_in_inputs(&args.output, &inputs)?;
+        check_output_not_in_inputs(&args.output, &ref_paths)?;
+
+        let ref_size = sum_file_sizes(&ref_paths)?;
+        let input_size = sum_file_sizes(&inputs)?;
+        let capped_input_size = if args.max_positions > 0 {
+            input_size.min(args.max_positions.saturating_mul(PSV_SIZE as u64))
+        } else {
+            input_size
+        };
+        let estimate = estimate_resources(
+            ref_size,
+            capped_input_size,
+            args.partitions,
+            partition_buffer_bytes,
+        );
+        preflight_check(
+            &estimate,
+            &args.temp_dir,
+            &args.output,
+            /* skip_temp_check = */ false,
+            args.force,
+        )?;
+
+        eprintln!("=== Phase 1: Partitioning ({} partitions) ===", args.partitions);
+        eprintln!(
+            "  partition buffer: {} KiB/partition (total ~{:.1} MiB)",
+            args.partition_buffer_kb,
+            (args.partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
+        );
+
+        let ref_records = if ref_paths.is_empty() {
+            // 過去の reference 残骸が残っていたら掃除しておく
+            if ref_subdir.is_dir() {
+                std::fs::remove_dir_all(&ref_subdir)?;
+            }
+            0
+        } else {
+            partition_files_into(
+                "reference",
+                &ref_paths,
+                &ref_subdir,
+                args.partitions,
+                partition_buffer_bytes,
+                0, // reference は常に全件
+            )?
+        };
+
+        let input_records = partition_files_into(
+            "input",
+            &inputs,
+            &input_subdir,
+            args.partitions,
+            partition_buffer_bytes,
+            args.max_positions,
+        )?;
+
+        (ref_records, input_records)
+    };
+
+    let ref_dir_opt = if ref_subdir.is_dir() {
+        Some(ref_subdir.as_path())
+    } else {
+        None
+    };
+
+    eprintln!(
+        "\n=== Phase 2: Deduplication{} ===",
+        if ref_dir_opt.is_some() {
+            " (with reference)"
+        } else {
+            ""
+        }
+    );
+    let (ref_seen, input_seen, unique) = deduplicate_partitions(
+        &input_subdir,
+        ref_dir_opt,
+        args.partitions,
+        &args.output,
+        args.keep_temp,
+    )?;
+
+    if !args.keep_temp {
+        cleanup_if_empty(&input_subdir)?;
+        if ref_dir_opt.is_some() {
+            cleanup_if_empty(&ref_subdir)?;
+        }
+        cleanup_if_empty(&args.temp_dir)?;
+    }
+
+    let duplicates = input_seen.saturating_sub(unique);
+    let dup_pct = if input_seen > 0 {
+        100.0 * duplicates as f64 / input_seen as f64
+    } else {
+        0.0
+    };
+    println!("=== Partition Dedup Summary ===");
+    if !args.phase2_only {
+        if phase1_ref_records > 0 {
+            println!("Reference records: {phase1_ref_records}");
+        }
+        println!("Input records:     {phase1_input_records}");
+    }
+    if ref_seen > 0 {
+        println!("Reference seen:    {ref_seen} (Phase 2 でロード)");
+    }
+    println!("Input seen:        {input_seen} (Phase 2 入力)");
+    println!(
+        "Output records:    {unique} ({:.2}%)",
+        100.0 * unique as f64 / input_seen.max(1) as f64,
+    );
+    println!("Duplicates:        {duplicates} ({dup_pct:.2}%)");
+    println!("Output file:       {}", args.output.display());
+
+    Ok(())
+}

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -178,6 +178,26 @@ fn same_fs_output_headroom_bytes(estimate: &ResourceEstimate, keep_temp: bool) -
     }
 }
 
+fn output_disk_required_bytes(
+    estimate: &ResourceEstimate,
+    same_fs: bool,
+    skip_temp_check: bool,
+    keep_temp: bool,
+) -> u64 {
+    if same_fs {
+        let same_fs_headroom =
+            (same_fs_output_headroom_bytes(estimate, keep_temp) as f64 * DISK_SAFETY_FACTOR) as u64;
+        if skip_temp_check {
+            same_fs_headroom
+        } else {
+            ((estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64)
+                .saturating_add(same_fs_headroom)
+        }
+    } else {
+        (estimate.output_upper_bound_bytes as f64 * DISK_SAFETY_FACTOR) as u64
+    }
+}
+
 /// 不足チェック結果を INFO 出力し、不足時は Err（`force` なら Warning）。
 fn preflight_check(
     estimate: &ResourceEstimate,
@@ -272,11 +292,7 @@ fn preflight_check(
     }
 
     // 出力ディスクチェック（temp と同一 fs の場合は Phase 2 の一時的な headroom を見る）
-    let same_fs = if skip_temp_check {
-        Some(false)
-    } else {
-        same_filesystem(temp_dir, output_parent)
-    };
+    let same_fs = same_filesystem(temp_dir, output_parent);
     // 出力上限は input 側のみ（reference は出力対象外なので除外する）
     let output_required = (estimate.output_upper_bound_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
     if let Some(avail) = get_disk_available(output_parent) {
@@ -294,12 +310,8 @@ fn preflight_check(
                     "（処理中の最大 input partition 想定）"
                 }
             );
-            let same_fs_required = if skip_temp_check {
-                same_fs_headroom
-            } else {
-                ((estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64)
-                    .saturating_add(same_fs_headroom)
-            };
+            let same_fs_required =
+                output_disk_required_bytes(estimate, true, skip_temp_check, keep_temp);
             if same_fs_required > avail {
                 let msg = if skip_temp_check {
                     format!(
@@ -948,6 +960,14 @@ mod tests {
         let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
 
         assert_eq!(same_fs_output_headroom_bytes(&estimate, true), 4_000);
+    }
+
+    #[test]
+    fn phase2_only_same_fs_uses_headroom_not_full_output() {
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+
+        assert_eq!(output_disk_required_bytes(&estimate, true, true, false), 1_260);
+        assert_eq!(output_disk_required_bytes(&estimate, false, true, false), 4_200);
     }
 
     #[test]

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -149,7 +149,7 @@ pub fn get_disk_available(path: &Path) -> Option<u64> {
     if rc != 0 {
         return None;
     }
-    Some(stat.f_bavail as u64 * stat.f_frsize as u64)
+    Some(stat.f_bavail * stat.f_frsize)
 }
 
 /// バイト値を `%.1f GiB` 形式で整形する。

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -3,7 +3,9 @@
 use crate::common::sfen::normalize_4t;
 use crate::common::sfen_ops::canonicalize_4t_with_mirror;
 use std::collections::HashSet;
+use std::ffi::CString;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 /// PackedSfenValue のレコードサイズ（バイト）
@@ -106,6 +108,72 @@ pub fn check_output_not_in_inputs(output: &Path, inputs: &[PathBuf]) -> io::Resu
         }
     }
     Ok(())
+}
+
+/// 入力ファイル群のサイズ合計（バイト）を返す。
+pub fn sum_file_sizes(paths: &[PathBuf]) -> io::Result<u64> {
+    let mut total = 0u64;
+    for p in paths {
+        total += std::fs::metadata(p)?.len();
+    }
+    Ok(total)
+}
+
+/// /proc/meminfo から MemAvailable をバイト単位で取得する。
+/// 取得できない環境では None を返す。
+pub fn get_mem_available() -> Option<u64> {
+    let content = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            let kb_str = rest.trim().strip_suffix("kB")?.trim();
+            let kb: u64 = kb_str.parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+/// `statvfs(2)` で指定パスが存在するファイルシステムの空き容量（バイト）を取得する。
+/// 取得できない場合は None。
+pub fn get_disk_available(path: &Path) -> Option<u64> {
+    let probe: &Path = if path.exists() {
+        path
+    } else {
+        path.parent().unwrap_or(Path::new("."))
+    };
+    let c = CString::new(probe.as_os_str().as_bytes()).ok()?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    // SAFETY: statvfs は POSIX 標準で、c は有効な C 文字列ポインタ、stat は書き込み可能な
+    // 構造体を指す。失敗時は -1 を返すだけで副作用はない。
+    let rc = unsafe { libc::statvfs(c.as_ptr(), &mut stat) };
+    if rc != 0 {
+        return None;
+    }
+    Some(stat.f_bavail as u64 * stat.f_frsize as u64)
+}
+
+/// バイト値を `%.1f GiB` 形式で整形する。
+pub fn format_gib(bytes: u64) -> String {
+    format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
+}
+
+/// 2 つのパスが同一ファイルシステム上にあるかを判定する。
+/// 取得できない場合は None。
+pub fn same_filesystem(a: &Path, b: &Path) -> Option<bool> {
+    use std::os::unix::fs::MetadataExt;
+    let probe_a: &Path = if a.exists() {
+        a
+    } else {
+        a.parent().unwrap_or(Path::new("."))
+    };
+    let probe_b: &Path = if b.exists() {
+        b
+    } else {
+        b.parent().unwrap_or(Path::new("."))
+    };
+    let ma = std::fs::metadata(probe_a).ok()?;
+    let mb = std::fs::metadata(probe_b).ok()?;
+    Some(ma.dev() == mb.dev())
 }
 
 /// In-memory de-duplicator keyed by 4-token SFEN or mirror-canonicalized 4-token SFEN.


### PR DESCRIPTION
## Summary

- 数百億規模の PSV を**完全一致 (exact)** で dedup する低メモリ向けツール `psv_dedup_partition` を追加。入力を PackedSfen のハッシュで N 個の一時パーティションに振り分け、Phase 2 でパーティション単位に `HashSet<[u8;32]>` へロードして first-wins で dedup する 2 パス構造
- 既存 `psv_dedup` (全件 HashSet、中規模) / `psv_dedup_bloom` (近似、1 パス・メモリ潤沢) と責務を分けた 3 つ目のオプション
- 起動時にメモリ/ディスク要件を見積もり、不足時は Err で停止 (`--force` で bypass)
- `--reference`: 既存 dedup 済みファイルとの**差分だけ**を抽出するモード
- `--keep-temp` + `--phase2-only`: Phase 1/2 を別日に分けて再開可

## 使い分け (docs/pack_tools.md の新セクション)

| ツール | 方式 | 正確性 | メモリ | 一時ディスク | I/O パス |
|---|---|---|---|---|---|
| `psv_dedup` | 全件 `HashSet<u64>` | ほぼ exact (64bit hash 衝突のみ) | ユニーク局面数 × ~16 B | 不要 | 1 |
| `psv_dedup_bloom` | Blocked Bloom Filter | 近似 (`--fpr` で制御) | 固定 (規模と fpr 次第) | 不要 | 1 |
| `psv_dedup_partition` | ディスクパーティション + `HashSet<[u8;32]>` | **完全 exact** | 最大パーティションぶん | 入力と同等 | 2 |

## 設計メモ

- キーは PackedSfen 32 B のみ (既存 `psv_dedup` と semantics 統一)
- パーティション振り分けに `hash_packed_sfen` (FNV-1a 64bit) を再利用
- Phase 2 peak memory = `(total_records / partitions) × 56 B × 1.2 variance`。`--partitions` を大きくするほど 1 パーティションが軽くなる (fd / 出力バッファとのトレードオフ)
- temp は Phase 2 の partition 処理ごとに削除、完走時に空ディレクトリごと削除 (`--keep-temp` 指定時のみ保持)
- `unsafe` は `getrlimit` と `statvfs` の libc 呼び出しのみ (SAFETY コメント付き)

## `--phase2-parallel` を実装しなかった理由

Phase 2 を N 並列化するとメモリが N 倍になり「低メモリで exact」という本ツールの存在意義と正面衝突。メモリ潤沢な環境は `psv_dedup_bloom` が 1 パスで速い。I/O 律速の可能性も考えると効果は限定的なため、実測で不足が見えてから再検討。

## Test plan

- [x] `cargo clippy -p tools --bin psv_dedup_partition --tests` 警告ゼロ
- [x] `cargo build --release -p tools --bin psv_dedup_partition` 成功
- [x] Smoke: 100 records (10 unique × 10 dup) → exact 10 件出力
- [x] `--keep-temp` + `--phase2-only` (reference モード auto-detect) でバイト一致の再生成を確認
- [x] `--reference` モード: ref 10 sfen + input 15 sfen (5 overlap) → 新規 10 sfen のみ出力
- [x] メモリ不足シナリオで Err、`--force` で bypass
- [x] temp cleanup (完走時は一時ディレクトリごと削除) を確認
- [ ] 本番規模 (150B + 20B records) での実測: パーティション数 / fd / disk の実挙動は別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)