### PR TITLE
ci: Workers crate の wasm32-unknown-unknown ビルド検査 job を追加 (task 23.1)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -174,8 +174,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Add wasm32 target to pinned toolchain
+        # `rust-toolchain.toml` が channel を 1.93.1 に pin しているため、
+        # cargo は dtolnay/rust-toolchain@stable が install した stable (1.95.0) では
+        # なく rust-toolchain.toml の channel を使う（`rustup show active-toolchain` で
+        # 確認できる）。dtolnay action の `targets:` パラメータは default toolchain
+        # （= stable）にのみ wasm32 target を追加するため、cargo の実行時には反映
+        # されない（`E0463: can't find crate for core` でビルドが落ちる）。
+        # rust-toolchain.toml の channel から動的に値を取り、その toolchain に
+        # 明示的に wasm32 target を追加する。channel が変わったら自動追従する。
+        run: |
+          CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)
+          echo "Adding wasm32-unknown-unknown to toolchain $CHANNEL"
+          rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Enable sccache

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -136,3 +136,59 @@ jobs:
       - uses: taiki-e/install-action@cargo-audit
       - name: Run security audit
         run: cargo audit --deny warnings
+
+  wasm-build:
+    # Workers crate (`rshogi-csa-server-workers`) の wasm32-unknown-unknown ビルドを検査する。
+    #
+    # 既存 `lint` / `test` job は host target でしか動かないため、
+    # `#[cfg(target_arch = "wasm32")]` 配下のコード（`game_room.rs` / `router.rs` /
+    # `lib.rs` の本体）は merge 前に検証されない。本番 deploy 直前の
+    # `worker-build --release` で初めて wasm32 ビルド退行が発覚する運用を防ぐため、
+    # PR チェックで wasm32 ビルド検査を並走させる。
+    #
+    # `cargo check` ではなく `cargo build` を使う:
+    #   `cargo check` は MIR 生成までで止まり codegen 段の退行（wasm-bindgen の
+    #   symbol 衝突・`getrandom` の wasm_js feature 不足・lld link error 等）を
+    #   検知できない。本 job の目的は「`worker-build --release` で初めて発覚する
+    #   退行を PR で止める」なので codegen を通す build を使う。
+    #
+    # mold / clang を入れない:
+    #   wasm32 は lld でリンクするため、host job (`lint` / `test`) が入れている
+    #   mold linker は不要。runner セットアップ時間を浪費しない。
+    #
+    # clippy を回さない:
+    #   clippy は host target の `lint` job で全 crate を網羅済み。本 job の責務は
+    #   「Workers crate の wasm32 ビルドが通ること」の回帰検知に限定し、
+    #   `rshogi-core` の wasm32 clippy 整理など別 crate 範囲の lint 課題は扱わない。
+    name: Workers wasm32 Build Check
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust_code == 'true'
+    timeout-minutes: 20
+    env:
+      # workflow 上位の `-C target-cpu=x86-64-v2` は x86 専用で wasm32 では
+      # `'x86-64-v2' is not a recognized processor for this target (ignoring processor)`
+      # 警告がコンパイル単位ごとに大量出力される。本 job では空文字で上書きし、
+      # wasm32 標準の codegen に任せる（host target 用の baseline 設定の意図とも整合）。
+      RUSTFLAGS: ""
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Enable sccache
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # host target キャッシュ (`lint` / `test` job) と完全分離する。
+          # `shared-key` 指定で本 job 専用のキャッシュ namespace を確保し、
+          # 同 base key 配下に host target sysroot が混入しないようにする。
+          shared-key: wasm32
+      - name: Build wasm32
+        run: cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true


### PR DESCRIPTION
## Summary

`rshogi-csa-server-workers` の wasm32 ビルド退行が PR チェックで検知
されない問題を修正する。既存 \`lint\` / \`test\` job は host target でしか
動かず、\`#[cfg(target_arch = \"wasm32\")]\` 配下の本体
(\`game_room.rs\` / \`router.rs\` / \`lib.rs\`) は merge 後の手動
\`worker-build --release\` で初めて wasm32 ビルド退行が発覚する運用に
なっていた。

task 23.1 (Cloudflare 運用基盤) の最初のサブタスク。

## 追加 job: \`wasm-build\`

\`changes\` filter の \`rust_code == 'true'\` で起動、
\`cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown\`
を実行する。

### スコープ判断

- **\`cargo check\` ではなく \`cargo build\`**: check は MIR 段で止まり
  codegen 段の退行（wasm-bindgen の symbol 衝突 / \`getrandom\` の
  wasm_js feature 不足 / lld link error 等）を検知できない。本 job
  の目的は「\`worker-build --release\` で初めて発覚する退行を PR で
  止める」ので codegen を通す build を使う
- **clippy なし**: host target の \`lint\` job で全 crate を網羅済み。
  本 job の責務は「Workers crate の wasm32 ビルドが通ること」の
  回帰検知に限定し、\`rshogi-core\` の wasm32 clippy 整理など別 crate
  範囲の lint 課題は扱わない
- **mold / clang なし**: wasm32 は lld でリンクするため、host job が
  入れている mold linker は不要

### 設定詳細

- \`timeout-minutes: 20\`: 初回 sysroot DL 詰まり等で runaway する保険
- \`RUSTFLAGS: \"\"\`: workflow 上位の \`-C target-cpu=x86-64-v2\` は x86 専用で
  wasm32 ではコンパイル単位ごとに warning が出るため空文字で override
- \`shared-key: wasm32\`: host target キャッシュ (\`lint\` / \`test\`) と完全
  分離。同 base key 配下に host target sysroot が混入しないよう明示

## レビュー履歴

ローカル Claude review 2 round 実施:

- **1st round**: P2-1 (\`cargo check\` → \`build\`) / P2-2 (\`shared-key\`) /
  P2-3 (mold 不要コメント) / P3-3 (timeout) の 4 件指摘
- **2nd round**: 全 4 件反映確認、新規問題なし、merge 可判定

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` YAML 構文 OK
- [x] \`RUSTFLAGS=\"\" cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown\`
      ローカル成功 (1m15s、warnings のみ・errors なし)
- [ ] CI 上で本 job が起動し PASS することを本 PR 自身で確認
- [ ] 退行検知の動作確認は次回の Workers crate 変更 PR で観察

## 関連タスク

- task 23.1: 本 PR で完了
- task 23.2 / 23.3 / 23.4: 別 PR で順次

🤖 Generated with [Claude Code](https://claude.com/claude-code)