### PR TITLE
fix(csa-server-tcp): TCP integration test の port re-bind と kifu read race を解消

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/lib.rs
+++ b/crates/rshogi-csa-server-tcp/src/lib.rs
@@ -30,5 +30,5 @@ pub mod transport;
 pub use auth::{AuthError, AuthOutcome, PasswordHasher, PlainPasswordHasher, authenticate};
 pub use broadcaster::InMemoryBroadcaster;
 pub use rate_limit::IpLoginRateLimiter;
-pub use server::{ServerConfig, run_server};
+pub use server::{ServerConfig, run_server, run_server_with_listener};
 pub use transport::TcpTransport;

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -524,9 +524,30 @@ where
     P: PasswordStore + 'static,
 {
     let listener = TcpListener::bind(state.config.bind_addr).await?;
+    run_server_with_listener(listener, state).await
+}
+
+/// 既に bind 済みの [`TcpListener`] を引き取り、accept ループを起動する。
+///
+/// テスト harness で `127.0.0.1:0` の空きポートを掴んだまま渡したいケース向けに
+/// `run_server` を分割したエントリポイント。`run_server` は `state.config.bind_addr`
+/// から自分で bind するが、テスト用に「先に listener を確保 → 実 addr を取得 →
+/// 同じ listener をそのままサーバーに渡す」フローを取らないと、probe を drop して
+/// から本体 bind する間に別タスクが同じポートを掴む TOCTOU race が起きるため、
+/// 別経路として公開する。
+pub async fn run_server_with_listener<R, K, P>(
+    listener: TcpListener,
+    state: Rc<SharedState<R, K, P>>,
+) -> Result<JoinHandle<()>, std::io::Error>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+{
+    let bind = listener.local_addr()?;
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
-        bind = %state.config.bind_addr,
+        bind = %bind,
         "rshogi-csa-server-tcp listening"
     );
     let handle = tokio::task::spawn_local(accept_loop(listener, state));

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -429,8 +429,15 @@ fn kifu_and_zerozero_list_match_format_contract() {
         let _ = read_until(&mut rb, "#LOSE").await;
 
         // 棋譜の場所は YYYY/MM/DD/<game_id>.csa（game_id は YYYYMMDDHHMMSS+連番）。
-        // persist_kifu 完了前の read_to_string で NotFound にならないようポーリング待機する。
-        let csa = wait_for_csa_text(&topdir, &game_id).await;
+        // 本テストは「format contract」として日付ディレクトリ配置も検証対象に含める
+        // ため、再帰探索ではなく game_id から組み立てた具体パスをポーリングする。
+        // `relative_kifu_path` が壊れて別ディレクトリへ書き出すような回帰は、ここで
+        // タイムアウト → panic で検知される。
+        let yyyy = &game_id[0..4];
+        let mm = &game_id[4..6];
+        let dd = &game_id[6..8];
+        let csa_path = topdir.join(yyyy).join(mm).join(dd).join(format!("{game_id}.csa"));
+        let csa = wait_for_file_text(&csa_path).await;
         // V2.2 ヘッダ、プレイヤ名、2 手、%TORYO の存在を確認。
         assert!(csa.starts_with("V2.2\n"));
         assert!(csa.contains("\nN+alice\n"));

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -23,7 +23,9 @@ use rshogi_csa_server::{ClockSpec, FileKifuStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
-use rshogi_csa_server_tcp::server::{InMemoryPasswordStore, ServerConfig, build_state, run_server};
+use rshogi_csa_server_tcp::server::{
+    InMemoryPasswordStore, ServerConfig, build_state, run_server_with_listener,
+};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -127,23 +129,20 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
     ];
     let rate_storage = support::MemRateStorage::new(rate_records);
     let kifu_storage = FileKifuStorage::new(topdir.clone());
+    // `127.0.0.1:0` を bind したまま実 addr を取得し、同じ listener をそのまま
+    // サーバーに渡す。probe を drop してから run_server 内で再 bind すると、
+    // その隙に並行テストが同じポートを掴んで「相手のサーバーに繋がる」事故
+    // (kifu が別 topdir に書かれて NotFound) が起きるため。
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let actual_addr = listener.local_addr().unwrap();
     let config = ServerConfig {
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        bind_addr: actual_addr,
         kifu_topdir: topdir.clone(),
         clock,
         login_timeout: Duration::from_secs(10),
         agree_timeout: Duration::from_secs(30),
         ..ServerConfig::sensible_defaults()
     };
-    // bind_addr=:0 を使うため、先に手動で bind してから actual addr を取る必要がある。
-    // ここでは ServerConfig を既定の :0 のまま build_state に渡し、run_server 内で
-    // bind される際のポートを取れない。そのため、TcpListener を先に bind して
-    // そのアドレスを config に書き戻す。
-    let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
-    let actual_addr = probe.local_addr().unwrap();
-    drop(probe); // 実際の bind は run_server が行う
-    let mut config = config;
-    config.bind_addr = actual_addr;
     let state = Rc::new(build_state(
         config,
         rate_storage,
@@ -153,7 +152,7 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
     ));
-    let _handle = run_server(state).await.expect("run_server");
+    let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     // accept ループが起動するまで少し待つ。
     tokio::time::sleep(Duration::from_millis(50)).await;
     (actual_addr, topdir)
@@ -330,8 +329,9 @@ fn login_ok_and_match_start_via_game_summary_and_agree() {
         assert!(b_end.iter().any(|l| l == "#RESIGN"));
 
         // 棋譜ファイルと 00LIST が出ていることを確認。
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        let zerozero = tokio::fs::read_to_string(topdir.join("00LIST")).await.unwrap();
+        // 固定 sleep だと並行実行時に persist_kifu の完了前に read_to_string する race が
+        // 起きる (NotFound でテストが flaky 化する) ため、ポーリング helper で待機する。
+        let zerozero = wait_for_file_text(&topdir.join("00LIST")).await;
         assert!(zerozero.contains(&game_id), "00LIST: {zerozero}");
         assert!(zerozero.contains("alice bob"));
         let _ = tokio::fs::remove_dir_all(&topdir).await;
@@ -428,13 +428,9 @@ fn kifu_and_zerozero_list_match_format_contract() {
         send_line(&mut wb, "%TORYO").await;
         let _ = read_until(&mut rb, "#LOSE").await;
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
         // 棋譜の場所は YYYY/MM/DD/<game_id>.csa（game_id は YYYYMMDDHHMMSS+連番）。
-        let yyyy = &game_id[0..4];
-        let mm = &game_id[4..6];
-        let dd = &game_id[6..8];
-        let csa_path = topdir.join(yyyy).join(mm).join(dd).join(format!("{game_id}.csa"));
-        let csa = tokio::fs::read_to_string(&csa_path).await.unwrap();
+        // persist_kifu 完了前の read_to_string で NotFound にならないようポーリング待機する。
+        let csa = wait_for_csa_text(&topdir, &game_id).await;
         // V2.2 ヘッダ、プレイヤ名、2 手、%TORYO の存在を確認。
         assert!(csa.starts_with("V2.2\n"));
         assert!(csa.contains("\nN+alice\n"));
@@ -443,7 +439,7 @@ fn kifu_and_zerozero_list_match_format_contract() {
         assert!(csa.contains("\n-3334FU,T"));
         assert!(csa.contains("\n%TORYO\n"));
         // 00LIST 1 行がフォーマット契約 (スペース区切り 6 カラム、末尾 #RESIGN) に従う。
-        let zerozero = tokio::fs::read_to_string(topdir.join("00LIST")).await.unwrap();
+        let zerozero = wait_for_file_text(&topdir.join("00LIST")).await;
         let line = zerozero.lines().last().unwrap();
         let cols: Vec<_> = line.split(' ').collect();
         assert_eq!(cols.len(), 6, "00LIST format expects 6 columns: {line}");
@@ -504,8 +500,10 @@ async fn spawn_server_with_agree_timeout(
     ];
     let rate_storage = support::MemRateStorage::new(rate_records);
     let kifu_storage = FileKifuStorage::new(topdir.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let actual_addr = listener.local_addr().unwrap();
     let config = ServerConfig {
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        bind_addr: actual_addr,
         kifu_topdir: topdir.clone(),
         clock: ClockSpec::Countdown {
             total_time_sec: 60,
@@ -515,11 +513,6 @@ async fn spawn_server_with_agree_timeout(
         agree_timeout,
         ..ServerConfig::sensible_defaults()
     };
-    let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
-    let actual_addr = probe.local_addr().unwrap();
-    drop(probe);
-    let mut config = config;
-    config.bind_addr = actual_addr;
     let state = Rc::new(build_state(
         config,
         rate_storage,
@@ -529,7 +522,7 @@ async fn spawn_server_with_agree_timeout(
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
     ));
-    let _handle = run_server(state).await.expect("run_server");
+    let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
     (actual_addr, topdir)
 }
@@ -1110,8 +1103,10 @@ async fn spawn_server_custom(
         .collect();
     let rate_storage = support::MemRateStorage::new(rate_records);
     let kifu_storage = FileKifuStorage::new(topdir.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let actual_addr = listener.local_addr().unwrap();
     let config = ServerConfig {
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        bind_addr: actual_addr,
         kifu_topdir: topdir.clone(),
         clock,
         login_timeout: Duration::from_secs(10),
@@ -1121,11 +1116,6 @@ async fn spawn_server_custom(
         admin_handles,
         ..ServerConfig::sensible_defaults()
     };
-    let probe = tokio::net::TcpListener::bind(config.bind_addr).await.unwrap();
-    let actual_addr = probe.local_addr().unwrap();
-    drop(probe);
-    let mut config = config;
-    config.bind_addr = actual_addr;
     let state = Rc::new(build_state(
         config,
         rate_storage,
@@ -1135,7 +1125,7 @@ async fn spawn_server_custom(
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
     ));
-    let _handle = run_server(state).await.expect("run_server");
+    let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
     (actual_addr, topdir)
 }
@@ -1522,9 +1512,8 @@ fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
         }];
         let rate_storage = support::MemRateStorage::new(rate_records);
         let kifu_storage = FileKifuStorage::new(topdir.clone());
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = probe.local_addr().unwrap();
-        drop(probe);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
         let config = ServerConfig {
             bind_addr: addr,
             kifu_topdir: topdir.clone(),
@@ -1541,7 +1530,7 @@ fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
         ));
-        let _handle = run_server(state.clone()).await.expect("run_server");
+        let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // 待機クライアントを接続。
@@ -1594,9 +1583,8 @@ fn graceful_shutdown_waits_for_in_flight_game_and_persists_kifu() {
             .collect();
         let rate_storage = support::MemRateStorage::new(rate_records);
         let kifu_storage = FileKifuStorage::new(topdir.clone());
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = probe.local_addr().unwrap();
-        drop(probe);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
         let config = ServerConfig {
             bind_addr: addr,
             kifu_topdir: topdir.clone(),
@@ -1613,7 +1601,7 @@ fn graceful_shutdown_waits_for_in_flight_game_and_persists_kifu() {
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
         ));
-        let _handle = run_server(state.clone()).await.expect("run_server");
+        let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         let (mut rb, mut wb) = connect(addr).await;
@@ -1703,9 +1691,8 @@ fn graceful_shutdown_prunes_observer_subscribers() {
             .collect();
         let rate_storage = support::MemRateStorage::new(rate_records);
         let kifu_storage = FileKifuStorage::new(topdir.clone());
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = probe.local_addr().unwrap();
-        drop(probe);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
         let config = ServerConfig {
             bind_addr: addr,
             kifu_topdir: topdir.clone(),
@@ -1722,7 +1709,7 @@ fn graceful_shutdown_prunes_observer_subscribers() {
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
         ));
-        let _handle = run_server(state.clone()).await.expect("run_server");
+        let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // 対局ペアを起動して AGREE まで進める。


### PR DESCRIPTION
## Summary

`cargo test -p rshogi-csa-server-tcp --release` の並行実行 (`--test-threads=8`) でまれに 2 つのテストが揃って `NotFound` で落ちる flaky を 2 段で修正する。

- 修正前: **2/50 (4%) 再現**
- 修正後: **0/200 連続 PASS**

## Root cause

### 1. Port TOCTOU race (本命)

テスト harness は `127.0.0.1:0` で probe 用 `TcpListener` を bind → `local_addr` 取得 → drop → `run_server` 内で同じ addr に再 bind、という流れだった。drop と再 bind の間に並行テストが同 port を掴むと、クライアントが他テストのサーバーに接続してしまい、kifu が別 topdir に書かれて `NotFound`。

ベースライン再現時、毎回必ず `login_ok_and_match_start_via_game_summary_and_agree` と `kifu_and_zerozero_list_match_format_contract` が **揃って** 落ちていたのが port 衝突を裏付けていた。

### 2. Kifu 永続化待ちの fixed sleep race

上記 2 テストだけ、他テストが使っている `wait_for_file_text` / `wait_for_csa_text` (40×50ms ポーリング) ではなく `tokio::time::sleep(50/100ms)` 直後に `read_to_string` していた。`persist_kifu` の完了前に読みに行く別 race が存在し、port race を直すと「単独で 1 テストだけ」失敗する形で顕在化した。

## Changes

- `src/server.rs`: `run_server_with_listener(listener, state)` を新設。`run_server` はそのラッパに (本番パスの挙動は不変)。
- `src/lib.rs`: 新関数を re-export。
- `tests/tcp_session.rs`:
  - 全 6 サイトの probe→drop→rebind を listener-passing に書き換え (`spawn_server_with_clock`, `spawn_server_with_agree_timeout`, `spawn_server_custom`, graceful_shutdown 系インライン 3 箇所)
  - 該当 2 テストの fixed sleep を `wait_for_file_text` / `wait_for_csa_text` に差し替え

`+57 / -49`、production code は最小 API 拡張 (`run_server_with_listener` 追加) のみ。

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --tests -p rshogi-csa-server-tcp` 警告ゼロ
- [x] `cargo test -p rshogi-csa-server-tcp --release` 単発 PASS
- [x] **stress run**: `cargo test --release --test-threads=8` を 200 連続 → **0/200 失敗**
- [x] reproduction baseline (修正前): 50 連続中 2 失敗で TOCTOU race を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)