### PR TITLE
feat(csa-server-workers): Workers 切断時の再接続プロトコル一式と Phase 5 gate を実装する

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -256,6 +256,10 @@ pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFe
             config.duplicate_login_policy,
             DuplicateLoginPolicy::EvictOld
         ),
+        // 切断時の再接続プロトコル。`reconnect_grace_duration > 0` を指定した
+        // 構成は grace registry / token 照合 / 状態再送 / 満了敗北確定経路を
+        // 全部有効化するため、Phase 5 features の opt-in を要求する。
+        enable_reconnect_protocol: !config.reconnect_grace_duration.is_zero(),
         ..FloodgateFeatureIntent::default()
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -258,7 +258,7 @@ pub(crate) fn floodgate_intent_from_config(config: &ServerConfig) -> FloodgateFe
         ),
         // 切断時の再接続プロトコル。`reconnect_grace_duration > 0` を指定した
         // 構成は grace registry / token 照合 / 状態再送 / 満了敗北確定経路を
-        // 全部有効化するため、Phase 5 features の opt-in を要求する。
+        // 全部有効化するため、Floodgate features の opt-in を要求する。
         enable_reconnect_protocol: !config.reconnect_grace_duration.is_zero(),
         ..FloodgateFeatureIntent::default()
     }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -56,6 +56,14 @@ impl ConfigKeys {
     /// `env.var(ConfigKeys::ADMIN_HANDLE)` で var/secret どちらも読む（Cloudflare
     /// 仕様で同じ namespace に展開される）。
     pub const ADMIN_HANDLE: &'static str = "ADMIN_HANDLE";
+    /// 切断時の再接続猶予秒数。`0` または未設定なら再接続プロトコルを無効化し、
+    /// WebSocket close を即時 `#ABNORMAL` に流す（保守的既定）。`> 0` を指定する
+    /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
+    /// を要求する Phase 5 features の opt-in 経路に乗る。
+    pub const RECONNECT_GRACE_SECONDS: &'static str = "RECONNECT_GRACE_SECONDS";
+    /// Floodgate 機能群を opt-in 有効化するブール変数。`true` / `1` / `yes` / `on`
+    /// で有効。`reconnect_protocol` 等の Floodgate 系を要求する構成で必須。
+    pub const ALLOW_FLOODGATE_FEATURES: &'static str = "ALLOW_FLOODGATE_FEATURES";
 
     /// `wrangler.toml` の `[[r2_buckets]] binding = "..."` で宣言されるべき名前の
     /// 網羅列挙。新規 R2 binding 定数を追加したら必ず本配列にも追加する。
@@ -95,6 +103,8 @@ impl ConfigKeys {
         Self::BYOYOMI_SEC,
         Self::TOTAL_TIME_MIN,
         Self::BYOYOMI_MIN,
+        Self::RECONNECT_GRACE_SECONDS,
+        Self::ALLOW_FLOODGATE_FEATURES,
     ];
 
     /// **local dev のみ** の `wrangler.toml.example` `[vars]` テーブルに追加で
@@ -105,6 +115,20 @@ impl ConfigKeys {
     /// 全件を `[vars]` として記載することで、新規メンバーが `cp wrangler.toml.example
     /// wrangler.toml && wrangler dev` で即動作確認できる friction レス運用を維持する。
     pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] = &[Self::ADMIN_HANDLE];
+}
+
+/// `RECONNECT_GRACE_SECONDS` 文字列を `Duration` へ解決する。`None` または空文字
+/// は `Duration::ZERO`（再接続プロトコル無効化）として扱う。負値や `u32::MAX` を
+/// 超える値は拒否する。
+pub fn parse_reconnect_grace_duration(raw: Option<&str>) -> Result<std::time::Duration, String> {
+    let trimmed = raw.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return Ok(std::time::Duration::ZERO);
+    }
+    let secs: u64 = trimmed
+        .parse()
+        .map_err(|e| format!("RECONNECT_GRACE_SECONDS: invalid u64 {trimmed:?}: {e}"))?;
+    Ok(std::time::Duration::from_secs(secs))
 }
 
 /// Workers `[vars]` 文字列群から時計設定を解決する。
@@ -218,5 +242,33 @@ mod tests {
     fn parse_clock_spec_rejects_unknown_kind() {
         let err = parse_clock_spec(Some("weird"), None, None, None, None).unwrap_err();
         assert!(err.contains("countdown|fischer|stopwatch"));
+    }
+
+    #[test]
+    fn parse_reconnect_grace_duration_defaults_to_zero() {
+        assert_eq!(parse_reconnect_grace_duration(None).unwrap(), std::time::Duration::ZERO);
+        assert_eq!(parse_reconnect_grace_duration(Some("")).unwrap(), std::time::Duration::ZERO);
+        assert_eq!(
+            parse_reconnect_grace_duration(Some(" \t ")).unwrap(),
+            std::time::Duration::ZERO,
+        );
+    }
+
+    #[test]
+    fn parse_reconnect_grace_duration_accepts_positive_seconds() {
+        assert_eq!(
+            parse_reconnect_grace_duration(Some("60")).unwrap(),
+            std::time::Duration::from_secs(60),
+        );
+        assert_eq!(
+            parse_reconnect_grace_duration(Some(" 30\n")).unwrap(),
+            std::time::Duration::from_secs(30),
+        );
+    }
+
+    #[test]
+    fn parse_reconnect_grace_duration_rejects_non_numeric() {
+        let err = parse_reconnect_grace_duration(Some("forever")).unwrap_err();
+        assert!(err.contains("RECONNECT_GRACE_SECONDS"));
     }
 }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -118,8 +118,8 @@ impl ConfigKeys {
 }
 
 /// `RECONNECT_GRACE_SECONDS` 文字列を `Duration` へ解決する。`None` または空文字
-/// は `Duration::ZERO`（再接続プロトコル無効化）として扱う。負値や `u32::MAX` を
-/// 超える値は拒否する。
+/// は `Duration::ZERO`（再接続プロトコル無効化）として扱う。負値・非数値文字列・
+/// `u64` の範囲外は `Err` で拒否する（実用上は分〜時間オーダーの設定だけを期待）。
 pub fn parse_reconnect_grace_duration(raw: Option<&str>) -> Result<std::time::Duration, String> {
     let trimmed = raw.unwrap_or("").trim();
     if trimmed.is_empty() {

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -59,7 +59,7 @@ impl ConfigKeys {
     /// 切断時の再接続猶予秒数。`0` または未設定なら再接続プロトコルを無効化し、
     /// WebSocket close を即時 `#ABNORMAL` に流す（保守的既定）。`> 0` を指定する
     /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
-    /// を要求する Phase 5 features の opt-in 経路に乗る。
+    /// を要求する Floodgate features の opt-in 経路に乗る。
     pub const RECONNECT_GRACE_SECONDS: &'static str = "RECONNECT_GRACE_SECONDS";
     /// Floodgate 機能群を opt-in 有効化するブール変数。`true` / `1` / `yes` / `on`
     /// で有効。`reconnect_protocol` 等の Floodgate 系を要求する構成で必須。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -40,12 +40,16 @@ use worker::{
 
 use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
+use rshogi_csa_server::config::{
+    FloodgateFeatureIntent, parse_allow_floodgate_features, validate_floodgate_feature_gate,
+};
 use rshogi_csa_server::game::clock::TimeClock;
 use rshogi_csa_server::game::room::{
     BroadcastEntry, BroadcastTarget, GameRoom as CoreRoom, GameRoomConfig, HandleOutcome,
     HandleResult,
 };
-use rshogi_csa_server::protocol::command::{ClientCommand, parse_command};
+use rshogi_csa_server::protocol::command::{ClientCommand, ReconnectRequest, parse_command};
+use rshogi_csa_server::protocol::summary::position_section_from_position;
 use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
@@ -56,10 +60,14 @@ use rshogi_csa_server::types::{
 };
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
-use crate::config::{ConfigKeys, parse_clock_spec};
+use crate::config::{ConfigKeys, parse_clock_spec, parse_reconnect_grace_duration};
 use crate::datetime::{format_csa_datetime, format_date_path};
 use crate::persistence::{
     FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
+};
+use crate::reconnect::{
+    PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot,
+    build_resume_message, color_from_str, color_to_str,
 };
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
 use crate::spectator_control::{MonitorDecision, resolve_monitor_target};
@@ -91,6 +99,12 @@ const KEY_ROOM_ID: &str = "room_id";
 const KEY_SLOTS: &str = "slots";
 const KEY_CONFIG: &str = "config";
 const KEY_FINISHED: &str = "finished";
+/// 切断 → 再接続待ちエントリの DO storage key (1 対局 = 0..=1 件)。
+const KEY_GRACE_REGISTRY: &str = "grace_registry";
+/// 次に発火する `state.alarm()` の種別タグ。`None` は alarm 未予約 / 既存 alarm
+/// が時間切れ駆動 (TimeUp) であることを示す。grace 経路に入ったときだけ
+/// `GraceExpired` を書き込む。
+const KEY_PENDING_ALARM_KIND: &str = "pending_alarm_kind";
 
 /// R2 上の buoy 保存フォーマット。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -219,6 +233,28 @@ impl DurableObject for GameRoom {
             return Ok(());
         }
 
+        // 再接続プロトコルが env で有効化されている (grace_duration > 0 + Floodgate
+        // features opt-in) なら即時 force_abnormal せず、grace registry に対局
+        // 状態のスナップショットを書いて alarm を grace deadline で予約する。
+        // ALLOW_FLOODGATE_FEATURES が立っていない構成で grace_duration が誤って
+        // > 0 になっていた場合は console_log で警告して保守的に旧経路へ落とす。
+        let grace_duration = match resolve_reconnect_grace(&self.env) {
+            Ok(d) => d,
+            Err(e) => {
+                console_log!("[GameRoom] reconnect grace disabled: {e}");
+                Duration::ZERO
+            }
+        };
+        if !grace_duration.is_zero() {
+            if let Err(e) = self.enter_grace_window(role, grace_duration).await {
+                // grace 経路のセットアップに失敗したら旧経路 (即時 force_abnormal)
+                // にフォールバックして部屋が宙ぶらりんにならないようにする。
+                console_log!("[GameRoom] enter_grace_window failed; fallback to abnormal: {e:?}");
+            } else {
+                return Ok(());
+            }
+        }
+
         // 対局中の切断は force_abnormal で敗北を確定する。
         self.ensure_core_loaded().await?;
         let result_opt =
@@ -238,6 +274,14 @@ impl DurableObject for GameRoom {
         // 既に終局済みの DO でアラームが届いたら何もしない（念のためのガード）。
         if self.load_finished().await?.is_some() {
             return Response::ok("already finished");
+        }
+
+        // alarm 種別タグを読み、`GraceExpired` 経路だけ grace registry の処理に
+        // 委譲する。既定値 (タグ未設定) は時間切れ駆動とみなす。
+        let kind = self.load_pending_alarm_kind().await?;
+        if matches!(kind, Some(PendingAlarmKind::GraceExpired)) {
+            self.handle_grace_expired_alarm().await?;
+            return Response::ok("grace_expired handled");
         }
 
         self.ensure_core_loaded().await?;
@@ -286,7 +330,10 @@ impl GameRoom {
                 return Ok(());
             }
         };
-        let ClientCommand::Login { name, .. } = cmd else {
+        let ClientCommand::Login {
+            name, reconnect, ..
+        } = cmd
+        else {
             // pending 状態で LOGIN 以外が来たら拒否して切断。
             send_line(ws, &LoginReply::Incorrect.to_line())?;
             let _ = ws.close(Some(1000), Some("expected LOGIN".to_owned()));
@@ -297,6 +344,15 @@ impl GameRoom {
             send_line(ws, &LoginReply::Incorrect.to_line())?;
             return Ok(());
         };
+
+        // 再接続要求の経路分岐。LOGIN 行 3 つ目トークンが
+        // `reconnect:<game_id>+<token>` の場合は新規対局参加 (slot 確保 + マッチ
+        // 成立) ではなく、grace 中の該当対局へ「同一対局者として再参加」する経路へ。
+        // 失敗時は LOGIN OK を送らずに `LOGIN:incorrect reconnect_rejected` で
+        // 拒否する (拒否は元の対局者による再試行を妨げない)。
+        if let Some(req) = reconnect {
+            return self.handle_reconnect_request(ws, &handle, role, req).await;
+        }
 
         // 新スロットを**仮に**加えて衝突判定する。`evaluate_match` が Conflict を返す
         // 場合は永続化も attachment 差し替えも行わず、部屋を破壊しないよう拒否する
@@ -387,6 +443,11 @@ impl GameRoom {
             }
         };
 
+        // 対局開始時に対局者ごとに一意な再接続トークンを発行する。`Game_Summary`
+        // 末尾拡張行で配布した値を、後の grace 経路 (websocket_close → 再接続要求の
+        // `expected_token` 照合) で参照するために `PersistedConfig` に保存しておく。
+        let black_reconnect_token = ReconnectToken::generate();
+        let white_reconnect_token = ReconnectToken::generate();
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
             black_handle: black_handle.to_owned(),
@@ -398,6 +459,8 @@ impl GameRoom {
             matched_at_ms: started,
             play_started_at_ms: None,
             initial_sfen,
+            black_reconnect_token: Some(black_reconnect_token.as_str().to_owned()),
+            white_reconnect_token: Some(white_reconnect_token.as_str().to_owned()),
         };
         self.state.storage().put(KEY_CONFIG, &cfg).await?;
 
@@ -433,12 +496,10 @@ impl GameRoom {
         *self.core.borrow_mut() = Some(core);
         *self.config.borrow_mut() = Some(cfg.clone());
 
-        // 対局開始時に対局者ごとに一意な再接続トークンを発行し、Game_Summary 末尾の
-        // 拡張行で配布する。デプロイ／DO 再起動による切断時、クライアントは
-        // この token を提示して同一対局・同一対局者として再参加する。
-        let black_reconnect_token = ReconnectToken::generate();
-        let white_reconnect_token = ReconnectToken::generate();
-        // Game_Summary を双方に送出（Your_Turn だけ色で変える）。
+        // 上で `PersistedConfig` に保存したトークンを Game_Summary の末尾拡張行で
+        // 配布する。クライアントは本トークンを保持しておき、デプロイ／DO 再起動
+        // による切断時に LOGIN reconnect 引数として提示して同一対局・同一対局者
+        // として再参加する。
         let builder = GameSummaryBuilder {
             game_id: GameId::new(cfg.game_id),
             black: PlayerName::new(cfg.black_handle),
@@ -1185,10 +1246,7 @@ impl GameRoom {
         }
         let rows: Vec<CountRow> = cursor.to_array()?;
         let next_ply = rows.first().map(|r| r.n).unwrap_or(1);
-        let color_str = match color {
-            Color::Black => "black",
-            Color::White => "white",
-        };
+        let color_str = color_to_str(color);
         sql.exec(
             "INSERT INTO moves(ply, color, line, at_ms) VALUES (?, ?, ?, ?)",
             vec![
@@ -1198,6 +1256,284 @@ impl GameRoom {
                 (now_ms as i64).into(),
             ],
         )?;
+        Ok(())
+    }
+
+    /// websocket_close で対局中の切断を grace registry に登録する経路。
+    ///
+    /// 1. `CoreRoom` を確保 (cold start なら replay) し、現在局面のスナップショット
+    ///    と切断側用の Game_Summary 文字列 (現在盤面で再構築) を組み立てる
+    /// 2. `PersistedConfig` から切断側に発行済の `reconnect_token` を取り出す
+    ///    （未発行なら grace 経路に乗らないので Err で旧経路にフォールバック）
+    /// 3. `PendingReconnect` を `KEY_GRACE_REGISTRY` に保存
+    /// 4. alarm 種別を `GraceExpired` でマークし、`grace_duration` 後に発火する
+    ///    `state.alarm()` を予約する (既存 turn alarm より早い場合のみ上書きする
+    ///    ため、現状予約済の alarm を `get_alarm` で読み取って比較する)
+    async fn enter_grace_window(&self, role: Role, grace_duration: Duration) -> Result<()> {
+        self.ensure_core_loaded().await?;
+        let cfg = self
+            .config
+            .borrow()
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| Error::RustError("enter_grace_window: config missing".into()))?;
+        let pending = {
+            let borrow = self.core.borrow();
+            let core = borrow.as_ref().ok_or_else(|| {
+                Error::RustError("enter_grace_window: core missing after ensure_core_loaded".into())
+            })?;
+            self.build_pending_reconnect(core, &cfg, role, grace_duration)?
+        };
+        self.state.storage().put(KEY_GRACE_REGISTRY, &pending).await?;
+        self.state
+            .storage()
+            .put(KEY_PENDING_ALARM_KIND, &PendingAlarmKind::GraceExpired)
+            .await?;
+        // 既存の turn alarm より grace deadline が早ければ上書き、遅ければ既存
+        // alarm (時間切れ) を残す。`get_alarm` は次回発火時刻 (epoch ms) を返し、
+        // 未予約なら `None`。
+        let now_ms = self.now_ms();
+        let grace_deadline_ms = pending.deadline_ms;
+        let existing = self.state.storage().get_alarm().await.ok().flatten();
+        let should_set_grace = match existing {
+            Some(epoch_ms) if (epoch_ms as u64) <= grace_deadline_ms => false,
+            _ => true,
+        };
+        if should_set_grace {
+            let delay = grace_deadline_ms.saturating_sub(now_ms).saturating_add(ALARM_SAFETY_MS);
+            self.state.storage().set_alarm(Duration::from_millis(delay)).await?;
+        }
+        console_log!(
+            "[GameRoom] entered grace window: role={role:?} grace_secs={}",
+            grace_duration.as_secs()
+        );
+        Ok(())
+    }
+
+    /// `enter_grace_window` の純粋ロジック部分。`CoreRoom` の現状から
+    /// `PendingReconnect` を組み立てる (snapshot / Game_Summary / token 取り出し)。
+    fn build_pending_reconnect(
+        &self,
+        core: &CoreRoom,
+        cfg: &PersistedConfig,
+        role: Role,
+        grace_duration: Duration,
+    ) -> Result<PendingReconnect> {
+        let disconnected_color = role.to_core();
+        let token = match disconnected_color {
+            Color::Black => cfg.black_reconnect_token.as_deref(),
+            Color::White => cfg.white_reconnect_token.as_deref(),
+        }
+        .ok_or_else(|| {
+            Error::RustError(format!(
+                "build_pending_reconnect: no reconnect_token issued for {disconnected_color:?}"
+            ))
+        })?
+        .to_owned();
+        let position_section = position_section_from_position(core.position());
+        let snapshot = ReconnectSnapshot {
+            position_section: position_section.clone(),
+            black_remaining_ms: core.clock_remaining_main_ms(Color::Black).max(0) as u64,
+            white_remaining_ms: core.clock_remaining_main_ms(Color::White).max(0) as u64,
+            current_turn: color_to_str(core.current_turn()).to_owned(),
+            // CoreRoom は最終手 token を露出していないため、moves テーブルから
+            // 再現する経路 (cold start 時) と整合するよう、現時点では None とする。
+            // E2E では Reconnect_State の `Last_Move:` 行省略動作を許容する。
+            last_move: None,
+        };
+
+        // 切断側宛の Game_Summary を「切断時点の現在局面」で再構築する。再接続
+        // クライアントは初接続時と同じ `Reconnect_Token:` 拡張行を再受信できる。
+        let clock_spec = load_clock_spec_from_env(&self.env)?;
+        let summary = GameSummaryBuilder {
+            game_id: GameId::new(cfg.game_id.clone()),
+            black: PlayerName::new(cfg.black_handle.clone()),
+            white: PlayerName::new(cfg.white_handle.clone()),
+            time_section: clock_spec.format_time_section(),
+            position_section,
+            rematch_on_draw: false,
+            to_move: core.current_turn(),
+            declaration: String::new(),
+            black_reconnect_token: cfg.black_reconnect_token.as_deref().map(ReconnectToken::new),
+            white_reconnect_token: cfg.white_reconnect_token.as_deref().map(ReconnectToken::new),
+        };
+        let game_summary_for_disconnected = summary.build_for(disconnected_color);
+
+        let now_ms = self.now_ms();
+        let deadline_ms = now_ms.saturating_add(grace_duration.as_millis() as u64);
+        let disconnected_handle = match disconnected_color {
+            Color::Black => cfg.black_handle.clone(),
+            Color::White => cfg.white_handle.clone(),
+        };
+        Ok(PendingReconnect {
+            disconnected_handle,
+            disconnected_color: color_to_str(disconnected_color).to_owned(),
+            expected_token: token,
+            deadline_ms,
+            snapshot,
+            game_summary_for_disconnected,
+        })
+    }
+
+    /// alarm が `GraceExpired` 種別で発火した経路。registry を読んで切断側を
+    /// `force_abnormal` で確定させる。registry が無い (race で削除済み) なら
+    /// 何もしない。
+    async fn handle_grace_expired_alarm(&self) -> Result<()> {
+        let pending: Option<PendingReconnect> =
+            self.state.storage().get(KEY_GRACE_REGISTRY).await.ok().flatten();
+        let Some(pending) = pending else {
+            // 再接続が成立して registry が片付けられた直後の race 等。alarm kind
+            // も並行で TimeUp に戻されているはずだが、念のため tag を片付けておく。
+            self.delete_pending_alarm_kind().await?;
+            return Ok(());
+        };
+        self.ensure_core_loaded().await?;
+        let role = match color_from_str(&pending.disconnected_color) {
+            Ok(c) => Role::from_core(c),
+            Err(e) => {
+                console_log!("[GameRoom] grace alarm: invalid color in registry: {e}");
+                self.delete_grace_registry().await?;
+                self.delete_pending_alarm_kind().await?;
+                return Ok(());
+            }
+        };
+        let result_opt =
+            self.core.borrow_mut().as_mut().map(|core| core.force_abnormal(role.to_core()));
+        if let Some(result) = result_opt {
+            self.dispatch_broadcasts(&result.broadcasts).await?;
+            self.finalize_if_ended(&result).await?;
+        }
+        self.delete_grace_registry().await?;
+        self.delete_pending_alarm_kind().await?;
+        Ok(())
+    }
+
+    /// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
+    /// grace 中対局へ再参加させる。
+    ///
+    /// 失敗ケース (`reconnect_unknown_game` / `handle_mismatch` / `color_mismatch` /
+    /// `token_mismatch` / `expired`) はすべて `LOGIN:incorrect reconnect_rejected`
+    /// で返す (拒否理由を分けると side-channel で「特定 handle / game_id が grace
+    /// 中に存在するか」を識別できるため、wire 上は統一)。詳細は console_log の
+    /// サーバーログ側にだけ残す。`reconnect_already_resumed` は token 知識を持つ
+    /// 正当者の二重接続経路で情報漏洩リスクが無いため原因を分けて返す。
+    async fn handle_reconnect_request(
+        &self,
+        ws: &WebSocket,
+        handle: &str,
+        role: Role,
+        req: ReconnectRequest,
+    ) -> Result<()> {
+        // DO instance が hibernate から起床した直後の再接続でも CoreRoom を
+        // ロードできるよう、registry 検索の前に `ensure_core_loaded` を呼ぶ。
+        // 成功確定後の `current_game_name_or_empty` / 状態再送はロード済を前提に
+        // できるので、この 1 箇所だけで grace 経路全体の cold-start 互換が成立する。
+        self.ensure_core_loaded().await?;
+        let pending: Option<PendingReconnect> =
+            self.state.storage().get(KEY_GRACE_REGISTRY).await.ok().flatten();
+        let Some(pending) = pending else {
+            console_log!(
+                "[GameRoom] reconnect rejected: no pending entry (game_id={})",
+                req.game_id
+            );
+            send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
+            return Ok(());
+        };
+
+        // game_id 照合は registry 検索 (DO instance = 1 対局専属) で済むため、
+        // ここでは LOGIN 経由の game_id が現在対局と一致するかだけ確認する。
+        let cfg_game_id = self.config.borrow().as_ref().map(|c| c.game_id.clone());
+        if cfg_game_id.as_deref() != Some(req.game_id.as_str()) {
+            // DO instance が想定と違う対局に紐づいている (game_id 未一致)。
+            console_log!(
+                "[GameRoom] reconnect rejected: game_id mismatch (req={}, current={:?})",
+                req.game_id,
+                cfg_game_id
+            );
+            send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
+            return Ok(());
+        }
+
+        let now_ms = self.now_ms();
+        let outcome = pending.match_request(handle, role.to_core(), req.token.as_str(), now_ms);
+        match outcome {
+            ReconnectMatchOutcome::Accepted => {}
+            ReconnectMatchOutcome::Rejected => {
+                console_log!(
+                    "[GameRoom] reconnect rejected: handle/color/token mismatch (handle={}, role={:?})",
+                    handle,
+                    role
+                );
+                send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
+                return Ok(());
+            }
+            ReconnectMatchOutcome::Expired => {
+                console_log!(
+                    "[GameRoom] reconnect rejected: grace expired (deadline_ms={}, now_ms={})",
+                    pending.deadline_ms,
+                    now_ms
+                );
+                send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
+                return Ok(());
+            }
+        }
+
+        // 成功確定。LOGIN OK → resume 送出 → attachment を Player に差し替え →
+        // grace registry / alarm tag を片付ける順で進める。
+        let game_name = self.current_game_name_or_empty().await?;
+        let login_name = format!("{handle}+{game_name}+{}", color_to_str(role.to_core()));
+        send_line(ws, &LoginReply::Ok { name: login_name }.to_line())?;
+        // 状態再送 (Game_Summary + Reconnect_State ブロック) は複数行なので
+        // 1 行ずつ `send_line` に分解する。`build_resume_message` の改行終端が
+        // 各行末改行と整合するので `lines()` でそのまま reuse できる。
+        let resume =
+            build_resume_message(&pending.game_summary_for_disconnected, &pending.snapshot);
+        for line in resume.lines() {
+            send_line(ws, line)?;
+        }
+
+        let att = WsAttachment::player(role, handle.to_owned(), game_name);
+        ws.serialize_attachment(&att)
+            .map_err(|e| Error::RustError(format!("attach player on reconnect: {e}")))?;
+
+        self.delete_grace_registry().await?;
+        // alarm tag を片付け、再接続後に時計切れ deadline をかけ直す。
+        self.delete_pending_alarm_kind().await?;
+        // 再接続クライアントに対する次手 deadline alarm は alarm_kind 未設定 (= TimeUp 既定)
+        // で reschedule する経路を流用したい。CoreRoom の current_turn と clock を
+        // 元に再設定するヘルパは既存にないが、`reschedule_turn_alarm` と等価な
+        // 入口を `HandleOutcome::Continue` 相当のダミー結果で叩く方法は
+        // 過剰実装。再接続直後は次手到来時に通常の `reschedule_turn_alarm` 経路で
+        // 再設定されるため、ここでは alarm を一旦解除するに留める (新規 alarm が
+        // 来るまで時計駆動が止まるが、対局者が即指せば通常経路で復帰する)。
+        let _ = self.state.storage().delete_alarm().await;
+        console_log!("[GameRoom] reconnect succeeded: handle={} role={:?}", handle, role);
+        Ok(())
+    }
+
+    /// 現在 DO の対局 game_name (`PersistedConfig.game_name`)。LOGIN OK 応答で
+    /// `<handle>+<game_name>+<color>` 形式を再構築するために使う。config 未設定
+    /// なら空文字を返す (handshake は LOGIN OK 後に拒否されている経路では呼ば
+    /// れないため、空文字到達は契約違反として handle される想定)。
+    async fn current_game_name_or_empty(&self) -> Result<String> {
+        if let Some(cfg) = self.config.borrow().as_ref() {
+            return Ok(cfg.game_name.clone());
+        }
+        let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
+        Ok(cfg_opt.map(|c| c.game_name).unwrap_or_default())
+    }
+
+    async fn delete_grace_registry(&self) -> Result<()> {
+        let _ = self.state.storage().delete(KEY_GRACE_REGISTRY).await;
+        Ok(())
+    }
+
+    async fn load_pending_alarm_kind(&self) -> Result<Option<PendingAlarmKind>> {
+        Ok(self.state.storage().get(KEY_PENDING_ALARM_KIND).await.ok().flatten())
+    }
+
+    async fn delete_pending_alarm_kind(&self) -> Result<()> {
+        let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
         Ok(())
     }
 }
@@ -1228,4 +1564,28 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
         byoyomi_min.as_deref(),
     )
     .map_err(Error::RustError)
+}
+
+/// `RECONNECT_GRACE_SECONDS` env を読み、Floodgate features の opt-in
+/// (`ALLOW_FLOODGATE_FEATURES`) と整合しているか検証して `Duration` を返す。
+///
+/// ```text
+/// grace=0 (or unset)  : OK (Floodgate gate を通さず保守的既定)
+/// grace>0 + allow=true: OK (再接続プロトコル有効)
+/// grace>0 + allow=false: Err (Phase 5 features の opt-in 漏れ)
+/// ```
+///
+/// 設定不正は `Err(String)` で返し、呼び出し側は安全側に grace を無効化する経路に
+/// 落とす (websocket_close で旧 force_abnormal 経路にフォールバック)。
+fn resolve_reconnect_grace(env: &Env) -> std::result::Result<Duration, String> {
+    let grace_raw = env.var(ConfigKeys::RECONNECT_GRACE_SECONDS).ok().map(|v| v.to_string());
+    let grace = parse_reconnect_grace_duration(grace_raw.as_deref())?;
+    let allow_raw = env.var(ConfigKeys::ALLOW_FLOODGATE_FEATURES).ok().map(|v| v.to_string());
+    let allow = parse_allow_floodgate_features(allow_raw.as_deref())?;
+    let intent = FloodgateFeatureIntent {
+        enable_reconnect_protocol: !grace.is_zero(),
+        ..FloodgateFeatureIntent::default()
+    };
+    validate_floodgate_feature_gate(allow, intent)?;
+    Ok(grace)
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1284,6 +1284,16 @@ impl GameRoom {
             })?;
             self.build_pending_reconnect(core, &cfg, role, grace_duration)?
         };
+        // `KEY_GRACE_REGISTRY` と `KEY_PENDING_ALARM_KIND` を 2 回の `put` で
+        // 書き分ける。Cloudflare DO は同一 instance に対する fetch / alarm /
+        // websocket_* を単一スレッドで逐次処理するため、1 件目 put 後の `await`
+        // 中に他ハンドラが割り込んで不整合を観測する race は起きない。本コード
+        // は `worker` 0.8 系で `transaction` API がまだ stable に提供されていない
+        // 前提で 2 回 put にしているが、`handle_grace_expired_alarm` 側は
+        // registry の存在を先に確認してから進む設計なので、最悪 (DO 強制終了等)
+        // でも整合性は壊れない (registry が無ければ何もせず alarm tag だけ
+        // 片付ける)。`worker` crate が `transaction` を提供したら本ブロックを
+        // 束ねる方が望ましい。
         self.state.storage().put(KEY_GRACE_REGISTRY, &pending).await?;
         self.state
             .storage()
@@ -1360,7 +1370,11 @@ impl GameRoom {
         let game_summary_for_disconnected = summary.build_for(disconnected_color);
 
         let now_ms = self.now_ms();
-        let deadline_ms = now_ms.saturating_add(grace_duration.as_millis() as u64);
+        // `Duration::as_millis()` は `u128` を返すため、`u64::try_from` で
+        // 範囲外をサチュレートさせて silent truncation を避ける (実用上の grace は
+        // 数十秒〜数時間オーダーで、`u64::MAX` ms の到達は無いが防御的に書く)。
+        let grace_ms = u64::try_from(grace_duration.as_millis()).unwrap_or(u64::MAX);
+        let deadline_ms = now_ms.saturating_add(grace_ms);
         let disconnected_handle = match disconnected_color {
             Color::Black => cfg.black_handle.clone(),
             Color::White => cfg.white_handle.clone(),
@@ -1497,16 +1511,34 @@ impl GameRoom {
             .map_err(|e| Error::RustError(format!("attach player on reconnect: {e}")))?;
 
         self.delete_grace_registry().await?;
-        // alarm tag を片付け、再接続後に時計切れ deadline をかけ直す。
+        // alarm tag を片付ける。直後に turn alarm を再セットして上書きするため、
+        // 順序は kind tag 削除 → set_alarm の順で書き直す（kind tag 未設定は
+        // 既定で `TimeUp` 扱い）。
         self.delete_pending_alarm_kind().await?;
-        // 再接続クライアントに対する次手 deadline alarm は alarm_kind 未設定 (= TimeUp 既定)
-        // で reschedule する経路を流用したい。CoreRoom の current_turn と clock を
-        // 元に再設定するヘルパは既存にないが、`reschedule_turn_alarm` と等価な
-        // 入口を `HandleOutcome::Continue` 相当のダミー結果で叩く方法は
-        // 過剰実装。再接続直後は次手到来時に通常の `reschedule_turn_alarm` 経路で
-        // 再設定されるため、ここでは alarm を一旦解除するに留める (新規 alarm が
-        // 来るまで時計駆動が止まるが、対局者が即指せば通常経路で復帰する)。
-        let _ = self.state.storage().delete_alarm().await;
+        // 再接続クライアントが指し手を送らず放置しても確実に turn deadline が
+        // 発火するよう、現在手番の本体時間 + 秒読み + 通信マージン + 安全側
+        // ゲタを乗せて即時 alarm を予約する。次手の `reschedule_turn_alarm`
+        // が通常経路で上書きするまでのフェールセーフ。
+        let alarm_total_ms = {
+            let core_borrow = self.core.borrow();
+            core_borrow.as_ref().map(|core| {
+                let next_turn = core.current_turn();
+                let budget = core.clock_turn_budget_ms(next_turn).max(0) as u64;
+                let margin = self
+                    .config
+                    .borrow()
+                    .as_ref()
+                    .map(|c| c.time_margin_ms)
+                    .unwrap_or(DEFAULT_TIME_MARGIN_MS);
+                budget.saturating_add(margin).saturating_add(ALARM_SAFETY_MS)
+            })
+        };
+        if let Some(total) = alarm_total_ms {
+            self.state.storage().set_alarm(Duration::from_millis(total)).await?;
+        } else {
+            // CoreRoom 不在 (異常系)。alarm を解除して保守的に振る舞う。
+            let _ = self.state.storage().delete_alarm().await;
+        }
         console_log!("[GameRoom] reconnect succeeded: handle={} role={:?}", handle, role);
         Ok(())
     }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1277,12 +1277,25 @@ impl GameRoom {
             .as_ref()
             .cloned()
             .ok_or_else(|| Error::RustError("enter_grace_window: config missing".into()))?;
+        // 既存 turn alarm の予定発火時刻を grace 経路前に取得しておき、
+        // `PendingReconnect` に保存する。再接続成功後に新規 alarm を貼り直すとき、
+        // この値と「再接続時刻 + 残時間 budget」のうち早い方を採用することで、
+        // 悪意あるクライアントが切断 → grace 直前再接続を繰り返して相手手番の
+        // wall-clock 上の deadline を不当に延長する経路を防ぐ。
+        let original_turn_alarm_epoch_ms =
+            self.state.storage().get_alarm().await.ok().flatten().map(|e| e as u64);
         let pending = {
             let borrow = self.core.borrow();
             let core = borrow.as_ref().ok_or_else(|| {
                 Error::RustError("enter_grace_window: core missing after ensure_core_loaded".into())
             })?;
-            self.build_pending_reconnect(core, &cfg, role, grace_duration)?
+            self.build_pending_reconnect(
+                core,
+                &cfg,
+                role,
+                grace_duration,
+                original_turn_alarm_epoch_ms,
+            )?
         };
         // `KEY_GRACE_REGISTRY` と `KEY_PENDING_ALARM_KIND` を 2 回の `put` で
         // 書き分ける。Cloudflare DO は同一 instance に対する fetch / alarm /
@@ -1328,6 +1341,7 @@ impl GameRoom {
         cfg: &PersistedConfig,
         role: Role,
         grace_duration: Duration,
+        original_turn_alarm_epoch_ms: Option<u64>,
     ) -> Result<PendingReconnect> {
         let disconnected_color = role.to_core();
         let token = match disconnected_color {
@@ -1386,6 +1400,7 @@ impl GameRoom {
             deadline_ms,
             snapshot,
             game_summary_for_disconnected,
+            original_turn_alarm_epoch_ms,
         })
     }
 
@@ -1516,10 +1531,16 @@ impl GameRoom {
         // 既定で `TimeUp` 扱い）。
         self.delete_pending_alarm_kind().await?;
         // 再接続クライアントが指し手を送らず放置しても確実に turn deadline が
-        // 発火するよう、現在手番の本体時間 + 秒読み + 通信マージン + 安全側
-        // ゲタを乗せて即時 alarm を予約する。次手の `reschedule_turn_alarm`
-        // が通常経路で上書きするまでのフェールセーフ。
-        let alarm_total_ms = {
+        // 発火するよう、即時 alarm を貼り直す。決定方針:
+        // - 候補 A: 切断時に取り置いた元 turn alarm の発火時刻 (`pending.original
+        //   _turn_alarm_epoch_ms`)
+        // - 候補 B: 再接続時刻 + (現在手番の本体時間 + 秒読み + 通信マージン +
+        //   安全側ゲタ)
+        // のうち**早い方**を採用する。常に B にすると悪意あるクライアントが
+        // 切断 → grace 直前再接続を繰り返して相手手番の wall-clock 上の deadline
+        // を延長する経路が成立するため、A を上限としても利く形にする。
+        let now = self.now_ms();
+        let candidate_b_total_ms = {
             let core_borrow = self.core.borrow();
             core_borrow.as_ref().map(|core| {
                 let next_turn = core.current_turn();
@@ -1533,8 +1554,17 @@ impl GameRoom {
                 budget.saturating_add(margin).saturating_add(ALARM_SAFETY_MS)
             })
         };
-        if let Some(total) = alarm_total_ms {
-            self.state.storage().set_alarm(Duration::from_millis(total)).await?;
+        if let Some(total_b) = candidate_b_total_ms {
+            let candidate_b_epoch = now.saturating_add(total_b);
+            let final_epoch = pending
+                .original_turn_alarm_epoch_ms
+                .map(|orig| orig.min(candidate_b_epoch))
+                .unwrap_or(candidate_b_epoch);
+            // `set_alarm(Duration)` は「now から N ms 後」に発火する API なので
+            // delay = final_epoch - now で渡す。`saturating_sub` は now が final_epoch
+            // を既に過ぎている場合に 0 を返し、即時発火させて time_up に進める。
+            let delay_ms = final_epoch.saturating_sub(now);
+            self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await?;
         } else {
             // CoreRoom 不在 (異常系)。alarm を解除して保守的に振る舞う。
             let _ = self.state.storage().delete_alarm().await;
@@ -1604,7 +1634,7 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
 /// ```text
 /// grace=0 (or unset)  : OK (Floodgate gate を通さず保守的既定)
 /// grace>0 + allow=true: OK (再接続プロトコル有効)
-/// grace>0 + allow=false: Err (Phase 5 features の opt-in 漏れ)
+/// grace>0 + allow=false: Err (Floodgate features の opt-in 漏れ)
 /// ```
 ///
 /// 設定不正は `Err(String)` で返し、呼び出し側は安全側に grace を無効化する経路に

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -33,6 +33,12 @@ pub mod origin;
 // コンパイルする。テストはホスト target で `cargo test` から到達できる。
 #[cfg(any(target_arch = "wasm32", test))]
 pub(crate) mod persistence;
+// `reconnect` も `persistence` と同じく DO ランタイム専用の I/O 非依存ロジック
+// (grace registry のスキーマ、`PendingAlarmKind`、`build_resume_message` 等)。
+// ホスト target からはテスト経由でしか到達しないため、wasm32 とテスト時のみ
+// コンパイルする。
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) mod reconnect;
 pub mod room_id;
 pub mod session_state;
 pub mod spectator_control;

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -49,6 +49,17 @@ pub struct PersistedConfig {
     /// 対局では `Some(sfen)` で、cold start 復元時もこの SFEN から `CoreRoom` を
     /// 組み直す。
     pub(crate) initial_sfen: Option<String>,
+    /// 先手向けに発行した再接続トークン。`Game_Summary` 末尾拡張行で配布した
+    /// 値そのまま (32 文字 hex)。`websocket_close` 時に grace registry へ写して
+    /// 切断側 LOGIN reconnect 要求の `expected_token` 照合に使う。再接続プロトコル
+    /// を有効化していない構成では `None`。`#[serde(default)]` を付けているのは、
+    /// 旧 schema (本フィールド導入前) で永続化された snapshot からの cold start
+    /// で deserialize 失敗を起こさないため。
+    #[serde(default)]
+    pub(crate) black_reconnect_token: Option<String>,
+    /// 後手向けの再接続トークン。挙動・契約は [`Self::black_reconnect_token`] と同様。
+    #[serde(default)]
+    pub(crate) white_reconnect_token: Option<String>,
 }
 
 /// 終局フラグ。一度 `Some` になったらその DO は同じ対局を二度開始しない。
@@ -225,6 +236,8 @@ mod tests {
             matched_at_ms: PLAY_STARTED_AT_MS - 100,
             play_started_at_ms: None,
             initial_sfen: None,
+            black_reconnect_token: None,
+            white_reconnect_token: None,
         }
     }
 

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -1,0 +1,297 @@
+//! 切断時の再接続プロトコル用 I/O 非依存ロジック。
+//!
+//! Workers DO は WebSocket close を契機に grace 期間の対局状態保持に入る。
+//! 本モジュールは grace registry のシリアライズ可能な型と、token / handle / 色
+//! の照合、状態再送メッセージの組み立てなど、DO ランタイムから完全に切り離した
+//! 純粋関数群を提供する。`game_room.rs` のアダプタは本モジュールの戻り値を
+//! パターンマッチして I/O 経路に流す形に薄く保つ。
+
+use serde::{Deserialize, Serialize};
+use std::fmt::Write as _;
+
+use rshogi_csa_server::types::Color;
+
+/// `Color` を `MoveRow.color` と整合する文字列形式 (`"black"` / `"white"`)
+/// に変換する。永続化スキーマは serde 文字列形式で安定化している。
+pub fn color_to_str(color: Color) -> &'static str {
+    match color {
+        Color::Black => "black",
+        Color::White => "white",
+    }
+}
+
+/// 文字列形式 (`"black"` / `"white"`) から `Color` に戻す。永続化データを
+/// `CoreRoom` API に流す際に使う。`MoveRow.color` の検証経路と同様、未知の
+/// 値は `Err` で返して呼び出し側に判断させる。
+pub fn color_from_str(raw: &str) -> Result<Color, String> {
+    match raw {
+        "black" => Ok(Color::Black),
+        "white" => Ok(Color::White),
+        other => Err(format!("unknown color string: {other:?}")),
+    }
+}
+
+/// 切断時に保持する対局スナップショット。再接続クライアントへ
+/// `Reconnect_State` ブロックで再送するため必要な情報を最小限で持つ。
+///
+/// 残り時間は `GameRoom::clock_remaining_main_ms` と同義の本体時間 (秒読み残
+/// は含まない)。再接続クライアント側で 1 手 deadline 計算に使うことはできず、
+/// 表示・ログ用途に限る。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconnectSnapshot {
+    /// 切断時点の `BEGIN Position` … `END Position` ブロック (末尾改行込み)。
+    pub position_section: String,
+    /// 先手の本体残り時間 (ms)。
+    pub black_remaining_ms: u64,
+    /// 後手の本体残り時間 (ms)。
+    pub white_remaining_ms: u64,
+    /// 現在の手番。`"black"` / `"white"` のみ書き込まれる契約。
+    pub current_turn: String,
+    /// 直前に確定した最終手 (CSA トークン)。1 手も指していない時点での切断は
+    /// `None`。
+    pub last_move: Option<String>,
+}
+
+/// 切断対局者の grace 中エントリ。DO storage の `KEY_GRACE_REGISTRY` (1 対局
+/// = 1 オブジェクト) にシリアライズして書き込む。
+///
+/// 二人の対局者のうち切断したのが一方だけの場合は本構造体 1 件で表現する
+/// (DO instance は 1 対局専属なので 0..=1 件しか持たない)。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingReconnect {
+    /// 切断側の handle (LOGIN 時の照合に使う)。
+    pub disconnected_handle: String,
+    /// 切断側の `Color` を文字列で持つ (`"black"` / `"white"`)。
+    pub disconnected_color: String,
+    /// 切断側に発行された再接続トークン (Game_Summary 末尾拡張行で配布済み)。
+    pub expected_token: String,
+    /// grace 期間の終了時刻。`now_ms()` がこれを超えたら満了。
+    pub deadline_ms: u64,
+    /// 状態再送に使うスナップショット。
+    pub snapshot: ReconnectSnapshot,
+    /// 切断側宛の Game_Summary 文字列 (`Reconnect_Token:` 拡張行を含む完全形、
+    /// `position_section` は切断時点の現在局面で再構築済み)。
+    pub game_summary_for_disconnected: String,
+}
+
+/// `PendingReconnect::match_request` の判定結果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconnectMatchOutcome {
+    /// handle / 色 / token が全て一致し、deadline 内。
+    Accepted,
+    /// handle / 色 / token のいずれかが不一致。grace 中の登録は変更しない。
+    Rejected,
+    /// `now_ms` が `deadline_ms` を超えている。grace は満了済みなので登録を
+    /// 取り除き、切断側を敗北として確定させる経路に進む。
+    Expired,
+}
+
+impl PendingReconnect {
+    /// 再接続要求 (LOGIN 行 `reconnect:<game_id>+<token>`) を本エントリと照合する。
+    ///
+    /// `game_id` は呼び出し側で DO storage の key 検索によって既に絞り込まれて
+    /// いる前提なので、本関数は handle / 色 / token / deadline のみを検査する。
+    pub fn match_request(
+        &self,
+        handle: &str,
+        color: Color,
+        token: &str,
+        now_ms: u64,
+    ) -> ReconnectMatchOutcome {
+        if now_ms > self.deadline_ms {
+            return ReconnectMatchOutcome::Expired;
+        }
+        if self.disconnected_handle != handle
+            || self.disconnected_color != color_to_str(color)
+            || self.expected_token != token
+        {
+            return ReconnectMatchOutcome::Rejected;
+        }
+        ReconnectMatchOutcome::Accepted
+    }
+
+}
+
+/// 再接続成立時にクライアントへ送出する状態再送メッセージを組み立てる。
+///
+/// フォーマット (TCP frontend と統一):
+/// 1. `BEGIN Game_Summary` ... `END Game_Summary` (`position_section` は切断時点
+///    の現在局面、`Reconnect_Token:` 拡張行を含む完全形)
+/// 2. `BEGIN Reconnect_State` ... `END Reconnect_State` (現在の手番・両者残時間・
+///    直前手のメタ情報)
+pub fn build_resume_message(
+    game_summary_for_disconnected: &str,
+    snapshot: &ReconnectSnapshot,
+) -> String {
+    let mut out = game_summary_for_disconnected.to_owned();
+    out.push_str("BEGIN Reconnect_State\n");
+    let turn_char = match snapshot.current_turn.as_str() {
+        "black" => '+',
+        "white" => '-',
+        _ => '+', // 永続化スキーマで弾く前提だが、未知値は黒手番扱いで安全側に倒す。
+    };
+    let _ = writeln!(out, "Current_Turn:{turn_char}");
+    let _ = writeln!(out, "Black_Time_Remaining_Ms:{}", snapshot.black_remaining_ms);
+    let _ = writeln!(out, "White_Time_Remaining_Ms:{}", snapshot.white_remaining_ms);
+    if let Some(last) = &snapshot.last_move {
+        let _ = writeln!(out, "Last_Move:{last}");
+    }
+    out.push_str("END Reconnect_State\n");
+    out
+}
+
+/// `state.alarm()` は DO 1 instance につき 1 つしか同時にセットできない。複数
+/// 種別の発火 (時間切れ / grace 満了) を扱うため、次に発火すべき種別を DO
+/// storage に明示記録する。alarm ハンドラはこのタグを読んで分岐する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PendingAlarmKind {
+    /// 時間切れ (turn deadline)。既存の `force_time_up` 経路を駆動する。
+    TimeUp,
+    /// grace 期間満了。grace registry を読み取り、切断側を `force_abnormal` で
+    /// 敗北として確定させる経路を駆動する。
+    GraceExpired,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_snapshot() -> ReconnectSnapshot {
+        ReconnectSnapshot {
+            position_section: "BEGIN Position\nP1...\nEND Position\n".to_owned(),
+            black_remaining_ms: 599_500,
+            white_remaining_ms: 600_000,
+            current_turn: "white".to_owned(),
+            last_move: Some("+7776FU".to_owned()),
+        }
+    }
+
+    fn sample_pending(deadline_ms: u64) -> PendingReconnect {
+        PendingReconnect {
+            disconnected_handle: "alice".to_owned(),
+            disconnected_color: "black".to_owned(),
+            expected_token: "abcd".to_owned(),
+            deadline_ms,
+            snapshot: sample_snapshot(),
+            game_summary_for_disconnected:
+                "BEGIN Game_Summary\nGame_ID:g1\nReconnect_Token:abcd\nEND Game_Summary\n"
+                    .to_owned(),
+        }
+    }
+
+    #[test]
+    fn match_request_accepts_when_all_fields_match_and_within_deadline() {
+        let p = sample_pending(1_000);
+        assert_eq!(
+            p.match_request("alice", Color::Black, "abcd", 500),
+            ReconnectMatchOutcome::Accepted
+        );
+    }
+
+    #[test]
+    fn match_request_rejects_handle_mismatch() {
+        let p = sample_pending(1_000);
+        assert_eq!(
+            p.match_request("bob", Color::Black, "abcd", 500),
+            ReconnectMatchOutcome::Rejected
+        );
+    }
+
+    #[test]
+    fn match_request_rejects_color_mismatch() {
+        let p = sample_pending(1_000);
+        assert_eq!(
+            p.match_request("alice", Color::White, "abcd", 500),
+            ReconnectMatchOutcome::Rejected
+        );
+    }
+
+    #[test]
+    fn match_request_rejects_token_mismatch() {
+        let p = sample_pending(1_000);
+        assert_eq!(
+            p.match_request("alice", Color::Black, "wrong", 500),
+            ReconnectMatchOutcome::Rejected
+        );
+    }
+
+    #[test]
+    fn match_request_returns_expired_when_now_passes_deadline() {
+        let p = sample_pending(1_000);
+        assert_eq!(
+            p.match_request("alice", Color::Black, "abcd", 1_001),
+            ReconnectMatchOutcome::Expired
+        );
+    }
+
+    #[test]
+    fn match_request_treats_deadline_boundary_as_in_window() {
+        let p = sample_pending(1_000);
+        // now_ms == deadline_ms はまだ猶予内 (`>` で判定)。
+        assert_eq!(
+            p.match_request("alice", Color::Black, "abcd", 1_000),
+            ReconnectMatchOutcome::Accepted
+        );
+    }
+
+    #[test]
+    fn pending_reconnect_round_trips_through_serde_json() {
+        let original = sample_pending(12_345);
+        let s = serde_json::to_string(&original).expect("serialize");
+        let restored: PendingReconnect = serde_json::from_str(&s).expect("deserialize");
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn build_resume_message_appends_reconnect_state_block() {
+        let snap = sample_snapshot();
+        let summary = "BEGIN Game_Summary\nGame_ID:g1\nReconnect_Token:abcd\nEND Game_Summary\n";
+        let out = build_resume_message(summary, &snap);
+        let end_summary = out.find("END Game_Summary\n").expect("END Game_Summary");
+        let begin_state = out.find("BEGIN Reconnect_State\n").expect("BEGIN Reconnect_State");
+        let end_state = out.find("END Reconnect_State\n").expect("END Reconnect_State");
+        assert!(end_summary < begin_state);
+        assert!(begin_state < end_state);
+        assert!(out.contains("\nCurrent_Turn:-\n"));
+        assert!(out.contains("\nBlack_Time_Remaining_Ms:599500\n"));
+        assert!(out.contains("\nWhite_Time_Remaining_Ms:600000\n"));
+        assert!(out.contains("\nLast_Move:+7776FU\n"));
+    }
+
+    #[test]
+    fn build_resume_message_emits_plus_for_black_turn() {
+        let mut snap = sample_snapshot();
+        snap.current_turn = "black".to_owned();
+        let out = build_resume_message("BEGIN Game_Summary\nEND Game_Summary\n", &snap);
+        assert!(out.contains("\nCurrent_Turn:+\n"));
+    }
+
+    #[test]
+    fn build_resume_message_omits_last_move_line_when_none() {
+        let mut snap = sample_snapshot();
+        snap.last_move = None;
+        let out = build_resume_message("BEGIN Game_Summary\nEND Game_Summary\n", &snap);
+        assert!(!out.contains("Last_Move:"), "must omit Last_Move when no move played: {out}");
+    }
+
+    #[test]
+    fn pending_alarm_kind_serde_round_trip() {
+        let s = serde_json::to_string(&PendingAlarmKind::TimeUp).expect("serialize TimeUp");
+        let restored: PendingAlarmKind = serde_json::from_str(&s).expect("deserialize TimeUp");
+        assert_eq!(restored, PendingAlarmKind::TimeUp);
+        let s =
+            serde_json::to_string(&PendingAlarmKind::GraceExpired).expect("serialize GraceExpired");
+        let restored: PendingAlarmKind =
+            serde_json::from_str(&s).expect("deserialize GraceExpired");
+        assert_eq!(restored, PendingAlarmKind::GraceExpired);
+    }
+
+    #[test]
+    fn color_str_round_trip() {
+        assert_eq!(color_to_str(Color::Black), "black");
+        assert_eq!(color_to_str(Color::White), "white");
+        assert_eq!(color_from_str("black").unwrap(), Color::Black);
+        assert_eq!(color_from_str("white").unwrap(), Color::White);
+        assert!(color_from_str("rainbow").is_err());
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -109,7 +109,6 @@ impl PendingReconnect {
         }
         ReconnectMatchOutcome::Accepted
     }
-
 }
 
 /// 再接続成立時にクライアントへ送出する状態再送メッセージを組み立てる。
@@ -128,7 +127,13 @@ pub fn build_resume_message(
     let turn_char = match snapshot.current_turn.as_str() {
         "black" => '+',
         "white" => '-',
-        _ => '+', // 永続化スキーマで弾く前提だが、未知値は黒手番扱いで安全側に倒す。
+        // `current_turn` は `color_to_str` 経由でしか書き込まれないため、ここに
+        // 到達するのは DO storage を外部から直接書き換えた等のスキーマ不整合
+        // ケースのみ。値判定不能で勝敗が変わる経路を作らないよう、安全側に
+        // 黒手番（先手）でフォールバックして再接続自体は成立させる（CSA 互換
+        // クライアントは Reconnect_Token / Game_Summary 由来の手番情報を再
+        // 受信するため、致命的影響は限定的）。
+        _ => '+',
     };
     let _ = writeln!(out, "Current_Turn:{turn_char}");
     let _ = writeln!(out, "Black_Time_Remaining_Ms:{}", snapshot.black_remaining_ms);

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -72,6 +72,15 @@ pub struct PendingReconnect {
     /// 切断側宛の Game_Summary 文字列 (`Reconnect_Token:` 拡張行を含む完全形、
     /// `position_section` は切断時点の現在局面で再構築済み)。
     pub game_summary_for_disconnected: String,
+    /// 切断時点で予約されていた turn alarm の発火時刻 (UNIX epoch ms)。
+    /// 再接続成功時に新しい turn alarm を貼り直す際、本値と「再接続時刻 + 残時間
+    /// budget」のうち**早い方**を採用することで、悪意あるクライアントが切断 →
+    /// grace 直前再接続を繰り返して相手手番の deadline を wall-clock 上で延長
+    /// する経路を防ぐ (元 deadline は壊さない)。`None` なら turn alarm 未予約
+    /// 時点での切断 (例: AGREE 直後の対局未開始) で、上書きせず素直に新規予約。
+    /// `#[serde(default)]` で旧 schema からの cold-start 互換も維持する。
+    #[serde(default)]
+    pub original_turn_alarm_epoch_ms: Option<u64>,
 }
 
 /// `PendingReconnect::match_request` の判定結果。
@@ -181,6 +190,7 @@ mod tests {
             game_summary_for_disconnected:
                 "BEGIN Game_Summary\nGame_ID:g1\nReconnect_Token:abcd\nEND Game_Summary\n"
                     .to_owned(),
+            original_turn_alarm_epoch_ms: None,
         }
     }
 

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -79,6 +79,13 @@ BYOYOMI_SEC = "10"
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
 
+# 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
+# `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
+RECONNECT_GRACE_SECONDS = "0"
+# Floodgate 系運用機能（再接続プロトコル等）を opt-in 有効化する。`true` / `1` /
+# `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
+ALLOW_FLOODGATE_FEATURES = "false"
+
 # --- secret として設定する値 ---
 # 本番運用に必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。
 # 実値は Cloudflare 側の secret store にのみ存在し、`env.var(name)` 経由で

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -65,3 +65,9 @@ TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
 # `%%SETBUOY` / `%%DELETEBUOY` を許可する運営ハンドル（LOGIN の handle 部分）。
 ADMIN_HANDLE = "admin"
+# 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
+# `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
+RECONNECT_GRACE_SECONDS = "0"
+# Floodgate 系運用機能（再接続プロトコル等）を opt-in で有効化する。`true` / `1` /
+# `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
+ALLOW_FLOODGATE_FEATURES = "false"

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -28,8 +28,8 @@ pub struct FloodgateFeatureIntent {
     /// を有効化する意図。本フラグが `true` のとき、各 frontend は
     /// `reconnect_grace_duration > 0` を運用設定として受け付け、`Game_Summary`
     /// 末尾拡張行で配布した `reconnect_token` の照合・状態再送・grace 満了時の
-    /// 切断敗北確定を有効化する。Phase 5 features の opt-in なしで本機能を要求
-    /// した場合は起動を fail-fast する。
+    /// 切断敗北確定を有効化する。`allow_floodgate_features` の opt-in なしで本
+    /// 機能を要求した場合は起動を fail-fast する。
     pub enable_reconnect_protocol: bool,
 }
 

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -24,6 +24,13 @@ pub struct FloodgateFeatureIntent {
     /// する経路を有効化する意図。`JsonlFloodgateHistoryStorage` を起動時に
     /// 構築し、終局時に append する経路を本フラグで gate する。
     pub enable_floodgate_history: bool,
+    /// 切断時の再接続プロトコル（grace 期間中の対局状態保持と再接続要求受理）
+    /// を有効化する意図。本フラグが `true` のとき、各 frontend は
+    /// `reconnect_grace_duration > 0` を運用設定として受け付け、`Game_Summary`
+    /// 末尾拡張行で配布した `reconnect_token` の照合・状態再送・grace 満了時の
+    /// 切断敗北確定を有効化する。Phase 5 features の opt-in なしで本機能を要求
+    /// した場合は起動を fail-fast する。
+    pub enable_reconnect_protocol: bool,
 }
 
 /// 真偽文字列から Floodgate 機能 gate を解決する。
@@ -78,6 +85,9 @@ pub fn validate_floodgate_feature_gate(
     }
     if intent.enable_floodgate_history {
         requested.push("floodgate_history");
+    }
+    if intent.enable_reconnect_protocol {
+        requested.push("reconnect_protocol");
     }
     if requested.is_empty() || allow_floodgate_features {
         return Ok(());
@@ -160,6 +170,7 @@ mod tests {
                 enable_duplicate_login_policy: true,
                 enable_persistent_player_rates: true,
                 enable_floodgate_history: true,
+                enable_reconnect_protocol: true,
             },
         )
         .unwrap_err();
@@ -168,6 +179,32 @@ mod tests {
         assert!(err.contains("duplicate_login_policy"));
         assert!(err.contains("persistent_player_rates"));
         assert!(err.contains("floodgate_history"));
+        assert!(err.contains("reconnect_protocol"));
+    }
+
+    #[test]
+    fn floodgate_gate_rejects_reconnect_protocol_when_disabled() {
+        let err = validate_floodgate_feature_gate(
+            false,
+            FloodgateFeatureIntent {
+                enable_reconnect_protocol: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("reconnect_protocol"));
+    }
+
+    #[test]
+    fn floodgate_gate_allows_reconnect_protocol_when_enabled() {
+        validate_floodgate_feature_gate(
+            true,
+            FloodgateFeatureIntent {
+                enable_reconnect_protocol: true,
+                ..FloodgateFeatureIntent::default()
+            },
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wave D の Workers frontend 統合 PR。task 18.2 / 18.3 / 18.4 (Workers 側) + task 16.1 (Phase 5 gate 配線) を 1 PR で実装する。これで Wave D が両 frontend で完結する。

### core gate (16.1)

- `FloodgateFeatureIntent::enable_reconnect_protocol: bool` を追加
- `validate_floodgate_feature_gate` で `reconnect_protocol` 要求を `--allow-floodgate-features` 必須にする
- TCP `floodgate_intent_from_config` で `reconnect_grace_duration > 0` を本フラグに紐付け
- Workers 側も `resolve_reconnect_grace` で env (`RECONNECT_GRACE_SECONDS` / `ALLOW_FLOODGATE_FEATURES`) を読んで gate と整合させる

### Workers grace registry (18.2)

- `crates/rshogi-csa-server-workers/src/reconnect.rs` を新設し、`PendingReconnect` / `ReconnectSnapshot` / `PendingAlarmKind` / `build_resume_message` / `match_request` を I/O 非依存の純粋ロジックとして置く
- `game_room.rs::websocket_close` を `enter_grace_window` 経由で grace 経路に分岐 (`reconnect_grace_duration == 0` のときは旧 force_abnormal 経路にフォールバック)
- DO storage `KEY_GRACE_REGISTRY` に `PendingReconnect` を保存、`KEY_PENDING_ALARM_KIND` に種別タグを保存
- `state.alarm()` は単一性制約があるので、grace deadline と既存 turn alarm を比較して早い方を採用

### Workers 再接続経路 (18.3)

- `handle_login` で `ClientCommand::Login.reconnect` を捕捉し `handle_reconnect_request` に分岐
- LOGIN OK 応答は成功確定後のみ送出 (拒否経路で `LOGIN:<handle> OK` の二重応答を防ぐ)
- registry 照合 → resume (Game_Summary 全文 + `Reconnect_State` ブロック) 送出 → WebSocket attachment を `Player` に差し替え → grace registry / alarm tag を片付ける順
- 状態再送フォーマットは TCP PR #504 と統一 (`Game_Summary` の `position_section` を切断時の現在局面で再構築 + `Reconnect_State` ブロック)
- `PersistedConfig` に `black_reconnect_token` / `white_reconnect_token: Option<String>` を `#[serde(default)]` で追加し、対局開始時に発行した token を DO storage に永続化

### Workers 拒否経路 (18.4)

- `unknown_game` / `handle/color mismatch` / `token mismatch` / `expired` のいずれも wire 上は `LOGIN:incorrect reconnect_rejected` に統一 (TCP PR #504 と整合、side-channel 防止)
- 詳細は `console_log!` のサーバーログ側にだけ残す
- `reconnect_already_resumed` 経路は本 PR では emit していない (Workers DO は 1 instance = 1 対局専属で oneshot 的な並行は起きない)
- alarm 種別 `GraceExpired` で `handle_grace_expired_alarm` が起動し、`force_abnormal` で切断側を敗北として確定

### 状態再送の制約 (本 PR スコープ外、tasks.md に持ち越し)

`ReconnectSnapshot.last_move` は現状常に `None`。`CoreRoom` が最終手 token を露出していないため、`moves` テーブル経由で取り直す経路は別 task として扱う。Reconnect_State ブロックは `Last_Move:` 行を省略して送出するため、再接続クライアントは盤面 SFEN から最終手を逆算する必要がある (TCP PR #504 では `recorded_moves.last()` を直接参照していたが Workers にはこの buffer がない)。

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --release`
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- 追加 unit test:
  - `core::config`: `floodgate_gate_rejects_reconnect_protocol_when_disabled` / `floodgate_gate_allows_reconnect_protocol_when_enabled` / `floodgate_gate_error_lists_all_requested_features` 拡張
  - `workers::config`: `parse_reconnect_grace_duration` 3 件
  - `workers::reconnect`: `PendingReconnect::match_request` 5 件 (Accepted / handle/color/token mismatch / Expired / boundary)、serde round-trip、`build_resume_message` 3 件、`PendingAlarmKind` round-trip、`color_str_round_trip`
- E2E (Miniflare smoke / wrangler dev) は task 23.3 完了後の別 PR で追加する。本 PR の E2E は host target unit test レベルに留める

## YAGNI / 範囲外

- `--allow-floodgate-features` opt-in での Workers 起動時 fail-fast は本 PR ではフォールバック警告に留めている (CI / wrangler deploy パイプライン側で gate 違反を fail-fast させる経路は別 task)
- E2E (Miniflare smoke での再接続シナリオ通電) は task 23.3 (Miniflare 整備) の後で別 PR
- `Last_Move:` 行の埋め込みは CoreRoom 側 API 拡張が必要で、本 PR では `None` のまま (Reconnect_State の他フィールドは正常に送出)

🤖 Generated with [Claude Code](https://claude.com/claude-code)