### PR TITLE
feat(csa-server): Ruby shogi-server 互換 players.yaml レート永続化を実装 (task 15.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "rshogi-csa",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "toml",
@@ -2092,6 +2093,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2611,6 +2625,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -226,12 +226,12 @@ fn main() -> anyhow::Result<()> {
     let players_yaml = cli.players_yaml;
     local.block_on(&rt, async move {
         // 4. レートストレージを `--players-yaml` の有無で切り替える。
-        //    YAML 経路: 起動時に既存ファイルを読み、TOML 由来の handle で未登録分を
-        //              既定値（rate=1500 / wins=0 / losses=0）で in-memory 補填。
-        //              書き戻しは `record_game_outcome` 経由で atomic に行う。
+        //    YAML 経路: 起動時に既存ファイルを読み、YAML 未登録の handle を
+        //              TOML 由来の `PlayerRateRecord`（rate / wins / losses）で
+        //              in-memory 補填する。書き戻しは `record_game_outcome` 経由
+        //              で atomic に行う。
         //    None 経路: TOML から再構築するインメモリ保存。再起動で wins/losses が
         //              失われるが、開発・テスト用途には十分。
-        let now_iso = chrono::Utc::now().to_rfc3339();
         if let Some(yaml_path) = players_yaml {
             // load_from_file が PathBuf を消費するので、エラーメッセージ用には
             // path 文字列を先に確保する（追加 PathBuf clone を避ける）。
@@ -239,9 +239,11 @@ fn main() -> anyhow::Result<()> {
             let storage = PlayersYamlRateStorage::load_from_file(yaml_path)
                 .await
                 .with_context(|| format!("failed to load players.yaml at {path_for_err}"))?;
-            // TOML 由来の handle でまだ YAML 上に存在しないものを既定値で補填する。
-            // PlayerRateRecord に rate=1500 を入れるのは Floodgate 既定の初期値。
-            storage.ensure_default_records(rate_map.into_keys(), 1500, &now_iso);
+            // TOML 由来の handle でまだ YAML 上に存在しないものを TOML 値そのままで
+            // 補填する。YAML 既存レコード側は ensure_default_records が保護する。
+            // `into_values()` で `PlayerRateRecord` 全体を渡すことで、TOML の
+            // rate / wins / losses が初期値補填経路でデータ破壊なく反映される。
+            storage.ensure_default_records(rate_map.into_values());
             run_with_state(config, storage, kifu_storage, password_store).await
         } else {
             let storage = InMemoryRateStorage::new(rate_map);

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -201,6 +201,9 @@ fn main() -> anyhow::Result<()> {
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
         allow_floodgate_features: cli.allow_floodgate_features,
+        // `cli.players_yaml` を一旦クローンして config に乗せる。下の `async move`
+        // ブロックが分岐ごとに `cli.players_yaml` の所有権を取れるよう、ここでは
+        // 1 回だけ clone する（残りはそのまま move される）。
         players_yaml_path: cli.players_yaml.clone(),
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
@@ -219,6 +222,8 @@ fn main() -> anyhow::Result<()> {
     //    `current_thread` ランタイム + `LocalSet` 経路で配線する（設計方針）。
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
     let local = tokio::task::LocalSet::new();
+    // `cli.players_yaml` の所有権を async 内に move する（追加 clone を避ける）。
+    let players_yaml = cli.players_yaml;
     local.block_on(&rt, async move {
         // 4. レートストレージを `--players-yaml` の有無で切り替える。
         //    YAML 経路: 起動時に既存ファイルを読み、TOML 由来の handle で未登録分を
@@ -227,11 +232,13 @@ fn main() -> anyhow::Result<()> {
         //    None 経路: TOML から再構築するインメモリ保存。再起動で wins/losses が
         //              失われるが、開発・テスト用途には十分。
         let now_iso = chrono::Utc::now().to_rfc3339();
-        if let Some(yaml_path) = cli.players_yaml.clone() {
-            let storage =
-                PlayersYamlRateStorage::load_from_file(yaml_path.clone()).await.with_context(
-                    || format!("failed to load players.yaml at {}", yaml_path.display()),
-                )?;
+        if let Some(yaml_path) = players_yaml {
+            // load_from_file が PathBuf を消費するので、エラーメッセージ用には
+            // path 文字列を先に確保する（追加 PathBuf clone を避ける）。
+            let path_for_err = yaml_path.display().to_string();
+            let storage = PlayersYamlRateStorage::load_from_file(yaml_path)
+                .await
+                .with_context(|| format!("failed to load players.yaml at {path_for_err}"))?;
             // TOML 由来の handle でまだ YAML 上に存在しないものを既定値で補填する。
             // PlayerRateRecord に rate=1500 を入れるのは Floodgate 既定の初期値。
             storage.ensure_default_records(rate_map.into_keys(), 1500, &now_iso);

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -18,14 +18,15 @@ use std::rc::Rc;
 use anyhow::Context;
 use clap::Parser;
 use rshogi_csa_server::error::StorageError;
-use rshogi_csa_server::port::{PlayerRateRecord, RateStorage};
+use rshogi_csa_server::port::{KifuStorage, PlayerRateRecord, RateStorage};
 use rshogi_csa_server::types::PlayerName;
-use rshogi_csa_server::{ClockSpec, FileKifuStorage};
+use rshogi_csa_server::{ClockSpec, FileKifuStorage, PlayersYamlRateStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
 use rshogi_csa_server_tcp::server::{
-    InMemoryPasswordStore, ServerConfig, build_state, prepare_runtime, run_server,
+    InMemoryPasswordStore, PasswordStore, ServerConfig, SharedState, build_state, prepare_runtime,
+    run_server,
 };
 use tokio::sync::Mutex;
 
@@ -44,9 +45,18 @@ struct Cli {
     /// 棋譜と 00LIST を保存するルートディレクトリ。
     #[arg(long, default_value = "./kifu")]
     kifu_dir: PathBuf,
-    /// プレイヤ定義ファイル（TOML 形式、keys = handle）。
+    /// プレイヤ定義ファイル（TOML 形式、keys = handle）。`password` フィールドを
+    /// 読むのは常に本ファイル。`--players-yaml` を併用するとレート関連フィールド
+    /// (`rate` / `wins` / `losses`) は YAML 側で永続管理される（TOML 側の
+    /// `rate` / `wins` / `losses` は YAML 未登録プレイヤの初期値補填にのみ使う）。
     #[arg(long)]
     players: PathBuf,
+    /// Ruby shogi-server 互換の `players.yaml` パス。指定すると終局時に
+    /// 勝敗・最終対局 ID・最終更新時刻が atomic write で書き戻される。
+    /// 未指定時はインメモリ保存（再起動で wins/losses が失われる開発用）。
+    /// `--allow-floodgate-features` の opt-in が立っていない場合は起動が失敗する。
+    #[arg(long, value_name = "PATH")]
+    players_yaml: Option<PathBuf>,
     /// 秒読み方式 / Fischer 方式で使う持ち時間 (秒)。
     #[arg(long, default_value_t = 600)]
     total_time_sec: u32,
@@ -171,7 +181,6 @@ fn main() -> anyhow::Result<()> {
     let (password_map, rate_map) = load_players_toml(&cli.players)
         .with_context(|| format!("failed to load players file {:?}", cli.players))?;
     let password_store = InMemoryPasswordStore { map: password_map };
-    let rate_storage = InMemoryRateStorage::new(rate_map);
 
     // 2. ServerConfig を構築。
     let config = ServerConfig {
@@ -192,10 +201,12 @@ fn main() -> anyhow::Result<()> {
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
         allow_floodgate_features: cli.allow_floodgate_features,
+        players_yaml_path: cli.players_yaml.clone(),
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
-    // Floodgate 系機能の opt-in ゲートを起動前に評価する。要求があるのに
-    // フラグが立っていない場合はここで起動を止める。
+    // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が
+    // `Some` の状態は `enable_persistent_player_rates` 要求として intent に乗るため、
+    // `--allow-floodgate-features` が立っていなければここで fail-fast する。
     prepare_runtime(&config).map_err(|msg| {
         anyhow::anyhow!(
             "{msg}; pass {ALLOW_FLOODGATE_FEATURES_FLAG} to enable Floodgate runtime features",
@@ -203,7 +214,51 @@ fn main() -> anyhow::Result<()> {
     })?;
 
     let kifu_storage = FileKifuStorage::new(config.kifu_topdir.clone());
-    let state = Rc::new(build_state(
+
+    // 3. port trait の `async fn in trait` は `Send` 境界を持たないため、TCP バイナリは
+    //    `current_thread` ランタイム + `LocalSet` 経路で配線する（設計方針）。
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+    let local = tokio::task::LocalSet::new();
+    local.block_on(&rt, async move {
+        // 4. レートストレージを `--players-yaml` の有無で切り替える。
+        //    YAML 経路: 起動時に既存ファイルを読み、TOML 由来の handle で未登録分を
+        //              既定値（rate=1500 / wins=0 / losses=0）で in-memory 補填。
+        //              書き戻しは `record_game_outcome` 経由で atomic に行う。
+        //    None 経路: TOML から再構築するインメモリ保存。再起動で wins/losses が
+        //              失われるが、開発・テスト用途には十分。
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        if let Some(yaml_path) = cli.players_yaml.clone() {
+            let storage =
+                PlayersYamlRateStorage::load_from_file(yaml_path.clone()).await.with_context(
+                    || format!("failed to load players.yaml at {}", yaml_path.display()),
+                )?;
+            // TOML 由来の handle でまだ YAML 上に存在しないものを既定値で補填する。
+            // PlayerRateRecord に rate=1500 を入れるのは Floodgate 既定の初期値。
+            storage.ensure_default_records(rate_map.into_keys(), 1500, &now_iso);
+            run_with_state(config, storage, kifu_storage, password_store).await
+        } else {
+            let storage = InMemoryRateStorage::new(rate_map);
+            run_with_state(config, storage, kifu_storage, password_store).await
+        }
+    })?;
+    Ok(())
+}
+
+/// 構築済みの依存（rate / kifu / password）から `SharedState` を組み立てて
+/// accept ループを起動し、SIGINT / SIGTERM 受信後の graceful shutdown を完遂する
+/// 共通経路。`R` を YAML / インメモリで切り替えるための monomorphize 用ヘルパ。
+async fn run_with_state<R, K, P>(
+    config: ServerConfig,
+    rate_storage: R,
+    kifu_storage: K,
+    password_store: P,
+) -> anyhow::Result<()>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let state: Rc<SharedState<R, K, P>> = Rc::new(build_state(
         config,
         rate_storage,
         kifu_storage,
@@ -213,79 +268,66 @@ fn main() -> anyhow::Result<()> {
         InMemoryBroadcaster::new(),
     ));
 
-    // 3. port trait の `async fn in trait` は `Send` 境界を持たないため、TCP バイナリは
-    //    `current_thread` ランタイム + `LocalSet` 経路で配線する（設計方針）。
-    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
-    let local = tokio::task::LocalSet::new();
-    local.block_on(&rt, async move {
-        let handle = run_server(state.clone()).await.context("run_server")?;
-        tracing::info!("rshogi-csa-server-tcp ready");
+    let handle = run_server(state.clone()).await.context("run_server")?;
+    tracing::info!("rshogi-csa-server-tcp ready");
 
-        // SIGINT と SIGTERM を並列待機する。SIGINT は Ctrl-C、SIGTERM は
-        // systemd / Docker / Kubernetes の停止シグナル。
-        let sig = wait_for_termination_signal().await;
-        tracing::info!(signal = sig, "initiating graceful shutdown");
+    // SIGINT と SIGTERM を並列待機する。SIGINT は Ctrl-C、SIGTERM は
+    // systemd / Docker / Kubernetes の停止シグナル。
+    let sig = wait_for_termination_signal().await;
+    tracing::info!(signal = sig, "initiating graceful shutdown");
 
-        // 1. 新規接続の受付停止 + 待機プール中のセッション切断を誘導する。
-        state.shutdown.trigger();
+    // 1. 新規接続の受付停止 + 待機プール中のセッション切断を誘導する。
+    state.shutdown.trigger();
 
-        // 2. accept ループの終了を待つ。shutdown が立っているので即座に抜ける。
-        //    panic した場合に listener 未解放のまま後段に進まないよう、panic は
-        //    error log に落として正常経路と同様に fall-through させる。
-        //    `{e:#}` は JoinError の Debug 出力（panic payload とロケーション）を
-        //    一行に展開するので、運用時の原因調査で使える。
-        match handle.await {
-            Ok(()) => {}
-            Err(e) if e.is_panic() => {
-                // `JoinError::Display` は "task X panicked" を返す。`{e:#}` の
-                // alternate flag は同種類で `{e}` と同等出力なので、`%e` に絞って
-                // 一時 String 確保を省く（panic payload を覗くなら別途
-                // `e.into_panic()` 経由が必要）。
-                tracing::error!(error = %e, "accept loop panicked during shutdown");
-            }
-            Err(e) => {
-                tracing::info!(error = %e, "accept loop joined with error");
-            }
+    // 2. accept ループの終了を待つ。shutdown が立っているので即座に抜ける。
+    //    panic した場合に listener 未解放のまま後段に進まないよう、panic は
+    //    error log に落として正常経路と同様に fall-through させる。
+    match handle.await {
+        Ok(()) => {}
+        Err(e) if e.is_panic() => {
+            tracing::error!(error = %e, "accept loop panicked during shutdown");
         }
+        Err(e) => {
+            tracing::info!(error = %e, "accept loop joined with error");
+        }
+    }
 
-        // 3. 進行中対局が終局するまで待つ。grace を超過したら warning を出して
-        //    プロセス終了へ進む（残りの対局タスクは LocalSet 終了で abort される）。
-        //    `shutdown_grace = 0` は「grace なし = 即切り」と解釈する。
-        //
-        //    TOCTOU 対策として `wait_active_games_notify` を先に登録してから
-        //    counter を確認する。これで登録と確認の間に `notify_waiters` が
-        //    発火しても取りこぼさない。
-        let grace = state.config().shutdown_grace;
-        let deadline = tokio::time::Instant::now() + grace;
-        loop {
-            let notified = state.wait_active_games_notify();
-            let active = state.active_game_count();
-            if active == 0 {
+    // 3. 進行中対局が終局するまで待つ。grace を超過したら warning を出して
+    //    プロセス終了へ進む（残りの対局タスクは LocalSet 終了で abort される）。
+    //    `shutdown_grace = 0` は「grace なし = 即切り」と解釈する。
+    //
+    //    TOCTOU 対策として `wait_active_games_notify` を先に登録してから
+    //    counter を確認する。これで登録と確認の間に `notify_waiters` が
+    //    発火しても取りこぼさない。
+    let grace = state.config().shutdown_grace;
+    let deadline = tokio::time::Instant::now() + grace;
+    loop {
+        let notified = state.wait_active_games_notify();
+        let active = state.active_game_count();
+        if active == 0 {
+            break;
+        }
+        tracing::info!(
+            active_games = active,
+            grace_sec = grace.as_secs(),
+            "waiting for active games to finish"
+        );
+        tokio::select! {
+            _ = notified => continue,
+            _ = tokio::time::sleep_until(deadline) => {
+                let remaining = state.active_game_count();
+                if remaining > 0 {
+                    tracing::warn!(
+                        unfinished_games = remaining,
+                        "shutdown grace expired"
+                    );
+                }
                 break;
             }
-            tracing::info!(
-                active_games = active,
-                grace_sec = grace.as_secs(),
-                "waiting for active games to finish"
-            );
-            tokio::select! {
-                _ = notified => continue,
-                _ = tokio::time::sleep_until(deadline) => {
-                    let remaining = state.active_game_count();
-                    if remaining > 0 {
-                        tracing::warn!(
-                            unfinished_games = remaining,
-                            "shutdown grace expired"
-                        );
-                    }
-                    break;
-                }
-            }
         }
+    }
 
-        tracing::info!("shutdown complete");
-        Ok::<(), anyhow::Error>(())
-    })?;
+    tracing::info!("shutdown complete");
     Ok(())
 }
 

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2182,15 +2182,15 @@ where
             "self-play detected at persist_kifu; League pairing layer violated black != white invariant",
         );
     }
+    // `record_game_outcome` は trait 既定実装を使う実装（[`InMemoryRateStorage`]
+    // 等）だと `now_iso: &str` を `.await` を跨いで保持する。`&end_time.to_rfc3339()`
+    // を直接渡すと一時 `String` への参照が future に閉じ込められ、ライフタイム
+    // 解析の都合でビルドが落ちうる。ローカル変数に束縛してから参照を渡し、
+    // 一時値の寿命を `.await` 完了後まで明示的に確保する。
+    let end_time_iso = end_time.to_rfc3339();
     if let Err(e) = state
         .rate_storage
-        .record_game_outcome(
-            &matched.black,
-            &matched.white,
-            winner_name,
-            game_id,
-            &end_time.to_rfc3339(),
-        )
+        .record_game_outcome(&matched.black, &matched.white, winner_name, game_id, &end_time_iso)
         .await
     {
         tracing::error!(

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2170,6 +2170,18 @@ where
         Color::White => &matched.white,
     });
     let winner_color = result.winner();
+    // 同名対局は League ペアリング層の不変条件違反。`record_game_outcome` 側で
+    // 早期 Ok return されて wins/losses は据置になるが、その状態は Err 経路では
+    // 無いため運用ログから黙って消える。ここで明示的に `tracing::error!` を出して
+    // 「League から self-play が混入した」事実を即追跡できるようにする。debug
+    // ビルドでは `record_game_outcome` 内の `debug_assert_ne!` が同時に発火する。
+    if matched.black == matched.white {
+        tracing::error!(
+            game_id = %game_id.as_str(),
+            player = %matched.black.as_str(),
+            "self-play detected at persist_kifu; League pairing layer violated black != white invariant",
+        );
+    }
     if let Err(e) = state
         .rate_storage
         .record_game_outcome(

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -137,6 +137,17 @@ pub struct ServerConfig {
     /// `ServerConfig` フィールドを増やしたうえで `floodgate_intent_from_config`
     /// が `true` を返すよう更新し、運用側に明示の opt-in を強制する。
     pub allow_floodgate_features: bool,
+    /// Ruby shogi-server 互換 `players.yaml` のパス。`Some` を指定すると
+    /// [`PlayersYamlRateStorage`](rshogi_csa_server::PlayersYamlRateStorage)
+    /// 経由でレートを永続化する経路が有効になり、終局時に勝敗・最終対局 ID・
+    /// 最終更新時刻が書き戻される。`None` の場合はインメモリレート保存で動作する
+    /// （再起動で wins/losses が失われる開発用既定）。
+    ///
+    /// 本フィールドが `Some` の状態は Floodgate 運用機能の一つ
+    /// (`enable_persistent_player_rates`) として
+    /// [`floodgate_intent_from_config`] により intent に変換され、
+    /// `--allow-floodgate-features` が立っていない場合は起動が `Err` で停止する。
+    pub players_yaml_path: Option<std::path::PathBuf>,
     /// SIGINT / SIGTERM 受信後に進行中対局の終了を待つ上限。超過分は未完了の
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
     /// を落とさない」ためのバッファで、既定 60 秒。
@@ -159,6 +170,7 @@ impl ServerConfig {
             initial_sfen: None,
             admin_handles: Vec::new(),
             allow_floodgate_features: false,
+            players_yaml_path: None,
             shutdown_grace: Duration::from_secs(60),
         }
     }
@@ -186,12 +198,12 @@ impl ServerConfig {
 /// 防ぐため。クレート外（`bin/main.rs` 含む）からは [`prepare_runtime`] のみが
 /// 入口になる。
 pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFeatureIntent {
-    // スタブ: 現状 `ServerConfig` に Floodgate 系フィールドが存在しないため、
-    // `config` を観測する必要がない。Floodgate 機能を実装する PR がフィールドを
-    // 追加した時点で本関数を更新するので、その更新漏れを `let _` の存在が
-    // リマインダになる（フィールド参照を追記する際に削除する）。
-    let _ = config;
-    FloodgateFeatureIntent::default()
+    FloodgateFeatureIntent {
+        // `players.yaml` 永続化はレート互換運用機能なので、Floodgate 系機能の
+        // opt-in が必要（`--allow-floodgate-features`）。
+        enable_persistent_player_rates: config.players_yaml_path.is_some(),
+        ..FloodgateFeatureIntent::default()
+    }
 }
 
 /// 起動前に opt-in ゲートを評価する。
@@ -2136,6 +2148,30 @@ where
         result_code: primary_result_code(result).to_owned(),
     };
     state.kifu_storage.append_summary(&entry).await.map_err(ServerError::Storage)?;
+
+    // 終局時のレート関連フィールドを更新する: 勝敗（wins / losses）、最終対局 ID、
+    // 最終更新時刻。`:rate` 値そのものは Ruby `mk_rate` 等の外部バッチが管理する
+    // 責務なので本サーバ側では触れない（`record_game_outcome` の契約）。
+    //
+    // `record_game_outcome` の中で原子性が保証されるかは実装依存だが、
+    // [`PlayersYamlRateStorage`] は disk_lock 配下で read-modify-write を直列化
+    // するため、複数対局が同一プレイヤを同時に書き換える経路でも lost-update が
+    // 起こらない（同一プロセス内に限る）。
+    let winner_name = result.winner().map(|c| match c {
+        Color::Black => &matched.black,
+        Color::White => &matched.white,
+    });
+    state
+        .rate_storage
+        .record_game_outcome(
+            &matched.black,
+            &matched.white,
+            winner_name,
+            game_id,
+            &end_time.to_rfc3339(),
+        )
+        .await
+        .map_err(ServerError::Storage)?;
     Ok(())
 }
 
@@ -2282,8 +2318,7 @@ mod tests {
 
     /// 将来 Floodgate 機能が `floodgate_intent_from_config` に配線された後、
     /// `allow_floodgate_features=false` のままで起動を試みると fail-fast する
-    /// 契約を直接検証する。helper 経路ではなく gate 関数を直接テストするのは、
-    /// 現状 `floodgate_intent_from_config` が常に `Default` を返すため。
+    /// 契約を直接検証する。
     #[test]
     fn floodgate_gate_rejects_intent_when_optin_is_off() {
         let intent = FloodgateFeatureIntent {
@@ -2292,5 +2327,42 @@ mod tests {
         };
         let err = validate_floodgate_feature_gate(false, intent).unwrap_err();
         assert!(err.contains("scheduler"), "error must list requested feature: {err}");
+    }
+
+    /// `players_yaml_path` を設定した状態で `--allow-floodgate-features` が
+    /// 立っていない場合、`prepare_runtime` が起動を fail-fast させる契約を固定。
+    /// レート永続化は Floodgate 互換運用機能なので opt-in が必要。
+    #[test]
+    fn prepare_runtime_rejects_players_yaml_when_floodgate_optin_off() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        cfg.players_yaml_path = Some(std::path::PathBuf::from("/tmp/players.yaml"));
+        cfg.allow_floodgate_features = false;
+        let err = prepare_runtime(&cfg)
+            .expect_err("must fail when persistent rates requested without opt-in");
+        assert!(
+            err.contains("persistent_player_rates"),
+            "error must list the requested feature: {err}",
+        );
+    }
+
+    /// `players_yaml_path` + `--allow-floodgate-features` の組み合わせで通過する
+    /// 契約を固定。レート永続化を本番で有効化する標準起動経路。
+    #[test]
+    fn prepare_runtime_accepts_players_yaml_with_floodgate_optin() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        cfg.players_yaml_path = Some(std::path::PathBuf::from("/tmp/players.yaml"));
+        cfg.allow_floodgate_features = true;
+        prepare_runtime(&cfg).expect("opt-in must allow persistent rate storage");
+    }
+
+    /// `floodgate_intent_from_config` が `players_yaml_path` の有無で
+    /// `enable_persistent_player_rates` を切り替えることを直接固定する。
+    /// 将来 ServerConfig フィールドを増やす際の回帰検出用。
+    #[test]
+    fn floodgate_intent_reflects_players_yaml_path() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        assert!(!floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
+        cfg.players_yaml_path = Some(std::path::PathBuf::from("/tmp/players.yaml"));
+        assert!(floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2157,11 +2157,20 @@ where
     // [`PlayersYamlRateStorage`] は disk_lock 配下で read-modify-write を直列化
     // するため、複数対局が同一プレイヤを同時に書き換える経路でも lost-update が
     // 起こらない（同一プロセス内に限る）。
+    //
+    // 失敗時の運用方針: 棋譜・00LIST は既に永続化済みなので、レート更新だけが
+    // 失敗した状態でこの関数が `Err` を返すと、`drive_game` 上位は終局メッセージを
+    // 既に送信済みのまま I/O 失敗を上に伝える。運用ログから「どの対局のレート
+    // 更新が失敗したか」を即特定できるよう、`tracing::error!` で `game_id` /
+    // `black` / `white` / `winner_color` を構造化フィールドとして残してから
+    // 上に Err を返す（mk_rate バッチは 00LIST から再計算可能なので、最終的な
+    // 整合性回復は運用側で取れる）。
     let winner_name = result.winner().map(|c| match c {
         Color::Black => &matched.black,
         Color::White => &matched.white,
     });
-    state
+    let winner_color = result.winner();
+    if let Err(e) = state
         .rate_storage
         .record_game_outcome(
             &matched.black,
@@ -2171,7 +2180,17 @@ where
             &end_time.to_rfc3339(),
         )
         .await
-        .map_err(ServerError::Storage)?;
+    {
+        tracing::error!(
+            game_id = %game_id.as_str(),
+            black = %matched.black.as_str(),
+            white = %matched.white.as_str(),
+            winner = ?winner_color,
+            error = %e,
+            "rate storage update failed; kifu is persisted but wins/losses were not advanced"
+        );
+        return Err(ServerError::Storage(e));
+    }
     Ok(())
 }
 

--- a/crates/rshogi-csa-server/Cargo.toml
+++ b/crates/rshogi-csa-server/Cargo.toml
@@ -15,6 +15,11 @@ thiserror.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Ruby shogi-server 互換 `players.yaml` の読み書きで使用する。実装本体は
+# `tokio-transport` 配下の `storage::players_yaml` のみが触れるため、wasm32
+# (workers) ビルドに不要な依存が入らないよう optional + `tokio-transport` 連動で
+# 引き込む。
+serde_yaml = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 
 [features]
@@ -22,7 +27,7 @@ tokio = { workspace = true, optional = true }
 # `--no-default-features --features workers` を渡して tokio 依存を外す。
 default = ["tokio-transport"]
 # tokio 非同期ランタイムを使う `GameRoom::run` 等を有効化する。
-tokio-transport = ["dep:tokio"]
+tokio-transport = ["dep:tokio", "dep:serde_yaml"]
 # Cloudflare Workers 等のシングルスレッド wasm ランタイム向けフラグ（現状は副作用なし）。
 workers = []
 

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -16,6 +16,10 @@ pub struct FloodgateFeatureIntent {
     pub enable_scheduler: bool,
     pub use_non_direct_pairing: bool,
     pub enable_duplicate_login_policy: bool,
+    /// Ruby shogi-server 互換 `players.yaml` 形式でレートを永続化する経路を
+    /// 有効化する意図。`PlayersYamlRateStorage` を起動時に読み込み、終局時に
+    /// 書き戻す経路を本フラグで gate する。
+    pub enable_persistent_player_rates: bool,
 }
 
 /// 真偽文字列から Floodgate 機能 gate を解決する。
@@ -64,6 +68,9 @@ pub fn validate_floodgate_feature_gate(
     }
     if intent.enable_duplicate_login_policy {
         requested.push("duplicate_login_policy");
+    }
+    if intent.enable_persistent_player_rates {
+        requested.push("persistent_player_rates");
     }
     if requested.is_empty() || allow_floodgate_features {
         return Ok(());
@@ -144,11 +151,26 @@ mod tests {
                 enable_scheduler: true,
                 use_non_direct_pairing: true,
                 enable_duplicate_login_policy: true,
+                enable_persistent_player_rates: true,
             },
         )
         .unwrap_err();
         assert!(err.contains("scheduler"));
         assert!(err.contains("non_direct_pairing"));
         assert!(err.contains("duplicate_login_policy"));
+        assert!(err.contains("persistent_player_rates"));
+    }
+
+    #[test]
+    fn floodgate_gate_rejects_persistent_player_rates_when_disabled() {
+        let err = validate_floodgate_feature_gate(
+            false,
+            FloodgateFeatureIntent {
+                enable_persistent_player_rates: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("persistent_player_rates"));
     }
 }

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -46,6 +46,8 @@ pub use record::kifu::{
 pub use storage::buoy::FileBuoyStorage;
 #[cfg(feature = "tokio-transport")]
 pub use storage::file::FileKifuStorage;
+#[cfg(feature = "tokio-transport")]
+pub use storage::players_yaml::PlayersYamlRateStorage;
 pub use types::{
     AdminId, Color, CsaLine, CsaMoveToken, GameId, GameName, IpKey, PlayerName, ReconnectToken,
     RoomId, Secret, StorageKey,

--- a/crates/rshogi-csa-server/src/port.rs
+++ b/crates/rshogi-csa-server/src/port.rs
@@ -141,6 +141,46 @@ pub trait RateStorage {
     fn list_all(
         &self,
     ) -> impl std::future::Future<Output = Result<Vec<PlayerRateRecord>, StorageError>>;
+
+    /// 終局時のレート関連フィールドを更新する（atomic な read-modify-write）。
+    ///
+    /// レート値そのもの（`rate`）は外部バッチ（Ruby `mk_rate` 等）が更新する責務
+    /// なので本関数では触れず、勝敗 / `last_game_id` / `last_modified` のみを
+    /// 更新する。`winner` が `Some(name)` なら該当者の `wins` を +1、それ以外の
+    /// 既知プレイヤの `losses` を +1 する。`winner` が `None`（千日手・最大手数・
+    /// 切断で勝者不確定 `Abnormal { winner: None }`）なら `wins`/`losses` は据置で
+    /// `last_*` のみ更新する。
+    ///
+    /// 既定実装は `load` → 変更 → `save` を逐次実行するため、複数対局が同時に
+    /// 同一プレイヤのレコードを書き換えると最後の `save` で勝敗増分が失われる
+    /// レースを抱える。アトミック性が必要な実装（[`crate::FileKifuStorage`] 系の
+    /// ファイルベース）は本関数を override して内部 lock 配下で読み書きする。
+    fn record_game_outcome(
+        &self,
+        black: &PlayerName,
+        white: &PlayerName,
+        winner: Option<&PlayerName>,
+        game_id: &GameId,
+        now_iso: &str,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        async move {
+            for name in [black, white] {
+                let mut rec = match self.load(name).await? {
+                    Some(r) => r,
+                    None => continue,
+                };
+                match winner {
+                    Some(w) if w == name => rec.wins = rec.wins.saturating_add(1),
+                    Some(_) => rec.losses = rec.losses.saturating_add(1),
+                    None => {}
+                }
+                rec.last_game_id = Some(game_id.clone());
+                rec.last_modified = now_iso.to_owned();
+                self.save(&rec).await?;
+            }
+            Ok(())
+        }
+    }
 }
 
 /// ブイ（途中局面テンプレート）の永続化抽象。

--- a/crates/rshogi-csa-server/src/port.rs
+++ b/crates/rshogi-csa-server/src/port.rs
@@ -151,10 +151,16 @@ pub trait RateStorage {
     /// 切断で勝者不確定 `Abnormal { winner: None }`）なら `wins`/`losses` は据置で
     /// `last_*` のみ更新する。
     ///
-    /// 既定実装は `load` → 変更 → `save` を逐次実行するため、複数対局が同時に
-    /// 同一プレイヤのレコードを書き換えると最後の `save` で勝敗増分が失われる
-    /// レースを抱える。アトミック性が必要な実装（[`crate::FileKifuStorage`] 系の
-    /// ファイルベース）は本関数を override して内部 lock 配下で読み書きする。
+    /// **契約**: `black != white` を呼び出し側が保証する（CSA 対局は同一プレイヤ
+    /// が先後に登場しないため League 層で守られる前提）。同名を渡した場合は早期
+    /// return し、`wins`/`losses` の二重加算を防ぐ。debug ビルドでは `debug_assert_ne!`
+    /// で契約違反を顕在化させる。
+    ///
+    /// **既定実装の race**: `load` → 変更 → `save` を逐次実行するため、複数対局が
+    /// 同時に同一プレイヤのレコードを書き換えると最後の `save` で勝敗増分が失われる
+    /// lost-update を抱える。本既定実装は単一プロセス内の小規模運用（テスト・
+    /// インメモリ Mock）向けで、本番フロントエンド（[`crate::PlayersYamlRateStorage`]
+    /// 等）はこのメソッドを override して内部 lock 配下で読み書きを直列化する。
     fn record_game_outcome(
         &self,
         black: &PlayerName,
@@ -163,7 +169,16 @@ pub trait RateStorage {
         game_id: &GameId,
         now_iso: &str,
     ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        debug_assert_ne!(
+            black, white,
+            "record_game_outcome: black and white must be distinct players",
+        );
         async move {
+            // self-play 防護: 同名を渡した場合は無視する。リリースビルドでも
+            // 二重加算を絶対に発生させない。
+            if black == white {
+                return Ok(());
+            }
             for name in [black, white] {
                 let mut rec = match self.load(name).await? {
                     Some(r) => r,

--- a/crates/rshogi-csa-server/src/storage/mod.rs
+++ b/crates/rshogi-csa-server/src/storage/mod.rs
@@ -4,3 +4,5 @@
 pub mod buoy;
 #[cfg(feature = "tokio-transport")]
 pub mod file;
+#[cfg(feature = "tokio-transport")]
+pub mod players_yaml;

--- a/crates/rshogi-csa-server/src/storage/players_yaml.rs
+++ b/crates/rshogi-csa-server/src/storage/players_yaml.rs
@@ -299,13 +299,19 @@ fn render_document(records: &HashMap<String, PlayerRateRecord>) -> Result<String
 
 async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageError> {
     // `rename(2)` は同一ファイルシステム上で atomic なので tmpfile は隣接ディレクトリ
-    // に作る。tmpfile 名は `pid.nanos.counter` を埋めて完全一意化することで:
+    // に作る。tmpfile 名衝突防止の構造:
     //
-    //   - 複数プロセスが同 dir に並行で書いた場合でも `O_CREAT|O_EXCL` のレース
-    //     にならない（`create_new(true)`）
-    //   - 攻撃者・他テナントが固定名 (`.players.yaml.tmp` 等) で先回りして
-    //     symlink を張り、`O_CREAT` の symlink follow で別ファイルを破壊書きする
-    //     攻撃面を狭める。さらに `create_new(true)` は既存 symlink を弾く。
+    //   - **異プロセス間**: `pid` で一意化する（PID が同時刻に再利用されるケースは
+    //     OS が pid 再利用を防ぐため実質ゼロ）。
+    //   - **同プロセス内**: `static AtomicU64` の `seq` が strict monotonic に増え、
+    //     同 pid 内では絶対衝突しない。
+    //   - `nanos` (subsec) は grep / 障害解析用の時刻ヒントで、衝突防止の根拠では
+    //     ない。`pid + seq` で衝突しないので不要にも見えるが、tmp 残骸が事後解析で
+    //     見つかった際に「いつ生成されたか」が分かるよう残す。
+    //
+    // 加えて `create_new(true)` を使うので、運悪く衝突した場合は `AlreadyExists` Err で
+    // 検出可能。攻撃者・他テナントが先回りして同名 symlink を張った場合も `create_new`
+    // が follow せず `EEXIST` で落ちる。
     //
     // dotfile 接頭辞は ls で隠して "中間ファイル" を示す慣習。
     let dir = path
@@ -347,12 +353,19 @@ async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageErr
         renamed: false,
     };
 
-    // `create_new(true)` は内部で `O_CREAT|O_EXCL` 相当を使い、既存ファイル / symlink
-    // 当たりで `AlreadyExists` Err を返す。tmpfile 名がプロセス間で一意なので通常
-    // は当たらないが、悪意ある先回り symlink を確実に弾く。
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
+    // unix では既存 `players.yaml` の mode を継承して tmp を開く（`chmod 0600` 運用で
+    // 人手で締めた permission が rename で 0644 に緩む事故を防ぐ）。Windows / その他
+    // 非 unix では mode 概念がないので素直に `create_new` のみで開く。
+    let mut open_options = fs::OpenOptions::new();
+    open_options.write(true).create_new(true);
+    // unix では `tokio::fs::OpenOptions::mode` が直接生えており trait import 不要。
+    // `Permissions::mode` 側のみ `std::os::unix::fs::PermissionsExt` を要する。
+    #[cfg(unix)]
+    if let Ok(meta) = std::fs::metadata(path) {
+        use std::os::unix::fs::PermissionsExt as _;
+        open_options.mode(meta.permissions().mode() & 0o7777);
+    }
+    let mut file = open_options
         .open(&tmp)
         .await
         .map_err(|e| StorageError::Io(format!("create {}: {}", tmp.display(), e)))?;
@@ -369,19 +382,32 @@ async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageErr
     cleanup.renamed = true;
     drop(cleanup);
 
-    // `rename(2)` のディレクトリエントリ更新は親 inode の fsync を行うまで永続化が
-    // 保証されない（ext4 / xfs の crash recovery で rename 結果が古い状態に戻る
-    // ケースが知られている）。`tokio::fs::File::open(dir).sync_all()` で親ディレクトリ
-    // を fsync してクラッシュ耐性を確保する。
-    let dir_handle = fs::OpenOptions::new()
-        .read(true)
-        .open(dir)
-        .await
-        .map_err(|e| StorageError::Io(format!("open dir {}: {}", dir.display(), e)))?;
-    dir_handle
-        .sync_all()
-        .await
-        .map_err(|e| StorageError::Io(format!("fsync dir {}: {}", dir.display(), e)))?;
+    // unix では `rename(2)` のディレクトリエントリ更新は親 inode の fsync を行うまで
+    // 永続化が保証されない（ext4 / xfs の crash recovery で rename 結果が古い状態に
+    // 戻るケースが知られている）。`tokio::fs::OpenOptions::open(dir).sync_all()` で
+    // 親ディレクトリを fsync してクラッシュ耐性を確保する。
+    //
+    // Windows / 非 unix ではディレクトリ open のセマンティクス自体が異なる
+    // (`CreateFileW` は `FILE_FLAG_BACKUP_SEMANTICS` 必須等) ため、ディレクトリ fsync
+    // は no-op として扱う。本サーバは VPS Linux 運用が一次ターゲットで、Windows は
+    // 開発・テスト経路の便宜上のサポート。
+    #[cfg(unix)]
+    {
+        let dir_handle = fs::OpenOptions::new()
+            .read(true)
+            .open(dir)
+            .await
+            .map_err(|e| StorageError::Io(format!("open dir {}: {}", dir.display(), e)))?;
+        dir_handle
+            .sync_all()
+            .await
+            .map_err(|e| StorageError::Io(format!("fsync dir {}: {}", dir.display(), e)))?;
+    }
+    #[cfg(not(unix))]
+    {
+        // 非 unix では no-op。`dir` 引数を未使用警告から逃すため明示的に消費する。
+        let _ = dir;
+    }
     Ok(())
 }
 
@@ -670,8 +696,14 @@ mod tests {
     }
 
     /// 日本語ハンドル名 / 数字始まりハンドル名など serde_yaml が quote を要する
-    /// 文字列で round-trip する契約を固定する。Ruby 互換 YAML として、UTF-8
-    /// 名前の対局者を扱える運用を保証する。
+    /// 可能性がある文字列で round-trip する契約を固定する。Ruby 互換 YAML として、
+    /// UTF-8 名前の対局者を扱える運用を保証する。
+    ///
+    /// (1) round-trip で意味的同値を保つ
+    /// (2) 日本語ハンドルは bare key として出力される（`田中太郎:` の出現を pin）
+    /// (3) 数字 only ハンドル `12345` は YAML 1.2 で integer scalar に解釈されうる
+    ///     ため `serde_yaml` は string quote を付ける。`'12345':` の出現を pin する
+    ///     （quote の有無は仕様変更で破壊的変化があるため byte 列で固定する）。
     #[test]
     fn render_and_parse_round_trip_handles_unicode_and_numeric_names() {
         let mut records = HashMap::new();
@@ -680,6 +712,16 @@ mod tests {
         let yaml = render_document(&records).unwrap();
         let parsed = parse_document(&yaml).unwrap();
         assert_eq!(parsed, records, "Unicode / numeric handles must round-trip");
+
+        // (2): 日本語ハンドルは bare で出力される。
+        assert!(yaml.contains("田中太郎:\n"), "non-ASCII handle must be unquoted, got:\n{yaml}",);
+        // (3): 数字 only ハンドルは integer 解釈を防ぐため quote される。
+        // serde_yaml 0.9 は single quote を採用するが、double quote 採用 minor バージョン
+        // 変化に保険を掛けるため両方許容する assertion にする。
+        assert!(
+            yaml.contains("'12345':\n") || yaml.contains("\"12345\":\n"),
+            "numeric handle must be string-quoted to avoid YAML integer coercion, got:\n{yaml}",
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server/src/storage/players_yaml.rs
+++ b/crates/rshogi-csa-server/src/storage/players_yaml.rs
@@ -1,0 +1,573 @@
+//! Ruby shogi-server 互換の `players.yaml` 形式でレートを永続化する
+//! [`RateStorage`](crate::port::RateStorage) 実装。
+//!
+//! ## 互換するフォーマット
+//!
+//! Ruby `YAML.dump` で書き出される `players.yaml` 形式（[design.md] 1110 行）に
+//! 合わせ、トップレベルはプレイヤ名（String）→ レコード（Ruby Symbol キー）の
+//! マップで構成する。Ruby の `Symbol` は YAML 上で `":name"` のようにコロン接頭辞
+//! つき文字列で表現されるため、本実装でも `:name`/`:rate`/`:win`/`:loss`/
+//! `:last_game_id`/`:last_modified` をキーとして読み書きする:
+//!
+//! ```yaml
+//! ---
+//! alice:
+//!   :name: alice
+//!   :rate: 2500
+//!   :win: 100
+//!   :loss: 50
+//!   :last_game_id: 20260426-001
+//!   :last_modified: '2026-04-26T12:34:56+00:00'
+//! bob:
+//!   :name: bob
+//!   :rate: 2400
+//!   :win: 80
+//!   :loss: 60
+//!   :last_modified: '2026-04-26T12:34:56+00:00'
+//! ```
+//!
+//! ## クリーンルーム方針
+//!
+//! Ruby shogi-server / mk_rate / mk_html のソースは参照せず、上記の公開ドキュメント
+//! にある形式情報のみから実装する（[Requirement 14.1] / `feedback_no_phase_and_session_refs.md`
+//! の OSS 互換ガイドライン）。CI も外部 Ruby ランタイムや shogi-server リポジトリを
+//! 引かない（[Task 21.1] 参照）。
+//!
+//! ## レート値の責務分担
+//!
+//! `:rate` フィールドは Ruby `mk_rate` バッチが Glicko 系のアルゴリズムで計算する
+//! 領域なので、本サーバ側では `record_game_outcome` で **触れない**。サーバが
+//! 更新するのは `:win` / `:loss` / `:last_game_id` / `:last_modified` の 4 つだけで、
+//! ロード時に取得した `:rate` をそのまま `save` 側に書き戻す。これにより `mk_rate`
+//! と本サーバを同居させる運用でも、レート値を踏まないで wins/losses を加算できる。
+//!
+//! ## アトミック性
+//!
+//! - **ファイル書き込み**: tmpfile 書き込み + `rename(2)` の POSIX atomic で
+//!   `players.yaml` の半端な状態を生まない。
+//! - **read-modify-write**: 複数対局が同時に同一プレイヤのレコードを書き換える
+//!   ケースを `disk_lock` (async Mutex) 配下で直列化し、`record_game_outcome` の
+//!   内部で「キャッシュ更新 → 全件 snapshot → atomic write」を 1 critical section
+//!   で完結する。`load` + `save` の 2 段呼び出しではなく `record_game_outcome` を
+//!   経由する限り、wins/losses の lost-update は発生しない。
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex as StdMutex;
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::error::StorageError;
+use crate::port::{PlayerRateRecord, RateStorage};
+use crate::types::{GameId, PlayerName};
+
+/// 1 プレイヤ分のレコードを Ruby Symbol キー（`:name` / `:rate` / ...）で表現する
+/// serde スキーマ。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct YamlRecord {
+    #[serde(rename = ":name")]
+    name: String,
+    #[serde(rename = ":rate")]
+    rate: i32,
+    #[serde(rename = ":win")]
+    win: u32,
+    #[serde(rename = ":loss")]
+    loss: u32,
+    #[serde(rename = ":last_game_id", default)]
+    last_game_id: Option<String>,
+    #[serde(rename = ":last_modified")]
+    last_modified: String,
+}
+
+impl YamlRecord {
+    fn from_record(r: &PlayerRateRecord) -> Self {
+        Self {
+            name: r.name.as_str().to_owned(),
+            rate: r.rate,
+            win: r.wins,
+            loss: r.losses,
+            last_game_id: r.last_game_id.as_ref().map(|g| g.as_str().to_owned()),
+            last_modified: r.last_modified.clone(),
+        }
+    }
+
+    fn into_record(self) -> PlayerRateRecord {
+        PlayerRateRecord {
+            name: PlayerName::new(self.name),
+            rate: self.rate,
+            wins: self.win,
+            losses: self.loss,
+            last_game_id: self.last_game_id.map(GameId::new),
+            last_modified: self.last_modified,
+        }
+    }
+}
+
+/// Ruby shogi-server 互換 `players.yaml` をレートストレージとして使う実装。
+///
+/// 起動時に `load_from_file` でファイル全体を in-memory `HashMap` に取り込み、
+/// `load` は cache lookup のみで応答する（disk read を発生させない）。
+/// `save` / `record_game_outcome` は cache を更新したあと、全件 snapshot を
+/// atomic write で `players.yaml` に書き戻す。
+///
+/// ファイルが存在しない場合は空のマップから始め、最初の `save` で生成する。
+#[derive(Debug)]
+pub struct PlayersYamlRateStorage {
+    path: PathBuf,
+    cache: StdMutex<HashMap<String, PlayerRateRecord>>,
+    /// disk write を直列化する async lock。`save` / `record_game_outcome` の
+    /// critical section 全体（cache 更新 → snapshot → atomic write）を覆う。
+    disk_lock: AsyncMutex<()>,
+}
+
+impl PlayersYamlRateStorage {
+    /// 既存の `players.yaml` を読み込んでレートストレージを構築する。
+    ///
+    /// ファイルが存在しない場合は空マップを返す（初回起動の運用シナリオ）。
+    /// ファイルが空文字列・空白のみの場合も同様に空マップとして扱う。
+    /// パース失敗は [`StorageError::Malformed`] として `Err` を返す。
+    pub async fn load_from_file(path: PathBuf) -> Result<Self, StorageError> {
+        let map = match fs::read_to_string(&path).await {
+            Ok(text) if text.trim().is_empty() => HashMap::new(),
+            Ok(text) => parse_document(&text)?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) => {
+                return Err(StorageError::Io(format!("read {}: {}", path.display(), e)));
+            }
+        };
+        Ok(Self {
+            path,
+            cache: StdMutex::new(map),
+            disk_lock: AsyncMutex::new(()),
+        })
+    }
+
+    /// 指定プレイヤがまだ未登録なら、既定値（rate=`initial_rate`、wins=0、losses=0）
+    /// でレコードを補填する。disk への書き戻しは行わず、cache を更新するのみ。
+    ///
+    /// `players.toml` で定義された全プレイヤを LOGIN 経路で受け付けるための
+    /// 起動時補填用。最初に終局して `record_game_outcome` が走った時点で
+    /// `players.yaml` に書き戻される。
+    pub fn ensure_default_records<I, S>(&self, names: I, initial_rate: i32, now_iso: &str)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut cache = self.cache.lock().expect("rate cache poisoned");
+        for raw in names {
+            let name: String = raw.into();
+            cache.entry(name.clone()).or_insert_with(|| PlayerRateRecord {
+                name: PlayerName::new(&name),
+                rate: initial_rate,
+                wins: 0,
+                losses: 0,
+                last_game_id: None,
+                last_modified: now_iso.to_owned(),
+            });
+        }
+    }
+
+    fn snapshot(&self) -> HashMap<String, PlayerRateRecord> {
+        self.cache.lock().expect("rate cache poisoned").clone()
+    }
+
+    async fn flush_to_disk(
+        &self,
+        snapshot: &HashMap<String, PlayerRateRecord>,
+    ) -> Result<(), StorageError> {
+        let yaml = render_document(snapshot)?;
+        atomic_write_yaml(&self.path, &yaml).await
+    }
+}
+
+impl RateStorage for PlayersYamlRateStorage {
+    fn load(
+        &self,
+        name: &PlayerName,
+    ) -> impl std::future::Future<Output = Result<Option<PlayerRateRecord>, StorageError>> {
+        let result = self.cache.lock().expect("rate cache poisoned").get(name.as_str()).cloned();
+        async move { Ok(result) }
+    }
+
+    fn save(
+        &self,
+        record: &PlayerRateRecord,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        let key = record.name.as_str().to_owned();
+        let value = record.clone();
+        async move {
+            let _guard = self.disk_lock.lock().await;
+            {
+                let mut cache = self.cache.lock().expect("rate cache poisoned");
+                cache.insert(key, value);
+            }
+            let snapshot = self.snapshot();
+            self.flush_to_disk(&snapshot).await
+        }
+    }
+
+    fn list_all(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<PlayerRateRecord>, StorageError>> {
+        let snapshot: Vec<PlayerRateRecord> =
+            self.cache.lock().expect("rate cache poisoned").values().cloned().collect();
+        async move { Ok(snapshot) }
+    }
+
+    fn record_game_outcome(
+        &self,
+        black: &PlayerName,
+        white: &PlayerName,
+        winner: Option<&PlayerName>,
+        game_id: &GameId,
+        now_iso: &str,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        let black_str = black.as_str().to_owned();
+        let white_str = white.as_str().to_owned();
+        let winner_str = winner.map(|w| w.as_str().to_owned());
+        let game_id_owned = game_id.clone();
+        let now_owned = now_iso.to_owned();
+        async move {
+            let _guard = self.disk_lock.lock().await;
+            {
+                let mut cache = self.cache.lock().expect("rate cache poisoned");
+                for key in [&black_str, &white_str] {
+                    if let Some(rec) = cache.get_mut(key) {
+                        match winner_str.as_deref() {
+                            Some(w) if w == key => rec.wins = rec.wins.saturating_add(1),
+                            Some(_) => rec.losses = rec.losses.saturating_add(1),
+                            None => {}
+                        }
+                        rec.last_game_id = Some(game_id_owned.clone());
+                        rec.last_modified = now_owned.clone();
+                    }
+                }
+            }
+            let snapshot = self.snapshot();
+            self.flush_to_disk(&snapshot).await
+        }
+    }
+}
+
+fn parse_document(text: &str) -> Result<HashMap<String, PlayerRateRecord>, StorageError> {
+    // 並びを byte-stable にして round-trip 比較しやすくするため、内部表現は
+    // BTreeMap で受けてから HashMap に変換する。
+    let doc: BTreeMap<String, YamlRecord> = serde_yaml::from_str(text)
+        .map_err(|e| StorageError::Malformed(format!("players.yaml: {e}")))?;
+    Ok(doc.into_iter().map(|(k, v)| (k, v.into_record())).collect())
+}
+
+fn render_document(records: &HashMap<String, PlayerRateRecord>) -> Result<String, StorageError> {
+    // `BTreeMap` でキーをソートして書き出すことで、同一データから出力 byte 列が
+    // 一致する（運用での diff 比較・自動レビューが安定する）。
+    let doc: BTreeMap<String, YamlRecord> =
+        records.iter().map(|(k, v)| (k.clone(), YamlRecord::from_record(v))).collect();
+    serde_yaml::to_string(&doc)
+        .map_err(|e| StorageError::Io(format!("serialize players.yaml: {e}")))
+}
+
+async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageError> {
+    // `rename(2)` は同一ファイルシステム上で atomic なので tmpfile は隣接ディレクトリ
+    // に作る。dotfile 接頭辞でユーザに対しても "中間ファイル" であることを示す。
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .ok_or_else(|| {
+            StorageError::Io(format!("players.yaml path has no file name: {}", path.display()))
+        })?
+        .to_string_lossy();
+    let tmp = dir.join(format!(".{stem}.rshogi-tmp"));
+    let mut file = fs::File::create(&tmp)
+        .await
+        .map_err(|e| StorageError::Io(format!("create {}: {}", tmp.display(), e)))?;
+    file.write_all(contents.as_bytes())
+        .await
+        .map_err(|e| StorageError::Io(format!("write {}: {}", tmp.display(), e)))?;
+    file.sync_all()
+        .await
+        .map_err(|e| StorageError::Io(format!("sync {}: {}", tmp.display(), e)))?;
+    drop(file);
+    fs::rename(&tmp, path).await.map_err(|e| {
+        StorageError::Io(format!("rename {} -> {}: {}", tmp.display(), path.display(), e))
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn rec(name: &str, rate: i32, wins: u32, losses: u32) -> PlayerRateRecord {
+        PlayerRateRecord {
+            name: PlayerName::new(name),
+            rate,
+            wins,
+            losses,
+            last_game_id: Some(GameId::new("20260426-001")),
+            last_modified: "2026-04-26T12:34:56+00:00".to_owned(),
+        }
+    }
+
+    #[test]
+    fn render_document_emits_byte_stable_yaml_with_ruby_symbol_keys() {
+        let mut records = HashMap::new();
+        records.insert("alice".to_owned(), rec("alice", 2500, 100, 50));
+        records.insert("bob".to_owned(), rec("bob", 2400, 80, 60));
+
+        let yaml = render_document(&records).unwrap();
+        // Ruby `YAML.dump` のキー順は内部 Hash 挿入順だが、本実装では BTreeMap で
+        // 名前昇順に正規化する。アルファベット順で alice → bob が確定。
+        // `:name`/`:rate`/`:win`/`:loss`/`:last_game_id`/`:last_modified` の
+        // Ruby Symbol キーが quote 無しで出力されることを byte 比較で固定する。
+        // `serde_yaml` は ASCII の `:` を quote 不要と判断するため、Ruby
+        // `YAML.dump` と同様にコロン接頭辞のみで bare key として出力される。
+        // diff 検証や grep で扱いやすくする上でも quote 無しの形を期待する。
+        let expected = concat!(
+            "alice:\n",
+            "  :name: alice\n",
+            "  :rate: 2500\n",
+            "  :win: 100\n",
+            "  :loss: 50\n",
+            "  :last_game_id: 20260426-001\n",
+            "  :last_modified: 2026-04-26T12:34:56+00:00\n",
+            "bob:\n",
+            "  :name: bob\n",
+            "  :rate: 2400\n",
+            "  :win: 80\n",
+            "  :loss: 60\n",
+            "  :last_game_id: 20260426-001\n",
+            "  :last_modified: 2026-04-26T12:34:56+00:00\n",
+        );
+        assert_eq!(yaml, expected);
+    }
+
+    #[test]
+    fn parse_document_round_trips_ruby_symbol_keys() {
+        let mut records = HashMap::new();
+        records.insert("alice".to_owned(), rec("alice", 2500, 100, 50));
+        records.insert("bob".to_owned(), rec("bob", 2400, 80, 60));
+
+        let yaml = render_document(&records).unwrap();
+        let parsed = parse_document(&yaml).unwrap();
+        assert_eq!(parsed, records);
+    }
+
+    #[test]
+    fn parse_document_accepts_optional_last_game_id_omitted() {
+        // Ruby YAML で `:last_game_id:` 行ごと省略するケース（新規プレイヤで
+        // 一度も対局していない状態）を許容する。
+        let yaml = "alice:\n  ':name': alice\n  ':rate': 1500\n  ':win': 0\n  ':loss': 0\n  ':last_modified': '2026-04-26T00:00:00+00:00'\n";
+        let parsed = parse_document(yaml).unwrap();
+        assert_eq!(parsed.len(), 1);
+        let r = parsed.get("alice").unwrap();
+        assert!(r.last_game_id.is_none());
+        assert_eq!(r.rate, 1500);
+        assert_eq!(r.wins, 0);
+        assert_eq!(r.losses, 0);
+    }
+
+    #[test]
+    fn parse_document_rejects_malformed_yaml() {
+        let err = parse_document(":not a mapping").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("players.yaml"), "expected error to mention players.yaml: {msg}");
+    }
+
+    #[test]
+    fn parse_document_treats_empty_input_as_empty_map() {
+        // 上位 `load_from_file` は trim 済みの空文字列を直接 `HashMap::new()` に
+        // 落とす経路だが、`parse_document` 単体でも空 mapping `{}` は受理する。
+        let parsed = parse_document("{}").unwrap();
+        assert!(parsed.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_from_file_returns_empty_when_file_missing() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        assert!(storage.list_all().await.unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn save_writes_atomic_yaml_and_round_trips() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
+        storage.save(&rec("alice", 2500, 100, 50)).await.unwrap();
+        storage.save(&rec("bob", 2400, 80, 60)).await.unwrap();
+
+        // Reload from disk and confirm same records exist.
+        let reloaded = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        let mut names: Vec<String> = reloaded
+            .list_all()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.name.as_str().to_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["alice".to_owned(), "bob".to_owned()]);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn record_game_outcome_increments_winner_and_loser_atomically() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
+        storage.ensure_default_records(
+            ["alice".to_owned(), "bob".to_owned()],
+            1500,
+            "2026-04-26T00:00:00+00:00",
+        );
+
+        let alice = PlayerName::new("alice");
+        let bob = PlayerName::new("bob");
+        let game_id = GameId::new("20260426-001");
+        storage
+            .record_game_outcome(&alice, &bob, Some(&alice), &game_id, "2026-04-26T12:34:56+00:00")
+            .await
+            .unwrap();
+
+        let alice_rec = storage.load(&alice).await.unwrap().unwrap();
+        let bob_rec = storage.load(&bob).await.unwrap().unwrap();
+        assert_eq!(alice_rec.wins, 1);
+        assert_eq!(alice_rec.losses, 0);
+        assert_eq!(bob_rec.wins, 0);
+        assert_eq!(bob_rec.losses, 1);
+        assert_eq!(alice_rec.last_game_id.as_ref().map(|g| g.as_str()), Some("20260426-001"));
+        assert_eq!(bob_rec.last_modified, "2026-04-26T12:34:56+00:00");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn record_game_outcome_draw_updates_last_fields_only() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
+        storage.ensure_default_records(
+            ["alice".to_owned(), "bob".to_owned()],
+            1500,
+            "2026-04-26T00:00:00+00:00",
+        );
+
+        let alice = PlayerName::new("alice");
+        let bob = PlayerName::new("bob");
+        let game_id = GameId::new("20260426-002");
+        storage
+            .record_game_outcome(&alice, &bob, None, &game_id, "2026-04-26T13:00:00+00:00")
+            .await
+            .unwrap();
+
+        let alice_rec = storage.load(&alice).await.unwrap().unwrap();
+        let bob_rec = storage.load(&bob).await.unwrap().unwrap();
+        // 千日手・最大手数では wins/losses は据置。last_* のみ更新される。
+        assert_eq!(alice_rec.wins, 0);
+        assert_eq!(alice_rec.losses, 0);
+        assert_eq!(bob_rec.wins, 0);
+        assert_eq!(bob_rec.losses, 0);
+        assert_eq!(alice_rec.last_modified, "2026-04-26T13:00:00+00:00");
+        assert_eq!(bob_rec.last_modified, "2026-04-26T13:00:00+00:00");
+        assert_eq!(alice_rec.last_game_id.as_ref().map(|g| g.as_str()), Some("20260426-002"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn record_game_outcome_does_not_mutate_rate_value() {
+        // `:rate` は外部バッチ（mk_rate）の責務。本サーバの終局処理では
+        // 触れないことを契約として固定する（同居運用で踏まないために重要）。
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
+        storage.save(&rec("alice", 2500, 0, 0)).await.unwrap();
+        storage.save(&rec("bob", 2400, 0, 0)).await.unwrap();
+
+        let alice = PlayerName::new("alice");
+        let bob = PlayerName::new("bob");
+        let game_id = GameId::new("20260426-003");
+        storage
+            .record_game_outcome(&alice, &bob, Some(&alice), &game_id, "2026-04-26T14:00:00+00:00")
+            .await
+            .unwrap();
+
+        let alice_rec = storage.load(&alice).await.unwrap().unwrap();
+        let bob_rec = storage.load(&bob).await.unwrap().unwrap();
+        assert_eq!(alice_rec.rate, 2500, "rate must be preserved verbatim");
+        assert_eq!(bob_rec.rate, 2400, "rate must be preserved verbatim");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn save_recovers_from_corrupted_file_with_explicit_error() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        // 不正な YAML を直接書く（mid-write クラッシュ等のシミュレーション）。
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b":invalid: [unterminated").unwrap();
+        drop(f);
+
+        let err = PlayersYamlRateStorage::load_from_file(path).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, StorageError::Malformed(_)),
+            "expected Malformed error, got: {msg}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ensure_default_records_does_not_overwrite_existing() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        storage.save(&rec("alice", 2500, 100, 50)).await.unwrap();
+
+        // alice は既に rate=2500/wins=100 で記録済み。ensure_default_records が
+        // これを既定値で上書きしないことを確認。
+        storage.ensure_default_records(
+            ["alice".to_owned(), "bob".to_owned()],
+            1500,
+            "2026-04-26T15:00:00+00:00",
+        );
+        let alice_rec = storage.load(&PlayerName::new("alice")).await.unwrap().unwrap();
+        assert_eq!(alice_rec.rate, 2500);
+        assert_eq!(alice_rec.wins, 100);
+        let bob_rec = storage.load(&PlayerName::new("bob")).await.unwrap().unwrap();
+        assert_eq!(bob_rec.rate, 1500);
+        assert_eq!(bob_rec.wins, 0);
+    }
+
+    /// `tempfile` クレートを使わずに済ませるため、テスト専用の薄い RAII
+    /// ディレクトリを定義する。`Drop` で再帰削除する。
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            // テスト失敗時のクリーンアップ漏れは許容（系列番号衝突は確率的に低い）
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn tempdir() -> TempDir {
+        let base = std::env::temp_dir();
+        let pid = std::process::id();
+        // counter を使って同 pid 内のテスト間衝突を避ける
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = base.join(format!("rshogi-players-yaml-{pid}-{n}"));
+        std::fs::create_dir_all(&path).expect("create tempdir");
+        TempDir { path }
+    }
+}

--- a/crates/rshogi-csa-server/src/storage/players_yaml.rs
+++ b/crates/rshogi-csa-server/src/storage/players_yaml.rs
@@ -64,8 +64,23 @@ use crate::error::StorageError;
 use crate::port::{PlayerRateRecord, RateStorage};
 use crate::types::{GameId, PlayerName};
 
+/// `StdMutex<HashMap<...>>` を poisoning に強くロックする小ヘルパ。
+///
+/// `current_thread + LocalSet` 運用では他スレッドが panic を伝播させる経路は
+/// 実質存在しないが、`poison`化は契約違反ではなく単に「ロック中にどこかで
+/// panic が起きた」副作用に過ぎない。CLAUDE.md の「panic は契約違反のみ」
+/// 方針に合わせ、poisoning は `into_inner` でデータをそのまま借りる。
+fn lock_cache<T>(m: &StdMutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// 1 プレイヤ分のレコードを Ruby Symbol キー（`:name` / `:rate` / ...）で表現する
 /// serde スキーマ。
+///
+/// `last_game_id` が `None` の場合は serde の `skip_serializing_if` でキー行ごと
+/// 出力から除外する（`null` リテラルや空値を吐かない）。Ruby `YAML.dump` で
+/// `Hash.delete(:last_game_id)` 済みの未対局レコードと等価な見え方になる。
+/// deserialize 側は `default` で `None` を許容する。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct YamlRecord {
     #[serde(rename = ":name")]
@@ -76,7 +91,11 @@ struct YamlRecord {
     win: u32,
     #[serde(rename = ":loss")]
     loss: u32,
-    #[serde(rename = ":last_game_id", default)]
+    #[serde(
+        rename = ":last_game_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     last_game_id: Option<String>,
     #[serde(rename = ":last_modified")]
     last_modified: String,
@@ -156,7 +175,7 @@ impl PlayersYamlRateStorage {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        let mut cache = self.cache.lock().expect("rate cache poisoned");
+        let mut cache = lock_cache(&self.cache);
         for raw in names {
             let name: String = raw.into();
             cache.entry(name.clone()).or_insert_with(|| PlayerRateRecord {
@@ -171,7 +190,7 @@ impl PlayersYamlRateStorage {
     }
 
     fn snapshot(&self) -> HashMap<String, PlayerRateRecord> {
-        self.cache.lock().expect("rate cache poisoned").clone()
+        lock_cache(&self.cache).clone()
     }
 
     async fn flush_to_disk(
@@ -188,7 +207,7 @@ impl RateStorage for PlayersYamlRateStorage {
         &self,
         name: &PlayerName,
     ) -> impl std::future::Future<Output = Result<Option<PlayerRateRecord>, StorageError>> {
-        let result = self.cache.lock().expect("rate cache poisoned").get(name.as_str()).cloned();
+        let result = lock_cache(&self.cache).get(name.as_str()).cloned();
         async move { Ok(result) }
     }
 
@@ -201,7 +220,7 @@ impl RateStorage for PlayersYamlRateStorage {
         async move {
             let _guard = self.disk_lock.lock().await;
             {
-                let mut cache = self.cache.lock().expect("rate cache poisoned");
+                let mut cache = lock_cache(&self.cache);
                 cache.insert(key, value);
             }
             let snapshot = self.snapshot();
@@ -212,8 +231,7 @@ impl RateStorage for PlayersYamlRateStorage {
     fn list_all(
         &self,
     ) -> impl std::future::Future<Output = Result<Vec<PlayerRateRecord>, StorageError>> {
-        let snapshot: Vec<PlayerRateRecord> =
-            self.cache.lock().expect("rate cache poisoned").values().cloned().collect();
+        let snapshot: Vec<PlayerRateRecord> = lock_cache(&self.cache).values().cloned().collect();
         async move { Ok(snapshot) }
     }
 
@@ -225,15 +243,25 @@ impl RateStorage for PlayersYamlRateStorage {
         game_id: &GameId,
         now_iso: &str,
     ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        debug_assert_ne!(
+            black, white,
+            "record_game_outcome: black and white must be distinct players",
+        );
         let black_str = black.as_str().to_owned();
         let white_str = white.as_str().to_owned();
+        // self-play 防護: 同名を渡した場合は二重加算を防ぐため `for` ループに
+        // 入る前に同一性チェックする。trait 既定実装と同じ契約を保つ。
+        let same_player = black_str == white_str;
         let winner_str = winner.map(|w| w.as_str().to_owned());
         let game_id_owned = game_id.clone();
         let now_owned = now_iso.to_owned();
         async move {
+            if same_player {
+                return Ok(());
+            }
             let _guard = self.disk_lock.lock().await;
             {
-                let mut cache = self.cache.lock().expect("rate cache poisoned");
+                let mut cache = lock_cache(&self.cache);
                 for key in [&black_str, &white_str] {
                     if let Some(rec) = cache.get_mut(key) {
                         match winner_str.as_deref() {
@@ -271,7 +299,15 @@ fn render_document(records: &HashMap<String, PlayerRateRecord>) -> Result<String
 
 async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageError> {
     // `rename(2)` は同一ファイルシステム上で atomic なので tmpfile は隣接ディレクトリ
-    // に作る。dotfile 接頭辞でユーザに対しても "中間ファイル" であることを示す。
+    // に作る。tmpfile 名は `pid.nanos.counter` を埋めて完全一意化することで:
+    //
+    //   - 複数プロセスが同 dir に並行で書いた場合でも `O_CREAT|O_EXCL` のレース
+    //     にならない（`create_new(true)`）
+    //   - 攻撃者・他テナントが固定名 (`.players.yaml.tmp` 等) で先回りして
+    //     symlink を張り、`O_CREAT` の symlink follow で別ファイルを破壊書きする
+    //     攻撃面を狭める。さらに `create_new(true)` は既存 symlink を弾く。
+    //
+    // dotfile 接頭辞は ls で隠して "中間ファイル" を示す慣習。
     let dir = path
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -282,8 +318,42 @@ async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageErr
             StorageError::Io(format!("players.yaml path has no file name: {}", path.display()))
         })?
         .to_string_lossy();
-    let tmp = dir.join(format!(".{stem}.rshogi-tmp"));
-    let mut file = fs::File::create(&tmp)
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!(".{stem}.rshogi-tmp.{pid}.{nanos}.{seq}"));
+
+    // tmpfile が rename 完走前に Err 経路へ落ちた場合の残骸を確実に掃除するための
+    // RAII ガード。`renamed = true` を立てると Drop で残骸削除をスキップする。
+    struct TmpCleanup<'a> {
+        tmp: &'a Path,
+        renamed: bool,
+    }
+    impl Drop for TmpCleanup<'_> {
+        fn drop(&mut self) {
+            if !self.renamed {
+                let _ = std::fs::remove_file(self.tmp);
+            }
+        }
+    }
+    let mut cleanup = TmpCleanup {
+        tmp: &tmp,
+        renamed: false,
+    };
+
+    // `create_new(true)` は内部で `O_CREAT|O_EXCL` 相当を使い、既存ファイル / symlink
+    // 当たりで `AlreadyExists` Err を返す。tmpfile 名がプロセス間で一意なので通常
+    // は当たらないが、悪意ある先回り symlink を確実に弾く。
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
         .await
         .map_err(|e| StorageError::Io(format!("create {}: {}", tmp.display(), e)))?;
     file.write_all(contents.as_bytes())
@@ -296,6 +366,22 @@ async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageErr
     fs::rename(&tmp, path).await.map_err(|e| {
         StorageError::Io(format!("rename {} -> {}: {}", tmp.display(), path.display(), e))
     })?;
+    cleanup.renamed = true;
+    drop(cleanup);
+
+    // `rename(2)` のディレクトリエントリ更新は親 inode の fsync を行うまで永続化が
+    // 保証されない（ext4 / xfs の crash recovery で rename 結果が古い状態に戻る
+    // ケースが知られている）。`tokio::fs::File::open(dir).sync_all()` で親ディレクトリ
+    // を fsync してクラッシュ耐性を確保する。
+    let dir_handle = fs::OpenOptions::new()
+        .read(true)
+        .open(dir)
+        .await
+        .map_err(|e| StorageError::Io(format!("open dir {}: {}", dir.display(), e)))?;
+    dir_handle
+        .sync_all()
+        .await
+        .map_err(|e| StorageError::Io(format!("fsync dir {}: {}", dir.display(), e)))?;
     Ok(())
 }
 
@@ -346,6 +432,40 @@ mod tests {
             "  :last_modified: 2026-04-26T12:34:56+00:00\n",
         );
         assert_eq!(yaml, expected);
+    }
+
+    /// `last_game_id` が `None` のレコードは `:last_game_id` 行ごと出力から
+    /// 除外される（serde の `skip_serializing_if`）。Ruby 側で `if rec[:last_game_id]`
+    /// truthiness チェックする実装でも、`has_key?(:last_game_id)` で存在判定する
+    /// 実装でも、どちらにも互換な見え方になる。`null` リテラルは Ruby `YAML.dump`
+    /// が出さない形なので避ける。
+    #[test]
+    fn render_document_omits_last_game_id_when_none() {
+        let mut records = HashMap::new();
+        records.insert(
+            "alice".to_owned(),
+            PlayerRateRecord {
+                name: PlayerName::new("alice"),
+                rate: 1500,
+                wins: 0,
+                losses: 0,
+                last_game_id: None,
+                last_modified: "2026-04-26T00:00:00+00:00".to_owned(),
+            },
+        );
+        let yaml = render_document(&records).unwrap();
+        let expected = concat!(
+            "alice:\n",
+            "  :name: alice\n",
+            "  :rate: 1500\n",
+            "  :win: 0\n",
+            "  :loss: 0\n",
+            "  :last_modified: 2026-04-26T00:00:00+00:00\n",
+        );
+        assert_eq!(yaml, expected);
+        // round-trip しても同じ shape を保つ（None で deserialize される）。
+        let parsed = parse_document(&yaml).unwrap();
+        assert_eq!(parsed, records);
     }
 
     #[test]
@@ -516,6 +636,50 @@ mod tests {
             matches!(err, StorageError::Malformed(_)),
             "expected Malformed error, got: {msg}"
         );
+    }
+
+    /// `record_game_outcome` の契約: `black == white` が誤って渡されても
+    /// `wins`/`losses` の二重加算が発生しない（self-play 防護）。debug ビルドでは
+    /// `debug_assert_ne!` が落とすが、release ビルドでも `Ok(())` で早期 return
+    /// して整合性を保つ。
+    #[cfg(not(debug_assertions))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn record_game_outcome_rejects_self_play_in_release_build() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        storage.save(&rec("alice", 1500, 5, 3)).await.unwrap();
+
+        let alice = PlayerName::new("alice");
+        let game_id = GameId::new("20260426-self");
+        // 同名を black / white 両方に渡しても 2 重加算しない。
+        storage
+            .record_game_outcome(
+                &alice,
+                &alice,
+                Some(&alice),
+                &game_id,
+                "2026-04-26T16:00:00+00:00",
+            )
+            .await
+            .unwrap();
+        let r = storage.load(&alice).await.unwrap().unwrap();
+        // wins/losses は据置（save 時の値そのまま）。
+        assert_eq!(r.wins, 5);
+        assert_eq!(r.losses, 3);
+    }
+
+    /// 日本語ハンドル名 / 数字始まりハンドル名など serde_yaml が quote を要する
+    /// 文字列で round-trip する契約を固定する。Ruby 互換 YAML として、UTF-8
+    /// 名前の対局者を扱える運用を保証する。
+    #[test]
+    fn render_and_parse_round_trip_handles_unicode_and_numeric_names() {
+        let mut records = HashMap::new();
+        records.insert("田中太郎".to_owned(), rec("田中太郎", 1500, 0, 0));
+        records.insert("12345".to_owned(), rec("12345", 1700, 10, 5));
+        let yaml = render_document(&records).unwrap();
+        let parsed = parse_document(&yaml).unwrap();
+        assert_eq!(parsed, records, "Unicode / numeric handles must round-trip");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server/src/storage/players_yaml.rs
+++ b/crates/rshogi-csa-server/src/storage/players_yaml.rs
@@ -10,21 +10,25 @@
 //! `:last_game_id`/`:last_modified` をキーとして読み書きする:
 //!
 //! ```yaml
-//! ---
 //! alice:
 //!   :name: alice
 //!   :rate: 2500
 //!   :win: 100
 //!   :loss: 50
 //!   :last_game_id: 20260426-001
-//!   :last_modified: '2026-04-26T12:34:56+00:00'
+//!   :last_modified: 2026-04-26T12:34:56+00:00
 //! bob:
 //!   :name: bob
 //!   :rate: 2400
 //!   :win: 80
 //!   :loss: 60
-//!   :last_modified: '2026-04-26T12:34:56+00:00'
+//!   :last_modified: 2026-04-26T12:34:56+00:00
 //! ```
+//!
+//! `serde_yaml` の `to_string` は document start (`---`) を出さず、`String` 型の
+//! `:last_modified` も quote 無しで bare scalar として出力する。例は
+//! `render_document` のテスト golden YAML と一致させる（実出力と差異が出たら
+//! `render_document_emits_byte_stable_yaml_with_ruby_symbol_keys` が落ちる）。
 //!
 //! ## クリーンルーム方針
 //!
@@ -148,11 +152,20 @@ impl PlayersYamlRateStorage {
     /// ファイルが存在しない場合は空マップを返す（初回起動の運用シナリオ）。
     /// ファイルが空文字列・空白のみの場合も同様に空マップとして扱う。
     /// パース失敗は [`StorageError::Malformed`] として `Err` を返す。
+    ///
+    /// **fail-fast**: ファイル自体が `NotFound` でも、親ディレクトリが存在しない
+    /// 場合は設定ミス（例: `--players-yaml /nonexistent-dir/players.yaml`）として
+    /// 起動時に `StorageError::Io` を返す。これを許容すると、サーバが accept ループ
+    /// に入ったあと初回終局時に毎回書き込みが失敗する形で運用障害が遅延顕在化
+    /// するため、最初の `record_game_outcome` を待たずに起動段階で検知する。
     pub async fn load_from_file(path: PathBuf) -> Result<Self, StorageError> {
         let map = match fs::read_to_string(&path).await {
             Ok(text) if text.trim().is_empty() => HashMap::new(),
             Ok(text) => parse_document(&text)?,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                ensure_parent_dir_exists(&path).await?;
+                HashMap::new()
+            }
             Err(e) => {
                 return Err(StorageError::Io(format!("read {}: {}", path.display(), e)));
             }
@@ -164,28 +177,24 @@ impl PlayersYamlRateStorage {
         })
     }
 
-    /// 指定プレイヤがまだ未登録なら、既定値（rate=`initial_rate`、wins=0、losses=0）
-    /// でレコードを補填する。disk への書き戻しは行わず、cache を更新するのみ。
+    /// `players.toml` 由来の `PlayerRateRecord` で、まだ YAML 上に未登録のプレイヤ
+    /// レコードを補填する。disk への書き戻しは行わず、cache を更新するのみ。
+    ///
+    /// **契約**: YAML 既存レコードは保護される（同名キーが既にあれば渡された
+    /// `PlayerRateRecord` は捨てる）。これにより YAML 側で運用中の `:rate` /
+    /// `:win` / `:loss` を上書きせず、TOML 側の値は「YAML 移行時の既存プレイヤ
+    /// 補填」目的にのみ使われる。
     ///
     /// `players.toml` で定義された全プレイヤを LOGIN 経路で受け付けるための
     /// 起動時補填用。最初に終局して `record_game_outcome` が走った時点で
     /// `players.yaml` に書き戻される。
-    pub fn ensure_default_records<I, S>(&self, names: I, initial_rate: i32, now_iso: &str)
+    pub fn ensure_default_records<I>(&self, defaults: I)
     where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
+        I: IntoIterator<Item = PlayerRateRecord>,
     {
         let mut cache = lock_cache(&self.cache);
-        for raw in names {
-            let name: String = raw.into();
-            cache.entry(name.clone()).or_insert_with(|| PlayerRateRecord {
-                name: PlayerName::new(&name),
-                rate: initial_rate,
-                wins: 0,
-                losses: 0,
-                last_game_id: None,
-                last_modified: now_iso.to_owned(),
-            });
+        for rec in defaults {
+            cache.entry(rec.name.as_str().to_owned()).or_insert(rec);
         }
     }
 
@@ -295,6 +304,37 @@ fn render_document(records: &HashMap<String, PlayerRateRecord>) -> Result<String
         records.iter().map(|(k, v)| (k.clone(), YamlRecord::from_record(v))).collect();
     serde_yaml::to_string(&doc)
         .map_err(|e| StorageError::Io(format!("serialize players.yaml: {e}")))
+}
+
+/// `path` の親ディレクトリが存在することを検証する（[`load_from_file`] の
+/// fail-fast 用）。`path` が単純なファイル名（親が空 / `Path::new(".")` 相当）
+/// の場合はカレントディレクトリが暗黙的な親なので存在チェックは省略する。
+///
+/// `tokio::fs::try_exists` は対象が存在しないときに `Ok(false)`、stat 自体が
+/// permission denied 等で失敗した場合に `Err` を返す。後者は親が存在しない
+/// 設定ミスとは別軸の運用障害（権限不足）なので、エラーメッセージにパスと
+/// 原因の両方を残して `Io` で上に伝える。
+async fn ensure_parent_dir_exists(path: &Path) -> Result<(), StorageError> {
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => return Ok(()),
+    };
+    let exists = fs::try_exists(parent).await.map_err(|e| {
+        StorageError::Io(format!(
+            "stat parent dir {} for {}: {}",
+            parent.display(),
+            path.display(),
+            e
+        ))
+    })?;
+    if !exists {
+        return Err(StorageError::Io(format!(
+            "players.yaml parent directory does not exist: {} (for {})",
+            parent.display(),
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 async fn atomic_write_yaml(path: &Path, contents: &str) -> Result<(), StorageError> {
@@ -542,6 +582,38 @@ mod tests {
         assert!(storage.list_all().await.unwrap().is_empty());
     }
 
+    /// **P2 回帰固定**: ファイル本体が無くても、親ディレクトリが存在しない
+    /// 場合は起動段階で `StorageError::Io` を返して fail-fast する。これを
+    /// 許容すると初回終局時の atomic write が必ず失敗する形で運用障害が遅延
+    /// 顕在化するため、accept ループに入る前に検知する契約を固定する。
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_from_file_fails_fast_when_parent_dir_missing() {
+        let dir = tempdir();
+        // 親ディレクトリ自体が存在しないパスを指す（typo / mount 漏れの設定ミス）。
+        let nonexistent_parent = dir.path().join("does-not-exist");
+        let path = nonexistent_parent.join("players.yaml");
+        let err = PlayersYamlRateStorage::load_from_file(path).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(matches!(err, StorageError::Io(_)), "expected Io error, got: {msg}");
+        assert!(
+            msg.contains("parent directory"),
+            "error message should mention parent directory: {msg}"
+        );
+    }
+
+    /// 親ディレクトリは存在するがファイル本体が無いケースは初回起動の正常経路
+    /// なので、空マップで起動できる。`load_from_file_returns_empty_when_file_missing`
+    /// と等価だが、parent 検証経路を踏むことで P2 修正の正常系副作用が無いこと
+    /// を明示する。
+    #[tokio::test(flavor = "current_thread")]
+    async fn load_from_file_accepts_missing_file_when_parent_dir_exists() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        // 親 (`dir`) は tempdir で生成済み、ファイル自体は無い状態。
+        let storage = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        assert!(storage.list_all().await.unwrap().is_empty());
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn save_writes_atomic_yaml_and_round_trips() {
         let dir = tempdir();
@@ -563,16 +635,33 @@ mod tests {
         assert_eq!(names, vec!["alice".to_owned(), "bob".to_owned()]);
     }
 
+    /// `ensure_default_records` 経由で初期レコードを差し込むテストヘルパ。
+    /// 旧 API（`names + initial_rate + now_iso`）の呼び出し記述を集約し、
+    /// 新 API（`IntoIterator<Item = PlayerRateRecord>`）への移行で
+    /// 各テストの差分を最小化する。
+    fn seed_default_records(
+        storage: &PlayersYamlRateStorage,
+        names: &[&str],
+        initial_rate: i32,
+        now_iso: &str,
+    ) {
+        let defaults = names.iter().map(|n| PlayerRateRecord {
+            name: PlayerName::new(*n),
+            rate: initial_rate,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: now_iso.to_owned(),
+        });
+        storage.ensure_default_records(defaults);
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn record_game_outcome_increments_winner_and_loser_atomically() {
         let dir = tempdir();
         let path = dir.path().join("players.yaml");
         let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
-        storage.ensure_default_records(
-            ["alice".to_owned(), "bob".to_owned()],
-            1500,
-            "2026-04-26T00:00:00+00:00",
-        );
+        seed_default_records(&storage, &["alice", "bob"], 1500, "2026-04-26T00:00:00+00:00");
 
         let alice = PlayerName::new("alice");
         let bob = PlayerName::new("bob");
@@ -597,11 +686,7 @@ mod tests {
         let dir = tempdir();
         let path = dir.path().join("players.yaml");
         let storage = PlayersYamlRateStorage::load_from_file(path.clone()).await.unwrap();
-        storage.ensure_default_records(
-            ["alice".to_owned(), "bob".to_owned()],
-            1500,
-            "2026-04-26T00:00:00+00:00",
-        );
+        seed_default_records(&storage, &["alice", "bob"], 1500, "2026-04-26T00:00:00+00:00");
 
         let alice = PlayerName::new("alice");
         let bob = PlayerName::new("bob");
@@ -732,18 +817,41 @@ mod tests {
         storage.save(&rec("alice", 2500, 100, 50)).await.unwrap();
 
         // alice は既に rate=2500/wins=100 で記録済み。ensure_default_records が
-        // これを既定値で上書きしないことを確認。
-        storage.ensure_default_records(
-            ["alice".to_owned(), "bob".to_owned()],
-            1500,
-            "2026-04-26T15:00:00+00:00",
-        );
+        // これを TOML 由来の既定値で上書きしないことを確認。
+        seed_default_records(&storage, &["alice", "bob"], 1500, "2026-04-26T15:00:00+00:00");
         let alice_rec = storage.load(&PlayerName::new("alice")).await.unwrap().unwrap();
         assert_eq!(alice_rec.rate, 2500);
         assert_eq!(alice_rec.wins, 100);
         let bob_rec = storage.load(&PlayerName::new("bob")).await.unwrap().unwrap();
         assert_eq!(bob_rec.rate, 1500);
         assert_eq!(bob_rec.wins, 0);
+    }
+
+    /// **P1 回帰固定**: TOML 由来の `PlayerRateRecord`（rate / wins / losses が
+    /// 1500 以外）が YAML 未登録プレイヤの補填値として実際に使われることを検証する。
+    /// 旧実装は `into_keys()` で名前のみ抽出して固定値 `1500` で補填していたため
+    /// TOML 側の運用値を黙って失う bug があった。新 API では `PlayerRateRecord`
+    /// 全体を受け取るため、未登録分は TOML 値そのままで in-memory 登録される。
+    #[tokio::test(flavor = "current_thread")]
+    async fn ensure_default_records_uses_toml_rate_wins_losses_for_unseen_players() {
+        let dir = tempdir();
+        let path = dir.path().join("players.yaml");
+        let storage = PlayersYamlRateStorage::load_from_file(path).await.unwrap();
+        // YAML には何もない状態。TOML 側で carol が rate=1800/wins=12/losses=7
+        // と運用されているケースを模倣する。
+        let toml_seed = vec![PlayerRateRecord {
+            name: PlayerName::new("carol"),
+            rate: 1800,
+            wins: 12,
+            losses: 7,
+            last_game_id: None,
+            last_modified: "2026-04-26T15:00:00+00:00".to_owned(),
+        }];
+        storage.ensure_default_records(toml_seed);
+        let carol = storage.load(&PlayerName::new("carol")).await.unwrap().unwrap();
+        assert_eq!(carol.rate, 1800, "TOML rate must be honored for unseen players");
+        assert_eq!(carol.wins, 12, "TOML wins must be honored for unseen players");
+        assert_eq!(carol.losses, 7, "TOML losses must be honored for unseen players");
     }
 
     /// `tempfile` クレートを使わずに済ませるため、テスト専用の薄い RAII


### PR DESCRIPTION
## Summary

`tasks.md` 15.5 で要求される TCP 側プレイヤレート永続化を Ruby `players.yaml` 互換で実装した。終局時に勝敗・最終対局 ID・最終更新時刻が atomic write で書き戻され、再起動を跨いで状態が保持される。`:rate` 値そのものは外部 `mk_rate` バッチ管理の責務として、本サーバは触れない契約。

## 主要変更

- **コア (`rshogi-csa-server`)**: `storage::players_yaml::PlayersYamlRateStorage` を新設。Ruby Symbol キー（`:name`/`:rate`/`:win`/`:loss`/`:last_game_id`/`:last_modified`）を `serde_yaml` で読み書き、`BTreeMap` で byte-stable な出力を保証。`RateStorage` trait に `record_game_outcome` を default 実装で追加し、`PlayersYamlRateStorage` は disk_lock 配下で「キャッシュ更新 → 全件 snapshot → tmpfile + rename」を 1 critical section に閉じ込めて lost-update を防ぐ。`FloodgateFeatureIntent::enable_persistent_player_rates` を追加し gate に配線。
- **TCP frontend**: `ServerConfig::players_yaml_path: Option<PathBuf>` を追加。`floodgate_intent_from_config` が `Some` 時に `enable_persistent_player_rates` を立て、`--allow-floodgate-features` opt-in が無いと `prepare_runtime` が起動を fail-fast。`persist_kifu` の最後で `record_game_outcome` を呼んで終局時のレート関連フィールドを atomic に更新。`bin/main.rs` に `--players-yaml <PATH>` CLI flag を追加し、`run_with_state` ヘルパで monomorphize して YAML / インメモリ両経路が同じ accept ループを通る。

## クリーンルーム方針

Ruby shogi-server / mk_rate / mk_html のソースは参照せず、design.md 1110 行の公開フォーマット情報のみから実装。CI に外部 Ruby ランタイムや shogi-server リポジトリは引かない（task 21.1 の互換ゲート方針を継承）。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (debug + release)
- [x] `cargo test --workspace --release`
- [x] `players_yaml` 単体テスト 11 件で:
  - byte-stable golden YAML 出力 / round-trip parse-serialize
  - `:last_game_id:` 省略レコード許容 / 不正 YAML → `Malformed` / 空ファイル → 空 map / ファイル不在 → 空 map
  - `record_game_outcome` の勝敗増分・千日手据置・`:rate` 非介入・`ensure_default_records` の上書き禁止
  - `save` 後にディスクから再ロードして round-trip
- [x] `prepare_runtime` の YAML opt-in / fail-fast 契約 3 件 + `floodgate_intent_from_config` の `players_yaml_path` 反映 1 件

## 持ち越し（明示）

- **Workers 側 KV レート永続化** (`WorkersKvRateStorage`) は本 PR 範囲外。Hibernation 1-isolate モデルでは TCP の `disk_lock` + atomic file write 経路と別実装が必要。task 9.4 の SQLite Storage 再利用を含めて、Workers Floodgate 必要時に別タスクで切り出す。
- **クロスプロセス書き込み**: 同一 `players.yaml` を複数プロセスから書く運用は YAGNI（shogi-server 標準運用は単一プロセス）。`flock(2)` advisory lock は導入していない。
- **`last_modified` 形式**: RFC3339 で出力。Ruby `Time.now.to_yaml` の `2026-04-26 12:34:56.000000000 +00:00` 形式とは構文が異なるが、YAML 1.2 timestamp として両方有効で、parse 時は `String` 保持。
- **新規プレイヤ登録 UI / API**: TOML handle が単一の真理ソース。動的追加 admin API は未実装（YAGNI）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)