### PR TITLE
chore: rust-toolchain.toml を 1.95.0 へ bump

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1564,11 +1564,7 @@ where
             let helper_nodes = 0u64;
 
             let total_nodes = worker.state.nodes.saturating_add(helper_nodes);
-            let nps = if time_ms > 0 {
-                total_nodes.saturating_mul(1000) / time_ms
-            } else {
-                0
-            };
+            let nps = total_nodes.saturating_mul(1000).checked_div(time_ms).unwrap_or(0);
 
             for pv_idx in 0..processed_pv {
                 let info = SearchInfo {

--- a/crates/tools/src/bin/analyze_selfplay.rs
+++ b/crates/tools/src/bin/analyze_selfplay.rs
@@ -1517,7 +1517,7 @@ fn print_text(
             }
             println!();
             let mut sides: Vec<_> = stats.by_side.iter().collect();
-            sides.sort_by(|(a, _), (b, _)| a.cmp(b));
+            sides.sort_by_key(|(a, _)| *a);
             for (side, bucket) in sides {
                 println!(
                     "    side {}: moves={} avg_elapsed={:.1}ms",

--- a/crates/tools/src/bin/compare_nodes.rs
+++ b/crates/tools/src/bin/compare_nodes.rs
@@ -949,8 +949,7 @@ fn write_summary(
 
     // 乖離が大きい局面トップ10
     let mut sorted: Vec<&PositionResult> = results.iter().collect();
-    sorted
-        .sort_by(|a, b| b.final_nodes_diff.unsigned_abs().cmp(&a.final_nodes_diff.unsigned_abs()));
+    sorted.sort_by_key(|r| std::cmp::Reverse(r.final_nodes_diff.unsigned_abs()));
     let top_n = sorted.len().min(10);
     writeln!(writer, "--- 乖離が大きい局面 (top {top_n}) ---")?;
     for r in &sorted[..top_n] {

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -1810,7 +1810,7 @@ fn process_file_with_engine(
     std::thread::scope(|s| {
         let mut handles = Vec::new();
 
-        for (engine, chunk) in engines.iter_mut().zip(chunks.into_iter()) {
+        for (engine, chunk) in engines.iter_mut().zip(chunks) {
             let tx = tx.clone();
             let progress = std::sync::Arc::clone(&progress_arc);
             let error_count = &error_count;

--- a/crates/tools/src/runner/usi.rs
+++ b/crates/tools/src/runner/usi.rs
@@ -228,40 +228,32 @@ impl InfoSnapshot {
 
         while i < tokens.len() {
             match tokens[i] {
-                "depth" => {
-                    if i + 1 < tokens.len() {
-                        if let Ok(val) = tokens[i + 1].parse() {
-                            self.depth = val;
-                        } else {
-                            eprintln!("Warning: Failed to parse depth: {}", tokens[i + 1]);
-                        }
+                "depth" if i + 1 < tokens.len() => {
+                    if let Ok(val) = tokens[i + 1].parse() {
+                        self.depth = val;
+                    } else {
+                        eprintln!("Warning: Failed to parse depth: {}", tokens[i + 1]);
                     }
                 }
-                "nodes" => {
-                    if i + 1 < tokens.len() {
-                        if let Ok(val) = tokens[i + 1].parse() {
-                            self.nodes = val;
-                        } else {
-                            eprintln!("Warning: Failed to parse nodes: {}", tokens[i + 1]);
-                        }
+                "nodes" if i + 1 < tokens.len() => {
+                    if let Ok(val) = tokens[i + 1].parse() {
+                        self.nodes = val;
+                    } else {
+                        eprintln!("Warning: Failed to parse nodes: {}", tokens[i + 1]);
                     }
                 }
-                "nps" => {
-                    if i + 1 < tokens.len() {
-                        if let Ok(val) = tokens[i + 1].parse() {
-                            self.nps = val;
-                        } else {
-                            eprintln!("Warning: Failed to parse nps: {}", tokens[i + 1]);
-                        }
+                "nps" if i + 1 < tokens.len() => {
+                    if let Ok(val) = tokens[i + 1].parse() {
+                        self.nps = val;
+                    } else {
+                        eprintln!("Warning: Failed to parse nps: {}", tokens[i + 1]);
                     }
                 }
-                "hashfull" => {
-                    if i + 1 < tokens.len() {
-                        if let Ok(val) = tokens[i + 1].parse() {
-                            self.hashfull = val;
-                        } else {
-                            eprintln!("Warning: Failed to parse hashfull: {}", tokens[i + 1]);
-                        }
+                "hashfull" if i + 1 < tokens.len() => {
+                    if let Ok(val) = tokens[i + 1].parse() {
+                        self.hashfull = val;
+                    } else {
+                        eprintln!("Warning: Failed to parse hashfull: {}", tokens[i + 1]);
                     }
                 }
                 _ => {}

--- a/crates/tools/src/selfplay/backend.rs
+++ b/crates/tools/src/selfplay/backend.rs
@@ -211,11 +211,7 @@ impl SearchBackend for NativeBackend {
             seldepth: None,
             nodes: Some(result.nodes),
             time_ms: Some(elapsed_ms),
-            nps: if elapsed_ms > 0 {
-                Some(result.nodes * 1000 / elapsed_ms)
-            } else {
-                None
-            },
+            nps: result.nodes.saturating_mul(1000).checked_div(elapsed_ms),
             pv: if result.pv.is_empty() {
                 None
             } else {

--- a/crates/tools/src/selfplay/types.rs
+++ b/crates/tools/src/selfplay/types.rs
@@ -84,53 +84,39 @@ impl InfoSnapshot {
         let mut i = 1;
         while i < tokens.len() {
             match tokens[i] {
-                "depth" => {
-                    if i + 1 < tokens.len() {
-                        depth = tokens[i + 1].parse::<u32>().ok();
-                        i += 1;
-                    }
+                "depth" if i + 1 < tokens.len() => {
+                    depth = tokens[i + 1].parse::<u32>().ok();
+                    i += 1;
                 }
-                "seldepth" => {
-                    if i + 1 < tokens.len() {
-                        seldepth = tokens[i + 1].parse::<u32>().ok();
-                        i += 1;
-                    }
+                "seldepth" if i + 1 < tokens.len() => {
+                    seldepth = tokens[i + 1].parse::<u32>().ok();
+                    i += 1;
                 }
-                "nodes" => {
-                    if i + 1 < tokens.len() {
-                        nodes = tokens[i + 1].parse::<u64>().ok();
-                        i += 1;
-                    }
+                "nodes" if i + 1 < tokens.len() => {
+                    nodes = tokens[i + 1].parse::<u64>().ok();
+                    i += 1;
                 }
-                "time" => {
-                    if i + 1 < tokens.len() {
-                        time_ms = tokens[i + 1].parse::<u64>().ok();
-                        i += 1;
-                    }
+                "time" if i + 1 < tokens.len() => {
+                    time_ms = tokens[i + 1].parse::<u64>().ok();
+                    i += 1;
                 }
-                "nps" => {
-                    if i + 1 < tokens.len() {
-                        nps = tokens[i + 1].parse::<u64>().ok();
-                        i += 1;
-                    }
+                "nps" if i + 1 < tokens.len() => {
+                    nps = tokens[i + 1].parse::<u64>().ok();
+                    i += 1;
                 }
-                "score" => {
-                    if i + 2 < tokens.len() {
-                        match tokens[i + 1] {
-                            "cp" => {
-                                score_cp = tokens[i + 2].parse::<i32>().ok();
-                                score_mate = None;
-                                i += 2;
-                            }
-                            "mate" => {
-                                score_mate = tokens[i + 2].parse::<i32>().ok();
-                                score_cp = None;
-                                i += 2;
-                            }
-                            _ => {}
-                        }
+                "score" if i + 2 < tokens.len() => match tokens[i + 1] {
+                    "cp" => {
+                        score_cp = tokens[i + 2].parse::<i32>().ok();
+                        score_mate = None;
+                        i += 2;
                     }
-                }
+                    "mate" => {
+                        score_mate = tokens[i + 2].parse::<i32>().ok();
+                        score_cp = None;
+                        i += 2;
+                    }
+                    _ => {}
+                },
                 "pv" => {
                     let mut j = i + 1;
                     while j < tokens.len() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,6 @@
+# 開発者間 / CI でツールチェーンバージョンを揃えるため patch 単位で pin する。
+# 新 stable が出たら本ファイルの bump で意図的に追従する運用（自動追従より
+# clippy lint 追加・breaking change を PR で受け止める方が安全）。
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

\`rust-toolchain.toml\` の channel pin を 1.93.1 (2026-02 #389 で導入) から
current stable 1.95.0 に追従する。pin 自体に「1.93.1 でなければ困る」理由は
コミット履歴からも見当たらず、~2 ヶ月前の bump 漏れ。

## 1.95.0 で新規追加された clippy lint への対応

\`-D warnings\` 配下で計 12 件のエラーが上がったため修正:

### \`clippy::manual_checked_ops\` (1.95.0 新規 lint)

- \`crates/rshogi-core/src/search/engine.rs:1567\`
  \`if time_ms > 0 { x / time_ms } else { 0 }\` →
  \`x.checked_div(time_ms).unwrap_or(0)\`
- \`crates/tools/src/selfplay/backend.rs:214\`
  \`if elapsed_ms > 0 { result.nodes * 1000 / elapsed_ms }\` →
  \`result.nodes.saturating_mul(1000).checked_div(elapsed_ms)\`
  （\`engine.rs\` 側と同じ \`saturating_mul\` で overflow 防衛、レビュー反映）

### \`clippy::collapsible_match\` (10 件、\`cargo clippy --fix\` で auto-fix)

- \`crates/tools/src/runner/usi.rs\` (4 件)
- \`crates/tools/src/selfplay/types.rs\` (6 件)

外側 \`match\` の arm 内 \`if\` を guard 化する書き換え。元のセマンティクス保持。

### \`clippy::sort_by_key\` (auto-fix)

- \`crates/tools/src/bin/compare_nodes.rs:952\`
  \`sort_by(|a, b| b.cmp(&a))\` → \`sort_by_key(|r| Reverse(...))\`
- \`analyze_selfplay.rs\` / \`rescore_psv.rs\` の同類 1 件ずつも auto-fix

## \`rust-toolchain.toml\` にコメント追加

将来の bump 判断者向けに patch 単位 pin の意図（CI 再現性 + 新 lint /
breaking change を PR で受け止める運用）を 1 段落で残す。

## 動作変更の評価

- \`checked_div\` 経路は元の \`if x > 0 { y / x }\` と意味論的に等価
- \`Reverse(unsigned_abs())\` の sort 順序は元の \`b.cmp(&a)\` と等価
- \`collapsible_match\` 系は guard 化のみで分岐構造保持

## CI workaround との関係

PR #503 で導入した wasm-build job の \`rustup target add --toolchain \$(awk ...)\`
workaround は \`rust-toolchain.toml\` から channel を動的抽出する設計のため、
本 bump 後も自然に 1.95.0 へ wasm32 target を追加する。CI 側修正は不要。

## レビュー履歴

ローカル Claude review:
- P2-1 (saturating_mul で engine.rs と統一): 反映済み
- P2-2 (rust-toolchain.toml の pin 意図コメント): 反映済み
- P2-3 (CI workflow 混入懸念): レビュアーの誤解（local main が stale で
  PR #503 の差分が見えていた）。実 PR diff には CI 変更は含まれない

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --release\` — 1394 passed / 0 failed
- [x] \`cargo audit\` — vulnerabilities ゼロ (347 deps)
- [x] \`cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown\` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)