### PR TITLE
[codex] feat(csa-server): gate floodgate config behind opt-in

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -75,6 +75,11 @@ struct Cli {
     /// round P2)。`%%GETBUOYCOUNT` は参照系なので権限不要で全ユーザー可。
     #[arg(long = "admin-handle", value_name = "HANDLE")]
     admin_handle: Vec<String>,
+    /// Floodgate 運用機能の opt-in フラグ。Floodgate 系機能を本バイナリで
+    /// 有効化する PR は、本フラグが `true` のときだけ配線を生かすように
+    /// 実装する（現時点ではまだ配線された機能は無い）。
+    #[arg(long, default_value_t = false)]
+    allow_floodgate_features: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -140,6 +145,7 @@ fn main() -> anyhow::Result<()> {
         entering_king_rule: rshogi_core::types::EnteringKingRule::Point24,
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
+        allow_floodgate_features: cli.allow_floodgate_features,
     };
     let kifu_storage = FileKifuStorage::new(config.kifu_topdir.clone());
     let state = Rc::new(build_state(

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -127,6 +127,10 @@ pub struct ServerConfig {
     /// `PERMISSION_DENIED` で拒否される。`%%GETBUOYCOUNT` は参照系なので
     /// 管理者権限を要求しない。
     pub admin_handles: Vec<String>,
+    /// Floodgate 運用機能の opt-in フラグ。現時点では本バイナリに配線された
+    /// Floodgate 機能は無く、将来 Floodgate 系機能が入る PR が本フラグを
+    /// 起動条件として参照する。
+    pub allow_floodgate_features: bool,
 }
 
 impl ServerConfig {
@@ -144,6 +148,7 @@ impl ServerConfig {
             entering_king_rule: EnteringKingRule::Point24,
             initial_sfen: None,
             admin_handles: Vec::new(),
+            allow_floodgate_features: false,
         }
     }
 }

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -131,14 +131,9 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
         clock,
-        time_margin_ms: 1_500,
-        max_moves: 256,
         login_timeout: Duration::from_secs(10),
         agree_timeout: Duration::from_secs(30),
-        x1_reply_write_timeout: Duration::from_secs(5),
-        entering_king_rule: EnteringKingRule::Point24,
-        initial_sfen: None,
-        admin_handles: Vec::new(),
+        ..ServerConfig::sensible_defaults()
     };
     // bind_addr=:0 を使うため、先に手動で bind してから actual addr を取る必要がある。
     // ここでは ServerConfig を既定の :0 のまま build_state に渡し、run_server 内で
@@ -463,14 +458,9 @@ async fn spawn_server_with_agree_timeout(
             total_time_sec: 60,
             byoyomi_sec: 10,
         },
-        time_margin_ms: 1_500,
-        max_moves: 256,
         login_timeout: Duration::from_secs(10),
         agree_timeout,
-        x1_reply_write_timeout: Duration::from_secs(5),
-        entering_king_rule: EnteringKingRule::Point24,
-        initial_sfen: None,
-        admin_handles: Vec::new(),
+        ..ServerConfig::sensible_defaults()
     };
     let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
     let actual_addr = probe.local_addr().unwrap();
@@ -1071,14 +1061,12 @@ async fn spawn_server_custom(
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         kifu_topdir: topdir.clone(),
         clock,
-        time_margin_ms: 1_500,
-        max_moves: 256,
         login_timeout: Duration::from_secs(10),
         agree_timeout: Duration::from_secs(30),
-        x1_reply_write_timeout: Duration::from_secs(5),
         entering_king_rule,
         initial_sfen: initial_sfen.map(str::to_owned),
         admin_handles,
+        ..ServerConfig::sensible_defaults()
     };
     let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
     let actual_addr = probe.local_addr().unwrap();

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -1,0 +1,154 @@
+//! Floodgate 運用機能の gate 定義。
+//!
+//! Floodgate 系の運用機能（定期スケジューラ、レート差ベースペアリング、履歴
+//! 永続化、`players.yaml` 互換レート保存、駒落ち対局、重複ログイン方針）を
+//! 起動設定で明示的に opt-in させるための共通 validation を提供する。
+//! 各 frontend は要求中の機能を [`FloodgateFeatureIntent`] に組み立て、
+//! [`validate_floodgate_feature_gate`] に通してから機能を有効化する。
+
+/// 起動時に Floodgate 系機能のうち何を有効化したいかを表す意図。
+///
+/// 現時点では各 frontend から `Default::default()` を渡すだけだが、Floodgate
+/// 機能実装時に該当フラグを true にして gate へ接続する。実配線されていない
+/// 機能はここに placeholder として足さず、接続するタイミングで追加する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FloodgateFeatureIntent {
+    pub enable_scheduler: bool,
+    pub use_non_direct_pairing: bool,
+    pub enable_duplicate_login_policy: bool,
+}
+
+/// 真偽文字列から Floodgate 機能 gate を解決する。
+///
+/// TCP frontend は clap が直接 `bool` にパースするため本関数を経由しない。
+/// 環境変数など文字列経由で読む経路（Workers frontend など）で利用する。
+/// 入力は前後空白を `trim` してから判定するため、`"true\n"` や `" 1 "` も
+/// 許容する。
+pub fn parse_allow_floodgate_features(raw: Option<&str>) -> Result<bool, String> {
+    let normalized = raw.unwrap_or("false").trim();
+    if normalized.eq_ignore_ascii_case("true")
+        || normalized.eq_ignore_ascii_case("yes")
+        || normalized.eq_ignore_ascii_case("on")
+        || normalized == "1"
+    {
+        return Ok(true);
+    }
+    if normalized.eq_ignore_ascii_case("false")
+        || normalized.eq_ignore_ascii_case("no")
+        || normalized.eq_ignore_ascii_case("off")
+        || normalized == "0"
+    {
+        return Ok(false);
+    }
+    Err(format!(
+        "allow_floodgate_features: expected true|false|1|0|yes|no|on|off, got {normalized:?}"
+    ))
+}
+
+/// Floodgate 機能が要求されているかを検証する。
+///
+/// フロントエンドに依らず、`allow_floodgate_features` が `false` のまま
+/// Floodgate 系機能を要求した場合にエラーを返す。エラーメッセージは特定の
+/// 環境変数名や CLI フラグ名に依存しない汎用形で返す（呼び出し側で
+/// `ALLOW_FLOODGATE_FEATURES` / `--allow-floodgate-features` 等に読み替える）。
+pub fn validate_floodgate_feature_gate(
+    allow_floodgate_features: bool,
+    intent: FloodgateFeatureIntent,
+) -> Result<(), String> {
+    let mut requested = Vec::new();
+    if intent.enable_scheduler {
+        requested.push("scheduler");
+    }
+    if intent.use_non_direct_pairing {
+        requested.push("non_direct_pairing");
+    }
+    if intent.enable_duplicate_login_policy {
+        requested.push("duplicate_login_policy");
+    }
+    if requested.is_empty() || allow_floodgate_features {
+        return Ok(());
+    }
+    Err(format!(
+        "floodgate features require allow_floodgate_features=true: {}",
+        requested.join(", ")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_allow_floodgate_features_defaults_to_false() {
+        assert!(!parse_allow_floodgate_features(None).unwrap());
+    }
+
+    #[test]
+    fn parse_allow_floodgate_features_accepts_true() {
+        assert!(parse_allow_floodgate_features(Some("true")).unwrap());
+    }
+
+    #[test]
+    fn parse_allow_floodgate_features_rejects_unknown_value() {
+        let err = parse_allow_floodgate_features(Some("weird")).unwrap_err();
+        assert!(err.contains("allow_floodgate_features"));
+    }
+
+    #[test]
+    fn parse_allow_floodgate_features_trims_surrounding_whitespace() {
+        // 環境変数経由で `"true\n"` や `" 1 "` が渡ることがあるため、前後
+        // 空白を吸収できる必要がある。
+        assert!(parse_allow_floodgate_features(Some(" true ")).unwrap());
+        assert!(parse_allow_floodgate_features(Some("true\n")).unwrap());
+        assert!(parse_allow_floodgate_features(Some("\tYES\t")).unwrap());
+        assert!(!parse_allow_floodgate_features(Some(" 0 ")).unwrap());
+    }
+
+    #[test]
+    fn floodgate_gate_rejects_requested_feature_when_disabled() {
+        let err = validate_floodgate_feature_gate(
+            false,
+            FloodgateFeatureIntent {
+                enable_scheduler: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("scheduler"));
+    }
+
+    #[test]
+    fn floodgate_gate_allows_requested_feature_when_enabled() {
+        validate_floodgate_feature_gate(
+            true,
+            FloodgateFeatureIntent {
+                enable_scheduler: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn floodgate_gate_allows_all_defaults_when_disabled() {
+        // gate off + 何も要求していない状態が既定の通常起動経路。この分岐で
+        // Err を返すと全起動が失敗するため、明示的なカバレッジを維持する。
+        validate_floodgate_feature_gate(false, FloodgateFeatureIntent::default()).unwrap();
+    }
+
+    #[test]
+    fn floodgate_gate_error_lists_all_requested_features() {
+        let err = validate_floodgate_feature_gate(
+            false,
+            FloodgateFeatureIntent {
+                enable_scheduler: true,
+                use_non_direct_pairing: true,
+                enable_duplicate_login_policy: true,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("scheduler"));
+        assert!(err.contains("non_direct_pairing"));
+        assert!(err.contains("duplicate_login_policy"));
+    }
+}

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -3,6 +3,7 @@
 //! I/O には直接依存せず、[`port`] モジュールで定義された trait 群を介して
 //! TCP 版と Cloudflare Workers 版の双方のフロントエンドから再利用できる。
 
+pub mod config;
 pub mod error;
 pub mod types;
 
@@ -13,6 +14,9 @@ pub mod protocol;
 pub mod record;
 pub mod storage;
 
+pub use config::{
+    FloodgateFeatureIntent, parse_allow_floodgate_features, validate_floodgate_feature_gate,
+};
 pub use error::{ProtocolError, ServerError, StateError, StorageError, TransportError};
 pub use game::clock::{
     ClockResult, ClockSpec, FischerClock, SecondsCountdownClock, StopWatchClock, TimeClock,


### PR DESCRIPTION
## Summary

Phase 4 の Floodgate 運用機能に入る前段として、Floodgate 運用機能を opt-in する最小基盤と、共通の gate validation primitive を `rshogi-csa-server` core に追加する。現時点では Floodgate 機能の実装は入れず、次以降の PR が各機能ごとに「ServerConfig フィールド + CLI flag + 配線 + 本 PR で入れた opt-in フラグ参照」を同一 PR でまとめて入れる構造を用意する。

## 含まれるもの

### core (`rshogi-csa-server`)

- `FloodgateFeatureIntent` — Floodgate 系機能のうち何を有効化したいかを表す struct（`enable_scheduler` / `use_non_direct_pairing` / `enable_duplicate_login_policy`）
- `validate_floodgate_feature_gate(allow: bool, intent: FloodgateFeatureIntent) -> Result<(), String>` — frontend 非依存の gate validation primitive。エラー文言は `allow_floodgate_features=true` を要求する汎用形で返す
- `parse_allow_floodgate_features(Option<&str>) -> Result<bool, String>` — Workers frontend の環境変数経路向けの bool パーサ。`.trim()` 済みで `" true\n"` や `"\tYES\t"` を許容

### TCP frontend (`rshogi-csa-server-tcp`)

- `ServerConfig::allow_floodgate_features` フィールド（既定 `false`）
- `--allow-floodgate-features` CLI フラグ

### テスト整理

- `tests/tcp_session.rs` のサーバー起動ヘルパ 3 箇所 (`spawn_server` / `spawn_server_with_agree_timeout` / `spawn_server_with_admin`) を `..ServerConfig::sensible_defaults()` の rest pattern で書き直し、今後のフィールド追加に自動追従
- 非同期書き込みのばらつきを吸収するため、棋譜・00LIST 参照を `wait_for_file_text` / `wait_for_csa_text` に置換。`find_csa_file_recursive` は `tokio::fs` 非同期経路で実装し、current-thread ランタイム上で executor を塞がない

## 含まれないもの（次以降の PR で入る）

- Floodgate 定期スケジューラの実装 (`enable_floodgate_scheduler`)
- レート差ベースペアリング (`pairing_mode=least-diff`)
- 重複ログイン方針 (`duplicate_login_policy=replace-old`)
- Floodgate 履歴 / `players.yaml` 互換永続化 / 駒落ち対局

これらは各 PR で実機能を配線するタイミングに合わせて ServerConfig field / CLI flag / gate 接続をまとめて入れる。本 PR では placeholder field を置かない（レビューで指摘された silent no-op を避けるため）。

## Why

Requirement 15.7「前 Phase の受入基準が未充足なら次 Phase の機能を本番ビルドで有効化しない」を満たすため、先行して opt-in の形を決めておく。抽象的な phase enum ではなく、何を許可する設定なのかが読める名前 (`allow_floodgate_features`) を使い、実装 PR が共通 primitive から差し込める土台を作る。

## Review 対応

Copilot / claude[bot] / codex の 3 経路のレビューで入った主な指摘に対応済み:

- `parse_allow_floodgate_features` の whitespace 非対応 → `.trim()` + `eq_ignore_ascii_case` で `"true\n"` / `" 1 "` を許容
- エラーメッセージが `ALLOW_FLOODGATE_FEATURES` env 変数名に依存 → backend-agnostic な `allow_floodgate_features=true` 表現に統一
- `build_state` + `run_server` 経路で gate を迂回可能 → core primitive のみに構造を簡素化し、TCP 側から未配線の gate 経由路を撤去
- 未配線の Floodgate 設定を `allow_floodgate_features=true` が silent no-op で受理する P1 → `pairing_mode` / `enable_floodgate_scheduler` / `duplicate_login_policy` フィールドと対応 CLI flag を削除し、実機能 PR まで表面に出さない
- テストヘルパの全フィールド列挙 → `..ServerConfig::sensible_defaults()` rest pattern 化
- `find_csa_file_recursive` の blocking `std::fs` → `tokio::fs::read_dir` 非同期化

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --tests`（警告ゼロ）
- `cargo test`（全パス）

## Follow-up

本 PR は opt-in フラグと core primitive のみ。Floodgate 系の実機能実装 PR は各機能ごとに対応 field / CLI flag / 配線 / `allow_floodgate_features` 参照を同一 PR でまとめて入れる。
