### PR TITLE
feat(csa-server-tcp): connection task に release-only panic boundary を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +597,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1668,6 +1683,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "futures",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,20 +522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +583,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1683,7 +1668,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "futures",
+ "futures-util",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",

--- a/crates/rshogi-csa-server-tcp/Cargo.toml
+++ b/crates/rshogi-csa-server-tcp/Cargo.toml
@@ -20,9 +20,11 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "tracing-log", "ansi"] }
 tracing-log = "0.2"
 # 1 connection task の panic を boundary に閉じ込めるため、async 対応の
-# `FutureExt::catch_unwind` を runtime dep として追加する。`std` feature だけで足りる
-# （executor / sink などは tokio で賄う）。
-futures = { version = "0.3", default-features = false, features = ["std"] }
+# `FutureExt::catch_unwind` を runtime dep として追加する。`futures` メタクレート
+# 経由ではなく `futures-util` を直接指定することで依存ツリーを最小化する
+# (`futures-channel` 等を引き込まない)。`catch_unwind` は `std` feature 配下なので
+# それのみを有効化する（async-await / executor / sink などは tokio で賄う）。
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 clap.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/rshogi-csa-server-tcp/Cargo.toml
+++ b/crates/rshogi-csa-server-tcp/Cargo.toml
@@ -19,6 +19,10 @@ tracing.workspace = true
 # 直接書く（dep 範囲を明示）。
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "tracing-log", "ansi"] }
 tracing-log = "0.2"
+# 1 connection task の panic を boundary に閉じ込めるため、async 対応の
+# `FutureExt::catch_unwind` を runtime dep として追加する。`std` feature だけで足りる
+# （executor / sink などは tokio で賄う）。
+futures = { version = "0.3", default-features = false, features = ["std"] }
 clap.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -451,6 +451,66 @@ where
     Ok(handle)
 }
 
+/// `Box<dyn Any>` の panic payload から人間可読な短い文字列を取り出す。
+///
+/// `panic!("...")` で渡した `&str` / `String` を最優先で抽出し、それ以外の
+/// payload 型は `"<non-string panic payload>"` で固定する。`tracing::error!` の
+/// 構造化フィールドにそのまま乗せられるよう `String` を返す。
+///
+/// debug ビルドでは [`run_connection_isolated`] が catch_unwind を行わないため
+/// 本関数は使われない。`#[cfg(not(debug_assertions))]` で release ビルド時のみ
+/// 定義することで、`#[allow(dead_code)]` 抑止に頼らずに dead_code 警告を回避する。
+#[cfg(not(debug_assertions))]
+fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_owned();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_owned()
+}
+
+/// 1 接続分の `handle_connection` を panic boundary で包むラッパ。
+///
+/// release ビルドでは `FutureExt::catch_unwind` で panic を捕捉し、`tracing::error!`
+/// に span (`conn_id` / `game_id`) 付きで記録した上で task を正常終了させる。
+/// 当該接続は途絶するが、accept ループや他の対局タスクには影響しない。
+///
+/// debug ビルド (`cfg(debug_assertions)`) では catch_unwind を行わずに panic を
+/// 透過させる。CLAUDE.md の「契約違反は panic で顕在化」方針に従い、開発中の
+/// 不変条件違反は即時クラッシュさせて気付きやすくするため。
+async fn run_connection_isolated<R, K, P>(stream: TcpStream, state: Rc<SharedState<R, K, P>>)
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    #[cfg(debug_assertions)]
+    {
+        if let Err(e) = handle_connection(stream, state).await {
+            tracing::info!(error = ?e, "connection ended");
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        use futures::FutureExt;
+        let fut = std::panic::AssertUnwindSafe(handle_connection(stream, state));
+        match fut.catch_unwind().await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::info!(error = ?e, "connection ended");
+            }
+            Err(payload) => {
+                tracing::error!(
+                    panic_payload = %panic_payload_to_string(payload.as_ref()),
+                    "connection task panicked; isolated to this connection"
+                );
+            }
+        }
+    }
+}
+
 /// 受理ループ。各接続を `spawn_local` で同スレッド内の独立タスクにする。
 async fn accept_loop<R, K, P>(listener: TcpListener, state: Rc<SharedState<R, K, P>>)
 where
@@ -490,12 +550,7 @@ where
                         span.in_scope(|| tracing::debug!("accepted"));
                         let st = state.clone();
                         tokio::task::spawn_local(
-                            async move {
-                                if let Err(e) = handle_connection(stream, st).await {
-                                    tracing::info!(error = ?e, "connection ended");
-                                }
-                            }
-                            .instrument(span),
+                            run_connection_isolated(stream, st).instrument(span),
                         );
                     }
                     Err(e) => {
@@ -2073,6 +2128,39 @@ mod tests {
         assert_eq!(parse_move_broadcast("-3334FU,T10"), Some(("-3334FU", 10)));
         assert_eq!(parse_move_broadcast("#RESIGN"), None);
         assert_eq!(parse_move_broadcast("+7776FU,Tx"), None);
+    }
+
+    /// `panic_payload_to_string` は release ビルドでのみ参照されるため、
+    /// テストも同じ cfg で囲む（debug ビルドでは関数自体が存在しない）。
+    /// `panic!("...")` で渡される `&'static str` / `String` 双方を抽出でき、
+    /// それ以外の型は固定文字列にフォールバックする契約を固定する。
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn panic_payload_to_string_extracts_str_and_string() {
+        let s_payload: Box<dyn std::any::Any + Send> = Box::new("static-msg");
+        assert_eq!(panic_payload_to_string(s_payload.as_ref()), "static-msg");
+
+        let owned_payload: Box<dyn std::any::Any + Send> = Box::new(String::from("owned-msg"));
+        assert_eq!(panic_payload_to_string(owned_payload.as_ref()), "owned-msg");
+
+        let other_payload: Box<dyn std::any::Any + Send> = Box::new(42_i32);
+        assert_eq!(panic_payload_to_string(other_payload.as_ref()), "<non-string panic payload>");
+    }
+
+    /// release ビルドでは `run_connection_isolated` 経路の `catch_unwind` が
+    /// `panic!` を tracing event に変換してタスクを正常終了させる。本テストは
+    /// `handle_connection` を叩かずに同経路の async catch_unwind を直接呼び、
+    /// debug build と release build の挙動契約が分岐していることを確認する。
+    #[cfg(not(debug_assertions))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_catch_unwind_isolates_panic_in_release_build() {
+        use futures::FutureExt;
+        let f = std::panic::AssertUnwindSafe(async {
+            panic!("intentional test panic");
+        });
+        let outcome = f.catch_unwind().await;
+        let payload = outcome.expect_err("AssertUnwindSafe future must surface panic");
+        assert_eq!(panic_payload_to_string(payload.as_ref()), "intentional test panic");
     }
 
     /// 既定構成は Floodgate 系機能を要求していないため、`allow_floodgate_features=false`

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -494,7 +494,17 @@ where
     }
     #[cfg(not(debug_assertions))]
     {
-        use futures::FutureExt;
+        use futures_util::FutureExt;
+        // `AssertUnwindSafe` の根拠:
+        // - `SharedState` の可変フィールドは `Mutex` / `AtomicUsize` / `Notify` で
+        //   構成され、tokio の `Mutex` は poison を持たないため unwind 中に
+        //   guard が Drop されればロックは解放され、他 task から再ロック可能。
+        // - 進行中対局のカウンタ (`active_drive_tasks`) と `active_games` notify は
+        //   `drive_game` 内の `DriveGuard` の Drop で巻き戻されるので、
+        //   panic 経路でも一貫した状態に戻る（graceful shutdown の完了判定が
+        //   このカウンタに依存しているため特に重要）。
+        // - 部分更新が残り得るのは当該接続専有のローカル状態のみで、当該接続は
+        //   この panic で切断されるため他 task からは観測されない。
         let fut = std::panic::AssertUnwindSafe(handle_connection(stream, state));
         match fut.catch_unwind().await {
             Ok(Ok(())) => {}
@@ -2151,10 +2161,16 @@ mod tests {
     /// `panic!` を tracing event に変換してタスクを正常終了させる。本テストは
     /// `handle_connection` を叩かずに同経路の async catch_unwind を直接呼び、
     /// debug build と release build の挙動契約が分岐していることを確認する。
+    ///
+    /// 注: テスト名に "isolates" を含むが、これは `run_connection_isolated`
+    /// そのものの connection レベル隔離ではなく、同関数が依拠する
+    /// `AssertUnwindSafe + catch_unwind` 機構の契約を固定するもの。
+    /// `handle_connection` を伴う実機 panic 注入は後続の TCP 負荷試験
+    /// ハーネスで扱う（持ち越し）。
     #[cfg(not(debug_assertions))]
     #[tokio::test(flavor = "current_thread")]
     async fn async_catch_unwind_isolates_panic_in_release_build() {
-        use futures::FutureExt;
+        use futures_util::FutureExt;
         let f = std::panic::AssertUnwindSafe(async {
             panic!("intentional test panic");
         });


### PR DESCRIPTION
> [!NOTE]
> Stacked on #488 (`feat/csa-server-tcp-structured-logging`)。マージ順は #488 → 本 PR。#488 マージ時に GitHub が自動で base を `main` に retarget します。

## Summary

CSA TCP frontend の accept ループで spawn される 1 接続分の task 本体を `run_connection_isolated` で包み、release ビルドでは `futures::FutureExt::catch_unwind` で panic を boundary に閉じ込める。捕捉した panic は既存 conn span (`conn_id` / `remote` / `game_id`) 付きで `tracing::error!` に記録され、当該接続のみが正常終了する。accept ループと他の進行中対局には影響しない。

debug ビルドでは catch_unwind を行わずに panic を透過させる（CLAUDE.md の「契約違反は panic で顕在化」方針維持）。

## 動機

設計仕様: 「対局タスクを境界で包み、回復不能エラー時は当該対局のみを異常終了させて他対局・受付ループを停止させない。デバッグビルドでは不変条件違反を即時検出、リリースビルドでは error ログと隔離で続行する」

`tokio::task::spawn_local` 自体は task panic を runtime には伝播させないが、panic は tokio の default panic handler でしか観測できず、PR #488 で導入した接続/対局相関 ID も乗らない。本 PR で boundary に明示の `catch_unwind` を入れることで:

- panic は当該接続のスパン情報（`conn_id` / `game_id`）と一緒に `tracing::error!` で記録される
- 隔離を「実装が明示している」ことが docs/test で固定される（観察できる契約）
- 将来 panic 注入による負荷試験を入れる時に「ここで止まる」ことを保証する基準点ができる

`drive_game` 内の RAII ガード (`DriveGuard`) は unwind 中も Drop が走り、`active_drive_tasks` カウンタの巻き戻しと `active_games` notify が漏れない。これは graceful shutdown が active count を信頼してプロセス終了する設計の前提。

## 変更点

### `server.rs`

- `run_connection_isolated` を新設。`accept_loop` から `spawn_local` 経由で起動される task 本体をこの関数で wrap
- release ビルド: `AssertUnwindSafe(handle_connection(...)).catch_unwind().await` で panic を捕捉し、`tracing::error!(panic_payload, ...)` で記録 → タスクは `Ok(())` で終わる
- debug ビルド: catch_unwind を行わず、`handle_connection(...).await` をそのまま呼ぶ（panic 透過）
- `panic_payload_to_string` ヘルパ: `Box<dyn Any>` から `&'static str` / `String` の payload を抽出し、それ以外は固定文字列にフォールバック。release ビルドでのみ使われるため `#[cfg(not(debug_assertions))]` でガード

### `Cargo.toml` (TCP crate)

- `futures = { version = "0.3", default-features = false, features = [\"std\"] }` を追加。async 対応の `FutureExt::catch_unwind` のみが目的。executor / sink などは tokio で賄うため `std` feature だけで足りる

## テスト

`#[cfg(not(debug_assertions))]` で release-only 2 件:

- `panic_payload_to_string_extracts_str_and_string`: `&'static str` / `String` / `i32` の各 payload 型に対する抽出契約を固定
- `async_catch_unwind_isolates_panic_in_release_build`: `AssertUnwindSafe(async { panic!(\"intentional test panic\") }).catch_unwind().await` が panic を Err として surface し、`panic_payload_to_string` で文字列を取り出せる契約を固定

実機 panic を伴う connection-level の E2E は SharedState 構築コストが重く、現状の async catch_unwind 単体テストで契約は固定済み。実機 panic 注入は TCP 負荷試験ハーネス（後続）で扱う方が合理的（持ち越し）。

## 既定挙動の変化

- release ビルド: connection task が panic した場合、tokio default の panic 処理ではなく `tracing::error!` 経由で記録され、当該接続のみが正常終了する
- debug ビルド: 何も変わらない（panic は従来通り透過）
- ログ filter は変えていない（`RUST_LOG`/EnvFilter そのまま）

## Test plan

- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo clippy -p rshogi-csa-server-tcp --all-targets -- -D warnings` 警告ゼロ（debug build）
- [x] `cargo clippy -p rshogi-csa-server-tcp --release --all-targets -- -D warnings` 警告ゼロ（release build）
- [x] `cargo test -p rshogi-csa-server-tcp --release` 全 pass（unit 36 / integration 30）

🤖 Generated with [Claude Code](https://claude.com/claude-code)