### PR TITLE
feat(csa-server-tcp): TCP 切断時の再接続プロトコル一式を実装する

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -250,6 +250,11 @@ fn main() -> anyhow::Result<()> {
             DuplicateLoginPolicy::RejectNew
         },
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
+        // 再接続プロトコルは Phase 5 features の opt-in 待ち。Phase 1-4 互換として
+        // Duration::ZERO で配線し、`run_game_loop_and_record` の grace 経路には立ち入らない
+        // (即時 `#ABNORMAL` 経路のまま)。Phase 5 gate 配線時に CLI / 設定経由で 60 秒
+        // 程度に切り替える。
+        reconnect_grace_duration: std::time::Duration::ZERO,
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が
     // `Some` の状態は `enable_persistent_player_rates` 要求として intent に乗るため、

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -250,10 +250,10 @@ fn main() -> anyhow::Result<()> {
             DuplicateLoginPolicy::RejectNew
         },
         shutdown_grace: std::time::Duration::from_secs(cli.shutdown_grace_sec),
-        // 再接続プロトコルは Phase 5 features の opt-in 待ち。Phase 1-4 互換として
-        // Duration::ZERO で配線し、`run_game_loop_and_record` の grace 経路には立ち入らない
-        // (即時 `#ABNORMAL` 経路のまま)。Phase 5 gate 配線時に CLI / 設定経由で 60 秒
-        // 程度に切り替える。
+        // 再接続プロトコルは opt-in。本バイナリは既定で `Duration::ZERO` を渡し、
+        // `run_game_loop_and_record` の grace 経路には立ち入らない (切断 → 即時
+        // `#ABNORMAL` 経路のまま)。再接続を有効化したい運用ではここで 60 秒等を
+        // 直接設定するか、後続の CLI / 設定経路で上書きする。
         reconnect_grace_duration: std::time::Duration::ZERO,
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -896,18 +896,23 @@ where
             return Ok(());
         }
     }
-    // LOGIN 成功応答: shogi-server 互換の `LOGIN:<handle> OK`。
-    transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
-
     // 4.5. 再接続要求の経路分岐。LOGIN 行の 3 つ目トークンが `reconnect:<game_id>+<token>`
     //      で来た場合は新規対局参加 (League 登録 / 待機プール) ではなく、grace 中の
     //      該当対局へ「同一対局者として再参加」する経路へ。`reconnect_pending` 検索
     //      → handle / token 照合 → game loop に新 transport を handoff。失敗時は
     //      `LOGIN:incorrect <reason>` で拒否し、grace 中の対局状態と registry エントリ
     //      は一切変更しない (拒否は元の対局者による再試行を妨げないため)。
+    //
+    //      `LOGIN:<handle> OK` 応答は `handle_reconnect_request` 内で「成功確定後」
+    //      にのみ送出する。ここで先行送信すると、拒否ケースで `OK` の直後に
+    //      `LOGIN:incorrect ...` が続く二重応答になる。
     if let Some(req) = reconnect {
         return handle_reconnect_request(&state, transport, &handle_player, color, req).await;
     }
+
+    // LOGIN 成功応答: shogi-server 互換の `LOGIN:<handle> OK`。新規対局参加経路のみ
+    // ここで送出する (再接続経路は上の分岐で先に return している)。
+    transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
 
     // 5. League に登録して GameWaiting に遷移する。x1 フラグはプロトコル拡張
     //    「このクライアントは `%%` 系コマンドも解釈できる」ことを示す属性で、
@@ -2655,30 +2660,57 @@ where
         return Ok(());
     }
 
+    // 順序が重要: クライアントへ何かを送る前に `reconnect_tx` の sender を `take()`
+    // して送信権を確保する。ここで失敗 (重複再接続) なら resume メッセージを一切
+    // 送らずに `LOGIN:incorrect reconnect_already_resumed` で拒否する (クライアント
+    // が「再接続成功した」と誤認するのを防ぐ)。lock を await を跨いで保持しないため
+    // ブロックで囲む。
+    let sender = {
+        let mut tx_slot = pending.reconnect_tx.lock().await;
+        let Some(sender) = tx_slot.take() else {
+            let _ = transport
+                .send_line(&CsaLine::new("LOGIN:incorrect reconnect_already_resumed"))
+                .await;
+            return Ok(());
+        };
+        sender
+    };
+
+    // 成功確定。LOGIN OK 応答 → 状態再送 → transport handoff の順で進める。
+    transport
+        .send_line(&CsaLine::new(format!("LOGIN:{} OK", handle_player.as_str())))
+        .await?;
     let resume_message =
         build_resume_message(&pending.game_summary_for_disconnected, &pending.snapshot);
-    send_multiline(&mut transport, &resume_message).await?;
-
-    let mut tx_slot = pending.reconnect_tx.lock().await;
-    let Some(sender) = tx_slot.take() else {
-        let _ = transport
-            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_already_resumed"))
-            .await;
-        return Ok(());
-    };
-    if sender.send(transport).is_err() {
-        // game loop 側が既に Aborted で終了 (deadline 超過直後の race など)。
-        // registry の片付けは game loop の終了処理が済ませている想定。
-        tracing::warn!(
-            game_id = %req.game_id,
-            "reconnect transport handoff failed: game loop already aborted"
-        );
+    if let Err(e) = send_multiline(&mut transport, &resume_message).await {
+        // resume 送信に失敗。game loop は依然 grace 待ちなので、sender を戻して
+        // 別の正当な再接続要求が引き続き受理可能な状態に保つ。
+        let mut tx_slot = pending.reconnect_tx.lock().await;
+        if tx_slot.is_none() {
+            *tx_slot = Some(sender);
+        }
+        return Err(ServerError::Transport(e));
     }
-    tracing::info!(
-        game_id = %req.game_id,
-        login_handle = %handle_player.as_str(),
-        "reconnect succeeded; transport handed off to game loop"
-    );
+
+    match sender.send(transport) {
+        Ok(()) => {
+            tracing::info!(
+                game_id = %req.game_id,
+                login_handle = %handle_player.as_str(),
+                "reconnect succeeded; transport handed off to game loop"
+            );
+        }
+        Err(mut transport) => {
+            // game loop 側が既に Aborted で終了 (deadline 超過直後の race)。
+            // registry の片付けは game loop の終了処理が済ませている想定。
+            // クライアントには曖昧な切断ではなく明示的な拒否行を返してから close する。
+            tracing::warn!(
+                game_id = %req.game_id,
+                "reconnect transport handoff failed: game loop already aborted"
+            );
+            let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect reconnect_aborted")).await;
+        }
+    }
     Ok(())
 }
 

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -473,6 +473,10 @@ pub(crate) struct ReconnectSnapshot {
 pub(crate) struct PendingReconnect {
     /// 切断された側の handle。LOGIN 時の照合に使う。
     pub(crate) disconnected_handle: PlayerName,
+    /// 切断された側の `Color`。LOGIN 時に提示された `<handle>+<game_name>+<color>`
+    /// の color と一致しない要求は (handle / token が合っていても) 拒否する
+    /// (defense-in-depth)。
+    pub(crate) disconnected_color: Color,
     /// 切断側に発行された再接続トークン (Game_Summary 末尾拡張行で配布済み)。
     pub(crate) expected_token: ReconnectToken,
     /// 再接続成立時に game loop へ新 `TcpTransport` を渡す one-shot 送信側。
@@ -902,7 +906,7 @@ where
     //      `LOGIN:incorrect <reason>` で拒否し、grace 中の対局状態と registry エントリ
     //      は一切変更しない (拒否は元の対局者による再試行を妨げないため)。
     if let Some(req) = reconnect {
-        return handle_reconnect_request(&state, transport, &handle_player, req).await;
+        return handle_reconnect_request(&state, transport, &handle_player, color, req).await;
     }
 
     // 5. League に登録して GameWaiting に遷移する。x1 フラグはプロトコル拡張
@@ -2539,6 +2543,7 @@ where
     let deadline = tokio::time::Instant::now() + grace;
     let pending = Arc::new(PendingReconnect {
         disconnected_handle: handle.clone(),
+        disconnected_color: disconnected,
         expected_token,
         reconnect_tx: Mutex::new(Some(tx)),
         snapshot,
@@ -2588,7 +2593,8 @@ where
 ///
 /// 失敗ケース:
 /// - `game_id` が registry に存在しない → `LOGIN:incorrect reconnect_unknown_game`
-/// - LOGIN handle と `disconnected_handle` が不一致 → `LOGIN:incorrect reconnect_handle_mismatch`
+/// - LOGIN handle / 色のいずれかが `disconnected_handle` / `disconnected_color`
+///   と一致しない → `LOGIN:incorrect reconnect_handle_mismatch`
 /// - `token` が `expected_token` と不一致 → `LOGIN:incorrect reconnect_token_mismatch`
 /// - registry エントリは残っているが `reconnect_tx` が既に消費済み (重複再接続) →
 ///   `LOGIN:incorrect reconnect_already_resumed`
@@ -2602,6 +2608,7 @@ async fn handle_reconnect_request<R, K, P, H>(
     state: &SharedState<R, K, P, H>,
     mut transport: TcpTransport,
     handle_player: &PlayerName,
+    requested_color: Color,
     req: ReconnectRequest,
 ) -> Result<(), ServerError>
 where
@@ -2620,12 +2627,16 @@ where
             .await;
         return Ok(());
     };
-    if pending.disconnected_handle.as_str() != handle_player.as_str() {
+    if pending.disconnected_handle.as_str() != handle_player.as_str()
+        || pending.disconnected_color != requested_color
+    {
         tracing::warn!(
             game_id = %req.game_id,
             login_handle = %handle_player.as_str(),
+            login_color = ?requested_color,
             expected_handle = %pending.disconnected_handle.as_str(),
-            "rejected reconnect: handle mismatch"
+            expected_color = ?pending.disconnected_color,
+            "rejected reconnect: handle/color mismatch"
         );
         let _ = transport
             .send_line(&CsaLine::new("LOGIN:incorrect reconnect_handle_mismatch"))

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -38,7 +38,7 @@ use rshogi_csa_server::port::{
     BroadcastTag, Broadcaster, BuoyStorage, ClientTransport, GameSummaryEntry, KifuStorage,
     RateDecision, RateStorage,
 };
-use rshogi_csa_server::protocol::command::{ClientCommand, parse_command};
+use rshogi_csa_server::protocol::command::{ClientCommand, ReconnectRequest, parse_command};
 use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
@@ -183,6 +183,13 @@ pub struct ServerConfig {
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
     /// を落とさない」ためのバッファで、既定 60 秒。
     pub shutdown_grace: Duration,
+    /// 対局中に対局者の接続が切れた際、即時 `#ABNORMAL` 終局せず再接続を待つ
+    /// 猶予時間。`Duration::ZERO` のとき、接続喪失で即時に異常終了させる
+    /// （Phase 1-4 互換、Requirement 2.5 の Phase 1-3 既定）。Phase 5 で再接続
+    /// プロトコルを有効化する場合は運用側で 60 秒程度を設定する。猶予中は
+    /// `SharedState::reconnect_pending` に対局状態を保持し、Game_Summary 末尾
+    /// 拡張行で配布した `reconnect_token` の照合で再参加を許可する。
+    pub reconnect_grace_duration: Duration,
 }
 
 impl ServerConfig {
@@ -207,6 +214,7 @@ impl ServerConfig {
             handicap_initial_sfens: std::collections::HashMap::new(),
             duplicate_login_policy: DuplicateLoginPolicy::RejectNew,
             shutdown_grace: Duration::from_secs(60),
+            reconnect_grace_duration: Duration::ZERO,
         }
     }
 }
@@ -441,6 +449,42 @@ impl WaitingPool {
     }
 }
 
+/// 切断時に保持される対局スナップショット。再接続成立時、再参加クライアントへ
+/// 現在の盤面・両者残時間・最終手・手番を再送するために保持する。
+#[derive(Debug, Clone)]
+pub(crate) struct ReconnectSnapshot {
+    /// 先手の残り持ち時間 (ms)。
+    pub(crate) black_remaining_ms: u64,
+    /// 後手の残り持ち時間 (ms)。
+    pub(crate) white_remaining_ms: u64,
+    /// 現在の手番。
+    pub(crate) current_turn: Color,
+    /// 直前に確定した最終手 (なければ `None`)。
+    pub(crate) last_move: Option<CsaMoveToken>,
+}
+
+/// 再接続待ち対局のエントリ。`SharedState::reconnect_pending` に登録される。
+///
+/// 切断された対局者の再接続要求を grace 期間内に受理する。LOGIN 行で
+/// `reconnect:<game_id>+<token>` が提示された際、本エントリの `expected_token`
+/// と照合し、一致すれば `reconnect_tx` から新 `TcpTransport` を game loop に
+/// handoff して対局を再開する。
+pub(crate) struct PendingReconnect {
+    /// 切断された側の handle。LOGIN 時の照合に使う。
+    pub(crate) disconnected_handle: PlayerName,
+    /// 切断側に発行された再接続トークン (Game_Summary 末尾拡張行で配布済み)。
+    pub(crate) expected_token: ReconnectToken,
+    /// 再接続成立時に game loop へ新 `TcpTransport` を渡す one-shot 送信側。
+    /// 1 回だけ使えるため `Mutex<Option<…>>` で「最初に `take()` できた者勝ち」を
+    /// 表現する。token 不一致など拒否ケースでは `take()` せずに残すことで、
+    /// 後続の正当な再接続要求が引き続き受理可能となる。
+    pub(crate) reconnect_tx: Mutex<Option<oneshot::Sender<TcpTransport>>>,
+    /// 切断時点の対局スナップショット。再送に使う。
+    pub(crate) snapshot: ReconnectSnapshot,
+    /// 切断側宛の Game_Summary 文字列 (再接続トークン拡張行を含む完全形)。
+    pub(crate) game_summary_for_disconnected: String,
+}
+
 /// サーバー全体で共有する状態。
 pub struct SharedState<R, K, P, H>
 where
@@ -504,6 +548,13 @@ where
     /// SIGINT / SIGTERM 由来の graceful shutdown トリガ。accept ループと
     /// 待機 waiter が監視して、新規受付停止と待機セッション切断を行う。
     pub shutdown: GracefulShutdown,
+    /// 切断検出後 grace 期間内の対局を一時保持するレジストリ。`game_id` で索引し、
+    /// LOGIN 時に `reconnect:<game_id>+<token>` を提示したクライアントが
+    /// `Arc<PendingReconnect>` を取り出して token 照合・transport handoff を行う。
+    /// `config.reconnect_grace_duration` が `Duration::ZERO` の場合（Phase 1-4
+    /// 互換）はこのレジストリは常に空のままで、`run_game_loop_and_record` は
+    /// 即時 `#ABNORMAL` に進む。
+    pub(crate) reconnect_pending: Mutex<HashMap<GameId, Arc<PendingReconnect>>>,
 }
 
 impl<R, K, P, H> SharedState<R, K, P, H>
@@ -795,8 +846,13 @@ where
     // 2. LOGIN 行を受信。
     let login_line = transport.recv_line(state.config.login_timeout).await?;
     let cmd = parse_command(&login_line)?;
-    let (full_name, password, x1) = match cmd {
-        ClientCommand::Login { name, password, x1 } => (name, password, x1),
+    let (full_name, password, x1, reconnect) = match cmd {
+        ClientCommand::Login {
+            name,
+            password,
+            x1,
+            reconnect,
+        } => (name, password, x1, reconnect),
         _ => {
             let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect")).await;
             return Err(ServerError::Protocol(ProtocolError::Malformed(
@@ -837,6 +893,15 @@ where
     }
     // LOGIN 成功応答: shogi-server 互換の `LOGIN:<handle> OK`。
     transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
+
+    // 4.5. 再接続要求の経路分岐。LOGIN 行の 3 つ目トークンが `reconnect:<game_id>+<token>`
+    //      で来た場合は新規対局参加 (League 登録 / 待機プール) ではなく、grace 中の
+    //      該当対局へ「同一対局者として再参加」する経路へ。`reconnect_pending` 検索
+    //      → handle / token 照合 → game loop に新 transport を handoff。失敗時は
+    //      `LOGIN:incorrect <reason>` で拒否し、対局状態は変更しない (Requirement 17.6)。
+    if let Some(req) = reconnect {
+        return handle_reconnect_request(&state, transport, &handle_player, req).await;
+    }
 
     // 5. League に登録して GameWaiting に遷移する。x1 フラグはプロトコル拡張
     //    「このクライアントは `%%` 系コマンドも解釈できる」ことを示す属性で、
@@ -2004,8 +2069,8 @@ where
         rematch_on_draw: false,
         to_move,
         declaration: "Jishogi 1.1".to_owned(),
-        black_reconnect_token: Some(black_reconnect_token),
-        white_reconnect_token: Some(white_reconnect_token),
+        black_reconnect_token: Some(black_reconnect_token.clone()),
+        white_reconnect_token: Some(white_reconnect_token.clone()),
     };
     send_multiline(black_transport, &summary.build_for(Color::Black)).await?;
     send_multiline(white_transport, &summary.build_for(Color::White)).await?;
@@ -2070,7 +2135,16 @@ where
         });
     }
 
-    // 指し手と消費時間を記録しつつ終局まで駆動する。
+    // 指し手と消費時間を記録しつつ終局まで駆動する。再接続経路で使う handle/token と
+    // Game_Summary builder への参照も渡す。`reconnect_grace_duration` が `Duration::ZERO`
+    // の構成では grace 関連経路には全く立ち寄らない。
+    let reconnect_ctx = ReconnectContext {
+        black_handle: &matched.black,
+        white_handle: &matched.white,
+        black_token: &black_reconnect_token,
+        white_token: &white_reconnect_token,
+        summary: &summary,
+    };
     let result_moves = run_game_loop_and_record(
         state,
         game_id,
@@ -2078,6 +2152,7 @@ where
         game_start_instant,
         black_transport,
         white_transport,
+        &reconnect_ctx,
     )
     .await;
     let end_time = chrono::Utc::now();
@@ -2292,6 +2367,19 @@ where
 ///
 /// `run_room` を直接使うと消費秒数を取り出せないため、ここでは `GameRoom` を直接駆動
 /// して手番イベントから `,T<sec>` を解析し `KifuMove` を収集する。
+/// `run_game_loop_and_record` に渡す再接続関連コンテキスト。
+///
+/// 各対局者の `handle` / `reconnect_token` / Game_Summary builder を一括で持ち、
+/// 引数列を膨らませず内部で使う。`reconnect_grace_duration == ZERO` の構成では
+/// このコンテキストは参照されるだけで実装経路には立ち入らない。
+struct ReconnectContext<'a> {
+    black_handle: &'a PlayerName,
+    white_handle: &'a PlayerName,
+    black_token: &'a ReconnectToken,
+    white_token: &'a ReconnectToken,
+    summary: &'a GameSummaryBuilder,
+}
+
 async fn run_game_loop_and_record<R, K, P, H>(
     state: &SharedState<R, K, P, H>,
     game_id: &GameId,
@@ -2299,6 +2387,7 @@ async fn run_game_loop_and_record<R, K, P, H>(
     start_instant: tokio::time::Instant,
     black: &mut TcpTransport,
     white: &mut TcpTransport,
+    reconnect_ctx: &ReconnectContext<'_>,
 ) -> Result<(GameResult, Vec<KifuMove>), ServerError>
 where
     R: RateStorage + 'static,
@@ -2310,7 +2399,7 @@ where
         || tokio::time::Instant::now().saturating_duration_since(start_instant).as_millis() as u64;
     let mut recorded_moves: Vec<KifuMove> = Vec::new();
 
-    loop {
+    'game_loop: loop {
         let status = room.status().clone();
         if let rshogi_csa_server::GameStatus::Finished(result) = status {
             return Ok((result, recorded_moves));
@@ -2332,7 +2421,33 @@ where
         let r = match evt {
             Evt::Recv(from, Ok(line)) => room.handle_line(from, &line, now_ms())?,
             Evt::Recv(from, Err(TransportError::Closed | TransportError::Timeout)) => {
-                room.force_abnormal(from)
+                let grace = state.config.reconnect_grace_duration;
+                if grace.is_zero() {
+                    room.force_abnormal(from)
+                } else {
+                    let outcome = handle_disconnect_with_grace(
+                        state,
+                        game_id,
+                        room,
+                        &recorded_moves,
+                        reconnect_ctx,
+                        from,
+                        grace,
+                    )
+                    .await?;
+                    match outcome {
+                        DisconnectOutcome::Reconnected(new_transport) => {
+                            // 切断側 transport を新接続で差し替えて対局継続。
+                            // 状態再送は handle_disconnect_with_grace 内で完了済み。
+                            match from {
+                                Color::Black => *black = new_transport,
+                                Color::White => *white = new_transport,
+                            }
+                            continue 'game_loop;
+                        }
+                        DisconnectOutcome::Aborted => room.force_abnormal(from),
+                    }
+                }
             }
             Evt::Recv(_, Err(e)) => return Err(ServerError::Transport(e)),
             Evt::TimeUp => {
@@ -2365,6 +2480,218 @@ where
 enum Evt {
     Recv(Color, Result<CsaLine, TransportError>),
     TimeUp,
+}
+
+/// 切断検出後の grace 経路の結末。
+enum DisconnectOutcome {
+    /// 猶予内に正当な再接続要求が成立し、新 `TcpTransport` を game loop に
+    /// handoff した。呼び出し側は切断側 transport を新接続で差し替えて対局を継続する。
+    Reconnected(TcpTransport),
+    /// 猶予を超過したか、再接続経路が中断された (oneshot 送信側 drop など)。
+    /// 呼び出し側は `room.force_abnormal(...)` で切断側を敗北として確定する。
+    Aborted,
+}
+
+/// 切断検出後 grace 期間内の対局状態を保持し、再接続要求の到着を待つ。
+///
+/// `state.reconnect_pending` に `PendingReconnect` を登録し、`tokio::select!` で
+/// (a) 再接続成功 (b) grace 期限超過 のどちらかを待つ。再接続成功時は新
+/// `TcpTransport` を game loop に渡す前に状態再送 (Game_Summary 全文 + 現在の
+/// 盤面 / 残時間 / 最終手 / 手番) を行う。途中で何が起きても registry から
+/// 当該 `game_id` のエントリを削除して戻る (満了 / 拒否 / panic 経由いずれも)。
+async fn handle_disconnect_with_grace<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
+    game_id: &GameId,
+    room: &GameRoom,
+    recorded_moves: &[KifuMove],
+    ctx: &ReconnectContext<'_>,
+    disconnected: Color,
+    grace: Duration,
+) -> Result<DisconnectOutcome, ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    let (handle, expected_token) = match disconnected {
+        Color::Black => (ctx.black_handle.clone(), ctx.black_token.clone()),
+        Color::White => (ctx.white_handle.clone(), ctx.white_token.clone()),
+    };
+    let snapshot = ReconnectSnapshot {
+        black_remaining_ms: room.clock_remaining_main_ms(Color::Black).max(0) as u64,
+        white_remaining_ms: room.clock_remaining_main_ms(Color::White).max(0) as u64,
+        current_turn: room.current_turn(),
+        last_move: recorded_moves.last().map(|m| m.token.clone()),
+    };
+    // 再接続成立時に送出する Game_Summary 文字列を「切断時点の現在局面」で組み立てておく。
+    // `position_section` だけを snapshot から差し替え、`Reconnect_Token:` 拡張行はそのまま
+    // 残るため、再接続クライアントは初接続時と同じく token 入りの完全な Game_Summary を
+    // 受け取れる。残時間や最終手は `Reconnect_State` ブロックで別途送る。
+    let mut summary_for_resume = ctx.summary.clone();
+    summary_for_resume.position_section =
+        rshogi_csa_server::protocol::summary::position_section_from_position(room.position());
+    let game_summary_for_disconnected = summary_for_resume.build_for(disconnected);
+
+    let (tx, rx) = oneshot::channel::<TcpTransport>();
+    let deadline = tokio::time::Instant::now() + grace;
+    let pending = Arc::new(PendingReconnect {
+        disconnected_handle: handle.clone(),
+        expected_token,
+        reconnect_tx: Mutex::new(Some(tx)),
+        snapshot,
+        game_summary_for_disconnected,
+    });
+    {
+        let mut pendings = state.reconnect_pending.lock().await;
+        pendings.insert(game_id.clone(), pending);
+    }
+    tracing::info!(
+        game_id = %game_id,
+        disconnected_color = ?disconnected,
+        disconnected_handle = %handle.as_str(),
+        grace_secs = grace.as_secs(),
+        "awaiting reconnect within grace window"
+    );
+
+    let outcome = tokio::select! {
+        recv_res = rx => match recv_res {
+            Ok(new_transport) => DisconnectOutcome::Reconnected(new_transport),
+            // sender 側が drop された場合 (handshake 側の panic 等)。registry には
+            // 残っていない可能性が高いので Aborted として上位で `force_abnormal` する。
+            Err(_) => DisconnectOutcome::Aborted,
+        },
+        _ = tokio::time::sleep_until(deadline) => DisconnectOutcome::Aborted,
+    };
+
+    // どの経路でも registry から自分のエントリを片付ける。再接続成功側で既に
+    // `take()` で sender を持ち出していても、PendingReconnect 自体は registry に
+    // 残ったままなので、ここで明示的に削除する (重複ログイン経路で別の handler が
+    // 古い registry エントリを誤って参照しないようにするため)。
+    {
+        let mut pendings = state.reconnect_pending.lock().await;
+        pendings.remove(game_id);
+    }
+
+    Ok(outcome)
+}
+
+/// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
+/// 該当 `game_id` の grace 中対局へ再参加させる。
+///
+/// 失敗ケース:
+/// - `game_id` が registry に存在しない → `LOGIN:incorrect reconnect_unknown_game`
+/// - LOGIN handle と `disconnected_handle` が不一致 → `LOGIN:incorrect reconnect_handle_mismatch`
+/// - `token` が `expected_token` と不一致 → `LOGIN:incorrect reconnect_token_mismatch`
+/// - registry エントリは残っているが `reconnect_tx` が既に消費済み (重複再接続) →
+///   `LOGIN:incorrect reconnect_already_resumed`
+///
+/// いずれの拒否ケースでも `reconnect_pending` のエントリは変更せず、対局状態は
+/// 保持されたままになる (Requirement 17.6)。成功時のみ `reconnect_tx` を `take()`
+/// して新 `TcpTransport` を game loop に渡し、状態再送 (Game_Summary 全文 +
+/// `Reconnect_State` ブロック) を済ませてから handoff する。
+async fn handle_reconnect_request<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
+    mut transport: TcpTransport,
+    handle_player: &PlayerName,
+    req: ReconnectRequest,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    let pending = {
+        let pendings = state.reconnect_pending.lock().await;
+        pendings.get(&req.game_id).cloned()
+    };
+    let Some(pending) = pending else {
+        let _ = transport
+            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_unknown_game"))
+            .await;
+        return Ok(());
+    };
+    if pending.disconnected_handle.as_str() != handle_player.as_str() {
+        tracing::warn!(
+            game_id = %req.game_id,
+            login_handle = %handle_player.as_str(),
+            expected_handle = %pending.disconnected_handle.as_str(),
+            "rejected reconnect: handle mismatch"
+        );
+        let _ = transport
+            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_handle_mismatch"))
+            .await;
+        return Ok(());
+    }
+    if pending.expected_token.as_str() != req.token.as_str() {
+        tracing::warn!(
+            game_id = %req.game_id,
+            login_handle = %handle_player.as_str(),
+            "rejected reconnect: token mismatch"
+        );
+        let _ = transport
+            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_token_mismatch"))
+            .await;
+        return Ok(());
+    }
+
+    let resume_message =
+        build_resume_message(&pending.game_summary_for_disconnected, &pending.snapshot);
+    send_multiline(&mut transport, &resume_message).await?;
+
+    let mut tx_slot = pending.reconnect_tx.lock().await;
+    let Some(sender) = tx_slot.take() else {
+        let _ = transport
+            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_already_resumed"))
+            .await;
+        return Ok(());
+    };
+    if sender.send(transport).is_err() {
+        // game loop 側が既に Aborted で終了 (deadline 超過直後の race など)。
+        // registry の片付けは game loop の終了処理が済ませている想定。
+        tracing::warn!(
+            game_id = %req.game_id,
+            "reconnect transport handoff failed: game loop already aborted"
+        );
+    }
+    tracing::info!(
+        game_id = %req.game_id,
+        login_handle = %handle_player.as_str(),
+        "reconnect succeeded; transport handed off to game loop"
+    );
+    Ok(())
+}
+
+/// 再接続成立時にクライアントへ送出する状態再送メッセージを組み立てる。
+///
+/// フォーマット:
+/// 1. `BEGIN Game_Summary` ... `END Game_Summary` (`position_section` は切断時点の
+///    現在局面、`Reconnect_Token:` 拡張行は含む)
+/// 2. `BEGIN Reconnect_State` ... `END Reconnect_State` (現在の手番・両者残時間・
+///    直前手のメタ情報)
+fn build_resume_message(
+    game_summary_for_disconnected: &str,
+    snapshot: &ReconnectSnapshot,
+) -> String {
+    use std::fmt::Write as _;
+    let mut out = game_summary_for_disconnected.to_owned();
+    out.push_str("BEGIN Reconnect_State\n");
+    let _ = writeln!(
+        out,
+        "Current_Turn:{}",
+        match snapshot.current_turn {
+            Color::Black => '+',
+            Color::White => '-',
+        }
+    );
+    let _ = writeln!(out, "Black_Time_Remaining_Ms:{}", snapshot.black_remaining_ms);
+    let _ = writeln!(out, "White_Time_Remaining_Ms:{}", snapshot.white_remaining_ms);
+    if let Some(last) = &snapshot.last_move {
+        let _ = writeln!(out, "Last_Move:{}", last.as_str());
+    }
+    out.push_str("END Reconnect_State\n");
+    out
 }
 
 /// `run_room` と同じ dispatch ロジック（コピー。run_loop 外で使うため）。
@@ -2613,6 +2940,7 @@ where
         started_at: chrono::Utc::now(),
         buoy_storage,
         shutdown: GracefulShutdown::new(),
+        reconnect_pending: Mutex::new(HashMap::new()),
     }
 }
 
@@ -2669,6 +2997,62 @@ mod tests {
         assert!(parse_handle("+g1+black").is_none());
         assert!(parse_handle("alice++black").is_none());
         assert!(parse_handle("alice+g1+purple").is_none());
+    }
+
+    fn sample_summary_text() -> String {
+        // 単体テスト用の簡易 Game_Summary 文字列。実コードでは GameSummaryBuilder
+        // 経由で生成されるが、build_resume_message は文字列を受けるだけなので
+        // 標準項目を満たす最小フレームで十分。
+        let mut s = String::new();
+        s.push_str("BEGIN Game_Summary\n");
+        s.push_str("Game_ID:20260426120000\n");
+        s.push_str("Reconnect_Token:abcd\n");
+        s.push_str("END Game_Summary\n");
+        s
+    }
+
+    fn sample_snapshot(last_move: Option<&str>) -> ReconnectSnapshot {
+        ReconnectSnapshot {
+            black_remaining_ms: 599_500,
+            white_remaining_ms: 600_000,
+            current_turn: Color::White,
+            last_move: last_move.map(CsaMoveToken::new),
+        }
+    }
+
+    #[test]
+    fn build_resume_message_includes_game_summary_then_reconnect_state_block() {
+        let summary = sample_summary_text();
+        let snap = sample_snapshot(Some("+7776FU"));
+        let out = build_resume_message(&summary, &snap);
+        let end_summary = out.find("END Game_Summary\n").expect("END Game_Summary");
+        let begin_state = out.find("BEGIN Reconnect_State\n").expect("BEGIN Reconnect_State");
+        let end_state = out.find("END Reconnect_State\n").expect("END Reconnect_State");
+        assert!(end_summary < begin_state, "Reconnect_State must follow Game_Summary");
+        assert!(begin_state < end_state);
+        assert!(out.contains("\nCurrent_Turn:-\n"));
+        assert!(out.contains("\nBlack_Time_Remaining_Ms:599500\n"));
+        assert!(out.contains("\nWhite_Time_Remaining_Ms:600000\n"));
+        assert!(out.contains("\nLast_Move:+7776FU\n"));
+    }
+
+    #[test]
+    fn build_resume_message_emits_plus_for_black_turn() {
+        let summary = sample_summary_text();
+        let snap = ReconnectSnapshot {
+            current_turn: Color::Black,
+            ..sample_snapshot(None)
+        };
+        let out = build_resume_message(&summary, &snap);
+        assert!(out.contains("\nCurrent_Turn:+\n"));
+    }
+
+    #[test]
+    fn build_resume_message_omits_last_move_line_when_none() {
+        let summary = sample_summary_text();
+        let snap = sample_snapshot(None);
+        let out = build_resume_message(&summary, &snap);
+        assert!(!out.contains("Last_Move:"), "must omit Last_Move when no move played: {out}");
     }
 
     #[test]

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2597,12 +2597,13 @@ where
 /// 該当 `game_id` の grace 中対局へ再参加させる。
 ///
 /// 失敗ケース:
-/// - `game_id` が registry に存在しない → `LOGIN:incorrect reconnect_unknown_game`
-/// - LOGIN handle / 色のいずれかが `disconnected_handle` / `disconnected_color`
-///   と一致しない → `LOGIN:incorrect reconnect_handle_mismatch`
-/// - `token` が `expected_token` と不一致 → `LOGIN:incorrect reconnect_token_mismatch`
+/// - `game_id` の登録なし / handle・色不一致 / token 不一致 のいずれも wire 上は
+///   `LOGIN:incorrect reconnect_rejected` で統一して返す (理由を分けて返すと
+///   side-channel で「特定 handle / game_id が grace 中に存在するか」を識別
+///   できる)。詳細は `tracing::warn!` のログ側にだけ残す。
 /// - registry エントリは残っているが `reconnect_tx` が既に消費済み (重複再接続) →
-///   `LOGIN:incorrect reconnect_already_resumed`
+///   `LOGIN:incorrect reconnect_already_resumed` (token 知識を持つ正当者の二重
+///   接続なので情報漏洩リスクは無く、原因を区別して返す)
 ///
 /// いずれの拒否ケースでも `reconnect_pending` のエントリは変更せず、対局状態
 /// は保持されたままになる (拒否は元の対局者による再試行を妨げない)。成功時のみ
@@ -2627,9 +2628,13 @@ where
         pendings.get(&req.game_id).cloned()
     };
     let Some(pending) = pending else {
-        let _ = transport
-            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_unknown_game"))
-            .await;
+        tracing::warn!(
+            game_id = %req.game_id,
+            login_handle = %handle_player.as_str(),
+            login_color = ?requested_color,
+            "rejected reconnect: unknown game_id"
+        );
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect reconnect_rejected")).await;
         return Ok(());
     };
     if pending.disconnected_handle.as_str() != handle_player.as_str()
@@ -2643,9 +2648,7 @@ where
             expected_color = ?pending.disconnected_color,
             "rejected reconnect: handle/color mismatch"
         );
-        let _ = transport
-            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_handle_mismatch"))
-            .await;
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect reconnect_rejected")).await;
         return Ok(());
     }
     if pending.expected_token.as_str() != req.token.as_str() {
@@ -2654,9 +2657,7 @@ where
             login_handle = %handle_player.as_str(),
             "rejected reconnect: token mismatch"
         );
-        let _ = transport
-            .send_line(&CsaLine::new("LOGIN:incorrect reconnect_token_mismatch"))
-            .await;
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect reconnect_rejected")).await;
         return Ok(());
     }
 

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -183,12 +183,12 @@ pub struct ServerConfig {
     /// まま log warning を出して切り捨てる。運用で「ローリング再起動時に対局
     /// を落とさない」ためのバッファで、既定 60 秒。
     pub shutdown_grace: Duration,
-    /// 対局中に対局者の接続が切れた際、即時 `#ABNORMAL` 終局せず再接続を待つ
+    /// 対局中に対局者の接続が切れた際、即時 `#ABNORMAL` 終局させず再接続を待つ
     /// 猶予時間。`Duration::ZERO` のとき、接続喪失で即時に異常終了させる
-    /// （Phase 1-4 互換、Requirement 2.5 の Phase 1-3 既定）。Phase 5 で再接続
-    /// プロトコルを有効化する場合は運用側で 60 秒程度を設定する。猶予中は
-    /// `SharedState::reconnect_pending` に対局状態を保持し、Game_Summary 末尾
-    /// 拡張行で配布した `reconnect_token` の照合で再参加を許可する。
+    /// （再接続プロトコルを有効化していない構成での保守的な既定）。`> 0` を
+    /// 指定した場合は猶予中 `SharedState::reconnect_pending` に対局状態を保持し、
+    /// Game_Summary 末尾拡張行で配布した `reconnect_token` の照合で再参加を許可
+    /// する。運用上の推奨は 60 秒。
     pub reconnect_grace_duration: Duration,
 }
 
@@ -453,9 +453,10 @@ impl WaitingPool {
 /// 現在の盤面・両者残時間・最終手・手番を再送するために保持する。
 #[derive(Debug, Clone)]
 pub(crate) struct ReconnectSnapshot {
-    /// 先手の残り持ち時間 (ms)。
+    /// 先手の本体残り持ち時間 (ms)。秒読み残は含まない (`GameRoom::clock_remaining_main_ms`
+    /// と同義)。表示・ログ用途で、再接続クライアントの 1 手 deadline 計算には使えない。
     pub(crate) black_remaining_ms: u64,
-    /// 後手の残り持ち時間 (ms)。
+    /// 後手の本体残り持ち時間 (ms)。`black_remaining_ms` と同じ契約。
     pub(crate) white_remaining_ms: u64,
     /// 現在の手番。
     pub(crate) current_turn: Color,
@@ -551,9 +552,9 @@ where
     /// 切断検出後 grace 期間内の対局を一時保持するレジストリ。`game_id` で索引し、
     /// LOGIN 時に `reconnect:<game_id>+<token>` を提示したクライアントが
     /// `Arc<PendingReconnect>` を取り出して token 照合・transport handoff を行う。
-    /// `config.reconnect_grace_duration` が `Duration::ZERO` の場合（Phase 1-4
-    /// 互換）はこのレジストリは常に空のままで、`run_game_loop_and_record` は
-    /// 即時 `#ABNORMAL` に進む。
+    /// `config.reconnect_grace_duration` が `Duration::ZERO` の場合（再接続経路を
+    /// 無効化した既定構成）はこのレジストリは常に空のままで、
+    /// `run_game_loop_and_record` は即時 `#ABNORMAL` に進む。
     pub(crate) reconnect_pending: Mutex<HashMap<GameId, Arc<PendingReconnect>>>,
 }
 
@@ -898,7 +899,8 @@ where
     //      で来た場合は新規対局参加 (League 登録 / 待機プール) ではなく、grace 中の
     //      該当対局へ「同一対局者として再参加」する経路へ。`reconnect_pending` 検索
     //      → handle / token 照合 → game loop に新 transport を handoff。失敗時は
-    //      `LOGIN:incorrect <reason>` で拒否し、対局状態は変更しない (Requirement 17.6)。
+    //      `LOGIN:incorrect <reason>` で拒否し、grace 中の対局状態と registry エントリ
+    //      は一切変更しない (拒否は元の対局者による再試行を妨げないため)。
     if let Some(req) = reconnect {
         return handle_reconnect_request(&state, transport, &handle_player, req).await;
     }
@@ -2554,7 +2556,12 @@ where
         "awaiting reconnect within grace window"
     );
 
+    // `biased;` で oneshot 受信側を優先する。deadline と sender.send が同時に
+    // ready になった場合に sleep_until が選ばれると、handshake 側で resume を
+    // 受信したクライアントに対して `#ABNORMAL` を返してしまう非決定 race を
+    // 起こすため、resume が成立し得るなら確実にそちらを採用する。
     let outcome = tokio::select! {
+        biased;
         recv_res = rx => match recv_res {
             Ok(new_transport) => DisconnectOutcome::Reconnected(new_transport),
             // sender 側が drop された場合 (handshake 側の panic 等)。registry には
@@ -2586,10 +2593,11 @@ where
 /// - registry エントリは残っているが `reconnect_tx` が既に消費済み (重複再接続) →
 ///   `LOGIN:incorrect reconnect_already_resumed`
 ///
-/// いずれの拒否ケースでも `reconnect_pending` のエントリは変更せず、対局状態は
-/// 保持されたままになる (Requirement 17.6)。成功時のみ `reconnect_tx` を `take()`
-/// して新 `TcpTransport` を game loop に渡し、状態再送 (Game_Summary 全文 +
-/// `Reconnect_State` ブロック) を済ませてから handoff する。
+/// いずれの拒否ケースでも `reconnect_pending` のエントリは変更せず、対局状態
+/// は保持されたままになる (拒否は元の対局者による再試行を妨げない)。成功時のみ
+/// `reconnect_tx` を `take()` して新 `TcpTransport` を game loop に渡し、状態
+/// 再送 (Game_Summary 全文 + `Reconnect_State` ブロック) を済ませてから
+/// handoff する。
 async fn handle_reconnect_request<R, K, P, H>(
     state: &SharedState<R, K, P, H>,
     mut transport: TcpTransport,

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1958,7 +1958,7 @@ fn reconnect_grace_rejects_token_mismatch_and_preserves_pending_state() {
         let (mut rx, mut wx) = connect(addr).await;
         send_line(&mut wx, &format!("LOGIN alice+g1+black pw reconnect:{game_id}+{bad_token}"))
             .await;
-        assert_eq!(read_line_raw(&mut rx).await.unwrap(), "LOGIN:alice OK");
+        // 拒否経路: `LOGIN:<handle> OK` は送出されず、即 `LOGIN:incorrect ...` のみ届く。
         assert_eq!(
             read_line_raw(&mut rx).await.unwrap(),
             "LOGIN:incorrect reconnect_token_mismatch"

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1958,11 +1958,9 @@ fn reconnect_grace_rejects_token_mismatch_and_preserves_pending_state() {
         let (mut rx, mut wx) = connect(addr).await;
         send_line(&mut wx, &format!("LOGIN alice+g1+black pw reconnect:{game_id}+{bad_token}"))
             .await;
-        // 拒否経路: `LOGIN:<handle> OK` は送出されず、即 `LOGIN:incorrect ...` のみ届く。
-        assert_eq!(
-            read_line_raw(&mut rx).await.unwrap(),
-            "LOGIN:incorrect reconnect_token_mismatch"
-        );
+        // 拒否経路: `LOGIN:<handle> OK` は送出されず、即 `LOGIN:incorrect reconnect_rejected`
+        // のみ届く (拒否理由は side-channel 防止のため wire 上は統一)。
+        assert_eq!(read_line_raw(&mut rx).await.unwrap(), "LOGIN:incorrect reconnect_rejected");
         drop(rx);
         drop(wx);
 

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -1782,3 +1782,232 @@ fn graceful_shutdown_prunes_observer_subscribers() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+/// 再接続経路向けに `reconnect_grace_duration` を上書きしたサーバを起動する。
+async fn spawn_server_with_reconnect_grace(
+    tag: &str,
+    grace: Duration,
+) -> (
+    std::net::SocketAddr,
+    PathBuf,
+    Rc<
+        rshogi_csa_server_tcp::server::SharedState<
+            support::MemRateStorage,
+            FileKifuStorage,
+            InMemoryPasswordStore,
+            JsonlFloodgateHistoryStorage,
+        >,
+    >,
+) {
+    let topdir = unique_topdir(tag);
+    let mut password_map = HashMap::new();
+    password_map.insert("alice".to_owned(), "pw".to_owned());
+    password_map.insert("bob".to_owned(), "pw".to_owned());
+    let rate_records: Vec<_> = ["alice", "bob"]
+        .iter()
+        .map(|n| PlayerRateRecord {
+            name: PlayerName::new(*n),
+            rate: 1500,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: "2026-04-17T00:00:00Z".to_owned(),
+        })
+        .collect();
+    let rate_storage = support::MemRateStorage::new(rate_records);
+    let kifu_storage = FileKifuStorage::new(topdir.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let actual_addr = listener.local_addr().unwrap();
+    let config = ServerConfig {
+        bind_addr: actual_addr,
+        kifu_topdir: topdir.clone(),
+        login_timeout: Duration::from_secs(10),
+        agree_timeout: Duration::from_secs(30),
+        reconnect_grace_duration: grace,
+        ..ServerConfig::sensible_defaults()
+    };
+    let state = Rc::new(build_state(
+        config,
+        rate_storage,
+        kifu_storage,
+        InMemoryPasswordStore { map: password_map },
+        Box::new(PlainPasswordHasher::new()),
+        IpLoginRateLimiter::default_limits(),
+        InMemoryBroadcaster::new(),
+        None::<JsonlFloodgateHistoryStorage>,
+    ));
+    let _handle = run_server_with_listener(listener, state.clone()).await.expect("run_server");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (actual_addr, topdir, state)
+}
+
+/// `BEGIN Game_Summary` の lines 配列から `<field>:` 行の値を取り出す。
+fn extract_summary_field(lines: &[String], field: &str) -> Option<String> {
+    let prefix = format!("{field}:");
+    lines.iter().find_map(|l| l.strip_prefix(&prefix).map(str::to_owned))
+}
+
+/// alice/bob を LOGIN → AGREE → START まで進めて `(game_id, alice_token)` を返す共通手順。
+/// ra/wa/rb/wb の transport は呼び出し側が管理する。
+async fn establish_match_and_capture_alice_token(
+    ra: &mut BufReader<OwnedReadHalf>,
+    wa: &mut OwnedWriteHalf,
+    rb: &mut BufReader<OwnedReadHalf>,
+    wb: &mut OwnedWriteHalf,
+) -> (String, String) {
+    send_line(wa, "LOGIN alice+g1+black pw").await;
+    send_line(wb, "LOGIN bob+g1+white pw").await;
+    assert_eq!(read_line_raw(ra).await.unwrap(), "LOGIN:alice OK");
+    assert_eq!(read_line_raw(rb).await.unwrap(), "LOGIN:bob OK");
+    let alice_lines = drain_game_summary(ra).await;
+    let _ = drain_game_summary(rb).await;
+    let game_id = extract_summary_field(&alice_lines, "Game_ID").expect("Game_ID line");
+    let alice_token =
+        extract_summary_field(&alice_lines, "Reconnect_Token").expect("Reconnect_Token line");
+    send_line(wa, "AGREE").await;
+    send_line(wb, "AGREE").await;
+    let _ = read_until(ra, &format!("START:{game_id}")).await;
+    let _ = read_until(rb, &format!("START:{game_id}")).await;
+    (game_id, alice_token)
+}
+
+#[test]
+fn reconnect_grace_allows_disconnected_player_to_resume_with_valid_token() {
+    // 切断 → 猶予内に正しい token を持って LOGIN → 再参加が成立し、状態再送
+    // (Game_Summary 全文 + Reconnect_State ブロック) を受け取った後に対局を継続できる。
+    run_local(|| async {
+        let (addr, topdir, _state) =
+            spawn_server_with_reconnect_grace("reconnect_resume", Duration::from_secs(5)).await;
+        let (mut ra, mut wa) = connect(addr).await;
+        let (mut rb, mut wb) = connect(addr).await;
+        let (game_id, alice_token) =
+            establish_match_and_capture_alice_token(&mut ra, &mut wa, &mut rb, &mut wb).await;
+
+        // 1. alice 側を切断する (TCP transport を drop)。
+        drop(ra);
+        drop(wa);
+        // grace 経路に入るのを待つ。`run_game_loop_and_record` の `Evt::Recv(Closed)` を
+        // 拾って `handle_disconnect_with_grace` に到達するまで少し時間を置く。
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // 2. alice として新接続で reconnect 要求。
+        let (mut ra2, mut wa2) = connect(addr).await;
+        send_line(&mut wa2, &format!("LOGIN alice+g1+black pw reconnect:{game_id}+{alice_token}"))
+            .await;
+        assert_eq!(read_line_raw(&mut ra2).await.unwrap(), "LOGIN:alice OK");
+
+        // 3. resume message を受信: Game_Summary + Reconnect_State。
+        let resume_summary = drain_game_summary(&mut ra2).await;
+        assert_eq!(
+            extract_summary_field(&resume_summary, "Reconnect_Token").as_deref(),
+            Some(alice_token.as_str()),
+            "resume Game_Summary must include the original token"
+        );
+        assert_eq!(read_line_raw(&mut ra2).await.unwrap(), "BEGIN Reconnect_State");
+        let mut state_lines = Vec::new();
+        loop {
+            let l = read_line_raw(&mut ra2).await.unwrap();
+            let done = l == "END Reconnect_State";
+            state_lines.push(l);
+            if done {
+                break;
+            }
+        }
+        assert!(state_lines.iter().any(|l| l == "Current_Turn:+"));
+        assert!(state_lines.iter().any(|l| l.starts_with("Black_Time_Remaining_Ms:")));
+        assert!(state_lines.iter().any(|l| l.starts_with("White_Time_Remaining_Ms:")));
+
+        // 4. 対局継続: alice が指し手を送って bob 側でも観測される。
+        send_line(&mut wa2, "+7776FU").await;
+        let echoed = read_until(&mut rb, "+7776FU,T0").await;
+        assert!(echoed.iter().any(|l| l == "+7776FU,T0"));
+
+        // 5. 後始末: bob 投了で alice (黒) が勝者として `#WIN` を受け取る。
+        send_line(&mut wb, "%TORYO").await;
+        let _ = read_until(&mut ra2, "#WIN").await;
+
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn reconnect_grace_rejects_token_mismatch_and_preserves_pending_state() {
+    // 切断 → 不正 token を持つ LOGIN は `LOGIN:incorrect reconnect_token_mismatch` で
+    // 拒否され、grace registry エントリは温存される。後続で正しい token を持って
+    // 再接続すれば対局を再開できる。
+    run_local(|| async {
+        let (addr, topdir, _state) =
+            spawn_server_with_reconnect_grace("reconnect_mismatch", Duration::from_secs(5)).await;
+        let (mut ra, mut wa) = connect(addr).await;
+        let (mut rb, mut wb) = connect(addr).await;
+        let (game_id, alice_token) =
+            establish_match_and_capture_alice_token(&mut ra, &mut wa, &mut rb, &mut wb).await;
+        drop(ra);
+        drop(wa);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // 1. 不正 token (alice_token と 1 文字違い) で LOGIN reconnect。
+        let bad_token = {
+            let mut t = alice_token.clone();
+            // hex 1 文字を確実に別の値へ書き換える。
+            let last = t.pop().unwrap();
+            let replacement = if last == 'a' { 'b' } else { 'a' };
+            t.push(replacement);
+            t
+        };
+        let (mut rx, mut wx) = connect(addr).await;
+        send_line(&mut wx, &format!("LOGIN alice+g1+black pw reconnect:{game_id}+{bad_token}"))
+            .await;
+        assert_eq!(read_line_raw(&mut rx).await.unwrap(), "LOGIN:alice OK");
+        assert_eq!(
+            read_line_raw(&mut rx).await.unwrap(),
+            "LOGIN:incorrect reconnect_token_mismatch"
+        );
+        drop(rx);
+        drop(wx);
+
+        // 2. registry が消えていないことを正しい token での再接続成功で確認する。
+        let (mut ra2, mut wa2) = connect(addr).await;
+        send_line(&mut wa2, &format!("LOGIN alice+g1+black pw reconnect:{game_id}+{alice_token}"))
+            .await;
+        assert_eq!(read_line_raw(&mut ra2).await.unwrap(), "LOGIN:alice OK");
+        let _ = drain_game_summary(&mut ra2).await;
+        // Reconnect_State block をスキップして対局継続できることを確認。
+        let begin = read_line_raw(&mut ra2).await.unwrap();
+        assert_eq!(begin, "BEGIN Reconnect_State");
+        let _ = read_until(&mut ra2, "END Reconnect_State").await;
+
+        // 後始末: bob 投了で alice (黒) が勝者として `#WIN` を受け取る。
+        send_line(&mut wb, "%TORYO").await;
+        let _ = read_until(&mut ra2, "#WIN").await;
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+#[test]
+fn reconnect_grace_falls_back_to_abnormal_when_deadline_expires() {
+    // grace 期間内に再接続が来ない場合、deadline 超過で `force_abnormal` に進み、
+    // 残留側に `#ABNORMAL` 経由の終局通知が届く。
+    run_local(|| async {
+        // grace を短く (300ms) してテスト時間を抑える。
+        let (addr, topdir, _state) =
+            spawn_server_with_reconnect_grace("reconnect_expired", Duration::from_millis(300))
+                .await;
+        let (mut ra, mut wa) = connect(addr).await;
+        let (mut rb, mut wb) = connect(addr).await;
+        let (_game_id, _alice_token) =
+            establish_match_and_capture_alice_token(&mut ra, &mut wa, &mut rb, &mut wb).await;
+
+        // alice を切断したまま放置。
+        drop(ra);
+        drop(wa);
+
+        // bob 側で `#ABNORMAL` を含む終局シグナルが grace 超過後に届く。
+        let abnormal = read_until(&mut rb, "#ABNORMAL").await;
+        assert!(abnormal.iter().any(|l| l == "#ABNORMAL"));
+
+        drop(rb);
+        drop(wb);
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -5,14 +5,28 @@
 //! [`crate::game`]）で行う。
 
 use crate::error::ProtocolError;
-use crate::types::{Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, Secret};
+use crate::types::{
+    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken, Secret,
+};
+
+/// 再接続要求の引数。LOGIN 行末尾の `reconnect:<game_id>+<token>` で送られる。
+///
+/// 通常の新規対局参加 LOGIN とは異なる経路で処理される（`game_id` の対局が
+/// grace 中に存在し、`token` が一致した場合に同一対局者として再参加する）。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconnectRequest {
+    /// 再参加対象の対局 ID。
+    pub game_id: GameId,
+    /// 対局開始時に発行された再接続トークン (Game_Summary 末尾拡張行で配布済み)。
+    pub token: ReconnectToken,
+}
 
 /// クライアントから到着し得るコマンド一覧。
 ///
 /// 非公開フィールドは持たず、パターンマッチによるルーティングが容易な `enum`。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClientCommand {
-    /// `LOGIN <name> <password> [x1]`
+    /// `LOGIN <name> <password> [x1 | reconnect:<game_id>+<token>]`
     Login {
         /// プレイヤ名。
         name: PlayerName,
@@ -20,6 +34,9 @@ pub enum ClientCommand {
         password: Secret,
         /// x1 拡張モードを要求するか。
         x1: bool,
+        /// 再接続要求。`Some` の場合は新規対局参加ではなく既存対局への再参加要求。
+        /// `x1` と排他: 同一 LOGIN 行で両方を指定することはできない。
+        reconnect: Option<ReconnectRequest>,
     },
     /// `LOGOUT`
     Logout,
@@ -163,13 +180,36 @@ pub fn parse_command(line: &CsaLine) -> Result<ClientCommand, ProtocolError> {
             let password = parts
                 .next()
                 .ok_or_else(|| ProtocolError::Malformed("LOGIN: missing password".into()))?;
-            let x1 = match parts.next() {
-                None => false,
-                Some("x1") => true,
-                Some(extra) => {
-                    return Err(ProtocolError::Malformed(format!(
-                        "LOGIN: unexpected trailing token `{extra}`"
-                    )));
+            let (x1, reconnect) = match parts.next() {
+                None => (false, None),
+                Some("x1") => (true, None),
+                Some(token) => {
+                    if let Some(rest) = token.strip_prefix("reconnect:") {
+                        let mut split = rest.splitn(2, '+');
+                        let game_id_part =
+                            split.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+                                ProtocolError::Malformed(
+                                    "LOGIN: reconnect requires `<game_id>+<token>`".into(),
+                                )
+                            })?;
+                        let token_part =
+                            split.next().filter(|s| !s.is_empty()).ok_or_else(|| {
+                                ProtocolError::Malformed(
+                                    "LOGIN: reconnect requires `<game_id>+<token>`".into(),
+                                )
+                            })?;
+                        (
+                            false,
+                            Some(ReconnectRequest {
+                                game_id: GameId::new(game_id_part),
+                                token: ReconnectToken::new(token_part),
+                            }),
+                        )
+                    } else {
+                        return Err(ProtocolError::Malformed(format!(
+                            "LOGIN: unexpected trailing token `{token}`"
+                        )));
+                    }
                 }
             };
             if parts.next().is_some() {
@@ -179,6 +219,7 @@ pub fn parse_command(line: &CsaLine) -> Result<ClientCommand, ProtocolError> {
                 name: PlayerName::new(name),
                 password: Secret::new(password),
                 x1,
+                reconnect,
             })
         }
         "LOGOUT" => {
@@ -397,6 +438,7 @@ mod tests {
                 name: PlayerName::new("alice"),
                 password: Secret::new("pw"),
                 x1: false,
+                reconnect: None,
             }
         );
     }
@@ -404,10 +446,38 @@ mod tests {
     #[test]
     fn parses_login_x1() {
         let cmd = parse_command(&line("LOGIN bob secret x1")).unwrap();
-        let ClientCommand::Login { x1, .. } = cmd else {
+        let ClientCommand::Login { x1, reconnect, .. } = cmd else {
             panic!("expected Login");
         };
         assert!(x1);
+        assert!(reconnect.is_none());
+    }
+
+    #[test]
+    fn parses_login_reconnect() {
+        let cmd = parse_command(&line("LOGIN alice pw reconnect:20260426120000+abcd1234ef567890"))
+            .unwrap();
+        let ClientCommand::Login { x1, reconnect, .. } = cmd else {
+            panic!("expected Login");
+        };
+        assert!(!x1);
+        let req = reconnect.expect("reconnect must be set");
+        assert_eq!(req.game_id.as_str(), "20260426120000");
+        assert_eq!(req.token.as_str(), "abcd1234ef567890");
+    }
+
+    #[test]
+    fn rejects_login_reconnect_without_separator() {
+        let err = parse_command(&line("LOGIN alice pw reconnect:onlygameid")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)));
+    }
+
+    #[test]
+    fn rejects_login_reconnect_with_empty_parts() {
+        let err = parse_command(&line("LOGIN alice pw reconnect:+token")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)));
+        let err = parse_command(&line("LOGIN alice pw reconnect:gid+")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wave D の TCP frontend 統合 PR。task 18.2 (切断時状態保持と猶予時間) / 18.3 (再接続要求検証と状態再送) / 18.4 (満了敗北確定とトークン不一致拒否) を 1 PR で実装する (frontend 単位 PR 分割方針)。Workers 側は別 PR で対応。

### 設定追加

- `ServerConfig::reconnect_grace_duration: Duration` (既定 `Duration::ZERO` = Phase 1-4 互換、即時 `#ABNORMAL`)
- `> 0` で再接続猶予を有効化。Phase 5 features の opt-in 経路は次の Workers 統合 PR で配線する (16.1 bundle)

### 切断検出経路 (18.2)

- `run_game_loop_and_record` の `Evt::Recv(from, Err(Closed | Timeout))` arm で `room.force_abnormal(from)` を直接呼ばず、`reconnect_grace_duration` が `> 0` の場合は `handle_disconnect_with_grace` に委譲
- `SharedState::reconnect_pending: Mutex<HashMap<GameId, Arc<PendingReconnect>>>` を新設し、対局スナップショット (盤面・両者残時間・手番・最終手) を保持
- `tokio::select!` で oneshot 経由の再接続成立か `sleep_until(deadline)` のどちらかを待つ。どの経路を抜けても registry エントリを除去する

### 再接続 handshake (18.3)

- `ClientCommand::Login.reconnect: Option<ReconnectRequest>` を core で追加し、LOGIN 行の 3 つ目トークン `reconnect:<game_id>+<token>` をパース。`x1` と排他、空文字 / 区切り欠落は `ProtocolError::Malformed` で拒否
- `handle_connection` は認証直後に `handle_reconnect_request` へ分岐 (新規対局参加経路には進まない)
- handle / token 照合に成功した場合のみ resume 文字列を送出して `oneshot::Sender::send` で新 `TcpTransport` を game loop に渡す。game loop は `*black = new_transport` (or white) で差し替えて `continue 'game_loop` で対局を継続

### 状態再送フォーマット

`build_resume_message(summary_for_disconnected, snapshot)` で組み立てる:

1. `BEGIN Game_Summary` ... `END Game_Summary` (`position_section` のみ切断時の現在局面に差し替え。`Reconnect_Token:` 拡張行は再送)
2. `BEGIN Reconnect_State` ... `END Reconnect_State` (`Current_Turn`, `Black_Time_Remaining_Ms`, `White_Time_Remaining_Ms`, `Last_Move` 省略可)

### 拒否経路 (18.4)

いずれも `reconnect_pending` エントリは温存して対局状態を変更しない (Requirement 17.6):

- `LOGIN:incorrect reconnect_unknown_game` - `game_id` が registry にない
- `LOGIN:incorrect reconnect_handle_mismatch` - LOGIN handle と切断側 handle が不一致
- `LOGIN:incorrect reconnect_token_mismatch` - token が不一致
- `LOGIN:incorrect reconnect_already_resumed` - 二重再接続 (sender が既に消費済み)

満了経路 (`DisconnectOutcome::Aborted`) は既存の `room.force_abnormal(from)` 経路に合流し、残留側に `#ABNORMAL` + `#WIN`/`#LOSE` を送出する。

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --release`
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- 追加 unit test:
  - `command::parses_login_reconnect`
  - `command::rejects_login_reconnect_without_separator`
  - `command::rejects_login_reconnect_with_empty_parts`
  - `server::tests::build_resume_message_includes_game_summary_then_reconnect_state_block`
  - `server::tests::build_resume_message_emits_plus_for_black_turn`
  - `server::tests::build_resume_message_omits_last_move_line_when_none`
- 追加 E2E test (`tests/tcp_session.rs`):
  - `reconnect_grace_allows_disconnected_player_to_resume_with_valid_token`
  - `reconnect_grace_rejects_token_mismatch_and_preserves_pending_state`
  - `reconnect_grace_falls_back_to_abnormal_when_deadline_expires`

## YAGNI / 範囲外

- CLI flag (`--reconnect-grace-sec` 等) は未配線。`reconnect_grace_duration` は Phase 5 gate 配線時 (Workers 統合 PR の task 16.1) に CLI から有効化する
- Workers frontend (DO `state.alarm` + WebSocket Hibernation 経路) は別 PR
- 既存クライアント (CSA v1.2.1 標準) は LOGIN 引数 2 個のままで動作。`reconnect:<game_id>+<token>` 拡張は本サーバ独自

🤖 Generated with [Claude Code](https://claude.com/claude-code)