### PR TITLE
feat(tools): analyze_selfplay で SPRT ラベル/パラメータを meta から自動推定

### DIFF
--- a/crates/tools/src/bin/analyze_selfplay.rs
+++ b/crates/tools/src/bin/analyze_selfplay.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use tools::sprt::{GameSide, Penta, SprtParameters, judge};
+use tools::sprt::{GameSide, Penta, SprtMetaLog, SprtParameters, judge};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -77,20 +77,6 @@ struct MetaLog {
     /// tournament.rs が --sprt 実行時のみ出力。未指定時のラベル自動推定に使う。
     #[serde(default)]
     sprt: Option<SprtMetaLog>,
-}
-
-#[derive(Deserialize, Clone)]
-struct SprtMetaLog {
-    base_label: String,
-    test_label: String,
-    #[serde(default)]
-    nelo0: Option<f64>,
-    #[serde(default)]
-    nelo1: Option<f64>,
-    #[serde(default)]
-    alpha: Option<f64>,
-    #[serde(default)]
-    beta: Option<f64>,
 }
 
 #[derive(Deserialize)]
@@ -660,15 +646,16 @@ fn parse_file(path: &str) -> Result<FileResult> {
 // SPRT post-hoc 集計
 // ---------------------------------------------------------------------------
 
-/// 入力ファイル群の meta 行から SPRT メタを収集し、単一のラベル組に合致するなら返す。
+/// 入力ファイル群の meta 行から SPRT メタを収集し、単一のラベル組/パラメータに合致するなら返す。
 ///
 /// - meta 行に SPRT 情報が書かれているのは `tournament.rs --sprt` 実行で生成された
 ///   base/test ペアの jsonl のみ
-/// - 複数ファイルが同じ `(base_label, test_label)` を示すなら採用
-/// - 複数ファイルが異なるラベル組を示す場合は衝突として `bail!`
+/// - 複数ファイルが同じ `(base_label, test_label, nelo0, nelo1, alpha, beta)` を示すなら採用
+/// - ラベルが異なる場合は衝突として `bail!`
+/// - ラベルは同じでも Wald パラメータが異なる場合も `bail!`（LLR 境界が変わるため誤集計防止）
 /// - どのファイルにも SPRT 情報が無ければ `None`（呼び出し側で CLI 必須）
 fn collect_sprt_meta(files: &[&str]) -> Result<Option<SprtMetaLog>> {
-    let mut found: Option<SprtMetaLog> = None;
+    let mut found: Option<(SprtMetaLog, String)> = None;
     for &path in files {
         if path.contains(".summary.") {
             continue;
@@ -680,29 +667,51 @@ fn collect_sprt_meta(files: &[&str]) -> Result<Option<SprtMetaLog>> {
         for line in reader.lines() {
             let Ok(line) = line else { break };
             let trimmed = line.trim();
-            if !trimmed.contains("\"type\":\"meta\"") {
-                // meta 行は各ファイルの先頭 1 行のみ。非 meta 行が出た時点で打ち切り。
-                if !trimmed.is_empty() {
-                    break;
-                }
+            if trimmed.is_empty() {
                 continue;
             }
-            let meta: MetaLog = serde_json::from_str(trimmed)
+            // JSON として parse し `type == "meta"` を判定する。文字列部分一致だと
+            // JSON 整形スタイル（スペースの有無）に依存してしまうため serde で判定。
+            let value: serde_json::Value = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+            if value.get("type").and_then(|v| v.as_str()) != Some("meta") {
+                // meta 行は各ファイルの先頭 1 行のみ。非 meta 行が出た時点で打ち切り。
+                break;
+            }
+            let meta: MetaLog = serde_json::from_value(value)
                 .with_context(|| format!("metaパースエラー: {path}"))?;
             if let Some(sprt) = meta.sprt {
                 match found.as_ref() {
-                    None => found = Some(sprt),
-                    Some(existing) => {
+                    None => found = Some((sprt, path.to_string())),
+                    Some((existing, existing_path)) => {
                         if existing.base_label != sprt.base_label
                             || existing.test_label != sprt.test_label
                         {
                             bail!(
-                                "入力ファイル間で SPRT ラベルが一致しません: ({} vs {}) と ({} vs {})。\
+                                "入力ファイル間で SPRT ラベルが一致しません: {existing_path} は ({} vs {})、{path} は ({} vs {})。\
                                  --sprt-base-label / --sprt-test-label を明示してください。",
                                 existing.base_label,
                                 existing.test_label,
                                 sprt.base_label,
                                 sprt.test_label
+                            );
+                        }
+                        if existing != &sprt {
+                            bail!(
+                                "入力ファイル間で SPRT Wald パラメータが一致しません: \
+                                 {existing_path} は (nelo0={}, nelo1={}, alpha={}, beta={})、\
+                                 {path} は (nelo0={}, nelo1={}, alpha={}, beta={})。\
+                                 --sprt-nelo0 / --sprt-nelo1 / --sprt-alpha / --sprt-beta を明示してください。",
+                                existing.nelo0,
+                                existing.nelo1,
+                                existing.alpha,
+                                existing.beta,
+                                sprt.nelo0,
+                                sprt.nelo1,
+                                sprt.alpha,
+                                sprt.beta
                             );
                         }
                     }
@@ -711,7 +720,7 @@ fn collect_sprt_meta(files: &[&str]) -> Result<Option<SprtMetaLog>> {
             break;
         }
     }
-    Ok(found)
+    Ok(found.map(|(m, _)| m))
 }
 
 /// 単一 JSONL ファイルから base/test ペアに該当する Penta を集計する。
@@ -1171,8 +1180,19 @@ fn main() -> Result<()> {
 
     // SPRT post-hoc 集計（JSON モードでは最終 JSON にフィールドとして埋め込むため事前に計算する）
     let sprt_payload: Option<(Penta, SprtJsonOutput)> = if cli.sprt {
-        // meta 行から SPRT 情報を収集し、CLI 未指定項目の補完に使う。
-        let meta_sprt = collect_sprt_meta(&files)?;
+        // CLI が全項目（ラベル+パラメータ）を明示している場合は meta 参照をスキップ。
+        // これにより meta 情報が混在・欠落していても CLI による上書きで解析可能。
+        let needs_meta = cli.sprt_base_label.is_none()
+            || cli.sprt_test_label.is_none()
+            || cli.sprt_nelo0.is_none()
+            || cli.sprt_nelo1.is_none()
+            || cli.sprt_alpha.is_none()
+            || cli.sprt_beta.is_none();
+        let meta_sprt = if needs_meta {
+            collect_sprt_meta(&files)?
+        } else {
+            None
+        };
 
         let base_label = cli
             .sprt_base_label
@@ -1197,22 +1217,10 @@ fn main() -> Result<()> {
         }
 
         // nelo / alpha / beta は CLI → meta → ハードコード fallback の順で解決する。
-        let nelo0 = cli
-            .sprt_nelo0
-            .or_else(|| meta_sprt.as_ref().and_then(|m| m.nelo0))
-            .unwrap_or(0.0);
-        let nelo1 = cli
-            .sprt_nelo1
-            .or_else(|| meta_sprt.as_ref().and_then(|m| m.nelo1))
-            .unwrap_or(5.0);
-        let alpha = cli
-            .sprt_alpha
-            .or_else(|| meta_sprt.as_ref().and_then(|m| m.alpha))
-            .unwrap_or(0.05);
-        let beta = cli
-            .sprt_beta
-            .or_else(|| meta_sprt.as_ref().and_then(|m| m.beta))
-            .unwrap_or(0.05);
+        let nelo0 = cli.sprt_nelo0.or_else(|| meta_sprt.as_ref().map(|m| m.nelo0)).unwrap_or(0.0);
+        let nelo1 = cli.sprt_nelo1.or_else(|| meta_sprt.as_ref().map(|m| m.nelo1)).unwrap_or(5.0);
+        let alpha = cli.sprt_alpha.or_else(|| meta_sprt.as_ref().map(|m| m.alpha)).unwrap_or(0.05);
+        let beta = cli.sprt_beta.or_else(|| meta_sprt.as_ref().map(|m| m.beta)).unwrap_or(0.05);
 
         let mut total = Penta::ZERO;
         for path in &files {

--- a/crates/tools/src/bin/analyze_selfplay.rs
+++ b/crates/tools/src/bin/analyze_selfplay.rs
@@ -35,33 +35,34 @@ struct Cli {
     json: bool,
 
     /// SPRT post-hoc 判定表示を有効化。
-    /// `--sprt-test-label`, `--sprt-base-label` が必須。
+    /// ラベル / パラメータは tournament.rs が meta 行に書き出した SPRT 情報から自動推定する。
+    /// meta に SPRT 情報がない（または異なる値が混在する）場合は明示指定が必須。
     #[arg(long, default_value_t = false)]
     sprt: bool,
 
-    /// H1 側（challenger / test）のラベル
+    /// H1 側（challenger / test）のラベル。未指定時は meta から推定。
     #[arg(long)]
     sprt_test_label: Option<String>,
 
-    /// H0 側（base）のラベル
+    /// H0 側（base）のラベル。未指定時は meta から推定。
     #[arg(long)]
     sprt_base_label: Option<String>,
 
-    /// H0 仮説の正規化 Elo（default: 0.0）
-    #[arg(long, default_value_t = 0.0)]
-    sprt_nelo0: f64,
+    /// H0 仮説の正規化 Elo。未指定時は meta から推定（fallback: 0.0）。
+    #[arg(long)]
+    sprt_nelo0: Option<f64>,
 
-    /// H1 仮説の正規化 Elo（default: 5.0）
-    #[arg(long, default_value_t = 5.0)]
-    sprt_nelo1: f64,
+    /// H1 仮説の正規化 Elo。未指定時は meta から推定（fallback: 5.0）。
+    #[arg(long)]
+    sprt_nelo1: Option<f64>,
 
-    /// 第一種過誤率 α（default: 0.05）
-    #[arg(long, default_value_t = 0.05)]
-    sprt_alpha: f64,
+    /// 第一種過誤率 α。未指定時は meta から推定（fallback: 0.05）。
+    #[arg(long)]
+    sprt_alpha: Option<f64>,
 
-    /// 第二種過誤率 β（default: 0.05）
-    #[arg(long, default_value_t = 0.05)]
-    sprt_beta: f64,
+    /// 第二種過誤率 β。未指定時は meta から推定（fallback: 0.05）。
+    #[arg(long)]
+    sprt_beta: Option<f64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +74,23 @@ struct Cli {
 struct MetaLog {
     settings: MetaSettings,
     engine_cmd: EngineCommandMeta,
+    /// tournament.rs が --sprt 実行時のみ出力。未指定時のラベル自動推定に使う。
+    #[serde(default)]
+    sprt: Option<SprtMetaLog>,
+}
+
+#[derive(Deserialize, Clone)]
+struct SprtMetaLog {
+    base_label: String,
+    test_label: String,
+    #[serde(default)]
+    nelo0: Option<f64>,
+    #[serde(default)]
+    nelo1: Option<f64>,
+    #[serde(default)]
+    alpha: Option<f64>,
+    #[serde(default)]
+    beta: Option<f64>,
 }
 
 #[derive(Deserialize)]
@@ -642,6 +660,60 @@ fn parse_file(path: &str) -> Result<FileResult> {
 // SPRT post-hoc 集計
 // ---------------------------------------------------------------------------
 
+/// 入力ファイル群の meta 行から SPRT メタを収集し、単一のラベル組に合致するなら返す。
+///
+/// - meta 行に SPRT 情報が書かれているのは `tournament.rs --sprt` 実行で生成された
+///   base/test ペアの jsonl のみ
+/// - 複数ファイルが同じ `(base_label, test_label)` を示すなら採用
+/// - 複数ファイルが異なるラベル組を示す場合は衝突として `bail!`
+/// - どのファイルにも SPRT 情報が無ければ `None`（呼び出し側で CLI 必須）
+fn collect_sprt_meta(files: &[&str]) -> Result<Option<SprtMetaLog>> {
+    let mut found: Option<SprtMetaLog> = None;
+    for &path in files {
+        if path.contains(".summary.") {
+            continue;
+        }
+        let Ok(file) = std::fs::File::open(path) else {
+            continue;
+        };
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            let trimmed = line.trim();
+            if !trimmed.contains("\"type\":\"meta\"") {
+                // meta 行は各ファイルの先頭 1 行のみ。非 meta 行が出た時点で打ち切り。
+                if !trimmed.is_empty() {
+                    break;
+                }
+                continue;
+            }
+            let meta: MetaLog = serde_json::from_str(trimmed)
+                .with_context(|| format!("metaパースエラー: {path}"))?;
+            if let Some(sprt) = meta.sprt {
+                match found.as_ref() {
+                    None => found = Some(sprt),
+                    Some(existing) => {
+                        if existing.base_label != sprt.base_label
+                            || existing.test_label != sprt.test_label
+                        {
+                            bail!(
+                                "入力ファイル間で SPRT ラベルが一致しません: ({} vs {}) と ({} vs {})。\
+                                 --sprt-base-label / --sprt-test-label を明示してください。",
+                                existing.base_label,
+                                existing.test_label,
+                                sprt.base_label,
+                                sprt.test_label
+                            );
+                        }
+                    }
+                }
+            }
+            break;
+        }
+    }
+    Ok(found)
+}
+
 /// 単一 JSONL ファイルから base/test ペアに該当する Penta を集計する。
 ///
 /// - ファイルの meta が base/test 両方のラベルを含まなければ `Penta::ZERO`
@@ -1099,31 +1171,62 @@ fn main() -> Result<()> {
 
     // SPRT post-hoc 集計（JSON モードでは最終 JSON にフィールドとして埋め込むため事前に計算する）
     let sprt_payload: Option<(Penta, SprtJsonOutput)> = if cli.sprt {
+        // meta 行から SPRT 情報を収集し、CLI 未指定項目の補完に使う。
+        let meta_sprt = collect_sprt_meta(&files)?;
+
         let base_label = cli
             .sprt_base_label
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("--sprt 有効時は --sprt-base-label が必須です"))?;
+            .clone()
+            .or_else(|| meta_sprt.as_ref().map(|m| m.base_label.clone()))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--sprt 有効時は --sprt-base-label が必須です（meta 行に SPRT 情報が無いため自動推定できませんでした）"
+                )
+            })?;
         let test_label = cli
             .sprt_test_label
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("--sprt 有効時は --sprt-test-label が必須です"))?;
+            .clone()
+            .or_else(|| meta_sprt.as_ref().map(|m| m.test_label.clone()))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--sprt 有効時は --sprt-test-label が必須です（meta 行に SPRT 情報が無いため自動推定できませんでした）"
+                )
+            })?;
         if base_label == test_label {
             bail!("--sprt-base-label と --sprt-test-label は異なる必要があります");
         }
+
+        // nelo / alpha / beta は CLI → meta → ハードコード fallback の順で解決する。
+        let nelo0 = cli
+            .sprt_nelo0
+            .or_else(|| meta_sprt.as_ref().and_then(|m| m.nelo0))
+            .unwrap_or(0.0);
+        let nelo1 = cli
+            .sprt_nelo1
+            .or_else(|| meta_sprt.as_ref().and_then(|m| m.nelo1))
+            .unwrap_or(5.0);
+        let alpha = cli
+            .sprt_alpha
+            .or_else(|| meta_sprt.as_ref().and_then(|m| m.alpha))
+            .unwrap_or(0.05);
+        let beta = cli
+            .sprt_beta
+            .or_else(|| meta_sprt.as_ref().and_then(|m| m.beta))
+            .unwrap_or(0.05);
+
         let mut total = Penta::ZERO;
         for path in &files {
             if path.contains(".summary.") {
                 continue;
             }
-            match collect_sprt_penta(path, base_label, test_label) {
+            match collect_sprt_penta(path, &base_label, &test_label) {
                 Ok(p) => total += p,
                 Err(e) => eprintln!("警告: SPRT 集計失敗 {path}: {e}"),
             }
         }
         let params =
-            SprtParameters::new(cli.sprt_nelo0, cli.sprt_nelo1, cli.sprt_alpha, cli.sprt_beta)
-                .map_err(|e| anyhow::anyhow!(e))?;
-        let json = build_sprt_json(total, base_label, test_label, params);
+            SprtParameters::new(nelo0, nelo1, alpha, beta).map_err(|e| anyhow::anyhow!(e))?;
+        let json = build_sprt_json(total, &base_label, &test_label, params);
         Some((total, json))
     } else {
         None

--- a/crates/tools/src/bin/tournament.rs
+++ b/crates/tools/src/bin/tournament.rs
@@ -264,6 +264,20 @@ struct MetaLogEntry {
     engine_cmd: EngineCommandMeta,
     start_positions: Vec<String>,
     output: String,
+    /// SPRT 実行時のみ付与される。base / test ラベルと Wald パラメータを含み、
+    /// analyze_selfplay 側でラベル自動推定に利用する。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sprt: Option<SprtMetaLog>,
+}
+
+#[derive(Serialize, Clone)]
+struct SprtMetaLog {
+    base_label: String,
+    test_label: String,
+    nelo0: f64,
+    nelo1: f64,
+    alpha: f64,
+    beta: f64,
 }
 
 #[derive(Serialize)]
@@ -1039,6 +1053,24 @@ fn main() -> Result<()> {
             let path = cli.out_dir.join(&filename);
             let mut pw = PairWriter::new(&path)?;
 
+            // SPRT 有効かつこのペアが base/test の組み合わせなら SPRT meta を付与する。
+            // pair_indices は (min, max) 正規化済みなので両順序をカバーする。
+            let sprt_meta = sprt_state.as_ref().and_then(|state| {
+                let pair = (state.base_idx.min(state.test_idx), state.base_idx.max(state.test_idx));
+                if pair == (i, j) {
+                    Some(SprtMetaLog {
+                        base_label: state.base_label.clone(),
+                        test_label: state.test_label.clone(),
+                        nelo0: state.params.nelo0,
+                        nelo1: state.params.nelo1,
+                        alpha: state.params.alpha,
+                        beta: state.params.beta,
+                    })
+                } else {
+                    None
+                }
+            });
+
             // meta行を書く
             let meta = MetaLogEntry {
                 kind: "meta".to_string(),
@@ -1065,6 +1097,7 @@ fn main() -> Result<()> {
                 },
                 start_positions: start_commands.clone(),
                 output: path.display().to_string(),
+                sprt: sprt_meta,
             };
             pw.write_json(&meta)?;
             pw.flush()?;

--- a/crates/tools/src/bin/tournament.rs
+++ b/crates/tools/src/bin/tournament.rs
@@ -52,7 +52,7 @@ use tools::selfplay::types::{EvalLog, side_label};
 use tools::selfplay::{
     EngineConfig, EngineProcess, GameOutcome, ParsedPosition, load_start_positions,
 };
-use tools::sprt::{Decision, GameSide, Penta, SprtParameters, judge};
+use tools::sprt::{Decision, GameSide, Penta, SprtMetaLog, SprtParameters, judge};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -268,16 +268,6 @@ struct MetaLogEntry {
     /// analyze_selfplay 側でラベル自動推定に利用する。
     #[serde(skip_serializing_if = "Option::is_none")]
     sprt: Option<SprtMetaLog>,
-}
-
-#[derive(Serialize, Clone)]
-struct SprtMetaLog {
-    base_label: String,
-    test_label: String,
-    nelo0: f64,
-    nelo1: f64,
-    alpha: f64,
-    beta: f64,
 }
 
 #[derive(Serialize)]

--- a/crates/tools/src/sprt/meta.rs
+++ b/crates/tools/src/sprt/meta.rs
@@ -1,0 +1,18 @@
+//! `tournament.rs --sprt` が jsonl の meta 行へ書き出し、
+//! `analyze_selfplay --sprt` がラベル/パラメータ自動推定に利用する共有スキーマ。
+
+use serde::{Deserialize, Serialize};
+
+/// SPRT 実行時の meta 行に埋め込む追加情報。
+///
+/// `tournament.rs` が書き出し、`analyze_selfplay.rs` が読み取る。
+/// 両側でスキーマが一致するように単一定義とする。
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+pub struct SprtMetaLog {
+    pub base_label: String,
+    pub test_label: String,
+    pub nelo0: f64,
+    pub nelo1: f64,
+    pub alpha: f64,
+    pub beta: f64,
+}

--- a/crates/tools/src/sprt/mod.rs
+++ b/crates/tools/src/sprt/mod.rs
@@ -13,8 +13,10 @@
 
 pub mod decision;
 pub mod llr;
+pub mod meta;
 pub mod penta;
 
 pub use decision::{Decision, judge};
 pub use llr::SprtParameters;
+pub use meta::SprtMetaLog;
 pub use penta::{GameSide, Penta};


### PR DESCRIPTION
## Summary
- `tournament.rs --sprt` 実行時、pair jsonl の meta 行に `sprt: { base_label, test_label, nelo0, nelo1, alpha, beta }` を書き出すようにした
- `analyze_selfplay --sprt` はその meta を走査し、CLI 未指定の SPRT ラベル / Wald パラメータを自動補完する（CLI → meta → hardcoded fallback の順）
- これまで毎回必須だった `--sprt-base-label` / `--sprt-test-label` / `--sprt-nelo0` / `--sprt-nelo1` / `--sprt-alpha` / `--sprt-beta` は、tournament の SPRT 出力をそのまま集計する場合は省略可能に

## Motivation
`./analyze_selfplay runs/.../*.jsonl --sprt --sprt-base-label yo-v96-400 --sprt-test-label yo-v98-400 --sprt-nelo0 0 --sprt-nelo1 5 --sprt-alpha 0.001 --sprt-beta 0.001` のように毎回全項目を手で書くのは冗長で、tournament 側は既に知っている情報。meta に載せれば `--sprt` だけで済む。

## Behavior
- 新形式 (sprt meta あり): `./analyze_selfplay <files> --sprt` で完結
- 旧形式 (sprt meta なし): 従来通り CLI 明示指定が必須。未指定時は「meta 行に SPRT 情報が無いため自動推定できませんでした」と明示エラー
- CLI 指定と meta が両方ある場合は CLI を優先（override 可）
- 複数ファイルの meta で `(base_label, test_label)` が食い違う場合は `bail!`（ラベル明示指定を促す）

## Test plan
- [x] `cargo fmt -p tools` / `cargo clippy -p tools --bins --tests -- -D warnings` / `cargo test -p tools`
- [x] 旧形式ログ (`runs/selfplay/20260419-031300-v87_280-vs-v96_280-sprt`) で `--sprt` のみ → 明確なエラー
- [x] 旧形式ログに従来の CLI フル指定 → 既存と同じ結果を出力（後方互換 OK）
- [ ] 新 tournament で生成した SPRT run に対し `--sprt` のみで実行して自動推定結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)