### PR TITLE
fix(csa-server-tcp): %%FORK 系テストの kifu read race を解消

### DIFF
--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1284,7 +1284,10 @@ fn fork_creates_single_use_buoy_from_existing_game() {
         let _ = read_until(&mut rb, "#WIN").await;
         let _ = read_until(&mut rw, "#LOSE").await;
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // 固定 sleep だと並行実行下で persist_kifu 完了前に %%FORK が走り、
+        // kifu_storage.load が NotFound を返して `##[FORK] NOT_FOUND` に落ちる
+        // race が出る (PR #497 と同種)。CSA ファイル書き込みを polling で待つ。
+        let _ = wait_for_csa_text(&topdir, &source_game_id).await;
 
         let (mut ra, mut wa) = connect(addr).await;
         send_line(&mut wa, "LOGIN admin+obs+black pw x1").await;
@@ -1386,7 +1389,10 @@ fn fork_gracefully_errors_and_keeps_connection_alive() {
         let _ = read_until(&mut rb, "#WIN").await;
         let _ = read_until(&mut rw, "#LOSE").await;
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // 固定 sleep だと並行実行下で persist_kifu 完了前に %%FORK が走り、
+        // 期待する `##[FORK] ERROR` ではなく `NOT_FOUND` に落ちる race が出る
+        // (PR #497 と同種)。CSA ファイル書き込みを polling で待つ。
+        let _ = wait_for_csa_text(&topdir, &source_game_id).await;
 
         // nth_move=999 は範囲外。切断せず ERROR + END を返す。
         send_line(&mut wa, &format!("%%FORK {source_game_id} bad 999")).await;


### PR DESCRIPTION
## Summary
- `fork_creates_single_use_buoy_from_existing_game` が CI で `##[FORK] NOT_FOUND <game_id>` を返して flaky に落ちる問題を修正。
- 同じ race を抱えていた `fork_gracefully_errors_and_keeps_connection_alive` も合わせて修正 (こちらは `NOT_FOUND` で `ERROR` 期待が外れるパス)。

## 原因
`#WIN`/`#LOSE` を読み取った直後に `tokio::time::sleep(Duration::from_millis(100))` で待ってから `%%FORK` を発行していたが、`%%FORK` ハンドラは `crates/rshogi-csa-server-tcp/src/server.rs` の `derive_fork_from_source_kifu` で `state.kifu_storage.load(source_game)` を呼ぶ。`drive_game` epilogue の `persist_kifu` (CSA 書き込み + `00LIST` append) が並行実行下で 100ms に収まらないと `load` が `None` を返し、`##[FORK] NOT_FOUND` に落ちる。PR #497 で同種の race を 2 箇所修正済みだったが、`%%FORK` 経路は見落とされていた。

## 修正
固定 sleep を、同ファイル内に既存の polling helper `wait_for_csa_text(&topdir, &source_game_id)` (最大 2s) に差し替えるだけ。サーバー側コードは変更なし。

## Test plan
- [x] `cargo fmt --check -p rshogi-csa-server-tcp`
- [x] `cargo clippy -p rshogi-csa-server-tcp --tests -- -D warnings`
- [x] `cargo test -p rshogi-csa-server-tcp --test tcp_session` を 5 連続実行: 30 テスト全緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)