### PR TITLE
[codex] feat(csa-server): complete phase3 x1/buoy/clocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "rshogi-core",
  "rshogi-csa",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
 ]

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -17,10 +17,10 @@ use std::rc::Rc;
 
 use anyhow::Context;
 use clap::Parser;
-use rshogi_csa_server::FileKifuStorage;
 use rshogi_csa_server::error::StorageError;
 use rshogi_csa_server::port::{PlayerRateRecord, RateStorage};
 use rshogi_csa_server::types::PlayerName;
+use rshogi_csa_server::{ClockSpec, FileKifuStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
@@ -45,12 +45,21 @@ struct Cli {
     /// プレイヤ定義ファイル（TOML 形式、keys = handle）。
     #[arg(long)]
     players: PathBuf,
-    /// 持ち時間 (秒)。
+    /// 秒読み方式 / Fischer 方式で使う持ち時間 (秒)。
     #[arg(long, default_value_t = 600)]
     total_time_sec: u32,
-    /// 秒読み (秒)。
+    /// 秒読み方式の秒読み、または Fischer 方式の増分 (秒)。
     #[arg(long, default_value_t = 10)]
     byoyomi_sec: u32,
+    /// StopWatch 方式で使う持ち時間 (分)。
+    #[arg(long, default_value_t = 10)]
+    total_time_min: u32,
+    /// StopWatch 方式の秒読み (分)。
+    #[arg(long, default_value_t = 1)]
+    byoyomi_min: u32,
+    /// 時計方式。`countdown` / `fischer` / `stopwatch`。
+    #[arg(long, value_enum, default_value_t = ClockKindArg::Countdown)]
+    clock_kind: ClockKindArg,
     /// 通信マージン (ミリ秒)。
     #[arg(long, default_value_t = 1_500)]
     margin_ms: u64,
@@ -66,6 +75,38 @@ struct Cli {
     /// round P2)。`%%GETBUOYCOUNT` は参照系なので権限不要で全ユーザー可。
     #[arg(long = "admin-handle", value_name = "HANDLE")]
     admin_handle: Vec<String>,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+enum ClockKindArg {
+    Countdown,
+    Fischer,
+    Stopwatch,
+}
+
+impl ClockKindArg {
+    fn to_clock_spec(
+        self,
+        total_time_sec: u32,
+        byoyomi_sec: u32,
+        total_time_min: u32,
+        byoyomi_min: u32,
+    ) -> ClockSpec {
+        match self {
+            Self::Countdown => ClockSpec::Countdown {
+                total_time_sec,
+                byoyomi_sec,
+            },
+            Self::Fischer => ClockSpec::Fischer {
+                total_time_sec,
+                increment_sec: byoyomi_sec,
+            },
+            Self::Stopwatch => ClockSpec::StopWatch {
+                total_time_min,
+                byoyomi_min,
+            },
+        }
+    }
 }
 
 fn main() -> anyhow::Result<()> {
@@ -85,8 +126,12 @@ fn main() -> anyhow::Result<()> {
     let config = ServerConfig {
         bind_addr,
         kifu_topdir: cli.kifu_dir,
-        total_time_sec: cli.total_time_sec,
-        byoyomi_sec: cli.byoyomi_sec,
+        clock: cli.clock_kind.to_clock_spec(
+            cli.total_time_sec,
+            cli.byoyomi_sec,
+            cli.total_time_min,
+            cli.byoyomi_min,
+        ),
         time_margin_ms: cli.margin_ms,
         max_moves: cli.max_moves,
         login_timeout: std::time::Duration::from_secs(30),

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -24,8 +24,8 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
+use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::error::{ProtocolError, ServerError};
-use rshogi_csa_server::game::clock::SecondsCountdownClock;
 use rshogi_csa_server::game::result::GameResult;
 use rshogi_csa_server::game::room::{GameRoom, GameRoomConfig};
 use rshogi_csa_server::matching::league::{League, LoginResult, MatchedPair, PlayerStatus};
@@ -46,7 +46,7 @@ use rshogi_csa_server::record::kifu::{
 use rshogi_csa_server::types::{
     Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, RoomId,
 };
-use rshogi_csa_server::{FileKifuStorage, TimeClock, TransportError};
+use rshogi_csa_server::{FileKifuStorage, TransportError};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, Notify, oneshot};
 use tokio::task::JoinHandle;
@@ -90,10 +90,8 @@ pub struct ServerConfig {
     pub bind_addr: SocketAddr,
     /// CSA V2 棋譜と 00LIST の保存先ルート。
     pub kifu_topdir: std::path::PathBuf,
-    /// Game_Summary に埋め込む持ち時間 (秒)。
-    pub total_time_sec: u32,
-    /// 秒読み (秒)。
-    pub byoyomi_sec: u32,
+    /// 対局で使う時計方式とパラメータ。
+    pub clock: ClockSpec,
     /// 通信マージン (ミリ秒)。`GameRoom` の `consume` 前に差し引かれる。
     pub time_margin_ms: u64,
     /// 最大手数。
@@ -137,8 +135,7 @@ impl ServerConfig {
         Self {
             bind_addr: "127.0.0.1:4081".parse().unwrap(),
             kifu_topdir: std::path::PathBuf::from("./kifu"),
-            total_time_sec: 600,
-            byoyomi_sec: 10,
+            clock: ClockSpec::default(),
             time_margin_ms: 1_500,
             max_moves: 256,
             login_timeout: Duration::from_secs(30),
@@ -1216,7 +1213,8 @@ where
     P: PasswordStore + 'static,
 {
     // Game_Summary を両対局者に送信。
-    let clock = SecondsCountdownClock::new(state.config.total_time_sec, state.config.byoyomi_sec);
+    let clock = state.config.clock.build_clock();
+    let time_section = state.config.clock.format_time_section();
     // `initial_sfen` が設定されていればそれから派生、無ければ平手固定のブロックを使う。
     // GameRoom / Game_Summary / 棋譜 の三点一致契約 (GameRoomConfig::initial_sfen の
     // doc を参照) を満たすため、同じ SFEN を複数入口で再利用する。
@@ -1236,7 +1234,7 @@ where
         game_id: game_id.clone(),
         black: matched.black.clone(),
         white: matched.white.clone(),
-        time_section: clock.format_summary(),
+        time_section,
         position_section,
         rematch_on_draw: false,
         to_move,
@@ -1468,7 +1466,7 @@ async fn initialize_game_and_dispatch_start<R, K, P>(
     state: &SharedState<R, K, P>,
     game_id: &GameId,
     matched: &MatchedPair,
-    clock: SecondsCountdownClock,
+    clock: Box<dyn rshogi_csa_server::TimeClock>,
     match_initial_sfen: Option<String>,
     black: &mut TcpTransport,
     white: &mut TcpTransport,
@@ -1487,7 +1485,7 @@ where
         entering_king_rule: state.config.entering_king_rule,
         initial_sfen: match_initial_sfen,
     };
-    let mut room = GameRoom::new(cfg, Box::new(clock))?;
+    let mut room = GameRoom::new(cfg, clock)?;
 
     let start_instant = tokio::time::Instant::now();
     let now_ms =
@@ -1637,7 +1635,6 @@ where
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
 {
-    let clock = SecondsCountdownClock::new(state.config.total_time_sec, state.config.byoyomi_sec);
     // initial_sfen が設定されていれば棋譜の `initial_position` も同じ SFEN から派生。
     // 設定されていない (= 平手) 場合は既存の CSA shorthand `PI\n+\n` を保つ。
     // 長期的には常に `BEGIN Position` 形式に統一しても良いが、shogi-server 互換
@@ -1655,7 +1652,7 @@ where
         start_time: start_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         end_time: end_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         event: "rshogi-csa-server-tcp".to_owned(),
-        time_section: clock.format_summary(),
+        time_section: state.config.clock.format_time_section(),
         initial_position,
         moves: moves.to_vec(),
         result: result.clone(),

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -424,27 +424,10 @@ where
         let mut pool = state.waiting.lock().await;
         pool.take_complement(&game_name, color)
     } {
-        let match_initial_sfen =
-            match reserve_match_initial_position(state.as_ref(), &game_name).await? {
-                MatchInitialPosition::Default(sfen) => sfen,
-                MatchInitialPosition::Reserved(sfen) => Some(sfen),
-                MatchInitialPosition::Exhausted => {
-                    let mut pool = state.waiting.lock().await;
-                    pool.push(game_name.clone(), slot);
-                    log::info!("buoy {game_name} exhausted; falling back to waiter");
-                    return run_waiter(
-                        state.clone(),
-                        transport,
-                        handle,
-                        color,
-                        game_name,
-                        handle_player,
-                        x1,
-                    )
-                    .await;
-                }
-            };
-        // drive 側パス。
+        // buoy を予約する前に相手 waiter の健在と transport handoff を確定する。
+        // 先に予約してしまうと、相手が直前に切断していた場合に buoy 残数が
+        // 消費されたまま復元されない問題があった (codex cloud P1 /
+        // codex CLI round 3 P2)。
         let (resp_tx, resp_rx) = oneshot::channel::<TcpTransport>();
         let (done_tx, done_rx) = oneshot::channel::<()>();
         let req = MatchRequest {
@@ -453,9 +436,36 @@ where
         };
         let opp_handle = slot.handle.clone();
         let opp_color = slot.color;
-        if slot.match_request_tx.send(req).is_ok()
-            && let Ok(opp_transport) = resp_rx.await
-        {
+        let handoff_ok = slot.match_request_tx.send(req).is_ok();
+        let opp_transport = if handoff_ok { resp_rx.await.ok() } else { None };
+        if let Some(opp_transport) = opp_transport {
+            // handoff が確定した後で buoy を予約する。buoy が存在しない場合は
+            // 通常対局、存在して残数があれば予約、残数 0 なら両者に通知して
+            // 対局を取り消す。
+            let match_initial_sfen =
+                match reserve_match_initial_position(state.as_ref(), &game_name).await? {
+                    MatchInitialPosition::Default(sfen) => sfen,
+                    MatchInitialPosition::Reserved(sfen) => Some(sfen),
+                    MatchInitialPosition::Exhausted => {
+                        // buoy 残数 0。相手の waiter に Abort を送りたいが、既に
+                        // Start を送って transport まで受け取ってしまっているので
+                        // 直接 transport にエラーを送って切断する。自分も同じ
+                        // エラーを送って終わる。再キューしない（silently ハング
+                        // するのを避ける）。
+                        log::info!("buoy {game_name} exhausted after handoff; aborting match");
+                        let err_line =
+                            CsaLine::new(format!("##[ERROR] buoy '{game_name}' exhausted"));
+                        let _ = transport.send_line(&err_line).await;
+                        let mut opp_transport = opp_transport;
+                        let _ = opp_transport.send_line(&err_line).await;
+                        let _ = done_tx.send(());
+                        // 両者の League エントリを片付ける。
+                        let mut league = state.league.lock().await;
+                        league.logout(&handle_player);
+                        league.logout(&PlayerName::new(opp_handle.as_str()));
+                        return Ok(());
+                    }
+                };
             return drive_game(
                 state.clone(),
                 opp_transport,
@@ -1087,9 +1097,23 @@ where
     }
     let initial_sfen = match buoy.initial_sfen {
         Some(sfen) => sfen,
-        None => initial_sfen_from_csa_moves(&buoy.moves).map_err(|e| {
-            ServerError::Protocol(ProtocolError::Malformed(format!("buoy {game_name}: {e}")))
-        })?,
+        None => match initial_sfen_from_csa_moves(&buoy.moves) {
+            Ok(sfen) => sfen,
+            Err(e) => {
+                // legacy buoy (initial_sfen 無し、moves からの導出) で moves が
+                // 不正な場合、`reserve_for_match` で既に消費した 1 回分を
+                // 巻き戻す。そうしないと不正 buoy が静かに burn し続ける
+                // (Copilot レビュー指摘)。
+                if let Err(rollback_err) = state.buoy_storage.release_reservation(game_name).await {
+                    log::error!(
+                        "failed to rollback buoy reservation for {game_name}: {rollback_err}"
+                    );
+                }
+                return Err(ServerError::Protocol(ProtocolError::Malformed(format!(
+                    "buoy {game_name}: {e}"
+                ))));
+            }
+        },
     };
     Ok(MatchInitialPosition::Reserved(initial_sfen))
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -39,7 +39,10 @@ use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
 };
-use rshogi_csa_server::record::kifu::{KifuMove, KifuRecord, primary_result_code};
+use rshogi_csa_server::record::kifu::{
+    KifuMove, KifuRecord, fork_initial_sfen_from_kifu, initial_sfen_from_csa_moves,
+    primary_result_code,
+};
 use rshogi_csa_server::types::{
     Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, RoomId,
 };
@@ -424,6 +427,26 @@ where
         let mut pool = state.waiting.lock().await;
         pool.take_complement(&game_name, color)
     } {
+        let match_initial_sfen =
+            match reserve_match_initial_position(state.as_ref(), &game_name).await? {
+                MatchInitialPosition::Default(sfen) => sfen,
+                MatchInitialPosition::Reserved(sfen) => Some(sfen),
+                MatchInitialPosition::Exhausted => {
+                    let mut pool = state.waiting.lock().await;
+                    pool.push(game_name.clone(), slot);
+                    log::info!("buoy {game_name} exhausted; falling back to waiter");
+                    return run_waiter(
+                        state.clone(),
+                        transport,
+                        handle,
+                        color,
+                        game_name,
+                        handle_player,
+                        x1,
+                    )
+                    .await;
+                }
+            };
         // drive 側パス。
         let (resp_tx, resp_rx) = oneshot::channel::<TcpTransport>();
         let (done_tx, done_rx) = oneshot::channel::<()>();
@@ -445,6 +468,7 @@ where
                 handle,
                 color,
                 game_name.clone(),
+                match_initial_sfen,
                 done_tx,
             )
             .await;
@@ -836,11 +860,21 @@ where
                         CsaLine::new("##[SETBUOY] END"),
                     ])
                 } else {
-                    match state.buoy_storage.set(&buoy_name, moves, count).await {
-                        Ok(()) => Some(vec![
-                            CsaLine::new(format!("##[SETBUOY] OK {buoy_name} {count}")),
-                            CsaLine::new("##[SETBUOY] END"),
-                        ]),
+                    match initial_sfen_from_csa_moves(&moves) {
+                        Ok(derived_initial_sfen) => match state
+                            .buoy_storage
+                            .store(&buoy_name, moves, count, Some(derived_initial_sfen))
+                            .await
+                        {
+                            Ok(()) => Some(vec![
+                                CsaLine::new(format!("##[SETBUOY] OK {buoy_name} {count}")),
+                                CsaLine::new("##[SETBUOY] END"),
+                            ]),
+                            Err(e) => Some(vec![
+                                CsaLine::new(format!("##[SETBUOY] ERROR {buoy_name} {e}")),
+                                CsaLine::new("##[SETBUOY] END"),
+                            ]),
+                        },
                         Err(e) => Some(vec![
                             CsaLine::new(format!("##[SETBUOY] ERROR {buoy_name} {e}")),
                             CsaLine::new("##[SETBUOY] END"),
@@ -888,11 +922,43 @@ where
                     ]),
                 }
             }
+            ClientCommand::Fork {
+                source_game,
+                new_buoy,
+                nth_move,
+            } => {
+                let buoy_name =
+                    new_buoy.unwrap_or_else(|| default_fork_buoy_name(&source_game, nth_move));
+                match derive_fork_from_source_kifu(state.as_ref(), &source_game, nth_move).await? {
+                    None => Some(vec![
+                        CsaLine::new(format!("##[FORK] NOT_FOUND {source_game}")),
+                        CsaLine::new("##[FORK] END"),
+                    ]),
+                    Some(derived) => match state
+                        .buoy_storage
+                        .store(&buoy_name, Vec::new(), 1, Some(derived.initial_sfen.clone()))
+                        .await
+                    {
+                        Ok(()) => Some(vec![
+                            CsaLine::new(format!(
+                                "##[FORK] OK {} {}",
+                                buoy_name.as_str(),
+                                derived.applied_moves
+                            )),
+                            CsaLine::new("##[FORK] END"),
+                        ]),
+                        Err(e) => Some(vec![
+                            CsaLine::new(format!("##[FORK] ERROR {} {e}", buoy_name.as_str())),
+                            CsaLine::new("##[FORK] END"),
+                        ]),
+                    },
+                }
+            }
             _ => None,
         };
         let Some(lines) = replies else {
             // 未サポートの x1 コマンド / 対局中コマンドは切断扱い（未配線の
-            // `%%FORK` は後続タスクで追加する）。
+            // x1 拡張以外はここへ落とす）。
             let mut pool = state.waiting.lock().await;
             let _removed = pool.remove_by_handle(&game_name, &handle);
             break 'outer WaiterOutcome::DisconnectedFromPool;
@@ -950,6 +1016,22 @@ enum WaiterOutcome {
     DisconnectedFromPool,
 }
 
+/// buoy 解決結果。通常対局 / buoy 起点 / 枯渇の 3 分岐を区別する。
+enum MatchInitialPosition {
+    /// buoy 未設定。グローバル既定値 (`ServerConfig::initial_sfen`) を使う。
+    Default(Option<String>),
+    /// buoy が有効で、今回の対局用に消費済み。
+    Reserved(String),
+    /// buoy は存在するが残数 0。対局を成立させない。
+    Exhausted,
+}
+
+/// `%%FORK` 派生の結果。
+struct ForkDerivation {
+    initial_sfen: String,
+    applied_moves: u32,
+}
+
 /// `%%MONITOR2ON` の TOCTOU 再確認用ヘルパ。`subscribe` 完了後に game_id が
 /// まだ `GameRegistry` に存在するかを確認する。
 ///
@@ -967,6 +1049,73 @@ where
     games.get(game_id).is_some()
 }
 
+/// 待機プールから相手を拾った後に、その対局で使う開始局面を確定する。
+///
+/// buoy があれば残数を 1 消費してその開始局面を返し、無ければグローバル既定値を返す。
+/// 残数 0 の buoy は対局を成立させない。
+async fn reserve_match_initial_position<R, K, P>(
+    state: &SharedState<R, K, P>,
+    game_name: &GameName,
+) -> Result<MatchInitialPosition, ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let Some(buoy) = state
+        .buoy_storage
+        .reserve_for_match(game_name)
+        .await
+        .map_err(ServerError::Storage)?
+    else {
+        return Ok(MatchInitialPosition::Default(state.config.initial_sfen.clone()));
+    };
+    if buoy.remaining == 0 {
+        return Ok(MatchInitialPosition::Exhausted);
+    }
+    let initial_sfen = match buoy.initial_sfen {
+        Some(sfen) => sfen,
+        None => initial_sfen_from_csa_moves(&buoy.moves).map_err(|e| {
+            ServerError::Protocol(ProtocolError::Malformed(format!("buoy {game_name}: {e}")))
+        })?,
+    };
+    Ok(MatchInitialPosition::Reserved(initial_sfen))
+}
+
+/// `%%FORK` の入力を既存棋譜から SFEN に落とす。
+async fn derive_fork_from_source_kifu<R, K, P>(
+    state: &SharedState<R, K, P>,
+    source_game: &GameId,
+    nth_move: Option<u32>,
+) -> Result<Option<ForkDerivation>, ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let Some(csa_v2_text) =
+        state.kifu_storage.load(source_game).await.map_err(ServerError::Storage)?
+    else {
+        return Ok(None);
+    };
+    let (initial_sfen, applied_moves) = fork_initial_sfen_from_kifu(&csa_v2_text, nth_move)
+        .map_err(|e| {
+            ServerError::Protocol(ProtocolError::Malformed(format!(
+                "%%FORK {}: {e}",
+                source_game.as_str()
+            )))
+        })?;
+    Ok(Some(ForkDerivation {
+        initial_sfen,
+        applied_moves,
+    }))
+}
+
+fn default_fork_buoy_name(source_game: &GameId, nth_move: Option<u32>) -> GameName {
+    let suffix = nth_move.map_or_else(|| "final".to_owned(), |n| n.to_string());
+    GameName::new(format!("{}-fork-{}", source_game.as_str(), suffix))
+}
+
 /// drive 側タスクのメインループ。両 transport を所有して 1 対局を完了まで運ぶ。
 #[allow(clippy::too_many_arguments)]
 async fn drive_game<R, K, P>(
@@ -978,6 +1127,7 @@ async fn drive_game<R, K, P>(
     self_handle: String,
     self_color: Color,
     game_name: GameName,
+    match_initial_sfen: Option<String>,
     opp_completion_tx: oneshot::Sender<()>,
 ) -> Result<(), ServerError>
 where
@@ -1025,6 +1175,7 @@ where
         &game_id,
         matched.clone(),
         game_name.clone(),
+        match_initial_sfen.clone(),
         &mut black_transport,
         &mut white_transport,
     )
@@ -1055,6 +1206,7 @@ async fn drive_game_inner<R, K, P>(
     game_id: &GameId,
     matched: MatchedPair,
     game_name: GameName,
+    match_initial_sfen: Option<String>,
     black_transport: &mut TcpTransport,
     white_transport: &mut TcpTransport,
 ) -> Result<(), ServerError>
@@ -1068,7 +1220,7 @@ where
     // `initial_sfen` が設定されていればそれから派生、無ければ平手固定のブロックを使う。
     // GameRoom / Game_Summary / 棋譜 の三点一致契約 (GameRoomConfig::initial_sfen の
     // doc を参照) を満たすため、同じ SFEN を複数入口で再利用する。
-    let (position_section, to_move) = match &state.config.initial_sfen {
+    let (position_section, to_move) = match &match_initial_sfen {
         Some(sfen) => {
             let section = position_section_from_sfen(sfen).map_err(|e| {
                 ServerError::Protocol(ProtocolError::Malformed(format!("initial_sfen: {e}")))
@@ -1116,6 +1268,7 @@ where
         game_id,
         &matched,
         clock,
+        match_initial_sfen.clone(),
         black_transport,
         white_transport,
     )
@@ -1186,7 +1339,17 @@ where
     let (result, moves) = result_moves?;
 
     // 棋譜 + 00LIST 永続化。
-    persist_kifu(state, game_id, &matched, start_time, end_time, &moves, &result).await?;
+    persist_kifu(
+        state,
+        game_id,
+        &matched,
+        match_initial_sfen.as_deref(),
+        start_time,
+        end_time,
+        &moves,
+        &result,
+    )
+    .await?;
     Ok(())
 }
 
@@ -1306,6 +1469,7 @@ async fn initialize_game_and_dispatch_start<R, K, P>(
     game_id: &GameId,
     matched: &MatchedPair,
     clock: SecondsCountdownClock,
+    match_initial_sfen: Option<String>,
     black: &mut TcpTransport,
     white: &mut TcpTransport,
 ) -> Result<(GameRoom, tokio::time::Instant), ServerError>
@@ -1321,7 +1485,7 @@ where
         max_moves: state.config.max_moves,
         time_margin_ms: state.config.time_margin_ms,
         entering_king_rule: state.config.entering_king_rule,
-        initial_sfen: state.config.initial_sfen.clone(),
+        initial_sfen: match_initial_sfen,
     };
     let mut room = GameRoom::new(cfg, Box::new(clock))?;
 
@@ -1462,6 +1626,7 @@ async fn persist_kifu<R, K, P>(
     state: &SharedState<R, K, P>,
     game_id: &GameId,
     matched: &MatchedPair,
+    initial_sfen: Option<&str>,
     start_time: chrono::DateTime<chrono::Utc>,
     end_time: chrono::DateTime<chrono::Utc>,
     moves: &[KifuMove],
@@ -1477,7 +1642,7 @@ where
     // 設定されていない (= 平手) 場合は既存の CSA shorthand `PI\n+\n` を保つ。
     // 長期的には常に `BEGIN Position` 形式に統一しても良いが、shogi-server 互換
     // バッチへの影響を避けるため hirate のみ現行踏襲 (deferral)。
-    let initial_position = match &state.config.initial_sfen {
+    let initial_position = match initial_sfen {
         Some(sfen) => position_section_from_sfen(sfen).map_err(|e| {
             ServerError::Protocol(ProtocolError::Malformed(format!("initial_sfen: {e}")))
         })?,

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -927,11 +927,15 @@ where
                 let buoy_name =
                     new_buoy.unwrap_or_else(|| default_fork_buoy_name(&source_game, nth_move));
                 match derive_fork_from_source_kifu(state.as_ref(), &source_game, nth_move).await? {
-                    None => Some(vec![
+                    ForkOutcome::NotFound => Some(vec![
                         CsaLine::new(format!("##[FORK] NOT_FOUND {source_game}")),
                         CsaLine::new("##[FORK] END"),
                     ]),
-                    Some(derived) => match state
+                    ForkOutcome::Malformed(msg) => Some(vec![
+                        CsaLine::new(format!("##[FORK] ERROR {} {msg}", buoy_name.as_str())),
+                        CsaLine::new("##[FORK] END"),
+                    ]),
+                    ForkOutcome::Derived(derived) => match state
                         .buoy_storage
                         .store(&buoy_name, Vec::new(), 1, Some(derived.initial_sfen.clone()))
                         .await
@@ -1029,6 +1033,17 @@ struct ForkDerivation {
     applied_moves: u32,
 }
 
+/// `%%FORK` の派生処理の結末。malformed は接続を切らずに x1 応答で
+/// `##[FORK] ERROR ...` に落とすため、Result の Err としては扱わない。
+enum ForkOutcome {
+    /// 元棋譜が存在しない。
+    NotFound,
+    /// 元棋譜は見つかったが CSA として壊れている／`nth_move` が範囲外。
+    Malformed(String),
+    /// 派生成功。
+    Derived(ForkDerivation),
+}
+
 /// `%%MONITOR2ON` の TOCTOU 再確認用ヘルパ。`subscribe` 完了後に game_id が
 /// まだ `GameRegistry` に存在するかを確認する。
 ///
@@ -1080,11 +1095,17 @@ where
 }
 
 /// `%%FORK` の入力を既存棋譜から SFEN に落とす。
+///
+/// 元棋譜が見つからない／壊れている／`nth_move` が範囲外のケースは `Err` では
+/// なく [`ForkOutcome`] の `NotFound` / `Malformed` バリアントで返す。waiter
+/// ループ側は x1 応答 `##[FORK] NOT_FOUND` / `##[FORK] ERROR ...` に落として
+/// 接続を維持し、graceful degradation にする。`Err` は storage I/O 失敗など
+/// 本当に復旧不能な経路にだけ残す。
 async fn derive_fork_from_source_kifu<R, K, P>(
     state: &SharedState<R, K, P>,
     source_game: &GameId,
     nth_move: Option<u32>,
-) -> Result<Option<ForkDerivation>, ServerError>
+) -> Result<ForkOutcome, ServerError>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
@@ -1093,19 +1114,15 @@ where
     let Some(csa_v2_text) =
         state.kifu_storage.load(source_game).await.map_err(ServerError::Storage)?
     else {
-        return Ok(None);
+        return Ok(ForkOutcome::NotFound);
     };
-    let (initial_sfen, applied_moves) = fork_initial_sfen_from_kifu(&csa_v2_text, nth_move)
-        .map_err(|e| {
-            ServerError::Protocol(ProtocolError::Malformed(format!(
-                "%%FORK {}: {e}",
-                source_game.as_str()
-            )))
-        })?;
-    Ok(Some(ForkDerivation {
-        initial_sfen,
-        applied_moves,
-    }))
+    match fork_initial_sfen_from_kifu(&csa_v2_text, nth_move) {
+        Ok((initial_sfen, applied_moves)) => Ok(ForkOutcome::Derived(ForkDerivation {
+            initial_sfen,
+            applied_moves,
+        })),
+        Err(e) => Ok(ForkOutcome::Malformed(format!("%%FORK {}: {e}", source_game.as_str()))),
+    }
 }
 
 fn default_fork_buoy_name(source_game: &GameId, nth_move: Option<u32>) -> GameName {

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -17,9 +17,9 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
-use rshogi_csa_server::FileKifuStorage;
 use rshogi_csa_server::port::PlayerRateRecord;
 use rshogi_csa_server::types::PlayerName;
+use rshogi_csa_server::{ClockSpec, FileKifuStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
@@ -81,6 +81,18 @@ fn unique_topdir(tag: &str) -> PathBuf {
 /// - `127.0.0.1:0` で bind し、実際のポートを返す。
 /// - players は alice/bob 固定（パスワードはどちらも `pw`）。
 async fn spawn_server(tag: &str) -> (std::net::SocketAddr, PathBuf) {
+    spawn_server_with_clock(
+        tag,
+        ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
+    )
+    .await
+}
+
+/// テストシナリオ 1 件分のサーバーを指定時計で立ち上げる。
+async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::SocketAddr, PathBuf) {
     let topdir = unique_topdir(tag);
     let mut password_map = HashMap::new();
     password_map.insert("alice".to_owned(), "pw".to_owned());
@@ -118,8 +130,7 @@ async fn spawn_server(tag: &str) -> (std::net::SocketAddr, PathBuf) {
     let config = ServerConfig {
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
-        total_time_sec: 60,
-        byoyomi_sec: 10,
+        clock,
         time_margin_ms: 1_500,
         max_moves: 256,
         login_timeout: Duration::from_secs(10),
@@ -280,6 +291,68 @@ fn login_ok_and_match_start_via_game_summary_and_agree() {
 }
 
 #[test]
+fn fischer_clock_summary_exposes_increment_field() {
+    run_local(|| async {
+        let (addr, topdir) = spawn_server_with_clock(
+            "fischer_summary",
+            ClockSpec::Fischer {
+                total_time_sec: 60,
+                increment_sec: 5,
+            },
+        )
+        .await;
+        let (mut rb, mut wb) = connect(addr).await;
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let s_black = drain_game_summary(&mut rb).await;
+        let s_white = drain_game_summary(&mut rw).await;
+        for summary in [&s_black, &s_white] {
+            assert!(summary.iter().any(|l| l == "Time_Unit:1sec"), "{summary:?}");
+            assert!(summary.iter().any(|l| l == "Total_Time:60"), "{summary:?}");
+            assert!(summary.iter().any(|l| l == "Increment:5"), "{summary:?}");
+            assert!(!summary.iter().any(|l| l.starts_with("Byoyomi:")), "{summary:?}");
+        }
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn stopwatch_clock_summary_uses_minute_unit() {
+    run_local(|| async {
+        let (addr, topdir) = spawn_server_with_clock(
+            "stopwatch_summary",
+            ClockSpec::StopWatch {
+                total_time_min: 15,
+                byoyomi_min: 1,
+            },
+        )
+        .await;
+        let (mut rb, mut wb) = connect(addr).await;
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let s_black = drain_game_summary(&mut rb).await;
+        let s_white = drain_game_summary(&mut rw).await;
+        for summary in [&s_black, &s_white] {
+            assert!(summary.iter().any(|l| l == "Time_Unit:1min"), "{summary:?}");
+            assert!(summary.iter().any(|l| l == "Total_Time:15"), "{summary:?}");
+            assert!(summary.iter().any(|l| l == "Byoyomi:1"), "{summary:?}");
+            assert!(!summary.iter().any(|l| l.starts_with("Increment:")), "{summary:?}");
+        }
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
 fn kifu_and_zerozero_list_compatible_with_mk_rate() {
     run_local(|| async {
         let (addr, topdir) = spawn_server("kifu_fmt").await;
@@ -386,8 +459,10 @@ async fn spawn_server_with_agree_timeout(
     let config = ServerConfig {
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
-        total_time_sec: 60,
-        byoyomi_sec: 10,
+        clock: ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
         time_margin_ms: 1_500,
         max_moves: 256,
         login_timeout: Duration::from_secs(10),
@@ -975,8 +1050,10 @@ async fn spawn_server_with_admin(
     let config = ServerConfig {
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
-        total_time_sec: 60,
-        byoyomi_sec: 10,
+        clock: ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
         time_margin_ms: 1_500,
         max_moves: 256,
         login_timeout: Duration::from_secs(10),

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1029,6 +1029,26 @@ async fn spawn_server_with_admin(
     tag: &str,
     admin_handles: Vec<String>,
 ) -> (std::net::SocketAddr, PathBuf) {
+    spawn_server_custom(
+        tag,
+        ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
+        EnteringKingRule::Point24,
+        None,
+        admin_handles,
+    )
+    .await
+}
+
+async fn spawn_server_custom(
+    tag: &str,
+    clock: ClockSpec,
+    entering_king_rule: EnteringKingRule,
+    initial_sfen: Option<&str>,
+    admin_handles: Vec<String>,
+) -> (std::net::SocketAddr, PathBuf) {
     let topdir = unique_topdir(tag);
     let mut password_map = HashMap::new();
     for h in ["alice", "bob", "carol", "admin"] {
@@ -1050,17 +1070,14 @@ async fn spawn_server_with_admin(
     let config = ServerConfig {
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
-        clock: ClockSpec::Countdown {
-            total_time_sec: 60,
-            byoyomi_sec: 10,
-        },
+        clock,
         time_margin_ms: 1_500,
         max_moves: 256,
         login_timeout: Duration::from_secs(10),
         agree_timeout: Duration::from_secs(30),
         x1_reply_write_timeout: Duration::from_secs(5),
-        entering_king_rule: EnteringKingRule::Point24,
-        initial_sfen: None,
+        entering_king_rule,
+        initial_sfen: initial_sfen.map(str::to_owned),
         admin_handles,
     };
     let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
@@ -1276,6 +1293,101 @@ fn monitor2_on_unknown_game_returns_not_found() {
         let chat = read_line_raw(&mut rc).await.unwrap();
         assert_eq!(chat, "##[CHAT] NOT_MONITORING");
         let _ = read_line_raw(&mut rc).await.unwrap(); // END
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn uchifuzume_from_initial_sfen_ends_as_illegal_move_e2e() {
+    // Phase 3 acceptance: 打ち歩詰の典型局面を TCP E2E で流し、
+    // `#ILLEGAL_MOVE` → `#LOSE/#WIN` が wire されることを固定する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server_custom(
+            "uchifuzume_e2e",
+            ClockSpec::Countdown {
+                total_time_sec: 60,
+                byoyomi_sec: 10,
+            },
+            EnteringKingRule::Point24,
+            Some("8k/6G2/8+P/9/9/9/9/9/4K4 b P 1"),
+            Vec::new(),
+        )
+        .await;
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let _ = drain_game_summary(&mut rb).await;
+        let _ = drain_game_summary(&mut rw).await;
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        let _ = read_line_raw(&mut rb).await.unwrap();
+        let _ = read_line_raw(&mut rw).await.unwrap();
+
+        send_line(&mut wb, "+0012FU").await;
+        let black_end = read_until(&mut rb, "#LOSE").await;
+        let white_end = read_until(&mut rw, "#WIN").await;
+        assert!(black_end.iter().any(|l| l == "#ILLEGAL_MOVE"), "black_end: {black_end:?}");
+        assert!(white_end.iter().any(|l| l == "#ILLEGAL_MOVE"), "white_end: {white_end:?}");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn oute_sennichite_from_initial_sfen_ends_as_perpetual_check_loss_e2e() {
+    // Phase 3 acceptance: 連続王手千日手の最小循環を TCP E2E で流し、
+    // `#OUTE_SENNICHITE` が終局メッセージとして表に出ることを確認する。
+    run_local(|| async {
+        let (addr, topdir) = spawn_server_custom(
+            "oute_sennichite_e2e",
+            ClockSpec::Countdown {
+                total_time_sec: 60,
+                byoyomi_sec: 10,
+            },
+            EnteringKingRule::Point24,
+            Some("9/6k2/9/9/9/9/9/6R2/K8 w - 1"),
+            Vec::new(),
+        )
+        .await;
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let s_black = drain_game_summary(&mut rb).await;
+        let s_white = drain_game_summary(&mut rw).await;
+        assert!(s_black.iter().any(|l| l == "To_Move:-"), "black summary: {s_black:?}");
+        assert!(s_white.iter().any(|l| l == "To_Move:-"), "white summary: {s_white:?}");
+
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        let _ = read_line_raw(&mut rb).await.unwrap();
+        let _ = read_line_raw(&mut rw).await.unwrap();
+
+        send_line(&mut ww, "-3242OU").await;
+        let _ = read_until(&mut rb, "-3242OU,T0").await;
+        let _ = read_until(&mut rw, "-3242OU,T0").await;
+        send_line(&mut wb, "+3848HI").await;
+        let _ = read_until(&mut rb, "+3848HI,T0").await;
+        let _ = read_until(&mut rw, "+3848HI,T0").await;
+        send_line(&mut ww, "-4232OU").await;
+        let _ = read_until(&mut rb, "-4232OU,T0").await;
+        let _ = read_until(&mut rw, "-4232OU,T0").await;
+        send_line(&mut wb, "+4838HI").await;
+
+        let black_end = read_until(&mut rb, "#LOSE").await;
+        let white_end = read_until(&mut rw, "#WIN").await;
+        assert!(black_end.iter().any(|l| l == "#OUTE_SENNICHITE"), "black_end: {black_end:?}");
+        assert!(white_end.iter().any(|l| l == "#OUTE_SENNICHITE"), "white_end: {white_end:?}");
+
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1091,6 +1091,96 @@ fn getbuoycount_for_unknown_buoy_returns_not_found_without_admin_check() {
 }
 
 #[test]
+fn setbuoy_is_consumed_when_match_starts_and_summary_uses_derived_turn() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_admin("buoy_match_start", vec!["admin".to_owned()]).await;
+
+        let (mut ra, mut wa) = connect(addr).await;
+        send_line(&mut wa, "LOGIN admin+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:admin OK");
+        send_line(&mut wa, "%%SETBUOY g1 +7776FU 1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[SETBUOY] OK g1 1");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[SETBUOY] END");
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let s_black = drain_game_summary(&mut rb).await;
+        let s_white = drain_game_summary(&mut rw).await;
+        assert!(s_black.iter().any(|l| l == "To_Move:-"), "black summary: {s_black:?}");
+        assert!(s_white.iter().any(|l| l == "To_Move:-"), "white summary: {s_white:?}");
+
+        send_line(&mut wa, "%%GETBUOYCOUNT g1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] g1 0");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] END");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn fork_creates_single_use_buoy_from_existing_game() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_admin("fork_from_kifu", vec!["admin".to_owned()]).await;
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+        let _ = drain_game_summary(&mut rb).await;
+        let _ = drain_game_summary(&mut rw).await;
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        let start_b = read_line_raw(&mut rb).await.unwrap();
+        let _ = read_line_raw(&mut rw).await.unwrap();
+        let source_game_id = start_b.trim_start_matches("START:").to_owned();
+        send_line(&mut wb, "+7776FU").await;
+        let _ = read_until(&mut rb, "+7776FU,T0").await;
+        let _ = read_until(&mut rw, "+7776FU,T0").await;
+        send_line(&mut ww, "%TORYO").await;
+        let _ = read_until(&mut rb, "#WIN").await;
+        let _ = read_until(&mut rw, "#LOSE").await;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let (mut ra, mut wa) = connect(addr).await;
+        send_line(&mut wa, "LOGIN admin+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:admin OK");
+        send_line(&mut wa, &format!("%%FORK {} forked 1", source_game_id)).await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[FORK] OK forked 1");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[FORK] END");
+        send_line(&mut wa, "%%GETBUOYCOUNT forked").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] forked 1");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] END");
+
+        let (mut rb2, mut wb2) = connect(addr).await;
+        send_line(&mut wb2, "LOGIN alice+forked+black pw").await;
+        assert_eq!(read_line_raw(&mut rb2).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw2, mut ww2) = connect(addr).await;
+        send_line(&mut ww2, "LOGIN bob+forked+white pw").await;
+        assert_eq!(read_line_raw(&mut rw2).await.unwrap(), "LOGIN:bob OK");
+        let s_black = drain_game_summary(&mut rb2).await;
+        let s_white = drain_game_summary(&mut rw2).await;
+        assert!(s_black.iter().any(|l| l == "To_Move:-"), "forked black summary: {s_black:?}");
+        assert!(s_white.iter().any(|l| l == "To_Move:-"), "forked white summary: {s_white:?}");
+
+        send_line(&mut wa, "%%GETBUOYCOUNT forked").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] forked 0");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] END");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
 fn monitor2_on_unknown_game_returns_not_found() {
     // 存在しない game_id への `%%MONITOR2ON` は `NOT_FOUND` を返し、購読状態を
     // 変更しない (broadcaster にも登録しない)。

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1298,6 +1298,74 @@ fn monitor2_on_unknown_game_returns_not_found() {
 }
 
 #[test]
+fn fork_gracefully_errors_and_keeps_connection_alive() {
+    // 元棋譜が存在しない場合・nth_move が範囲外の場合の `%%FORK` で接続が
+    // 切れずに `##[FORK] NOT_FOUND` / `##[FORK] ERROR ...` + `END` を返すこと
+    // を検証する (codex レビュー PR #474 P2)。検証後に `%%GETBUOYCOUNT` が
+    // 通ることで、waiter ループが健在であることを確認する。
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_admin("fork_graceful_error", vec!["admin".to_owned()]).await;
+
+        // admin で x1 接続。
+        let (mut ra, mut wa) = connect(addr).await;
+        send_line(&mut wa, "LOGIN admin+obs+black pw x1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:admin OK");
+
+        // 1) 存在しない game_id への FORK → NOT_FOUND。
+        send_line(&mut wa, "%%FORK nonexistent-game forked 1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[FORK] NOT_FOUND nonexistent-game");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[FORK] END");
+
+        // 接続が生きていることを %%GETBUOYCOUNT で確認。
+        send_line(&mut wa, "%%GETBUOYCOUNT nothing").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] NOT_FOUND nothing");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] END");
+
+        // 2) 既存対局を作って nth_move を範囲外にした FORK → ERROR。
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+        let _ = drain_game_summary(&mut rb).await;
+        let _ = drain_game_summary(&mut rw).await;
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        // START:<game_id> を読み取って game_id を確定する。
+        let start_b = read_line_raw(&mut rb).await.unwrap();
+        assert!(start_b.starts_with("START:"), "expected START line, got {start_b:?}");
+        let source_game_id = start_b.trim_start_matches("START:").to_owned();
+        let _ = read_line_raw(&mut rw).await.unwrap(); // white 側の START
+        send_line(&mut wb, "+7776FU,T0").await;
+        let _ = read_until(&mut rb, "+7776FU,T0").await;
+        let _ = read_until(&mut rw, "+7776FU,T0").await;
+        send_line(&mut ww, "%TORYO").await;
+        let _ = read_until(&mut rb, "#WIN").await;
+        let _ = read_until(&mut rw, "#LOSE").await;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // nth_move=999 は範囲外。切断せず ERROR + END を返す。
+        send_line(&mut wa, &format!("%%FORK {source_game_id} bad 999")).await;
+        let err_line = read_line_raw(&mut ra).await.unwrap();
+        assert!(
+            err_line.starts_with("##[FORK] ERROR bad"),
+            "expected graceful ERROR response, got {err_line:?}",
+        );
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[FORK] END");
+
+        // まだ接続は生きている。
+        send_line(&mut wa, "%%GETBUOYCOUNT bad").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] NOT_FOUND bad");
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "##[GETBUOYCOUNT] END");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
 fn uchifuzume_from_initial_sfen_ends_as_illegal_move_e2e() {
     // Phase 3 acceptance: 打ち歩詰の典型局面を TCP E2E で流し、
     // `#ILLEGAL_MOVE` → `#LOSE/#WIN` が wire されることを固定する。

--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -54,7 +54,7 @@ impl Role {
 /// - [`WsAttachment::Pending`]: LOGIN 到着前の匿名接続。`websocket_message`
 ///   ハンドラは最初に受信した行を LOGIN として解釈しようとする。
 /// - [`WsAttachment::Player`]: 認証済みプレイヤ。色・ハンドル・game_name を保持する。
-/// - [`WsAttachment::Spectator`]: 観戦者。`game_id` で観戦対象の対局を特定する。
+/// - [`WsAttachment::Spectator`]: 観戦者。`room_id` で観戦対象の部屋を特定する。
 ///   観戦系メッセージ (`%%MONITOR2ON/OFF`, `%%CHAT`) の経路判定と broadcast
 ///   fanout の対象判定に使う。
 ///
@@ -77,11 +77,11 @@ pub enum WsAttachment {
     /// 観戦者。`/ws/<room_id>/spectate` から接続したセッションに付与する。
     ///
     /// Player との違いは「盤面を動かす権限を持たず、broadcast を一方向受信する」点。
-    /// `game_id` は観戦対象の対局 ID で、`GameRoom` DO が broadcast fanout 時に
+    /// `room_id` は観戦対象の部屋 ID で、`GameRoom` DO が broadcast fanout 時に
     /// `WsAttachment::Spectator` 持ちセッション全てへ配信する判定で使う。
     Spectator {
-        /// 観戦対象の対局 ID。
-        game_id: String,
+        /// 観戦対象の部屋 ID。
+        room_id: String,
     },
 }
 
@@ -96,9 +96,9 @@ impl WsAttachment {
     }
 
     /// 観戦者 attachment を構築する補助関数。
-    pub fn spectator(game_id: impl Into<String>) -> Self {
+    pub fn spectator(room_id: impl Into<String>) -> Self {
         Self::Spectator {
-            game_id: game_id.into(),
+            room_id: room_id.into(),
         }
     }
 }
@@ -209,7 +209,7 @@ mod tests {
         let s = serde_json::to_string(&att).unwrap();
         // `#[serde(tag = "type")]` の下では variant 名が `type` 値に入る。
         assert!(s.contains("\"type\":\"Spectator\""));
-        assert!(s.contains("\"game_id\":\"room-xyz\""));
+        assert!(s.contains("\"room_id\":\"room-xyz\""));
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -28,6 +28,8 @@ impl ConfigKeys {
     pub const TOTAL_TIME_MIN: &'static str = "TOTAL_TIME_MIN";
     /// StopWatch 用の秒読み（分）。
     pub const BYOYOMI_MIN: &'static str = "BYOYOMI_MIN";
+    /// 運営権限を持つハンドル名（`%%SETBUOY` / `%%DELETEBUOY`）。
+    pub const ADMIN_HANDLE: &'static str = "ADMIN_HANDLE";
 }
 
 /// Workers `[vars]` 文字列群から時計設定を解決する。

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -4,6 +4,8 @@
 //! 分離してテスト可能にする。値取得の実体は wasm32 ビルドでのみ行い、
 //! 本モジュールが返すのは「取得結果から導出した純粋データ」に閉じる。
 
+use rshogi_csa_server::ClockSpec;
+
 use crate::origin;
 
 /// 起動時にバインディング名として参照する環境変数キー群。
@@ -16,6 +18,48 @@ impl ConfigKeys {
     pub const GAME_ROOM_BINDING: &'static str = "GAME_ROOM";
     /// R2 バケットバインディング名（CSA V2 棋譜保存）。
     pub const KIFU_BUCKET_BINDING: &'static str = "KIFU_BUCKET";
+    /// 時計方式。`countdown` / `fischer` / `stopwatch`。
+    pub const CLOCK_KIND: &'static str = "CLOCK_KIND";
+    /// 秒読み / Fischer 用の持ち時間（秒）。
+    pub const TOTAL_TIME_SEC: &'static str = "TOTAL_TIME_SEC";
+    /// 秒読みの秒読み、または Fischer の増分（秒）。
+    pub const BYOYOMI_SEC: &'static str = "BYOYOMI_SEC";
+    /// StopWatch 用の持ち時間（分）。
+    pub const TOTAL_TIME_MIN: &'static str = "TOTAL_TIME_MIN";
+    /// StopWatch 用の秒読み（分）。
+    pub const BYOYOMI_MIN: &'static str = "BYOYOMI_MIN";
+}
+
+/// Workers `[vars]` 文字列群から時計設定を解決する。
+pub fn parse_clock_spec(
+    clock_kind: Option<&str>,
+    total_time_sec: Option<&str>,
+    byoyomi_sec: Option<&str>,
+    total_time_min: Option<&str>,
+    byoyomi_min: Option<&str>,
+) -> Result<ClockSpec, String> {
+    fn parse_u32(name: &str, raw: Option<&str>, default: u32) -> Result<u32, String> {
+        match raw {
+            Some(s) => s.parse::<u32>().map_err(|e| format!("{name}: invalid u32 {s:?}: {e}")),
+            None => Ok(default),
+        }
+    }
+
+    match clock_kind.unwrap_or("countdown").to_ascii_lowercase().as_str() {
+        "countdown" => Ok(ClockSpec::Countdown {
+            total_time_sec: parse_u32("TOTAL_TIME_SEC", total_time_sec, 600)?,
+            byoyomi_sec: parse_u32("BYOYOMI_SEC", byoyomi_sec, 10)?,
+        }),
+        "fischer" => Ok(ClockSpec::Fischer {
+            total_time_sec: parse_u32("TOTAL_TIME_SEC", total_time_sec, 600)?,
+            increment_sec: parse_u32("BYOYOMI_SEC", byoyomi_sec, 10)?,
+        }),
+        "stopwatch" => Ok(ClockSpec::StopWatch {
+            total_time_min: parse_u32("TOTAL_TIME_MIN", total_time_min, 10)?,
+            byoyomi_min: parse_u32("BYOYOMI_MIN", byoyomi_min, 1)?,
+        }),
+        other => Err(format!("CLOCK_KIND: expected countdown|fischer|stopwatch, got {other:?}")),
+    }
 }
 
 /// 取得済みの Origin 許可リスト設定。
@@ -58,5 +102,44 @@ mod tests {
         let list = OriginAllowList::from_csv("https://a.example, https://b.example");
         let collected: Vec<&str> = list.iter().collect();
         assert_eq!(collected, vec!["https://a.example", "https://b.example"]);
+    }
+
+    #[test]
+    fn parse_clock_spec_defaults_to_countdown() {
+        assert_eq!(
+            parse_clock_spec(None, None, None, None, None).unwrap(),
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_clock_spec_accepts_fischer() {
+        assert_eq!(
+            parse_clock_spec(Some("fischer"), Some("300"), Some("5"), None, None).unwrap(),
+            ClockSpec::Fischer {
+                total_time_sec: 300,
+                increment_sec: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_clock_spec_accepts_stopwatch() {
+        assert_eq!(
+            parse_clock_spec(Some("stopwatch"), None, None, Some("15"), Some("2")).unwrap(),
+            ClockSpec::StopWatch {
+                total_time_min: 15,
+                byoyomi_min: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_clock_spec_rejects_unknown_kind() {
+        let err = parse_clock_spec(Some("weird"), None, None, None, None).unwrap_err();
+        assert!(err.contains("countdown|fischer|stopwatch"));
     }
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -50,7 +50,8 @@ use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
 };
-use rshogi_csa_server::types::{Color, CsaLine, GameId, PlayerName};
+use rshogi_csa_server::record::kifu::{fork_initial_sfen_from_kifu, initial_sfen_from_csa_moves};
+use rshogi_csa_server::types::{Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName};
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::{ConfigKeys, parse_clock_spec};
@@ -58,6 +59,7 @@ use crate::datetime::{format_csa_datetime, format_date_path};
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
 use crate::spectator_control::{MonitorDecision, resolve_monitor_target};
 use crate::ws_route::{WsRoute, parse_ws_route};
+use crate::x1_paths::{buoy_object_key, default_fork_buoy_name, kifu_by_id_object_key};
 
 const DEFAULT_MAX_MOVES: u32 = 256;
 const DEFAULT_TIME_MARGIN_MS: u64 = 1000;
@@ -154,6 +156,21 @@ struct MoveRow {
     color: String,
     line: String,
     at_ms: i64,
+}
+
+/// R2 上の buoy 保存フォーマット。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedBuoy {
+    moves: Vec<String>,
+    remaining: u32,
+    #[serde(default)]
+    initial_sfen: Option<String>,
+}
+
+enum BuoyReservation {
+    Missing,
+    Reserved(Option<String>),
+    Exhausted,
 }
 
 /// 1 対局分の Durable Object。
@@ -403,6 +420,15 @@ impl GameRoom {
         let game_id = format!("{room_id}-{started}");
         let clock_spec = load_clock_spec_from_env(&self.env)?;
         let (main_time_sec, byoyomi_sec) = legacy_clock_fields(&clock_spec);
+        let initial_sfen =
+            match self.reserve_initial_sfen_from_buoy(&GameName::new(game_name)).await? {
+                BuoyReservation::Missing => None,
+                BuoyReservation::Reserved(initial_sfen) => initial_sfen,
+                BuoyReservation::Exhausted => {
+                    console_log!("[GameRoom] buoy '{game_name}' exhausted; match start deferred");
+                    return Ok(());
+                }
+            };
 
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
@@ -416,10 +442,7 @@ impl GameRoom {
             time_margin_ms: DEFAULT_TIME_MARGIN_MS,
             matched_at_ms: started,
             play_started_at_ms: None,
-            // `%%FORK` / buoy 成立経路は未配線のため現時点では常に平手で開始する。
-            // 将来 buoy / fork 経由でここに SFEN が入った場合、cold start 復元も
-            // 同じ SFEN から立ち上がる (PersistedConfig 経由で永続化しているため)。
-            initial_sfen: None,
+            initial_sfen,
         };
         self.state.storage().put(KEY_CONFIG, &cfg).await?;
 
@@ -493,12 +516,13 @@ impl GameRoom {
         let now = self.now_ms();
         let color = role.to_core();
         let csa = CsaLine::new(line);
-        if let Ok(ClientCommand::Chat { message }) = parse_command(&csa) {
-            self.relay_chat(handle, &message).await?;
-            let monitor_id = self.current_monitor_id().await?;
-            send_line(ws, &format!("##[CHAT] OK {monitor_id}"))?;
-            send_line(ws, "##[CHAT] END")?;
-            return Ok(());
+        if let Ok(cmd) = parse_command(&csa) {
+            if let Some(replies) = self.handle_player_control_command(handle, cmd).await? {
+                for out in replies {
+                    send_line(ws, &out)?;
+                }
+                return Ok(());
+            }
         }
 
         let result = {
@@ -577,6 +601,206 @@ impl GameRoom {
             }
             _ => Ok(()),
         }
+    }
+
+    /// プレイヤー接続から受け付ける制御系コマンドを処理する。
+    ///
+    /// `Some(replies)` を返した場合は、呼び出し側が返信行を送って通常の
+    /// `CoreRoom::handle_line` 経路をスキップする。
+    async fn handle_player_control_command(
+        &self,
+        handle: &str,
+        cmd: ClientCommand,
+    ) -> Result<Option<Vec<String>>> {
+        match cmd {
+            ClientCommand::Chat { message } => {
+                self.relay_chat(handle, &message).await?;
+                let monitor_id = self.current_monitor_id().await?;
+                Ok(Some(vec![
+                    format!("##[CHAT] OK {monitor_id}"),
+                    "##[CHAT] END".to_owned(),
+                ]))
+            }
+            ClientCommand::SetBuoy {
+                game_name,
+                moves,
+                count,
+            } => {
+                if !self.is_admin_handle(handle) {
+                    return Ok(Some(vec![
+                        format!("##[SETBUOY] PERMISSION_DENIED {game_name}"),
+                        "##[SETBUOY] END".to_owned(),
+                    ]));
+                }
+                let derived = match initial_sfen_from_csa_moves(&moves) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return Ok(Some(vec![
+                            format!("##[SETBUOY] ERROR {game_name} {e}"),
+                            "##[SETBUOY] END".to_owned(),
+                        ]));
+                    }
+                };
+                let doc = PersistedBuoy {
+                    moves: moves.into_iter().map(|m| m.as_str().to_owned()).collect(),
+                    remaining: count,
+                    initial_sfen: Some(derived),
+                };
+                if let Err(e) = self.store_buoy(&game_name, &doc).await {
+                    return Ok(Some(vec![
+                        format!("##[SETBUOY] ERROR {game_name} {e}"),
+                        "##[SETBUOY] END".to_owned(),
+                    ]));
+                }
+                Ok(Some(vec![
+                    format!("##[SETBUOY] OK {game_name} {count}"),
+                    "##[SETBUOY] END".to_owned(),
+                ]))
+            }
+            ClientCommand::DeleteBuoy { game_name } => {
+                if !self.is_admin_handle(handle) {
+                    return Ok(Some(vec![
+                        format!("##[DELETEBUOY] PERMISSION_DENIED {game_name}"),
+                        "##[DELETEBUOY] END".to_owned(),
+                    ]));
+                }
+                if let Err(e) = self.delete_buoy(&game_name).await {
+                    return Ok(Some(vec![
+                        format!("##[DELETEBUOY] ERROR {game_name} {e}"),
+                        "##[DELETEBUOY] END".to_owned(),
+                    ]));
+                }
+                Ok(Some(vec![
+                    format!("##[DELETEBUOY] OK {game_name}"),
+                    "##[DELETEBUOY] END".to_owned(),
+                ]))
+            }
+            ClientCommand::GetBuoyCount { game_name } => match self.load_buoy(&game_name).await? {
+                Some(doc) => Ok(Some(vec![
+                    format!("##[GETBUOYCOUNT] {game_name} {}", doc.remaining),
+                    "##[GETBUOYCOUNT] END".to_owned(),
+                ])),
+                None => Ok(Some(vec![
+                    format!("##[GETBUOYCOUNT] NOT_FOUND {game_name}"),
+                    "##[GETBUOYCOUNT] END".to_owned(),
+                ])),
+            },
+            ClientCommand::Fork {
+                source_game,
+                new_buoy,
+                nth_move,
+            } => {
+                let buoy_name = new_buoy.unwrap_or_else(|| {
+                    GameName::new(default_fork_buoy_name(source_game.as_str(), nth_move))
+                });
+                let Some(csa_v2) = self.load_kifu_by_game_id(&source_game).await? else {
+                    return Ok(Some(vec![
+                        format!("##[FORK] NOT_FOUND {source_game}"),
+                        "##[FORK] END".to_owned(),
+                    ]));
+                };
+                let (initial_sfen, applied_moves) =
+                    match fork_initial_sfen_from_kifu(&csa_v2, nth_move) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return Ok(Some(vec![
+                                format!("##[FORK] ERROR {buoy_name} {e}"),
+                                "##[FORK] END".to_owned(),
+                            ]));
+                        }
+                    };
+                let doc = PersistedBuoy {
+                    moves: Vec::new(),
+                    remaining: 1,
+                    initial_sfen: Some(initial_sfen),
+                };
+                if let Err(e) = self.store_buoy(&buoy_name, &doc).await {
+                    return Ok(Some(vec![
+                        format!("##[FORK] ERROR {buoy_name} {e}"),
+                        "##[FORK] END".to_owned(),
+                    ]));
+                }
+                Ok(Some(vec![
+                    format!("##[FORK] OK {buoy_name} {applied_moves}"),
+                    "##[FORK] END".to_owned(),
+                ]))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn is_admin_handle(&self, handle: &str) -> bool {
+        let configured = self.env.var(ConfigKeys::ADMIN_HANDLE).ok().map(|v| v.to_string());
+        configured
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_some_and(|admin| admin == handle)
+    }
+
+    async fn reserve_initial_sfen_from_buoy(
+        &self,
+        game_name: &GameName,
+    ) -> Result<BuoyReservation> {
+        let Some(mut buoy) = self.load_buoy(game_name).await? else {
+            return Ok(BuoyReservation::Missing);
+        };
+        if buoy.remaining == 0 {
+            return Ok(BuoyReservation::Exhausted);
+        }
+        let reserved_initial_sfen = match buoy.initial_sfen.as_ref() {
+            Some(sfen) => Some(sfen.clone()),
+            None => {
+                let moves: Vec<CsaMoveToken> =
+                    buoy.moves.iter().map(|mv| CsaMoveToken::new(mv.as_str())).collect();
+                Some(initial_sfen_from_csa_moves(&moves).map_err(Error::RustError)?)
+            }
+        };
+        buoy.remaining -= 1;
+        self.store_buoy(game_name, &buoy).await?;
+        Ok(BuoyReservation::Reserved(reserved_initial_sfen))
+    }
+
+    async fn load_kifu_by_game_id(&self, game_id: &GameId) -> Result<Option<String>> {
+        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
+        let key = kifu_by_id_object_key(game_id.as_str());
+        let Some(obj) = bucket.get(&key).execute().await? else {
+            return Ok(None);
+        };
+        let Some(body) = obj.body() else {
+            return Ok(None);
+        };
+        Ok(Some(body.text().await?))
+    }
+
+    async fn load_buoy(&self, game_name: &GameName) -> Result<Option<PersistedBuoy>> {
+        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
+        let key = buoy_object_key(game_name.as_str());
+        let Some(obj) = bucket.get(&key).execute().await? else {
+            return Ok(None);
+        };
+        let Some(body) = obj.body() else {
+            return Ok(None);
+        };
+        let text = body.text().await?;
+        let doc = serde_json::from_str::<PersistedBuoy>(&text)
+            .map_err(|e| Error::RustError(format!("parse buoy json: {e}")))?;
+        Ok(Some(doc))
+    }
+
+    async fn store_buoy(&self, game_name: &GameName, doc: &PersistedBuoy) -> Result<()> {
+        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
+        let key = buoy_object_key(game_name.as_str());
+        let payload = serde_json::to_vec(doc)
+            .map_err(|e| Error::RustError(format!("serialize buoy json: {e}")))?;
+        bucket.put(&key, payload).execute().await?;
+        Ok(())
+    }
+
+    async fn delete_buoy(&self, game_name: &GameName) -> Result<()> {
+        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
+        let key = buoy_object_key(game_name.as_str());
+        bucket.delete(&key).await
     }
 
     /// 直前の `HandleOutcome` に応じて Alarm を張り替える。
@@ -743,9 +967,11 @@ impl GameRoom {
 
         let date_path = format_date_path(cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms));
         let key = format!("{date_path}/{}.csa", cfg.game_id);
+        let by_id_key = kifu_by_id_object_key(&cfg.game_id);
 
         let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
         bucket.put(&key, text.as_bytes().to_vec()).execute().await?;
+        bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
         console_log!("[GameRoom] kifu exported to R2 key='{key}'");
         Ok(())
     }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -39,7 +39,7 @@ use worker::{
 };
 
 use rshogi_core::types::EnteringKingRule;
-use rshogi_csa_server::game::clock::SecondsCountdownClock;
+use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::game::clock::TimeClock;
 use rshogi_csa_server::game::room::{
     BroadcastEntry, BroadcastTarget, GameRoom as CoreRoom, GameRoomConfig, HandleOutcome,
@@ -53,16 +53,12 @@ use rshogi_csa_server::protocol::summary::{
 use rshogi_csa_server::types::{Color, CsaLine, GameId, PlayerName};
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
-use crate::config::ConfigKeys;
+use crate::config::{ConfigKeys, parse_clock_spec};
 use crate::datetime::{format_csa_datetime, format_date_path};
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
 use crate::spectator_control::{MonitorDecision, resolve_monitor_target};
 use crate::ws_route::{WsRoute, parse_ws_route};
 
-/// 時計既定値 (Floodgate 600-10 互換)。実運用で可変にする必要が出たら
-/// `PersistedConfig` を受け取る構成に切り替える。
-const DEFAULT_MAIN_TIME_SEC: u32 = 600;
-const DEFAULT_BYOYOMI_SEC: u32 = 10;
 const DEFAULT_MAX_MOVES: u32 = 256;
 const DEFAULT_TIME_MARGIN_MS: u64 = 1000;
 
@@ -89,6 +85,23 @@ const KEY_SLOTS: &str = "slots";
 const KEY_CONFIG: &str = "config";
 const KEY_FINISHED: &str = "finished";
 
+fn legacy_clock_fields(clock: &ClockSpec) -> (u32, u32) {
+    match clock {
+        ClockSpec::Countdown {
+            total_time_sec,
+            byoyomi_sec,
+        } => (*total_time_sec, *byoyomi_sec),
+        ClockSpec::Fischer {
+            total_time_sec,
+            increment_sec,
+        } => (*total_time_sec, *increment_sec),
+        ClockSpec::StopWatch {
+            total_time_min,
+            byoyomi_min,
+        } => (*total_time_min, *byoyomi_min),
+    }
+}
+
 /// マッチ成立時に永続化する対局設定。CoreRoom の再構築に必要な最小情報。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistedConfig {
@@ -98,6 +111,10 @@ struct PersistedConfig {
     game_name: String,
     main_time_sec: u32,
     byoyomi_sec: u32,
+    /// 新しい時計設定。旧 JSON では欠落するため `None` を許容し、legacy
+    /// `main_time_sec/byoyomi_sec` へ fallback する。
+    #[serde(default)]
+    clock: Option<ClockSpec>,
     max_moves: u32,
     time_margin_ms: u64,
     /// マッチ成立（2 人目の LOGIN 受理）時刻。`$START_TIME` などの参考に使う。
@@ -112,6 +129,15 @@ struct PersistedConfig {
     /// 組み直す。serde は `#[serde(default)]` で旧 JSON (= `None`) と後方互換。
     #[serde(default)]
     initial_sfen: Option<String>,
+}
+
+impl PersistedConfig {
+    fn clock_spec(&self) -> ClockSpec {
+        self.clock.clone().unwrap_or(ClockSpec::Countdown {
+            total_time_sec: self.main_time_sec,
+            byoyomi_sec: self.byoyomi_sec,
+        })
+    }
 }
 
 /// 終局フラグ。一度 `Some` になったらその DO は同じ対局を二度開始しない。
@@ -375,14 +401,17 @@ impl GameRoom {
             .await?
             .unwrap_or_else(|| "unknown".to_owned());
         let game_id = format!("{room_id}-{started}");
+        let clock_spec = load_clock_spec_from_env(&self.env)?;
+        let (main_time_sec, byoyomi_sec) = legacy_clock_fields(&clock_spec);
 
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
             black_handle: black_handle.to_owned(),
             white_handle: white_handle.to_owned(),
             game_name: game_name.to_owned(),
-            main_time_sec: DEFAULT_MAIN_TIME_SEC,
-            byoyomi_sec: DEFAULT_BYOYOMI_SEC,
+            main_time_sec,
+            byoyomi_sec,
+            clock: Some(clock_spec.clone()),
             max_moves: DEFAULT_MAX_MOVES,
             time_margin_ms: DEFAULT_TIME_MARGIN_MS,
             matched_at_ms: started,
@@ -395,9 +424,8 @@ impl GameRoom {
         self.state.storage().put(KEY_CONFIG, &cfg).await?;
 
         // CoreRoom を構築して in-memory に置く。
-        let clock: Box<dyn TimeClock> =
-            Box::new(SecondsCountdownClock::new(cfg.main_time_sec, cfg.byoyomi_sec));
-        let time_section = clock.format_summary();
+        let clock: Box<dyn TimeClock> = clock_spec.build_clock();
+        let time_section = clock_spec.format_time_section();
         // initial_sfen 指定時は Game_Summary `position_section` / `To_Move` を
         // 同じ SFEN から派生させる。未指定時は平手相当のブロックと `Color::Black`。
         let (position_section, to_move) = match cfg.initial_sfen.as_deref() {
@@ -689,8 +717,7 @@ impl GameRoom {
 
         // `time_section` は clock の初期設定値に依存し、持ち時間の残量には
         // 左右されないので cfg から再構築しても同じ出力になる。
-        let time_section =
-            SecondsCountdownClock::new(cfg.main_time_sec, cfg.byoyomi_sec).format_summary();
+        let time_section = cfg.clock_spec().format_time_section();
 
         let start_str = format_csa_datetime(cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms));
         let end_str = format_csa_datetime(ended_at_ms);
@@ -791,8 +818,7 @@ impl GameRoom {
         let Some(cfg) = cfg_opt else {
             return Ok(());
         };
-        let clock: Box<dyn TimeClock> =
-            Box::new(SecondsCountdownClock::new(cfg.main_time_sec, cfg.byoyomi_sec));
+        let clock: Box<dyn TimeClock> = cfg.clock_spec().build_clock();
         // 永続化済み initial_sfen を信用して CoreRoom を再構築。もし永続化データが
         // 壊れて `set_sfen` が落ちる場合は panic ではなく Err として返し、呼び出し側
         // (`ensure_core_loaded`) の Result で伝搬できるようにする (Codex review
@@ -950,4 +976,20 @@ fn send_line(ws: &WebSocket, line: &str) -> Result<()> {
     }
     ws.send_with_str(&out)
         .map_err(|e| Error::RustError(format!("send_with_str: {e}")))
+}
+
+fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
+    let clock_kind = env.var(ConfigKeys::CLOCK_KIND).ok().map(|v| v.to_string());
+    let total_time_sec = env.var(ConfigKeys::TOTAL_TIME_SEC).ok().map(|v| v.to_string());
+    let byoyomi_sec = env.var(ConfigKeys::BYOYOMI_SEC).ok().map(|v| v.to_string());
+    let total_time_min = env.var(ConfigKeys::TOTAL_TIME_MIN).ok().map(|v| v.to_string());
+    let byoyomi_min = env.var(ConfigKeys::BYOYOMI_MIN).ok().map(|v| v.to_string());
+    parse_clock_spec(
+        clock_kind.as_deref(),
+        total_time_sec.as_deref(),
+        byoyomi_sec.as_deref(),
+        total_time_min.as_deref(),
+        byoyomi_min.as_deref(),
+    )
+    .map_err(Error::RustError)
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -87,6 +87,13 @@ const KEY_SLOTS: &str = "slots";
 const KEY_CONFIG: &str = "config";
 const KEY_FINISHED: &str = "finished";
 
+/// 旧 schema との互換用に `main_time_sec` / `byoyomi_sec` を秒単位で返す。
+///
+/// StopWatch は内部表現が分単位だが、フィールド名が `_sec` なので秒単位に
+/// 揃えて JSON を内部整合させる (Copilot レビュー指摘)。ClockSpec 自体も
+/// `clock` に丸ごと永続化しているため、legacy フィールドは ClockSpec が
+/// 無い旧 JSON からの fallback 専用だが、それでも単位不整合は footgun なので
+/// 秒に正規化しておく。
 fn legacy_clock_fields(clock: &ClockSpec) -> (u32, u32) {
     match clock {
         ClockSpec::Countdown {
@@ -100,7 +107,7 @@ fn legacy_clock_fields(clock: &ClockSpec) -> (u32, u32) {
         ClockSpec::StopWatch {
             total_time_min,
             byoyomi_min,
-        } => (*total_time_min, *byoyomi_min),
+        } => (total_time_min.saturating_mul(60), byoyomi_min.saturating_mul(60)),
     }
 }
 
@@ -1107,11 +1114,17 @@ impl GameRoom {
     }
 
     /// 全観戦者へ 1 行送出する。
+    ///
+    /// 観戦者は best-effort 配信。特定の WS への書き込みが失敗しても他の
+    /// 観戦者や対局進行を止めず、エラーは log に落として継続する (Copilot
+    /// レビュー指摘)。観戦者 1 人の切断が DO を不安定化させないようにする。
     async fn send_to_spectators(&self, line: &str) -> Result<()> {
         for ws in self.state.get_websockets() {
             let att: Option<WsAttachment> = ws.deserialize_attachment().ok().flatten();
-            if let Some(WsAttachment::Spectator { .. }) = att {
-                send_line(&ws, line)?;
+            if let Some(WsAttachment::Spectator { .. }) = att
+                && let Err(e) = send_line(&ws, line)
+            {
+                console_log!("[GameRoom] spectator send failed (ignored): {e:?}");
             }
         }
         Ok(())

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -56,6 +56,7 @@ use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::ConfigKeys;
 use crate::datetime::{format_csa_datetime, format_date_path};
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
+use crate::spectator_control::{MonitorDecision, resolve_monitor_target};
 use crate::ws_route::{WsRoute, parse_ws_route};
 
 /// 時計既定値 (Floodgate 600-10 互換)。実運用で可変にする必要が出たら
@@ -199,7 +200,7 @@ impl DurableObject for GameRoom {
         match attachment {
             WsAttachment::Pending => self.handle_login(&ws, &line).await,
             WsAttachment::Player { role, handle, .. } => {
-                self.handle_game_line(role, &handle, &line).await
+                self.handle_game_line(&ws, role, &handle, &line).await
             }
             WsAttachment::Spectator { room_id } => {
                 self.handle_spectator_line(&ws, &room_id, &line).await
@@ -448,7 +449,13 @@ impl GameRoom {
     }
 
     /// 対局中のプレイヤからの行を CoreRoom に流す。
-    async fn handle_game_line(&self, role: Role, handle: &str, line: &str) -> Result<()> {
+    async fn handle_game_line(
+        &self,
+        ws: &WebSocket,
+        role: Role,
+        handle: &str,
+        line: &str,
+    ) -> Result<()> {
         if self.load_finished().await?.is_some() {
             // 終局後に届いた行は無視する。
             return Ok(());
@@ -460,6 +467,9 @@ impl GameRoom {
         let csa = CsaLine::new(line);
         if let Ok(ClientCommand::Chat { message }) = parse_command(&csa) {
             self.relay_chat(handle, &message).await?;
+            let monitor_id = self.current_monitor_id().await?;
+            send_line(ws, &format!("##[CHAT] OK {monitor_id}"))?;
+            send_line(ws, "##[CHAT] END")?;
             return Ok(());
         }
 
@@ -512,17 +522,27 @@ impl GameRoom {
                 Ok(())
             }
             ClientCommand::Monitor2Off { game_id } => {
-                send_line(ws, &format!("##[MONITOR2OFF] {game_id}"))?;
-                send_line(ws, "##[MONITOR2OFF] END")?;
-                let _ = ws.close(Some(1000), Some("spectator off".to_owned()));
+                match resolve_monitor_target(room_id, active_game_id.as_deref(), game_id.as_str()) {
+                    MonitorDecision::Accept { monitor_id } => {
+                        send_line(ws, &format!("##[MONITOR2OFF] {monitor_id}"))?;
+                        send_line(ws, "##[MONITOR2OFF] END")?;
+                        let _ = ws.close(Some(1000), Some("spectator off".to_owned()));
+                    }
+                    MonitorDecision::NotFound { requested } => {
+                        send_line(ws, &format!("##[MONITOR2OFF] NOT_FOUND {requested}"))?;
+                        send_line(ws, "##[MONITOR2OFF] END")?;
+                    }
+                }
                 Ok(())
             }
             ClientCommand::Monitor2On { game_id } => {
-                let requested = game_id.as_str();
-                if requested == room_id || active_game_id.as_deref() == Some(requested) {
-                    send_line(ws, &format!("##[MONITOR2] BEGIN {monitor_id}"))?;
-                } else {
-                    send_line(ws, &format!("##[MONITOR2] NOT_FOUND {game_id}"))?;
+                match resolve_monitor_target(room_id, active_game_id.as_deref(), game_id.as_str()) {
+                    MonitorDecision::Accept { monitor_id } => {
+                        send_line(ws, &format!("##[MONITOR2] BEGIN {monitor_id}"))?;
+                    }
+                    MonitorDecision::NotFound { requested } => {
+                        send_line(ws, &format!("##[MONITOR2] NOT_FOUND {requested}"))?;
+                    }
                 }
                 send_line(ws, "##[MONITOR2] END")?;
                 Ok(())
@@ -735,6 +755,15 @@ impl GameRoom {
         }
         let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
         Ok(cfg_opt.map(|cfg| cfg.game_id))
+    }
+
+    /// 応答に載せる現在の観戦対象 ID。対局中は `game_id`、それ以前は `room_id`。
+    async fn current_monitor_id(&self) -> Result<String> {
+        if let Some(game_id) = self.active_game_id().await? {
+            return Ok(game_id);
+        }
+        let room_id: Option<String> = self.state.storage().get(KEY_ROOM_ID).await?;
+        Ok(room_id.unwrap_or_else(|| "unknown".to_owned()))
     }
 
     /// CoreRoom が in-memory に無ければ永続化から復元する（`moves` replay 付き）。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -312,7 +312,10 @@ impl DurableObject for GameRoom {
             let Some(core) = borrow.as_mut() else {
                 return Response::ok("no core");
             };
-            let loser = current_turn_color(core.moves_played());
+            // 時計切れ側は現在手番（SFEN `side_to_move` を起点に手数で交代した
+            // 色）。buoy / `%%FORK` で白開始の局面でも正しく白を時間切れ扱いに
+            // する。
+            let loser = core.current_turn();
             Some(core.force_time_up(loser))
         };
         if let Some(result) = outcome {
@@ -420,15 +423,24 @@ impl GameRoom {
         let game_id = format!("{room_id}-{started}");
         let clock_spec = load_clock_spec_from_env(&self.env)?;
         let (main_time_sec, byoyomi_sec) = legacy_clock_fields(&clock_spec);
-        let initial_sfen =
-            match self.reserve_initial_sfen_from_buoy(&GameName::new(game_name)).await? {
-                BuoyReservation::Missing => None,
-                BuoyReservation::Reserved(initial_sfen) => initial_sfen,
-                BuoyReservation::Exhausted => {
-                    console_log!("[GameRoom] buoy '{game_name}' exhausted; match start deferred");
-                    return Ok(false);
-                }
-            };
+        let initial_sfen = match self
+            .reserve_initial_sfen_from_buoy(&GameName::new(game_name))
+            .await?
+        {
+            BuoyReservation::Missing => None,
+            BuoyReservation::Reserved(initial_sfen) => initial_sfen,
+            BuoyReservation::Exhausted => {
+                // 双方の LOGIN は既に OK を返しているので、ここで何もせずに
+                // return するとスロットが永久に詰まる。エラー行を送って
+                // WS を閉じ、slots をクリアして部屋を再利用可能にする。
+                console_log!("[GameRoom] buoy '{game_name}' exhausted; rejecting pending match");
+                self.abort_pending_match_with_error(&format!(
+                    "##[ERROR] buoy '{game_name}' exhausted"
+                ))
+                .await?;
+                return Ok(false);
+            }
+        };
 
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
@@ -760,23 +772,65 @@ impl GameRoom {
         &self,
         game_name: &GameName,
     ) -> Result<BuoyReservation> {
-        let Some(mut buoy) = self.load_buoy(game_name).await? else {
-            return Ok(BuoyReservation::Missing);
-        };
-        if buoy.remaining == 0 {
-            return Ok(BuoyReservation::Exhausted);
-        }
-        let reserved_initial_sfen = match buoy.initial_sfen.as_ref() {
-            Some(sfen) => Some(sfen.clone()),
-            None => {
-                let moves: Vec<CsaMoveToken> =
-                    buoy.moves.iter().map(|mv| CsaMoveToken::new(mv.as_str())).collect();
-                Some(initial_sfen_from_csa_moves(&moves).map_err(Error::RustError)?)
+        // R2 には CAS プリミティブが無い代わりに conditional PUT（etag 一致時
+        // のみ書き込み）が使える。`load → decrement → put(onlyIf=etag)` を
+        // リトライループで回し、別 DO が同時に同じ buoy を予約してきた場合は
+        // etag 不一致で put が Ok(None) に落ちるので再読み込みする。
+        //
+        // リトライ上限は 5 回。実運用では同一 buoy への同時アクセスは稀と
+        // 見込むが、同一 game_name の room が連続して LOGIN を受けると再試行
+        // が必要になり得る。上限に達したら Exhausted 相当にフォールバックせず
+        // 明示的なエラーを返し、`abort_pending_match_with_error` 経由で部屋を
+        // 閉じる（静かな誤受理より fail-fast の方が運用上安全）。
+        const MAX_ATTEMPTS: u32 = 5;
+        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
+        let key = buoy_object_key(game_name.as_str());
+        for attempt in 0..MAX_ATTEMPTS {
+            let Some(obj) = bucket.get(&key).execute().await? else {
+                return Ok(BuoyReservation::Missing);
+            };
+            let etag = obj.etag();
+            let Some(body) = obj.body() else {
+                return Ok(BuoyReservation::Missing);
+            };
+            let text = body.text().await?;
+            let mut buoy: PersistedBuoy = serde_json::from_str(&text)
+                .map_err(|e| Error::RustError(format!("parse buoy json: {e}")))?;
+            if buoy.remaining == 0 {
+                return Ok(BuoyReservation::Exhausted);
             }
-        };
-        buoy.remaining -= 1;
-        self.store_buoy(game_name, &buoy).await?;
-        Ok(BuoyReservation::Reserved(reserved_initial_sfen))
+            let reserved_initial_sfen = match buoy.initial_sfen.as_ref() {
+                Some(sfen) => Some(sfen.clone()),
+                None => {
+                    let moves: Vec<CsaMoveToken> =
+                        buoy.moves.iter().map(|mv| CsaMoveToken::new(mv.as_str())).collect();
+                    Some(initial_sfen_from_csa_moves(&moves).map_err(Error::RustError)?)
+                }
+            };
+            buoy.remaining -= 1;
+            let payload = serde_json::to_vec(&buoy)
+                .map_err(|e| Error::RustError(format!("serialize buoy json: {e}")))?;
+            let put_result = bucket
+                .put(&key, payload)
+                .only_if(worker::Conditional {
+                    etag_matches: Some(etag),
+                    ..Default::default()
+                })
+                .execute()
+                .await?;
+            if put_result.is_some() {
+                return Ok(BuoyReservation::Reserved(reserved_initial_sfen));
+            }
+            console_log!(
+                "[GameRoom] buoy '{}' reservation etag mismatch, retry {}/{MAX_ATTEMPTS}",
+                game_name.as_str(),
+                attempt + 1,
+            );
+        }
+        Err(Error::RustError(format!(
+            "buoy '{}' reservation retry exhausted after {MAX_ATTEMPTS} attempts",
+            game_name.as_str(),
+        )))
     }
 
     async fn try_start_pending_match(&self) -> Result<bool> {
@@ -848,7 +902,7 @@ impl GameRoom {
                     let Some(core) = borrow.as_ref() else {
                         return Ok(());
                     };
-                    let next_turn = current_turn_color(core.moves_played());
+                    let next_turn = core.current_turn();
                     core.clock_turn_budget_ms(next_turn)
                 };
                 let margin_ms = self
@@ -1004,6 +1058,25 @@ impl GameRoom {
         bucket.put(&key, text.as_bytes().to_vec()).execute().await?;
         bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
         console_log!("[GameRoom] kifu exported to R2 key='{key}'");
+        Ok(())
+    }
+
+    /// マッチ開始直前の致命的条件（buoy 枯渇等）で対局を開始できない場合に、
+    /// 既に LOGIN OK を受けている Player ロールの WS 全員にエラー行を送出し、
+    /// 接続を閉じてスロットを空にする。
+    ///
+    /// ここでクリアしないと、スロットは Match 状態のまま残ってしまい 2 人目に
+    /// Game_Summary もエラーも届かないため、部屋が永久に詰まる (codex review
+    /// PR #474 P2)。
+    async fn abort_pending_match_with_error(&self, error_line: &str) -> Result<()> {
+        for ws in self.state.get_websockets() {
+            let att: Option<WsAttachment> = ws.deserialize_attachment().ok().flatten();
+            if matches!(att, Some(WsAttachment::Player { .. })) {
+                let _ = send_line(&ws, error_line);
+                let _ = ws.close(Some(1011), Some("match aborted".to_owned()));
+            }
+        }
+        self.state.storage().put(KEY_SLOTS, &Vec::<Slot>::new()).await?;
         Ok(())
     }
 
@@ -1210,16 +1283,6 @@ impl GameRoom {
             ],
         )?;
         Ok(())
-    }
-}
-
-/// 既消費手数から次の手番色を導出する。平手開始は先手 (Black) なので偶数手目の
-/// 次手番は Black、奇数手目の次手番は White。replay 後や Alarm 起動時に呼ぶ。
-fn current_turn_color(moves_played: u32) -> Color {
-    if moves_played % 2 == 0 {
-        Color::Black
-    } else {
-        Color::White
     }
 }
 

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -2,7 +2,8 @@
 //!
 //! 1 部屋 = 1 DO インスタンス。以下のライフサイクルを駆動する:
 //!
-//! 1. **WebSocket Upgrade** (`fetch`): [`WsAttachment::Pending`] を付けて
+//! 1. **WebSocket Upgrade** (`fetch`): 対局者は [`WsAttachment::Pending`]、
+//!    観戦者は [`WsAttachment::Spectator`] を付けて
 //!    `state.accept_web_socket` で hibernation を有効化する。
 //! 2. **LOGIN** (`websocket_message` / pending): `<handle>+<game_name>+<color>`
 //!    形式を分解し、役割 (Role) 付きスロットとして [`state.storage().put`] に
@@ -55,6 +56,7 @@ use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::ConfigKeys;
 use crate::datetime::{format_csa_datetime, format_date_path};
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
+use crate::ws_route::{WsRoute, parse_ws_route};
 
 /// 時計既定値 (Floodgate 600-10 互換)。実運用で可変にする必要が出たら
 /// `PersistedConfig` を受け取る構成に切り替える。
@@ -151,9 +153,10 @@ impl DurableObject for GameRoom {
     async fn fetch(&self, req: Request) -> Result<Response> {
         let url = req.url()?;
         let path = url.path();
-        let Some(room_id) = path.strip_prefix("/ws/") else {
+        let Some(route) = parse_ws_route(&path) else {
             return Response::error("Upgrade required", 426);
         };
+        let room_id = route.room_id();
 
         // 初回 fetch でのみ room_id を永続化する。`start_match` 側で game_id 生成に
         // 使うため、DO 再構築後でも同じ値を参照できるよう storage に置く。
@@ -168,7 +171,10 @@ impl DurableObject for GameRoom {
         let server = pair.server;
         self.state.accept_web_socket(&server);
 
-        let pending = WsAttachment::Pending;
+        let pending = match route {
+            WsRoute::Player { .. } => WsAttachment::Pending,
+            WsRoute::Spectator { room_id } => WsAttachment::spectator(room_id),
+        };
         server
             .serialize_attachment(&pending)
             .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
@@ -195,13 +201,8 @@ impl DurableObject for GameRoom {
             WsAttachment::Player { role, handle, .. } => {
                 self.handle_game_line(role, &handle, &line).await
             }
-            // 観戦者の受付ルート (`/ws/<room_id>/spectate`) と observer 系コマンドは
-            // 後続 PR で `router::handle_fetch` / `GameRoom` DO へ配線する。現時点では
-            // `WsAttachment::Spectator` 付きセッションは enum 互換性のためだけに存在し、
-            // 受信行は黙って破棄する (Player 経路への誤入を防ぐ)。
-            WsAttachment::Spectator { .. } => {
-                console_log!("[GameRoom] spectator message ignored (route not wired yet)");
-                Ok(())
+            WsAttachment::Spectator { room_id } => {
+                self.handle_spectator_line(&ws, &room_id, &line).await
             }
         }
     }
@@ -457,6 +458,10 @@ impl GameRoom {
         let now = self.now_ms();
         let color = role.to_core();
         let csa = CsaLine::new(line);
+        if let Ok(ClientCommand::Chat { message }) = parse_command(&csa) {
+            self.relay_chat(handle, &message).await?;
+            return Ok(());
+        }
 
         let result = {
             let mut borrow = self.core.borrow_mut();
@@ -487,6 +492,43 @@ impl GameRoom {
         self.reschedule_turn_alarm(&result.outcome).await?;
         self.finalize_if_ended(&result).await?;
         Ok(())
+    }
+
+    /// 観戦者からの制御行。`%%CHAT` を同一 room の全参加者へ relay し、
+    /// `%%MONITOR2OFF` は確認応答後に socket を閉じる。
+    async fn handle_spectator_line(&self, ws: &WebSocket, room_id: &str, line: &str) -> Result<()> {
+        let csa = CsaLine::new(line);
+        let Ok(cmd) = parse_command(&csa) else {
+            return Ok(());
+        };
+        let active_game_id = self.active_game_id().await?;
+        let monitor_id = active_game_id.as_deref().unwrap_or(room_id);
+        match cmd {
+            ClientCommand::KeepAlive => Ok(()),
+            ClientCommand::Chat { message } => {
+                self.relay_chat("spectator", &message).await?;
+                send_line(ws, &format!("##[CHAT] OK {monitor_id}"))?;
+                send_line(ws, "##[CHAT] END")?;
+                Ok(())
+            }
+            ClientCommand::Monitor2Off { game_id } => {
+                send_line(ws, &format!("##[MONITOR2OFF] {game_id}"))?;
+                send_line(ws, "##[MONITOR2OFF] END")?;
+                let _ = ws.close(Some(1000), Some("spectator off".to_owned()));
+                Ok(())
+            }
+            ClientCommand::Monitor2On { game_id } => {
+                let requested = game_id.as_str();
+                if requested == room_id || active_game_id.as_deref() == Some(requested) {
+                    send_line(ws, &format!("##[MONITOR2] BEGIN {monitor_id}"))?;
+                } else {
+                    send_line(ws, &format!("##[MONITOR2] NOT_FOUND {game_id}"))?;
+                }
+                send_line(ws, "##[MONITOR2] END")?;
+                Ok(())
+            }
+            _ => Ok(()),
+        }
     }
 
     /// 直前の `HandleOutcome` に応じて Alarm を張り替える。
@@ -541,11 +583,23 @@ impl GameRoom {
                     self.send_to_role(Role::Black, entry.line.as_str()).await?;
                     self.send_to_role(Role::White, entry.line.as_str()).await?;
                 }
-                // 観戦者は本クレートが扱わないので Spectators は no-op。
-                BroadcastTarget::Spectators => {}
+                BroadcastTarget::Spectators => {
+                    self.send_to_spectators(entry.line.as_str()).await?;
+                }
+            }
+            if matches!(entry.target, BroadcastTarget::All) {
+                self.send_to_spectators(entry.line.as_str()).await?;
             }
         }
         Ok(())
+    }
+
+    /// 同一 room の対局者 + 観戦者全員へ chat を relay する。
+    async fn relay_chat(&self, sender: &str, message: &str) -> Result<()> {
+        let line = format!("##[CHAT] {sender}: {message}");
+        self.send_to_role(Role::Black, &line).await?;
+        self.send_to_role(Role::White, &line).await?;
+        self.send_to_spectators(&line).await
     }
 
     /// 終局したなら R2 に棋譜を書き出し、finished フラグを立てて両 ws を close する。
@@ -661,6 +715,26 @@ impl GameRoom {
             }
         }
         Ok(())
+    }
+
+    /// 全観戦者へ 1 行送出する。
+    async fn send_to_spectators(&self, line: &str) -> Result<()> {
+        for ws in self.state.get_websockets() {
+            let att: Option<WsAttachment> = ws.deserialize_attachment().ok().flatten();
+            if let Some(WsAttachment::Spectator { .. }) = att {
+                send_line(&ws, line)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// 現在アクティブな `game_id` を返す。マッチ成立前は `None`。
+    async fn active_game_id(&self) -> Result<Option<String>> {
+        if let Some(cfg) = self.config.borrow().as_ref() {
+            return Ok(Some(cfg.game_id.clone()));
+        }
+        let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
+        Ok(cfg_opt.map(|cfg| cfg.game_id))
     }
 
     /// CoreRoom が in-memory に無ければ永続化から復元する（`moves` replay 付き）。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -423,16 +423,28 @@ impl GameRoom {
         let game_id = format!("{room_id}-{started}");
         let clock_spec = load_clock_spec_from_env(&self.env)?;
         let (main_time_sec, byoyomi_sec) = legacy_clock_fields(&clock_spec);
-        let initial_sfen = match self
-            .reserve_initial_sfen_from_buoy(&GameName::new(game_name))
-            .await?
+        // 双方の LOGIN は既に OK を返しているので、予約で失敗したまま早期
+        // return するとスロットが永久に詰まる。Exhausted に加え、CAS リトライ
+        // 上限到達などの Err も pending match abort 経路に落として部屋を
+        // 再利用可能にする (codex レビュー PR #474 2nd round P2)。
+        let reservation = match self.reserve_initial_sfen_from_buoy(&GameName::new(game_name)).await
         {
+            Ok(r) => r,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] buoy '{game_name}' reservation failed: {e:?}; rejecting pending match"
+                );
+                self.abort_pending_match_with_error(&format!(
+                    "##[ERROR] buoy '{game_name}' reservation failed"
+                ))
+                .await?;
+                return Ok(false);
+            }
+        };
+        let initial_sfen = match reservation {
             BuoyReservation::Missing => None,
             BuoyReservation::Reserved(initial_sfen) => initial_sfen,
             BuoyReservation::Exhausted => {
-                // 双方の LOGIN は既に OK を返しているので、ここで何もせずに
-                // return するとスロットが永久に詰まる。エラー行を送って
-                // WS を閉じ、slots をクリアして部屋を再利用可能にする。
                 console_log!("[GameRoom] buoy '{game_name}' exhausted; rejecting pending match");
                 self.abort_pending_match_with_error(&format!(
                     "##[ERROR] buoy '{game_name}' exhausted"

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -393,7 +393,7 @@ impl GameRoom {
             game_name,
         } = evaluate_match(&next_slots)
         {
-            self.start_match(&black_handle, &white_handle, &game_name).await?;
+            let _ = self.start_match(&black_handle, &white_handle, &game_name).await?;
         }
 
         Ok(())
@@ -405,7 +405,7 @@ impl GameRoom {
         black_handle: &str,
         white_handle: &str,
         game_name: &str,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         // `room_id` は fetch 時に永続化している（DO インスタンス = room_id なので
         // 他 DO と衝突しない。game_id は `<room_id>-<epoch_ms>` 形式で、
         // 別 DO が同一ミリ秒にマッチしても R2 キー `YYYY/MM/DD/<game_id>.csa` が
@@ -426,7 +426,7 @@ impl GameRoom {
                 BuoyReservation::Reserved(initial_sfen) => initial_sfen,
                 BuoyReservation::Exhausted => {
                     console_log!("[GameRoom] buoy '{game_name}' exhausted; match start deferred");
-                    return Ok(());
+                    return Ok(false);
                 }
             };
 
@@ -496,7 +496,7 @@ impl GameRoom {
         self.send_to_role(Role::Black, &summary_black).await?;
         self.send_to_role(Role::White, &summary_white).await?;
 
-        Ok(())
+        Ok(true)
     }
 
     /// 対局中のプレイヤからの行を CoreRoom に流す。
@@ -512,9 +512,6 @@ impl GameRoom {
             return Ok(());
         }
 
-        self.ensure_core_loaded().await?;
-        let now = self.now_ms();
-        let color = role.to_core();
         let csa = CsaLine::new(line);
         if let Ok(cmd) = parse_command(&csa) {
             if let Some(replies) = self.handle_player_control_command(handle, cmd).await? {
@@ -524,6 +521,14 @@ impl GameRoom {
                 return Ok(());
             }
         }
+
+        if self.active_game_id().await?.is_none() && !self.try_start_pending_match().await? {
+            return Ok(());
+        }
+
+        self.ensure_core_loaded().await?;
+        let now = self.now_ms();
+        let color = role.to_core();
 
         let result = {
             let mut borrow = self.core.borrow_mut();
@@ -675,13 +680,17 @@ impl GameRoom {
                     "##[DELETEBUOY] END".to_owned(),
                 ]))
             }
-            ClientCommand::GetBuoyCount { game_name } => match self.load_buoy(&game_name).await? {
-                Some(doc) => Ok(Some(vec![
+            ClientCommand::GetBuoyCount { game_name } => match self.load_buoy(&game_name).await {
+                Ok(Some(doc)) => Ok(Some(vec![
                     format!("##[GETBUOYCOUNT] {game_name} {}", doc.remaining),
                     "##[GETBUOYCOUNT] END".to_owned(),
                 ])),
-                None => Ok(Some(vec![
+                Ok(None) => Ok(Some(vec![
                     format!("##[GETBUOYCOUNT] NOT_FOUND {game_name}"),
+                    "##[GETBUOYCOUNT] END".to_owned(),
+                ])),
+                Err(e) => Ok(Some(vec![
+                    format!("##[GETBUOYCOUNT] ERROR {game_name} {e}"),
                     "##[GETBUOYCOUNT] END".to_owned(),
                 ])),
             },
@@ -693,11 +702,20 @@ impl GameRoom {
                 let buoy_name = new_buoy.unwrap_or_else(|| {
                     GameName::new(default_fork_buoy_name(source_game.as_str(), nth_move))
                 });
-                let Some(csa_v2) = self.load_kifu_by_game_id(&source_game).await? else {
-                    return Ok(Some(vec![
-                        format!("##[FORK] NOT_FOUND {source_game}"),
-                        "##[FORK] END".to_owned(),
-                    ]));
+                let csa_v2 = match self.load_kifu_by_game_id(&source_game).await {
+                    Ok(Some(csa_v2)) => csa_v2,
+                    Ok(None) => {
+                        return Ok(Some(vec![
+                            format!("##[FORK] NOT_FOUND {source_game}"),
+                            "##[FORK] END".to_owned(),
+                        ]));
+                    }
+                    Err(e) => {
+                        return Ok(Some(vec![
+                            format!("##[FORK] ERROR {buoy_name} {e}"),
+                            "##[FORK] END".to_owned(),
+                        ]));
+                    }
                 };
                 let (initial_sfen, applied_moves) =
                     match fork_initial_sfen_from_kifu(&csa_v2, nth_move) {
@@ -759,6 +777,19 @@ impl GameRoom {
         buoy.remaining -= 1;
         self.store_buoy(game_name, &buoy).await?;
         Ok(BuoyReservation::Reserved(reserved_initial_sfen))
+    }
+
+    async fn try_start_pending_match(&self) -> Result<bool> {
+        let slots = self.load_slots().await?;
+        let MatchResult::Match {
+            black_handle,
+            white_handle,
+            game_name,
+        } = evaluate_match(&slots)
+        else {
+            return Ok(false);
+        };
+        self.start_match(&black_handle, &white_handle, &game_name).await
     }
 
     async fn load_kifu_by_game_id(&self, game_id: &GameId) -> Result<Option<String>> {

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -28,6 +28,7 @@ pub mod datetime;
 pub mod origin;
 pub mod room_id;
 pub mod session_state;
+pub mod ws_route;
 
 #[cfg(target_arch = "wasm32")]
 mod game_room;

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -28,6 +28,7 @@ pub mod datetime;
 pub mod origin;
 pub mod room_id;
 pub mod session_state;
+pub mod spectator_control;
 pub mod ws_route;
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -30,6 +30,7 @@ pub mod room_id;
 pub mod session_state;
 pub mod spectator_control;
 pub mod ws_route;
+pub mod x1_paths;
 
 #[cfg(target_arch = "wasm32")]
 mod game_room;

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -14,7 +14,7 @@ use worker::{Env, Method, Request, Response, Result};
 
 use crate::config::{ConfigKeys, OriginAllowList};
 use crate::origin::{OriginDecision, evaluate};
-use crate::room_id::is_valid_room_id;
+use crate::ws_route::parse_ws_route;
 
 /// `#[event(fetch)]` から委譲されるディスパッチ。
 pub async fn handle_fetch(req: Request, env: Env) -> Result<Response> {
@@ -26,20 +26,23 @@ pub async fn handle_fetch(req: Request, env: Env) -> Result<Response> {
         return Response::ok(format!("rshogi-csa-server-workers v{}", env!("CARGO_PKG_VERSION")));
     }
 
-    if method == Method::Get {
-        if let Some(room_id) = path.strip_prefix("/ws/") {
-            if !is_valid_room_id(room_id) {
-                return Response::error("Invalid room_id", 400);
-            }
-            return forward_ws_to_room(req, env, room_id).await;
-        }
+    if method == Method::Get && path.starts_with("/ws/") {
+        let Some(route) = parse_ws_route(&path) else {
+            return Response::error("Invalid room_id", 400);
+        };
+        return forward_ws_to_room(req, env, &path, route.room_id()).await;
     }
 
     Response::error("Not Found", 404)
 }
 
 /// `/ws/:room_id` を Origin 検査し、許可された場合のみ GameRoom DO に転送する。
-async fn forward_ws_to_room(req: Request, env: Env, room_id: &str) -> Result<Response> {
+async fn forward_ws_to_room(
+    req: Request,
+    env: Env,
+    request_path: &str,
+    room_id: &str,
+) -> Result<Response> {
     // Origin 許可リストは `[vars] CORS_ORIGINS = "<csv>"` から取得する。
     // 値が空や未設定なら `OriginAllowList` は空 = 全拒否（安全側）。
     let allow_csv = env
@@ -68,8 +71,8 @@ async fn forward_ws_to_room(req: Request, env: Env, room_id: &str) -> Result<Res
     let stub = namespace.id_from_name(room_id)?.get_stub()?;
 
     // DO 側 fetch は完全な URL を要求する仕様。転送用のダミー host を立て、
-    // path に `/ws/:room_id` を引き継ぐ（DO 側の path prefix チェックで使う）。
-    let forward_url = format!("https://do.internal/ws/{room_id}");
+    // path をそのまま DO 側へ引き継ぐ（`/spectate` を含む route 判定に使う）。
+    let forward_url = format!("https://do.internal{request_path}");
     let mut fwd = Request::new(&forward_url, Method::Get)?;
     let fwd_headers = fwd.headers_mut()?;
 

--- a/crates/rshogi-csa-server-workers/src/spectator_control.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_control.rs
@@ -1,0 +1,69 @@
+//! 観戦セッション制御の純粋ヘルパ。
+//!
+//! room 固定の WebSocket route と、CSA x1 由来の `game_id` 指定コマンドの対応を
+//! ここに閉じ込める。host target の単体テストで `%%MONITOR2ON/OFF` の判定を
+//! 固定し、wasm32 専用の `GameRoom` 側は結果の送信だけに集中させる。
+
+/// `%%MONITOR2ON/OFF` 解決結果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MonitorDecision<'a> {
+    /// 現在の観戦対象として受理する。
+    Accept {
+        /// 応答に載せる識別子。active な `game_id` があればそれを優先し、無ければ
+        /// `room_id` を返す。
+        monitor_id: &'a str,
+    },
+    /// 指定 ID が現在の room / game と一致しない。
+    NotFound {
+        /// クライアントが要求した識別子。
+        requested: &'a str,
+    },
+}
+
+/// 観戦コマンドの対象 ID を解決する。
+pub fn resolve_monitor_target<'a>(
+    room_id: &'a str,
+    active_game_id: Option<&'a str>,
+    requested: &'a str,
+) -> MonitorDecision<'a> {
+    if requested == room_id || active_game_id == Some(requested) {
+        MonitorDecision::Accept {
+            monitor_id: active_game_id.unwrap_or(room_id),
+        }
+    } else {
+        MonitorDecision::NotFound { requested }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn room_id_is_accepted_before_match() {
+        assert_eq!(
+            resolve_monitor_target("room-1", None, "room-1"),
+            MonitorDecision::Accept {
+                monitor_id: "room-1",
+            }
+        );
+    }
+
+    #[test]
+    fn active_game_id_is_accepted_after_match() {
+        assert_eq!(
+            resolve_monitor_target("room-1", Some("room-1-1712345678"), "room-1-1712345678"),
+            MonitorDecision::Accept {
+                monitor_id: "room-1-1712345678",
+            }
+        );
+    }
+
+    #[test]
+    fn unrelated_id_is_rejected() {
+        assert_eq!(
+            resolve_monitor_target("room-1", Some("room-1-1712345678"), "other"),
+            MonitorDecision::NotFound { requested: "other" }
+        );
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/ws_route.rs
+++ b/crates/rshogi-csa-server-workers/src/ws_route.rs
@@ -1,0 +1,87 @@
+//! Workers 側 WebSocket path の純粋パーサ。
+//!
+//! `GET /ws/<room_id>` は対局者、`GET /ws/<room_id>/spectate` は観戦者として扱う。
+//! ルーティング規則を worker ランタイムから分離し、host target でも単体テスト
+//! できるようにする。
+
+use crate::room_id::is_valid_room_id;
+
+/// WebSocket 接続先の種別。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsRoute {
+    /// 対局者セッション。
+    Player { room_id: String },
+    /// 観戦者セッション。
+    Spectator { room_id: String },
+}
+
+impl WsRoute {
+    /// ルートが参照する room_id。
+    pub fn room_id(&self) -> &str {
+        match self {
+            Self::Player { room_id } | Self::Spectator { room_id } => room_id,
+        }
+    }
+
+    /// 観戦 route かどうか。
+    pub fn is_spectator(&self) -> bool {
+        matches!(self, Self::Spectator { .. })
+    }
+}
+
+/// path 文字列から WebSocket route を解釈する。
+///
+/// `/ws/<room_id>` と `/ws/<room_id>/spectate` だけを受け付ける。`room_id` は
+/// [`is_valid_room_id`] を満たす必要がある。
+pub fn parse_ws_route(path: &str) -> Option<WsRoute> {
+    let tail = path.strip_prefix("/ws/")?;
+    let (room_id, spectator) = match tail.split_once('/') {
+        None => (tail, false),
+        Some((room_id, "spectate")) => (room_id, true),
+        Some(_) => return None,
+    };
+    if !is_valid_room_id(room_id) {
+        return None;
+    }
+    Some(if spectator {
+        WsRoute::Spectator {
+            room_id: room_id.to_owned(),
+        }
+    } else {
+        WsRoute::Player {
+            room_id: room_id.to_owned(),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_player_route() {
+        assert_eq!(
+            parse_ws_route("/ws/room-1"),
+            Some(WsRoute::Player {
+                room_id: "room-1".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_spectator_route() {
+        assert_eq!(
+            parse_ws_route("/ws/room_1/spectate"),
+            Some(WsRoute::Spectator {
+                room_id: "room_1".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_suffix_and_invalid_room() {
+        assert_eq!(parse_ws_route("/ws/room-1/extra"), None);
+        assert_eq!(parse_ws_route("/ws/room/1"), None);
+        assert_eq!(parse_ws_route("/health"), None);
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/x1_paths.rs
+++ b/crates/rshogi-csa-server-workers/src/x1_paths.rs
@@ -1,0 +1,62 @@
+//! Workers 側 x1 拡張で使う R2 キー生成ヘルパ。
+//!
+//! buoy 名 / game_id は任意文字列を含み得るため、R2 オブジェクトキーへ埋める前に
+//! 可逆な `%XX` 形式でエスケープする。
+
+/// オブジェクトキーに安全なエンコーディングへ変換する。
+///
+/// - ASCII 英数字と `-` / `_` はそのまま。
+/// - それ以外は UTF-8 byte 単位で `%XX` (大文字 hex) にエスケープする。
+pub fn encode_component(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for b in raw.bytes() {
+        let is_safe = b.is_ascii_alphanumeric() || b == b'-' || b == b'_';
+        if is_safe {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0f) as usize] as char);
+        }
+    }
+    out
+}
+
+/// buoy 保存先の R2 キー。
+pub fn buoy_object_key(game_name: &str) -> String {
+    format!("buoys/{}.json", encode_component(game_name))
+}
+
+/// game_id から逆引きする棋譜本体キー。
+pub fn kifu_by_id_object_key(game_id: &str) -> String {
+    format!("kifu-by-id/{}.csa", encode_component(game_id))
+}
+
+/// `%%FORK` で省略時に使う既定の buoy 名。
+pub fn default_fork_buoy_name(source_game: &str, nth_move: Option<u32>) -> String {
+    let suffix = nth_move.map_or_else(|| "final".to_owned(), |n| n.to_string());
+    format!("{source_game}-fork-{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_component_preserves_safe_ascii() {
+        assert_eq!(encode_component("floodgate-600_10"), "floodgate-600_10");
+    }
+
+    #[test]
+    fn encode_component_escapes_slash_and_dot_and_utf8() {
+        assert_eq!(encode_component("../a/b"), "%2E%2E%2Fa%2Fb");
+        assert_eq!(encode_component("対局"), "%E5%AF%BE%E5%B1%80");
+    }
+
+    #[test]
+    fn fork_default_name_uses_final_when_nth_missing() {
+        assert_eq!(default_fork_buoy_name("20260417120000", None), "20260417120000-fork-final");
+        assert_eq!(default_fork_buoy_name("20260417120000", Some(24)), "20260417120000-fork-24");
+    }
+}

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -47,3 +47,5 @@ BYOYOMI_SEC = "10"
 # stopwatch 用（分）。CLOCK_KIND=stopwatch のときのみ使う。
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
+# `%%SETBUOY` / `%%DELETEBUOY` を許可する運営ハンドル（LOGIN の handle 部分）。
+ADMIN_HANDLE = "admin"

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -39,3 +39,11 @@ preview_bucket_name = "local-kifu-dev"
 # 空文字列・未設定時は全 Upgrade 要求を 403 で拒否する（安全側の既定）。
 [vars]
 CORS_ORIGINS = ""
+# 対局時計。`countdown` / `fischer` / `stopwatch`。
+CLOCK_KIND = "countdown"
+# countdown / fischer 用（秒）。
+TOTAL_TIME_SEC = "600"
+BYOYOMI_SEC = "10"
+# stopwatch 用（分）。CLOCK_KIND=stopwatch のときのみ使う。
+TOTAL_TIME_MIN = "10"
+BYOYOMI_MIN = "1"

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -17,6 +17,8 @@
 //! 意味が曖昧な単一の `remaining_ms` にせず明確に 2 種類へ分けているのは、
 //! deadline 計算側で秒読みを無視するバグを防ぐため。
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::Color;
 
 /// 1 手消費後の時計判定結果。
@@ -54,7 +56,8 @@ pub trait TimeClock {
 }
 
 /// フロントエンド設定から選択する時計方式。
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ClockSpec {
     /// CSA 2014 改訂互換の秒読み。
     Countdown {

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -53,6 +53,60 @@ pub trait TimeClock {
     fn turn_budget_ms(&self, color: Color) -> i64;
 }
 
+/// フロントエンド設定から選択する時計方式。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClockSpec {
+    /// CSA 2014 改訂互換の秒読み。
+    Countdown {
+        total_time_sec: u32,
+        byoyomi_sec: u32,
+    },
+    /// Fischer 方式（秒単位）。
+    Fischer {
+        total_time_sec: u32,
+        increment_sec: u32,
+    },
+    /// StopWatch 方式（分単位）。
+    StopWatch {
+        total_time_min: u32,
+        byoyomi_min: u32,
+    },
+}
+
+impl Default for ClockSpec {
+    fn default() -> Self {
+        Self::Countdown {
+            total_time_sec: 600,
+            byoyomi_sec: 10,
+        }
+    }
+}
+
+impl ClockSpec {
+    /// 指定設定に対応する時計インスタンスを生成する。
+    pub fn build_clock(&self) -> Box<dyn TimeClock> {
+        match self {
+            Self::Countdown {
+                total_time_sec,
+                byoyomi_sec,
+            } => Box::new(SecondsCountdownClock::new(*total_time_sec, *byoyomi_sec)),
+            Self::Fischer {
+                total_time_sec,
+                increment_sec,
+            } => Box::new(FischerClock::new(*total_time_sec, *increment_sec)),
+            Self::StopWatch {
+                total_time_min,
+                byoyomi_min,
+            } => Box::new(StopWatchClock::new(*total_time_min, *byoyomi_min)),
+        }
+    }
+
+    /// `Game_Summary` / 棋譜へ埋め込む時間セクションを生成する。
+    pub fn format_time_section(&self) -> String {
+        self.build_clock().format_summary()
+    }
+}
+
 /// 秒読み方式の時計（CSA 2014 改訂互換）。
 ///
 /// - `total_time_seconds`: 持ち時間本体（秒）。使い切ると秒読みへ移行。
@@ -630,5 +684,35 @@ mod tests {
         let mut c = StopWatchClock::new(15, 1);
         assert_eq!(c.consume(Color::Black, 60_000), ClockResult::Continue);
         assert_eq!(c.remaining_main_ms(Color::White), 15 * 60 * 1000);
+    }
+
+    #[test]
+    fn clock_spec_builds_matching_summary_for_countdown() {
+        let spec = ClockSpec::Countdown {
+            total_time_sec: 600,
+            byoyomi_sec: 10,
+        };
+        assert_eq!(
+            spec.format_time_section(),
+            SecondsCountdownClock::new(600, 10).format_summary()
+        );
+    }
+
+    #[test]
+    fn clock_spec_builds_matching_summary_for_fischer() {
+        let spec = ClockSpec::Fischer {
+            total_time_sec: 600,
+            increment_sec: 10,
+        };
+        assert_eq!(spec.format_time_section(), FischerClock::new(600, 10).format_summary());
+    }
+
+    #[test]
+    fn clock_spec_builds_matching_summary_for_stopwatch() {
+        let spec = ClockSpec::StopWatch {
+            total_time_min: 15,
+            byoyomi_min: 1,
+        };
+        assert_eq!(spec.format_time_section(), StopWatchClock::new(15, 1).format_summary());
     }
 }

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -216,6 +216,14 @@ impl GameRoom {
         self.moves_played
     }
 
+    /// 現在手番色。`initial_sfen` の `side_to_move` を起点に指し手で交代するため、
+    /// buoy / `%%FORK` 由来の非平手開始局面でも正しい手番を返す。時計アラームや
+    /// replay 後の手番色を `moves_played` から再計算すると SFEN の `w` 開始に
+    /// 対応できないので、時計発火・手番判定では本 API を使う。
+    pub fn current_turn(&self) -> Color {
+        self.pos.side_to_move().into()
+    }
+
     /// 指定側の **本体持ち時間** の残り（ミリ秒）。秒読みは含まない。
     ///
     /// 表示・ログ・棋譜メタデータ用。deadline 計算には
@@ -1204,5 +1212,19 @@ mod tests {
             other => panic!("unexpected outcome: {other:?}"),
         }
         assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#OUTE_SENNICHITE"));
+    }
+
+    #[test]
+    fn current_turn_follows_initial_sfen_side_to_move() {
+        // 平手開始は先手から。
+        let room = make_room();
+        assert_eq!(room.current_turn(), Color::Black);
+
+        // `w`（白手番）開始の SFEN で構築した場合、初手前は White を返す。
+        // codex レビュー P1 回帰防止: buoy / %%FORK 由来で白開始の局面でも
+        // 時計切れ時の loser が先手に誤判定されないことを保証する。
+        let white_turn_sfen = "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2";
+        let room = room_with_sfen(EnteringKingRule::Point24, white_turn_sfen);
+        assert_eq!(room.current_turn(), Color::White);
     }
 }

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -14,7 +14,9 @@ pub mod record;
 pub mod storage;
 
 pub use error::{ProtocolError, ServerError, StateError, StorageError, TransportError};
-pub use game::clock::{ClockResult, SecondsCountdownClock, TimeClock};
+pub use game::clock::{
+    ClockResult, ClockSpec, FischerClock, SecondsCountdownClock, StopWatchClock, TimeClock,
+};
 pub use game::result::{GameResult, IllegalReason};
 pub use game::room::{
     BroadcastEntry, BroadcastTarget, GameRoom, GameRoomConfig, GameStatus, HandleOutcome,

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -33,8 +33,8 @@ pub use protocol::command::{ClientCommand, parse_command};
 pub use protocol::info::{help_lines, list_lines, show_lines, version_lines, who_lines};
 pub use protocol::summary::{GameSummaryBuilder, standard_initial_position_block};
 pub use record::kifu::{
-    KifuMove, KifuRecord, format_zerozero_list_line, illegal_reason_subcode, primary_result_code,
-    winner_of,
+    KifuMove, KifuRecord, fork_initial_sfen_from_kifu, format_zerozero_list_line,
+    illegal_reason_subcode, initial_sfen_from_csa_moves, primary_result_code, winner_of,
 };
 #[cfg(feature = "tokio-transport")]
 pub use storage::buoy::FileBuoyStorage;

--- a/crates/rshogi-csa-server/src/port.rs
+++ b/crates/rshogi-csa-server/src/port.rs
@@ -90,6 +90,15 @@ pub trait KifuStorage {
         csa_v2_text: &str,
     ) -> impl std::future::Future<Output = Result<StorageKey, StorageError>>;
 
+    /// 既存の CSA V2 棋譜を読み出す。
+    ///
+    /// `%%FORK` のように過去棋譜から任意手数の局面を再構築する経路で使う。
+    /// 未保存の `game_id` は `Ok(None)` を返す。
+    fn load(
+        &self,
+        game_id: &GameId,
+    ) -> impl std::future::Future<Output = Result<Option<String>, StorageError>>;
+
     /// 00LIST に 1 行追記する。
     fn append_summary(
         &self,

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -101,6 +101,12 @@ pub enum ClientCommand {
         game_name: GameName,
     },
     /// `%%FORK <source_game> [buoy_name] [nth_move]`
+    ///
+    /// 省略形の曖昧性: 第 2 トークンだけが与えられたとき、それが数字だけなら
+    /// `nth_move`、そうでなければ `buoy_name` として解釈する。数字だけの
+    /// buoy 名（例: `"42"`）を指定したい場合は、3 トークン目に `nth_move`
+    /// を付けて `%%FORK <id> 42 0` のように明示する必要がある（Copilot
+    /// レビュー指摘）。通常の buoy 命名では影響しない。
     Fork {
         /// 派生元の対局 ID。
         source_game: GameId,

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -312,17 +312,26 @@ fn parse_x1(rest: &str) -> Result<ClientCommand, ProtocolError> {
             let src = toks
                 .next()
                 .ok_or_else(|| ProtocolError::Malformed("%%FORK: missing source_game".into()))?;
-            let buoy = toks.next().map(GameName::new);
-            let nth = match toks.next() {
-                Some(s) => Some(
-                    s.parse()
-                        .map_err(|e| ProtocolError::Malformed(format!("%%FORK: bad nth ({e})")))?,
-                ),
-                None => None,
-            };
+            let second = toks.next();
+            let third = toks.next();
             if toks.next().is_some() {
                 return Err(ProtocolError::Malformed("%%FORK: unexpected trailing tokens".into()));
             }
+            let (buoy, nth) =
+                match (second, third) {
+                    (None, None) => (None, None),
+                    (Some(s), None) => match s.parse() {
+                        Ok(nth) => (None, Some(nth)),
+                        Err(_) => (Some(GameName::new(s)), None),
+                    },
+                    (Some(buoy), Some(nth)) => (
+                        Some(GameName::new(buoy)),
+                        Some(nth.parse().map_err(|e| {
+                            ProtocolError::Malformed(format!("%%FORK: bad nth ({e})"))
+                        })?),
+                    ),
+                    (None, Some(_)) => unreachable!("third token without second token"),
+                };
             Ok(ClientCommand::Fork {
                 source_game: GameId::new(src),
                 new_buoy: buoy,
@@ -509,6 +518,42 @@ mod tests {
             parse_command(&line("%%GETBUOYCOUNT buoy1")).unwrap(),
             ClientCommand::GetBuoyCount {
                 game_name: GameName::new("buoy1")
+            }
+        );
+    }
+
+    #[test]
+    fn parses_fork_with_optional_buoy_and_nth_move() {
+        assert_eq!(
+            parse_command(&line("%%FORK 20260417120000")).unwrap(),
+            ClientCommand::Fork {
+                source_game: GameId::new("20260417120000"),
+                new_buoy: None,
+                nth_move: None,
+            }
+        );
+        assert_eq!(
+            parse_command(&line("%%FORK 20260417120000 forked")).unwrap(),
+            ClientCommand::Fork {
+                source_game: GameId::new("20260417120000"),
+                new_buoy: Some(GameName::new("forked")),
+                nth_move: None,
+            }
+        );
+        assert_eq!(
+            parse_command(&line("%%FORK 20260417120000 24")).unwrap(),
+            ClientCommand::Fork {
+                source_game: GameId::new("20260417120000"),
+                new_buoy: None,
+                nth_move: Some(24),
+            }
+        );
+        assert_eq!(
+            parse_command(&line("%%FORK 20260417120000 forked 24")).unwrap(),
+            ClientCommand::Fork {
+                source_game: GameId::new("20260417120000"),
+                new_buoy: Some(GameName::new("forked")),
+                nth_move: Some(24),
             }
         );
     }

--- a/crates/rshogi-csa-server/src/protocol/info.rs
+++ b/crates/rshogi-csa-server/src/protocol/info.rs
@@ -144,6 +144,7 @@ re-LOGIN to return to matchmaking)",
         "%%SETBUOY <game_name> <moves> <count> - register a buoy (admin only)",
         "%%DELETEBUOY <game_name> - delete a buoy (admin only)",
         "%%GETBUOYCOUNT <game_name> - query remaining count of a buoy",
+        "%%FORK <source_game> [buoy_name] [nth_move] - derive a buoy from an existing game",
     ];
     let mut out: Vec<CsaLine> =
         entries.iter().map(|e| CsaLine::new(format!("##[HELP] {e}"))).collect();
@@ -169,7 +170,6 @@ mod tests {
     #[test]
     fn help_lines_cover_currently_wired_commands() {
         // HELP は「実際に受け付けるコマンドだけを advertise する」方針。
-        // 未配線のコマンドが含まれていたら falsely advertised なので弾く。
         let lines = help_lines();
         let joined: String =
             lines.iter().map(|l| l.as_str().to_owned()).collect::<Vec<_>>().join("\n");
@@ -185,11 +185,10 @@ mod tests {
             "%%SETBUOY",
             "%%DELETEBUOY",
             "%%GETBUOYCOUNT",
+            "%%FORK",
         ] {
             assert!(joined.contains(cmd), "help missing {cmd}: {joined}");
         }
-        // 現時点で未配線のコマンド: `%%FORK` のみ。HELP に混入していたら回帰。
-        assert!(!joined.contains("%%FORK"), "help advertises unwired command %%FORK: {joined}");
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/record/kifu.rs
+++ b/crates/rshogi-csa-server/src/record/kifu.rs
@@ -16,6 +16,8 @@
 
 use std::fmt::Write as _;
 
+use rshogi_csa::{ParsedMove, initial_position, parse_csa_full};
+
 use crate::game::result::{GameResult, IllegalReason};
 use crate::types::{Color, CsaMoveToken, GameId, PlayerName};
 
@@ -202,6 +204,46 @@ pub fn illegal_reason_subcode(reason: IllegalReason) -> &'static str {
     }
 }
 
+/// 平手初期局面に CSA 手列を順に適用し、開始局面 SFEN を導出する。
+pub fn initial_sfen_from_csa_moves(moves: &[CsaMoveToken]) -> Result<String, String> {
+    let mut pos = initial_position();
+    for mv in moves {
+        pos.apply_csa_move(mv.as_str())
+            .map_err(|e| format!("invalid buoy move {}: {e}", mv.as_str()))?;
+    }
+    Ok(pos.to_sfen())
+}
+
+/// 既存棋譜から任意手数の派生開始局面 SFEN を導出する。
+///
+/// 返り値の第 2 要素は実際に適用した通常手数。`nth_move = None` のときは
+/// 特殊手 (`%TORYO` など) を除く全通常手を適用する。
+pub fn fork_initial_sfen_from_kifu(
+    csa_v2_text: &str,
+    nth_move: Option<u32>,
+) -> Result<(String, u32), String> {
+    let (mut pos, moves, _info) =
+        parse_csa_full(csa_v2_text).map_err(|e| format!("parse source kifu: {e}"))?;
+    let normal_moves: Vec<_> = moves
+        .into_iter()
+        .filter_map(|m| match m {
+            ParsedMove::Normal(mv) => Some(mv.mv),
+            ParsedMove::Special(_) => None,
+        })
+        .collect();
+    let apply_count = nth_move.unwrap_or(normal_moves.len() as u32) as usize;
+    if apply_count > normal_moves.len() {
+        return Err(format!(
+            "nth_move {apply_count} exceeds available moves {}",
+            normal_moves.len()
+        ));
+    }
+    for mv in normal_moves.iter().take(apply_count) {
+        pos.apply_csa_move(mv).map_err(|e| format!("replay move {mv}: {e}"))?;
+    }
+    Ok((pos.to_sfen(), apply_count as u32))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,6 +413,35 @@ mod tests {
             },
         );
         assert_eq!(line, "g1 alice bob 2026-04-17T12:00:00Z 2026-04-17T12:10:00Z #RESIGN");
+    }
+
+    #[test]
+    fn initial_sfen_from_csa_moves_applies_moves_on_hirate() {
+        let sfen = initial_sfen_from_csa_moves(&[
+            CsaMoveToken::new("+7776FU"),
+            CsaMoveToken::new("-3334FU"),
+        ])
+        .unwrap();
+        assert_eq!(sfen, "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 3");
+    }
+
+    #[test]
+    fn fork_initial_sfen_from_kifu_respects_nth_move() {
+        let mut rec = rec_skeleton();
+        rec.initial_position = "PI\n+\n".to_owned();
+        let txt = rec.build_v2();
+        let (sfen, applied) = fork_initial_sfen_from_kifu(&txt, Some(1)).unwrap();
+        assert_eq!(applied, 1);
+        assert_eq!(sfen, "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2");
+    }
+
+    #[test]
+    fn fork_initial_sfen_from_kifu_rejects_out_of_range_nth_move() {
+        let mut rec = rec_skeleton();
+        rec.initial_position = "PI\n+\n".to_owned();
+        let txt = rec.build_v2();
+        let err = fork_initial_sfen_from_kifu(&txt, Some(3)).unwrap_err();
+        assert!(err.contains("exceeds available moves"), "unexpected: {err}");
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/storage/buoy.rs
+++ b/crates/rshogi-csa-server/src/storage/buoy.rs
@@ -6,6 +6,7 @@
 //! ```text
 //! {
 //!   "moves": ["+7776FU", "-3334FU", ...],
+//!   "initial_sfen": "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2",
 //!   "remaining": 3
 //! }
 //! ```
@@ -15,6 +16,8 @@
 //!   互いの tmp を踏まない (Codex review PR #470 P3)。
 //! - `delete` はファイル削除。ファイル未存在は no-op (`Ok(())`)。
 //! - `count` は JSON を読んで `remaining` を返す。ファイル未存在なら `Ok(None)`。
+//! - `initial_sfen` は任意。通常の `%%SETBUOY` では CSA 手列から導出した開始局面を
+//!   キャッシュし、`%%FORK` では派生局面の SFEN を直接保存する。
 //!
 //! ## ファイル名エンコーディング
 //!
@@ -28,11 +31,13 @@
 //! `tokio-transport` フィーチャ下でのみコンパイルされる (`tokio::fs` が必要)。
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
 
 use crate::error::StorageError;
 use crate::port::BuoyStorage;
@@ -51,6 +56,7 @@ static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug, Clone)]
 pub struct FileBuoyStorage {
     topdir: PathBuf,
+    reserve_lock: Arc<Mutex<()>>,
 }
 
 /// ディスク上の JSON schema。serde が直接 roundtrip できる最小形。
@@ -58,8 +64,22 @@ pub struct FileBuoyStorage {
 struct BuoyFile {
     /// 初期局面に差し込む CSA 手列 (生文字列。検証は呼び出し側の責務)。
     moves: Vec<String>,
+    /// 派生対局の開始局面 SFEN。旧 schema からの後方互換のため省略可。
+    #[serde(default)]
+    initial_sfen: Option<String>,
     /// 残り対局数。0 になると実質 "消費済み"。
     remaining: u32,
+}
+
+/// ストレージから読み出したブイ 1 件分。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredBuoy {
+    /// 初期局面に差し込む CSA 手列。
+    pub moves: Vec<CsaMoveToken>,
+    /// 派生対局の開始局面 SFEN。`Some` ならこちらを優先して使う。
+    pub initial_sfen: Option<String>,
+    /// 残り対局数。
+    pub remaining: u32,
 }
 
 impl FileBuoyStorage {
@@ -67,6 +87,7 @@ impl FileBuoyStorage {
     pub fn new<P: Into<PathBuf>>(topdir: P) -> Self {
         Self {
             topdir: topdir.into(),
+            reserve_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -92,6 +113,94 @@ impl FileBuoyStorage {
         let stem = final_path.file_stem().and_then(|s| s.to_str()).unwrap_or("buoy");
         let parent = final_path.parent().unwrap_or(std::path::Path::new("."));
         parent.join(format!("{stem}.{pid}.{seq}.tmp"))
+    }
+
+    /// ブイを拡張メタデータ付きで保存する。
+    pub async fn store(
+        &self,
+        game_name: &GameName,
+        moves: Vec<CsaMoveToken>,
+        remaining: u32,
+        initial_sfen: Option<String>,
+    ) -> Result<(), StorageError> {
+        let path = self.path_for(game_name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.map_err(to_storage_err)?;
+        }
+        let payload = BuoyFile {
+            moves: moves.into_iter().map(|t| t.as_str().to_owned()).collect(),
+            initial_sfen,
+            remaining,
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .map_err(|e| StorageError::Io(format!("serialize buoy: {e}")))?;
+
+        // .tmp → rename で原子的書き換え。中断時に半端な JSON が残らないようにする。
+        // tmp 名は `<stem>.<pid>.<counter>.tmp` で一意化する。並列 `set` が同じ
+        // buoy に走っても互いの tmp を踏まず、rename は last-writer-wins で
+        // 確定する (Codex review PR #470 P3)。
+        let tmp = self.tmp_path_for(&path);
+        let mut f = fs::File::create(&tmp).await.map_err(to_storage_err)?;
+        f.write_all(&bytes).await.map_err(to_storage_err)?;
+        f.flush().await.map_err(to_storage_err)?;
+        drop(f);
+        fs::rename(&tmp, &path).await.map_err(to_storage_err)?;
+        Ok(())
+    }
+
+    /// ブイを丸ごと読み出す。未登録なら `Ok(None)`。
+    pub async fn load(&self, game_name: &GameName) -> Result<Option<StoredBuoy>, StorageError> {
+        let path = self.path_for(game_name);
+        let bytes = match fs::read(&path).await {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(StorageError::Io(format!("read buoy: {e}"))),
+        };
+        let parsed: BuoyFile = serde_json::from_slice(&bytes)
+            .map_err(|e| StorageError::Io(format!("parse buoy: {e}")))?;
+        Ok(Some(StoredBuoy {
+            moves: parsed.moves.into_iter().map(CsaMoveToken::new).collect(),
+            initial_sfen: parsed.initial_sfen,
+            remaining: parsed.remaining,
+        }))
+    }
+
+    /// 残り対局数を 1 減らす。未登録なら `Ok(None)`。
+    pub async fn decrement_remaining(
+        &self,
+        game_name: &GameName,
+    ) -> Result<Option<u32>, StorageError> {
+        let Some(mut buoy) = self.load(game_name).await? else {
+            return Ok(None);
+        };
+        if buoy.remaining > 0 {
+            buoy.remaining -= 1;
+        }
+        let new_remaining = buoy.remaining;
+        self.store(game_name, buoy.moves, new_remaining, buoy.initial_sfen).await?;
+        Ok(Some(new_remaining))
+    }
+
+    /// マッチ成立時に buoy を 1 回分予約する。
+    ///
+    /// 1 プロセス内では `reserve_lock` で `load + decrement + persist` を直列化し、
+    /// 「残数 1 を 2 対局が同時に拾う」race を防ぐ。
+    pub async fn reserve_for_match(
+        &self,
+        game_name: &GameName,
+    ) -> Result<Option<StoredBuoy>, StorageError> {
+        let _guard = self.reserve_lock.lock().await;
+        let Some(mut buoy) = self.load(game_name).await? else {
+            return Ok(None);
+        };
+        if buoy.remaining == 0 {
+            return Ok(Some(buoy));
+        }
+        let reserved = buoy.clone();
+        buoy.remaining -= 1;
+        self.store(game_name, buoy.moves.clone(), buoy.remaining, buoy.initial_sfen.clone())
+            .await?;
+        Ok(Some(reserved))
     }
 }
 
@@ -125,28 +234,7 @@ impl BuoyStorage for FileBuoyStorage {
         moves: Vec<CsaMoveToken>,
         remaining: u32,
     ) -> Result<(), StorageError> {
-        let path = self.path_for(game_name);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await.map_err(to_storage_err)?;
-        }
-        let payload = BuoyFile {
-            moves: moves.into_iter().map(|t| t.as_str().to_owned()).collect(),
-            remaining,
-        };
-        let bytes = serde_json::to_vec(&payload)
-            .map_err(|e| StorageError::Io(format!("serialize buoy: {e}")))?;
-
-        // .tmp → rename で原子的書き換え。中断時に半端な JSON が残らないようにする。
-        // tmp 名は `<stem>.<pid>.<counter>.tmp` で一意化する。並列 `set` が同じ
-        // buoy に走っても互いの tmp を踏まず、rename は last-writer-wins で
-        // 確定する (Codex review PR #470 P3)。
-        let tmp = self.tmp_path_for(&path);
-        let mut f = fs::File::create(&tmp).await.map_err(to_storage_err)?;
-        f.write_all(&bytes).await.map_err(to_storage_err)?;
-        f.flush().await.map_err(to_storage_err)?;
-        drop(f);
-        fs::rename(&tmp, &path).await.map_err(to_storage_err)?;
-        Ok(())
+        self.store(game_name, moves, remaining, None).await
     }
 
     async fn delete(&self, game_name: &GameName) -> Result<(), StorageError> {
@@ -160,15 +248,7 @@ impl BuoyStorage for FileBuoyStorage {
     }
 
     async fn count(&self, game_name: &GameName) -> Result<Option<u32>, StorageError> {
-        let path = self.path_for(game_name);
-        let bytes = match fs::read(&path).await {
-            Ok(b) => b,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => return Err(StorageError::Io(format!("read buoy: {e}"))),
-        };
-        let parsed: BuoyFile = serde_json::from_slice(&bytes)
-            .map_err(|e| StorageError::Io(format!("parse buoy: {e}")))?;
-        Ok(Some(parsed.remaining))
+        Ok(self.load(game_name).await?.map(|b| b.remaining))
     }
 }
 
@@ -330,6 +410,7 @@ mod tests {
         let bytes = fs::read(&storage.path_for(&gn)).await.unwrap();
         let parsed: BuoyFile = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.remaining, 7);
+        assert_eq!(parsed.initial_sfen, None);
         assert_eq!(
             parsed.moves,
             vec![
@@ -338,6 +419,58 @@ mod tests {
                 "+2726FU".to_owned()
             ]
         );
+        let _ = fs::remove_dir_all(&topdir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_returns_initial_sfen_when_present() {
+        let topdir = unique_topdir("load_initial_sfen");
+        let storage = FileBuoyStorage::new(topdir.clone());
+        let gn = GameName::new("forked");
+        storage
+            .store(
+                &gn,
+                vec![CsaMoveToken::new("+7776FU")],
+                1,
+                Some(
+                    "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2".to_owned(),
+                ),
+            )
+            .await
+            .unwrap();
+        let buoy = storage.load(&gn).await.unwrap().unwrap();
+        assert_eq!(buoy.moves, vec![CsaMoveToken::new("+7776FU")]);
+        assert_eq!(
+            buoy.initial_sfen.as_deref(),
+            Some("lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2")
+        );
+        assert_eq!(buoy.remaining, 1);
+        let _ = fs::remove_dir_all(&topdir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn decrement_remaining_updates_stored_value() {
+        let topdir = unique_topdir("decrement");
+        let storage = FileBuoyStorage::new(topdir.clone());
+        let gn = GameName::new("forked");
+        storage.set(&gn, vec![CsaMoveToken::new("+7776FU")], 2).await.unwrap();
+        assert_eq!(storage.decrement_remaining(&gn).await.unwrap(), Some(1));
+        assert_eq!(storage.count(&gn).await.unwrap(), Some(1));
+        assert_eq!(storage.decrement_remaining(&gn).await.unwrap(), Some(0));
+        assert_eq!(storage.count(&gn).await.unwrap(), Some(0));
+        let _ = fs::remove_dir_all(&topdir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reserve_for_match_returns_original_entry_and_persists_decremented_count() {
+        let topdir = unique_topdir("reserve_for_match");
+        let storage = FileBuoyStorage::new(topdir.clone());
+        let gn = GameName::new("forked");
+        storage.set(&gn, vec![CsaMoveToken::new("+7776FU")], 1).await.unwrap();
+        let reserved = storage.reserve_for_match(&gn).await.unwrap().unwrap();
+        assert_eq!(reserved.remaining, 1);
+        assert_eq!(reserved.moves, vec![CsaMoveToken::new("+7776FU")]);
+        assert_eq!(storage.count(&gn).await.unwrap(), Some(0));
         let _ = fs::remove_dir_all(&topdir).await;
     }
 }

--- a/crates/rshogi-csa-server/src/storage/buoy.rs
+++ b/crates/rshogi-csa-server/src/storage/buoy.rs
@@ -202,6 +202,23 @@ impl FileBuoyStorage {
             .await?;
         Ok(Some(reserved))
     }
+
+    /// `reserve_for_match` で消費した 1 回分を巻き戻す。
+    ///
+    /// マッチ handoff が失敗した（相手が切断していた 等）場合や、buoy からの
+    /// 初期局面導出に失敗した場合に、消費済みの残数を復元するために使う。
+    /// `reserve_for_match` と同じ `reserve_lock` を取るので、`reserve` と
+    /// `release` は 1 プロセス内で直列化される。対象の buoy が既に削除されて
+    /// いれば Ok(()) を返す（巻き戻し対象なしで no-op）。
+    pub async fn release_reservation(&self, game_name: &GameName) -> Result<(), StorageError> {
+        let _guard = self.reserve_lock.lock().await;
+        let Some(mut buoy) = self.load(game_name).await? else {
+            return Ok(());
+        };
+        buoy.remaining = buoy.remaining.saturating_add(1);
+        self.store(game_name, buoy.moves, buoy.remaining, buoy.initial_sfen).await?;
+        Ok(())
+    }
 }
 
 /// `game_name` をファイル名に安全なエンコーディングに変換する。
@@ -471,6 +488,33 @@ mod tests {
         assert_eq!(reserved.remaining, 1);
         assert_eq!(reserved.moves, vec![CsaMoveToken::new("+7776FU")]);
         assert_eq!(storage.count(&gn).await.unwrap(), Some(0));
+        let _ = fs::remove_dir_all(&topdir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn release_reservation_restores_consumed_count() {
+        // handoff 失敗や初期局面導出失敗のロールバック経路。`reserve_for_match`
+        // で 3 → 2 に減らした後、`release_reservation` で 2 → 3 に戻せる。
+        let topdir = unique_topdir("release_reservation");
+        let storage = FileBuoyStorage::new(topdir.clone());
+        let gn = GameName::new("forked-rollback");
+        storage.set(&gn, vec![CsaMoveToken::new("+7776FU")], 3).await.unwrap();
+        let _ = storage.reserve_for_match(&gn).await.unwrap().unwrap();
+        assert_eq!(storage.count(&gn).await.unwrap(), Some(2));
+        storage.release_reservation(&gn).await.unwrap();
+        assert_eq!(storage.count(&gn).await.unwrap(), Some(3));
+        let _ = fs::remove_dir_all(&topdir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn release_reservation_is_no_op_for_missing_buoy() {
+        // buoy が既に削除されている場合、release_reservation は no-op を返す。
+        // 存在しない buoy を作り直さないことも同時に確認する。
+        let topdir = unique_topdir("release_reservation_missing");
+        let storage = FileBuoyStorage::new(topdir.clone());
+        let gn = GameName::new("never-set");
+        storage.release_reservation(&gn).await.unwrap();
+        assert_eq!(storage.count(&gn).await.unwrap(), None);
         let _ = fs::remove_dir_all(&topdir).await;
     }
 }

--- a/crates/rshogi-csa-server/src/storage/file.rs
+++ b/crates/rshogi-csa-server/src/storage/file.rs
@@ -81,6 +81,16 @@ impl KifuStorage for FileKifuStorage {
         Ok(StorageKey::new(rel.to_string_lossy().into_owned()))
     }
 
+    async fn load(&self, game_id: &GameId) -> Result<Option<String>, StorageError> {
+        let rel = self.relative_kifu_path(game_id);
+        let abs = self.topdir.join(&rel);
+        match fs::read_to_string(&abs).await {
+            Ok(body) => Ok(Some(body)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(StorageError::Io(format!("read {abs:?}: {e}"))),
+        }
+    }
+
     async fn append_summary(&self, entry: &GameSummaryEntry) -> Result<(), StorageError> {
         // 同一 FileKifuStorage インスタンスからの append を直列化する。
         // `tokio::fs::File::write_all` は内部で複数 write を呼び得るため、
@@ -178,6 +188,26 @@ mod tests {
         let body = fs::read_to_string(&abs).await.unwrap();
         assert_eq!(body, "V2.2\nN+alice\n");
         // テストの後始末。
+        let _ = fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_returns_saved_kifu_text() {
+        let dir = unique_topdir("load_saved");
+        let store = FileKifuStorage::new(&dir);
+        let game_id = GameId::new("20260417120000");
+        store.save(&game_id, "V2.2\nN+alice\n").await.unwrap();
+        let body = store.load(&game_id).await.unwrap();
+        assert_eq!(body.as_deref(), Some("V2.2\nN+alice\n"));
+        let _ = fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_returns_none_for_unknown_game() {
+        let dir = unique_topdir("load_unknown");
+        let store = FileKifuStorage::new(&dir);
+        let body = store.load(&GameId::new("20260417120000")).await.unwrap();
+        assert_eq!(body, None);
         let _ = fs::remove_dir_all(&dir).await;
     }
 


### PR DESCRIPTION
## Summary

Phase 3 の未完をまとめて進めました。元の `%%FORK` / buoy 対局開始に加えて、Workers 側の観戦 relay・buoy / `%%FORK` 配線、TCP / Workers の追加時計選択、Phase 3 受入 E2E まで含めています。

今回の PR で入る主な変更:

- TCP 側
  - `%%FORK <source_game> [buoy_name] [nth_move]`
  - `%%SETBUOY` 登録時の開始局面 SFEN 導出
  - buoy 消費時の `initial_sfen` を `Game_Summary` / `GameRoom` / 棋譜へ三点配線
  - `Fischer` / `StopWatch` の時計選択
- Workers 側
  - `/ws/<room_id>/spectate` と spectator relay
  - player / spectator 双方の `%%CHAT`
  - `%%MONITOR2ON/OFF` fanout
  - buoy / `%%FORK` / `%%GETBUOYCOUNT` / `%%DELETEBUOY`
  - buoy 由来開始局面の対局開始反映
  - `ADMIN_HANDLE` による `%%SETBUOY` / `%%DELETEBUOY` 制御
  - R2 上の `buoys/` と `kifu-by-id/` を使った fork 元棋譜参照
- 受入シナリオ
  - Phase 3 横断の TCP E2E を追加
  - `打ち歩詰` と `連続王手千日手` を end-to-end で固定

## Why

Phase 3 では個別要素は揃いつつも、実運用に必要な end-to-end の穴が残っていました。

- Workers 側は観戦 relay と buoy / `%%FORK` が未配線だった
- 追加時計は型実装のみで、設定経路が未接続だった
- Phase 3 受入としては `打ち歩詰` / `連続王手千日手` の TCP E2E が不足していた

この PR で、Phase 3 のタスク 11.3 / 12.1 / 12.2 / 13.2 / 13.3 が実装ベースで揃います。

## Notes

- Workers 側 buoy は `KIFU_BUCKET` の R2 に保存し、終局棋譜は日付パスに加えて `kifu-by-id/<game_id>.csa` にも保存します
- `%%FORK` はそこから元棋譜を引いて派生 SFEN を作成します
- review 指摘により、Workers 側の以下も修正済みです
  - buoy 枯渇時に zombie 化しないよう再試行可能に修正
  - R2 読み取り失敗を切断ではなく `ERROR ... END` 応答へ変更

## Validation

実行したチェック:

- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- `cargo test`

追加・強化した主なテスト:

- Workers spectator / chat / monitor 制御
- Workers buoy / `%%FORK` / R2 error recovery
- TCP `Fischer` / `StopWatch` summary
- TCP Phase 3 acceptance E2E:
  - `uchifuzume_from_initial_sfen_ends_as_illegal_move_e2e`
  - `oute_sennichite_from_initial_sfen_ends_as_perpetual_check_loss_e2e`
  - 既存の `%%SETBUOY` / `%%FORK` / x1 info / monitor 系シナリオ

## Impact

- Phase 3 の主要機能が TCP / Workers の両 frontend で揃います
- PR 取り込み後は、残タスクは主に `14.1` の Phase gate と Phase 4 以降に移ります
- 未追跡のローカル作業ファイル群は今回の commit / PR には含めていません