### PR TITLE
feat(csa-server): Floodgate スケジュール宣言と定刻起動マッチメイクを追加 (task 15.1)

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -57,6 +57,12 @@ struct Cli {
     /// `--allow-floodgate-features` の opt-in が立っていない場合は起動が失敗する。
     #[arg(long, value_name = "PATH")]
     players_yaml: Option<PathBuf>,
+    /// Floodgate スケジュール宣言の TOML パス。`[[schedules]]` 配列で複数の
+    /// スケジュールを指定できる（`game_name` / `weekday` / `hour` / `minute` /
+    /// `clock` / `pairing_strategy`）。指定すると定刻起動マッチメイクが有効化
+    /// され、`--allow-floodgate-features` opt-in が必須になる。
+    #[arg(long, value_name = "PATH")]
+    floodgate_schedule_toml: Option<PathBuf>,
     /// 秒読み方式 / Fischer 方式で使う持ち時間 (秒)。
     #[arg(long, default_value_t = 600)]
     total_time_sec: u32,
@@ -182,6 +188,14 @@ fn main() -> anyhow::Result<()> {
         .with_context(|| format!("failed to load players file {:?}", cli.players))?;
     let password_store = InMemoryPasswordStore { map: password_map };
 
+    // Floodgate スケジュール TOML を読み込む（指定時のみ）。
+    let floodgate_schedules = if let Some(path) = cli.floodgate_schedule_toml.as_ref() {
+        load_floodgate_schedule_toml(path)
+            .with_context(|| format!("failed to load floodgate schedule TOML at {path:?}"))?
+    } else {
+        Vec::new()
+    };
+
     // 2. ServerConfig を構築。
     let config = ServerConfig {
         bind_addr,
@@ -205,6 +219,7 @@ fn main() -> anyhow::Result<()> {
         // ブロックが分岐ごとに `cli.players_yaml` の所有権を取れるよう、ここでは
         // 1 回だけ clone する（残りはそのまま move される）。
         players_yaml_path: cli.players_yaml.clone(),
+        floodgate_schedules,
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が
@@ -280,6 +295,16 @@ where
     let handle = run_server(state.clone()).await.context("run_server")?;
     tracing::info!("rshogi-csa-server-tcp ready");
 
+    // Floodgate スケジューラを起動。`floodgate_schedules` が空なら無動作。
+    // `run_schedules` は各スケジュールを `spawn_local` で独立タスク化して
+    // JoinHandle を返す。各タスクは内部で `state.shutdown` を監視して
+    // shutdown 時に自動終了する。
+    let scheduler_handles = rshogi_csa_server_tcp::scheduler::run_schedules(state.clone())
+        .map_err(|msg| anyhow::anyhow!("failed to start floodgate scheduler: {msg}"))?;
+    if !scheduler_handles.is_empty() {
+        tracing::info!(schedules = scheduler_handles.len(), "floodgate scheduler tasks started");
+    }
+
     // SIGINT と SIGTERM を並列待機する。SIGINT は Ctrl-C、SIGTERM は
     // systemd / Docker / Kubernetes の停止シグナル。
     let sig = wait_for_termination_signal().await;
@@ -299,6 +324,13 @@ where
         Err(e) => {
             tracing::info!(error = %e, "accept loop joined with error");
         }
+    }
+
+    // 2.5 scheduler tasks の完了も待つ。`state.shutdown` が立っているので各
+    //     スケジューラループは select! で抜けて自然終了する。残りの対局完了は
+    //     後続の active_drive_tasks 待機で吸収する。
+    for h in scheduler_handles {
+        let _ = h.await;
     }
 
     // 3. 進行中対局が終局するまで待つ。grace を超過したら warning を出して
@@ -450,6 +482,36 @@ fn load_players_toml(
         );
     }
     Ok((password_map, rate_map))
+}
+
+/// Floodgate スケジュール TOML を読む。
+///
+/// 期待する形式:
+/// ```toml
+/// [[schedules]]
+/// game_name = "floodgate-600-10"
+/// weekday = "Mon"
+/// hour = 13
+/// minute = 0
+/// pairing_strategy = "direct"
+///
+/// [schedules.clock]
+/// kind = "countdown"
+/// total_time_sec = 600
+/// byoyomi_sec = 10
+/// ```
+fn load_floodgate_schedule_toml(
+    path: &std::path::Path,
+) -> anyhow::Result<Vec<rshogi_csa_server::FloodgateSchedule>> {
+    use serde::Deserialize;
+    #[derive(Debug, Deserialize)]
+    struct Root {
+        #[serde(default)]
+        schedules: Vec<rshogi_csa_server::FloodgateSchedule>,
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let root: Root = toml::from_str(&raw)?;
+    Ok(root.schedules)
 }
 
 /// インメモリの `RateStorage`。再起動時は players.toml から再構築する前提で、

--- a/crates/rshogi-csa-server-tcp/src/lib.rs
+++ b/crates/rshogi-csa-server-tcp/src/lib.rs
@@ -23,6 +23,7 @@ pub mod auth;
 pub mod broadcaster;
 pub mod metrics;
 pub mod rate_limit;
+pub mod scheduler;
 pub mod server;
 pub mod transport;
 

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -44,6 +44,8 @@ use tokio::sync::oneshot;
 
 use crate::server::{MatchRequest, PasswordStore, SharedState, WaitingSlot, drive_game};
 use crate::transport::TcpTransport;
+use rshogi_csa_server::ClientTransport;
+use rshogi_csa_server::types::CsaLine;
 
 /// `tokio::time::sleep_until` ベースの `FloodgateTimer` 実装。
 ///
@@ -107,6 +109,47 @@ where
 }
 
 async fn run_one_schedule<R, K, P, T>(
+    state: Rc<SharedState<R, K, P>>,
+    schedule: FloodgateSchedule,
+    strategy: Box<dyn PairingLogic>,
+    timer: T,
+) where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    T: FloodgateTimer + 'static,
+{
+    // release ビルドでは scheduler ループ全体を `catch_unwind` で囲み、`fire_schedule`
+    // 内で起きた panic がこのスケジュールタスクを静かに殺すのを防ぐ。catch 後は
+    // `tracing::error!` で記録してタスクは終了させる（再 spawn は YAGNI）。debug
+    // ビルドでは透過させて契約違反を顕在化させる（CLAUDE.md 「契約違反は panic」
+    // 方針）。`AssertUnwindSafe` の根拠は `run_connection_isolated` と同様で、
+    // SharedState の可変フィールドは Mutex / Atomic / Notify で構成されており、
+    // `drive_game` 側の `DriveGuard` Drop で in-flight 状態は巻き戻る。
+    #[cfg(debug_assertions)]
+    {
+        run_one_schedule_loop(state, schedule, strategy, timer).await;
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        use futures_util::FutureExt;
+        let game_name_for_log = schedule.game_name.clone();
+        let fut =
+            std::panic::AssertUnwindSafe(run_one_schedule_loop(state, schedule, strategy, timer));
+        match fut.catch_unwind().await {
+            Ok(()) => {}
+            Err(payload) => {
+                tracing::error!(
+                    game_name = %game_name_for_log,
+                    panic_payload = %crate::server::panic_payload_to_string(payload.as_ref()),
+                    "scheduler task panicked; isolated to this schedule"
+                );
+            }
+        }
+    }
+}
+
+async fn run_one_schedule_loop<R, K, P, T>(
     state: Rc<SharedState<R, K, P>>,
     schedule: FloodgateSchedule,
     strategy: Box<dyn PairingLogic>,
@@ -189,6 +232,11 @@ pub(crate) async fn fire_schedule<R, K, P>(
             preferred_color: Some(s.color),
         })
         .collect();
+    // 注: 現在配線されている戦略 [`DirectMatchStrategy`] は最初に見つかった
+    // 1 ペアだけを返す（複数ペア成立は未対応）。`pairs.len()` を引数に下流処理
+    // を組んでいるが、`"direct"` 経由では最大 1 ペアに収束する。複数ペア対応
+    // は Floodgate の `"least_diff"` 戦略を入れるタスクで multi-pair 対応戦略を
+    // 追加して切り替える想定。
     let pairs = strategy.try_pair(&candidates);
     tracing::info!(
         game_name = %schedule.game_name,
@@ -249,6 +297,15 @@ pub(crate) async fn fire_schedule<R, K, P>(
 /// `spawn_local` で起動する。`drive_game` は片方の waiter（black）の done_tx を
 /// 消費して終局通知するので、もう片方（white）の done_tx は本関数が drive 完了
 /// 後に手動で signal する。
+///
+/// 異常系（handoff 失敗 / transport recv 失敗）では:
+/// - 既に確定した側の transport は `##[ERROR]` 通知してから close
+/// - **両 player を `League` から logout**（`drain_for_game_name` で WaitingPool
+///   からは除去済みなので、League を生で残すと再 LOGIN が `AlreadyLoggedIn` で
+///   弾かれる leak になるため）
+/// - drop により残った oneshot は recv Err になり、surviving waiter は
+///   `WaiterOutcome::Completed` 経路で抜ける（drive_game に到達していないため
+///   logout は本関数が代行する）
 async fn spawn_scheduled_drive<R, K, P>(
     state: Rc<SharedState<R, K, P>>,
     game_name: GameName,
@@ -286,22 +343,33 @@ async fn spawn_scheduled_drive<R, K, P>(
             white_alive = w_handoff_ok,
             "scheduled match handoff failed (waiter disconnected before handoff)"
         );
-        // 残った transport_responder / done_tx は drop により waiter が
-        // recv エラーで起床し、`run_waiter` 内のリカバリ経路で再キューされる。
+        // WaitingPool からは drain 済みで、drive_game にも到達していないので
+        // League エントリは本関数が責任を持って除去する。
+        logout_pair(&state, &black_handle, &white_handle).await;
         return;
     }
 
-    // 両 waiter から transport を吸い上げる。`recv` 失敗（waiter 直後切断）時は
-    // 残った片側の done_tx を drop して waiter を起こし、リカバリさせる。
+    // 両 waiter から transport を吸い上げる。`recv` 失敗（waiter 直後切断）時は:
+    // - 確定した側の transport には `##[ERROR]` 通知を送って drop（無音切断回避）
+    // - 双方とも League から logout（drive_game に到達しないため孤児化防止）
     let (b_transport, w_transport) = match (b_resp_rx.await, w_resp_rx.await) {
         (Ok(b), Ok(w)) => (b, w),
-        (Ok(_), Err(_)) | (Err(_), Ok(_)) | (Err(_), Err(_)) => {
+        (got_black, got_white) => {
             tracing::warn!(
                 game_name = %game_name.as_str(),
                 black = %black_handle,
                 white = %white_handle,
-                "scheduled match handoff: transport recv failed; aborting drive spawn"
+                black_recv_ok = got_black.is_ok(),
+                white_recv_ok = got_white.is_ok(),
+                "scheduled match handoff: transport recv failed; aborting"
             );
+            if let Ok(mut surviving) = got_black {
+                notify_aborted_match(&mut surviving, &game_name).await;
+            }
+            if let Ok(mut surviving) = got_white {
+                notify_aborted_match(&mut surviving, &game_name).await;
+            }
+            logout_pair(&state, &black_handle, &white_handle).await;
             return;
         }
     };
@@ -338,9 +406,28 @@ async fn spawn_scheduled_drive<R, K, P>(
             );
         }
     });
+}
 
-    // ペアリング選好で「ここまでで未消費の handle 文字列」を log に残しておく。
-    let _ = (black_handle, white_handle); // 既に閉じ込め済みだが、move 検証用。
+/// abort 経路で確定した transport に対し、`##[ERROR]` 通知を 1 行送ってから
+/// 接続を閉じる。送信失敗（既に切断済み等）は best-effort で無視する。
+async fn notify_aborted_match(transport: &mut TcpTransport, game_name: &GameName) {
+    let line = CsaLine::new(format!(
+        "##[ERROR] scheduled match aborted: opponent disconnected for {game_name}"
+    ));
+    let _ = transport.send_line(&line).await;
+}
+
+/// `drain_for_game_name` で WaitingPool から取り出した両 player を League から
+/// logout する。drive_game に到達できなかった経路で必ず呼ぶ（League 孤児化防止）。
+async fn logout_pair<R, K, P>(state: &SharedState<R, K, P>, black: &str, white: &str)
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let mut league = state.league.lock().await;
+    league.logout(&PlayerName::new(black));
+    league.logout(&PlayerName::new(white));
 }
 
 #[cfg(test)]

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -1,0 +1,386 @@
+//! Floodgate スケジューラ実行系（TCP frontend 用）。
+//!
+//! コア crate `rshogi_csa_server::scheduler` で定義された値型 / trait
+//! ([`FloodgateSchedule`] / [`FloodgateTimer`]) を実装し、tokio current_thread
+//! ランタイム上でスケジュール定刻にマッチメイクを発火する。
+//!
+//! # ライフサイクル
+//!
+//! [`run_schedules`] が `state.config.floodgate_schedules` の各エントリを
+//! 独立した tokio task に配って起動する。各タスクは:
+//!
+//! 1. `next_fire_after(now)` で次回発火 UTC 時刻を算出
+//! 2. `FloodgateTimer::wait_until` または shutdown シグナルを `tokio::select!`
+//!    で並列待機
+//! 3. shutdown が立った場合は即座に終了。発火タイミングが先に来たら
+//!    [`fire_schedule`] を呼んで 1 周分マッチメイクし、ループに戻る
+//!
+//! # `fire_schedule` のフロー
+//!
+//! 1. `WaitingPool::drain_for_game_name` で当該 `game_name` の全 slot を取得
+//! 2. `PairingLogic::try_pair` で `Vec<MatchedPair>` を計算
+//! 3. ペア化された slot は両 waiter に [`MatchRequest`] を送って transport を
+//!    吸い上げ、`drive_game` を `spawn_local` で起動
+//! 4. ペア化されなかった slot は WaitingPool に再 push（次回まで待機）
+//!
+//! # 既知の制約（後続タスクで対応）
+//!
+//! - **per-schedule clock**: 現状は `state.config.clock`（global）を使う。
+//!   スケジュール毎に異なる時計（`floodgate-600-10` と `floodgate-180-3` 等）
+//!   をサポートするには `drive_game` のシグネチャに `ClockSpec` 引数を足して
+//!   呼び出し側で上書きする必要があり、本タスクの範囲外として持ち越し。
+//! - **buoy / 駒落ち**: スケジューラ起動の対局は常に平手（`initial_sfen = None`）。
+//!   駒落ちサポートはタスク 15.4 で対応する。
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use chrono::{DateTime, Utc};
+use rshogi_csa_server::matching::pairing::{DirectMatchStrategy, PairingLogic};
+use rshogi_csa_server::scheduler::{FloodgateSchedule, FloodgateTimer};
+use rshogi_csa_server::types::{Color, GameName, PlayerName};
+use rshogi_csa_server::{KifuStorage, PairingCandidate, RateStorage};
+use tokio::sync::oneshot;
+
+use crate::server::{MatchRequest, PasswordStore, SharedState, WaitingSlot, drive_game};
+use crate::transport::TcpTransport;
+
+/// `tokio::time::sleep_until` ベースの `FloodgateTimer` 実装。
+///
+/// `current_thread` ランタイム上で動き、deadline までスリープする。deadline が
+/// 既に過去であれば即座に return する（spurious tick 等の安全側挙動）。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokioFloodgateTimer;
+
+impl FloodgateTimer for TokioFloodgateTimer {
+    async fn wait_until(&self, deadline: DateTime<Utc>) {
+        let now = Utc::now();
+        let dur = (deadline - now).to_std().unwrap_or(std::time::Duration::ZERO);
+        if dur.is_zero() {
+            return;
+        }
+        tokio::time::sleep(dur).await;
+    }
+}
+
+/// `pairing_strategy` 文字列からペアリング戦略インスタンスを構築する。
+///
+/// `"direct"` のみ本タスクで配線する。`"least_diff"` 等の Floodgate 系戦略は
+/// 別タスクで `Box<dyn PairingLogic>` 化するクロージャを足す形で拡張する。
+/// 未知の名前は起動時に `Err` で fail-fast する（`run_schedules` 経由で）。
+pub(crate) fn build_strategy(name: &str) -> Result<Box<dyn PairingLogic>, String> {
+    match name {
+        "direct" => Ok(Box::new(DirectMatchStrategy)),
+        other => Err(format!("unknown pairing_strategy {other:?}; supported: \"direct\"")),
+    }
+}
+
+/// 全 [`FloodgateSchedule`] をそれぞれ独立した task に乗せて起動する。
+///
+/// 戻り値は spawn された各 task の `JoinHandle<()>`。`run_server` 起動と並行に
+/// `tokio::task::spawn_local` で呼ばれることを想定する。各 task は内部で
+/// `state.shutdown` を監視し、shutdown 時に自動終了する。main 側は join handle
+/// を保持し、shutdown 後の `await` で終了確認する。
+///
+/// 戦略構築は task spawn より前にまとめて行い、未知 strategy 名は起動段階で
+/// `Err` を返す（run loop に入ってから初めて detected すると、無音でスケジュール
+/// が動かない事故になりうる）。
+pub fn run_schedules<R, K, P>(
+    state: Rc<SharedState<R, K, P>>,
+) -> Result<Vec<tokio::task::JoinHandle<()>>, String>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let schedules = state.config().floodgate_schedules.clone();
+    let mut handles = Vec::with_capacity(schedules.len());
+    for schedule in schedules {
+        let strategy = build_strategy(&schedule.pairing_strategy)?;
+        let s = state.clone();
+        let h = tokio::task::spawn_local(async move {
+            run_one_schedule(s, schedule, strategy, TokioFloodgateTimer).await;
+        });
+        handles.push(h);
+    }
+    Ok(handles)
+}
+
+async fn run_one_schedule<R, K, P, T>(
+    state: Rc<SharedState<R, K, P>>,
+    schedule: FloodgateSchedule,
+    strategy: Box<dyn PairingLogic>,
+    timer: T,
+) where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    T: FloodgateTimer + 'static,
+{
+    let game_name_for_log = schedule.game_name.clone();
+    loop {
+        if state.shutdown.is_triggered() {
+            tracing::info!(
+                game_name = %game_name_for_log,
+                "scheduler task exiting (shutdown triggered)"
+            );
+            return;
+        }
+        let now = Utc::now();
+        let next_fire = schedule.next_fire_after(now);
+        tracing::info!(
+            game_name = %game_name_for_log,
+            strategy = strategy.name(),
+            next_fire = %next_fire,
+            "scheduler waiting for next fire"
+        );
+        tokio::select! {
+            _ = timer.wait_until(next_fire) => {}
+            _ = state.shutdown.wait() => {
+                tracing::info!(
+                    game_name = %game_name_for_log,
+                    "scheduler task exiting (shutdown signal during wait)"
+                );
+                return;
+            }
+        }
+        // shutdown が wait_until 完了と同時に立っていた場合は fire しない。
+        if state.shutdown.is_triggered() {
+            return;
+        }
+        fire_schedule(state.clone(), &schedule, strategy.as_ref()).await;
+    }
+}
+
+/// 1 回分のマッチメイク発火: 待機 slot を取得 → ペア化 → drive_game を spawn。
+///
+/// 副作用は state.waiting / state.league（drive_game 内）/ tokio::task::spawn_local
+/// に閉じる。ペアリング戦略の純関数部分とテスト容易性のため、戦略は呼び出し側が
+/// `&dyn PairingLogic` で渡す（`run_schedules` 経路では `Box<dyn ...>` を借りる）。
+pub(crate) async fn fire_schedule<R, K, P>(
+    state: Rc<SharedState<R, K, P>>,
+    schedule: &FloodgateSchedule,
+    strategy: &dyn PairingLogic,
+) where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let game_name = schedule.game_name();
+
+    // 1. WaitingPool から当該 game_name の全 slot を抜き取る。
+    let drained: Vec<WaitingSlot> = {
+        let mut pool = state.waiting.lock().await;
+        pool.drain_for_game_name(&game_name)
+    };
+    if drained.is_empty() {
+        tracing::info!(
+            game_name = %schedule.game_name,
+            "scheduler fired but no waiters were in the pool"
+        );
+        return;
+    }
+
+    // 2. PairingCandidate に変換して戦略を回す。
+    let candidates: Vec<PairingCandidate> = drained
+        .iter()
+        .map(|s| PairingCandidate {
+            name: PlayerName::new(&s.handle),
+            preferred_color: Some(s.color),
+        })
+        .collect();
+    let pairs = strategy.try_pair(&candidates);
+    tracing::info!(
+        game_name = %schedule.game_name,
+        waiters = drained.len(),
+        pairs = pairs.len(),
+        strategy = strategy.name(),
+        "scheduler fired"
+    );
+
+    // 3. ペア成立した slot と未成立 slot に分割。
+    let mut by_handle: HashMap<String, WaitingSlot> =
+        drained.into_iter().map(|s| (s.handle.clone(), s)).collect();
+    let mut to_drive: Vec<(WaitingSlot, WaitingSlot)> = Vec::with_capacity(pairs.len());
+    for pair in &pairs {
+        let black = by_handle.remove(pair.black.as_str());
+        let white = by_handle.remove(pair.white.as_str());
+        match (black, white) {
+            (Some(b), Some(w)) => to_drive.push((b, w)),
+            // どちらか取り出せなかったケース: 戦略が不整合な MatchedPair を返した
+            // 異常系。戦略実装の不変条件違反として log のみ残し、両 slot は
+            // 残置（後で leftover として再キュー）。
+            (b, w) => {
+                if let Some(slot) = b {
+                    by_handle.insert(slot.handle.clone(), slot);
+                }
+                if let Some(slot) = w {
+                    by_handle.insert(slot.handle.clone(), slot);
+                }
+                tracing::warn!(
+                    game_name = %schedule.game_name,
+                    pair_black = %pair.black.as_str(),
+                    pair_white = %pair.white.as_str(),
+                    "pairing strategy returned a MatchedPair with handles not in candidate set"
+                );
+            }
+        }
+    }
+
+    // 4. 不成立 slot を WaitingPool に再 push（決定論的順序）。
+    {
+        let mut pool = state.waiting.lock().await;
+        let mut leftover: Vec<WaitingSlot> = by_handle.into_values().collect();
+        leftover.sort_by(|a, b| a.handle.cmp(&b.handle));
+        for slot in leftover {
+            pool.push(game_name.clone(), slot);
+        }
+    }
+
+    // 5. 成立ペアごとに transport を吸い上げて drive_game を spawn。
+    for (black, white) in to_drive {
+        spawn_scheduled_drive(state.clone(), game_name.clone(), black, white).await;
+    }
+}
+
+/// 1 ペア分の transport handoff と drive_game spawn。
+///
+/// 両 waiter に [`MatchRequest`] を送って transport を回収し、`drive_game` を
+/// `spawn_local` で起動する。`drive_game` は片方の waiter（black）の done_tx を
+/// 消費して終局通知するので、もう片方（white）の done_tx は本関数が drive 完了
+/// 後に手動で signal する。
+async fn spawn_scheduled_drive<R, K, P>(
+    state: Rc<SharedState<R, K, P>>,
+    game_name: GameName,
+    black: WaitingSlot,
+    white: WaitingSlot,
+) where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let (b_resp_tx, b_resp_rx) = oneshot::channel::<TcpTransport>();
+    let (b_done_tx, b_done_rx) = oneshot::channel::<()>();
+    let (w_resp_tx, w_resp_rx) = oneshot::channel::<TcpTransport>();
+    let (w_done_tx, w_done_rx) = oneshot::channel::<()>();
+
+    let b_req = MatchRequest {
+        transport_responder: b_resp_tx,
+        completion_rx: b_done_rx,
+    };
+    let w_req = MatchRequest {
+        transport_responder: w_resp_tx,
+        completion_rx: w_done_rx,
+    };
+
+    let black_handle = black.handle.clone();
+    let white_handle = white.handle.clone();
+    let b_handoff_ok = black.match_request_tx.send(b_req).is_ok();
+    let w_handoff_ok = white.match_request_tx.send(w_req).is_ok();
+    if !b_handoff_ok || !w_handoff_ok {
+        tracing::warn!(
+            game_name = %game_name.as_str(),
+            black = %black_handle,
+            white = %white_handle,
+            black_alive = b_handoff_ok,
+            white_alive = w_handoff_ok,
+            "scheduled match handoff failed (waiter disconnected before handoff)"
+        );
+        // 残った transport_responder / done_tx は drop により waiter が
+        // recv エラーで起床し、`run_waiter` 内のリカバリ経路で再キューされる。
+        return;
+    }
+
+    // 両 waiter から transport を吸い上げる。`recv` 失敗（waiter 直後切断）時は
+    // 残った片側の done_tx を drop して waiter を起こし、リカバリさせる。
+    let (b_transport, w_transport) = match (b_resp_rx.await, w_resp_rx.await) {
+        (Ok(b), Ok(w)) => (b, w),
+        (Ok(_), Err(_)) | (Err(_), Ok(_)) | (Err(_), Err(_)) => {
+            tracing::warn!(
+                game_name = %game_name.as_str(),
+                black = %black_handle,
+                white = %white_handle,
+                "scheduled match handoff: transport recv failed; aborting drive spawn"
+            );
+            return;
+        }
+    };
+
+    // drive_game は black の done_tx を消費して終局通知する。white の done_tx は
+    // 本関数のクロージャに残し、drive 完了後に手動 signal する。
+    let game_name_for_task = game_name.clone();
+    let black_handle_for_task = black_handle.clone();
+    let white_handle_for_task = white_handle.clone();
+    tokio::task::spawn_local(async move {
+        let result = drive_game(
+            state,
+            // drive_game の引数は (opp_*, self_*) 並び。Floodgate 経路では
+            // どちらも waiter なので役割は対称。black を「opp 役」（drive_game が
+            // done_tx を消費する側）に割り当てる。
+            b_transport,
+            black_handle_for_task.clone(),
+            Color::Black,
+            w_transport,
+            white_handle_for_task.clone(),
+            Color::White,
+            game_name_for_task,
+            None, // initial_sfen — buoy/駒落ち は本タスクの範囲外
+            b_done_tx,
+        )
+        .await;
+        let _ = w_done_tx.send(());
+        if let Err(e) = result {
+            tracing::error!(
+                error = %e,
+                black = %black_handle_for_task,
+                white = %white_handle_for_task,
+                "scheduled drive_game returned error"
+            );
+        }
+    });
+
+    // ペアリング選好で「ここまでで未消費の handle 文字列」を log に残しておく。
+    let _ = (black_handle, white_handle); // 既に閉じ込め済みだが、move 検証用。
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_strategy` が `"direct"` を受理し、その他はエラーにする契約を固定。
+    /// 15.2 で `"least_diff"` 等を追加するときに本テストを更新する。
+    #[test]
+    fn build_strategy_accepts_direct_and_rejects_unknown() {
+        // `dyn PairingLogic` は Debug 非実装なので `unwrap` ベースのアサートは
+        // 通らない。match で取り出して name() を確認する。
+        match build_strategy("direct") {
+            Ok(s) => assert_eq!(s.name(), "direct"),
+            Err(e) => panic!("direct must be accepted, got Err: {e}"),
+        }
+
+        let err = expect_err(build_strategy("least_diff"));
+        assert!(err.contains("least_diff"), "error must mention input: {err}");
+
+        let err = expect_err(build_strategy("unknown"));
+        assert!(err.contains("\"unknown\""));
+    }
+
+    fn expect_err(r: Result<Box<dyn PairingLogic>, String>) -> String {
+        match r {
+            Ok(_) => panic!("expected Err but got Ok"),
+            Err(e) => e,
+        }
+    }
+
+    /// `TokioFloodgateTimer::wait_until` が「過去 deadline」を渡されても即座に
+    /// return する契約を固定。spurious tick やシステム時刻ジャンプで scheduler
+    /// が無限ループ的に長時間スリープするのを防ぐ。
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn tokio_timer_wait_until_returns_immediately_for_past_deadline() {
+        let timer = TokioFloodgateTimer;
+        let past = Utc::now() - chrono::Duration::seconds(10);
+        // start_paused のため `tokio::time::sleep` は明示的に進めないと進まないが、
+        // `dur.is_zero()` 早期 return 経路を通るため即 return する。
+        timer.wait_until(past).await;
+    }
+}

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -298,8 +298,11 @@ pub(crate) async fn fire_schedule<R, K, P>(
 /// 消費して終局通知するので、もう片方（white）の done_tx は本関数が drive 完了
 /// 後に手動で signal する。
 ///
-/// 異常系（handoff 失敗 / transport recv 失敗）では:
-/// - 既に確定した側の transport は `##[ERROR]` 通知してから close
+/// 異常系（`MatchRequest` 配送失敗 / transport recv 失敗）では:
+/// - 既に `MatchRequest` が届いた側 waiter は `transport_responder.send` を
+///   呼んで transport を引き渡そうとしているので、本関数が responder_rx を
+///   `await` して transport を回収し `##[ERROR]` 通知してから close する
+///   （片側瞬断 partial handoff 経路でも生存側を無通知切断しない）
 /// - **両 player を `League` から logout**（`drain_for_game_name` で WaitingPool
 ///   からは除去済みなので、League を生で残すと再 LOGIN が `AlreadyLoggedIn` で
 ///   弾かれる leak になるため）
@@ -343,6 +346,19 @@ async fn spawn_scheduled_drive<R, K, P>(
             white_alive = w_handoff_ok,
             "scheduled match handoff failed (waiter disconnected before handoff)"
         );
+        // 片側だけ MatchRequest が届いたケースでは、生存側 waiter は
+        // `transport_responder.send(transport)` を呼んで transport を引き渡そうと
+        // している（[`run_waiter`] 設計）。本関数が即 return すると responder_rx
+        // が drop されて waiter 側が `MatchHandoffFailed` で無通知切断する。
+        // 既存の `(Ok, Err) | (Err, Ok)` recv 経路と同じ扱いに統一し、生存側
+        // transport を吸い上げて `##[ERROR]` 通知を送ってから drop することで
+        // 片側瞬断時でも健全側 player に切断理由を残す。
+        if b_handoff_ok && let Ok(mut surviving) = b_resp_rx.await {
+            notify_aborted_match(&mut surviving, &game_name).await;
+        }
+        if w_handoff_ok && let Ok(mut surviving) = w_resp_rx.await {
+            notify_aborted_match(&mut surviving, &game_name).await;
+        }
         // WaitingPool からは drain 済みで、drive_game にも到達していないので
         // League エントリは本関数が責任を持って除去する。
         logout_pair(&state, &black_handle, &white_handle).await;

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -387,17 +387,37 @@ async fn spawn_scheduled_drive<R, K, P>(
         );
         // 片側だけ MatchRequest が届いたケースでは、生存側 waiter は
         // `transport_responder.send(transport)` を呼んで transport を引き渡そうと
-        // している（[`run_waiter`] 設計）。本関数が即 return すると responder_rx
-        // が drop されて waiter 側が `MatchHandoffFailed` で無通知切断する。
+        // している（waiter loop の MatchRequest 受信枝設計）。本関数が即 return
+        // すると responder_rx が drop されて waiter 側が無通知切断する。
         // 既存の `(Ok, Err) | (Err, Ok)` recv 経路と同じ扱いに統一し、生存側
         // transport を吸い上げて `##[ERROR]` 通知を送ってから drop することで
         // 片側瞬断時でも健全側 player に切断理由を残す。
         // `recv_transport_with_timeout` で `TRANSPORT_HANDOFF_TIMEOUT` を被せ、
         // waiter 側が応答を返せない deadlock 状態でも本経路は永久ブロックしない。
-        if b_handoff_ok && let Ok(mut surviving) = recv_transport_with_timeout(b_resp_rx).await {
+        // `tokio::join!` で b/w を並列に await することで、両 waiter 同時 deadlock
+        // 時にもブロック時間を最大 `TRANSPORT_HANDOFF_TIMEOUT` に抑える。`bool`
+        // ガード分岐を `async move` 内に閉じ込めることで、`b_handoff_ok = false`
+        // 側は `None` を即返し、もう片側の await を妨げない。
+        let (b_surviving, w_surviving) = tokio::join!(
+            async move {
+                if b_handoff_ok {
+                    recv_transport_with_timeout(b_resp_rx).await.ok()
+                } else {
+                    None
+                }
+            },
+            async move {
+                if w_handoff_ok {
+                    recv_transport_with_timeout(w_resp_rx).await.ok()
+                } else {
+                    None
+                }
+            },
+        );
+        if let Some(mut surviving) = b_surviving {
             notify_aborted_match(&mut surviving, &game_name).await;
         }
-        if w_handoff_ok && let Ok(mut surviving) = recv_transport_with_timeout(w_resp_rx).await {
+        if let Some(mut surviving) = w_surviving {
             notify_aborted_match(&mut surviving, &game_name).await;
         }
         // WaitingPool からは drain 済みで、drive_game にも到達していないので
@@ -412,8 +432,17 @@ async fn spawn_scheduled_drive<R, K, P>(
     // recv 失敗時は:
     // - 確定した側の transport には `##[ERROR]` 通知を送って drop（無音切断回避）
     // - 双方とも League から logout（drive_game に到達しないため孤児化防止）
-    let b_recv = recv_transport_with_timeout(b_resp_rx).await;
-    let w_recv = recv_transport_with_timeout(w_resp_rx).await;
+    //
+    // `tokio::join!` で b/w を並列に await することで、両 waiter 同時 deadlock 時
+    // にもブロック時間を最大 `TRANSPORT_HANDOFF_TIMEOUT` に抑える（順次 await だと
+    // 最悪 `2 * TRANSPORT_HANDOFF_TIMEOUT`）。`current_thread` ランタイム上でも
+    // `tokio::join!` は両 future を交互ポーリングするため、片側 timeout の間にも
+    // う片側の完了を進められる。multi-pair 戦略（`least_diff`）で複数ペアを順次
+    // handoff する経路では、deadlock ペアの後続ペア handoff への遅延波及を防ぐ。
+    let (b_recv, w_recv) = tokio::join!(
+        recv_transport_with_timeout(b_resp_rx),
+        recv_transport_with_timeout(w_resp_rx),
+    );
     let (b_transport, w_transport) = match (b_recv, w_recv) {
         (Ok(b), Ok(w)) => (b, w),
         (got_black, got_white) => {
@@ -566,10 +595,7 @@ mod tests {
         // sender (`_tx`) は drop せず保持したまま、仮想時刻だけ進める。
         // `start_paused` 下では `tokio::time::timeout` が auto-advance で
         // 即座に発火する（runtime が「次に進めるべき時刻」を検出する）。
-        let err = recv_transport_with_timeout(rx)
-            .await
-            .err()
-            .expect("timeout must produce Err");
+        let err = recv_transport_with_timeout(rx).await.err().expect("timeout must produce Err");
         assert!(
             matches!(err, TransportHandoffError::TimedOut),
             "expected TimedOut, got: {err:?}"

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -34,6 +34,7 @@
 
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use rshogi_csa_server::matching::pairing::{DirectMatchStrategy, PairingLogic};
@@ -46,6 +47,44 @@ use crate::server::{MatchRequest, PasswordStore, SharedState, WaitingSlot, drive
 use crate::transport::TcpTransport;
 use rshogi_csa_server::ClientTransport;
 use rshogi_csa_server::types::CsaLine;
+
+/// Floodgate 定刻発火で waiter から transport を回収する際の最大待機時間。
+///
+/// 通常 waiter は `MatchRequest` を受信した select! 枝で即座に
+/// `transport_responder.send(transport)` を呼ぶため、この timeout は ms 単位の
+/// 応答前提のセーフティネットとして 5 秒に置く。waiter 側が deadlock した場合
+/// （別 select 枝で stall 等）でも本 timeout で scheduler ループが永久ブロック
+/// するのを防ぐ。timeout 経過後の transport は abort 扱いで logout_pair の
+/// 経路に乗せる。
+const TRANSPORT_HANDOFF_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `transport_responder` の oneshot 受信に失敗した理由を区別する。
+///
+/// scheduler の handoff 経路で waiter が transport を引き渡せなかった場合の
+/// 内訳をログに残すため、`SenderDropped`（waiter loop が responder を drop）と
+/// `TimedOut`（[`TRANSPORT_HANDOFF_TIMEOUT`] 経過）を分ける。両者とも abort
+/// 経路に流すが、運用ログから「waiter が応答を返せない deadlock 状態」を
+/// 即特定できるようにする。
+#[derive(Debug, Clone, Copy)]
+enum TransportHandoffError {
+    /// waiter が transport を送る前に responder の sender 側が drop された
+    /// （waiter loop が exit / channel が壊れた等）。
+    SenderDropped,
+    /// `TRANSPORT_HANDOFF_TIMEOUT` を経過しても waiter が transport を送らなかった。
+    TimedOut,
+}
+
+/// `transport_responder` の受信に [`TRANSPORT_HANDOFF_TIMEOUT`] のタイムアウトを
+/// 被せる。timeout か sender drop のどちらでも `Err` で abort 経路に流す。
+async fn recv_transport_with_timeout(
+    rx: oneshot::Receiver<TcpTransport>,
+) -> Result<TcpTransport, TransportHandoffError> {
+    match tokio::time::timeout(TRANSPORT_HANDOFF_TIMEOUT, rx).await {
+        Ok(Ok(t)) => Ok(t),
+        Ok(Err(_)) => Err(TransportHandoffError::SenderDropped),
+        Err(_) => Err(TransportHandoffError::TimedOut),
+    }
+}
 
 /// `tokio::time::sleep_until` ベースの `FloodgateTimer` 実装。
 ///
@@ -353,10 +392,12 @@ async fn spawn_scheduled_drive<R, K, P>(
         // 既存の `(Ok, Err) | (Err, Ok)` recv 経路と同じ扱いに統一し、生存側
         // transport を吸い上げて `##[ERROR]` 通知を送ってから drop することで
         // 片側瞬断時でも健全側 player に切断理由を残す。
-        if b_handoff_ok && let Ok(mut surviving) = b_resp_rx.await {
+        // `recv_transport_with_timeout` で `TRANSPORT_HANDOFF_TIMEOUT` を被せ、
+        // waiter 側が応答を返せない deadlock 状態でも本経路は永久ブロックしない。
+        if b_handoff_ok && let Ok(mut surviving) = recv_transport_with_timeout(b_resp_rx).await {
             notify_aborted_match(&mut surviving, &game_name).await;
         }
-        if w_handoff_ok && let Ok(mut surviving) = w_resp_rx.await {
+        if w_handoff_ok && let Ok(mut surviving) = recv_transport_with_timeout(w_resp_rx).await {
             notify_aborted_match(&mut surviving, &game_name).await;
         }
         // WaitingPool からは drain 済みで、drive_game にも到達していないので
@@ -365,18 +406,26 @@ async fn spawn_scheduled_drive<R, K, P>(
         return;
     }
 
-    // 両 waiter から transport を吸い上げる。`recv` 失敗（waiter 直後切断）時は:
+    // 両 waiter から transport を吸い上げる。`recv_transport_with_timeout` で
+    // [`TRANSPORT_HANDOFF_TIMEOUT`] を被せ、waiter 直後切断（SenderDropped）と
+    // waiter deadlock（TimedOut）の両方を `Err` として abort 経路に流す。
+    // recv 失敗時は:
     // - 確定した側の transport には `##[ERROR]` 通知を送って drop（無音切断回避）
     // - 双方とも League から logout（drive_game に到達しないため孤児化防止）
-    let (b_transport, w_transport) = match (b_resp_rx.await, w_resp_rx.await) {
+    let b_recv = recv_transport_with_timeout(b_resp_rx).await;
+    let w_recv = recv_transport_with_timeout(w_resp_rx).await;
+    let (b_transport, w_transport) = match (b_recv, w_recv) {
         (Ok(b), Ok(w)) => (b, w),
         (got_black, got_white) => {
             tracing::warn!(
                 game_name = %game_name.as_str(),
                 black = %black_handle,
                 white = %white_handle,
-                black_recv_ok = got_black.is_ok(),
-                white_recv_ok = got_white.is_ok(),
+                // `Result::err()` で `Option<TransportHandoffError>` を取り出して
+                // `Debug` 出力する。`None` は recv 成功側、
+                // `Some(SenderDropped)` / `Some(TimedOut)` が失敗理由の内訳。
+                black_recv_err = ?got_black.as_ref().err(),
+                white_recv_err = ?got_white.as_ref().err(),
                 "scheduled match handoff: transport recv failed; aborting"
             );
             if let Ok(mut surviving) = got_black {
@@ -485,5 +534,45 @@ mod tests {
         // start_paused のため `tokio::time::sleep` は明示的に進めないと進まないが、
         // `dur.is_zero()` 早期 return 経路を通るため即 return する。
         timer.wait_until(past).await;
+    }
+
+    /// `recv_transport_with_timeout` の sender drop 経路: oneshot の sender 側
+    /// が drop されたら `Err(SenderDropped)` で即 return する（waiter loop が
+    /// transport を送る前に exit したケースの再現）。
+    ///
+    /// `TcpTransport` は `Debug` 非実装なので `Result` を `{:?}` で出さず、
+    /// `err()` 側だけ取り出して assert する。
+    #[tokio::test(flavor = "current_thread")]
+    async fn recv_transport_with_timeout_returns_sender_dropped_when_tx_drops() {
+        let (tx, rx) = oneshot::channel::<TcpTransport>();
+        drop(tx);
+        let err = recv_transport_with_timeout(rx)
+            .await
+            .err()
+            .expect("sender drop must produce Err");
+        assert!(
+            matches!(err, TransportHandoffError::SenderDropped),
+            "expected SenderDropped, got: {err:?}"
+        );
+    }
+
+    /// `recv_transport_with_timeout` の timeout 経路: tokio start_paused で
+    /// 仮想時刻を `TRANSPORT_HANDOFF_TIMEOUT` 超過まで進め、`Err(TimedOut)` を
+    /// 返すことを固定する。waiter 側が deadlock した場合に scheduler ループが
+    /// 永久ブロックしないことを保証する。
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn recv_transport_with_timeout_returns_timed_out_on_no_response() {
+        let (_tx, rx) = oneshot::channel::<TcpTransport>();
+        // sender (`_tx`) は drop せず保持したまま、仮想時刻だけ進める。
+        // `start_paused` 下では `tokio::time::timeout` が auto-advance で
+        // 即座に発火する（runtime が「次に進めるべき時刻」を検出する）。
+        let err = recv_transport_with_timeout(rx)
+            .await
+            .err()
+            .expect("timeout must produce Err");
+        assert!(
+            matches!(err, TransportHandoffError::TimedOut),
+            "expected TimedOut, got: {err:?}"
+        );
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -148,6 +148,16 @@ pub struct ServerConfig {
     /// [`floodgate_intent_from_config`] により intent に変換され、
     /// `--allow-floodgate-features` が立っていない場合は起動が `Err` で停止する。
     pub players_yaml_path: Option<std::path::PathBuf>,
+    /// 定刻起動でマッチメイクを発火する Floodgate スケジュール宣言。空 `Vec` は
+    /// 「スケジューラ無し」を意味する。非空の場合は Floodgate 運用機能
+    /// (`enable_scheduler`) として gate 経由で `--allow-floodgate-features`
+    /// opt-in を要求する。
+    ///
+    /// 各 [`FloodgateSchedule`](rshogi_csa_server::FloodgateSchedule) は独立した
+    /// スケジュールタスクで駆動され、UTC の `weekday × hour:minute` に到達した
+    /// 時点で当該 `game_name` の待機プールから候補を抽出し、`pairing_strategy`
+    /// が指定する戦略でペアを作って Game_Summary を送信する。
+    pub floodgate_schedules: Vec<rshogi_csa_server::FloodgateSchedule>,
     /// SIGINT / SIGTERM 受信後に進行中対局の終了を待つ上限。超過分は未完了の
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
     /// を落とさない」ためのバッファで、既定 60 秒。
@@ -171,6 +181,7 @@ impl ServerConfig {
             admin_handles: Vec::new(),
             allow_floodgate_features: false,
             players_yaml_path: None,
+            floodgate_schedules: Vec::new(),
             shutdown_grace: Duration::from_secs(60),
         }
     }
@@ -202,6 +213,9 @@ pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFe
         // `players.yaml` 永続化はレート互換運用機能なので、Floodgate 系機能の
         // opt-in が必要（`--allow-floodgate-features`）。
         enable_persistent_player_rates: config.players_yaml_path.is_some(),
+        // 定刻起動スケジュールも Floodgate 系機能。1 件以上のスケジュール宣言
+        // があれば opt-in 要求。
+        enable_scheduler: !config.floodgate_schedules.is_empty(),
         ..FloodgateFeatureIntent::default()
     }
 }
@@ -282,11 +296,15 @@ impl Default for GracefulShutdown {
 /// drive は自分の `completion_rx`（game 終了通知）と、waiter の transport を受け取るための
 /// `transport_responder` を両方含めて送る。waiter はこれを受け取ったら自分の transport を
 /// `transport_responder` で返送し、`completion_rx` を await して終局まで待機する。
-struct MatchRequest {
+///
+/// 通常の direct match 経路では `handle_connection` 内の drive 役が構築する。
+/// Floodgate scheduler 経路（`scheduler::fire_schedule`）でも同じ構造を使い、
+/// scheduler が両 waiter に MatchRequest を送って transport を吸い上げる。
+pub(crate) struct MatchRequest {
     /// waiter が自分の `TcpTransport` をここで返送する。
-    transport_responder: oneshot::Sender<TcpTransport>,
+    pub(crate) transport_responder: oneshot::Sender<TcpTransport>,
     /// drive 側が終局後に `send(())` する。waiter はこれを受けてタスクを終える。
-    completion_rx: oneshot::Receiver<()>,
+    pub(crate) completion_rx: oneshot::Receiver<()>,
 }
 
 /// 待機プール内の 1 スロット。
@@ -295,34 +313,50 @@ struct MatchRequest {
 /// drive 側はここに入っている [`oneshot::Sender<MatchRequest>`] を通して待機側へ
 /// マッチ確定を通知する。`take_complement` でプールから取り出された slot は、
 /// `match_request_tx.send(...)` の成否で waiter が健在かどうか判定できる。
-struct WaitingSlot {
+pub(crate) struct WaitingSlot {
     /// 認証後に確定した handle 単独部分（League へ登録した名前）。
-    handle: String,
+    pub(crate) handle: String,
     /// 希望手番。
-    color: Color,
+    pub(crate) color: Color,
     /// drive 側 → waiter への確定通知。
-    match_request_tx: oneshot::Sender<MatchRequest>,
+    pub(crate) match_request_tx: oneshot::Sender<MatchRequest>,
 }
 
 /// 待機プール。
 ///
 /// `game_name` 別にキューを持ち、各キュー内で先着順に保持する。
-/// drive 側は相補手番のスロットを先頭から順に探す。
+/// drive 側は相補手番のスロットを先頭から順に探す。Floodgate scheduler は
+/// [`Self::drain_for_game_name`] で当該 `game_name` の全 slot を一括取得する。
 #[derive(Default)]
-struct WaitingPool {
+pub(crate) struct WaitingPool {
     queues: HashMap<GameName, VecDeque<WaitingSlot>>,
 }
 
 impl WaitingPool {
-    fn push(&mut self, game_name: GameName, slot: WaitingSlot) {
+    pub(crate) fn push(&mut self, game_name: GameName, slot: WaitingSlot) {
         self.queues.entry(game_name).or_default().push_back(slot);
     }
 
     /// 相補手番のスロットを 1 件取り出す。見つからなければ `None`。
-    fn take_complement(&mut self, game_name: &GameName, want: Color) -> Option<WaitingSlot> {
+    pub(crate) fn take_complement(
+        &mut self,
+        game_name: &GameName,
+        want: Color,
+    ) -> Option<WaitingSlot> {
         let queue = self.queues.get_mut(game_name)?;
         let idx = queue.iter().position(|s| s.color == want.opposite())?;
         queue.remove(idx)
+    }
+
+    /// 指定 `game_name` の待機 slot を全て取り出してプールから消す。
+    ///
+    /// Floodgate scheduler の発火経路で使う。返却された `Vec` は元のキューの
+    /// 先着順を維持する。`None` 系（キュー自体が無い）の場合は空 `Vec` を返す。
+    pub(crate) fn drain_for_game_name(&mut self, game_name: &GameName) -> Vec<WaitingSlot> {
+        match self.queues.get_mut(game_name) {
+            Some(queue) => queue.drain(..).collect(),
+            None => Vec::new(),
+        }
     }
 
     /// 指定 handle のスロットをプールから除去する（待機中の切断検知時の掃除用）。
@@ -346,8 +380,8 @@ where
     P: PasswordStore + 'static,
 {
     config: ServerConfig,
-    league: Mutex<League>,
-    waiting: Mutex<WaitingPool>,
+    pub(crate) league: Mutex<League>,
+    pub(crate) waiting: Mutex<WaitingPool>,
     rate_limiter: IpLoginRateLimiter,
     broadcaster: InMemoryBroadcaster,
     rate_storage: R,
@@ -1502,7 +1536,7 @@ fn default_fork_buoy_name(source_game: &GameId, nth_move: Option<u32>) -> GameNa
 
 /// drive 側タスクのメインループ。両 transport を所有して 1 対局を完了まで運ぶ。
 #[allow(clippy::too_many_arguments)]
-async fn drive_game<R, K, P>(
+pub(crate) async fn drive_game<R, K, P>(
     state: Rc<SharedState<R, K, P>>,
     opp_transport: TcpTransport,
     opp_handle: String,

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -226,9 +226,30 @@ pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFe
 /// を [`validate_floodgate_feature_gate`] に通し、要求があるのにフラグが立って
 /// いない場合は `Err` を返して fail-fast する。CLI / バイナリは `build_state`
 /// より前に本関数を呼ぶこと。
+///
+/// あわせて Floodgate 機能の起動引数に対する shape 検証も行う（後段の
+/// `run_schedules` まで未知 strategy 名を運ばずに、起動時点で fail-fast する）。
 pub fn prepare_runtime(config: &ServerConfig) -> Result<(), String> {
     let intent = floodgate_intent_from_config(config);
-    validate_floodgate_feature_gate(config.allow_floodgate_features, intent)
+    validate_floodgate_feature_gate(config.allow_floodgate_features, intent)?;
+    validate_floodgate_schedule_strategies(&config.floodgate_schedules)?;
+    Ok(())
+}
+
+/// `floodgate_schedules` の各エントリの `pairing_strategy` 名が
+/// [`crate::scheduler::build_strategy`] で受理可能かを起動時点で検証する。
+///
+/// `run_schedules` 経路でも `build_strategy` が Err を返すが、その時点では
+/// `prepare_runtime` 通過後 `build_state` も済んでおり、エラーログの読みづらさ
+/// （初期化 panic と区別がつきづらい）が問題になる。本関数で先回り検証する。
+fn validate_floodgate_schedule_strategies(
+    schedules: &[rshogi_csa_server::FloodgateSchedule],
+) -> Result<(), String> {
+    for schedule in schedules {
+        crate::scheduler::build_strategy(&schedule.pairing_strategy)
+            .map_err(|e| format!("schedule {:?}: {}", schedule.game_name, e))?;
+    }
+    Ok(())
 }
 
 /// graceful shutdown 用トリガ。SIGINT / SIGTERM 受信で `trigger` され、
@@ -507,7 +528,7 @@ where
 /// 本関数は使われない。`#[cfg(not(debug_assertions))]` で release ビルド時のみ
 /// 定義することで、`#[allow(dead_code)]` 抑止に頼らずに dead_code 警告を回避する。
 #[cfg(not(debug_assertions))]
-fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
+pub(crate) fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         return (*s).to_owned();
     }
@@ -2429,5 +2450,55 @@ mod tests {
         assert!(!floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
         cfg.players_yaml_path = Some(std::path::PathBuf::from("/tmp/players.yaml"));
         assert!(floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
+    }
+
+    /// `floodgate_intent_from_config` が `floodgate_schedules` の非空で
+    /// `enable_scheduler` を立てることを直接固定。
+    #[test]
+    fn floodgate_intent_reflects_floodgate_schedules() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        assert!(!floodgate_intent_from_config(&cfg).enable_scheduler);
+        cfg.floodgate_schedules.push(rshogi_csa_server::FloodgateSchedule {
+            game_name: "floodgate-600-10".to_owned(),
+            weekday: rshogi_csa_server::FloodgateWeekday::Mon,
+            hour: 9,
+            minute: 0,
+            pairing_strategy: "direct".to_owned(),
+        });
+        assert!(floodgate_intent_from_config(&cfg).enable_scheduler);
+    }
+
+    /// `prepare_runtime` が `floodgate_schedules` の `pairing_strategy` を
+    /// 起動時点で検証する契約を固定。未知 strategy 名は run_schedules 経路に
+    /// 持ち込まれず、起動時点で fail-fast する（gate 通過後の後段失敗ではなく）。
+    #[test]
+    fn prepare_runtime_rejects_unknown_pairing_strategy() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        cfg.allow_floodgate_features = true;
+        cfg.floodgate_schedules.push(rshogi_csa_server::FloodgateSchedule {
+            game_name: "floodgate-600-10".to_owned(),
+            weekday: rshogi_csa_server::FloodgateWeekday::Mon,
+            hour: 9,
+            minute: 0,
+            pairing_strategy: "least_diff".to_owned(),
+        });
+        let err = prepare_runtime(&cfg).expect_err("unknown strategy must fail-fast");
+        assert!(err.contains("least_diff"), "error must mention strategy: {err}");
+        assert!(err.contains("floodgate-600-10"), "error must mention schedule: {err}");
+    }
+
+    /// `prepare_runtime` が `direct` strategy を accept することを固定。
+    #[test]
+    fn prepare_runtime_accepts_direct_pairing_strategy() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        cfg.allow_floodgate_features = true;
+        cfg.floodgate_schedules.push(rshogi_csa_server::FloodgateSchedule {
+            game_name: "floodgate-600-10".to_owned(),
+            weekday: rshogi_csa_server::FloodgateWeekday::Mon,
+            hour: 9,
+            minute: 0,
+            pairing_strategy: "direct".to_owned(),
+        });
+        prepare_runtime(&cfg).expect("direct strategy must pass prepare_runtime");
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -373,11 +373,13 @@ impl WaitingPool {
     ///
     /// Floodgate scheduler の発火経路で使う。返却された `Vec` は元のキューの
     /// 先着順を維持する。`None` 系（キュー自体が無い）の場合は空 `Vec` を返す。
+    /// `HashMap` の entry ごと `remove` するため、毎週発火で空 `VecDeque` が
+    /// プール内に累積しない（`drain(..)` 単体では entry が残る）。
     pub(crate) fn drain_for_game_name(&mut self, game_name: &GameName) -> Vec<WaitingSlot> {
-        match self.queues.get_mut(game_name) {
-            Some(queue) => queue.drain(..).collect(),
-            None => Vec::new(),
-        }
+        self.queues
+            .remove(game_name)
+            .map(|q| q.into_iter().collect())
+            .unwrap_or_default()
     }
 
     /// 指定 handle のスロットをプールから除去する（待機中の切断検知時の掃除用）。
@@ -2450,6 +2452,66 @@ mod tests {
         assert!(!floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
         cfg.players_yaml_path = Some(std::path::PathBuf::from("/tmp/players.yaml"));
         assert!(floodgate_intent_from_config(&cfg).enable_persistent_player_rates);
+    }
+
+    /// `WaitingPool::drain_for_game_name` が:
+    /// - 同 `game_name` 配下の slot を挿入順で全件返す
+    /// - 戻ったあと当該 `HashMap` entry は `remove` されている（空 `VecDeque`
+    ///   が累積しない）
+    /// - 他 `game_name` の entry は触らない
+    /// - 既に entry が無い場合は空 `Vec` を返す
+    ///
+    /// Floodgate scheduler が毎週発火するため、空 entry が `HashMap` に
+    /// 残り続けると long-running 運用で内部表現が肥大化する。`remove` 経路を
+    /// 回帰固定する。
+    #[test]
+    fn waiting_pool_drain_for_game_name_returns_in_order_and_removes_empty_entry() {
+        let mut pool = WaitingPool::default();
+        let game = GameName::new("floodgate-600-10");
+        let other_game = GameName::new("g1");
+
+        // 同一 game_name に 3 件、別 game_name に 1 件 push する。
+        for handle in ["alice", "bob", "carol"] {
+            let (tx, _rx) = oneshot::channel::<MatchRequest>();
+            pool.push(
+                game.clone(),
+                WaitingSlot {
+                    handle: handle.to_owned(),
+                    color: Color::Black,
+                    match_request_tx: tx,
+                },
+            );
+        }
+        let (tx_other, _rx_other) = oneshot::channel::<MatchRequest>();
+        pool.push(
+            other_game.clone(),
+            WaitingSlot {
+                handle: "dave".to_owned(),
+                color: Color::White,
+                match_request_tx: tx_other,
+            },
+        );
+
+        let drained = pool.drain_for_game_name(&game);
+        let handles: Vec<String> = drained.into_iter().map(|s| s.handle).collect();
+        assert_eq!(
+            handles,
+            vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()],
+            "drain must preserve insertion order"
+        );
+
+        // drain 後の `HashMap` から当該 entry は消えている（空 VecDeque が残らない）。
+        assert!(
+            !pool.queues.contains_key(&game),
+            "drain should remove the empty HashMap entry to prevent accumulation"
+        );
+
+        // 別 `game_name` の entry は保護される。
+        assert!(pool.queues.contains_key(&other_game), "other game_name entry must be preserved");
+
+        // 既に entry が無い場合の二度目 drain は空 `Vec` を返す。
+        let again = pool.drain_for_game_name(&game);
+        assert!(again.is_empty(), "drain on missing entry returns empty vec");
     }
 
     /// `floodgate_intent_from_config` が `floodgate_schedules` の非空で

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod matching;
 pub mod port;
 pub mod protocol;
 pub mod record;
+pub mod scheduler;
 pub mod storage;
 
 pub use config::{
@@ -42,6 +43,7 @@ pub use record::kifu::{
     KifuMove, KifuRecord, fork_initial_sfen_from_kifu, format_zerozero_list_line,
     illegal_reason_subcode, initial_sfen_from_csa_moves, primary_result_code, winner_of,
 };
+pub use scheduler::{FloodgateSchedule, FloodgateTimer, Weekday as FloodgateWeekday};
 #[cfg(feature = "tokio-transport")]
 pub use storage::buoy::FileBuoyStorage;
 #[cfg(feature = "tokio-transport")]

--- a/crates/rshogi-csa-server/src/scheduler.rs
+++ b/crates/rshogi-csa-server/src/scheduler.rs
@@ -20,7 +20,6 @@
 use chrono::{DateTime, Datelike, NaiveDate, TimeZone, Utc, Weekday as ChronoWeekday};
 use serde::{Deserialize, Serialize};
 
-use crate::game::clock::ClockSpec;
 use crate::types::GameName;
 
 /// 曜日（Floodgate スケジュールの宣言で使う）。
@@ -91,11 +90,15 @@ pub struct FloodgateSchedule {
     pub hour: u8,
     /// 発火時刻の分（0..=59、UTC）。
     pub minute: u8,
-    /// 対局で使う時計方式。
-    pub clock: ClockSpec,
     /// ペアリング戦略名。`"direct"` をフロントエンドが認識し、Floodgate 系の
     /// 追加戦略は別タスクで配線する。未知の名前は起動時 `Err`。
     pub pairing_strategy: String,
+    // NOTE: per-schedule の時計（`ClockSpec`）は本タスクの範囲外。スケジュール
+    // 起動の対局は `state.config.clock`（global）を使う。スケジュール毎に異なる
+    // 時計を実現するには `drive_game` のシグネチャに `ClockSpec` を追加する
+    // 侵襲的な改修が必要になるため、必要になった時点で別タスクで対応する。
+    // 不要なフィールドを「parse はするけど無視する」silent drop は YAGNI 違反な
+    // ので意図的に省く（field を持たないことで利用者の誤解を防ぐ）。
 }
 
 impl FloodgateSchedule {
@@ -179,7 +182,6 @@ mod tests {
             weekday,
             hour,
             minute,
-            clock: ClockSpec::default(),
             pairing_strategy: "direct".to_owned(),
         }
     }
@@ -253,10 +255,6 @@ mod tests {
             weekday: Weekday::Wed,
             hour: 9,
             minute: 30,
-            clock: ClockSpec::Countdown {
-                total_time_sec: 600,
-                byoyomi_sec: 10,
-            },
             pairing_strategy: "direct".to_owned(),
         };
         // GameName アクセサが正しく newtype 変換することも確認。
@@ -268,9 +266,37 @@ mod tests {
         );
         assert!(toml_text.contains("weekday = \"Wed\""), "toml shape: {toml_text}");
         assert!(toml_text.contains("pairing_strategy = \"direct\""));
-        assert!(toml_text.contains("kind = \"countdown\""));
         let parsed: FloodgateSchedule = toml::from_str(&toml_text).unwrap();
         assert_eq!(parsed, s);
+    }
+
+    /// 月末跨ぎ: 2026-04-30 (Thu) 23:30 UTC の時点で「Fri 00:00」を狙うと、
+    /// 2026-05-01 (Fri) 00:00 UTC（日数 +1、月またぎ）。
+    #[test]
+    fn next_fire_handles_month_rollover() {
+        let s = schedule(Weekday::Fri, 0, 0);
+        let now = dt(2026, 4, 30, 23, 30);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2026, 5, 1, 0, 0));
+    }
+
+    /// 閏年跨ぎ: 2024-02-28 (Wed) 12:00 UTC の時点で「Sat 00:00」を狙うと、
+    /// 閏日 2024-02-29 (Thu) を経て 2024-03-02 (Sat) 00:00 UTC。
+    #[test]
+    fn next_fire_handles_leap_day_rollover() {
+        let s = schedule(Weekday::Sat, 0, 0);
+        let now = dt(2024, 2, 28, 12, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2024, 3, 2, 0, 0));
+    }
+
+    /// 閏年の 2-29 (Thu) 自身を起点にしたケース。「Thu 23:00」を狙うと同日 23:00。
+    #[test]
+    fn next_fire_handles_leap_day_as_origin() {
+        let s = schedule(Weekday::Thu, 23, 0);
+        let now = dt(2024, 2, 29, 12, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2024, 2, 29, 23, 0));
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/scheduler.rs
+++ b/crates/rshogi-csa-server/src/scheduler.rs
@@ -1,0 +1,285 @@
+//! Floodgate スケジュール宣言と次回起動時刻の純関数。
+//!
+//! 1 つの `FloodgateSchedule` は「ある `game_name` に対して、UTC の特定曜日・
+//! 時刻に matchmaking を発火する」宣言。複数のスケジュールを並列に持てる。
+//!
+//! 本モジュールは時刻計算と TOML 入力の値型のみを提供する純粋ロジックで、
+//! 実際の発火（accept ループや待機プールへのアクセス）はフロントエンド側
+//! （`rshogi-csa-server-tcp/src/scheduler.rs`）が担う。
+//!
+//! # 設計判断
+//!
+//! - **UTC 固定**: 曜日 / 時刻は UTC で解釈する。日本運用では運用者が +9 時間
+//!   分の換算を行う前提（DST がない / 設定が静的に追えるメリット）。
+//! - **永続化なし**: スケジュールは静的な設定であり、サーバ再起動で次回時刻を
+//!   再計算するのみ（YAGNI）。
+//! - **タイマー抽象**: `FloodgateTimer` トレイトで「指定時刻まで待機する」操作
+//!   を抽象化し、TCP（`tokio::time::sleep_until`）と Workers 将来対応
+//!   （Durable Object Alarms API）を同 API で吸収する。
+
+use chrono::{DateTime, Datelike, NaiveDate, TimeZone, Utc, Weekday as ChronoWeekday};
+use serde::{Deserialize, Serialize};
+
+use crate::game::clock::ClockSpec;
+use crate::types::GameName;
+
+/// 曜日（Floodgate スケジュールの宣言で使う）。
+///
+/// `chrono::Weekday` は外部公開クレートの enum なので serde でシリアライズ
+/// する際の文字列表現が安定しない可能性がある。設定ファイルで使う表現を
+/// 自前で定義し、Mon/Tue/.../Sun の 3 文字頭で読み書きする。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum Weekday {
+    Mon,
+    Tue,
+    Wed,
+    Thu,
+    Fri,
+    Sat,
+    Sun,
+}
+
+impl Weekday {
+    /// `chrono::Weekday` から構築する。
+    pub fn from_chrono(w: ChronoWeekday) -> Self {
+        match w {
+            ChronoWeekday::Mon => Self::Mon,
+            ChronoWeekday::Tue => Self::Tue,
+            ChronoWeekday::Wed => Self::Wed,
+            ChronoWeekday::Thu => Self::Thu,
+            ChronoWeekday::Fri => Self::Fri,
+            ChronoWeekday::Sat => Self::Sat,
+            ChronoWeekday::Sun => Self::Sun,
+        }
+    }
+
+    /// `chrono::Weekday` に変換する。
+    pub fn to_chrono(self) -> ChronoWeekday {
+        match self {
+            Self::Mon => ChronoWeekday::Mon,
+            Self::Tue => ChronoWeekday::Tue,
+            Self::Wed => ChronoWeekday::Wed,
+            Self::Thu => ChronoWeekday::Thu,
+            Self::Fri => ChronoWeekday::Fri,
+            Self::Sat => ChronoWeekday::Sat,
+            Self::Sun => ChronoWeekday::Sun,
+        }
+    }
+}
+
+/// 1 つの Floodgate スケジュール宣言。
+///
+/// `game_name` ごとに、UTC の `weekday` × `hour:minute` に発火する。複数の
+/// スケジュールエントリを 1 game_name に紐付けたい場合は本構造体を複数並べる
+/// （TOML の `[[schedules]]` 配列に複数要素を書く）形を取る。
+///
+/// `pairing_strategy` は文字列で受ける。`"direct"` は本タスクで配線、
+/// `"least_diff"` 等は別タスクで戦略実装が入った時点で受け付ける。未知の値は
+/// 起動時に `Err` で fail-fast（fronend `build_strategy_from_name` が拒否）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FloodgateSchedule {
+    /// CSA `LOGIN <name> <pass> <game_name>` の `game_name`。発火時に同じ
+    /// game_name で待機しているプレイヤだけが対象になる。
+    ///
+    /// 内部表現は `String`（TOML serde 対応のため）。`GameName` への変換は
+    /// [`Self::game_name`] アクセサを使う。
+    pub game_name: String,
+    /// 発火曜日（UTC）。
+    pub weekday: Weekday,
+    /// 発火時刻の時（0..=23、UTC）。
+    pub hour: u8,
+    /// 発火時刻の分（0..=59、UTC）。
+    pub minute: u8,
+    /// 対局で使う時計方式。
+    pub clock: ClockSpec,
+    /// ペアリング戦略名。`"direct"` をフロントエンドが認識し、Floodgate 系の
+    /// 追加戦略は別タスクで配線する。未知の名前は起動時 `Err`。
+    pub pairing_strategy: String,
+}
+
+impl FloodgateSchedule {
+    /// `game_name` を core の newtype `GameName` として取り出す。
+    pub fn game_name(&self) -> GameName {
+        GameName::new(&self.game_name)
+    }
+}
+
+impl FloodgateSchedule {
+    /// `now` 時点から見た次回発火時刻を返す。
+    ///
+    /// アルゴリズム:
+    /// 1. 同じ曜日 + 同じ時刻の今週分を組み立てる（`now` が月曜なら、月曜の
+    ///    `hour:minute`）。
+    /// 2. その時刻が `now` より厳密に未来であればそれを返す（同時刻ぴったりは
+    ///    「次の週」へ送り、`now == next_fire` の同一性を避ける）。
+    /// 3. そうでなければ「次の同曜日」（7 日進める）を返す。
+    ///
+    /// 入力が常に UTC なので DST 跨ぎはなく、結果は 1 週間以内に収まる。
+    pub fn next_fire_after(&self, now: DateTime<Utc>) -> DateTime<Utc> {
+        let target_wd = self.weekday.to_chrono();
+        let now_wd = now.weekday();
+
+        // `weekday` の 0..=6 表現を「月曜起点」で取り、差分を mod 7 する。
+        let now_idx = chrono_weekday_index(now_wd);
+        let target_idx = chrono_weekday_index(target_wd);
+        let mut delta_days = (target_idx + 7 - now_idx) % 7;
+
+        // 候補日付を作る（now の日付に delta_days 加算）。
+        let candidate_date = now.date_naive() + chrono::Duration::days(delta_days as i64);
+        let candidate = build_utc_datetime(candidate_date, self.hour, self.minute);
+
+        // 候補が `now` 以前なら次の週へ（厳密未来になるよう 7 日加算）。
+        if candidate <= now {
+            delta_days += 7;
+            let next_week_date = now.date_naive() + chrono::Duration::days(delta_days as i64);
+            return build_utc_datetime(next_week_date, self.hour, self.minute);
+        }
+        candidate
+    }
+}
+
+fn chrono_weekday_index(wd: ChronoWeekday) -> u32 {
+    // 月曜起点で 0..=6 を割り当てる（ISO-8601 の num_days_from_monday と同義）。
+    wd.num_days_from_monday()
+}
+
+fn build_utc_datetime(date: NaiveDate, hour: u8, minute: u8) -> DateTime<Utc> {
+    // `hour` / `minute` は外部入力なので 0..23 / 0..59 にクランプする。
+    // 範囲外の場合は最寄りの境界値を使い、後段で fail しない（設定の早期検証は
+    // TOML パース層で行われる）。
+    let h = hour.min(23) as u32;
+    let m = minute.min(59) as u32;
+    let naive = date.and_hms_opt(h, m, 0).expect("h / m clamped to valid range");
+    Utc.from_utc_datetime(&naive)
+}
+
+/// 「指定時刻まで眠る」抽象化。
+///
+/// 実装は frontend に持つ:
+/// - `tokio::time::sleep_until` をラップする `TokioFloodgateTimer`（TCP）
+/// - 将来の Durable Object Alarms API ベース実装（Workers）
+pub trait FloodgateTimer {
+    /// `deadline`（UTC 絶対時刻）まで待機する。`deadline <= 現在時刻` の場合は
+    /// 即座に return することが望ましい（spurious tick 等の安全側挙動）。
+    fn wait_until(&self, deadline: DateTime<Utc>) -> impl std::future::Future<Output = ()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dt(y: i32, m: u32, d: u32, h: u32, mi: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, h, mi, 0).unwrap()
+    }
+
+    fn schedule(weekday: Weekday, hour: u8, minute: u8) -> FloodgateSchedule {
+        FloodgateSchedule {
+            game_name: "floodgate-600-10".to_owned(),
+            weekday,
+            hour,
+            minute,
+            clock: ClockSpec::default(),
+            pairing_strategy: "direct".to_owned(),
+        }
+    }
+
+    #[test]
+    fn next_fire_returns_today_when_time_is_in_the_future() {
+        // 2026-04-26 (Sun) 10:00 UTC の時点で「Sun 12:00」を狙うと、同日 12:00。
+        let s = schedule(Weekday::Sun, 12, 0);
+        let now = dt(2026, 4, 26, 10, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2026, 4, 26, 12, 0));
+    }
+
+    #[test]
+    fn next_fire_advances_to_next_week_when_today_already_passed() {
+        // 2026-04-26 (Sun) 13:00 UTC の時点で「Sun 12:00」を狙うと、来週日曜 12:00。
+        let s = schedule(Weekday::Sun, 12, 0);
+        let now = dt(2026, 4, 26, 13, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2026, 5, 3, 12, 0));
+    }
+
+    #[test]
+    fn next_fire_advances_to_next_week_when_time_equals_now_exactly() {
+        // 同時刻ぴったりは厳密未来になるよう次の週へ送る（`>` 比較のため）。
+        let s = schedule(Weekday::Sun, 12, 0);
+        let now = dt(2026, 4, 26, 12, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2026, 5, 3, 12, 0));
+    }
+
+    #[test]
+    fn next_fire_steps_to_target_weekday_when_today_is_different() {
+        // 2026-04-26 (Sun) 23:00 UTC の時点で「Wed 09:00」を狙うと、3 日後 4-29 (Wed) 09:00。
+        let s = schedule(Weekday::Wed, 9, 0);
+        let now = dt(2026, 4, 26, 23, 0);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2026, 4, 29, 9, 0));
+    }
+
+    #[test]
+    fn next_fire_handles_year_rollover() {
+        // 大晦日 2026-12-31 (Thu) 23:30 UTC の時点で「Sat 00:00」を狙うと、
+        // 2027-01-02 (Sat) 00:00 UTC。
+        let s = schedule(Weekday::Sat, 0, 0);
+        let now = dt(2026, 12, 31, 23, 30);
+        let next = s.next_fire_after(now);
+        assert_eq!(next, dt(2027, 1, 2, 0, 0));
+    }
+
+    #[test]
+    fn weekday_round_trips_through_chrono() {
+        for w in [
+            Weekday::Mon,
+            Weekday::Tue,
+            Weekday::Wed,
+            Weekday::Thu,
+            Weekday::Fri,
+            Weekday::Sat,
+            Weekday::Sun,
+        ] {
+            assert_eq!(Weekday::from_chrono(w.to_chrono()), w);
+        }
+    }
+
+    #[test]
+    fn schedule_serde_round_trips_through_toml() {
+        // TOML 設定での書式契約を固定。フィールド rename / 形式変更を CI で検知。
+        let s = FloodgateSchedule {
+            game_name: "floodgate-600-10".to_owned(),
+            weekday: Weekday::Wed,
+            hour: 9,
+            minute: 30,
+            clock: ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+            pairing_strategy: "direct".to_owned(),
+        };
+        // GameName アクセサが正しく newtype 変換することも確認。
+        assert_eq!(s.game_name().as_str(), "floodgate-600-10");
+        let toml_text = toml::to_string(&s).unwrap();
+        assert!(
+            toml_text.contains("game_name = \"floodgate-600-10\""),
+            "toml shape: {toml_text}",
+        );
+        assert!(toml_text.contains("weekday = \"Wed\""), "toml shape: {toml_text}");
+        assert!(toml_text.contains("pairing_strategy = \"direct\""));
+        assert!(toml_text.contains("kind = \"countdown\""));
+        let parsed: FloodgateSchedule = toml::from_str(&toml_text).unwrap();
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn build_utc_datetime_clamps_out_of_range_inputs_to_boundary() {
+        // 範囲外入力（hour=99, minute=99）は 23:59 にクランプする防衛挙動。
+        // 通常は TOML パース層で fail するが、build_utc_datetime 単体で安全側に
+        // 落ちることを契約として固定する。
+        let date = NaiveDate::from_ymd_opt(2026, 4, 26).unwrap();
+        let dt_clamped = build_utc_datetime(date, 99, 99);
+        assert_eq!(dt_clamped, dt(2026, 4, 26, 23, 59));
+    }
+}


### PR DESCRIPTION
## Summary

`tasks.md` 15.1 で要求される「Floodgate スケジュール宣言と定刻起動」を実装。`game_name` ごとに UTC 曜日・時刻を宣言的に設定し、その時刻に到達したら待機プールから候補を抽出して `PairingLogic` でペアを決定、Game_Summary を送信する。不成立は次回まで待機。

**Stacked on #491** (`feat/csa-server-tcp-players-rate-storage`)。先に #491 を merge してください。

## 主要変更

### コア (`rshogi-csa-server`)

- `scheduler` モジュールを新設:
  - `FloodgateSchedule` / `Weekday` (UTC 曜日 enum) / `FloodgateTimer` trait
  - `next_fire_after(now)` 純関数（同時刻ぴったりは次の週へ送る、年跨ぎ対応）
  - serde 派生で TOML から直接デシリアライズ可能（`game_name` は内部 `String`、`game_name()` で `GameName` newtype に変換）

### TCP frontend

- `scheduler` モジュール:
  - `TokioFloodgateTimer`: `tokio::time::sleep_until` ベース。過去 deadline 即時 return
  - `build_strategy(name)`: `"direct"` を受理し未知名は起動時 fail-fast
  - `run_schedules(state)`: 各 schedule を `spawn_local` で独立タスク化、JoinHandle Vec を返す
  - `fire_schedule`: drain WaitingPool → 戦略適用 → 成立は drive_game spawn、不成立は再 push
  - `spawn_scheduled_drive`: 両 waiter に `MatchRequest` 送って transport 吸い上げ、`drive_game` を spawn。`drive_game` 消費の `done_tx` と scheduler 保持の もう一方の `done_tx` で両 waiter を確実に終了

- `ServerConfig::floodgate_schedules` 追加。非空で `enable_scheduler` 要求 → opt-in 必須
- `WaitingPool`/`WaitingSlot`/`MatchRequest` を `pub(crate)`、`WaitingPool::drain_for_game_name` 追加、`SharedState::waiting`/`league` と `drive_game` を `pub(crate)`
- CLI: `--floodgate-schedule-toml <PATH>` で `[[schedules]]` 配列を受け取る

## 範囲外（後続タスクで対応）

- **per-schedule clock**: 現状は `state.config.clock`（global）を使う。スケジュール毎に異なる時計サポートには `drive_game` シグネチャに `ClockSpec` 引数追加が必要
- **buoy / 駒落ち**: スケジューラ起動の対局は常に平手（`initial_sfen = None`）。task 15.4
- **`"least_diff"` ペアリング戦略**: 文字列受け付け配線済み、実体は task 15.2

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (debug + release)
- [x] `cargo test --workspace --release`
- [x] `scheduler` 単体テスト 8 件 (core): `next_fire_after` の今日中・今日経過後・同時刻ぴったり・別曜日・年跨ぎ、`Weekday` chrono 往復、TOML serde 往復、範囲外クランプ
- [x] `scheduler` 単体テスト 2 件 (TCP): `build_strategy` 受理/拒否、`TokioFloodgateTimer` 過去 deadline 即時 return

🤖 Generated with [Claude Code](https://claude.com/claude-code)