### PR TITLE
chore(csa-server): 未使用依存を Workers / core crate から削除する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,51 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,12 +1090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,7 +1761,6 @@ dependencies = [
 name = "rshogi-csa-server"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "rand",
  "rand_xoshiro",
@@ -1851,21 +1799,12 @@ dependencies = [
 name = "rshogi-csa-server-workers"
 version = "0.1.0"
 dependencies = [
- "async-trait",
- "axum",
  "chrono",
- "futures-util",
- "js-sys",
  "rshogi-core",
- "rshogi-csa",
  "rshogi-csa-server",
  "serde",
  "serde_json",
- "thiserror",
  "tokio",
- "tower-service",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "worker",
  "worker-macros",
 ]
@@ -2064,17 +2003,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -3313,7 +3241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4afd7ae4f7fcc11e0e5e64b964890b3dda90f1290b0612f7cd821b381cc18826"
 dependencies = [
  "async-trait",
- "axum",
  "bytes",
  "chrono",
  "futures-channel",
@@ -3321,7 +3248,7 @@ dependencies = [
  "http",
  "http-body",
  "js-sys",
- "matchit 0.7.3",
+ "matchit",
  "pin-project",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -15,13 +15,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # ホスト／wasm32 の双方で利用する依存のみをここに置く。
-# Workers 固有 (`worker`, `worker-macros`, `wasm-bindgen` 等) は
+# Workers 固有 (`worker`, `worker-macros`) は
 # `[target.'cfg(target_arch = "wasm32")'.dependencies]` に分離して
 # ホスト側 `cargo check --workspace` を壊さない。
 rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false, features = ["workers"] }
-rshogi-csa = { path = "../rshogi-csa" }
 rshogi-core = { path = "../rshogi-core" }
-thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 # chrono はホスト／wasm32 で挙動を揃えるため `clock` 既定を切り、
@@ -30,19 +28,11 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm32-unknown-unknown 以外では参照しない。worker-build / wrangler dev から
-# ビルドされる経路のみで有効化される。
-worker = { version = "0.8", features = ["http", "axum"] }
+# ビルドされる経路のみで有効化される。`worker` 0.8 が `wasm-bindgen` /
+# `wasm-bindgen-futures` / `js-sys` / `async-trait` / `futures-util` を内部で
+# 引き込むので、本 crate からは worker のみを直接参照すればよい。
+worker = { version = "0.8", features = ["http"] }
 worker-macros = { version = "0.8", features = ["http"] }
-# `ws` feature は tokio-tungstenite を引き込み wasm32 でビルドが壊れる。
-# WebSocket の受理は Durable Object の `state.acceptWebSocket` 側で行うため、
-# axum には Router と json extractor のみを使う。
-axum = { version = "0.8", default-features = false, features = ["json"] }
-tower-service = "0.3"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
-futures-util = "0.3"
-async-trait = "0.1"
 
 [features]
 default = []

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -47,8 +47,8 @@ mod router;
 #[cfg(target_arch = "wasm32")]
 pub use game_room::GameRoom;
 
-/// Workers ランタイムの fetch イベント。axum 等を経由せず直接
-/// [`router::handle_fetch`] に委譲する薄いエントリポイント。
+/// Workers ランタイムの fetch イベント。`router::handle_fetch` に委譲する
+/// 薄いエントリポイント。
 ///
 /// `#[event(fetch)]` マクロが呼び出し側の wasm-bindgen 配線を生成する。
 #[cfg(target_arch = "wasm32")]

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -5,10 +5,6 @@
 //!   決定論的に解決した Durable Object へ Upgrade 要求を転送する。
 //! - `GET /` と `GET /health` → サーバ識別を返す簡易ヘルスチェック。
 //! - 他は 404。
-//!
-//! axum を介さず worker-rs のプリミティブだけでさばくのは、WebSocket Upgrade
-//! を axum と DO の間で橋渡しするコストが大きいため。HTTP API を増やす段階で
-//! 非 WS 経路は axum Router に切り出す想定。
 
 use worker::{Env, Method, Request, Response, Result};
 

--- a/crates/rshogi-csa-server/Cargo.toml
+++ b/crates/rshogi-csa-server/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/SH11235/rshogi"
 [dependencies]
 rshogi-core = { path = "../rshogi-core" }
 rshogi-csa = { path = "../rshogi-csa" }
-anyhow.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

`rshogi-csa-server-workers` の wasm32 deps と `rshogi-csa-server` core
crate の host deps から、ソース内で直接 import されていない依存を削除し、
`worker` 0.8 が transitive dep として既に取り込んでいるものに統合する。
CLAUDE.md「YAGNI: 将来用のフィールド/フラグ追加、未使用コードの温存は禁止」
に従う整理。

## 削除対象

### `rshogi-csa-server-workers` (wasm32 deps)

- **`axum` / `tower-service`**: Phase 2 着手 (PR #464) 時点で「HTTP API を
  増やす段階で axum Router に切り出す想定」として宣言されていたが、現在の
  `router.rs` は worker-rs の `Request` / `Response` プリミティブだけで
  4 ルート (`/`, `/health`, `/ws/:id`, DO `/ws/:id[/spectate]`) をさばいて
  おり、axum Router の出番は無い。未着手タスク (15.7-15.11 / 16.1 / 17.x /
  18.x / 20.x / 22.x) を精査しても axum を要求するものは無く、CSA は HTTP
  ではない以上将来予定も無い
- **`wasm-bindgen` / `wasm-bindgen-futures` / `js-sys` / `async-trait` /
  `futures-util`**: ソース内に直接 import 無し (`game_room.rs:38` の
  `wasm_bindgen` は `worker::wasm_bindgen` の再エクスポート利用)。`worker`
  の transitive dep として常に解決されるので明示宣言は不要

### `rshogi-csa-server-workers` (host deps)

- **`rshogi-csa`**: 直接 import 無し (\`rshogi-csa-server\` 経由)
- **`thiserror`**: 直接 import 無し (現状の Worker error 型は \`worker::Error\`
  と \`serde_json::Error\` の \`RustError\` ラップで完結)

### `rshogi-csa-server` (core crate)

- **`anyhow`**: 直接 import 無し (\`Result\` 型はすべて \`ServerError\` /
  \`TransportError\` 等の専用 enum)

## コメント整理

\`router.rs\` の \`//! axum を介さず worker-rs のプリミティブだけでさばくのは...
HTTP API を増やす段階で非 WS 経路は axum Router に切り出す想定。\` および
\`lib.rs\` の \`/// axum 等を経由せず直接\` を除去 (必要時に書く、YAGNI)。

## 効果

- \`Cargo.lock\` から \`axum\` / \`axum-core\` / \`matchit\` /
  \`serde_path_to_error\` の 4 crate が落ちる
- 他削除分は worker の transitive で同一バージョンが残るため lock サイズ
  変化なし。ただし宣言の整合性が CLAUDE.md と一致する

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown\`
- [x] \`cargo check -p rshogi-csa-server -p rshogi-csa-server-tcp\`
- [x] \`cargo clippy -p rshogi-csa-server -p rshogi-csa-server-tcp -p rshogi-csa-server-workers --all-targets -- -D warnings\`
- [x] \`cargo test -p rshogi-csa-server -p rshogi-csa-server-tcp -p rshogi-csa-server-workers --release\` 全 pass
- [x] \`cargo audit\` (347 dependencies スキャン、vulnerabilities ゼロ)

## 補足: Cloudflare デプロイ実態（PR と独立）

本 PR の調査中、Cloudflare デプロイ運用の以下のギャップを発見した
(別 issue / PR で追跡):

- \`wrangler.toml.example\` に \`FLOODGATE_HISTORY_BUCKET\` R2 binding が無い
  (PR #500 で \`R2FloodgateHistoryStorage\` 追加時に template 更新漏れ。
  task 15.7 で game_room.rs 配線時に併せて修正想定)
- CI に wasm32 ビルド job が無く、Workers crate の wasm32 ビルド退行が
  PR チェックで検知できない (task 17.7 / 別 chore で追跡)
- \`wrangler deploy\` の自動化なし (運用は手動 \`wrangler deploy\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)