### PR TITLE
feat(csa-server): Floodgate 履歴を JSONL で永続化する経路を追加 (task 15.3)

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -63,6 +63,11 @@ struct Cli {
     /// され、`--allow-floodgate-features` opt-in が必須になる。
     #[arg(long, value_name = "PATH")]
     floodgate_schedule_toml: Option<PathBuf>,
+    /// Floodgate 履歴 JSONL ファイルのパス。指定すると終局時に 1 entry / 1 line
+    /// で append される（開始時刻・ペア・結果・勝者）。`--allow-floodgate-features`
+    /// opt-in が必須。
+    #[arg(long, value_name = "PATH")]
+    floodgate_history_jsonl: Option<PathBuf>,
     /// 秒読み方式 / Fischer 方式で使う持ち時間 (秒)。
     #[arg(long, default_value_t = 600)]
     total_time_sec: u32,
@@ -220,6 +225,7 @@ fn main() -> anyhow::Result<()> {
         // 1 回だけ clone する（残りはそのまま move される）。
         players_yaml_path: cli.players_yaml.clone(),
         floodgate_schedules,
+        floodgate_history_path: cli.floodgate_history_jsonl.clone(),
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2169,7 +2169,6 @@ fn parse_move_broadcast(line: &str) -> Option<(&str, u32)> {
 
 /// 棋譜 + 00LIST を永続化する。`game_name` は Floodgate 履歴 JSONL に記録する
 /// ためのみ使う（kifu / 00LIST 出力には影響しない）。
-#[allow(clippy::too_many_arguments)]
 async fn persist_kifu<R, K, P>(
     state: &SharedState<R, K, P>,
     game_id: &GameId,
@@ -2280,6 +2279,20 @@ where
 
     // Floodgate 履歴 JSONL に append（`floodgate_history_path` が Some のとき
     // のみ。失敗時はレート同様に `tracing::error!` で記録してから上に Err を返す）。
+    //
+    // best-effort に倒さず Err を伝播する判断理由:
+    // - 履歴は単なる運用参照ではなく、Floodgate 月例集計など 00LIST と
+    //   突き合わせる外部バッチの突合元としても利用され得る。silent skip すると
+    //   運用ログから消えて整合性チェックを後追いできなくなる。
+    // - 上位 `drive_game_inner` には既に終局メッセージ送出済みの状態で I/O
+    //   失敗を返す形になるが、`csa_games_finished_total{result_code}` の集計や
+    //   kifu/00LIST/rate と同じく storage 失敗を 1 経路に集約しておけば
+    //   alert ルールが一本化できる（kifu 失敗・rate 失敗・history 失敗で挙動が
+    //   分岐すると運用側のフィルタがぶれる）。
+    // - history 失敗で `drive_game_inner` 上位が見るのは `Err` だが、`DriveGuard`
+    //   Drop は既に `result_code_slot` 経由で正規ラベルを set 済み（L1869）なので
+    //   `csa_games_finished_total` の集計ラベルは正しい。Err は alert ルートに
+    //   流れるだけで、メトリクス側の整合性は崩れない。
     if let Some(history) = state.history_storage.as_ref() {
         let entry = rshogi_csa_server::FloodgateHistoryEntry::new(
             game_id,
@@ -2310,7 +2323,6 @@ where
 /// `floodgate_history_path` が `Some` の場合は [`JsonlFloodgateHistoryStorage`]
 /// を構築して `SharedState.history_storage` に乗せる。`None` の場合は履歴
 /// 記録 skip。
-#[allow(clippy::too_many_arguments)]
 pub fn build_state<R, K, P>(
     config: ServerConfig,
     rate_storage: R,

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -26,6 +26,7 @@ use std::time::Duration;
 
 use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
+use rshogi_csa_server::FloodgateHistoryStorage;
 use rshogi_csa_server::config::{FloodgateFeatureIntent, validate_floodgate_feature_gate};
 use rshogi_csa_server::error::{ProtocolError, ServerError};
 use rshogi_csa_server::game::result::GameResult;
@@ -158,6 +159,11 @@ pub struct ServerConfig {
     /// 時点で当該 `game_name` の待機プールから候補を抽出し、`pairing_strategy`
     /// が指定する戦略でペアを作って Game_Summary を送信する。
     pub floodgate_schedules: Vec<rshogi_csa_server::FloodgateSchedule>,
+    /// Floodgate 履歴 JSONL ファイルのパス。`Some` を指定すると終局時に
+    /// 1 entry / 1 line で append される。本フィールドが `Some` の状態は
+    /// Floodgate 運用機能の一つ (`enable_floodgate_history`) として
+    /// `--allow-floodgate-features` opt-in を要求する。
+    pub floodgate_history_path: Option<std::path::PathBuf>,
     /// SIGINT / SIGTERM 受信後に進行中対局の終了を待つ上限。超過分は未完了の
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
     /// を落とさない」ためのバッファで、既定 60 秒。
@@ -182,6 +188,7 @@ impl ServerConfig {
             allow_floodgate_features: false,
             players_yaml_path: None,
             floodgate_schedules: Vec::new(),
+            floodgate_history_path: None,
             shutdown_grace: Duration::from_secs(60),
         }
     }
@@ -216,6 +223,8 @@ pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFe
         // 定刻起動スケジュールも Floodgate 系機能。1 件以上のスケジュール宣言
         // があれば opt-in 要求。
         enable_scheduler: !config.floodgate_schedules.is_empty(),
+        // Floodgate 履歴 JSONL も Floodgate 系運用機能。`Some` で opt-in 要求。
+        enable_floodgate_history: config.floodgate_history_path.is_some(),
         ..FloodgateFeatureIntent::default()
     }
 }
@@ -411,6 +420,10 @@ where
     kifu_storage: K,
     password_store: P,
     hasher: Box<dyn PasswordHasher>,
+    /// Floodgate 履歴 JSONL の append 先。`None` の場合は履歴記録を skip する。
+    /// 異 trait 実装は不要なので具体型 `Option<...>` で持つ（generic 引数で受ける
+    /// より型増殖を避けたい）。
+    history_storage: Option<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
     /// 進行中対局のメモリ内レジストリ。`%%LIST` / `%%SHOW` 応答で参照する。
     ///
     /// **注意**: このカウントは graceful shutdown の完了判定に使ってはならない。
@@ -1803,7 +1816,7 @@ where
             game_id: game_id.clone(),
             black: matched.black.clone(),
             white: matched.white.clone(),
-            game_name,
+            game_name: game_name.clone(),
             started_at: started_at_iso,
         });
     }
@@ -1861,6 +1874,7 @@ where
     persist_kifu(
         state,
         game_id,
+        &game_name,
         &matched,
         match_initial_sfen.as_deref(),
         start_time,
@@ -2153,10 +2167,13 @@ fn parse_move_broadcast(line: &str) -> Option<(&str, u32)> {
     Some((tok, sec))
 }
 
-/// 棋譜 + 00LIST を永続化する。
+/// 棋譜 + 00LIST を永続化する。`game_name` は Floodgate 履歴 JSONL に記録する
+/// ためのみ使う（kifu / 00LIST 出力には影響しない）。
+#[allow(clippy::too_many_arguments)]
 async fn persist_kifu<R, K, P>(
     state: &SharedState<R, K, P>,
     game_id: &GameId,
+    game_name: &GameName,
     matched: &MatchedPair,
     initial_sfen: Option<&str>,
     start_time: chrono::DateTime<chrono::Utc>,
@@ -2260,10 +2277,39 @@ where
         );
         return Err(ServerError::Storage(e));
     }
+
+    // Floodgate 履歴 JSONL に append（`floodgate_history_path` が Some のとき
+    // のみ。失敗時はレート同様に `tracing::error!` で記録してから上に Err を返す）。
+    if let Some(history) = state.history_storage.as_ref() {
+        let entry = rshogi_csa_server::FloodgateHistoryEntry::new(
+            game_id,
+            game_name,
+            &matched.black,
+            &matched.white,
+            start_time,
+            end_time,
+            primary_result_code(result),
+            winner_color,
+        );
+        if let Err(e) = history.append(&entry).await {
+            tracing::error!(
+                game_id = %game_id.as_str(),
+                black = %matched.black.as_str(),
+                white = %matched.white.as_str(),
+                error = %e,
+                "floodgate history append failed; kifu/00LIST/rate are persisted but history entry was lost"
+            );
+            return Err(ServerError::Storage(e));
+        }
+    }
     Ok(())
 }
 
 /// `SharedState` を組み立てるヘルパ（運用コードとテストで再利用）。
+///
+/// `floodgate_history_path` が `Some` の場合は [`JsonlFloodgateHistoryStorage`]
+/// を構築して `SharedState.history_storage` に乗せる。`None` の場合は履歴
+/// 記録 skip。
 #[allow(clippy::too_many_arguments)]
 pub fn build_state<R, K, P>(
     config: ServerConfig,
@@ -2280,6 +2326,10 @@ where
     P: PasswordStore + 'static,
 {
     let buoy_storage = rshogi_csa_server::FileBuoyStorage::new(config.kifu_topdir.clone());
+    let history_storage = config
+        .floodgate_history_path
+        .clone()
+        .map(rshogi_csa_server::JsonlFloodgateHistoryStorage::new);
     SharedState {
         config,
         league: Mutex::new(League::new()),
@@ -2290,6 +2340,7 @@ where
         kifu_storage,
         password_store,
         hasher,
+        history_storage,
         games: Mutex::new(GameRegistry::new()),
         active_drive_tasks: AtomicUsize::new(0),
         active_games: Notify::new(),
@@ -2562,5 +2613,26 @@ mod tests {
             pairing_strategy: "direct".to_owned(),
         });
         prepare_runtime(&cfg).expect("direct strategy must pass prepare_runtime");
+    }
+
+    /// `floodgate_intent_from_config` が `floodgate_history_path` の有無で
+    /// `enable_floodgate_history` を切り替えることを直接固定。
+    #[test]
+    fn floodgate_intent_reflects_floodgate_history_path() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        assert!(!floodgate_intent_from_config(&cfg).enable_floodgate_history);
+        cfg.floodgate_history_path = Some(std::path::PathBuf::from("/tmp/history.jsonl"));
+        assert!(floodgate_intent_from_config(&cfg).enable_floodgate_history);
+    }
+
+    /// `--allow-floodgate-features` opt-in なしで `floodgate_history_path` を
+    /// 設定すると `prepare_runtime` が fail-fast する契約を固定。
+    #[test]
+    fn prepare_runtime_rejects_floodgate_history_when_optin_off() {
+        let mut cfg = ServerConfig::sensible_defaults();
+        cfg.floodgate_history_path = Some(std::path::PathBuf::from("/tmp/history.jsonl"));
+        cfg.allow_floodgate_features = false;
+        let err = prepare_runtime(&cfg).expect_err("must fail without opt-in");
+        assert!(err.contains("floodgate_history"), "error must list feature: {err}");
     }
 }

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -20,6 +20,10 @@ pub struct FloodgateFeatureIntent {
     /// 有効化する意図。`PlayersYamlRateStorage` を起動時に読み込み、終局時に
     /// 書き戻す経路を本フラグで gate する。
     pub enable_persistent_player_rates: bool,
+    /// Floodgate 履歴（開始時刻・ペア・結果）を再起動跨ぎで参照可能に永続化
+    /// する経路を有効化する意図。`JsonlFloodgateHistoryStorage` を起動時に
+    /// 構築し、終局時に append する経路を本フラグで gate する。
+    pub enable_floodgate_history: bool,
 }
 
 /// 真偽文字列から Floodgate 機能 gate を解決する。
@@ -71,6 +75,9 @@ pub fn validate_floodgate_feature_gate(
     }
     if intent.enable_persistent_player_rates {
         requested.push("persistent_player_rates");
+    }
+    if intent.enable_floodgate_history {
+        requested.push("floodgate_history");
     }
     if requested.is_empty() || allow_floodgate_features {
         return Ok(());
@@ -152,6 +159,7 @@ mod tests {
                 use_non_direct_pairing: true,
                 enable_duplicate_login_policy: true,
                 enable_persistent_player_rates: true,
+                enable_floodgate_history: true,
             },
         )
         .unwrap_err();
@@ -159,6 +167,20 @@ mod tests {
         assert!(err.contains("non_direct_pairing"));
         assert!(err.contains("duplicate_login_policy"));
         assert!(err.contains("persistent_player_rates"));
+        assert!(err.contains("floodgate_history"));
+    }
+
+    #[test]
+    fn floodgate_gate_rejects_floodgate_history_when_disabled() {
+        let err = validate_floodgate_feature_gate(
+            false,
+            FloodgateFeatureIntent {
+                enable_floodgate_history: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("floodgate_history"));
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -49,6 +49,10 @@ pub use storage::buoy::FileBuoyStorage;
 #[cfg(feature = "tokio-transport")]
 pub use storage::file::FileKifuStorage;
 #[cfg(feature = "tokio-transport")]
+pub use storage::floodgate_history::{
+    FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor, JsonlFloodgateHistoryStorage,
+};
+#[cfg(feature = "tokio-transport")]
 pub use storage::players_yaml::PlayersYamlRateStorage;
 pub use types::{
     AdminId, Color, CsaLine, CsaMoveToken, GameId, GameName, IpKey, PlayerName, ReconnectToken,

--- a/crates/rshogi-csa-server/src/storage/floodgate_history.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history.rs
@@ -158,6 +158,19 @@ impl FloodgateHistoryStorage for JsonlFloodgateHistoryStorage {
         async move {
             let line = serialized?;
             let _guard = self.append_lock.lock().await;
+            // 親ディレクトリ未作成時のフェイル連発を防ぐ。`--floodgate-history-jsonl`
+            // にデプロイ初回などで存在しないディレクトリ配下のパスを指定された場合、
+            // `OpenOptions::open` だけだと毎ゲーム ENOENT で `StorageError::Io` を
+            // 返し続けて「履歴 opt-in したのに永続化が常に失敗する」状態になる。
+            // `create_dir_all` は idempotent でディレクトリが既にあれば no-op、
+            // ファイル作成より遥かに低頻度なので append-lock 内で一度ずつ呼んで OK。
+            if let Some(parent) = self.path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                    StorageError::Io(format!("create_dir_all {}: {}", parent.display(), e))
+                })?;
+            }
             let mut file =
                 OpenOptions::new().create(true).append(true).open(&self.path).await.map_err(
                     |e| StorageError::Io(format!("open {} (append): {}", self.path.display(), e)),
@@ -184,12 +197,23 @@ impl FloodgateHistoryStorage for JsonlFloodgateHistoryStorage {
             if limit == 0 {
                 return Ok(Vec::new());
             }
+            // TODO: 件数が膨らんだ場合は末尾シーク + バッファ後退で `\n` を逆方向に
+            //       探す実装に置き換え検討（現状は logrotate 前提の中小規模運用で
+            //       全読みでも実害が無いため `read_to_string` で済ませている）。
             let raw = match tokio::fs::read_to_string(&path).await {
                 Ok(s) => s,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
                 Err(e) => return Err(StorageError::Io(format!("read {}: {}", path.display(), e))),
             };
             // 後ろから limit 行までを集めて、新しい順（最後に書かれた順）で返す。
+            //
+            // malformed 行は strict に `Err` で返す（`tracing::warn!` で skip しない）。
+            // 理由は履歴 JSONL が運用ダッシュボード / x1 拡張コマンド経由の参照に
+            // 加えて勝敗集計（mk_rate 等の外部バッチ）の入力にも使われ得るため、
+            // 不整合行を黙って無視するとプレイヤごとの win/lose が静かに乖離して
+            // 後追い切り分けが極めて困難になる。append-lock + write_all で書き込み
+            // 中の crash 痕跡が残った場合は、運用が手作業で末尾の半行を切る or
+            // logrotate の rotate 境界で物理削除するなど明示的に対処する方針。
             let mut entries: Vec<FloodgateHistoryEntry> = Vec::new();
             for line in raw.lines().rev() {
                 if line.trim().is_empty() {
@@ -296,6 +320,21 @@ mod tests {
         let storage = JsonlFloodgateHistoryStorage::new(path);
         let err = storage.list_recent(5).await.unwrap_err();
         assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn append_creates_missing_parent_directories() {
+        // `--floodgate-history-jsonl` にデプロイ初回で未作成のサブディレクトリを
+        // 含むパスを指定された場合でも、append が ENOENT で失敗し続けず、ディレクトリ
+        // ごと作って成功する契約。
+        let dir = tempdir();
+        let nested = dir.path().join("a").join("b").join("c").join("history.jsonl");
+        let storage = JsonlFloodgateHistoryStorage::new(nested.clone());
+        storage.append(&entry("g1", Some(HistoryColor::Black))).await.unwrap();
+        let recent = storage.list_recent(5).await.unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].game_id, "g1");
+        assert!(nested.exists(), "history file should be created at {nested:?}");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server/src/storage/floodgate_history.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history.rs
@@ -127,7 +127,7 @@ pub trait FloodgateHistoryStorage {
 #[derive(Debug)]
 pub struct JsonlFloodgateHistoryStorage {
     path: PathBuf,
-    /// append を直列化する async lock。`load_recent` は別 read 経路なのでロック
+    /// append を直列化する async lock。`list_recent` は別 read 経路なのでロック
     /// 範囲は短い。
     append_lock: AsyncMutex<()>,
 }
@@ -317,6 +317,24 @@ mod tests {
         let storage = JsonlFloodgateHistoryStorage::new(path);
         let err = storage.list_recent(5).await.unwrap_err();
         assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn append_returns_err_when_parent_path_is_regular_file() {
+        // 親ディレクトリ作成が失敗する経路（同名の regular file が居座っている）でも
+        // panic せず `StorageError::Io` で上に返す契約を固定する。これにより
+        // `persist_kifu` 側の `if let Err(e) = ... return Err(...)` 経路が
+        // 型システム上だけでなく実 I/O 失敗で踏まれることを保証し、将来 silent な
+        // best-effort 化に戻された場合に CI で気付ける。
+        let dir = tempdir();
+        let blocker = dir.path().join("blocker");
+        // ファイルを作って、その配下にパスを作ろうとすると create_dir_all が
+        // ENOTDIR で落ちる（regular file 上にディレクトリは作れない）。
+        std::fs::write(&blocker, b"").unwrap();
+        let bad_path = blocker.join("history.jsonl");
+        let storage = JsonlFloodgateHistoryStorage::new(bad_path);
+        let err = storage.append(&entry("g1", None)).await.unwrap_err();
+        assert!(matches!(err, StorageError::Io(_)), "expected Io error, got: {err:?}");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server/src/storage/floodgate_history.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history.rs
@@ -1,0 +1,346 @@
+//! Floodgate 履歴の永続化（開始時刻・ペア・結果を再起動跨ぎで参照可能にする）。
+//!
+//! 各対局の終局時に 1 件の [`FloodgateHistoryEntry`] を append-only な JSONL
+//! ファイルに追記する。読み込み側（`%%FLOODGATE history` 等）は近傍 N 件を
+//! tail で読む利用を想定し、行末改行で 1 entry = 1 line のフォーマットを採用。
+//!
+//! # 設計判断
+//!
+//! - **YAML ではなく JSONL**: 大量のエントリを高速に追記するなら 1 entry =
+//!   1 line + `\n` の append-only が一番衝突しにくい。Ruby Floodgate の
+//!   `floodgate.history.dump` 等の特定フォーマットを引き継ぐ要件は無く、本
+//!   サーバ独自フォーマットで `serde_json::to_string` で安定生成する
+//! - **append 単位の atomic 性**: ファイル末尾への append は POSIX 上 1 write
+//!   == 1 syscall でブロック分の atomic 性が保証される（512B 程度）。1 entry が
+//!   PIPE_BUF (= 4096B) を超えない範囲でオープン append-mode 書き込みが atomic
+//!   なので、追加の lock は不要（同一プロセス内での同時 append は内部 Mutex で
+//!   直列化）
+//! - **クロスプロセス並行 append は非対応**: 単一プロセス前提。複数プロセスが
+//!   同ファイルを書く運用は想定しない（YAGNI）
+//! - **ローテーションは外部任せ**: ファイルサイズ管理は logrotate 等の外部
+//!   ツールに任せ、本実装は append のみ責任を持つ
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::error::StorageError;
+use crate::types::{Color, GameId, GameName, PlayerName};
+
+/// Floodgate 履歴 1 件分のエントリ。`persist_kifu` 経由で終局確定時に
+/// `FloodgateHistoryStorage::append` に渡される。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FloodgateHistoryEntry {
+    /// 対局識別子（サーバ発行）。
+    pub game_id: String,
+    /// マッチが帰属する `game_name`（Floodgate スケジュールの分類軸と一致）。
+    pub game_name: String,
+    /// 先手プレイヤ名。
+    pub black: String,
+    /// 後手プレイヤ名。
+    pub white: String,
+    /// 対局開始時刻（UTC、RFC3339）。
+    pub start_time: String,
+    /// 対局終了時刻（UTC、RFC3339）。
+    pub end_time: String,
+    /// 終局理由コード（`#RESIGN` / `#TIME_UP` / `#ILLEGAL_MOVE` 等）。
+    pub result_code: String,
+    /// 勝者の色。引き分け（千日手・最大手数）や勝敗不確定の `#ABNORMAL` では
+    /// `None`。シリアライズ時は `Black` / `White` 文字列。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub winner: Option<HistoryColor>,
+}
+
+/// `Color` を JSON スキーマ用に文字列シリアライズする小 enum。core の
+/// `Color` は serde 派生していないので独立させる（serde を core 全体に拡げる
+/// より隔離する方が依存範囲が読みやすい）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum HistoryColor {
+    Black,
+    White,
+}
+
+impl From<Color> for HistoryColor {
+    fn from(c: Color) -> Self {
+        match c {
+            Color::Black => Self::Black,
+            Color::White => Self::White,
+        }
+    }
+}
+
+impl FloodgateHistoryEntry {
+    /// 業務型から構築するヘルパ。`persist_kifu` 経路から呼ばれる。
+    pub fn new(
+        game_id: &GameId,
+        game_name: &GameName,
+        black: &PlayerName,
+        white: &PlayerName,
+        start_time: DateTime<Utc>,
+        end_time: DateTime<Utc>,
+        result_code: &str,
+        winner: Option<Color>,
+    ) -> Self {
+        Self {
+            game_id: game_id.as_str().to_owned(),
+            game_name: game_name.as_str().to_owned(),
+            black: black.as_str().to_owned(),
+            white: white.as_str().to_owned(),
+            start_time: start_time.to_rfc3339(),
+            end_time: end_time.to_rfc3339(),
+            result_code: result_code.to_owned(),
+            winner: winner.map(HistoryColor::from),
+        }
+    }
+}
+
+/// Floodgate 履歴の永続化抽象。`append` で 1 件追加、`list_recent` で末尾 N 件
+/// 取得（運用ダッシュボードや x1 拡張コマンドで使う想定）。
+pub trait FloodgateHistoryStorage {
+    /// 1 件の履歴エントリを末尾に追記する。失敗時は `StorageError` で伝播。
+    fn append(
+        &self,
+        entry: &FloodgateHistoryEntry,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>>;
+
+    /// 末尾 N 件を新しい順で取得する。`limit` は 0 で空 `Vec`、`usize::MAX` で
+    /// 全件相当（実装依存上限あり）。再起動を跨いだ参照に使う。
+    fn list_recent(
+        &self,
+        limit: usize,
+    ) -> impl std::future::Future<Output = Result<Vec<FloodgateHistoryEntry>, StorageError>>;
+}
+
+/// JSONL 形式（1 entry = 1 line）でファイルに append-only 記録する `FloodgateHistoryStorage`
+/// 実装。`tokio-transport` 配下でのみコンパイルされる。
+///
+/// `append` は内部 `AsyncMutex` で直列化し、`OpenOptions::append(true)` で
+/// 開いて 1 entry を書く。POSIX 上の `O_APPEND` 書き込みは「現在のファイル末尾
+/// にカーソルを移動 → write」を 1 syscall で行うため、同一プロセス内の追記は
+/// 上述 Mutex で直列化、他プロセスからの追記は OS 任せ（PIPE_BUF 以下なら atomic、
+/// 超える場合は interleave 可能だが本実装は単一プロセス前提）。
+#[derive(Debug)]
+pub struct JsonlFloodgateHistoryStorage {
+    path: PathBuf,
+    /// append を直列化する async lock。`load_recent` は別 read 経路なのでロック
+    /// 範囲は短い。
+    append_lock: AsyncMutex<()>,
+}
+
+impl JsonlFloodgateHistoryStorage {
+    /// 指定パスをベースに storage を構築する。ファイルは存在しなくてよく、
+    /// 最初の `append` で作成される。`load_recent` ではファイル不在を空 Vec で
+    /// 返す。
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            append_lock: AsyncMutex::new(()),
+        }
+    }
+}
+
+impl FloodgateHistoryStorage for JsonlFloodgateHistoryStorage {
+    fn append(
+        &self,
+        entry: &FloodgateHistoryEntry,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>> {
+        // serde_json による serialize は I/O より前に同期で完了するため、async
+        // ブロックの外で実行して成否を `Result` に畳み、async ブロック内で `?`
+        // 経由で伝播する（早期 return パスと async ブロックパスの戻り型が
+        // 異なる問題を回避する）。
+        let serialized: Result<String, StorageError> = serde_json::to_string(entry)
+            .map_err(|e| StorageError::Io(format!("serialize FloodgateHistoryEntry: {e}")));
+        async move {
+            let line = serialized?;
+            let _guard = self.append_lock.lock().await;
+            let mut file =
+                OpenOptions::new().create(true).append(true).open(&self.path).await.map_err(
+                    |e| StorageError::Io(format!("open {} (append): {}", self.path.display(), e)),
+                )?;
+            // 1 entry につき 1 行 + `\n` を 1 回の write で出す。`write_all` は
+            // 内部で複数 syscall に分割し得るが、`O_APPEND` 下では各 write が
+            // 末尾に書かれるので順序は保たれる。
+            let mut payload = line.into_bytes();
+            payload.push(b'\n');
+            file.write_all(&payload)
+                .await
+                .map_err(|e| StorageError::Io(format!("append entry: {e}")))?;
+            file.flush().await.map_err(|e| StorageError::Io(format!("flush entry: {e}")))?;
+            Ok(())
+        }
+    }
+
+    fn list_recent(
+        &self,
+        limit: usize,
+    ) -> impl std::future::Future<Output = Result<Vec<FloodgateHistoryEntry>, StorageError>> {
+        let path = self.path.clone();
+        async move {
+            if limit == 0 {
+                return Ok(Vec::new());
+            }
+            let raw = match tokio::fs::read_to_string(&path).await {
+                Ok(s) => s,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+                Err(e) => return Err(StorageError::Io(format!("read {}: {}", path.display(), e))),
+            };
+            // 後ろから limit 行までを集めて、新しい順（最後に書かれた順）で返す。
+            let mut entries: Vec<FloodgateHistoryEntry> = Vec::new();
+            for line in raw.lines().rev() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let entry: FloodgateHistoryEntry = serde_json::from_str(line)
+                    .map_err(|e| StorageError::Malformed(format!("history line: {e}")))?;
+                entries.push(entry);
+                if entries.len() >= limit {
+                    break;
+                }
+            }
+            Ok(entries)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn entry(game_id: &str, winner: Option<HistoryColor>) -> FloodgateHistoryEntry {
+        FloodgateHistoryEntry {
+            game_id: game_id.to_owned(),
+            game_name: "floodgate-600-10".to_owned(),
+            black: "alice".to_owned(),
+            white: "bob".to_owned(),
+            start_time: "2026-04-26T12:00:00+00:00".to_owned(),
+            end_time: "2026-04-26T12:30:00+00:00".to_owned(),
+            result_code: "#RESIGN".to_owned(),
+            winner,
+        }
+    }
+
+    #[test]
+    fn entry_round_trips_through_json() {
+        let e = entry("g1", Some(HistoryColor::Black));
+        let s = serde_json::to_string(&e).unwrap();
+        let parsed: FloodgateHistoryEntry = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, e);
+    }
+
+    #[test]
+    fn entry_omits_winner_when_none() {
+        let e = entry("g1", None);
+        let s = serde_json::to_string(&e).unwrap();
+        // 引き分け（千日手 / 最大手数）では `winner` フィールドが出力に出ない。
+        assert!(!s.contains("\"winner\""), "winner must be omitted: {s}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_recent_returns_empty_when_file_missing() {
+        let dir = tempdir();
+        let path = dir.path().join("history.jsonl");
+        let storage = JsonlFloodgateHistoryStorage::new(path);
+        let entries = storage.list_recent(10).await.unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn append_then_list_recent_returns_newest_first() {
+        let dir = tempdir();
+        let path = dir.path().join("history.jsonl");
+        let storage = JsonlFloodgateHistoryStorage::new(path.clone());
+        for n in 0..5 {
+            storage
+                .append(&entry(&format!("g{n}"), Some(HistoryColor::Black)))
+                .await
+                .unwrap();
+        }
+        // limit 3 で末尾 3 件（g4 / g3 / g2）を新しい順で取る契約。
+        let recent = storage.list_recent(3).await.unwrap();
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0].game_id, "g4");
+        assert_eq!(recent[1].game_id, "g3");
+        assert_eq!(recent[2].game_id, "g2");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn append_persists_across_storage_instances() {
+        let dir = tempdir();
+        let path = dir.path().join("history.jsonl");
+        {
+            let storage = JsonlFloodgateHistoryStorage::new(path.clone());
+            storage.append(&entry("g1", None)).await.unwrap();
+        }
+        // 新しい instance で list_recent を呼んでも前回 append 内容が読める
+        // （永続化要件 11.4 の本質）。
+        let storage2 = JsonlFloodgateHistoryStorage::new(path);
+        let recent = storage2.list_recent(10).await.unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].game_id, "g1");
+        assert!(recent[0].winner.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_recent_rejects_malformed_lines() {
+        let dir = tempdir();
+        let path = dir.path().join("history.jsonl");
+        // 不正な JSON 行を 1 行だけ書いた状態を作る。
+        tokio::fs::write(&path, b"{not json}\n").await.unwrap();
+        let storage = JsonlFloodgateHistoryStorage::new(path);
+        let err = storage.list_recent(5).await.unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn list_recent_skips_blank_lines() {
+        // 末尾改行や空行が混ざっていてもパース継続する（外部 logrotate などで
+        // 末尾に空行が挿入される運用を想定）。
+        let dir = tempdir();
+        let path = dir.path().join("history.jsonl");
+        let storage = JsonlFloodgateHistoryStorage::new(path.clone());
+        storage.append(&entry("g1", Some(HistoryColor::White))).await.unwrap();
+        // 手で空行 + entry を追記
+        let mut file = OpenOptions::new().append(true).open(&path).await.unwrap();
+        file.write_all(b"\n").await.unwrap();
+        let line = serde_json::to_string(&entry("g2", None)).unwrap();
+        file.write_all(line.as_bytes()).await.unwrap();
+        file.write_all(b"\n").await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+        let recent = storage.list_recent(10).await.unwrap();
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].game_id, "g2");
+        assert_eq!(recent[1].game_id, "g1");
+    }
+
+    /// テスト専用 RAII tempdir（`tempfile` クレート依存を避ける）。
+    struct TempDir {
+        path: PathBuf,
+    }
+    impl TempDir {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+    fn tempdir() -> TempDir {
+        let base = std::env::temp_dir();
+        let pid = std::process::id();
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = base.join(format!("rshogi-floodgate-history-{pid}-{n}"));
+        std::fs::create_dir_all(&path).expect("create tempdir");
+        TempDir { path }
+    }
+}

--- a/crates/rshogi-csa-server/src/storage/floodgate_history.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history.rs
@@ -197,9 +197,6 @@ impl FloodgateHistoryStorage for JsonlFloodgateHistoryStorage {
             if limit == 0 {
                 return Ok(Vec::new());
             }
-            // TODO: 件数が膨らんだ場合は末尾シーク + バッファ後退で `\n` を逆方向に
-            //       探す実装に置き換え検討（現状は logrotate 前提の中小規模運用で
-            //       全読みでも実害が無いため `read_to_string` で済ませている）。
             let raw = match tokio::fs::read_to_string(&path).await {
                 Ok(s) => s,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),

--- a/crates/rshogi-csa-server/src/storage/mod.rs
+++ b/crates/rshogi-csa-server/src/storage/mod.rs
@@ -5,4 +5,6 @@ pub mod buoy;
 #[cfg(feature = "tokio-transport")]
 pub mod file;
 #[cfg(feature = "tokio-transport")]
+pub mod floodgate_history;
+#[cfg(feature = "tokio-transport")]
 pub mod players_yaml;


### PR DESCRIPTION
## Summary

`tasks.md` 15.3 で要求される「開始時刻・ペア・結果を再起動跨ぎで参照可能に永続化する」を実装。終局時に JSONL に append-only で記録する。

**Stacked on #492** (`feat/csa-server-floodgate-scheduler`)。先に #492 を merge してください。

## 主要変更

- core: `storage::floodgate_history` 新設。`FloodgateHistoryEntry` (serde 派生) + `FloodgateHistoryStorage` trait + `JsonlFloodgateHistoryStorage` (tokio fs append-only + AsyncMutex 直列化)
- core: `FloodgateFeatureIntent::enable_floodgate_history` 追加
- TCP: `ServerConfig::floodgate_history_path: Option<PathBuf>` 追加 + `floodgate_intent_from_config` 配線 + `--floodgate-history-jsonl <PATH>` CLI flag
- TCP: `SharedState::history_storage: Option<...>`、`build_state` で構築
- TCP: `persist_kifu` に `game_name` パラメータ追加し終局時に `history.append` を呼ぶ（失敗時は `tracing::error!` で構造化フィールド付きログ + 上位 Err 伝播）

## Test plan

- [x] core 単体テスト 7 件: entry round-trip / winner None 出力省略 / append→list_recent / 永続化跨ぎ / malformed 拒否 / blank line skip / ファイル不在
- [x] gate 検証 2 件: `floodgate_history` の error 列挙含有 / 個別 reject
- [x] TCP `prepare_runtime` 検証 2 件: `floodgate_history_path` 反映 / opt-in なしで fail-fast
- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings`（debug + release）/ `cargo test --workspace --release` (0 FAILED)

## 範囲外（後続タスクで対応）

- **x1 拡張コマンドでの履歴照会**: `list_recent` API は提供したが CSA 経路口（`%%FLOODGATE history` 等）は task 15.6 受入の範囲
- **Workers 側履歴永続化**: trait は対応可能、実装は別タスク
- **履歴ローテーション**: logrotate 等の外部ツール任せ（YAGNI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)