### PR TITLE
refactor(csa-server): FloodgateHistoryStorage を cfg-clean 化し SharedState へ generic H を導入

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -300,6 +300,10 @@ fn main() -> anyhow::Result<()> {
 /// 構築済みの依存（rate / kifu / password）から `SharedState` を組み立てて
 /// accept ループを起動し、SIGINT / SIGTERM 受信後の graceful shutdown を完遂する
 /// 共通経路。`R` を YAML / インメモリで切り替えるための monomorphize 用ヘルパ。
+///
+/// Floodgate 履歴の backend は TCP 既定の [`JsonlFloodgateHistoryStorage`] を
+/// 直接使う。Workers 等の別 backend に差し替えるのは当面想定外なので、本
+/// バイナリでは H を generic にせず固定する（過剰な型展開を避ける）。
 async fn run_with_state<R, K, P>(
     config: ServerConfig,
     rate_storage: R,
@@ -311,15 +315,21 @@ where
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
 {
-    let state: Rc<SharedState<R, K, P>> = Rc::new(build_state(
-        config,
-        rate_storage,
-        kifu_storage,
-        password_store,
-        Box::new(PlainPasswordHasher::new()),
-        IpLoginRateLimiter::default_limits(),
-        InMemoryBroadcaster::new(),
-    ));
+    let history_storage = config
+        .floodgate_history_path
+        .clone()
+        .map(rshogi_csa_server::JsonlFloodgateHistoryStorage::new);
+    let state: Rc<SharedState<R, K, P, rshogi_csa_server::JsonlFloodgateHistoryStorage>> =
+        Rc::new(build_state(
+            config,
+            rate_storage,
+            kifu_storage,
+            password_store,
+            Box::new(PlainPasswordHasher::new()),
+            IpLoginRateLimiter::default_limits(),
+            InMemoryBroadcaster::new(),
+            history_storage,
+        ));
 
     let handle = run_server(state.clone()).await.context("run_server")?;
     tracing::info!("rshogi-csa-server-tcp ready");

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -137,13 +137,14 @@ pub(crate) fn build_strategy(name: &str) -> Result<Box<dyn PairingLogic>, String
 /// 戦略構築は task spawn より前にまとめて行い、未知 strategy 名は起動段階で
 /// `Err` を返す（run loop に入ってから初めて detected すると、無音でスケジュール
 /// が動かない事故になりうる）。
-pub fn run_schedules<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+pub fn run_schedules<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
 ) -> Result<Vec<tokio::task::JoinHandle<()>>, String>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let schedules = state.config().floodgate_schedules.clone();
     let mut handles = Vec::with_capacity(schedules.len());
@@ -158,8 +159,8 @@ where
     Ok(handles)
 }
 
-async fn run_one_schedule<R, K, P, T>(
-    state: Rc<SharedState<R, K, P>>,
+async fn run_one_schedule<R, K, P, H, T>(
+    state: Rc<SharedState<R, K, P, H>>,
     schedule: FloodgateSchedule,
     strategy: Box<dyn PairingLogic>,
     timer: T,
@@ -167,6 +168,7 @@ async fn run_one_schedule<R, K, P, T>(
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
     T: FloodgateTimer + 'static,
 {
     // release ビルドでは scheduler ループ全体を `catch_unwind` で囲み、`fire_schedule`
@@ -199,8 +201,8 @@ async fn run_one_schedule<R, K, P, T>(
     }
 }
 
-async fn run_one_schedule_loop<R, K, P, T>(
-    state: Rc<SharedState<R, K, P>>,
+async fn run_one_schedule_loop<R, K, P, H, T>(
+    state: Rc<SharedState<R, K, P, H>>,
     schedule: FloodgateSchedule,
     strategy: Box<dyn PairingLogic>,
     timer: T,
@@ -208,6 +210,7 @@ async fn run_one_schedule_loop<R, K, P, T>(
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
     T: FloodgateTimer + 'static,
 {
     let game_name_for_log = schedule.game_name.clone();
@@ -250,14 +253,15 @@ async fn run_one_schedule_loop<R, K, P, T>(
 /// 副作用は state.waiting / state.league（drive_game 内）/ tokio::task::spawn_local
 /// に閉じる。ペアリング戦略の純関数部分とテスト容易性のため、戦略は呼び出し側が
 /// `&dyn PairingLogic` で渡す（`run_schedules` 経路では `Box<dyn ...>` を借りる）。
-pub(crate) async fn fire_schedule<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+pub(crate) async fn fire_schedule<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
     schedule: &FloodgateSchedule,
     strategy: &dyn PairingLogic,
 ) where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let game_name = schedule.game_name();
 
@@ -407,8 +411,8 @@ pub(crate) async fn fire_schedule<R, K, P>(
 /// - drop により残った oneshot は recv Err になり、surviving waiter は
 ///   `WaiterOutcome::Completed` 経路で抜ける（drive_game に到達していないため
 ///   logout は本関数が代行する）
-async fn spawn_scheduled_drive<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+async fn spawn_scheduled_drive<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
     game_name: GameName,
     black: WaitingSlot,
     white: WaitingSlot,
@@ -416,6 +420,7 @@ async fn spawn_scheduled_drive<R, K, P>(
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let (b_resp_tx, b_resp_rx) = oneshot::channel::<TcpTransport>();
     let (b_done_tx, b_done_rx) = oneshot::channel::<()>();
@@ -572,11 +577,12 @@ async fn notify_aborted_match(transport: &mut TcpTransport, game_name: &GameName
 
 /// `drain_for_game_name` で WaitingPool から取り出した両 player を League から
 /// logout する。drive_game に到達できなかった経路で必ず呼ぶ（League 孤児化防止）。
-async fn logout_pair<R, K, P>(state: &SharedState<R, K, P>, black: &str, white: &str)
+async fn logout_pair<R, K, P, H>(state: &SharedState<R, K, P, H>, black: &str, white: &str)
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let black_player = PlayerName::new(black);
     let white_player = PlayerName::new(white);

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -468,9 +468,9 @@ where
     kifu_storage: K,
     password_store: P,
     hasher: Box<dyn PasswordHasher>,
-    /// Floodgate 履歴 JSONL の append 先。`None` の場合は履歴記録を skip する。
-    /// 異 trait 実装は不要なので具体型 `Option<...>` で持つ（generic 引数で受ける
-    /// より型増殖を避けたい）。
+    /// Floodgate 履歴の append 先。`None` の場合は履歴記録を skip する。
+    /// `H` は [`FloodgateHistoryStorage`] を実装する具体 backend（TCP 既定は
+    /// `JsonlFloodgateHistoryStorage`、Workers では R2 + DO storage backend など）。
     pub(crate) history_storage: Option<H>,
     /// 進行中対局のメモリ内レジストリ。`%%LIST` / `%%SHOW` 応答で参照する。
     ///

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -442,11 +442,12 @@ impl WaitingPool {
 }
 
 /// サーバー全体で共有する状態。
-pub struct SharedState<R, K, P>
+pub struct SharedState<R, K, P, H>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     config: ServerConfig,
     pub(crate) league: Mutex<League>,
@@ -470,7 +471,7 @@ where
     /// Floodgate 履歴 JSONL の append 先。`None` の場合は履歴記録を skip する。
     /// 異 trait 実装は不要なので具体型 `Option<...>` で持つ（generic 引数で受ける
     /// より型増殖を避けたい）。
-    pub(crate) history_storage: Option<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+    pub(crate) history_storage: Option<H>,
     /// 進行中対局のメモリ内レジストリ。`%%LIST` / `%%SHOW` 応答で参照する。
     ///
     /// **注意**: このカウントは graceful shutdown の完了判定に使ってはならない。
@@ -505,11 +506,12 @@ where
     pub shutdown: GracefulShutdown,
 }
 
-impl<R, K, P> SharedState<R, K, P>
+impl<R, K, P, H> SharedState<R, K, P, H>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     /// 起動時に渡した [`ServerConfig`] を参照する。graceful shutdown などで
     /// `shutdown_grace` のような設定値を読むために使う。
@@ -562,13 +564,14 @@ impl PasswordStore for InMemoryPasswordStore {
 /// 配線する設計を取る。
 ///
 /// 戻り値は accept ループのタスクハンドル。テストでは `abort()` でシャットダウンする。
-pub async fn run_server<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+pub async fn run_server<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
 ) -> Result<JoinHandle<()>, std::io::Error>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let listener = TcpListener::bind(state.config.bind_addr).await?;
     run_server_with_listener(listener, state).await
@@ -582,14 +585,15 @@ where
 /// 同じ listener をそのままサーバーに渡す」フローを取らないと、probe を drop して
 /// から本体 bind する間に別タスクが同じポートを掴む TOCTOU race が起きるため、
 /// 別経路として公開する。
-pub async fn run_server_with_listener<R, K, P>(
+pub async fn run_server_with_listener<R, K, P, H>(
     listener: TcpListener,
-    state: Rc<SharedState<R, K, P>>,
+    state: Rc<SharedState<R, K, P, H>>,
 ) -> Result<JoinHandle<()>, std::io::Error>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let bind = listener.local_addr()?;
     tracing::info!(
@@ -660,11 +664,12 @@ impl Drop for ConnectionActiveGuard {
 /// Drop に任せている。release ビルドの catch_unwind 経路でも debug ビルドの
 /// 透過経路でも、`?` early return / panic / 正常終了のどの分岐でも guard の Drop
 /// が確実に走るため gauge は leak しない。
-async fn run_connection_isolated<R, K, P>(stream: TcpStream, state: Rc<SharedState<R, K, P>>)
+async fn run_connection_isolated<R, K, P, H>(stream: TcpStream, state: Rc<SharedState<R, K, P, H>>)
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let _conn_active = ConnectionActiveGuard::acquire();
     #[cfg(debug_assertions)]
@@ -703,11 +708,12 @@ where
 }
 
 /// 受理ループ。各接続を `spawn_local` で同スレッド内の独立タスクにする。
-async fn accept_loop<R, K, P>(listener: TcpListener, state: Rc<SharedState<R, K, P>>)
+async fn accept_loop<R, K, P, H>(listener: TcpListener, state: Rc<SharedState<R, K, P, H>>)
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     // 接続ごとに `conn_id` を採番し、tracing span のフィールドとして全ログイベント
     // に伝播する。プロセス再起動でリセットされる単純な `AtomicU64` で十分（同一
@@ -760,14 +766,15 @@ where
 }
 
 /// 1 接続分の処理。LOGIN → 待機プール or drive → 終局まで。
-async fn handle_connection<R, K, P>(
+async fn handle_connection<R, K, P, H>(
     stream: TcpStream,
-    state: Rc<SharedState<R, K, P>>,
+    state: Rc<SharedState<R, K, P, H>>,
 ) -> Result<(), ServerError>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let peer = TcpTransport::peer_key(&stream)?;
     let mut transport = TcpTransport::new(stream, peer.clone());
@@ -1036,8 +1043,8 @@ where
 ///   空行 keep-alive に応答し、それ以外の入力で切断する。マッチングへの参加は
 ///   非 x1 と同じ経路なので、相補手番の相手が到着すれば drive 側へ handoff する。
 #[allow(clippy::too_many_arguments)]
-async fn run_waiter<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+async fn run_waiter<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
     mut transport: TcpTransport,
     handle: String,
     color: Color,
@@ -1051,6 +1058,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let (match_req_tx, mut match_req_rx) = oneshot::channel::<MatchRequest>();
     {
@@ -1690,11 +1698,15 @@ enum ForkOutcome {
 /// subscribe 完了時点でゲームが既に終局している可能性がある。その場合 stale
 /// なエントリを broadcaster に残さないよう、呼び出し側で drop + prune して
 /// NOT_FOUND を返す。
-async fn subscribe_still_registered<R, K, P>(state: &SharedState<R, K, P>, game_id: &GameId) -> bool
+async fn subscribe_still_registered<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
+    game_id: &GameId,
+) -> bool
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let games = state.games.lock().await;
     games.get(game_id).is_some()
@@ -1704,14 +1716,15 @@ where
 ///
 /// buoy があれば残数を 1 消費してその開始局面を返し、無ければグローバル既定値を返す。
 /// 残数 0 の buoy は対局を成立させない。
-async fn reserve_match_initial_position<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn reserve_match_initial_position<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     game_name: &GameName,
 ) -> Result<MatchInitialPosition, ServerError>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let Some(buoy) = state
         .buoy_storage
@@ -1761,8 +1774,8 @@ where
 /// ループ側は x1 応答 `##[FORK] NOT_FOUND` / `##[FORK] ERROR ...` に落として
 /// 接続を維持し、graceful degradation にする。`Err` は storage I/O 失敗など
 /// 本当に復旧不能な経路にだけ残す。
-async fn derive_fork_from_source_kifu<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn derive_fork_from_source_kifu<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     source_game: &GameId,
     nth_move: Option<u32>,
 ) -> Result<ForkOutcome, ServerError>
@@ -1770,6 +1783,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let Some(csa_v2_text) =
         state.kifu_storage.load(source_game).await.map_err(ServerError::Storage)?
@@ -1792,8 +1806,8 @@ fn default_fork_buoy_name(source_game: &GameId, nth_move: Option<u32>) -> GameNa
 
 /// drive 側タスクのメインループ。両 transport を所有して 1 対局を完了まで運ぶ。
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn drive_game<R, K, P>(
-    state: Rc<SharedState<R, K, P>>,
+pub(crate) async fn drive_game<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
     opp_transport: TcpTransport,
     opp_handle: String,
     opp_color: Color,
@@ -1808,6 +1822,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     debug_assert_eq!(opp_color, self_color.opposite());
 
@@ -1942,8 +1957,8 @@ where
 /// の `DriveGuard` が Drop で読み取って `csa_games_finished_total{result_code}`
 /// を +1 する経路に使う。本関数が Err で抜けた・slot を埋めずに完了した場合は
 /// `RESULT_CODE_ABORTED` (`#ABORTED`) で集計される。
-async fn drive_game_inner<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn drive_game_inner<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     game_id: &GameId,
     matched: MatchedPair,
     game_name: GameName,
@@ -1956,6 +1971,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     // Game_Summary を両対局者に送信。
     let clock = state.config.clock.build_clock();
@@ -2224,8 +2240,8 @@ async fn wait_both_agree(
 /// 呼び出し側は続けて `GameRegistry::register` してから `run_game_loop_and_record`
 /// を呼ぶ流れに乗せる。`dispatch` が送信失敗した場合は `ServerError::Transport`
 /// で早期 return し、GameRegistry には入れない（幽霊対局を防ぐ）。
-async fn initialize_game_and_dispatch_start<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn initialize_game_and_dispatch_start<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     game_id: &GameId,
     matched: &MatchedPair,
     clock: Box<dyn rshogi_csa_server::TimeClock>,
@@ -2237,6 +2253,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let cfg = GameRoomConfig {
         game_id: game_id.clone(),
@@ -2269,8 +2286,8 @@ where
 ///
 /// `run_room` を直接使うと消費秒数を取り出せないため、ここでは `GameRoom` を直接駆動
 /// して手番イベントから `,T<sec>` を解析し `KifuMove` を収集する。
-async fn run_game_loop_and_record<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn run_game_loop_and_record<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     game_id: &GameId,
     room: &mut GameRoom,
     start_instant: tokio::time::Instant,
@@ -2281,6 +2298,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let now_ms =
         || tokio::time::Instant::now().saturating_duration_since(start_instant).as_millis() as u64;
@@ -2396,8 +2414,8 @@ fn parse_move_broadcast(line: &str) -> Option<(&str, u32)> {
 
 /// 棋譜 + 00LIST を永続化する。`game_name` は Floodgate 履歴 JSONL に記録する
 /// ためのみ使う（kifu / 00LIST 出力には影響しない）。
-async fn persist_kifu<R, K, P>(
-    state: &SharedState<R, K, P>,
+async fn persist_kifu<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
     game_id: &GameId,
     game_name: &GameName,
     matched: &MatchedPair,
@@ -2411,6 +2429,7 @@ where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     // initial_sfen が設定されていれば棋譜の `initial_position` も同じ SFEN から派生。
     // 設定されていない (= 平手) 場合は既存の CSA shorthand `PI\n+\n` を保つ。
@@ -2547,10 +2566,12 @@ where
 
 /// `SharedState` を組み立てるヘルパ（運用コードとテストで再利用）。
 ///
-/// `floodgate_history_path` が `Some` の場合は [`JsonlFloodgateHistoryStorage`]
-/// を構築して `SharedState.history_storage` に乗せる。`None` の場合は履歴
-/// 記録 skip。
-pub fn build_state<R, K, P>(
+/// `history_storage` は呼び出し側で構築して渡す（履歴永続化を行わない場合は
+/// `None`）。`H` を generic にしているのは TCP の JSONL 実装と Workers 等の
+/// 別 backend 実装を `FloodgateHistoryStorage` trait の下で差し替え可能にする
+/// ため。テストでは `None::<JsonlFloodgateHistoryStorage>` のように turbofish で
+/// 型を確定させて呼ぶ。
+pub fn build_state<R, K, P, H>(
     config: ServerConfig,
     rate_storage: R,
     kifu_storage: K,
@@ -2558,17 +2579,15 @@ pub fn build_state<R, K, P>(
     hasher: Box<dyn PasswordHasher>,
     rate_limiter: IpLoginRateLimiter,
     broadcaster: InMemoryBroadcaster,
-) -> SharedState<R, K, P>
+    history_storage: Option<H>,
+) -> SharedState<R, K, P, H>
 where
     R: RateStorage + 'static,
     K: KifuStorage + 'static,
     P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
 {
     let buoy_storage = rshogi_csa_server::FileBuoyStorage::new(config.kifu_topdir.clone());
-    let history_storage = config
-        .floodgate_history_path
-        .clone()
-        .map(rshogi_csa_server::JsonlFloodgateHistoryStorage::new);
     SharedState {
         config,
         league: Mutex::new(League::new()),
@@ -2592,16 +2611,23 @@ where
 }
 
 /// 既定の TCP サーバー構築ヘルパ。`bind_addr` と `kifu_topdir` を上書きする用途。
+///
+/// `floodgate_history_path` が `Some` の場合は [`JsonlFloodgateHistoryStorage`]
+/// を構築して `history_storage` に乗せる（TCP 既定の履歴 backend）。
 pub fn default_tcp_shared_state<R, P>(
     config: ServerConfig,
     rate_storage: R,
     password_store: P,
-) -> SharedState<R, FileKifuStorage, P>
+) -> SharedState<R, FileKifuStorage, P, rshogi_csa_server::JsonlFloodgateHistoryStorage>
 where
     R: RateStorage + 'static,
     P: PasswordStore + 'static,
 {
     let kifu_storage = FileKifuStorage::new(config.kifu_topdir.clone());
+    let history_storage = config
+        .floodgate_history_path
+        .clone()
+        .map(rshogi_csa_server::JsonlFloodgateHistoryStorage::new);
     build_state(
         config,
         rate_storage,
@@ -2610,6 +2636,7 @@ where
         Box::new(crate::auth::PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
+        history_storage,
     )
 }
 

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -151,6 +151,7 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
+        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     // accept ループが起動するまで少し待つ。
@@ -528,6 +529,7 @@ async fn spawn_server_with_agree_timeout(
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
+        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1131,6 +1133,7 @@ async fn spawn_server_custom(
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
+        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1536,6 +1539,7 @@ fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
+            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1607,6 +1611,7 @@ fn graceful_shutdown_waits_for_in_flight_game_and_persists_kifu() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
+            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1715,6 +1720,7 @@ fn graceful_shutdown_prunes_observer_subscribers() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
+            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::port::PlayerRateRecord;
 use rshogi_csa_server::types::PlayerName;
-use rshogi_csa_server::{ClockSpec, FileKifuStorage};
+use rshogi_csa_server::{ClockSpec, FileKifuStorage, JsonlFloodgateHistoryStorage};
 use rshogi_csa_server_tcp::auth::PlainPasswordHasher;
 use rshogi_csa_server_tcp::broadcaster::InMemoryBroadcaster;
 use rshogi_csa_server_tcp::rate_limit::IpLoginRateLimiter;
@@ -151,7 +151,7 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
-        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+        None::<JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     // accept ループが起動するまで少し待つ。
@@ -529,7 +529,7 @@ async fn spawn_server_with_agree_timeout(
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
-        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+        None::<JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1133,7 +1133,7 @@ async fn spawn_server_custom(
         Box::new(PlainPasswordHasher::new()),
         IpLoginRateLimiter::default_limits(),
         InMemoryBroadcaster::new(),
-        None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+        None::<JsonlFloodgateHistoryStorage>,
     ));
     let _handle = run_server_with_listener(listener, state).await.expect("run_server");
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1539,7 +1539,7 @@ fn graceful_shutdown_disconnects_waiter_and_stops_accepting() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
-            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+            None::<JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1611,7 +1611,7 @@ fn graceful_shutdown_waits_for_in_flight_game_and_persists_kifu() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
-            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+            None::<JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -1720,7 +1720,7 @@ fn graceful_shutdown_prunes_observer_subscribers() {
             Box::new(PlainPasswordHasher::new()),
             IpLoginRateLimiter::default_limits(),
             InMemoryBroadcaster::new(),
-            None::<rshogi_csa_server::JsonlFloodgateHistoryStorage>,
+            None::<JsonlFloodgateHistoryStorage>,
         ));
         let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
         tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -49,8 +49,9 @@ pub use storage::buoy::FileBuoyStorage;
 #[cfg(feature = "tokio-transport")]
 pub use storage::file::FileKifuStorage;
 #[cfg(feature = "tokio-transport")]
+pub use storage::floodgate_history::JsonlFloodgateHistoryStorage;
 pub use storage::floodgate_history::{
-    FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor, JsonlFloodgateHistoryStorage,
+    FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor,
 };
 #[cfg(feature = "tokio-transport")]
 pub use storage::players_yaml::PlayersYamlRateStorage;

--- a/crates/rshogi-csa-server/src/storage/floodgate_history/jsonl.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history/jsonl.rs
@@ -1,8 +1,4 @@
-//! Floodgate 履歴の永続化（開始時刻・ペア・結果を再起動跨ぎで参照可能にする）。
-//!
-//! 各対局の終局時に 1 件の [`FloodgateHistoryEntry`] を append-only な JSONL
-//! ファイルに追記する。読み込み側（`%%FLOODGATE history` 等）は近傍 N 件を
-//! tail で読む利用を想定し、行末改行で 1 entry = 1 line のフォーマットを採用。
+//! JSONL 形式の Floodgate 履歴ストレージ実装（tokio ランタイム前提）。
 //!
 //! # 設計判断
 //!
@@ -22,102 +18,17 @@
 
 use std::path::PathBuf;
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::error::StorageError;
-use crate::types::{Color, GameId, GameName, PlayerName};
 
-/// Floodgate 履歴 1 件分のエントリ。`persist_kifu` 経由で終局確定時に
-/// `FloodgateHistoryStorage::append` に渡される。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FloodgateHistoryEntry {
-    /// 対局識別子（サーバ発行）。
-    pub game_id: String,
-    /// マッチが帰属する `game_name`（Floodgate スケジュールの分類軸と一致）。
-    pub game_name: String,
-    /// 先手プレイヤ名。
-    pub black: String,
-    /// 後手プレイヤ名。
-    pub white: String,
-    /// 対局開始時刻（UTC、RFC3339）。
-    pub start_time: String,
-    /// 対局終了時刻（UTC、RFC3339）。
-    pub end_time: String,
-    /// 終局理由コード（`#RESIGN` / `#TIME_UP` / `#ILLEGAL_MOVE` 等）。
-    pub result_code: String,
-    /// 勝者の色。引き分け（千日手・最大手数）や勝敗不確定の `#ABNORMAL` では
-    /// `None`。シリアライズ時は `Black` / `White` 文字列。
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub winner: Option<HistoryColor>,
-}
-
-/// `Color` を JSON スキーマ用に文字列シリアライズする小 enum。core の
-/// `Color` は serde 派生していないので独立させる（serde を core 全体に拡げる
-/// より隔離する方が依存範囲が読みやすい）。
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub enum HistoryColor {
-    Black,
-    White,
-}
-
-impl From<Color> for HistoryColor {
-    fn from(c: Color) -> Self {
-        match c {
-            Color::Black => Self::Black,
-            Color::White => Self::White,
-        }
-    }
-}
-
-impl FloodgateHistoryEntry {
-    /// 業務型から構築するヘルパ。`persist_kifu` 経路から呼ばれる。
-    pub fn new(
-        game_id: &GameId,
-        game_name: &GameName,
-        black: &PlayerName,
-        white: &PlayerName,
-        start_time: DateTime<Utc>,
-        end_time: DateTime<Utc>,
-        result_code: &str,
-        winner: Option<Color>,
-    ) -> Self {
-        Self {
-            game_id: game_id.as_str().to_owned(),
-            game_name: game_name.as_str().to_owned(),
-            black: black.as_str().to_owned(),
-            white: white.as_str().to_owned(),
-            start_time: start_time.to_rfc3339(),
-            end_time: end_time.to_rfc3339(),
-            result_code: result_code.to_owned(),
-            winner: winner.map(HistoryColor::from),
-        }
-    }
-}
-
-/// Floodgate 履歴の永続化抽象。`append` で 1 件追加、`list_recent` で末尾 N 件
-/// 取得（運用ダッシュボードや x1 拡張コマンドで使う想定）。
-pub trait FloodgateHistoryStorage {
-    /// 1 件の履歴エントリを末尾に追記する。失敗時は `StorageError` で伝播。
-    fn append(
-        &self,
-        entry: &FloodgateHistoryEntry,
-    ) -> impl std::future::Future<Output = Result<(), StorageError>>;
-
-    /// 末尾 N 件を新しい順で取得する。`limit` は 0 で空 `Vec`、`usize::MAX` で
-    /// 全件相当（実装依存上限あり）。再起動を跨いだ参照に使う。
-    fn list_recent(
-        &self,
-        limit: usize,
-    ) -> impl std::future::Future<Output = Result<Vec<FloodgateHistoryEntry>, StorageError>>;
-}
+use super::port::FloodgateHistoryStorage;
+use super::types::FloodgateHistoryEntry;
 
 /// JSONL 形式（1 entry = 1 line）でファイルに append-only 記録する `FloodgateHistoryStorage`
-/// 実装。`tokio-transport` 配下でのみコンパイルされる。
+/// 実装。
 ///
 /// `append` は内部 `AsyncMutex` で直列化し、`OpenOptions::append(true)` で
 /// 開いて 1 entry を書く。POSIX 上の `O_APPEND` 書き込みは「現在のファイル末尾
@@ -230,6 +141,7 @@ impl FloodgateHistoryStorage for JsonlFloodgateHistoryStorage {
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::HistoryColor;
     use super::*;
     use std::path::Path;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -245,22 +157,6 @@ mod tests {
             result_code: "#RESIGN".to_owned(),
             winner,
         }
-    }
-
-    #[test]
-    fn entry_round_trips_through_json() {
-        let e = entry("g1", Some(HistoryColor::Black));
-        let s = serde_json::to_string(&e).unwrap();
-        let parsed: FloodgateHistoryEntry = serde_json::from_str(&s).unwrap();
-        assert_eq!(parsed, e);
-    }
-
-    #[test]
-    fn entry_omits_winner_when_none() {
-        let e = entry("g1", None);
-        let s = serde_json::to_string(&e).unwrap();
-        // 引き分け（千日手 / 最大手数）では `winner` フィールドが出力に出ない。
-        assert!(!s.contains("\"winner\""), "winner must be omitted: {s}");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server/src/storage/floodgate_history/mod.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history/mod.rs
@@ -1,0 +1,25 @@
+//! Floodgate 履歴の永続化ポート。
+//!
+//! `FloodgateHistoryStorage` trait と履歴 entry の型 (`FloodgateHistoryEntry`,
+//! `HistoryColor`) はランタイムに依存しないため `port` / `types` モジュールで
+//! 常時コンパイル可能とし、TCP / Workers の双方から trait を実装できる形に
+//! しておく。
+//!
+//! 具体実装はランタイム別に分かれる:
+//!
+//! - `JsonlFloodgateHistoryStorage`: tokio ベースの JSONL append-only 実装。
+//!   `tokio-transport` feature 配下でのみコンパイル
+//! - Workers (Cloudflare DO) 向けの実装は `rshogi-csa-server-workers` 側に置き、
+//!   本モジュールの trait を実装する
+
+mod port;
+mod types;
+
+#[cfg(feature = "tokio-transport")]
+mod jsonl;
+
+pub use port::FloodgateHistoryStorage;
+pub use types::{FloodgateHistoryEntry, HistoryColor};
+
+#[cfg(feature = "tokio-transport")]
+pub use jsonl::JsonlFloodgateHistoryStorage;

--- a/crates/rshogi-csa-server/src/storage/floodgate_history/port.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history/port.rs
@@ -1,0 +1,26 @@
+//! Floodgate 履歴永続化の抽象ポート。
+//!
+//! `append` で 1 件追加、`list_recent` で末尾 N 件取得する責務を持つ。具体実装
+//! はランタイム別に分かれる: TCP は JSONL ファイル append、Workers (Cloudflare DO)
+//! は R2 day-shard + DO storage ring buffer のハイブリッド等。
+
+use crate::error::StorageError;
+
+use super::types::FloodgateHistoryEntry;
+
+/// Floodgate 履歴の永続化抽象。`append` で 1 件追加、`list_recent` で末尾 N 件
+/// 取得（運用ダッシュボードや x1 拡張コマンドで使う想定）。
+pub trait FloodgateHistoryStorage {
+    /// 1 件の履歴エントリを末尾に追記する。失敗時は `StorageError` で伝播。
+    fn append(
+        &self,
+        entry: &FloodgateHistoryEntry,
+    ) -> impl std::future::Future<Output = Result<(), StorageError>>;
+
+    /// 末尾 N 件を新しい順で取得する。`limit` は 0 で空 `Vec`、`usize::MAX` で
+    /// 全件相当（実装依存上限あり）。再起動を跨いだ参照に使う。
+    fn list_recent(
+        &self,
+        limit: usize,
+    ) -> impl std::future::Future<Output = Result<Vec<FloodgateHistoryEntry>, StorageError>>;
+}

--- a/crates/rshogi-csa-server/src/storage/floodgate_history/types.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history/types.rs
@@ -1,0 +1,111 @@
+//! Floodgate 履歴 entry の値オブジェクト。
+//!
+//! ランタイム非依存の純データ型のみを置き、tokio や I/O 系 crate は読み込まない。
+//! TCP/Workers いずれの crate からも安全に import できる。
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::types::{Color, GameId, GameName, PlayerName};
+
+/// Floodgate 履歴 1 件分のエントリ。`persist_kifu` 経由で終局確定時に
+/// `FloodgateHistoryStorage::append` に渡される。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FloodgateHistoryEntry {
+    /// 対局識別子（サーバ発行）。
+    pub game_id: String,
+    /// マッチが帰属する `game_name`（Floodgate スケジュールの分類軸と一致）。
+    pub game_name: String,
+    /// 先手プレイヤ名。
+    pub black: String,
+    /// 後手プレイヤ名。
+    pub white: String,
+    /// 対局開始時刻（UTC、RFC3339）。
+    pub start_time: String,
+    /// 対局終了時刻（UTC、RFC3339）。
+    pub end_time: String,
+    /// 終局理由コード（`#RESIGN` / `#TIME_UP` / `#ILLEGAL_MOVE` 等）。
+    pub result_code: String,
+    /// 勝者の色。引き分け（千日手・最大手数）や勝敗不確定の `#ABNORMAL` では
+    /// `None`。シリアライズ時は `Black` / `White` 文字列。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub winner: Option<HistoryColor>,
+}
+
+/// `Color` を JSON スキーマ用に文字列シリアライズする小 enum。core の
+/// `Color` は serde 派生していないので独立させる（serde を core 全体に拡げる
+/// より隔離する方が依存範囲が読みやすい）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum HistoryColor {
+    Black,
+    White,
+}
+
+impl From<Color> for HistoryColor {
+    fn from(c: Color) -> Self {
+        match c {
+            Color::Black => Self::Black,
+            Color::White => Self::White,
+        }
+    }
+}
+
+impl FloodgateHistoryEntry {
+    /// 業務型から構築するヘルパ。`persist_kifu` 経路から呼ばれる。
+    pub fn new(
+        game_id: &GameId,
+        game_name: &GameName,
+        black: &PlayerName,
+        white: &PlayerName,
+        start_time: DateTime<Utc>,
+        end_time: DateTime<Utc>,
+        result_code: &str,
+        winner: Option<Color>,
+    ) -> Self {
+        Self {
+            game_id: game_id.as_str().to_owned(),
+            game_name: game_name.as_str().to_owned(),
+            black: black.as_str().to_owned(),
+            white: white.as_str().to_owned(),
+            start_time: start_time.to_rfc3339(),
+            end_time: end_time.to_rfc3339(),
+            result_code: result_code.to_owned(),
+            winner: winner.map(HistoryColor::from),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(game_id: &str, winner: Option<HistoryColor>) -> FloodgateHistoryEntry {
+        FloodgateHistoryEntry {
+            game_id: game_id.to_owned(),
+            game_name: "floodgate-600-10".to_owned(),
+            black: "alice".to_owned(),
+            white: "bob".to_owned(),
+            start_time: "2026-04-26T12:00:00+00:00".to_owned(),
+            end_time: "2026-04-26T12:30:00+00:00".to_owned(),
+            result_code: "#RESIGN".to_owned(),
+            winner,
+        }
+    }
+
+    #[test]
+    fn entry_round_trips_through_json() {
+        let e = entry("g1", Some(HistoryColor::Black));
+        let s = serde_json::to_string(&e).unwrap();
+        let parsed: FloodgateHistoryEntry = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed, e);
+    }
+
+    #[test]
+    fn entry_omits_winner_when_none() {
+        let e = entry("g1", None);
+        let s = serde_json::to_string(&e).unwrap();
+        // 引き分け（千日手 / 最大手数）では `winner` フィールドが出力に出ない。
+        assert!(!s.contains("\"winner\""), "winner must be omitted: {s}");
+    }
+}

--- a/crates/rshogi-csa-server/src/storage/mod.rs
+++ b/crates/rshogi-csa-server/src/storage/mod.rs
@@ -1,10 +1,18 @@
-//! 永続化アダプタ実装。現状は TCP 向けのファイルストレージのみ。
+//! 永続化ポートとアダプタ実装。
+//!
+//! `floodgate_history` モジュールはランタイム非依存な trait + entry 型を
+//! 公開し、tokio ベースの JSONL 実装は `tokio-transport` feature 配下で
+//! のみコンパイルされる。Workers (Cloudflare DO) など他のランタイムは同 trait
+//! を実装する形で別 crate から接続する。
+//!
+//! 残りのアダプタ（`buoy` / `file` / `players_yaml`）は現状 tokio 前提のため
+//! `tokio-transport` 配下のみでコンパイルされる。
+
+pub mod floodgate_history;
 
 #[cfg(feature = "tokio-transport")]
 pub mod buoy;
 #[cfg(feature = "tokio-transport")]
 pub mod file;
-#[cfg(feature = "tokio-transport")]
-pub mod floodgate_history;
 #[cfg(feature = "tokio-transport")]
 pub mod players_yaml;


### PR DESCRIPTION
## Summary

Floodgate 履歴永続化の trait + entry 型を **TCP / Workers (Cloudflare DO) 双方から実装可能にする下地**を整備する。これまで `FloodgateHistoryStorage` は `storage/floodgate_history.rs` 全体が `tokio-transport` feature gate されており、Workers (wasm32) ビルドでは trait すら見えなかった。

これは Workers 側 Floodgate 履歴永続化の前段で、本 PR は **抽象化のみ**。Workers 実装本体（R2 day-shard + DO storage ring buffer の hybrid backend）は後続の stacked PR で導入する。

## 主要変更

### 1. `storage/floodgate_history/` ディレクトリ module へ分割

`floodgate_history.rs` を 4 ファイルに分割:

| ファイル | gate | 内容 |
|---|---|---|
| `mod.rs` | 無条件 | 子 mod 宣言と re-export |
| `port.rs` | 無条件 | `FloodgateHistoryStorage` trait（既存 `BuoyStorage` 等と同じ RPITIT パターン）|
| `types.rs` | 無条件 | `FloodgateHistoryEntry` / `HistoryColor`（serde 派生のみ、ランタイム非依存）|
| `jsonl.rs` | `tokio-transport` | `JsonlFloodgateHistoryStorage`（tokio I/O 前提）|

`storage/mod.rs` / `lib.rs` の cfg と re-export を調整し、両 feature ビルドで csa-server crate が通ることを確認。

### 2. TCP `SharedState<R, K, P>` → `<R, K, P, H>`

`SharedState.history_storage` を具象型 `Option<JsonlFloodgateHistoryStorage>` から generic `Option<H>` に変更し、`H: FloodgateHistoryStorage + 'static` を where 句に追加。`server.rs` / `scheduler.rs` 全体で `<R, K, P>` を `<R, K, P, H>` に cascade（47 機械的サイト）。既存 `RateStorage` / `KifuStorage` / `PasswordStore` と同じパターンで揃え、`async-trait` 等の新規依存は導入していない。

### 3. `build_state` API 調整

履歴 backend の生成箇所を `build_state` 内部から呼び出し側へ移動:

- 旧: `build_state` が `config.floodgate_history_path` を内部で `map(JsonlFloodgateHistoryStorage::new)` で構築
- 新: `build_state` が `history_storage: Option<H>` を引数で受け取る

`bin/main.rs` の `run_with_state` は TCP 既定の `JsonlFloodgateHistoryStorage` を直接構築して渡す（H を generic 化せず固定）。`default_tcp_shared_state` ヘルパは戻り値型を `SharedState<R, FileKifuStorage, P, JsonlFloodgateHistoryStorage>` に固定し、従来同等の API を維持。

`tests/tcp_session.rs` の 6 callsite は履歴を使わないため `None::<JsonlFloodgateHistoryStorage>` を turbofish で渡す。

## なぜ generic H (option b) を選んだか

3 案を比較した結果 (Plan 議論):

| 案 | 採否 | 理由 |
|---|---|---|
| (a) `async-trait` crate | 却下 | 既存 storage trait 群（`BuoyStorage` / `RateStorage` / `KifuStorage`）が全て RPITIT で揃っているところに `#[async_trait]` を 1 つだけ持ち込むと整合性が崩れる + 新規 workspace dep |
| **(b) generic H** | **採用** | 既存 `SharedState<R, K, P>` パターンと完全に揃う。ゼロオーバーヘッド・ゼロ新規依存。「diff が広い」懸念は調査で 3 src + 1 test file・47 機械的箇所と判明、許容範囲 |
| (c) enum sum type | 却下 | `rshogi-csa-server` core crate が Workers 型を知る必要があり、open/closed 原則に反する |

## 範囲外（後続タスク）

- **Workers DO 側 backend 実装**: 本 PR は trait の cfg-clean 化と TCP 抽象化のみ。`crates/rshogi-csa-server-workers/src/floodgate_history.rs` を新設して `FloodgateHistoryStorage` を実装する PR を stack で続ける
- **R2 day-shard + DO storage ring buffer の選定**: 後続 PR で実装。KV (1MB 上限・eventually consistent) は append log には不適なので不採用

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`（debug + release）
- [x] `cargo build -p rshogi-csa-server --no-default-features --features workers`
- [x] `cargo build -p rshogi-csa-server-workers --no-default-features`
- [x] `cargo test --workspace --release`（全 pass、failed 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)