### PR TITLE
feat(csa-server): フォーマット golden test とライセンス整合性 test を追加して互換性ゲートを CI に組み込む

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/crates/rshogi-csa-server-tcp/src/auth.rs
+++ b/crates/rshogi-csa-server-tcp/src/auth.rs
@@ -1,6 +1,6 @@
 //! 認証とパスワードハッシュ検証。
 //!
-//! Ruby shogi-server と互換の players.yaml で提供される plain パスワードを
+//! shogi-server プロトコルの players.yaml で提供される平文パスワードを
 //! ハッシュ照合できるよう [`PasswordHasher`] を trait として分離する。
 //! 現状は [`PlainPasswordHasher`]（equals 比較）のみ実装。
 //! bcrypt 等を接続する場合はこの trait を別 crate で実装する。
@@ -54,10 +54,10 @@ pub enum AuthOutcome {
 
 /// パスワード照合ロジックの抽象。
 ///
-/// Ruby shogi-server の players.yaml と互換のため、既定実装は平文比較
-/// [`PlainPasswordHasher`]。将来ハッシュ方式（bcrypt 等）に移行する場合は
-/// この trait を実装して差し替え、その際に入力長で分岐しない定数時間比較
-/// （`subtle::ConstantTimeEq` 等）を採用する。
+/// shogi-server 互換 players.yaml は平文パスワード保存が既定なので、既定実装は
+/// 平文比較 [`PlainPasswordHasher`]。将来ハッシュ方式（bcrypt 等）に移行する
+/// 場合はこの trait を実装して差し替え、その際に入力長で分岐しない定数時間
+/// 比較（`subtle::ConstantTimeEq` 等）を採用する。
 pub trait PasswordHasher {
     /// 入力平文 `candidate` と保存ハッシュ `stored_hash` が一致するか判定する。
     fn verify(&self, candidate: &Secret, stored_hash: &str) -> bool;
@@ -65,7 +65,7 @@ pub trait PasswordHasher {
 
 /// players.yaml 互換の平文パスワード照合。
 ///
-/// Ruby shogi-server の players.yaml は平文パスワード保存が既定なので、移行期は
+/// shogi-server 互換 players.yaml は平文パスワード保存が既定なので、移行期は
 /// 平文比較で互換性を確保する。
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PlainPasswordHasher;
@@ -80,8 +80,8 @@ impl PlainPasswordHasher {
 impl PasswordHasher for PlainPasswordHasher {
     fn verify(&self, candidate: &Secret, stored_hash: &str) -> bool {
         // 注意: 平文比較かつ長さ不一致で即 return するため、処理時間からパスワード長を
-        // 推定する攻撃に対して定数時間ではない。本実装は Ruby shogi-server の
-        // players.yaml 平文互換のための暫定経路であり、ハッシュ方式への移行時は
+        // 推定する攻撃に対して定数時間ではない。本実装は shogi-server 互換
+        // players.yaml の平文保存に合わせた暫定経路であり、ハッシュ方式への移行時は
         // 長さ分岐ごと `subtle::ConstantTimeEq` 等の完全定数時間比較に置き換える。
         let a = candidate.expose().as_bytes();
         let b = stored_hash.as_bytes();

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -4,7 +4,7 @@
 //!
 //! - 認証（LOGIN / 成功・失敗・レート制限）
 //! - マッチ成立 → Game_Summary → AGREE → 対局進行 → 終局（投了 / 最大手数）
-//! - CSA V2 棋譜と 00LIST が shogi-server mk_rate 互換形式で吐かれる
+//! - CSA V2 棋譜と 00LIST が `split(' ')` 6 列のフォーマット契約に従って吐かれる
 //! - 待機中の切断・`agree_timeout` 総窓の enforcement 等の不変条件
 //!
 //! `flavor = "current_thread"` + `LocalSet` でサーバーを起動し、同じタスク内から
@@ -401,7 +401,7 @@ fn stopwatch_clock_summary_uses_minute_unit() {
 }
 
 #[test]
-fn kifu_and_zerozero_list_compatible_with_mk_rate() {
+fn kifu_and_zerozero_list_match_format_contract() {
     run_local(|| async {
         let (addr, topdir) = spawn_server("kifu_fmt").await;
         let (mut rb, mut wb) = connect(addr).await;
@@ -442,11 +442,11 @@ fn kifu_and_zerozero_list_compatible_with_mk_rate() {
         assert!(csa.contains("\n+7776FU,T"));
         assert!(csa.contains("\n-3334FU,T"));
         assert!(csa.contains("\n%TORYO\n"));
-        // 00LIST 1 行分が mk_rate 互換（スペース区切り 6 カラム、末尾 #RESIGN）。
+        // 00LIST 1 行がフォーマット契約 (スペース区切り 6 カラム、末尾 #RESIGN) に従う。
         let zerozero = tokio::fs::read_to_string(topdir.join("00LIST")).await.unwrap();
         let line = zerozero.lines().last().unwrap();
         let cols: Vec<_> = line.split(' ').collect();
-        assert_eq!(cols.len(), 6, "mk_rate expects 6 columns: {line}");
+        assert_eq!(cols.len(), 6, "00LIST format expects 6 columns: {line}");
         assert_eq!(cols[5], "#RESIGN");
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1011,9 +1011,9 @@ impl GameRoom {
 
     /// R2 バケットに CSA V2 形式の棋譜を書き出す。
     ///
-    /// キー体系: `YYYY/MM/DD/<game_id>.csa`。TCP 版 `FileKifuStorage` と
-    /// 同一構造なので、既存 Ruby 系のバッチ（mk_rate / mk_html）を R2 を
-    /// mount して流用できる。
+    /// キー体系: `YYYY/MM/DD/<game_id>.csa`。TCP 版 `FileKifuStorage` と同一
+    /// 構造なので、外部のレート集計や HTML レンダリングなどの後段処理は R2 を
+    /// mount するだけで TCP 版と同じパスで読める。
     async fn export_kifu_to_r2(
         &self,
         game_result: &rshogi_csa_server::game::result::GameResult,

--- a/crates/rshogi-csa-server/Cargo.toml
+++ b/crates/rshogi-csa-server/Cargo.toml
@@ -28,3 +28,6 @@ workers = []
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "io-util", "sync", "fs", "test-util"] }
+# License 整合性 integration test (`tests/license_integrity.rs`) で workspace の各
+# Cargo.toml を読むためだけに使う。
+toml = { workspace = true }

--- a/crates/rshogi-csa-server/src/record/kifu.rs
+++ b/crates/rshogi-csa-server/src/record/kifu.rs
@@ -444,6 +444,133 @@ mod tests {
         assert!(err.contains("exceeds available moves"), "unexpected: {err}");
     }
 
+    /// 既存 Ruby `mk_rate` / `mk_html` 等のレートバッチが消費するフォーマットは、
+    /// 軽微な format 変更でも壊れる（行末の trailing space 1 つで列分割が破綻する等）。
+    /// build_v2() の出力 1 byte でも変わったら本テストが落ちる「ゴールデン」テスト
+    /// として固定し、format 変更時に必ず明示的な golden 更新を要求する。
+    ///
+    /// このテストは Ruby ランタイム依存無しでフォーマット契約を担保する CI 互換性
+    /// ゲートの一翼を担う（外部処理系を CI に持ち込まない方針）。
+    #[test]
+    fn csa_v2_full_text_is_byte_stable_for_representative_record() {
+        let mut rec = rec_skeleton();
+        rec.initial_position = "PI\n+\n".to_owned();
+        let txt = rec.build_v2();
+        let expected = "\
+V2.2
+N+alice
+N-bob
+$EVENT:rshogi-csa-server-test
+$GAME_ID:20140101120000
+$START_TIME:2026/04/17 12:00:00
+$END_TIME:2026/04/17 12:05:00
+BEGIN Time
+Time_Unit:1sec
+Total_Time:600
+Byoyomi:10
+Least_Time_Per_Move:0
+END Time
+PI
++
++7776FU,T3
+-3334FU,T4
+'eval=12 pv 3c3d
+%TORYO
+";
+        assert_eq!(
+            txt, expected,
+            "CSA V2 棋譜のゴールデン形式が変更されました。\
+            外部レートバッチ互換が壊れる可能性があるため、format 変更を意図する場合は \
+            expected を更新したうえで Ruby `mk_rate` 仕様 (記号方針セクション参照) との \
+            整合を再確認すること"
+        );
+    }
+
+    /// 00LIST の 1 行が `<game_id> <sente> <gote> <start_time> <end_time> <result_code>`
+    /// 形式（単一スペース区切り、改行なし）であることを全 `GameResult` variant について
+    /// 完全一致で固定する。レートバッチ側は `split(' ')` の単純パースを前提にしている
+    /// ため、列数や区切り文字の違反は致命的になる。
+    #[test]
+    fn zerozero_list_format_is_byte_stable_for_all_result_variants() {
+        let game_id = GameId::new("g1");
+        let black = PlayerName::new("alice");
+        let white = PlayerName::new("bob");
+        let start = "2026-04-17T12:00:00Z";
+        let end = "2026-04-17T12:10:00Z";
+
+        // (variant, expected_result_code) を網羅する。新しい variant が `GameResult` に
+        // 増えた場合、本テストの match と list 両方を更新する必要がある (single source
+        // of truth として `primary_result_code` も同時に更新する契約)。
+        let cases: Vec<(GameResult, &str)> = vec![
+            (
+                GameResult::Toryo {
+                    winner: Color::Black,
+                },
+                "#RESIGN",
+            ),
+            (
+                GameResult::TimeUp {
+                    loser: Color::White,
+                },
+                "#TIME_UP",
+            ),
+            (
+                GameResult::IllegalMove {
+                    loser: Color::Black,
+                    reason: IllegalReason::Generic,
+                },
+                "#ILLEGAL_MOVE",
+            ),
+            (
+                GameResult::IllegalMove {
+                    loser: Color::Black,
+                    reason: IllegalReason::Uchifuzume,
+                },
+                "#ILLEGAL_MOVE",
+            ),
+            (
+                GameResult::IllegalMove {
+                    loser: Color::Black,
+                    reason: IllegalReason::IllegalKachi,
+                },
+                "#ILLEGAL_MOVE",
+            ),
+            (
+                GameResult::Kachi {
+                    winner: Color::Black,
+                },
+                "#JISHOGI",
+            ),
+            (
+                GameResult::OuteSennichite {
+                    loser: Color::Black,
+                },
+                "#OUTE_SENNICHITE",
+            ),
+            (GameResult::Sennichite, "#SENNICHITE"),
+            (GameResult::MaxMoves, "#MAX_MOVES"),
+            (
+                GameResult::Abnormal {
+                    winner: Some(Color::Black),
+                },
+                "#ABNORMAL",
+            ),
+            (GameResult::Abnormal { winner: None }, "#ABNORMAL"),
+        ];
+
+        for (result, code) in cases {
+            let line = format_zerozero_list_line(&game_id, &black, &white, start, end, &result);
+            let expected = format!("g1 alice bob {start} {end} {code}");
+            assert_eq!(line, expected, "00LIST 行が固定形式から外れました: {result:?}");
+            // 列数 6 と区切り単一スペースを直接固定する（leading/trailing space 0、
+            // タブ混入なし、改行なし）。
+            assert_eq!(line.split(' ').count(), 6, "列数が 6 から逸脱: {line}");
+            assert!(!line.contains('\t'), "タブ文字混入: {line}");
+            assert!(!line.contains('\n'), "改行混入: {line}");
+            assert!(!line.contains("  "), "連続スペース混入: {line}");
+        }
+    }
+
     #[test]
     fn winner_of_resolves_correctly() {
         assert_eq!(

--- a/crates/rshogi-csa-server/src/record/kifu.rs
+++ b/crates/rshogi-csa-server/src/record/kifu.rs
@@ -149,7 +149,8 @@ fn result_lines(result: &GameResult) -> Vec<String> {
 /// 00LIST 1 行分のフォーマット。
 ///
 /// 形式: `<game_id> <sente> <gote> <start_time> <end_time> <result_code>`
-/// （Ruby `mk_rate` 互換のシンプルなスペース区切り）。改行は呼び出し側で付ける。
+/// （単一スペース区切り、改行は呼び出し側で付ける）。`split(' ')` で 6 列に
+/// 一意分割できることが消費側との契約。
 pub fn format_zerozero_list_line(
     game_id: &GameId,
     black: &PlayerName,
@@ -164,8 +165,8 @@ pub fn format_zerozero_list_line(
 
 /// 終局結果から「主要結果コード 1 つ」を返す。00LIST 用に集約値が必要な箇所で使う。
 ///
-/// 00LIST の `result_code` 列は CSA プロトコル通知コード (`#...`) を採用する
-/// （Ruby `mk_rate` 互換）。棋譜本体の特殊手 (`%...`) とは語彙が異なる点に注意。
+/// 00LIST の `result_code` 列は CSA プロトコル通知コード (`#...`) を採用する。
+/// 棋譜本体の特殊手 (`%...`) とは語彙が異なる点に注意。
 ///
 /// フロントエンド crate からも同じ語彙で `GameSummaryEntry::result_code` を
 /// 埋めるため `pub` で公開している（TCP 側に二重定義を作らないためのシングルソース）。
@@ -182,7 +183,7 @@ pub fn primary_result_code(result: &GameResult) -> &'static str {
     }
 }
 
-/// 勝敗側を 00LIST 補助情報として取得するヘルパ。Floodgate 等のレートバッチが
+/// 勝敗側を 00LIST 補助情報として取得するヘルパ。レート集計などの後段処理が
 /// 必要に応じて利用する（現状は公開のみで、本 crate 内部では未使用）。
 pub fn winner_of(result: &GameResult) -> Option<Color> {
     match result {
@@ -402,6 +403,10 @@ mod tests {
 
     #[test]
     fn zerozero_list_line_format() {
+        // 00LIST の時刻列は `split(' ')` で単一トークンに収まる必要があるため、
+        // 実呼び出し側 (`storage/file.rs::append_summary`) は ISO 8601 形式
+        // `YYYY-MM-DDTHH:MM:SSZ` を渡す（CSA V2 棋譜の `$START_TIME` /
+        // `$END_TIME` は `YYYY/MM/DD HH:MM:SS` で空白入り、こちらは別経路）。
         let line = format_zerozero_list_line(
             &GameId::new("g1"),
             &PlayerName::new("alice"),
@@ -444,13 +449,10 @@ mod tests {
         assert!(err.contains("exceeds available moves"), "unexpected: {err}");
     }
 
-    /// 既存 Ruby `mk_rate` / `mk_html` 等のレートバッチが消費するフォーマットは、
-    /// 軽微な format 変更でも壊れる（行末の trailing space 1 つで列分割が破綻する等）。
-    /// build_v2() の出力 1 byte でも変わったら本テストが落ちる「ゴールデン」テスト
-    /// として固定し、format 変更時に必ず明示的な golden 更新を要求する。
-    ///
-    /// このテストは Ruby ランタイム依存無しでフォーマット契約を担保する CI 互換性
-    /// ゲートの一翼を担う（外部処理系を CI に持ち込まない方針）。
+    /// CSA V2 棋譜全文をバイト一致で固定するゴールデン。trailing space や区切り
+    /// 文字の混入を 1 byte 単位で検出するため、既存の `contains` 系テストでは
+    /// 拾えない静かな破壊を防ぐ。format を意図的に変える際は `expected` を
+    /// 更新する。
     #[test]
     fn csa_v2_full_text_is_byte_stable_for_representative_record() {
         let mut rec = rec_skeleton();
@@ -477,30 +479,28 @@ PI
 'eval=12 pv 3c3d
 %TORYO
 ";
-        assert_eq!(
-            txt, expected,
-            "CSA V2 棋譜のゴールデン形式が変更されました。\
-            外部レートバッチ互換が壊れる可能性があるため、format 変更を意図する場合は \
-            expected を更新したうえで Ruby `mk_rate` 仕様 (記号方針セクション参照) との \
-            整合を再確認すること"
-        );
+        assert_eq!(txt, expected, "CSA V2 棋譜のゴールデン形式が変更されました");
     }
 
-    /// 00LIST の 1 行が `<game_id> <sente> <gote> <start_time> <end_time> <result_code>`
-    /// 形式（単一スペース区切り、改行なし）であることを全 `GameResult` variant について
-    /// 完全一致で固定する。レートバッチ側は `split(' ')` の単純パースを前提にしている
-    /// ため、列数や区切り文字の違反は致命的になる。
+    /// 00LIST の 1 行を全 `GameResult` variant について完全一致で固定するゴールデン。
+    /// 単一スペース 6 列のフォーマット契約 (`split(' ')` 前提) を 1 byte 単位で
+    /// 守ることが消費側との契約。
     #[test]
     fn zerozero_list_format_is_byte_stable_for_all_result_variants() {
         let game_id = GameId::new("g1");
         let black = PlayerName::new("alice");
         let white = PlayerName::new("bob");
+        // 00LIST の時刻列は `split(' ')` で単一トークンに収まる必要があるため、
+        // 実呼び出し側は ISO 8601 形式 `YYYY-MM-DDTHH:MM:SSZ` を渡す。CSA V2
+        // 棋譜の `$START_TIME` / `$END_TIME` は `YYYY/MM/DD HH:MM:SS` で空白
+        // 入りだが、それは別経路なのでここではテストしない。
         let start = "2026-04-17T12:00:00Z";
         let end = "2026-04-17T12:10:00Z";
 
         // (variant, expected_result_code) を網羅する。新しい variant が `GameResult` に
         // 増えた場合、本テストの match と list 両方を更新する必要がある (single source
         // of truth として `primary_result_code` も同時に更新する契約)。
+        // `winner` / `loser` は `primary_result_code` が無視するため片側のみ網羅する。
         let cases: Vec<(GameResult, &str)> = vec![
             (
                 GameResult::Toryo {

--- a/crates/rshogi-csa-server/tests/license_integrity.rs
+++ b/crates/rshogi-csa-server/tests/license_integrity.rs
@@ -1,0 +1,126 @@
+//! csa-server 系クレート群の `license` メタデータが GPL-3.0-only に揃っている
+//! ことを CI で機械的に検証する。
+//!
+//! Ruby shogi-server からのクリーンルーム再実装である本サーバ群は、生成物
+//! （`crates/rshogi-csa-server*` の rlib / cdylib / バイナリ）に GPL-3.0-only を
+//! 引き継がせる必要がある。各 `Cargo.toml` の `license` フィールドが手作業で
+//! 書き換わって不揃いになる事故を、ビルド時 / cargo test 時に確実に止める。
+//!
+//! 本テストは workspace ルートの `Cargo.toml` の `members` を動的に走査するため、
+//! 将来 `crates/rshogi-csa-server-*` という名前で新クレートが追加された場合も
+//! 自動で検査対象になる（追加 PR が license を忘れるとここで落ちる）。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// csa-server 系クレートのライセンスとして許可される唯一の値。
+const REQUIRED_LICENSE: &str = "GPL-3.0-only";
+
+/// workspace 内クレートのうち、本テストが整合性を要求する名前接頭辞。
+const SCOPED_PREFIX: &str = "rshogi-csa-server";
+
+/// `CARGO_MANIFEST_DIR` から workspace ルート（= `Cargo.toml` に
+/// `[workspace]` セクションを持つ最上位ディレクトリ）を探す。
+fn workspace_root() -> PathBuf {
+    let mut cur = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        let cargo = cur.join("Cargo.toml");
+        if cargo.is_file() {
+            let text = fs::read_to_string(&cargo).expect("read Cargo.toml");
+            let parsed: toml::Value = toml::from_str(&text).expect("parse Cargo.toml");
+            if parsed.get("workspace").is_some() {
+                return cur;
+            }
+        }
+        if !cur.pop() {
+            panic!("could not find workspace root from CARGO_MANIFEST_DIR");
+        }
+    }
+}
+
+/// 1 クレートの `Cargo.toml` から `package.name` と `package.license` を取り出す。
+fn read_package_metadata(cargo_toml: &Path) -> (String, Option<String>) {
+    let text = fs::read_to_string(cargo_toml)
+        .unwrap_or_else(|e| panic!("read {}: {e}", cargo_toml.display()));
+    let parsed: toml::Value =
+        toml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", cargo_toml.display()));
+    let pkg = parsed
+        .get("package")
+        .unwrap_or_else(|| panic!("{}: missing [package]", cargo_toml.display()));
+    let name = pkg
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("{}: package.name missing", cargo_toml.display()))
+        .to_owned();
+    let license = pkg.get("license").and_then(|v| v.as_str()).map(|s| s.to_owned());
+    (name, license)
+}
+
+/// `crates/rshogi-csa-server*` 系メンバーの Cargo.toml を全て検査し、`license`
+/// が `GPL-3.0-only` で一貫していることを保証する。
+///
+/// 失敗時は具体的な crate 名と検出したライセンス値をエラーメッセージに含めるため、
+/// CI ログだけで「どの crate の Cargo.toml を直せばよいか」が分かる。
+#[test]
+fn csa_server_crates_declare_gpl_3_only_license() {
+    let root = workspace_root();
+    let workspace_toml_text =
+        fs::read_to_string(root.join("Cargo.toml")).expect("read workspace Cargo.toml");
+    let workspace_toml: toml::Value =
+        toml::from_str(&workspace_toml_text).expect("parse workspace Cargo.toml");
+    let members = workspace_toml
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .expect("workspace.members must be an array");
+
+    let mut checked: Vec<String> = Vec::new();
+    let mut violations: Vec<String> = Vec::new();
+
+    for member in members {
+        let path = member.as_str().expect("member must be a string");
+        let cargo_toml = root.join(path).join("Cargo.toml");
+        let (name, license) = read_package_metadata(&cargo_toml);
+        if !name.starts_with(SCOPED_PREFIX) {
+            continue;
+        }
+        match license.as_deref() {
+            Some(REQUIRED_LICENSE) => {
+                checked.push(name);
+            }
+            Some(other) => {
+                violations
+                    .push(format!("{name}: license = {other:?}, expected {REQUIRED_LICENSE:?}"));
+            }
+            None => {
+                violations
+                    .push(format!("{name}: license field missing, expected {REQUIRED_LICENSE:?}"));
+            }
+        }
+    }
+
+    assert!(
+        !checked.is_empty(),
+        "no `{SCOPED_PREFIX}*` crates found in workspace; the prefix or members layout has changed"
+    );
+    assert!(
+        violations.is_empty(),
+        "license integrity violations detected:\n  - {}\n\nFix the listed Cargo.toml files to use license = \"{REQUIRED_LICENSE}\".",
+        violations.join("\n  - ")
+    );
+
+    // 想定リストとの差分を防ぐため、最低限「3 つの代表 crate」が検査されていることを担保。
+    // 新しい csa-server* crate が追加された場合は自動で `checked` に乗るため、本 assert は
+    // 既存セットの脱落（リネーム漏れ等）を検知する役割を持つ。
+    let expected_at_least: &[&str] = &[
+        "rshogi-csa-server",
+        "rshogi-csa-server-tcp",
+        "rshogi-csa-server-workers",
+    ];
+    for name in expected_at_least {
+        assert!(
+            checked.iter().any(|c| c == name),
+            "expected csa-server crate `{name}` was not checked (workspace layout changed?)"
+        );
+    }
+}

--- a/crates/rshogi-csa-server/tests/license_integrity.rs
+++ b/crates/rshogi-csa-server/tests/license_integrity.rs
@@ -1,9 +1,9 @@
 //! csa-server 系クレート群の `license` メタデータが GPL-3.0-only に揃っている
 //! ことを CI で機械的に検証する。
 //!
-//! Ruby shogi-server からのクリーンルーム再実装である本サーバ群は、生成物
-//! （`crates/rshogi-csa-server*` の rlib / cdylib / バイナリ）に GPL-3.0-only を
-//! 引き継がせる必要がある。各 `Cargo.toml` の `license` フィールドが手作業で
+//! 本サーバ群は GPL-3.0-only を採用するクリーンルーム実装で、生成物
+//! （`crates/rshogi-csa-server*` の rlib / cdylib / バイナリ）にも同ライセンス
+//! を引き継がせる必要がある。各 `Cargo.toml` の `license` フィールドが手作業で
 //! 書き換わって不揃いになる事故を、ビルド時 / cargo test 時に確実に止める。
 //!
 //! 本テストは workspace ルートの `Cargo.toml` の `members` を動的に走査するため、


### PR DESCRIPTION
## Summary

Ruby shogi-server の `mk_rate` / `mk_html` 等のレートバッチが消費する 00LIST と CSA V2 棋譜のフォーマット契約と、`crates/rshogi-csa-server*` 群のライセンス整合性 (GPL-3.0-only) を、Rust 側のテストだけで継続的に保証するゲートを追加する。

**外部ソース依存ゼロ**: Ruby ランタイムや shogi-server リポを CI に取り込まず、仕様は人間が「仕様参照ソース」として読む方針。

## 動機

- 既存の `record/kifu.rs#tests` は `txt.contains(...)` ベースの substring assertion 中心で、行末の trailing space や区切り文字の混入など「外部レートバッチが `split(' ')` で消費する時に致命的になる軽微な変更」が素通りする
- ライセンス表記は各 `Cargo.toml` の `license` フィールドを手で直す運用で、新クレート追加時や typo の事故が起こりやすい
- どちらも CI で機械的に守ると、フォーマット契約とライセンス契約を「壊れた瞬間に PR チェックが落ちる」状態にできる

## 追加した test

### `record/kifu.rs#tests` の golden test 2 件

| テスト | 目的 |
|--------|------|
| `csa_v2_full_text_is_byte_stable_for_representative_record` | 代表的な `KifuRecord` の `build_v2()` 出力を **完全一致** で固定。1 byte でも変わると落ちる |
| `zerozero_list_format_is_byte_stable_for_all_result_variants` | `GameResult` 全 8 variant (重複バリエーション含む 11 ケース) で 00LIST 1 行を固定形式で完全一致 + 列数 6 / 単一スペース区切り / 改行・タブ・連続スペース禁止を直接固定 |

### `crates/rshogi-csa-server/tests/license_integrity.rs` (新規)

- workspace ルート `Cargo.toml` の `workspace.members` を読み、`rshogi-csa-server` 接頭辞のクレート全件で `package.license = \"GPL-3.0-only\"` を assert
- **新クレートが `crates/rshogi-csa-server-*` で追加されても自動的に対象に乗る**動的列挙
- 失敗時は具体的な crate 名と検出した license 値をエラーメッセージに含める

`crates/rshogi-csa-server/Cargo.toml` の dev-dependencies に `toml`（workspace 既存依存）を追加して各 Cargo.toml を読む。

## CI 構成の判断

CI yml は変更していない。新テストは既存 `cargo test --release --workspace` job に自動的に拾われ、PR チェックの test 結果でフォーマット / ライセンス契約の違反が明示的に落ちる。冗長な専用 job を新設するよりテスト結果から違反の所在が分かる構造を優先した（YAGNI）。

## 既定挙動の変化

なし。既存の `KifuRecord::build_v2()` / `format_zerozero_list_line` / `primary_result_code` の出力は変わっていない。本 PR は「現在の出力が固定された契約である」ことを test で明示するもの。

## Test plan

- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo clippy -p rshogi-csa-server --all-targets -- -D warnings` 警告ゼロ
- [x] `cargo test -p rshogi-csa-server -p rshogi-csa-server-tcp -p rshogi-csa-server-workers --release` 全 pass
  - core: 215 (新規 golden 2 件追加で 213 → 215) / TCP unit+integration: 30+1 / Workers: 49+1 / license_integrity: 1 件 pass

## 持ち越し（明示）

- Ruby `mk_rate` / `mk_html` の実呼び出しを CI に取り込む構成は採用しない方針を確定（外部ソース依存ゼロ）。Ruby 仕様は今後も人間が「仕様参照ソース」として読むに留める
- 新たな `GameResult` variant が追加された場合は、本 PR の `cases` リストと `primary_result_code` の match を同時に更新する契約

🤖 Generated with [Claude Code](https://claude.com/claude-code)