### PR TITLE
[codex] fix cargo-audit failure caused by rustls-webpki advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## 概要
`cargo audit --deny warnings` が `RUSTSEC-2026-0104` で失敗していたため、`Cargo.lock` 上の `rustls-webpki` を安全版へ更新しました。

## 原因
`crates/tools` の `reqwest` 依存が引く `rustls-webpki 0.103.12` に、証明書失効リスト (CRL) パース時の到達可能 panic に関する脆弱性がありました。

## 変更内容
- `Cargo.lock` の `rustls-webpki` を `0.103.12` から `0.103.13` へ更新
- コード変更はなし

## 検証
- `cargo audit --deny warnings`
- `cargo fmt --all --check`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`
