### PR TITLE
[codex] Support Windows preflight for psv_dedup_partition

### DIFF
--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use std::io;
 use std::path::{Path, PathBuf};
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 use std::path::{Component, Prefix};
 #[cfg(not(unix))]
 use sysinfo::Disks;
@@ -185,7 +185,7 @@ fn disk_probe_path(path: &Path) -> Option<PathBuf> {
     canonicalize_maybe_new(probe).ok()
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn normalize_mount_compare_path(path: &Path) -> PathBuf {
     let mut components = path.components();
     let Some(first) = components.next() else {
@@ -205,6 +205,11 @@ fn normalize_mount_compare_path(path: &Path) -> PathBuf {
         normalized.push(component.as_os_str());
     }
     normalized
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn normalize_mount_compare_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
 }
 
 #[cfg(not(unix))]

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -3,10 +3,11 @@
 use crate::common::sfen::normalize_4t;
 use crate::common::sfen_ops::canonicalize_4t_with_mirror;
 use std::collections::HashSet;
-use std::ffi::CString;
 use std::io;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+
+#[cfg(not(unix))]
+use sysinfo::Disks;
 
 /// PackedSfenValue のレコードサイズ（バイト）
 pub const PSV_SIZE: usize = 40;
@@ -173,23 +174,51 @@ pub fn get_mem_available() -> Option<u64> {
     None
 }
 
-/// `statvfs(2)` で指定パスが存在するファイルシステムの空き容量（バイト）を取得する。
-/// 取得できない場合は None。
-pub fn get_disk_available(path: &Path) -> Option<u64> {
-    let probe: &Path = if path.exists() {
+fn disk_probe_path(path: &Path) -> Option<PathBuf> {
+    let probe = if path.exists() {
         path
     } else {
         path.parent().unwrap_or(Path::new("."))
     };
+    canonicalize_maybe_new(probe).ok()
+}
+
+#[cfg(not(unix))]
+fn disk_for_path(path: &Path) -> Option<(PathBuf, u64)> {
+    let probe = disk_probe_path(path)?;
+    let disks = Disks::new_with_refreshed_list();
+    disks
+        .list()
+        .iter()
+        .filter(|disk| probe.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().components().count())
+        .map(|disk| (disk.mount_point().to_path_buf(), disk.available_space()))
+}
+
+/// 指定パスが属するファイルシステムの空き容量（バイト）を取得する。
+/// 取得できない場合は None。
+#[cfg(unix)]
+pub fn get_disk_available(path: &Path) -> Option<u64> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let probe = disk_probe_path(path)?;
     let c = CString::new(probe.as_os_str().as_bytes()).ok()?;
     let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
-    // SAFETY: statvfs は POSIX 標準で、c は有効な C 文字列ポインタ、stat は書き込み可能な
-    // 構造体を指す。失敗時は -1 を返すだけで副作用はない。
+    // SAFETY: statvfs は POSIX 標準で、c は NUL を含まない有効な C 文字列、
+    // stat は書き込み可能な領域を指す。失敗時は None を返すだけ。
     let rc = unsafe { libc::statvfs(c.as_ptr(), &mut stat) };
     if rc != 0 {
         return None;
     }
     Some(stat.f_bavail * stat.f_frsize)
+}
+
+/// 指定パスが属するファイルシステムの空き容量（バイト）を取得する。
+/// 取得できない場合は None。
+#[cfg(not(unix))]
+pub fn get_disk_available(path: &Path) -> Option<u64> {
+    disk_for_path(path).map(|(_, available_space)| available_space)
 }
 
 /// バイト値を `%.1f GiB` 形式で整形する。
@@ -199,21 +228,24 @@ pub fn format_gib(bytes: u64) -> String {
 
 /// 2 つのパスが同一ファイルシステム上にあるかを判定する。
 /// 取得できない場合は None。
+#[cfg(unix)]
 pub fn same_filesystem(a: &Path, b: &Path) -> Option<bool> {
     use std::os::unix::fs::MetadataExt;
-    let probe_a: &Path = if a.exists() {
-        a
-    } else {
-        a.parent().unwrap_or(Path::new("."))
-    };
-    let probe_b: &Path = if b.exists() {
-        b
-    } else {
-        b.parent().unwrap_or(Path::new("."))
-    };
+
+    let probe_a = disk_probe_path(a)?;
+    let probe_b = disk_probe_path(b)?;
     let ma = std::fs::metadata(probe_a).ok()?;
     let mb = std::fs::metadata(probe_b).ok()?;
     Some(ma.dev() == mb.dev())
+}
+
+/// 2 つのパスが同一ファイルシステム上にあるかを判定する。
+/// 取得できない場合は None。
+#[cfg(not(unix))]
+pub fn same_filesystem(a: &Path, b: &Path) -> Option<bool> {
+    let (mount_a, _) = disk_for_path(a)?;
+    let (mount_b, _) = disk_for_path(b)?;
+    Some(mount_a == mount_b)
 }
 
 /// In-memory de-duplicator keyed by 4-token SFEN or mirror-canonicalized 4-token SFEN.

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -7,6 +7,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(unix))]
+use std::path::{Component, Prefix};
+#[cfg(not(unix))]
 use sysinfo::Disks;
 
 /// PackedSfenValue のレコードサイズ（バイト）
@@ -184,15 +186,39 @@ fn disk_probe_path(path: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(not(unix))]
+fn normalize_mount_compare_path(path: &Path) -> PathBuf {
+    let mut components = path.components();
+    let Some(first) = components.next() else {
+        return PathBuf::new();
+    };
+
+    let mut normalized = PathBuf::new();
+    match first {
+        Component::Prefix(prefix) => match prefix.kind() {
+            Prefix::VerbatimDisk(drive) => normalized.push(format!("{}:", drive as char)),
+            _ => normalized.push(first.as_os_str()),
+        },
+        _ => normalized.push(first.as_os_str()),
+    }
+
+    for component in components {
+        normalized.push(component.as_os_str());
+    }
+    normalized
+}
+
+#[cfg(not(unix))]
 fn disk_for_path(path: &Path) -> Option<(PathBuf, u64)> {
-    let probe = disk_probe_path(path)?;
+    let probe = normalize_mount_compare_path(&disk_probe_path(path)?);
     let disks = Disks::new_with_refreshed_list();
     disks
         .list()
         .iter()
-        .filter(|disk| probe.starts_with(disk.mount_point()))
-        .max_by_key(|disk| disk.mount_point().components().count())
-        .map(|disk| (disk.mount_point().to_path_buf(), disk.available_space()))
+        .filter_map(|disk| {
+            let mount = normalize_mount_compare_path(disk.mount_point());
+            probe.starts_with(&mount).then_some((mount, disk.available_space()))
+        })
+        .max_by_key(|(mount, _)| mount.components().count())
 }
 
 /// 指定パスが属するファイルシステムの空き容量（バイト）を取得する。
@@ -315,6 +341,34 @@ mod tests {
         fs::write(&input, [0u8; PSV_SIZE]).unwrap();
 
         check_output_not_in_inputs(&dir.path().join("new/out.psv"), &[input]).unwrap();
+    }
+
+    #[test]
+    fn disk_probe_path_uses_existing_parent_for_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let probe = disk_probe_path(&dir.path().join("out/new.psv")).unwrap();
+
+        assert_eq!(probe, dir.path().canonicalize().unwrap().join("out"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn same_filesystem_returns_true_within_same_tempdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.psv");
+        let b = dir.path().join("nested/b.psv");
+        fs::create_dir_all(b.parent().unwrap()).unwrap();
+
+        assert_eq!(same_filesystem(&a, &b), Some(true));
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn normalize_mount_compare_path_normalizes_verbatim_disk_prefix() {
+        let original = Path::new(r"\\?\C:\work\tmp\dedup");
+        let normalized = normalize_mount_compare_path(original);
+
+        assert_eq!(normalized, PathBuf::from(r"C:\work\tmp\dedup"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`psv_dedup_partition` の事前見積りロジックを OS ごとに分岐し、Windows でも preflight のディスク見積りが動くようにしました。

## Why
`crates/tools/src/common/dedup.rs` が Unix 専用 API に直接依存しており、`psv_dedup_partition` が Windows でコンパイルできませんでした。

## Changes
- Unix では従来どおり `statvfs` と `MetadataExt::dev()` を利用
- 非 Unix では `sysinfo::Disks` で空き容量取得と filesystem 判定を実装
- 既存の `canonicalize_maybe_new` を使って、未作成パスでも比較用の probe path を正規化

## Impact
- Linux/Unix 側の見積り挙動と起動時コストは従来相当を維持
- Windows 側でも `psv_dedup_partition` の preflight 見積り機能を落とさずにビルド可能
- 変更は起動時の事前チェックに限定され、partitioning / dedup 本体ループには影響しません

## Validation
- `cargo fmt`
- `cargo check -p tools --bin psv_dedup_partition`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`

## Root Cause
共通ユーティリティ `dedup.rs` に Unix 固有の `std::os::unix::*` と `libc::statvfs` が直書きされており、Windows 向けビルド時にコンパイル不能になっていました.