### PR TITLE
feat(csa-server): 対局開始時に再接続トークンを発行し Game_Summary 末尾拡張行で配布する

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -48,7 +48,7 @@ use rshogi_csa_server::record::kifu::{
     primary_result_code,
 };
 use rshogi_csa_server::types::{
-    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, RoomId,
+    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken, RoomId,
 };
 use rshogi_csa_server::{FileKifuStorage, TransportError};
 use tokio::net::{TcpListener, TcpStream};
@@ -1991,6 +1991,10 @@ where
         }
         None => (standard_initial_position_block(), Color::Black),
     };
+    // 対局開始時に対局者ごとに一意な再接続トークンを発行し、Game_Summary 末尾の
+    // 拡張行で配布する。再接続経路はトークン照合で同一対局・同一対局者を識別する。
+    let black_reconnect_token = ReconnectToken::generate();
+    let white_reconnect_token = ReconnectToken::generate();
     let summary = GameSummaryBuilder {
         game_id: game_id.clone(),
         black: matched.black.clone(),
@@ -2000,6 +2004,8 @@ where
         rematch_on_draw: false,
         to_move,
         declaration: "Jishogi 1.1".to_owned(),
+        black_reconnect_token: Some(black_reconnect_token),
+        white_reconnect_token: Some(white_reconnect_token),
     };
     send_multiline(black_transport, &summary.build_for(Color::Black)).await?;
     send_multiline(white_transport, &summary.build_for(Color::White)).await?;

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -51,7 +51,9 @@ use rshogi_csa_server::protocol::summary::{
     standard_initial_position_block,
 };
 use rshogi_csa_server::record::kifu::{fork_initial_sfen_from_kifu, initial_sfen_from_csa_moves};
-use rshogi_csa_server::types::{Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName};
+use rshogi_csa_server::types::{
+    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken,
+};
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::{ConfigKeys, parse_clock_spec};
@@ -431,6 +433,11 @@ impl GameRoom {
         *self.core.borrow_mut() = Some(core);
         *self.config.borrow_mut() = Some(cfg.clone());
 
+        // 対局開始時に対局者ごとに一意な再接続トークンを発行し、Game_Summary 末尾の
+        // 拡張行で配布する。デプロイ／DO 再起動による切断時、クライアントは
+        // この token を提示して同一対局・同一対局者として再参加する。
+        let black_reconnect_token = ReconnectToken::generate();
+        let white_reconnect_token = ReconnectToken::generate();
         // Game_Summary を双方に送出（Your_Turn だけ色で変える）。
         let builder = GameSummaryBuilder {
             game_id: GameId::new(cfg.game_id),
@@ -441,6 +448,8 @@ impl GameRoom {
             rematch_on_draw: false,
             to_move,
             declaration: String::new(),
+            black_reconnect_token: Some(black_reconnect_token),
+            white_reconnect_token: Some(white_reconnect_token),
         };
         let summary_black = builder.build_for(Color::Black);
         let summary_white = builder.build_for(Color::White);

--- a/crates/rshogi-csa-server/src/protocol/summary.rs
+++ b/crates/rshogi-csa-server/src/protocol/summary.rs
@@ -9,7 +9,7 @@ use std::fmt::Write as _;
 use rshogi_core::position::Position;
 use rshogi_core::types::{Color as CoreColor, File, PieceType, Rank, Square};
 
-use crate::types::{Color, GameId, PlayerName};
+use crate::types::{Color, GameId, PlayerName, ReconnectToken};
 
 /// `Game_Summary` の入力パラメタ。
 #[derive(Debug, Clone)]
@@ -32,6 +32,13 @@ pub struct GameSummaryBuilder {
     pub to_move: Color,
     /// 入玉宣言ルール表示（`Declaration:Jishogi 1.1` など）。空ならデフォルト省略。
     pub declaration: String,
+    /// 先手向けの再接続トークン。`Some` の場合、`build_for(Color::Black)` 出力に
+    /// 標準項目の後・`END Game_Summary` の直前で `Reconnect_Token:<token>` 拡張行
+    /// として埋め込む。`None` なら拡張行を出さず CSA v1.2.1 標準互換の出力に戻る。
+    pub black_reconnect_token: Option<ReconnectToken>,
+    /// 後手向けの再接続トークン。`build_for(Color::White)` 出力に対する挙動は
+    /// [`Self::black_reconnect_token`] と同様。
+    pub white_reconnect_token: Option<ReconnectToken>,
 }
 
 impl GameSummaryBuilder {
@@ -63,6 +70,15 @@ impl GameSummaryBuilder {
         out.push_str(&self.position_section);
         if !self.position_section.ends_with('\n') {
             out.push('\n');
+        }
+        // CSA v1.2.1 標準項目の後に続く拡張行として再接続トークンを末尾追加する。
+        // 標準互換クライアントは未知キーを無視できるため、CSA v1.2.1 とは後方互換。
+        let token = match you {
+            Color::Black => self.black_reconnect_token.as_ref(),
+            Color::White => self.white_reconnect_token.as_ref(),
+        };
+        if let Some(t) = token {
+            let _ = writeln!(out, "Reconnect_Token:{t}");
         }
         out.push_str("END Game_Summary\n");
         out
@@ -238,6 +254,8 @@ mod tests {
             rematch_on_draw: false,
             to_move: Color::Black,
             declaration: "Jishogi 1.1".to_owned(),
+            black_reconnect_token: None,
+            white_reconnect_token: None,
         }
     }
 
@@ -336,6 +354,54 @@ mod tests {
         // 手番行も `-` になることを固定する。
         let block = position_section_from_sfen("9/6k2/9/9/9/9/9/6R2/K8 w - 1").unwrap();
         assert!(block.contains("\n-\nEND Position"));
+    }
+
+    #[test]
+    fn build_for_omits_reconnect_token_when_none() {
+        let txt = skeleton().build_for(Color::Black);
+        assert!(!txt.contains("Reconnect_Token:"), "unexpected token line: {txt}");
+    }
+
+    #[test]
+    fn build_for_emits_per_color_reconnect_token() {
+        let mut b = skeleton();
+        b.black_reconnect_token = Some(ReconnectToken::new("aaaa1111"));
+        b.white_reconnect_token = Some(ReconnectToken::new("bbbb2222"));
+        let black_out = b.build_for(Color::Black);
+        let white_out = b.build_for(Color::White);
+        assert!(black_out.contains("\nReconnect_Token:aaaa1111\n"));
+        assert!(!black_out.contains("bbbb2222"));
+        assert!(white_out.contains("\nReconnect_Token:bbbb2222\n"));
+        assert!(!white_out.contains("aaaa1111"));
+    }
+
+    #[test]
+    fn build_for_places_reconnect_token_after_end_position_and_before_end_game_summary() {
+        let mut b = skeleton();
+        b.black_reconnect_token = Some(ReconnectToken::new("0123abcd"));
+        let txt = b.build_for(Color::Black);
+        let end_position = txt
+            .find("END Position\n")
+            .unwrap_or_else(|| panic!("missing END Position: {txt}"));
+        let token_line = txt
+            .find("\nReconnect_Token:0123abcd\n")
+            .unwrap_or_else(|| panic!("missing token line: {txt}"));
+        let end_game = txt
+            .find("END Game_Summary\n")
+            .unwrap_or_else(|| panic!("missing END Game_Summary: {txt}"));
+        assert!(end_position < token_line, "token must follow END Position");
+        assert!(token_line < end_game, "token must precede END Game_Summary");
+    }
+
+    #[test]
+    fn build_for_emits_only_one_color_token_when_other_is_none() {
+        let mut b = skeleton();
+        b.black_reconnect_token = Some(ReconnectToken::new("only-black"));
+        // 後手向け出力は何も入れていない。
+        let white_out = b.build_for(Color::White);
+        assert!(!white_out.contains("Reconnect_Token:"), "white must omit token: {white_out}");
+        let black_out = b.build_for(Color::Black);
+        assert!(black_out.contains("\nReconnect_Token:only-black\n"));
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/types.rs
+++ b/crates/rshogi-csa-server/src/types.rs
@@ -91,6 +91,26 @@ newtype_str! {
     pub ReconnectToken
 }
 
+impl ReconnectToken {
+    /// 128 bit の乱数を引き、32 文字の小文字 hex 文字列としてトークンに包む。
+    ///
+    /// 値は `[0-9a-f]` のみを取るため、CSA プロトコルの空白／改行／コロン
+    /// などの区切り文字と衝突せず、Game_Summary 拡張行へそのまま埋め込める。
+    /// 乱数源は `rand::random()` 経由のスレッドローカル RNG（OS RNG から seed
+    /// された ChaCha 派生 CSPRNG）で、wasm32 (Workers) では `getrandom` の
+    /// `wasm_js` feature を介して Web Crypto API から bytes が供給される。
+    pub fn generate() -> Self {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let bytes: [u8; 16] = rand::random();
+        let mut s = String::with_capacity(32);
+        for b in bytes {
+            s.push(HEX[(b >> 4) as usize] as char);
+            s.push(HEX[(b & 0x0f) as usize] as char);
+        }
+        Self(s)
+    }
+}
+
 newtype_str! {
     /// 運営権限を持つクライアント識別子（`%%SETBUOY` 等で権限判定に用いる）。
     pub AdminId
@@ -197,5 +217,26 @@ mod tests {
     fn color_opposite() {
         assert_eq!(Color::Black.opposite(), Color::White);
         assert_eq!(Color::White.opposite(), Color::Black);
+    }
+
+    #[test]
+    fn reconnect_token_generate_is_32_lowercase_hex() {
+        let t = ReconnectToken::generate();
+        let s = t.as_str();
+        assert_eq!(s.len(), 32, "expected 32 hex chars: {s}");
+        assert!(
+            s.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+            "expected lowercase hex only: {s}",
+        );
+    }
+
+    #[test]
+    fn reconnect_token_generate_is_unique_across_calls() {
+        // 128 bit 乱数なので 100 回引いても全て異なるはず（衝突は無視できる）。
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            let t = ReconnectToken::generate();
+            assert!(seen.insert(t.into_string()), "duplicate token observed");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `GameSummaryBuilder` に `black_reconnect_token` / `white_reconnect_token: Option<ReconnectToken>` を追加し、`build_for(you)` が対応色 `Some` のとき標準項目の後・`END Game_Summary` 直前に `Reconnect_Token:<token>` 拡張行を出力する
- `ReconnectToken::generate()` を実装。`rand::random()` から 128 bit 引いて 32 文字の小文字 hex として包む。値は `[0-9a-f]` のみで CSA プロトコルの区切り文字と衝突しない
- TCP `serve_match` と Workers `GameRoom::start` の双方で対局開始時に対局者ごとに 1 個ずつトークンを発行して `GameSummaryBuilder` に渡す（同じトークンの再利用なし、両者で異なる）

CSA v1.2.1 標準項目との互換性は維持される（未知キー `Reconnect_Token:` は既存クライアントが安全に無視できる位置・形式に置く）。

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (debug + release)
- [x] `cargo test --workspace --release`
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- 追加 unit test:
  - `summary::build_for_omits_reconnect_token_when_none`
  - `summary::build_for_emits_per_color_reconnect_token`
  - `summary::build_for_places_reconnect_token_after_end_position_and_before_end_game_summary`
  - `summary::build_for_emits_only_one_color_token_when_other_is_none`
  - `types::reconnect_token_generate_is_32_lowercase_hex`
  - `types::reconnect_token_generate_is_unique_across_calls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)