### PR TITLE
add PSV split and merge tools

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -18,6 +18,8 @@
 | ツール | 説明 |
 |--------|------|
 | `shuffle_psv` | PSV ファイルのシャッフル |
+| `split_psv` | PSV ファイルを局面数または容量で分割 |
+| `merge_psv` | 複数の PSV ファイルを順序どおり結合 |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |

--- a/crates/tools/docs/pack_tools.md
+++ b/crates/tools/docs/pack_tools.md
@@ -33,6 +33,59 @@ cargo run -p tools --release --bin shuffle_psv -- \
 | `--seed` | 乱数シード（再現性） | ランダム |
 | `--chunk-size` | チャンクサイズ（大規模ファイル用） | 0（全読み込み） |
 
+### split_psv
+
+PSV ファイルを複数ファイルへ分割。1 ファイルあたりの局面数または容量を指定できる。
+入出力はストリーミングで行うため、大きなファイルでも少しずつ書き出せる。
+
+```bash
+# 1 ファイル 1 億局面で分割
+cargo run -p tools --release --bin split_psv -- \
+  --input data.psv --output-prefix split/train \
+  --records-per-file 100000000
+
+# 1 ファイル 4GB 目安で分割
+cargo run -p tools --release --bin split_psv -- \
+  --input data.psv --output-prefix split/train \
+  --bytes-per-file 4GB
+```
+
+| オプション | 説明 | デフォルト |
+|------------|------|------------|
+| `-i, --input` | 入力ファイル | 必須 |
+| `--output-prefix` | 出力プレフィックス（`prefix_000.bin` 形式） | 必須 |
+| `--records-per-file` | 1 ファイルあたりの局面数 | - |
+| `--bytes-per-file` | 1 ファイルあたりの容量（`4GB`, `3500MiB` など） | - |
+| `--write-chunk-records` | 1 回の読み書きで扱う局面数 | `1000000` |
+| `--start-index` | 出力ファイル番号の開始値 | `0` |
+| `--digits` | 出力ファイル番号の最小桁数 | `3` |
+| `--suffix` | 出力ファイル拡張子 | `.bin` |
+
+### merge_psv
+
+複数の PSV ファイルを入力順どおりに 1 ファイルへ結合。
+`--input-dir` 使用時はファイル名の昇順で処理する。
+
+```bash
+# 明示した順序で結合
+cargo run -p tools --release --bin merge_psv -- \
+  --input split/train_000.bin,split/train_001.bin,split/train_002.bin \
+  --output merged.psv
+
+# ディレクトリから結合
+cargo run -p tools --release --bin merge_psv -- \
+  --input-dir split --pattern "train_*.bin" \
+  --output merged.psv
+```
+
+| オプション | 説明 | デフォルト |
+|------------|------|------------|
+| `--input` | 入力ファイル（カンマ区切り） | - |
+| `--input-dir` | 入力ディレクトリ（`--input` と排他） | - |
+| `--pattern` | `--input-dir` 使用時の glob パターン | `*.bin` |
+| `-o, --output` | 出力ファイル | 必須 |
+| `--write-chunk-records` | 1 回の読み書きで扱う局面数 | `1000000` |
+
 ### rescore_psv
 
 局面に探索スコアを付与。既存データの再評価に使用。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # rshogi tools リファレンス
 
-crates/tools/src/bin/ 配下の全31バイナリの一覧と解説。
+crates/tools/src/bin/ 配下の全33バイナリの一覧と解説。
 
 ## 対局・トーナメント
 
@@ -35,6 +35,8 @@ crates/tools/src/bin/ 配下の全31バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `shuffle_psv` | PSV ファイル内のレコード（40バイト単位）をシャッフル |
+| `split_psv` | PSV ファイルを局面数または容量で複数ファイルへ分割 |
+| `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
 | `rescore_psv` | PSV ファイルの評価値を NNUE または外部エンジンで再計算 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -1,6 +1,6 @@
 # rshogi tools リファレンス
 
-crates/tools/src/bin/ 配下の全33バイナリの一覧と解説。
+crates/tools/src/bin/ 配下の全31バイナリの一覧と解説。
 
 ## 対局・トーナメント
 

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -38,6 +38,8 @@ use tools::common::dedup::{PSV_SIZE, check_output_not_in_inputs, collect_input_p
 
 const IO_BUF_SIZE: usize = 8 * 1024 * 1024;
 const DEFAULT_WRITE_CHUNK_RECORDS: usize = 1_000_000;
+const MAX_WRITE_CHUNK_BYTES: usize = 512 * 1024 * 1024;
+const MAX_WRITE_CHUNK_RECORDS: usize = MAX_WRITE_CHUNK_BYTES / PSV_SIZE;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -115,6 +117,7 @@ fn merge_files(inputs: &[PathBuf], output_path: &Path, config: &MergeConfig) -> 
     if config.write_chunk_records == 0 {
         bail!("--write-chunk-records は 1 以上を指定してください");
     }
+    validate_write_chunk_records(config.write_chunk_records)?;
 
     ensure_parent_dir(output_path)?;
 
@@ -198,6 +201,18 @@ fn ensure_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn validate_write_chunk_records(write_chunk_records: usize) -> Result<()> {
+    if write_chunk_records > MAX_WRITE_CHUNK_RECORDS {
+        bail!(
+            "--write-chunk-records={} は大きすぎます。最大値は {} records ({} bytes) です",
+            write_chunk_records,
+            MAX_WRITE_CHUNK_RECORDS,
+            MAX_WRITE_CHUNK_BYTES,
+        );
+    }
+    Ok(())
+}
+
 fn progress_style(label: &str) -> ProgressStyle {
     ProgressStyle::default_bar()
         .template(&format!(
@@ -258,5 +273,10 @@ mod tests {
         expected.extend_from_slice(&chunk0);
         expected.extend_from_slice(&chunk1);
         assert_eq!(merged, expected);
+    }
+
+    #[test]
+    fn validate_write_chunk_records_rejects_huge_value() {
+        assert!(validate_write_chunk_records(MAX_WRITE_CHUNK_RECORDS + 1).is_err());
     }
 }

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -12,10 +12,17 @@
 //!   --input data_000.bin,data_001.bin,data_002.bin \
 //!   --output merged.psv
 //!
-//! # ディレクトリから glob で拾って名前順に結合
+//! # ディレクトリ直下から glob で拾って shard 番号順に結合
 //! cargo run -p tools --release --bin merge_psv -- \
 //!   --input-dir split \
 //!   --pattern "train_*.bin" \
+//!   --output merged.psv
+//!
+//! # 入れ子ディレクトリも明示的に含める
+//! cargo run -p tools --release --bin merge_psv -- \
+//!   --input-dir split \
+//!   --pattern "train_*.bin" \
+//!   --recursive \
 //!   --output merged.psv
 //!
 //! # 20 万局面ずつ読み書きしてメモリ使用量を抑える
@@ -34,7 +41,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
-use tools::common::dedup::{PSV_SIZE, check_output_not_in_inputs, collect_input_paths};
+use tools::common::dedup::{PSV_SIZE, check_output_not_in_inputs};
 
 const IO_BUF_SIZE: usize = 8 * 1024 * 1024;
 const DEFAULT_WRITE_CHUNK_RECORDS: usize = 1_000_000;
@@ -63,6 +70,10 @@ struct Cli {
     #[arg(long, default_value = "*.bin")]
     pattern: String,
 
+    /// --input-dir 配下を再帰的に探索する
+    #[arg(long, default_value_t = false)]
+    recursive: bool,
+
     /// 出力 PSV ファイル
     #[arg(short, long)]
     output: PathBuf,
@@ -87,8 +98,7 @@ fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
 
-    let inputs = collect_input_paths(cli.input.as_deref(), cli.input_dir.as_ref(), &cli.pattern)
-        .context("入力ファイル一覧の収集に失敗しました")?;
+    let inputs = resolve_input_paths(&cli).context("入力ファイル一覧の収集に失敗しました")?;
     if inputs.is_empty() {
         bail!("入力ファイルが 0 件です");
     }
@@ -108,6 +118,115 @@ fn main() -> Result<()> {
     info!("出力: {}", cli.output.display());
 
     Ok(())
+}
+
+fn resolve_input_paths(cli: &Cli) -> Result<Vec<PathBuf>> {
+    match (&cli.input, &cli.input_dir) {
+        (Some(_), Some(_)) => bail!("--input と --input-dir は同時に指定できません"),
+        (None, None) => bail!("--input または --input-dir のいずれかを指定してください"),
+        (Some(input), None) => parse_explicit_input_paths(input),
+        (None, Some(input_dir)) => {
+            collect_merge_input_paths(input_dir, &cli.pattern, cli.recursive)
+        }
+    }
+}
+
+fn parse_explicit_input_paths(input: &str) -> Result<Vec<PathBuf>> {
+    let paths: Vec<PathBuf> = input.split(',').map(|part| PathBuf::from(part.trim())).collect();
+    for path in &paths {
+        if !path.exists() {
+            bail!("入力ファイルが存在しません: {}", path.display());
+        }
+    }
+    Ok(paths)
+}
+
+fn collect_merge_input_paths(dir: &Path, pattern: &str, recursive: bool) -> Result<Vec<PathBuf>> {
+    if !dir.is_dir() {
+        bail!("入力ディレクトリが存在しません: {}", dir.display());
+    }
+
+    let pattern = glob::Pattern::new(pattern)
+        .with_context(|| format!("無効な glob パターンです: {pattern}"))?;
+    let mut paths = if recursive {
+        walkdir::WalkDir::new(dir)
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| entry.into_path())
+            .collect::<Vec<_>>()
+    } else {
+        std::fs::read_dir(dir)
+            .with_context(|| format!("入力ディレクトリを読み取れませんでした: {}", dir.display()))?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                entry
+                    .file_type()
+                    .ok()
+                    .filter(|file_type| file_type.is_file())
+                    .map(|_| entry.path())
+            })
+            .collect::<Vec<_>>()
+    };
+
+    paths.retain(|path| {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| pattern.matches(name))
+    });
+    paths.sort_by(compare_merge_input_paths);
+
+    Ok(paths)
+}
+
+fn compare_merge_input_paths(a: &PathBuf, b: &PathBuf) -> std::cmp::Ordering {
+    match (a.parent(), b.parent()) {
+        (Some(a_parent), Some(b_parent)) if a_parent == b_parent => {
+            compare_file_names_with_numeric_suffix(a, b).then_with(|| a.cmp(b))
+        }
+        _ => a.cmp(b),
+    }
+}
+
+fn compare_file_names_with_numeric_suffix(a: &Path, b: &Path) -> std::cmp::Ordering {
+    let Some(a_key) = trailing_numeric_suffix_key(a) else {
+        return a.file_name().cmp(&b.file_name());
+    };
+    let Some(b_key) = trailing_numeric_suffix_key(b) else {
+        return a.file_name().cmp(&b.file_name());
+    };
+
+    if a_key.prefix == b_key.prefix && a_key.extension == b_key.extension {
+        a_key.number.cmp(&b_key.number).then_with(|| a.file_name().cmp(&b.file_name()))
+    } else {
+        a.file_name().cmp(&b.file_name())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NumericSuffixKey {
+    prefix: String,
+    number: u64,
+    extension: String,
+}
+
+fn trailing_numeric_suffix_key(path: &Path) -> Option<NumericSuffixKey> {
+    let stem = path.file_stem()?.to_str()?;
+    let digit_start = stem
+        .char_indices()
+        .rev()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .last()
+        .map(|(index, _)| index)?;
+    let digits = &stem[digit_start..];
+    let prefix = &stem[..digit_start];
+    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or_default().to_string();
+
+    Some(NumericSuffixKey {
+        prefix: prefix.to_string(),
+        number: digits.parse().ok()?,
+        extension,
+    })
 }
 
 fn merge_files(inputs: &[PathBuf], output_path: &Path, config: &MergeConfig) -> Result<MergeStats> {
@@ -278,5 +397,68 @@ mod tests {
     #[test]
     fn validate_write_chunk_records_rejects_huge_value() {
         assert!(validate_write_chunk_records(MAX_WRITE_CHUNK_RECORDS + 1).is_err());
+    }
+
+    #[test]
+    fn collect_merge_input_paths_sorts_numeric_suffix() {
+        let dir = tempdir().unwrap();
+        for name in [
+            "train_099.bin",
+            "train_100.bin",
+            "train_1000.bin",
+            "train_101.bin",
+        ] {
+            fs::write(dir.path().join(name), []).unwrap();
+        }
+
+        let paths = collect_merge_input_paths(dir.path(), "train_*.bin", false).unwrap();
+        let names: Vec<_> = paths
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "train_099.bin",
+                "train_100.bin",
+                "train_101.bin",
+                "train_1000.bin"
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_merge_input_paths_ignores_nested_dirs_by_default() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("train_000.bin"), []).unwrap();
+        let nested = dir.path().join("archive");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("train_001.bin"), []).unwrap();
+
+        let paths = collect_merge_input_paths(dir.path(), "train_*.bin", false).unwrap();
+        let names: Vec<_> = paths
+            .iter()
+            .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(names, vec!["train_000.bin"]);
+    }
+
+    #[test]
+    fn collect_merge_input_paths_includes_nested_dirs_when_recursive() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("train_000.bin"), []).unwrap();
+        let nested = dir.path().join("archive");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("train_001.bin"), []).unwrap();
+
+        let paths = collect_merge_input_paths(dir.path(), "train_*.bin", true).unwrap();
+        let names: Vec<_> = paths
+            .iter()
+            .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(names, vec!["archive/train_001.bin", "train_000.bin"]);
     }
 }

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -134,9 +134,7 @@ fn resolve_input_paths(cli: &Cli) -> Result<Vec<PathBuf>> {
 fn parse_explicit_input_paths(input: &str) -> Result<Vec<PathBuf>> {
     let paths: Vec<PathBuf> = input.split(',').map(|part| PathBuf::from(part.trim())).collect();
     for path in &paths {
-        if !path.exists() {
-            bail!("入力ファイルが存在しません: {}", path.display());
-        }
+        ensure_input_is_file(path)?;
     }
     Ok(paths)
 }
@@ -162,17 +160,14 @@ fn collect_merge_input_paths(dir: &Path, pattern: &str, recursive: bool) -> Resu
             .map(|entry| entry.into_path())
             .collect()
     } else {
-        std::fs::read_dir(dir)
+        let entries = std::fs::read_dir(dir)
             .with_context(|| format!("入力ディレクトリを読み取れませんでした: {}", dir.display()))?
-            .filter_map(|entry| entry.ok())
-            .filter_map(|entry| {
-                entry
-                    .file_type()
-                    .ok()
-                    .filter(|file_type| file_type.is_file())
-                    .map(|_| entry.path())
-            })
-            .collect::<Vec<_>>()
+            .collect::<std::io::Result<Vec<_>>>()
+            .with_context(|| format!("入力ディレクトリ走査中に失敗しました: {}", dir.display()))?;
+        collect_regular_file_paths(
+            entries.into_iter().map(|entry| entry.path()).collect(),
+            Some(dir),
+        )?
     };
 
     paths.retain(|path| {
@@ -183,6 +178,39 @@ fn collect_merge_input_paths(dir: &Path, pattern: &str, recursive: bool) -> Resu
     paths.sort_by(compare_merge_input_paths);
 
     Ok(paths)
+}
+
+fn collect_regular_file_paths(
+    paths: Vec<PathBuf>,
+    source_dir: Option<&Path>,
+) -> Result<Vec<PathBuf>> {
+    let mut regular_files = Vec::with_capacity(paths.len());
+    for path in paths {
+        let file_type = std::fs::metadata(&path)
+            .with_context(|| match source_dir {
+                Some(dir) => format!(
+                    "入力ディレクトリ内エントリの種別判定に失敗しました: {} (dir: {})",
+                    path.display(),
+                    dir.display()
+                ),
+                None => format!("入力ファイルの種別判定に失敗しました: {}", path.display()),
+            })?
+            .file_type();
+        if file_type.is_file() {
+            regular_files.push(path);
+        }
+    }
+    Ok(regular_files)
+}
+
+fn ensure_input_is_file(path: &Path) -> Result<()> {
+    if !path.exists() {
+        bail!("入力ファイルが存在しません: {}", path.display());
+    }
+    if !path.is_file() {
+        bail!("入力パスはファイルである必要があります: {}", path.display());
+    }
+    Ok(())
 }
 
 fn compare_merge_input_paths(a: &PathBuf, b: &PathBuf) -> std::cmp::Ordering {
@@ -493,5 +521,26 @@ mod tests {
         fs::set_permissions(&locked, restore_permissions).unwrap();
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_explicit_input_paths_rejects_directory() {
+        let dir = tempdir().unwrap();
+
+        let err = parse_explicit_input_paths(&dir.path().display().to_string()).unwrap_err();
+
+        assert!(err.to_string().contains("入力パスはファイルである必要があります"));
+    }
+
+    #[test]
+    fn collect_regular_file_paths_propagates_metadata_errors() {
+        let dir = tempdir().unwrap();
+        let gone = dir.path().join("train_000.bin");
+        fs::write(&gone, []).unwrap();
+        fs::remove_file(&gone).unwrap();
+
+        let err = collect_regular_file_paths(vec![gone], Some(dir.path())).unwrap_err();
+
+        assert!(err.to_string().contains("入力ディレクトリ内エントリの種別判定に失敗しました"));
     }
 }

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -1,0 +1,262 @@
+//! merge_psv - 複数の PSV ファイルを順序どおり結合
+//!
+//! PackedSfenValue 形式（40 バイト/レコード）の複数ファイルを順に連結して
+//! 1 つの出力ファイルへまとめる。入力全体をメモリへ載せず、
+//! ストリーミングで少しずつ書き出す。
+//!
+//! # 使用例
+//!
+//! ```bash
+//! # 明示した順序で結合
+//! cargo run -p tools --release --bin merge_psv -- \
+//!   --input data_000.bin,data_001.bin,data_002.bin \
+//!   --output merged.psv
+//!
+//! # ディレクトリから glob で拾って名前順に結合
+//! cargo run -p tools --release --bin merge_psv -- \
+//!   --input-dir split \
+//!   --pattern "train_*.bin" \
+//!   --output merged.psv
+//!
+//! # 20 万局面ずつ読み書きしてメモリ使用量を抑える
+//! cargo run -p tools --release --bin merge_psv -- \
+//!   --input-dir split \
+//!   --pattern "train_*.bin" \
+//!   --output merged.psv \
+//!   --write-chunk-records 200000
+//! ```
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use log::{info, warn};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use tools::common::dedup::{PSV_SIZE, check_output_not_in_inputs, collect_input_paths};
+
+const IO_BUF_SIZE: usize = 8 * 1024 * 1024;
+const DEFAULT_WRITE_CHUNK_RECORDS: usize = 1_000_000;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "merge_psv",
+    version,
+    about = "複数の PSV ファイルを順序どおり結合",
+    long_about = "PackedSfenValue 形式（40 バイト/レコード）の複数ファイルを、\
+入力順のまま 1 つの出力ファイルへ結合します。\
+入出力はストリーミングで行うため、大きなファイルでも少しずつ書き出せます。"
+)]
+struct Cli {
+    /// 入力 PSV ファイル（カンマ区切りで複数指定可）
+    #[arg(long, conflicts_with = "input_dir")]
+    input: Option<String>,
+
+    /// 入力ディレクトリ（--input と排他）
+    #[arg(long, conflicts_with = "input")]
+    input_dir: Option<PathBuf>,
+
+    /// --input-dir 使用時の glob パターン
+    #[arg(long, default_value = "*.bin")]
+    pattern: String,
+
+    /// 出力 PSV ファイル
+    #[arg(short, long)]
+    output: PathBuf,
+
+    /// 1 回の読み書きで扱う局面数
+    #[arg(long, default_value_t = DEFAULT_WRITE_CHUNK_RECORDS)]
+    write_chunk_records: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MergeConfig {
+    write_chunk_records: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MergeStats {
+    input_count: usize,
+    total_records: u64,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    let inputs = collect_input_paths(cli.input.as_deref(), cli.input_dir.as_ref(), &cli.pattern)
+        .context("入力ファイル一覧の収集に失敗しました")?;
+    if inputs.is_empty() {
+        bail!("入力ファイルが 0 件です");
+    }
+    check_output_not_in_inputs(&cli.output, &inputs)
+        .context("出力パスが入力に含まれていないかの検証に失敗しました")?;
+
+    let stats = merge_files(
+        &inputs,
+        &cli.output,
+        &MergeConfig {
+            write_chunk_records: cli.write_chunk_records,
+        },
+    )?;
+
+    info!("入力ファイル数: {}", stats.input_count);
+    info!("結合局面数: {}", stats.total_records);
+    info!("出力: {}", cli.output.display());
+
+    Ok(())
+}
+
+fn merge_files(inputs: &[PathBuf], output_path: &Path, config: &MergeConfig) -> Result<MergeStats> {
+    if inputs.is_empty() {
+        bail!("入力ファイルが 0 件です");
+    }
+    if config.write_chunk_records == 0 {
+        bail!("--write-chunk-records は 1 以上を指定してください");
+    }
+
+    ensure_parent_dir(output_path)?;
+
+    let mut total_records = 0u64;
+    for input in inputs {
+        let size = std::fs::metadata(input)
+            .with_context(|| format!("入力ファイル情報の取得に失敗しました: {}", input.display()))?
+            .len();
+        let records = size / PSV_SIZE as u64;
+        let trailing = size % PSV_SIZE as u64;
+        if trailing != 0 {
+            warn!(
+                "{} の末尾 {} バイトは完全なレコードではないため無視します",
+                input.display(),
+                trailing
+            );
+        }
+        total_records += records;
+    }
+
+    let out_file = File::create(output_path).with_context(|| {
+        format!("出力ファイルを作成できませんでした: {}", output_path.display())
+    })?;
+    let mut writer = BufWriter::with_capacity(IO_BUF_SIZE, out_file);
+    let buffer_len = config
+        .write_chunk_records
+        .checked_mul(PSV_SIZE)
+        .context("書き出しチャンクが大きすぎます")?;
+    let mut buffer = vec![0u8; buffer_len];
+
+    let progress = ProgressBar::new(total_records);
+    progress.set_style(progress_style("Merging"));
+
+    let mut written_records = 0u64;
+    for input in inputs {
+        let size = std::fs::metadata(input)
+            .with_context(|| format!("入力ファイル情報の取得に失敗しました: {}", input.display()))?
+            .len();
+        let mut remaining = size / PSV_SIZE as u64;
+        info!("入力: {} ({} records)", input.display(), remaining);
+
+        let in_file = File::open(input)
+            .with_context(|| format!("入力ファイルを開けませんでした: {}", input.display()))?;
+        let mut reader = BufReader::with_capacity(IO_BUF_SIZE, in_file);
+
+        while remaining > 0 {
+            let to_read_records = remaining.min(config.write_chunk_records as u64) as usize;
+            let byte_len =
+                to_read_records.checked_mul(PSV_SIZE).context("読み込みサイズが大きすぎます")?;
+            reader.read_exact(&mut buffer[..byte_len]).with_context(|| {
+                format!("入力ファイル読み込み中に失敗しました: {}", input.display())
+            })?;
+            writer.write_all(&buffer[..byte_len]).with_context(|| {
+                format!("出力ファイル書き込み中に失敗しました: {}", output_path.display())
+            })?;
+            remaining -= to_read_records as u64;
+            written_records += to_read_records as u64;
+            progress.inc(to_read_records as u64);
+        }
+    }
+
+    writer
+        .flush()
+        .with_context(|| format!("出力ファイル flush に失敗しました: {}", output_path.display()))?;
+    progress.finish_and_clear();
+
+    Ok(MergeStats {
+        input_count: inputs.len(),
+        total_records: written_records,
+    })
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("親ディレクトリを作成できませんでした: {}", parent.display())
+        })?;
+    }
+    Ok(())
+}
+
+fn progress_style(label: &str) -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template(&format!(
+            "[{{elapsed_precise}}] {{bar:40.cyan/blue}} {{pos}}/{{len}} ({{per_sec}}) {label}"
+        ))
+        .expect("valid template")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_records(start: usize, count: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(count * PSV_SIZE);
+        for i in start..start + count {
+            let mut record = [0u8; PSV_SIZE];
+            record[0..8].copy_from_slice(&(i as u64).to_le_bytes());
+            record[32..34].copy_from_slice(&(i as i16).to_le_bytes());
+            record[36..38].copy_from_slice(&(i as u16).to_le_bytes());
+            bytes.extend_from_slice(&record);
+        }
+        bytes
+    }
+
+    #[test]
+    fn merge_files_keeps_input_order() {
+        let dir = tempdir().unwrap();
+        let input0 = dir.path().join("part_000.bin");
+        let input1 = dir.path().join("part_001.bin");
+        let output = dir.path().join("merged/out.psv");
+
+        let chunk0 = make_records(0, 5);
+        let chunk1 = make_records(5, 7);
+        fs::write(&input0, &chunk0).unwrap();
+        fs::write(&input1, &chunk1).unwrap();
+
+        let stats = merge_files(
+            &[input0.clone(), input1.clone()],
+            &output,
+            &MergeConfig {
+                write_chunk_records: 3,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            stats,
+            MergeStats {
+                input_count: 2,
+                total_records: 12
+            }
+        );
+
+        let merged = fs::read(output).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&chunk0);
+        expected.extend_from_slice(&chunk1);
+        assert_eq!(merged, expected);
+    }
+}

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -214,7 +214,10 @@ fn ensure_input_is_file(path: &Path) -> Result<()> {
 }
 
 fn compare_merge_input_paths(a: &PathBuf, b: &PathBuf) -> std::cmp::Ordering {
-    compare_file_names_with_numeric_suffix(a, b).then_with(|| a.cmp(b))
+    a.parent()
+        .cmp(&b.parent())
+        .then_with(|| compare_file_names_with_numeric_suffix(a, b))
+        .then_with(|| a.cmp(b))
 }
 
 fn compare_file_names_with_numeric_suffix(a: &Path, b: &Path) -> std::cmp::Ordering {
@@ -494,11 +497,40 @@ mod tests {
     }
 
     #[test]
-    fn compare_merge_input_paths_prefers_numeric_suffix_across_dirs() {
-        let a = PathBuf::from("archive/train_001.bin");
-        let b = PathBuf::from("train_000.bin");
+    fn compare_merge_input_paths_keeps_directory_groups_contiguous() {
+        let a = PathBuf::from("a/train_001.bin");
+        let b = PathBuf::from("b/train_000.bin");
 
-        assert_eq!(compare_merge_input_paths(&a, &b), std::cmp::Ordering::Greater);
+        assert_eq!(compare_merge_input_paths(&a, &b), std::cmp::Ordering::Less);
+    }
+
+    #[test]
+    fn collect_merge_input_paths_keeps_recursive_directory_batches_contiguous() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        fs::create_dir_all(&a).unwrap();
+        fs::create_dir_all(&b).unwrap();
+        fs::write(a.join("train_000.bin"), []).unwrap();
+        fs::write(a.join("train_001.bin"), []).unwrap();
+        fs::write(b.join("train_000.bin"), []).unwrap();
+        fs::write(b.join("train_001.bin"), []).unwrap();
+
+        let paths = collect_merge_input_paths(dir.path(), "train_*.bin", true).unwrap();
+        let names: Vec<_> = paths
+            .iter()
+            .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "a/train_000.bin",
+                "a/train_001.bin",
+                "b/train_000.bin",
+                "b/train_001.bin"
+            ]
+        );
     }
 
     #[cfg(unix)]

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -151,10 +151,16 @@ fn collect_merge_input_paths(dir: &Path, pattern: &str, recursive: bool) -> Resu
     let mut paths = if recursive {
         walkdir::WalkDir::new(dir)
             .into_iter()
-            .filter_map(|entry| entry.ok())
+            .map(|entry| {
+                entry.with_context(|| {
+                    format!("入力ディレクトリの再帰走査中に失敗しました: {}", dir.display())
+                })
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
             .filter(|entry| entry.file_type().is_file())
             .map(|entry| entry.into_path())
-            .collect::<Vec<_>>()
+            .collect()
     } else {
         std::fs::read_dir(dir)
             .with_context(|| format!("入力ディレクトリを読み取れませんでした: {}", dir.display()))?
@@ -180,12 +186,7 @@ fn collect_merge_input_paths(dir: &Path, pattern: &str, recursive: bool) -> Resu
 }
 
 fn compare_merge_input_paths(a: &PathBuf, b: &PathBuf) -> std::cmp::Ordering {
-    match (a.parent(), b.parent()) {
-        (Some(a_parent), Some(b_parent)) if a_parent == b_parent => {
-            compare_file_names_with_numeric_suffix(a, b).then_with(|| a.cmp(b))
-        }
-        _ => a.cmp(b),
-    }
+    compare_file_names_with_numeric_suffix(a, b).then_with(|| a.cmp(b))
 }
 
 fn compare_file_names_with_numeric_suffix(a: &Path, b: &Path) -> std::cmp::Ordering {
@@ -344,6 +345,8 @@ fn progress_style(label: &str) -> ProgressStyle {
 mod tests {
     use super::*;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
     fn make_records(start: usize, count: usize) -> Vec<u8> {
@@ -459,6 +462,36 @@ mod tests {
             .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
             .collect();
 
-        assert_eq!(names, vec!["archive/train_001.bin", "train_000.bin"]);
+        assert_eq!(names, vec!["train_000.bin", "archive/train_001.bin"]);
+    }
+
+    #[test]
+    fn compare_merge_input_paths_prefers_numeric_suffix_across_dirs() {
+        let a = PathBuf::from("archive/train_001.bin");
+        let b = PathBuf::from("train_000.bin");
+
+        assert_eq!(compare_merge_input_paths(&a, &b), std::cmp::Ordering::Greater);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_merge_input_paths_propagates_recursive_walk_errors() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("train_000.bin"), []).unwrap();
+        let locked = dir.path().join("locked");
+        fs::create_dir_all(&locked).unwrap();
+        fs::write(locked.join("train_001.bin"), []).unwrap();
+
+        let mut permissions = fs::metadata(&locked).unwrap().permissions();
+        permissions.set_mode(0o000);
+        fs::set_permissions(&locked, permissions).unwrap();
+
+        let result = collect_merge_input_paths(dir.path(), "train_*.bin", true);
+
+        let mut restore_permissions = fs::metadata(&locked).unwrap().permissions();
+        restore_permissions.set_mode(0o755);
+        fs::set_permissions(&locked, restore_permissions).unwrap();
+
+        assert!(result.is_err());
     }
 }

--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -214,10 +214,7 @@ fn ensure_input_is_file(path: &Path) -> Result<()> {
 }
 
 fn compare_merge_input_paths(a: &PathBuf, b: &PathBuf) -> std::cmp::Ordering {
-    a.parent()
-        .cmp(&b.parent())
-        .then_with(|| compare_file_names_with_numeric_suffix(a, b))
-        .then_with(|| a.cmp(b))
+    compare_file_names_with_numeric_suffix(a, b).then_with(|| a.cmp(b))
 }
 
 fn compare_file_names_with_numeric_suffix(a: &Path, b: &Path) -> std::cmp::Ordering {
@@ -497,24 +494,24 @@ mod tests {
     }
 
     #[test]
-    fn compare_merge_input_paths_keeps_directory_groups_contiguous() {
-        let a = PathBuf::from("a/train_001.bin");
-        let b = PathBuf::from("b/train_000.bin");
+    fn compare_merge_input_paths_preserves_global_shard_order_across_dirs() {
+        let a = PathBuf::from("a/train_002.bin");
+        let b = PathBuf::from("b/train_001.bin");
 
-        assert_eq!(compare_merge_input_paths(&a, &b), std::cmp::Ordering::Less);
+        assert_eq!(compare_merge_input_paths(&a, &b), std::cmp::Ordering::Greater);
     }
 
     #[test]
-    fn collect_merge_input_paths_keeps_recursive_directory_batches_contiguous() {
+    fn collect_merge_input_paths_preserves_global_shard_order_across_recursive_dirs() {
         let dir = tempdir().unwrap();
         let a = dir.path().join("a");
         let b = dir.path().join("b");
         fs::create_dir_all(&a).unwrap();
         fs::create_dir_all(&b).unwrap();
         fs::write(a.join("train_000.bin"), []).unwrap();
-        fs::write(a.join("train_001.bin"), []).unwrap();
-        fs::write(b.join("train_000.bin"), []).unwrap();
+        fs::write(a.join("train_002.bin"), []).unwrap();
         fs::write(b.join("train_001.bin"), []).unwrap();
+        fs::write(b.join("train_003.bin"), []).unwrap();
 
         let paths = collect_merge_input_paths(dir.path(), "train_*.bin", true).unwrap();
         let names: Vec<_> = paths
@@ -526,9 +523,9 @@ mod tests {
             names,
             vec![
                 "a/train_000.bin",
-                "a/train_001.bin",
-                "b/train_000.bin",
-                "b/train_001.bin"
+                "b/train_001.bin",
+                "a/train_002.bin",
+                "b/train_003.bin"
             ]
         );
     }

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -107,9 +107,7 @@ fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
 
-    if !cli.input.exists() {
-        bail!("入力ファイルが存在しません: {}", cli.input.display());
-    }
+    ensure_input_is_file(&cli.input)?;
 
     let records_per_file = resolve_records_per_file(&cli)?;
     let config = SplitConfig {
@@ -147,6 +145,7 @@ fn main() -> Result<()> {
 }
 
 fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> Result<SplitStats> {
+    ensure_input_is_file(input_path)?;
     if config.records_per_file == 0 {
         bail!(
             "--records-per-file / --bytes-per-file から算出される局面数は 1 以上である必要があります"
@@ -254,6 +253,16 @@ fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> 
         total_records,
         part_count,
     })
+}
+
+fn ensure_input_is_file(input_path: &Path) -> Result<()> {
+    if !input_path.exists() {
+        bail!("入力ファイルが存在しません: {}", input_path.display());
+    }
+    if !input_path.is_file() {
+        bail!("入力パスはファイルである必要があります: {}", input_path.display());
+    }
+    Ok(())
 }
 
 fn resolve_records_per_file(cli: &Cli) -> Result<u64> {
@@ -507,5 +516,25 @@ mod tests {
     #[test]
     fn validate_write_chunk_records_rejects_huge_value() {
         assert!(validate_write_chunk_records(MAX_WRITE_CHUNK_RECORDS + 1).is_err());
+    }
+
+    #[test]
+    fn split_rejects_directory_input_before_processing() {
+        let dir = tempdir().unwrap();
+
+        let err = split_file(
+            dir.path(),
+            &dir.path().join("train"),
+            &SplitConfig {
+                records_per_file: 2,
+                write_chunk_records: 1,
+                start_index: 0,
+                digits: 3,
+                suffix: ".bin".to_string(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("入力パスはファイルである必要があります"));
     }
 }

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -1,0 +1,403 @@
+//! split_psv - PSV ファイルを複数ファイルへ分割
+//!
+//! PackedSfenValue 形式（40 バイト/レコード）の PSV ファイルを、
+//! 1 ファイルあたりの局面数または容量を指定して分割する。
+//! 入力全体をメモリへ載せず、ストリーミングで少しずつ書き出す。
+//!
+//! # 使用例
+//!
+//! ```bash
+//! # 1 ファイル 1 億局面で分割
+//! cargo run -p tools --release --bin split_psv -- \
+//!   --input data.psv \
+//!   --output-prefix out/train \
+//!   --records-per-file 100000000
+//!
+//! # 1 ファイル 4GB 目安で分割
+//! cargo run -p tools --release --bin split_psv -- \
+//!   --input data.psv \
+//!   --output-prefix out/train \
+//!   --bytes-per-file 4GB
+//!
+//! # 40 万局面ずつ読み書きしてメモリ使用量を抑える
+//! cargo run -p tools --release --bin split_psv -- \
+//!   --input data.psv \
+//!   --output-prefix out/train \
+//!   --records-per-file 100000000 \
+//!   --write-chunk-records 400000
+//! ```
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use log::{info, warn};
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use tools::packed_sfen::PackedSfenValue;
+
+const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const IO_BUF_SIZE: usize = 8 * 1024 * 1024;
+const DEFAULT_WRITE_CHUNK_RECORDS: usize = 1_000_000;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "split_psv",
+    version,
+    about = "PSV ファイルを複数ファイルへ分割",
+    long_about = "PackedSfenValue 形式（40 バイト/レコード）の PSV ファイルを、\
+1 ファイルあたりの局面数または容量で分割して出力します。\
+入出力はストリーミングで行うため、大きなファイルでも少しずつ書き出せます。"
+)]
+struct Cli {
+    /// 入力 PSV ファイル
+    #[arg(short, long)]
+    input: PathBuf,
+
+    /// 出力プレフィックス（例: out/train -> out/train_000.bin）
+    #[arg(long)]
+    output_prefix: PathBuf,
+
+    /// 1 ファイルあたりの局面数
+    #[arg(long, conflicts_with = "bytes_per_file")]
+    records_per_file: Option<u64>,
+
+    /// 1 ファイルあたりの容量（例: 4GB, 3500MiB, 4000000000）
+    #[arg(long, conflicts_with = "records_per_file")]
+    bytes_per_file: Option<String>,
+
+    /// 1 回の読み書きで扱う局面数
+    #[arg(long, default_value_t = DEFAULT_WRITE_CHUNK_RECORDS)]
+    write_chunk_records: usize,
+
+    /// 出力ファイルの開始インデックス
+    #[arg(long, default_value_t = 0)]
+    start_index: u64,
+
+    /// 出力ファイル番号の最小桁数
+    #[arg(long, default_value_t = 3)]
+    digits: usize,
+
+    /// 出力ファイル拡張子
+    #[arg(long, default_value = ".bin")]
+    suffix: String,
+}
+
+#[derive(Debug, Clone)]
+struct SplitConfig {
+    records_per_file: u64,
+    write_chunk_records: usize,
+    start_index: u64,
+    digits: usize,
+    suffix: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SplitStats {
+    total_records: u64,
+    part_count: u64,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    if !cli.input.exists() {
+        bail!("入力ファイルが存在しません: {}", cli.input.display());
+    }
+
+    let records_per_file = resolve_records_per_file(&cli)?;
+    let config = SplitConfig {
+        records_per_file,
+        write_chunk_records: cli.write_chunk_records,
+        start_index: cli.start_index,
+        digits: cli.digits.max(1),
+        suffix: cli.suffix,
+    };
+
+    let stats = split_file(&cli.input, &cli.output_prefix, &config)?;
+
+    info!("総局面数: {}", stats.total_records);
+    info!("出力ファイル数: {}", stats.part_count);
+    if stats.part_count > 0 {
+        let last_index = cli.start_index + stats.part_count - 1;
+        info!(
+            "出力範囲: {}_{}..{}{}",
+            cli.output_prefix.display(),
+            zero_pad(cli.start_index, config.digits),
+            zero_pad(last_index, config.digits),
+            config.suffix,
+        );
+    }
+
+    Ok(())
+}
+
+fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> Result<SplitStats> {
+    if config.records_per_file == 0 {
+        bail!(
+            "--records-per-file / --bytes-per-file から算出される局面数は 1 以上である必要があります"
+        );
+    }
+    if config.write_chunk_records == 0 {
+        bail!("--write-chunk-records は 1 以上を指定してください");
+    }
+
+    ensure_parent_dir(output_prefix)?;
+
+    let file_size = std::fs::metadata(input_path)
+        .with_context(|| format!("入力ファイル情報の取得に失敗しました: {}", input_path.display()))?
+        .len();
+    let total_records = file_size / RECORD_SIZE as u64;
+    let trailing_bytes = file_size % RECORD_SIZE as u64;
+    if trailing_bytes != 0 {
+        warn!(
+            "入力ファイル末尾の {} バイトは完全なレコードではないため無視します",
+            trailing_bytes
+        );
+    }
+
+    info!(
+        "入力: {} ({} bytes, {} records)",
+        input_path.display(),
+        file_size,
+        total_records
+    );
+    info!("分割単位: {} records/file", config.records_per_file);
+    info!("書き出しチャンク: {} records", config.write_chunk_records);
+
+    if total_records == 0 {
+        warn!("完全なレコードが 0 件のため、出力ファイルは作成しません");
+        return Ok(SplitStats {
+            total_records: 0,
+            part_count: 0,
+        });
+    }
+
+    let file = File::open(input_path)
+        .with_context(|| format!("入力ファイルを開けませんでした: {}", input_path.display()))?;
+    let mut reader = BufReader::with_capacity(IO_BUF_SIZE, file);
+
+    let chunk_records = config.write_chunk_records.min(config.records_per_file as usize).max(1);
+    let buffer_len = chunk_records
+        .checked_mul(RECORD_SIZE)
+        .context("書き出しチャンクが大きすぎます")?;
+    let mut buffer = vec![0u8; buffer_len];
+
+    let progress = ProgressBar::new(total_records);
+    progress.set_style(progress_style("Splitting"));
+
+    let mut remaining = total_records;
+    let mut part_index = config.start_index;
+    let mut part_count = 0u64;
+
+    while remaining > 0 {
+        let output_path = build_part_path(output_prefix, part_index, config.digits, &config.suffix);
+        ensure_parent_dir(&output_path)?;
+
+        let out_file = File::create(&output_path).with_context(|| {
+            format!("出力ファイルを作成できませんでした: {}", output_path.display())
+        })?;
+        let mut writer = BufWriter::with_capacity(IO_BUF_SIZE, out_file);
+
+        let mut written_in_part = 0u64;
+        while written_in_part < config.records_per_file && remaining > 0 {
+            let to_read_records = remaining
+                .min(config.records_per_file - written_in_part)
+                .min(chunk_records as u64) as usize;
+            let byte_len = to_read_records
+                .checked_mul(RECORD_SIZE)
+                .context("読み込みサイズが大きすぎます")?;
+            reader.read_exact(&mut buffer[..byte_len]).with_context(|| {
+                format!("入力ファイル読み込み中に失敗しました: {}", input_path.display())
+            })?;
+            writer.write_all(&buffer[..byte_len]).with_context(|| {
+                format!("出力ファイル書き込み中に失敗しました: {}", output_path.display())
+            })?;
+            written_in_part += to_read_records as u64;
+            remaining -= to_read_records as u64;
+            progress.inc(to_read_records as u64);
+        }
+
+        writer.flush().with_context(|| {
+            format!("出力ファイル flush に失敗しました: {}", output_path.display())
+        })?;
+        info!("part {}: {} ({} records)", part_index, output_path.display(), written_in_part);
+
+        part_index += 1;
+        part_count += 1;
+    }
+
+    progress.finish_and_clear();
+
+    Ok(SplitStats {
+        total_records,
+        part_count,
+    })
+}
+
+fn resolve_records_per_file(cli: &Cli) -> Result<u64> {
+    match (&cli.records_per_file, &cli.bytes_per_file) {
+        (Some(records), None) => {
+            if *records == 0 {
+                bail!("--records-per-file は 1 以上を指定してください");
+            }
+            Ok(*records)
+        }
+        (None, Some(bytes_str)) => {
+            let bytes = parse_byte_size(bytes_str)?;
+            if bytes < RECORD_SIZE as u64 {
+                bail!("--bytes-per-file は少なくとも {} bytes 以上を指定してください", RECORD_SIZE);
+            }
+            let records = bytes / RECORD_SIZE as u64;
+            let aligned_bytes = records * RECORD_SIZE as u64;
+            if aligned_bytes != bytes {
+                warn!(
+                    "--bytes-per-file={} はレコード境界に合わないため、{} bytes ({} records) に切り下げます",
+                    bytes_str, aligned_bytes, records
+                );
+            }
+            Ok(records)
+        }
+        (Some(_), Some(_)) => {
+            bail!("--records-per-file と --bytes-per-file は同時に指定できません")
+        }
+        (None, None) => {
+            bail!("--records-per-file または --bytes-per-file のいずれかを指定してください")
+        }
+    }
+}
+
+fn parse_byte_size(input: &str) -> Result<u64> {
+    let normalized = input.trim().replace('_', "").to_ascii_lowercase();
+    if normalized.is_empty() {
+        bail!("容量指定が空です");
+    }
+
+    let split_at = normalized.find(|c: char| !c.is_ascii_digit()).unwrap_or(normalized.len());
+    let (value_str, suffix) = normalized.split_at(split_at);
+    if value_str.is_empty() {
+        bail!("容量の数値部分を解釈できません: {input}");
+    }
+    let value: u64 = value_str
+        .parse()
+        .with_context(|| format!("容量の数値部分を解釈できません: {input}"))?;
+
+    let multiplier = match suffix {
+        "" | "b" => 1u64,
+        "k" | "kb" => 1_000u64,
+        "m" | "mb" => 1_000_000u64,
+        "g" | "gb" => 1_000_000_000u64,
+        "t" | "tb" => 1_000_000_000_000u64,
+        "ki" | "kib" => 1024u64,
+        "mi" | "mib" => 1024u64.pow(2),
+        "gi" | "gib" => 1024u64.pow(3),
+        "ti" | "tib" => 1024u64.pow(4),
+        _ => bail!("未対応の容量単位です: {input}"),
+    };
+
+    value
+        .checked_mul(multiplier)
+        .with_context(|| format!("容量が大きすぎます: {input}"))
+}
+
+fn build_part_path(prefix: &Path, index: u64, digits: usize, suffix: &str) -> PathBuf {
+    let mut path = OsString::from(prefix.as_os_str());
+    path.push(format!("_{}{suffix}", zero_pad(index, digits)));
+    PathBuf::from(path)
+}
+
+fn zero_pad(value: u64, digits: usize) -> String {
+    format!("{value:0digits$}")
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("親ディレクトリを作成できませんでした: {}", parent.display())
+        })?;
+    }
+    Ok(())
+}
+
+fn progress_style(label: &str) -> ProgressStyle {
+    ProgressStyle::default_bar()
+        .template(&format!(
+            "[{{elapsed_precise}}] {{bar:40.cyan/blue}} {{pos}}/{{len}} ({{per_sec}}) {label}"
+        ))
+        .expect("valid template")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_records(count: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(count * RECORD_SIZE);
+        for i in 0..count {
+            let mut record = [0u8; RECORD_SIZE];
+            record[0..8].copy_from_slice(&(i as u64).to_le_bytes());
+            record[32..34].copy_from_slice(&(i as i16).to_le_bytes());
+            record[36..38].copy_from_slice(&(i as u16).to_le_bytes());
+            bytes.extend_from_slice(&record);
+        }
+        bytes
+    }
+
+    #[test]
+    fn parse_byte_size_supports_decimal_and_binary_units() {
+        assert_eq!(parse_byte_size("4000").unwrap(), 4000);
+        assert_eq!(parse_byte_size("4GB").unwrap(), 4_000_000_000);
+        assert_eq!(parse_byte_size("4GiB").unwrap(), 4 * 1024 * 1024 * 1024);
+        assert!(parse_byte_size("12XB").is_err());
+    }
+
+    #[test]
+    fn split_file_streams_into_multiple_outputs() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("input.psv");
+        let output_prefix = dir.path().join("split/train");
+        let original = make_records(23);
+        fs::write(&input_path, &original).unwrap();
+
+        let stats = split_file(
+            &input_path,
+            &output_prefix,
+            &SplitConfig {
+                records_per_file: 10,
+                write_chunk_records: 3,
+                start_index: 7,
+                digits: 3,
+                suffix: ".bin".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            stats,
+            SplitStats {
+                total_records: 23,
+                part_count: 3
+            }
+        );
+
+        let part0 = fs::read(dir.path().join("split/train_007.bin")).unwrap();
+        let part1 = fs::read(dir.path().join("split/train_008.bin")).unwrap();
+        let part2 = fs::read(dir.path().join("split/train_009.bin")).unwrap();
+        assert_eq!(part0.len(), 10 * RECORD_SIZE);
+        assert_eq!(part1.len(), 10 * RECORD_SIZE);
+        assert_eq!(part2.len(), 3 * RECORD_SIZE);
+
+        let mut merged = Vec::new();
+        merged.extend_from_slice(&part0);
+        merged.extend_from_slice(&part1);
+        merged.extend_from_slice(&part2);
+        assert_eq!(merged, original);
+    }
+}

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -41,6 +41,8 @@ use tools::packed_sfen::PackedSfenValue;
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
 const IO_BUF_SIZE: usize = 8 * 1024 * 1024;
 const DEFAULT_WRITE_CHUNK_RECORDS: usize = 1_000_000;
+const MAX_WRITE_CHUNK_BYTES: usize = 512 * 1024 * 1024;
+const MAX_WRITE_CHUNK_RECORDS: usize = MAX_WRITE_CHUNK_BYTES / RECORD_SIZE;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -121,16 +123,23 @@ fn main() -> Result<()> {
 
     info!("総局面数: {}", stats.total_records);
     info!("出力ファイル数: {}", stats.part_count);
-    if stats.part_count > 0 {
-        let last_index = cli.start_index + stats.part_count - 1;
-        info!(
-            "出力範囲: {}_{}..{}{}",
-            cli.output_prefix.display(),
-            zero_pad(cli.start_index, config.digits),
-            zero_pad(last_index, config.digits),
-            config.suffix,
-        );
-    }
+    if stats.part_count > 0
+        && let Some(offset) = stats.part_count.checked_sub(1) {
+            if let Some(last_index) = cli.start_index.checked_add(offset) {
+                info!(
+                    "出力範囲: {}_{}..{}{}",
+                    cli.output_prefix.display(),
+                    zero_pad(cli.start_index, config.digits),
+                    zero_pad(last_index, config.digits),
+                    config.suffix,
+                );
+            } else {
+                warn!(
+                    "出力範囲の表示を省略しました: start_index ({}) と part_count ({}) から最終インデックスを安全に計算できません",
+                    cli.start_index, stats.part_count,
+                );
+            }
+        }
 
     Ok(())
 }
@@ -144,6 +153,7 @@ fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> 
     if config.write_chunk_records == 0 {
         bail!("--write-chunk-records は 1 以上を指定してください");
     }
+    validate_write_chunk_records(config.write_chunk_records)?;
 
     ensure_parent_dir(output_prefix)?;
 
@@ -176,11 +186,15 @@ fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> 
         });
     }
 
+    check_output_paths_do_not_hit_input(input_path, output_prefix, config, total_records)?;
+
     let file = File::open(input_path)
         .with_context(|| format!("入力ファイルを開けませんでした: {}", input_path.display()))?;
     let mut reader = BufReader::with_capacity(IO_BUF_SIZE, file);
 
-    let chunk_records = config.write_chunk_records.min(config.records_per_file as usize).max(1);
+    let chunk_records_u64 = (config.write_chunk_records as u64).min(config.records_per_file);
+    let chunk_records =
+        usize::try_from(chunk_records_u64).context("チャンク局面数を usize に変換できません")?;
     let buffer_len = chunk_records
         .checked_mul(RECORD_SIZE)
         .context("書き出しチャンクが大きすぎます")?;
@@ -226,8 +240,10 @@ fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> 
         })?;
         info!("part {}: {} ({} records)", part_index, output_path.display(), written_in_part);
 
-        part_index += 1;
-        part_count += 1;
+        part_index =
+            part_index.checked_add(1).context("出力ファイル番号が u64 の上限を超えました")?;
+        part_count =
+            part_count.checked_add(1).context("出力ファイル数が u64 の上限を超えました")?;
     }
 
     progress.finish_and_clear();
@@ -307,6 +323,63 @@ fn build_part_path(prefix: &Path, index: u64, digits: usize, suffix: &str) -> Pa
     let mut path = OsString::from(prefix.as_os_str());
     path.push(format!("_{}{suffix}", zero_pad(index, digits)));
     PathBuf::from(path)
+}
+
+fn validate_write_chunk_records(write_chunk_records: usize) -> Result<()> {
+    if write_chunk_records > MAX_WRITE_CHUNK_RECORDS {
+        bail!(
+            "--write-chunk-records={} は大きすぎます。最大値は {} records ({} bytes) です",
+            write_chunk_records,
+            MAX_WRITE_CHUNK_RECORDS,
+            MAX_WRITE_CHUNK_BYTES,
+        );
+    }
+    Ok(())
+}
+
+fn check_output_paths_do_not_hit_input(
+    input_path: &Path,
+    output_prefix: &Path,
+    config: &SplitConfig,
+    total_records: u64,
+) -> Result<()> {
+    let input_canonical = input_path
+        .canonicalize()
+        .with_context(|| format!("入力パスを正規化できませんでした: {}", input_path.display()))?;
+    let part_count = total_records.div_ceil(config.records_per_file);
+
+    for offset in 0..part_count {
+        let index = config
+            .start_index
+            .checked_add(offset)
+            .context("出力ファイル番号が u64 の上限を超えました")?;
+        let output_path = build_part_path(output_prefix, index, config.digits, &config.suffix);
+        let output_canonical = canonicalize_maybe_new(&output_path)?;
+        if output_canonical == input_canonical {
+            bail!(
+                "出力ファイルが入力ファイルと衝突します: {}\n\
+                 --output-prefix / --start-index / --digits / --suffix を見直してください",
+                output_path.display(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn canonicalize_maybe_new(path: &Path) -> Result<PathBuf> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Ok(canonical);
+    }
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("出力パスにファイル名がありません"))?;
+    Ok(parent
+        .canonicalize()
+        .with_context(|| format!("親ディレクトリを正規化できませんでした: {}", parent.display()))?
+        .join(name))
 }
 
 fn zero_pad(value: u64, digits: usize) -> String {
@@ -399,5 +472,32 @@ mod tests {
         merged.extend_from_slice(&part1);
         merged.extend_from_slice(&part2);
         assert_eq!(merged, original);
+    }
+
+    #[test]
+    fn split_rejects_output_path_that_hits_input() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("train_000.bin");
+        fs::write(&input_path, make_records(5)).unwrap();
+
+        let err = split_file(
+            &input_path,
+            &dir.path().join("train"),
+            &SplitConfig {
+                records_per_file: 2,
+                write_chunk_records: 1,
+                start_index: 0,
+                digits: 3,
+                suffix: ".bin".to_string(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("出力ファイルが入力ファイルと衝突します"));
+    }
+
+    #[test]
+    fn validate_write_chunk_records_rejects_huge_value() {
+        assert!(validate_write_chunk_records(MAX_WRITE_CHUNK_RECORDS + 1).is_err());
     }
 }

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -124,22 +124,23 @@ fn main() -> Result<()> {
     info!("総局面数: {}", stats.total_records);
     info!("出力ファイル数: {}", stats.part_count);
     if stats.part_count > 0
-        && let Some(offset) = stats.part_count.checked_sub(1) {
-            if let Some(last_index) = cli.start_index.checked_add(offset) {
-                info!(
-                    "出力範囲: {}_{}..{}{}",
-                    cli.output_prefix.display(),
-                    zero_pad(cli.start_index, config.digits),
-                    zero_pad(last_index, config.digits),
-                    config.suffix,
-                );
-            } else {
-                warn!(
-                    "出力範囲の表示を省略しました: start_index ({}) と part_count ({}) から最終インデックスを安全に計算できません",
-                    cli.start_index, stats.part_count,
-                );
-            }
+        && let Some(offset) = stats.part_count.checked_sub(1)
+    {
+        if let Some(last_index) = cli.start_index.checked_add(offset) {
+            info!(
+                "出力範囲: {}_{}..{}{}",
+                cli.output_prefix.display(),
+                zero_pad(cli.start_index, config.digits),
+                zero_pad(last_index, config.digits),
+                config.suffix,
+            );
+        } else {
+            warn!(
+                "出力範囲の表示を省略しました: start_index ({}) と part_count ({}) から最終インデックスを安全に計算できません",
+                cli.start_index, stats.part_count,
+            );
         }
+    }
 
     Ok(())
 }

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -36,6 +36,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
+use tools::common::dedup::canonicalize_maybe_new;
 use tools::packed_sfen::PackedSfenValue;
 
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
@@ -368,21 +369,6 @@ fn check_output_paths_do_not_hit_input(
     Ok(())
 }
 
-fn canonicalize_maybe_new(path: &Path) -> Result<PathBuf> {
-    if let Ok(canonical) = path.canonicalize() {
-        return Ok(canonical);
-    }
-
-    let parent = path.parent().unwrap_or(Path::new("."));
-    let name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("出力パスにファイル名がありません"))?;
-    Ok(parent
-        .canonicalize()
-        .with_context(|| format!("親ディレクトリを正規化できませんでした: {}", parent.display()))?
-        .join(name))
-}
-
 fn zero_pad(value: u64, digits: usize) -> String {
     format!("{value:0digits$}")
 }
@@ -495,6 +481,27 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("出力ファイルが入力ファイルと衝突します"));
+    }
+
+    #[test]
+    fn split_collision_check_allows_relative_output_prefix_in_cwd() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("input.psv");
+        fs::write(&input_path, make_records(5)).unwrap();
+
+        check_output_paths_do_not_hit_input(
+            &input_path,
+            Path::new("train"),
+            &SplitConfig {
+                records_per_file: 2,
+                write_chunk_records: 1,
+                start_index: 0,
+                digits: 3,
+                suffix: ".bin".to_string(),
+            },
+            5,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/tools/src/bin/split_psv.rs
+++ b/crates/tools/src/bin/split_psv.rs
@@ -241,10 +241,12 @@ fn split_file(input_path: &Path, output_prefix: &Path, config: &SplitConfig) -> 
         })?;
         info!("part {}: {} ({} records)", part_index, output_path.display(), written_in_part);
 
-        part_index =
-            part_index.checked_add(1).context("出力ファイル番号が u64 の上限を超えました")?;
         part_count =
             part_count.checked_add(1).context("出力ファイル数が u64 の上限を超えました")?;
+        if remaining > 0 {
+            part_index =
+                part_index.checked_add(1).context("出力ファイル番号が u64 の上限を超えました")?;
+        }
     }
 
     progress.finish_and_clear();
@@ -357,25 +359,97 @@ fn check_output_paths_do_not_hit_input(
     let input_canonical = input_path
         .canonicalize()
         .with_context(|| format!("入力パスを正規化できませんでした: {}", input_path.display()))?;
-    let part_count = total_records.div_ceil(config.records_per_file);
+    let output_family = SplitOutputFamily::new(output_prefix, config, total_records)
+        .context("出力パス系列を解決できませんでした")?;
 
-    for offset in 0..part_count {
-        let index = config
-            .start_index
-            .checked_add(offset)
-            .context("出力ファイル番号が u64 の上限を超えました")?;
-        let output_path = build_part_path(output_prefix, index, config.digits, &config.suffix);
-        let output_canonical = canonicalize_maybe_new(&output_path)?;
-        if output_canonical == input_canonical {
-            bail!(
-                "出力ファイルが入力ファイルと衝突します: {}\n\
-                 --output-prefix / --start-index / --digits / --suffix を見直してください",
-                output_path.display(),
-            );
-        }
+    if output_family.contains(&input_canonical) {
+        bail!(
+            "出力ファイルが入力ファイルと衝突します: {}\n\
+             --output-prefix / --start-index / --digits / --suffix を見直してください",
+            input_path.display(),
+        );
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SplitOutputFamily {
+    canonical_parent: PathBuf,
+    filename_prefix: String,
+    suffix: String,
+    digits: usize,
+    start_index: u64,
+    last_index: u64,
+}
+
+impl SplitOutputFamily {
+    fn new(output_prefix: &Path, config: &SplitConfig, total_records: u64) -> Result<Self> {
+        let part_count = total_records.div_ceil(config.records_per_file);
+        let last_index = config
+            .start_index
+            .checked_add(part_count.saturating_sub(1))
+            .context("出力ファイル番号が u64 の上限を超えました")?;
+        let canonical_parent = canonicalize_output_parent(output_prefix)?;
+        let filename_prefix = output_prefix
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        Ok(Self {
+            canonical_parent,
+            filename_prefix,
+            suffix: config.suffix.clone(),
+            digits: config.digits,
+            start_index: config.start_index,
+            last_index,
+        })
+    }
+
+    fn contains(&self, path: &Path) -> bool {
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+        if parent != self.canonical_parent {
+            return false;
+        }
+
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+
+        let prefix = format!("{}_", self.filename_prefix);
+        if !file_name.starts_with(&prefix) || !file_name.ends_with(&self.suffix) {
+            return false;
+        }
+
+        let digits_end = file_name.len().saturating_sub(self.suffix.len());
+        let digits_str = &file_name[prefix.len()..digits_end];
+        if digits_str.is_empty() || !digits_str.bytes().all(|byte| byte.is_ascii_digit()) {
+            return false;
+        }
+
+        let Ok(index) = digits_str.parse::<u64>() else {
+            return false;
+        };
+        if index < self.start_index || index > self.last_index {
+            return false;
+        }
+
+        zero_pad(index, self.digits) == digits_str
+    }
+}
+
+fn canonicalize_output_parent(output_prefix: &Path) -> Result<PathBuf> {
+    let parent = output_prefix.parent().unwrap_or(Path::new("."));
+    let marker = parent.join("__rshogi_split_output_parent_check__");
+    let canonical_marker = canonicalize_maybe_new(&marker).with_context(|| {
+        format!("出力先親ディレクトリを正規化できませんでした: {}", parent.display())
+    })?;
+    canonical_marker
+        .parent()
+        .map(Path::to_path_buf)
+        .context("出力先親ディレクトリを特定できませんでした")
 }
 
 fn zero_pad(value: u64, digits: usize) -> String {
@@ -493,6 +567,29 @@ mod tests {
     }
 
     #[test]
+    fn split_detects_collision_for_large_part_count_without_enumerating_all_parts() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join(format!("train_{}.bin", u64::MAX - 1));
+        fs::write(&input_path, make_records(1)).unwrap();
+
+        let err = check_output_paths_do_not_hit_input(
+            &input_path,
+            &dir.path().join("train"),
+            &SplitConfig {
+                records_per_file: 1,
+                write_chunk_records: 1,
+                start_index: 0,
+                digits: 1,
+                suffix: ".bin".to_string(),
+            },
+            u64::MAX,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("出力ファイルが入力ファイルと衝突します"));
+    }
+
+    #[test]
     fn split_collision_check_allows_relative_output_prefix_in_cwd() {
         let dir = tempdir().unwrap();
         let input_path = dir.path().join("input.psv");
@@ -536,5 +633,34 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("入力パスはファイルである必要があります"));
+    }
+
+    #[test]
+    fn split_file_allows_last_valid_index_at_u64_max() {
+        let dir = tempdir().unwrap();
+        let input_path = dir.path().join("input.psv");
+        fs::write(&input_path, make_records(1)).unwrap();
+
+        let stats = split_file(
+            &input_path,
+            &dir.path().join("train"),
+            &SplitConfig {
+                records_per_file: 1,
+                write_chunk_records: 1,
+                start_index: u64::MAX,
+                digits: 1,
+                suffix: ".bin".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            stats,
+            SplitStats {
+                total_records: 1,
+                part_count: 1
+            }
+        );
+        assert!(dir.path().join(format!("train_{}.bin", u64::MAX)).is_file());
     }
 }

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -79,16 +79,56 @@ pub fn collect_input_paths(
 }
 
 /// まだ存在しないかもしれないパスを正規化する。
-/// `parent().canonicalize() / file_name()` で解決する。
-fn canonicalize_maybe_new(path: &Path) -> io::Result<PathBuf> {
-    if let Ok(c) = path.canonicalize() {
-        return Ok(c);
+///
+/// 既存の最長祖先ディレクトリだけを `canonicalize` し、残りの成分は
+/// パス構文どおりに連結する。これにより、まだ存在しない出力ファイルや
+/// 親ディレクトリを含むパスでも比較用の絶対パスへ正規化できる。
+pub fn canonicalize_maybe_new(path: &Path) -> io::Result<PathBuf> {
+    let components: Vec<_> = path.components().collect();
+
+    for prefix_len in (0..=components.len()).rev() {
+        let prefix = join_components(&components[..prefix_len]);
+        let base = if prefix_len == 0 && path.is_relative() {
+            std::env::current_dir()?.canonicalize()?
+        } else if prefix.as_os_str().is_empty() {
+            continue;
+        } else if let Ok(base) = prefix.canonicalize() {
+            base
+        } else {
+            continue;
+        };
+
+        return Ok(append_components(base, &components[prefix_len..]));
     }
-    let parent = path.parent().unwrap_or(Path::new("."));
-    let name = path.file_name().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "出力パスにファイル名がありません")
-    })?;
-    Ok(parent.canonicalize()?.join(name))
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("パスを正規化できませんでした: {}", path.display()),
+    ))
+}
+
+fn join_components(components: &[std::path::Component<'_>]) -> PathBuf {
+    let mut path = PathBuf::new();
+    for component in components {
+        path.push(component.as_os_str());
+    }
+    path
+}
+
+fn append_components(mut base: PathBuf, components: &[std::path::Component<'_>]) -> PathBuf {
+    for component in components {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                let _ = base.pop();
+            }
+            std::path::Component::Normal(part) => base.push(part),
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                base.push(component.as_os_str());
+            }
+        }
+    }
+    base
 }
 
 /// 出力パスが入力パスのいずれかと一致していないか検査する。
@@ -147,6 +187,36 @@ impl DedupSet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    #[test]
+    fn canonicalize_maybe_new_handles_new_relative_file_in_cwd() {
+        let expected =
+            std::env::current_dir().unwrap().canonicalize().unwrap().join("train_000.bin");
+
+        assert_eq!(canonicalize_maybe_new(Path::new("train_000.bin")).unwrap(), expected);
+    }
+
+    #[test]
+    fn canonicalize_maybe_new_handles_nonexistent_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("out/merged.psv");
+
+        assert_eq!(
+            canonicalize_maybe_new(&output).unwrap(),
+            dir.path().canonicalize().unwrap().join("out/merged.psv")
+        );
+    }
+
+    #[test]
+    fn check_output_not_in_inputs_accepts_new_output_under_new_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("input.psv");
+        fs::write(&input, [0u8; PSV_SIZE]).unwrap();
+
+        check_output_not_in_inputs(&dir.path().join("new/out.psv"), &[input]).unwrap();
+    }
+
     #[test]
     fn test_dedup_with_mirror() {
         let a = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/2B4R1/LNSGKGSNL b - 1";


### PR DESCRIPTION
## 概要
PSV 形式の教師データを分割・結合する Rust ツールを `crates/tools` に追加しました。

## 変更内容
- `split_psv` を追加
- `--records-per-file` または `--bytes-per-file` で分割単位を指定可能
- `--write-chunk-records` で少しずつ読み書きするストリーミング処理を追加
- `merge_psv` を追加
- 複数の PSV ファイルを入力順のまま少しずつ書き出して結合する処理を追加
- `tools` の README とドキュメントを更新

## 背景
既存の Python スクリプト相当の処理を、このリポジトリの `tools` クレート内で完結できるようにするためです。大きい教師データでもメモリへ全載せせず扱えるよう、分割・結合ともストリーミング実装にしています。

## 影響
- 大容量の PSV 教師データを Rust 製 CLI で安全に分割・結合できます
- 既存の `crates/tools` ワークフローにそのまま組み込めます

## 検証
- `cargo fmt`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`