### PR TITLE
feat(csa-server-tcp): graceful shutdown for SIGINT/SIGTERM (task 17.1)

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -80,6 +80,11 @@ struct Cli {
     /// 実装する（現時点ではまだ配線された機能は無い）。
     #[arg(long, default_value_t = false)]
     allow_floodgate_features: bool,
+    /// SIGINT / SIGTERM 受信後に進行中対局の完了を待つ秒数。超過分は未完了の
+    /// まま warning log を出して切り捨てる。ローリング再起動で対局を落とさない
+    /// ためのバッファ。
+    #[arg(long, default_value_t = 60)]
+    shutdown_grace_sec: u64,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
@@ -146,6 +151,7 @@ fn main() -> anyhow::Result<()> {
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
         allow_floodgate_features: cli.allow_floodgate_features,
+        shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
     let kifu_storage = FileKifuStorage::new(config.kifu_topdir.clone());
     let state = Rc::new(build_state(
@@ -163,23 +169,82 @@ fn main() -> anyhow::Result<()> {
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
     let local = tokio::task::LocalSet::new();
     local.block_on(&rt, async move {
-        let handle = run_server(state).await.context("run_server")?;
+        let handle = run_server(state.clone()).await.context("run_server")?;
         log::info!("rshogi-csa-server-tcp ready");
-        // 暫定のシャットダウン経路: SIGINT のみ監視し、受信したら受付タスクを `abort` で
-        // 強制停止する。SIGTERM（Docker / Kubernetes）は未対応で、また abort は進行中の
-        // 対局タスクと棋譜書き込みを中途半端な状態で切り捨てる可能性がある。
-        //
-        // 完全な graceful shutdown を入れる場合に必要な要素:
-        //   - SIGTERM も含めた終了シグナル待機
-        //   - 新規接続の受付停止
-        //   - 進行中対局の終局待ちおよび棋譜・00LIST の原子的 flush
-        // graceful shutdown 実装時にここの `handle.abort()` は cancellation token 経路へ置き換える。
-        let _ = tokio::signal::ctrl_c().await;
-        log::info!("shutting down");
-        handle.abort();
+
+        // SIGINT と SIGTERM を並列待機する。SIGINT は Ctrl-C、SIGTERM は
+        // systemd / Docker / Kubernetes の停止シグナル。
+        let sig = wait_for_termination_signal().await;
+        log::info!("received {sig}, initiating graceful shutdown");
+
+        // 1. 新規接続の受付停止 + 待機プール中のセッション切断を誘導する。
+        state.shutdown.trigger();
+
+        // 2. accept ループの終了を待つ。shutdown が立っているので即座に抜ける。
+        let _ = handle.await;
+
+        // 3. 進行中対局が終局するまで待つ。grace を超過したら warning を出して
+        //    プロセス終了へ進む（残りの対局タスクは LocalSet 終了で abort される）。
+        let grace = state.config().shutdown_grace;
+        let deadline = tokio::time::Instant::now() + grace;
+        loop {
+            let active = state.active_game_count().await;
+            if active == 0 {
+                break;
+            }
+            log::info!(
+                "waiting for {active} active game(s) to finish (grace {}s)",
+                grace.as_secs()
+            );
+            tokio::select! {
+                _ = state.wait_active_games_notify() => continue,
+                _ = tokio::time::sleep_until(deadline) => {
+                    let remaining = state.active_game_count().await;
+                    if remaining > 0 {
+                        log::warn!(
+                            "shutdown grace expired; {remaining} game(s) left unfinished"
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+
+        log::info!("shutdown complete");
         Ok::<(), anyhow::Error>(())
     })?;
     Ok(())
+}
+
+/// SIGINT / SIGTERM のどちらかを受けるまで待つ。受けたシグナル名を返す。
+///
+/// Unix 以外のプラットフォームでは SIGTERM 経路は `pending` になるため、
+/// 実質 SIGINT (Ctrl-C) のみが反応する。
+async fn wait_for_termination_signal() -> &'static str {
+    let sigint = async {
+        let _ = tokio::signal::ctrl_c().await;
+        "SIGINT"
+    };
+    #[cfg(unix)]
+    let sigterm = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+                "SIGTERM"
+            }
+            Err(e) => {
+                log::warn!("failed to install SIGTERM handler: {e}");
+                std::future::pending::<&'static str>().await
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let sigterm = std::future::pending::<&'static str>();
+    tokio::select! {
+        s = sigint => s,
+        s = sigterm => s,
+    }
 }
 
 /// players.toml を読む。

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -183,13 +183,15 @@ fn main() -> anyhow::Result<()> {
         // 2. accept ループの終了を待つ。shutdown が立っているので即座に抜ける。
         //    panic した場合に listener 未解放のまま後段に進まないよう、panic は
         //    error log に落として正常経路と同様に fall-through させる。
+        //    `{e:#}` は JoinError の Debug 出力（panic payload とロケーション）を
+        //    一行に展開するので、運用時の原因調査で使える。
         match handle.await {
             Ok(()) => {}
             Err(e) if e.is_panic() => {
-                log::error!("accept loop panicked during shutdown: {e}");
+                log::error!("accept loop panicked during shutdown: {e:#}");
             }
             Err(e) => {
-                log::info!("accept loop joined with error: {e}");
+                log::info!("accept loop joined with error: {e:#}");
             }
         }
 

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -181,14 +181,30 @@ fn main() -> anyhow::Result<()> {
         state.shutdown.trigger();
 
         // 2. accept ループの終了を待つ。shutdown が立っているので即座に抜ける。
-        let _ = handle.await;
+        //    panic した場合に listener 未解放のまま後段に進まないよう、panic は
+        //    error log に落として正常経路と同様に fall-through させる。
+        match handle.await {
+            Ok(()) => {}
+            Err(e) if e.is_panic() => {
+                log::error!("accept loop panicked during shutdown: {e}");
+            }
+            Err(e) => {
+                log::info!("accept loop joined with error: {e}");
+            }
+        }
 
         // 3. 進行中対局が終局するまで待つ。grace を超過したら warning を出して
         //    プロセス終了へ進む（残りの対局タスクは LocalSet 終了で abort される）。
+        //    `shutdown_grace = 0` は「grace なし = 即切り」と解釈する。
+        //
+        //    TOCTOU 対策として `wait_active_games_notify` を先に登録してから
+        //    counter を確認する。これで登録と確認の間に `notify_waiters` が
+        //    発火しても取りこぼさない。
         let grace = state.config().shutdown_grace;
         let deadline = tokio::time::Instant::now() + grace;
         loop {
-            let active = state.active_game_count().await;
+            let notified = state.wait_active_games_notify();
+            let active = state.active_game_count();
             if active == 0 {
                 break;
             }
@@ -197,9 +213,9 @@ fn main() -> anyhow::Result<()> {
                 grace.as_secs()
             );
             tokio::select! {
-                _ = state.wait_active_games_notify() => continue,
+                _ = notified => continue,
                 _ = tokio::time::sleep_until(deadline) => {
-                    let remaining = state.active_game_count().await;
+                    let remaining = state.active_game_count();
                     if remaining > 0 {
                         log::warn!(
                             "shutdown grace expired; {remaining} game(s) left unfinished"

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -175,14 +175,15 @@ pub struct GracefulShutdown {
 
 impl GracefulShutdown {
     /// 未トリガ状態のインスタンスを返す。
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             triggered: AtomicBool::new(false),
             notify: Notify::new(),
         }
     }
 
-    /// シャットダウンを開始する。複数回呼ばれても冪等。
+    /// シャットダウンを開始する。複数回呼ばれても冪等。main の signal ハンドラ
+    /// とテストから呼ばれる。
     pub fn trigger(&self) {
         if !self.triggered.swap(true, Ordering::Release) {
             // 待機中の全 waiter に通知。新しく `wait()` してくる経路は
@@ -191,13 +192,14 @@ impl GracefulShutdown {
         }
     }
 
-    /// 既にトリガ済みか。
-    pub fn is_triggered(&self) -> bool {
+    /// 既にトリガ済みか。クレート内で `wait()` の lost-wakeup ガードに使う。
+    pub(crate) fn is_triggered(&self) -> bool {
         self.triggered.load(Ordering::Acquire)
     }
 
-    /// トリガされるまで待機する。トリガ済みなら即座に返る。
-    pub async fn wait(&self) {
+    /// トリガされるまで待機する。トリガ済みなら即座に返る。accept ループと
+    /// waiter タスクが `tokio::select!` ブランチで使う内部 API。
+    pub(crate) async fn wait(&self) {
         if self.is_triggered() {
             return;
         }
@@ -350,7 +352,10 @@ where
     /// 呼び出し側は起床後に [`Self::active_game_count`] を再確認してから
     /// `break` すること（run_waiter 終了時の wake は counter を減らさないため
     /// spurious に見える）。
-    pub fn wait_active_games_notify(&self) -> tokio::sync::futures::Notified<'_> {
+    ///
+    /// 戻り型は `impl Future` でラップして内部で使う `Notify` の詳細を漏らさない。
+    /// 将来 notify 実装を差し替える際の破壊的変更を避ける。
+    pub fn wait_active_games_notify(&self) -> impl std::future::Future<Output = ()> + '_ {
         self.active_games.notified()
     }
 }
@@ -1533,6 +1538,14 @@ where
     // いる、という不整合を防ぐ）。`drive_game` epilogue の end_game / logout /
     // unregister はいずれも idempotent なので、ここで先行してもダブルコール
     // で破綻しない。
+    //
+    // **shutdown 判定との関係**: graceful shutdown の「対局完了待ち」は
+    // `GameRegistry` 件数ではなく `SharedState::active_drive_tasks`
+    // (AtomicUsize) を真実源とする。`drive_game` の RAII guard が epilogue の
+    // 最後 (persist_kifu 完了後) で decrement するため、ここでの `unregister`
+    // を前倒ししても shutdown 判定は 0 に落ちない。逆に言うと、将来
+    // `active_game_count()` の参照先をうかつに `GameRegistry` に戻すと
+    // persist_kifu 中の棋譜消失 race が再発するので注意。
     {
         let mut league = state.league.lock().await;
         let _ = league.end_game(&matched);

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -21,7 +21,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
@@ -163,9 +163,11 @@ impl ServerConfig {
 /// accept ループや待機 waiter が `wait()` を `tokio::select!` に組み込んで
 /// cancellation を検知する。
 ///
-/// `current_thread` ランタイム + `LocalSet` 前提で `Rc` 共有するため
-/// `Send`/`Sync` 境界は不要だが、実装は `AtomicBool` + `Notify` にして
-/// 将来マルチスレッドへ広げた場合にも耐えられるようにしている。
+/// 現在は `current_thread` ランタイム + `LocalSet` 前提で `Rc` 共有するが、
+/// 同期プリミティブは `AtomicBool` + `Notify` で組んであるので、他ランタイム
+/// へ移す場合も追加改修なしで使える。メモリオーダリングは `Release` (swap) /
+/// `Acquire` (load) で十分で、`Notify` 側のバリアと合わせて
+/// trigger → wait の happens-before 関係を維持する。
 pub struct GracefulShutdown {
     triggered: AtomicBool,
     notify: Notify,
@@ -182,7 +184,7 @@ impl GracefulShutdown {
 
     /// シャットダウンを開始する。複数回呼ばれても冪等。
     pub fn trigger(&self) {
-        if !self.triggered.swap(true, Ordering::SeqCst) {
+        if !self.triggered.swap(true, Ordering::Release) {
             // 待機中の全 waiter に通知。新しく `wait()` してくる経路は
             // 下の `is_triggered` チェックで即座に抜ける。
             self.notify.notify_waiters();
@@ -191,7 +193,7 @@ impl GracefulShutdown {
 
     /// 既にトリガ済みか。
     pub fn is_triggered(&self) -> bool {
-        self.triggered.load(Ordering::SeqCst)
+        self.triggered.load(Ordering::Acquire)
     }
 
     /// トリガされるまで待機する。トリガ済みなら即座に返る。
@@ -293,8 +295,23 @@ where
     password_store: P,
     hasher: Box<dyn PasswordHasher>,
     /// 進行中対局のメモリ内レジストリ。`%%LIST` / `%%SHOW` 応答で参照する。
+    ///
+    /// **注意**: このカウントは graceful shutdown の完了判定に使ってはならない。
+    /// `drive_game_inner` が `persist_kifu` より先に `unregister` を呼ぶため、
+    /// 棋譜 flush 中に件数 0 と誤判定され得る。shutdown 判定には
+    /// [`Self::active_drive_tasks`] を使う（`drive_game` epilogue の最後で
+    /// デクリメントされる）。
     games: Mutex<GameRegistry>,
-    /// 全接続タスクの終了を待つためのカウンタ通知。graceful shutdown で使用。
+    /// `drive_game` タスクの在籍カウンタ。`drive_game` の entry で +1、epilogue
+    /// の最後（`persist_kifu` 完了を含む全後始末の後）に -1 される。graceful
+    /// shutdown の「対局完了待ち」はこのカウンタを 0 まで落とすのを待つ。
+    /// `GameRegistry` の件数を使うと `persist_kifu` 中に 0 と判定される race
+    /// があるため、こちらを唯一の真実とする。
+    active_drive_tasks: AtomicUsize,
+    /// 対局 1 件が終了（`drive_game` の epilogue 完了）したことを通知する。
+    /// graceful shutdown ループがこれで起床して `active_drive_tasks` を再確認
+    /// する。`run_waiter` からも呼ばれるので spurious wake が起き得るが、
+    /// 起床後に counter を再確認するので正しく判定できる。
     active_games: Notify,
     /// 連番カウンタ（game_id 生成）。起動時刻 + 連番で衝突を避ける。
     game_counter: Mutex<u64>,
@@ -323,14 +340,16 @@ where
         &self.config
     }
 
-    /// 現在の進行中対局数。graceful shutdown 中に残対局数を監視するために使う。
-    pub async fn active_game_count(&self) -> usize {
-        self.games.lock().await.len()
+    /// 進行中の `drive_game` タスク数。`persist_kifu` を含む epilogue が完了
+    /// して初めて 0 になる。graceful shutdown 完了判定はこのカウンタを使う。
+    pub fn active_game_count(&self) -> usize {
+        self.active_drive_tasks.load(Ordering::Acquire)
     }
 
-    /// 進行中対局数が 0 になったことを通知する [`Notify`] への待機ハンドル。
-    /// 対局 1 件が終了するたびに `notify_waiters` が呼ばれるため、呼び出し側は
-    /// 受信後に [`Self::active_game_count`] を再確認してから `break` する。
+    /// `drive_game` epilogue 完了と `run_waiter` 終了のどちらでも起床する通知。
+    /// 呼び出し側は起床後に [`Self::active_game_count`] を再確認してから
+    /// `break` すること（run_waiter 終了時の wake は counter を減らさないため
+    /// spurious に見える）。
     pub fn wait_active_games_notify(&self) -> tokio::sync::futures::Notified<'_> {
         self.active_games.notified()
     }
@@ -655,12 +674,22 @@ where
             // graceful shutdown: 待機中のセッションに `##[NOTICE] ...` を送って
             // 切断する。プレイヤー側は LOGIN 済みだが対局には入っていないので、
             // 安全に接続を閉じてプロセス終了を待てる。
+            //
+            // observer_mode の waiter が持っている `monitor_rx` は通常切断経路と
+            // 同じく take() + prune_closed() する。こうしないと broadcaster に
+            // dead sender が残って同 room の後続観戦者 / 終局 clear_room まで
+            // 掃除されない。
             _ = state.shutdown.wait() => {
                 let _ = transport
                     .send_line(&CsaLine::new("##[NOTICE] server shutting down"))
                     .await;
-                let mut pool = state.waiting.lock().await;
-                let _ = pool.remove_by_handle(&game_name, &handle);
+                {
+                    let mut pool = state.waiting.lock().await;
+                    let _ = pool.remove_by_handle(&game_name, &handle);
+                }
+                if let Some((room, _)) = monitor_rx.take() {
+                    state.broadcaster.prune_closed(&RoomId::new(room.as_str())).await;
+                }
                 break 'outer WaiterOutcome::DisconnectedFromPool;
             }
             // observer_mode 時は `match_req_rx` の Err は自分が pool から自主的に
@@ -1292,6 +1321,26 @@ where
 {
     debug_assert_eq!(opp_color, self_color.opposite());
 
+    // `drive_game` 在籍をカウントする RAII ガード。graceful shutdown の完了
+    // 判定で使うため、`persist_kifu` を含む epilogue 全体が終わるまで生存
+    // させる必要がある。Err 早期 return / panic でも確実に decrement + notify
+    // されるように `Drop` で解放する。
+    struct DriveGuard<'a> {
+        counter: &'a AtomicUsize,
+        notify: &'a Notify,
+    }
+    impl Drop for DriveGuard<'_> {
+        fn drop(&mut self) {
+            self.counter.fetch_sub(1, Ordering::Release);
+            self.notify.notify_waiters();
+        }
+    }
+    state.active_drive_tasks.fetch_add(1, Ordering::Release);
+    let _drive_guard = DriveGuard {
+        counter: &state.active_drive_tasks,
+        notify: &state.active_games,
+    };
+
     // 役割割り当て: Black / White transport を色で確定。
     let (mut black_transport, mut white_transport, black_handle, white_handle) =
         if self_color == Color::Black {
@@ -1350,7 +1399,9 @@ where
     state.broadcaster.clear_room(&RoomId::new(game_id.as_str())).await;
     // 待機タスクに完了通知（これで先着側のタスクが抜ける）。
     let _ = opp_completion_tx.send(());
-    state.active_games.notify_waiters();
+    // `active_drive_tasks` の decrement + `active_games.notify_waiters()` は
+    // `_drive_guard` の Drop で行う。ここで明示的に呼ぶと二重通知になり、
+    // Err 早期 return 経路との挙動差も生まれるので guard に一任する。
     inner
 }
 
@@ -1860,6 +1911,7 @@ where
         password_store,
         hasher,
         games: Mutex::new(GameRegistry::new()),
+        active_drive_tasks: AtomicUsize::new(0),
         active_games: Notify::new(),
         game_counter: Mutex::new(0),
         started_at: chrono::Utc::now(),

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -21,6 +21,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
@@ -131,6 +132,10 @@ pub struct ServerConfig {
     /// Floodgate 機能は無く、将来 Floodgate 系機能が入る PR が本フラグを
     /// 起動条件として参照する。
     pub allow_floodgate_features: bool,
+    /// SIGINT / SIGTERM 受信後に進行中対局の終了を待つ上限。超過分は未完了の
+    /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
+    /// を落とさない」ためのバッファで、既定 60 秒。
+    pub shutdown_grace: Duration,
 }
 
 impl ServerConfig {
@@ -149,7 +154,64 @@ impl ServerConfig {
             initial_sfen: None,
             admin_handles: Vec::new(),
             allow_floodgate_features: false,
+            shutdown_grace: Duration::from_secs(60),
         }
+    }
+}
+
+/// graceful shutdown 用トリガ。SIGINT / SIGTERM 受信で `trigger` され、
+/// accept ループや待機 waiter が `wait()` を `tokio::select!` に組み込んで
+/// cancellation を検知する。
+///
+/// `current_thread` ランタイム + `LocalSet` 前提で `Rc` 共有するため
+/// `Send`/`Sync` 境界は不要だが、実装は `AtomicBool` + `Notify` にして
+/// 将来マルチスレッドへ広げた場合にも耐えられるようにしている。
+pub struct GracefulShutdown {
+    triggered: AtomicBool,
+    notify: Notify,
+}
+
+impl GracefulShutdown {
+    /// 未トリガ状態のインスタンスを返す。
+    pub fn new() -> Self {
+        Self {
+            triggered: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    /// シャットダウンを開始する。複数回呼ばれても冪等。
+    pub fn trigger(&self) {
+        if !self.triggered.swap(true, Ordering::SeqCst) {
+            // 待機中の全 waiter に通知。新しく `wait()` してくる経路は
+            // 下の `is_triggered` チェックで即座に抜ける。
+            self.notify.notify_waiters();
+        }
+    }
+
+    /// 既にトリガ済みか。
+    pub fn is_triggered(&self) -> bool {
+        self.triggered.load(Ordering::SeqCst)
+    }
+
+    /// トリガされるまで待機する。トリガ済みなら即座に返る。
+    pub async fn wait(&self) {
+        if self.is_triggered() {
+            return;
+        }
+        // notify_waiters は現在待機中の全 waiter にのみ通知するため、
+        // notified 登録 → atomic 再確認で lost-wakeup を避ける。
+        let notified = self.notify.notified();
+        if self.is_triggered() {
+            return;
+        }
+        notified.await;
+    }
+}
+
+impl Default for GracefulShutdown {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -244,6 +306,34 @@ where
     /// は常に同一プロセス・同一プロセス内で単一インスタンスを保持する前提
     /// (複数プロセス並行書き込みは非対応)。
     buoy_storage: rshogi_csa_server::FileBuoyStorage,
+    /// SIGINT / SIGTERM 由来の graceful shutdown トリガ。accept ループと
+    /// 待機 waiter が監視して、新規受付停止と待機セッション切断を行う。
+    pub shutdown: GracefulShutdown,
+}
+
+impl<R, K, P> SharedState<R, K, P>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    /// 起動時に渡した [`ServerConfig`] を参照する。graceful shutdown などで
+    /// `shutdown_grace` のような設定値を読むために使う。
+    pub fn config(&self) -> &ServerConfig {
+        &self.config
+    }
+
+    /// 現在の進行中対局数。graceful shutdown 中に残対局数を監視するために使う。
+    pub async fn active_game_count(&self) -> usize {
+        self.games.lock().await.len()
+    }
+
+    /// 進行中対局数が 0 になったことを通知する [`Notify`] への待機ハンドル。
+    /// 対局 1 件が終了するたびに `notify_waiters` が呼ばれるため、呼び出し側は
+    /// 受信後に [`Self::active_game_count`] を再確認してから `break` する。
+    pub fn wait_active_games_notify(&self) -> tokio::sync::futures::Notified<'_> {
+        self.active_games.notified()
+    }
 }
 
 /// パスワードストアの抽象。`handle` に対応する保存ハッシュ（現状は平文）を返す。
@@ -299,19 +389,30 @@ where
     P: PasswordStore + 'static,
 {
     loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                log::debug!("accepted {addr}");
-                let st = state.clone();
-                tokio::task::spawn_local(async move {
-                    if let Err(e) = handle_connection(stream, st).await {
-                        log::info!("connection {addr} ended: {e:?}");
-                    }
-                });
+        tokio::select! {
+            // graceful shutdown 中は新規受付を止める。listener は drop されて
+            // port が解放されるまでの short window では SYN が失敗する可能性が
+            // あるが、既存接続と進行中対局には影響しない。
+            _ = state.shutdown.wait() => {
+                log::info!("accept loop received shutdown signal; stopping new connections");
+                break;
             }
-            Err(e) => {
-                log::warn!("accept error: {e}");
-                tokio::time::sleep(Duration::from_millis(10)).await;
+            res = listener.accept() => {
+                match res {
+                    Ok((stream, addr)) => {
+                        log::debug!("accepted {addr}");
+                        let st = state.clone();
+                        tokio::task::spawn_local(async move {
+                            if let Err(e) = handle_connection(stream, st).await {
+                                log::info!("connection {addr} ended: {e:?}");
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        log::warn!("accept error: {e}");
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                }
             }
         }
     }
@@ -551,6 +652,17 @@ where
     // 先に到着した場合はバッファを保ったまま drive 側へ transport を渡せる。
     let waiter_outcome: WaiterOutcome = 'outer: loop {
         let recv = tokio::select! {
+            // graceful shutdown: 待機中のセッションに `##[NOTICE] ...` を送って
+            // 切断する。プレイヤー側は LOGIN 済みだが対局には入っていないので、
+            // 安全に接続を閉じてプロセス終了を待てる。
+            _ = state.shutdown.wait() => {
+                let _ = transport
+                    .send_line(&CsaLine::new("##[NOTICE] server shutting down"))
+                    .await;
+                let mut pool = state.waiting.lock().await;
+                let _ = pool.remove_by_handle(&game_name, &handle);
+                break 'outer WaiterOutcome::DisconnectedFromPool;
+            }
             // observer_mode 時は `match_req_rx` の Err は自分が pool から自主的に
             // 外れたことが原因。`recv_line` / `forwarded` ブランチを使い続けられるよう、
             // pending() に切り替えて本ブランチを実質無効化する。`match_req_rx` を
@@ -1752,6 +1864,7 @@ where
         game_counter: Mutex::new(0),
         started_at: chrono::Utc::now(),
         buoy_storage,
+        shutdown: GracefulShutdown::new(),
     }
 }
 

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1447,3 +1447,68 @@ fn oute_sennichite_from_initial_sfen_ends_as_perpetual_check_loss_e2e() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+#[test]
+fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
+    // graceful shutdown 回帰テスト:
+    //   1. 待機中の x1 クライアント (LOGIN OK 済み、マッチ待ち) を 1 本接続。
+    //   2. `state.shutdown.trigger()` を呼ぶ。
+    //   3. 待機クライアントに `##[NOTICE] server shutting down` が届く。
+    //   4. active_game_count が 0 に留まり、shutdown 検証が進める状態を確認する。
+    run_local(|| async {
+        let topdir = unique_topdir("graceful_shutdown");
+        let mut password_map = HashMap::new();
+        password_map.insert("alice".to_owned(), "pw".to_owned());
+        let rate_records = vec![PlayerRateRecord {
+            name: PlayerName::new("alice"),
+            rate: 1500,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: "2026-04-17T00:00:00Z".to_owned(),
+        }];
+        let rate_storage = support::MemRateStorage::new(rate_records);
+        let kifu_storage = FileKifuStorage::new(topdir.clone());
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+        let config = ServerConfig {
+            bind_addr: addr,
+            kifu_topdir: topdir.clone(),
+            login_timeout: Duration::from_secs(10),
+            agree_timeout: Duration::from_secs(30),
+            ..ServerConfig::sensible_defaults()
+        };
+        let state = Rc::new(build_state(
+            config,
+            rate_storage,
+            kifu_storage,
+            InMemoryPasswordStore { map: password_map },
+            Box::new(PlainPasswordHasher::new()),
+            IpLoginRateLimiter::default_limits(),
+            InMemoryBroadcaster::new(),
+        ));
+        let _handle = run_server(state.clone()).await.expect("run_server");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // 待機クライアントを接続。
+        let (mut ra, mut wa) = connect(addr).await;
+        send_line(&mut wa, "LOGIN alice+g1+black pw x1").await;
+        assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+
+        // shutdown を起動。
+        state.shutdown.trigger();
+
+        // 待機クライアントに NOTICE が届く。
+        let notice = read_line_raw(&mut ra).await.unwrap();
+        assert_eq!(notice, "##[NOTICE] server shutting down");
+        drop(ra);
+        drop(wa);
+
+        // 対局は動いていないので active_game_count は 0。shutdown 後 grace なしで
+        // 進める状態を確認する。
+        assert_eq!(state.active_game_count().await, 0);
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -211,6 +211,59 @@ async fn read_until(reader: &mut BufReader<OwnedReadHalf>, expect: &str) -> Vec<
     }
 }
 
+/// ファイルが現れるまで短ポーリングで待機する。非同期書き込み完了タイミング
+/// のばらつきを吸収する。上限 2 秒 (40 × 50ms)。
+async fn wait_for_file_text(path: &std::path::Path) -> String {
+    for _ in 0..40 {
+        if let Ok(body) = tokio::fs::read_to_string(path).await {
+            return body;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    tokio::fs::read_to_string(path)
+        .await
+        .unwrap_or_else(|e| panic!("expected file {path:?} after wait: {e}"))
+}
+
+/// `<topdir>/YYYY/MM/DD/<game_id>.csa` の書き込みを tokio::fs 非同期経路で
+/// 再帰的に探す。current-thread ランタイムでも executor を塞がない。
+async fn find_csa_file_recursive(root: &std::path::Path, game_id: &str) -> Option<PathBuf> {
+    let target = format!("{game_id}.csa");
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let mut entries = tokio::fs::read_dir(&dir).await.ok()?;
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            let file_type = match entry.file_type().await {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if path.file_name().and_then(|s| s.to_str()) == Some(target.as_str()) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// 指定 game_id の CSA 棋譜ファイルが書き込まれるのを待って読み出す。
+async fn wait_for_csa_text(topdir: &std::path::Path, game_id: &str) -> String {
+    for _ in 0..40 {
+        if let Some(path) = find_csa_file_recursive(topdir, game_id).await
+            && let Ok(body) = tokio::fs::read_to_string(&path).await
+        {
+            return body;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let path = find_csa_file_recursive(topdir, game_id)
+        .await
+        .unwrap_or_else(|| panic!("csa file for game_id {game_id} not found under {topdir:?}"));
+    tokio::fs::read_to_string(path).await.unwrap()
+}
+
 fn run_local<F, Fut>(f: F)
 where
     F: FnOnce() -> Fut + 'static,
@@ -1507,7 +1560,218 @@ fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
 
         // 対局は動いていないので active_game_count は 0。shutdown 後 grace なしで
         // 進める状態を確認する。
-        assert_eq!(state.active_game_count().await, 0);
+        assert_eq!(state.active_game_count(), 0);
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn graceful_shutdown_waits_for_in_flight_game_and_persists_kifu() {
+    // in-flight 対局が走っている最中に shutdown を起動したケース。
+    // graceful shutdown の中核契約 (棋譜を落とさない) が機能するかを検証する。
+    //
+    //   1. alice / bob で対局を開始 → AGREE → +7776FU を指す。
+    //   2. `state.shutdown.trigger()` を呼ぶ（対局は進行中）。
+    //   3. %TORYO で対局を通常終了させる。
+    //   4. grace 内に `active_game_count()` が 0 に落ちることを確認。
+    //   5. 棋譜ファイルが書き込み完了していることを確認 (CSA 本文 + 00LIST)。
+    run_local(|| async {
+        let topdir = unique_topdir("graceful_shutdown_inflight");
+        let mut password_map = HashMap::new();
+        password_map.insert("alice".to_owned(), "pw".to_owned());
+        password_map.insert("bob".to_owned(), "pw".to_owned());
+        let rate_records: Vec<_> = ["alice", "bob"]
+            .iter()
+            .map(|n| PlayerRateRecord {
+                name: PlayerName::new(*n),
+                rate: 1500,
+                wins: 0,
+                losses: 0,
+                last_game_id: None,
+                last_modified: "2026-04-17T00:00:00Z".to_owned(),
+            })
+            .collect();
+        let rate_storage = support::MemRateStorage::new(rate_records);
+        let kifu_storage = FileKifuStorage::new(topdir.clone());
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+        let config = ServerConfig {
+            bind_addr: addr,
+            kifu_topdir: topdir.clone(),
+            login_timeout: Duration::from_secs(10),
+            agree_timeout: Duration::from_secs(30),
+            ..ServerConfig::sensible_defaults()
+        };
+        let state = Rc::new(build_state(
+            config,
+            rate_storage,
+            kifu_storage,
+            InMemoryPasswordStore { map: password_map },
+            Box::new(PlainPasswordHasher::new()),
+            IpLoginRateLimiter::default_limits(),
+            InMemoryBroadcaster::new(),
+        ));
+        let _handle = run_server(state.clone()).await.expect("run_server");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+        let _ = drain_game_summary(&mut rb).await;
+        let _ = drain_game_summary(&mut rw).await;
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        let start_b = read_line_raw(&mut rb).await.unwrap();
+        assert!(start_b.starts_with("START:"), "expected START line, got {start_b:?}");
+        let game_id = start_b.trim_start_matches("START:").to_owned();
+        let _ = read_line_raw(&mut rw).await.unwrap(); // white 側 START
+
+        send_line(&mut wb, "+7776FU,T0").await;
+        let _ = read_until(&mut rb, "+7776FU,T0").await;
+        let _ = read_until(&mut rw, "+7776FU,T0").await;
+
+        // 対局中に shutdown を起動。active_drive_tasks は 1 のまま。
+        assert_eq!(state.active_game_count(), 1);
+        state.shutdown.trigger();
+
+        // 投了で対局を正常終了させる。
+        send_line(&mut ww, "%TORYO").await;
+        let _ = read_until(&mut rb, "#WIN").await;
+        let _ = read_until(&mut rw, "#LOSE").await;
+
+        // drive_game の epilogue が走って active_drive_tasks が 0 に落ちるのを
+        // 待つ。TOCTOU 対策として notified を先に生成してから counter 確認。
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let notified = state.wait_active_games_notify();
+            if state.active_game_count() == 0 {
+                break;
+            }
+            tokio::select! {
+                _ = notified => continue,
+                _ = tokio::time::sleep_until(deadline) => {
+                    panic!("active_game_count did not reach 0 within grace");
+                }
+            }
+        }
+
+        // 棋譜と 00LIST が書き込まれていることを確認。graceful shutdown が
+        // persist_kifu の完了を待っていた証拠。
+        let csa = wait_for_csa_text(&topdir, &game_id).await;
+        assert!(csa.contains("N+alice"), "kifu body missing alice: {csa}");
+        assert!(csa.contains("%TORYO"), "kifu body missing TORYO: {csa}");
+        let zerozero = wait_for_file_text(&topdir.join("00LIST")).await;
+        assert!(zerozero.contains(&game_id), "00LIST missing game_id: {zerozero}");
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn graceful_shutdown_prunes_observer_subscribers() {
+    // observer_mode (`%%MONITOR2ON`) 中の waiter が shutdown を受けた場合に、
+    // broadcaster の subscriber が leak しないことを検証する。
+    //
+    // 1. alice / bob で対局を開始 → AGREE 済みの in-flight 状態を作る。
+    // 2. 第 3 者 carol が x1 + `%%MONITOR2ON` で観戦者になる。
+    // 3. `state.shutdown.trigger()` を呼ぶ。
+    // 4. carol に `##[NOTICE] server shutting down` が届く。
+    // 5. 対局を正常終了させ、grace 内に active_game_count が 0 になる。
+    //    observer_mode の waiter が prune_closed を呼んでいれば broadcaster
+    //    の clear_room が clean に完了する。
+    run_local(|| async {
+        let topdir = unique_topdir("graceful_shutdown_observer");
+        let mut password_map = HashMap::new();
+        for h in ["alice", "bob", "carol"] {
+            password_map.insert(h.to_owned(), "pw".to_owned());
+        }
+        let rate_records: Vec<_> = ["alice", "bob", "carol"]
+            .iter()
+            .map(|n| PlayerRateRecord {
+                name: PlayerName::new(*n),
+                rate: 1500,
+                wins: 0,
+                losses: 0,
+                last_game_id: None,
+                last_modified: "2026-04-17T00:00:00Z".to_owned(),
+            })
+            .collect();
+        let rate_storage = support::MemRateStorage::new(rate_records);
+        let kifu_storage = FileKifuStorage::new(topdir.clone());
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+        let config = ServerConfig {
+            bind_addr: addr,
+            kifu_topdir: topdir.clone(),
+            login_timeout: Duration::from_secs(10),
+            agree_timeout: Duration::from_secs(30),
+            ..ServerConfig::sensible_defaults()
+        };
+        let state = Rc::new(build_state(
+            config,
+            rate_storage,
+            kifu_storage,
+            InMemoryPasswordStore { map: password_map },
+            Box::new(PlainPasswordHasher::new()),
+            IpLoginRateLimiter::default_limits(),
+            InMemoryBroadcaster::new(),
+        ));
+        let _handle = run_server(state.clone()).await.expect("run_server");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // 対局ペアを起動して AGREE まで進める。
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+g1+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+g1+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+        let _ = drain_game_summary(&mut rb).await;
+        let _ = drain_game_summary(&mut rw).await;
+        send_line(&mut wb, "AGREE").await;
+        send_line(&mut ww, "AGREE").await;
+        let start_b = read_line_raw(&mut rb).await.unwrap();
+        let game_id = start_b.trim_start_matches("START:").to_owned();
+        let _ = read_line_raw(&mut rw).await.unwrap();
+
+        // carol を x1 + observer にする。
+        let (mut rc, mut wc) = connect(addr).await;
+        send_line(&mut wc, "LOGIN carol+g2+black pw x1").await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:carol OK");
+        send_line(&mut wc, &format!("%%MONITOR2ON {game_id}")).await;
+        assert_eq!(read_line_raw(&mut rc).await.unwrap(), format!("##[MONITOR2] BEGIN {game_id}"));
+        let _ = read_line_raw(&mut rc).await.unwrap(); // END
+
+        // shutdown を起動。
+        state.shutdown.trigger();
+        let notice = read_line_raw(&mut rc).await.unwrap();
+        assert_eq!(notice, "##[NOTICE] server shutting down");
+
+        // 対局を正常終了。
+        send_line(&mut ww, "%TORYO").await;
+        let _ = read_until(&mut rb, "#WIN").await;
+        let _ = read_until(&mut rw, "#LOSE").await;
+
+        // active_drive_tasks が 0 に落ちるのを待つ。
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let notified = state.wait_active_games_notify();
+            if state.active_game_count() == 0 {
+                break;
+            }
+            tokio::select! {
+                _ = notified => continue,
+                _ = tokio::time::sleep_until(deadline) => {
+                    panic!("active_game_count did not reach 0 within grace");
+                }
+            }
+        }
 
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });


### PR DESCRIPTION
## Summary

tasks.md 17.1「SIGINT/SIGTERM による graceful shutdown」の最小実装。\`handle.abort()\` 経路を graceful shutdown に置き換え、ローリング再起動・コンテナ停止で棋譜が途中で落ちるのを防ぐ。

## 変更点

### core (\`rshogi-csa-server-tcp/src/server.rs\`)
- \`GracefulShutdown\` トークンを新設（\`AtomicBool\` + \`Notify\`）
- \`SharedState\` に \`shutdown\` フィールドを追加、\`config()\` / \`active_game_count()\` / \`wait_active_games_notify()\` の公開アクセサ追加
- \`accept_loop\` に \`shutdown.wait()\` 監視を \`tokio::select!\` で組み込み、cancellation で新規受付停止
- \`run_waiter\` にも同様のブランチを追加。shutdown 時は \`##[NOTICE] server shutting down\` を送って切断
- \`ServerConfig::shutdown_grace\`（既定 60 秒）を追加

### CLI (\`src/bin/main.rs\`)
- \`--shutdown-grace-sec\` CLI フラグ
- \`wait_for_termination_signal()\` で SIGINT + SIGTERM を \`tokio::select!\` 並列待機（Unix 以外は SIGTERM 無効）
- シグナル受信後: \`shutdown.trigger()\` → accept loop 終了待ち → active games 完了待ち (grace 付き) → 終了
- 旧暫定コメントブロックを削除

### テスト
- \`graceful_shutdown_disconnects_waiter_and_stops_accepting\` 統合テストを追加。x1 待機クライアント 1 本に対して \`state.shutdown.trigger()\` を呼び、\`##[NOTICE] server shutting down\` が届くこと、active_game_count が 0 のまま進めることを回帰検証

## 未対応（フォローアップ）
- **進行中対局の強制終了**: grace 超過時に \`#ABNORMAL\` で強制終局して flush する経路は未実装。現在は超過分を warning log に出して LocalSet 終了で abort。実運用で grace 超過が観測されたら追加検討。
- **Workers 側**: 本 PR は TCP frontend のみ。Workers の Durable Object は Cloudflare 側の lifecycle 管理なので graceful shutdown の要件が異なる。

## Why
- SIGTERM に対応していなかった（systemd / Docker / Kubernetes の停止で 0.1 秒以内に強制終了）
- 進行中対局が途中で切断されて棋譜が落ちていた（ローリング再起動で最後の 1 手が R2/file に書かれない）
- この 2 点が test 運用に入る前に必要な最小品質ライン

## Validation
- \`cargo fmt --all\`
- \`cargo clippy --all-targets --tests -- -D warnings\`（警告 0）
- \`cargo test\`（全パス、新規テスト 1 件込み）
- \`cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)