### PR TITLE
feat(csa-server-workers): wrangler.toml.example と ConfigKeys 定数の整合性を CI で固定 (task 23.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "worker",
  "worker-macros",
 ]

--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -46,3 +46,6 @@ tokio-transport = []
 # host target の async テスト（`FloodgateHistoryStorage` の cold-start 契約検証等）
 # で futures を駆動するためにのみ使用する。wasm32 ランタイムには取り込まれない。
 tokio = { workspace = true, features = ["rt", "macros"] }
+# `wrangler.toml.example` を解析して `ConfigKeys` 定数全件が宣言されていることを
+# 検証する integration test (`tests/wrangler_template_consistency.rs`) でのみ使用。
+toml = { workspace = true }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -9,6 +9,14 @@ use rshogi_csa_server::ClockSpec;
 use crate::origin;
 
 /// 起動時にバインディング名として参照する環境変数キー群。
+///
+/// # 新規定数を追加するときは
+///
+/// 個別 const と併せて、用途別の網羅配列 [`ConfigKeys::ALL_R2_BINDINGS`] /
+/// [`ConfigKeys::ALL_DO_BINDINGS`] / [`ConfigKeys::ALL_VARS_KEYS`] への追加を
+/// 必ず行うこと。`tests/wrangler_template_consistency.rs` がこれら配列と
+/// `wrangler.toml.example` の双方向整合を検証しているため、配列追加を忘れると
+/// template 更新忘れも検出できなくなる。
 pub struct ConfigKeys;
 
 impl ConfigKeys {
@@ -34,6 +42,29 @@ impl ConfigKeys {
     pub const BYOYOMI_MIN: &'static str = "BYOYOMI_MIN";
     /// 運営権限を持つハンドル名（`%%SETBUOY` / `%%DELETEBUOY`）。
     pub const ADMIN_HANDLE: &'static str = "ADMIN_HANDLE";
+
+    /// `wrangler.toml` の `[[r2_buckets]] binding = "..."` で宣言されるべき名前の
+    /// 網羅列挙。新規 R2 binding 定数を追加したら必ず本配列にも追加する。
+    pub const ALL_R2_BINDINGS: &'static [&'static str] = &[
+        Self::KIFU_BUCKET_BINDING,
+        Self::FLOODGATE_HISTORY_BUCKET_BINDING,
+    ];
+
+    /// `wrangler.toml` の `[[durable_objects.bindings]] name = "..."` で宣言される
+    /// べき名前の網羅列挙。新規 DO binding 定数を追加したら必ず本配列にも追加する。
+    pub const ALL_DO_BINDINGS: &'static [&'static str] = &[Self::GAME_ROOM_BINDING];
+
+    /// `wrangler.toml` の `[vars]` で宣言されるべきキーの網羅列挙。
+    /// 新規 `[vars]` キー定数を追加したら必ず本配列にも追加する。
+    pub const ALL_VARS_KEYS: &'static [&'static str] = &[
+        Self::CORS_ORIGINS,
+        Self::CLOCK_KIND,
+        Self::TOTAL_TIME_SEC,
+        Self::BYOYOMI_SEC,
+        Self::TOTAL_TIME_MIN,
+        Self::BYOYOMI_MIN,
+        Self::ADMIN_HANDLE,
+    ];
 }
 
 /// Workers `[vars]` 文字列群から時計設定を解決する。

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -1,0 +1,139 @@
+//! `wrangler.toml.example` と `ConfigKeys` 定数の整合性検証。
+//!
+//! Workers コードに新しい binding 定数（R2 / DO / `[vars]` キー）を追加した PR が、
+//! `wrangler.toml.example` のテンプレート更新を忘れて merge されると、運用者が
+//! `cp wrangler.toml.example wrangler.toml` で派生させた本番設定で binding 不足の
+//! まま deploy する事故が発生する。逆に、template にだけ binding を追加して
+//! `ConfigKeys` への追加を忘れたケースもコード側で参照されない dead binding を
+//! 抱え込む原因になる。
+//!
+//! 過去事例: PR #500 で `R2FloodgateHistoryStorage` を新設し
+//! `ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING` を追加したが、対応する
+//! `[[r2_buckets]]` エントリの template への追加が漏れていた（task 23.2 で修正）。
+//!
+//! 本テストは `wrangler.toml.example` を TOML として parse し、`ConfigKeys` の
+//! 網羅配列 (`ALL_R2_BINDINGS` / `ALL_DO_BINDINGS` / `ALL_VARS_KEYS`) と
+//! template の宣言が **双方向に一致** することを assert する。
+//!
+//! - 順方向: `ConfigKeys::ALL_*` の各要素 ⊆ template 宣言（コード追加 → template 漏れ検出）
+//! - 逆方向: template 宣言 ⊆ `ConfigKeys::ALL_*` の各要素（template 追加 → コード参照漏れ検出）
+
+use std::sync::LazyLock;
+
+use rshogi_csa_server_workers::config::ConfigKeys;
+
+/// `wrangler.toml.example` を解析した結果。テンプレートに宣言されている
+/// 各種 binding / `[vars]` キーを集約する。
+struct TemplateBindings {
+    r2_bindings: Vec<String>,
+    do_bindings: Vec<String>,
+    vars_keys: Vec<String>,
+}
+
+/// テスト 1 本ごとに file I/O + parse を繰り返さないため `LazyLock` で 1 回化する。
+/// 失敗時は `panic!` する（dev 経路でのみ動作するテストなので Result 化は不要）。
+static TEMPLATE: LazyLock<TemplateBindings> = LazyLock::new(load_template_bindings);
+
+fn load_template_bindings() -> TemplateBindings {
+    let template_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("wrangler.toml.example");
+    let raw = std::fs::read_to_string(&template_path).unwrap_or_else(|e| {
+        panic!("failed to read {}: {e}", template_path.display());
+    });
+    let doc: toml::Value = toml::from_str(&raw).unwrap_or_else(|e| {
+        panic!("failed to parse {} as TOML: {e}", template_path.display());
+    });
+
+    // `[[r2_buckets]]` 配列の各エントリから `binding = "..."` を集める。
+    let r2_bindings = doc
+        .get("r2_buckets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("binding").and_then(|v| v.as_str()).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // `[[durable_objects.bindings]]` 配列の各エントリから `name = "..."` を集める。
+    let do_bindings = doc
+        .get("durable_objects")
+        .and_then(|v| v.get("bindings"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("name").and_then(|v| v.as_str()).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // `[vars]` テーブルのキー集合を集める。
+    let vars_keys = doc
+        .get("vars")
+        .and_then(|v| v.as_table())
+        .map(|t| t.keys().cloned().collect())
+        .unwrap_or_default();
+
+    TemplateBindings {
+        r2_bindings,
+        do_bindings,
+        vars_keys,
+    }
+}
+
+/// 双方向整合 assert ヘルパ。
+///
+/// `code_side` (= `ConfigKeys::ALL_*`) と `template_side` (= `wrangler.toml.example`
+/// から抽出したリスト) が同一集合であることを検証する。
+///
+/// - `code_side` にあって `template_side` に無い要素 → コード追加忘れ
+///   (`ConfigKeys` に定数追加したが template 更新を怠った)
+/// - `template_side` にあって `code_side` に無い要素 → template 追加忘れ
+///   (template に binding を入れたが `ConfigKeys::ALL_*` への登録を怠った)
+fn assert_bidirectional(category: &str, code_side: &[&'static str], template_side: &[String]) {
+    let missing_from_template: Vec<&&str> = code_side
+        .iter()
+        .filter(|name| !template_side.iter().any(|t| t == **name))
+        .collect();
+    assert!(
+        missing_from_template.is_empty(),
+        "wrangler.toml.example missing {category} entries declared in ConfigKeys::ALL_{cat_upper}: \
+         {missing_from_template:?}; template currently declares: {template_side:?}",
+        cat_upper = category.to_ascii_uppercase(),
+    );
+
+    let missing_from_code: Vec<&String> = template_side
+        .iter()
+        .filter(|name| !code_side.contains(&name.as_str()))
+        .collect();
+    assert!(
+        missing_from_code.is_empty(),
+        "wrangler.toml.example declares {category} entries not present in ConfigKeys::ALL_{cat_upper}: \
+         {missing_from_code:?}; ConfigKeys::ALL_{cat_upper} currently lists: {code_side:?}",
+        cat_upper = category.to_ascii_uppercase(),
+    );
+}
+
+/// `wrangler.toml.example` の `[[r2_buckets]]` 配列が、`ConfigKeys::ALL_R2_BINDINGS`
+/// と双方向に一致することを検証する。
+#[test]
+fn wrangler_template_r2_bindings_match_config_keys() {
+    assert_bidirectional("r2_bindings", ConfigKeys::ALL_R2_BINDINGS, &TEMPLATE.r2_bindings);
+}
+
+/// `wrangler.toml.example` の `[[durable_objects.bindings]]` 配列が、
+/// `ConfigKeys::ALL_DO_BINDINGS` と双方向に一致することを検証する。
+#[test]
+fn wrangler_template_do_bindings_match_config_keys() {
+    assert_bidirectional("do_bindings", ConfigKeys::ALL_DO_BINDINGS, &TEMPLATE.do_bindings);
+}
+
+/// `wrangler.toml.example` の `[vars]` テーブルキーが、`ConfigKeys::ALL_VARS_KEYS`
+/// と双方向に一致することを検証する。
+///
+/// `[vars]` 値は運用側で書き換える前提なので空文字や placeholder で構わない。
+/// 本テストは「キーの集合が一致すること」のみを検証し、値の内容には関与しない。
+#[test]
+fn wrangler_template_vars_keys_match_config_keys() {
+    assert_bidirectional("vars_keys", ConfigKeys::ALL_VARS_KEYS, &TEMPLATE.vars_keys);
+}

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -86,12 +86,12 @@ fn load_template_bindings() -> TemplateBindings {
 /// `code_side` (= `ConfigKeys::ALL_*`) と `template_side` (= `wrangler.toml.example`
 /// から抽出したリスト) が同一集合であることを検証する。
 ///
-/// - `code_side` にあって `template_side` に無い要素 → コード追加忘れ
+/// - `code_side` にあって `template_side` に無い要素 → template 更新忘れ
 ///   (`ConfigKeys` に定数追加したが template 更新を怠った)
-/// - `template_side` にあって `code_side` に無い要素 → template 追加忘れ
+/// - `template_side` にあって `code_side` に無い要素 → `ConfigKeys::ALL_*` 登録忘れ
 ///   (template に binding を入れたが `ConfigKeys::ALL_*` への登録を怠った)
 fn assert_bidirectional(category: &str, code_side: &[&'static str], template_side: &[String]) {
-    let missing_from_template: Vec<&&str> = code_side
+    let missing_from_template: Vec<_> = code_side
         .iter()
         .filter(|name| !template_side.iter().any(|t| t == **name))
         .collect();
@@ -102,7 +102,7 @@ fn assert_bidirectional(category: &str, code_side: &[&'static str], template_sid
         cat_upper = category.to_ascii_uppercase(),
     );
 
-    let missing_from_code: Vec<&String> = template_side
+    let missing_from_code: Vec<_> = template_side
         .iter()
         .filter(|name| !code_side.contains(&name.as_str()))
         .collect();

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -34,6 +34,19 @@ binding = "KIFU_BUCKET"
 bucket_name = "local-kifu-dev"
 preview_bucket_name = "local-kifu-dev"
 
+# --- R2 (Floodgate 履歴保存) ---
+# Floodgate 運用での 1 対局 = 1 オブジェクト形式の履歴永続化先。
+# `R2FloodgateHistoryStorage` が `floodgate-history/YYYY/MM/DD/HHMMSS-<game_id>.json`
+# キー（UTC 正規化）で書き出し、`list_recent(N)` は当日 day-shard から逆順走査して
+# 直近 N 件を返す（最大 366 日まで遡る安全上限）。
+# task 15.7 で `game_room.rs` 終局経路から `append` を呼ぶ配線が入る。
+# Floodgate 運用を行わない構成でも binding 宣言は残して問題ない（実書き込みは
+# game_room から呼ばれるまで発生しない）。
+[[r2_buckets]]
+binding = "FLOODGATE_HISTORY_BUCKET"
+bucket_name = "local-floodgate-history-dev"
+preview_bucket_name = "local-floodgate-history-dev"
+
 # --- 変数 ---
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。
 # 空文字列・未設定時は全 Upgrade 要求を 403 で拒否する（安全側の既定）。


### PR DESCRIPTION
## Summary

\`crates/rshogi-csa-server-workers/wrangler.toml.example\` のテンプレートと
Workers コードの \`ConfigKeys\` 定数の整合を保つ仕組みを導入する。

**過去事例**: PR #500 で \`R2FloodgateHistoryStorage\` を新設し
\`ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING\` を追加したが、対応する
\`[[r2_buckets]]\` エントリの template への追加が漏れていた。本 PR で
template 側の漏れを修正すると同時に、同パターンの再発を防ぐ整合性 test を
追加する。

task 23.1 (PR #503) に続く Cloudflare 運用基盤整備の 2 本目。

## 主要変更

### \`wrangler.toml.example\`

\`[[r2_buckets]] binding = \"FLOODGATE_HISTORY_BUCKET\"\` エントリを追加。
task 15.7 で \`game_room.rs\` 終局経路から \`R2FloodgateHistoryStorage::append\`
を呼ぶ配線が入った瞬間に R2 binding 不足で起動失敗する事故を防ぐ。

### \`ConfigKeys\` に網羅配列を追加 (\`config.rs\`)

- \`ALL_R2_BINDINGS\`: KIFU_BUCKET / FLOODGATE_HISTORY_BUCKET (2 件)
- \`ALL_DO_BINDINGS\`: GAME_ROOM (1 件)
- \`ALL_VARS_KEYS\`: CORS_ORIGINS / CLOCK_KIND / TOTAL_TIME_{SEC,MIN} /
  BYOYOMI_{SEC,MIN} / ADMIN_HANDLE (7 件)

\`ConfigKeys\` の doc comment に「新規定数追加時は ALL_* への登録必須」を
明示。配列を介して test 側と整合性を一元管理する。

### 整合性 integration test (\`tests/wrangler_template_consistency.rs\`)

\`wrangler.toml.example\` を TOML として parse し、template 宣言と
\`ConfigKeys::ALL_*\` の **双方向** 一致を 3 件の test で assert する。

- 順方向: \`ALL_*\` ⊆ template 宣言 (コード追加 → template 漏れ検出)
- 逆方向: template 宣言 ⊆ \`ALL_*\` (template 追加 → コード参照漏れ検出)

\`assert_bidirectional\` ヘルパで category 別の重複を抑え、\`LazyLock\` で
template parse を test 間 1 回化。失敗時は不足要素と現在の両側リストを
error message に含め、CI ログから追加先が即座に分かるようにする。

### \`Cargo.toml\` dev-dep

\`toml = { workspace = true }\` を追加 (workspace 既存依存、wasm32 ビルド
への影響なし)。

## ローカル確認

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test -p rshogi-csa-server-workers --release\` 全 pass
      (新規 3 件含む 86 tests pass)
- [x] \`cargo clippy -p rshogi-csa-server-workers --all-targets -- -D warnings\`
      警告ゼロ
- [x] **退行検知の動作確認**: 一時的に \`wrangler.toml.example\` から
      \`[[r2_buckets]] binding = \"FLOODGATE_HISTORY_BUCKET\"\` を削除した状態で
      \`cargo test\` を実行 → \`wrangler_template_r2_bindings_match_config_keys\`
      が期待通り fail し、error message に不足要素 \`FLOODGATE_HISTORY_BUCKET\`
      と現状 declared list が含まれることを目視確認

## レビュー履歴

ローカル Claude review 2 round 実施:

- **1st round**: P2-1 (網羅配列化 + 双方向整合) / P3-2 (ヘルパ DRY) /
  P3-4 (LazyLock キャッシュ) の 3 件指摘
- **2nd round**: 全 3 件反映確認、\`ConfigKeys\` 全 10 const の分類整合 OK、
  \`assert_bidirectional\` の論理正確性 OK、新規バグなし、merge 可判定

## 範囲外（follow-up 候補）

- \`[[migrations]] new_sqlite_classes\` と \`[[durable_objects.bindings]] class_name\`
  の整合性検証は本 PR では扱わない。\`#[durable_object]\` 構造体名と
  template の class 名のずれを検出する経路は別タスクで追加検討
- \`wrangler.toml.example\` の \`[vars]\` の値の妥当性検証は範囲外
  (\`parse_clock_spec\` の既存単体テストで網羅済み)

## 関連タスク

- task 23.1 (PR #503): CI wasm32 build job
- task 23.2: 本 PR で完了
- task 23.3 / 23.4: 後続

🤖 Generated with [Claude Code](https://claude.com/claude-code)