### PR TITLE
feat(csa-server-tcp): Floodgate 系機能の opt-in gate を起動経路に配線

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -24,7 +24,9 @@ use rshogi_csa_server::{ClockSpec, FileKifuStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
-use rshogi_csa_server_tcp::server::{InMemoryPasswordStore, ServerConfig, build_state, run_server};
+use rshogi_csa_server_tcp::server::{
+    InMemoryPasswordStore, ServerConfig, build_state, prepare_runtime, run_server,
+};
 use tokio::sync::Mutex;
 
 /// rshogi-csa-server-tcp CLI 引数。
@@ -153,6 +155,14 @@ fn main() -> anyhow::Result<()> {
         allow_floodgate_features: cli.allow_floodgate_features,
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
+    // Floodgate 系機能の opt-in ゲートを起動前に評価する。要求があるのに
+    // `--allow-floodgate-features` が立っていない場合はここで起動を止める。
+    prepare_runtime(&config).map_err(|msg| {
+        anyhow::anyhow!(
+            "{msg}; pass --allow-floodgate-features to enable Floodgate runtime features",
+        )
+    })?;
+
     let kifu_storage = FileKifuStorage::new(config.kifu_topdir.clone());
     let state = Rc::new(build_state(
         config,

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -80,6 +80,9 @@ struct Cli {
     /// Floodgate 運用機能の opt-in フラグ。Floodgate 系機能を本バイナリで
     /// 有効化する PR は、本フラグが `true` のときだけ配線を生かすように
     /// 実装する（現時点ではまだ配線された機能は無い）。
+    /// CLI 名は `prepare_runtime` 失敗時のエラーメッセージで参照する
+    /// [`ALLOW_FLOODGATE_FEATURES_FLAG`] と同じ綴り。リネームする際は両方
+    /// 同時に変更すること（同期は下のユニットテストが回帰検知する）。
     #[arg(long, default_value_t = false)]
     allow_floodgate_features: bool,
     /// SIGINT / SIGTERM 受信後に進行中対局の完了を待つ秒数。超過分は未完了の
@@ -121,6 +124,13 @@ impl ClockKindArg {
     }
 }
 
+/// `Cli::allow_floodgate_features` から clap が生成する CLI フラグ名。
+/// `prepare_runtime` 失敗時のエラーメッセージ生成に使う。clap derive の
+/// `#[arg(long, ...)]` はフィールド名から flag を生成するため、この const と
+/// フィールド名を同期させる必要がある。`flag_name_matches_field_name`
+/// テストが両者の一致を回帰検知する。
+const ALLOW_FLOODGATE_FEATURES_FLAG: &str = "--allow-floodgate-features";
+
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     log::info!("rshogi-csa-server-tcp starting (v{})", env!("CARGO_PKG_VERSION"));
@@ -156,10 +166,10 @@ fn main() -> anyhow::Result<()> {
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。要求があるのに
-    // `--allow-floodgate-features` が立っていない場合はここで起動を止める。
+    // フラグが立っていない場合はここで起動を止める。
     prepare_runtime(&config).map_err(|msg| {
         anyhow::anyhow!(
-            "{msg}; pass --allow-floodgate-features to enable Floodgate runtime features",
+            "{msg}; pass {ALLOW_FLOODGATE_FEATURES_FLAG} to enable Floodgate runtime features",
         )
     })?;
 
@@ -354,5 +364,29 @@ impl RateStorage for InMemoryRateStorage {
 
     async fn list_all(&self) -> Result<Vec<PlayerRateRecord>, StorageError> {
         Ok(self.inner.lock().await.values().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    /// `ALLOW_FLOODGATE_FEATURES_FLAG` 定数と clap が生成する CLI フラグ名が
+    /// 一致することを固定する。`Cli::allow_floodgate_features` のフィールド名を
+    /// リネームしたら本テストが落ち、エラーメッセージ生成側との同期忘れを検知する。
+    #[test]
+    fn allow_floodgate_features_flag_matches_clap_long() {
+        let cmd = Cli::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "allow_floodgate_features")
+            .expect("allow_floodgate_features arg must exist on Cli");
+        let long = arg.get_long().expect("--allow-floodgate-features must have a long form");
+        assert_eq!(
+            format!("--{long}"),
+            ALLOW_FLOODGATE_FEATURES_FLAG,
+            "ALLOW_FLOODGATE_FEATURES_FLAG must stay in sync with clap-generated flag",
+        );
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -180,7 +180,15 @@ impl ServerConfig {
 ///
 /// この単一窓口を経由することで、Floodgate 機能の追加 PR がゲート呼び出しを
 /// 忘れる事故を構造的に防ぐ。
-pub fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFeatureIntent {
+///
+/// `pub(crate)` に閉じているのは「単一窓口を迂回した直接呼び出し」を型システムで
+/// 防ぐため。クレート外（`bin/main.rs` 含む）からは [`prepare_runtime`] のみが
+/// 入口になる。
+pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFeatureIntent {
+    // スタブ: 現状 `ServerConfig` に Floodgate 系フィールドが存在しないため、
+    // `config` を観測する必要がない。Floodgate 機能を実装する PR がフィールドを
+    // 追加した時点で本関数を更新するので、その更新漏れを `let _` の存在が
+    // リマインダになる（フィールド参照を追記する際に削除する）。
     let _ = config;
     FloodgateFeatureIntent::default()
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
+use rshogi_csa_server::config::{FloodgateFeatureIntent, validate_floodgate_feature_gate};
 use rshogi_csa_server::error::{ProtocolError, ServerError};
 use rshogi_csa_server::game::result::GameResult;
 use rshogi_csa_server::game::room::{GameRoom, GameRoomConfig};
@@ -128,9 +129,12 @@ pub struct ServerConfig {
     /// `PERMISSION_DENIED` で拒否される。`%%GETBUOYCOUNT` は参照系なので
     /// 管理者権限を要求しない。
     pub admin_handles: Vec<String>,
-    /// Floodgate 運用機能の opt-in フラグ。現時点では本バイナリに配線された
-    /// Floodgate 機能は無く、将来 Floodgate 系機能が入る PR が本フラグを
-    /// 起動条件として参照する。
+    /// Floodgate 運用機能の opt-in フラグ。`floodgate_intent_from_config` が
+    /// 返す要求集合に何か含まれていて本フラグが `false` の場合、
+    /// [`validate_floodgate_feature_gate`](rshogi_csa_server::config::validate_floodgate_feature_gate)
+    /// が起動時に Err を返す。Floodgate 系機能を追加する PR は、対応する
+    /// `ServerConfig` フィールドを増やしたうえで `floodgate_intent_from_config`
+    /// が `true` を返すよう更新し、運用側に明示の opt-in を強制する。
     pub allow_floodgate_features: bool,
     /// SIGINT / SIGTERM 受信後に進行中対局の終了を待つ上限。超過分は未完了の
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
@@ -157,6 +161,39 @@ impl ServerConfig {
             shutdown_grace: Duration::from_secs(60),
         }
     }
+}
+
+/// `ServerConfig` から「この起動構成が要求している Floodgate 系機能集合」を
+/// 導出する単一窓口。
+///
+/// 現状は Floodgate 系設定フィールドが `ServerConfig` に存在しないため常に
+/// 既定（空集合）を返し、`allow_floodgate_features` が `false` でも起動が
+/// 通る。Floodgate 機能を導入する PR は次の手順で配線する:
+///
+/// 1. 新フィールド（例: スケジュール宣言・非 direct ペアリング戦略・重複ログイン
+///    方針など）を `ServerConfig` に追加する。
+/// 2. 当ヘルパで該当フィールドが「機能を要求している」状態を検出し、対応する
+///    [`FloodgateFeatureIntent`] フラグを `true` にして返す。
+/// 3. CLI / config 経由の入力で該当フィールドが埋まり、かつ
+///    `allow_floodgate_features = false` の場合は `prepare_runtime` が
+///    `validate_floodgate_feature_gate` 経由で起動失敗させる。
+///
+/// この単一窓口を経由することで、Floodgate 機能の追加 PR がゲート呼び出しを
+/// 忘れる事故を構造的に防ぐ。
+pub fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFeatureIntent {
+    let _ = config;
+    FloodgateFeatureIntent::default()
+}
+
+/// 起動前に opt-in ゲートを評価する。
+///
+/// `floodgate_intent_from_config` が返す要求集合と `config.allow_floodgate_features`
+/// を [`validate_floodgate_feature_gate`] に通し、要求があるのにフラグが立って
+/// いない場合は `Err` を返して fail-fast する。CLI / バイナリは `build_state`
+/// より前に本関数を呼ぶこと。
+pub fn prepare_runtime(config: &ServerConfig) -> Result<(), String> {
+    let intent = floodgate_intent_from_config(config);
+    validate_floodgate_feature_gate(config.allow_floodgate_features, intent)
 }
 
 /// graceful shutdown 用トリガ。SIGINT / SIGTERM 受信で `trigger` され、
@@ -1986,5 +2023,29 @@ mod tests {
         assert_eq!(parse_move_broadcast("-3334FU,T10"), Some(("-3334FU", 10)));
         assert_eq!(parse_move_broadcast("#RESIGN"), None);
         assert_eq!(parse_move_broadcast("+7776FU,Tx"), None);
+    }
+
+    /// 既定構成は Floodgate 系機能を要求していないため、`allow_floodgate_features=false`
+    /// のままでも `prepare_runtime` が成功する。これが崩れると通常起動経路が
+    /// 全停止するため、契約として固定する。
+    #[test]
+    fn prepare_runtime_passes_for_default_config_without_floodgate_optin() {
+        let cfg = ServerConfig::sensible_defaults();
+        assert!(!cfg.allow_floodgate_features);
+        prepare_runtime(&cfg).expect("default config must start without floodgate opt-in");
+    }
+
+    /// 将来 Floodgate 機能が `floodgate_intent_from_config` に配線された後、
+    /// `allow_floodgate_features=false` のままで起動を試みると fail-fast する
+    /// 契約を直接検証する。helper 経路ではなく gate 関数を直接テストするのは、
+    /// 現状 `floodgate_intent_from_config` が常に `Default` を返すため。
+    #[test]
+    fn floodgate_gate_rejects_intent_when_optin_is_off() {
+        let intent = FloodgateFeatureIntent {
+            enable_scheduler: true,
+            ..FloodgateFeatureIntent::default()
+        };
+        let err = validate_floodgate_feature_gate(false, intent).unwrap_err();
+        assert!(err.contains("scheduler"), "error must list requested feature: {err}");
     }
 }

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1408,8 +1408,8 @@ fn fork_gracefully_errors_and_keeps_connection_alive() {
 
 #[test]
 fn uchifuzume_from_initial_sfen_ends_as_illegal_move_e2e() {
-    // Phase 3 acceptance: 打ち歩詰の典型局面を TCP E2E で流し、
-    // `#ILLEGAL_MOVE` → `#LOSE/#WIN` が wire されることを固定する。
+    // 打ち歩詰の典型局面を TCP E2E で流し、`#ILLEGAL_MOVE` → `#LOSE/#WIN` が
+    // wire されることを固定する（追加終局判定の受入回帰）。
     run_local(|| async {
         let (addr, topdir) = spawn_server_custom(
             "uchifuzume_e2e",
@@ -1449,8 +1449,8 @@ fn uchifuzume_from_initial_sfen_ends_as_illegal_move_e2e() {
 
 #[test]
 fn oute_sennichite_from_initial_sfen_ends_as_perpetual_check_loss_e2e() {
-    // Phase 3 acceptance: 連続王手千日手の最小循環を TCP E2E で流し、
-    // `#OUTE_SENNICHITE` が終局メッセージとして表に出ることを確認する。
+    // 連続王手千日手の最小循環を TCP E2E で流し、`#OUTE_SENNICHITE` が終局
+    // メッセージとして表に出ることを確認する（追加終局判定の受入回帰）。
     run_local(|| async {
         let (addr, topdir) = spawn_server_custom(
             "oute_sennichite_e2e",

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -984,7 +984,7 @@ mod tests {
     }
 
     #[test]
-    fn x1_command_in_phase1_is_not_enabled() {
+    fn x1_command_without_x1_login_is_not_enabled() {
         let mut room = make_room();
         let err = room.handle_line(Color::Black, &line("%%WHO"), 0).unwrap_err();
         assert!(matches!(err, ServerError::Protocol(ProtocolError::X1NotEnabled(_))));

--- a/crates/rshogi-csa-server/src/matching/pairing.rs
+++ b/crates/rshogi-csa-server/src/matching/pairing.rs
@@ -133,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_match_skips_unspecified_color_in_phase1() {
+    fn direct_match_skips_unspecified_color() {
         let s = DirectMatchStrategy::new();
         let pairs = s.try_pair(&[cand("alice", None), cand("bob", Some(Color::Black))]);
         assert!(pairs.is_empty());


### PR DESCRIPTION
## Summary

- `validate_floodgate_feature_gate` を `prepare_runtime` 経由で TCP `bin/main.rs` の起動経路に接続。Floodgate 系機能（定期スケジューラ、レート差ベースペアリング、重複ログイン方針など）を将来の PR で本バイナリに有効化する際、`--allow-floodgate-features` の opt-in が立っていなければ `build_state` より前で fail-fast する。
- `floodgate_intent_from_config(&ServerConfig)` を「構成 → Floodgate 要求集合」の単一窓口として導入。現状は `ServerConfig` に Floodgate 系フィールドが無いため常に既定（空集合）を返し、**既定構成の起動挙動は変わらない**。Floodgate 機能を追加する PR は本ヘルパを更新するだけで gate 呼び出しが構造的に強制される。
- 合わせて、tracked コードに残っていた時系列ラベル（テスト名 2 件 / コメント 2 件）を機能名ベースに置換するクリーンアップ。

## 動機

`FloodgateFeatureIntent` / `validate_floodgate_feature_gate` 自体は既に core crate に存在するが、**起動経路から呼ばれていなかった**。このため将来 Floodgate 機能を追加する PR が gate 呼び出しを忘れる事故を起こせる構造になっていた。
本 PR で「単一窓口 (`floodgate_intent_from_config`) 経由で gate を必ず通る」配線を入れることで、Floodgate 機能追加 PR の手順が「フィールド追加 → 単一窓口を更新 → 回帰テストを足す」に固定される。

## 変更点

### 起動経路の配線
- `crates/rshogi-csa-server-tcp/src/server.rs`
  - `floodgate_intent_from_config(&ServerConfig) -> FloodgateFeatureIntent` を追加（単一窓口、現状は `Default` を返す）
  - `prepare_runtime(&ServerConfig) -> Result<(), String>` を追加（gate 評価のエントリポイント）
  - `ServerConfig::allow_floodgate_features` の docstring を更新し、配線の存在と Floodgate 機能追加手順を明示
- `crates/rshogi-csa-server-tcp/src/bin/main.rs`
  - `build_state` 直前で `prepare_runtime(&config)` を呼び、Err 時はリスナー作成より前に終了

### 回帰テスト (`crates/rshogi-csa-server-tcp/src/server.rs`)
- `prepare_runtime_passes_for_default_config_without_floodgate_optin`
  既定構成 + opt-in なしで起動が通る契約を固定（崩れると全起動が止まる）
- `floodgate_gate_rejects_intent_when_optin_is_off`
  要求 + opt-in なしで gate が要求機能名入りの Err を返す契約を固定

### クリーンアップ
- `crates/rshogi-csa-server/src/matching/pairing.rs`: `direct_match_skips_unspecified_color_in_phase1` → `direct_match_skips_unspecified_color`
- `crates/rshogi-csa-server/src/game/room.rs`: `x1_command_in_phase1_is_not_enabled` → `x1_command_without_x1_login_is_not_enabled`
- `crates/rshogi-csa-server-tcp/tests/tcp_session.rs`: 打ち歩詰 / 連続王手千日手の E2E テストの `// Phase 3 acceptance:` コメントを「追加終局判定の受入回帰」表現に置換

## 既定挙動の変化

なし（既定構成では `floodgate_intent_from_config` が空集合を返すため、`prepare_runtime` は常に `Ok` を返して通過する）。

## Test plan

- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo clippy -p rshogi-csa-server -p rshogi-csa-server-tcp --all-targets -- -D warnings` 警告ゼロ
- [x] `cargo test -p rshogi-csa-server -p rshogi-csa-server-tcp --release` 全 pass
  - core crate: 137 pass（リネーム済み 2 件含む）
  - TCP crate: unit + 30 E2E pass（新規 wiring テスト 2 件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)