### PR TITLE
feat(csa-server-workers): Miniflare 経由の WebSocket smoke E2E ハーネスを追加する

### DIFF
--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -63,10 +63,22 @@ jobs:
         with:
           # `rust-ci.yml` の `wasm-build` job、`deploy-workers.yml` と
           # 同じ wasm32 sysroot キャッシュ namespace を共有する。
+          # `Swatinem/rust-cache` は `RUSTFLAGS` を cache key 構成要素に含めるため、
+          # 共有する 3 workflow すべてが job 直下で `RUSTFLAGS: ""` を立てる契約で
+          # 揃える必要がある。どれか 1 つで `RUSTFLAGS` が立つと cache miss / 汚染
+          # が発生する。本 job の `RUSTFLAGS: ""` は `env:` で明示済み (44-50 行)。
           shared-key: wasm32
       # `cargo install` の成果物 (`~/.cargo/bin/worker-build`) は `Swatinem/rust-cache`
       # の対象外なので、`actions/cache` で明示キャッシュする。`deploy-workers.yml`
-      # と同じキー規約に揃える（バージョン更新時はキー末尾も同時更新）。
+      # と同じキー規約に揃える。
+      #
+      # ⚠️ バージョン更新時の二重管理に注意:
+      #   `cargo install worker-build@^0.8` を `^0.9` 系に上げる場合、本キャッシュキー
+      #   末尾の `v0.8` も同時に `v0.9` へ更新する必要がある。`v0.8` のままだと
+      #   過去 cache が hit して 0.8.x バイナリが使われ続け、新 0.9.x が install
+      #   step で skip される (`steps.cache-worker-build.outputs.cache-hit == 'true'`)。
+      #   インストールコマンドとキャッシュキーの **2 箇所同時更新** が必須。
+      #   `deploy-workers.yml` の同箇所と同契約。
       - name: Cache worker-build binary
         id: cache-worker-build
         uses: actions/cache@v4

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -1,0 +1,103 @@
+# Cloudflare Workers (rshogi-csa-server-workers) の Miniflare smoke E2E。
+#
+# - `worker-build --release` で生成した wasm worker を Miniflare に直接ロードし、
+#   1 対局 (LOGIN → AGREE → 数手 → TORYO → R2 棋譜オブジェクト確認) を Vitest
+#   で通電する
+# - DO restart シナリオ: Miniflare instance を `dispose()` → 再起動して、R2 永続化
+#   が cross-instance で保持されることを確認する
+# - 本 workflow は wrangler dev を spawn しない。Miniflare 4 の API を直接利用し、
+#   テストプロセス内で worker を起動する経路で軽量化する
+#
+# `cargo check --target wasm32` の build 検査では wasm32 限定コードの論理バグを
+# 検知できない（codegen が通るだけ）。本 workflow が PR で実 worker 経路を通電
+# することで、論理回帰を merge 前に検出する。
+name: Workers Smoke
+
+on:
+  push:
+    paths:
+      - 'crates/rshogi-csa-server-workers/**'
+      - 'crates/rshogi-csa-server/**'
+      - 'crates/rshogi-csa/**'
+      - 'crates/rshogi-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/workers-smoke.yml'
+  pull_request:
+    paths:
+      - 'crates/rshogi-csa-server-workers/**'
+      - 'crates/rshogi-csa-server/**'
+      - 'crates/rshogi-csa/**'
+      - 'crates/rshogi-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/workers-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Miniflare smoke E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # `rust-ci.yml` の host job が x86-64-v2 を要求するのと違い、本 job は
+      # wasm32 ビルド主体なので空文字で上書きする。x86 専用フラグは wasm32
+      # ターゲットで warning を大量発生させる。
+      RUSTFLAGS: ""
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Add wasm32 target to pinned toolchain
+        run: |
+          CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)
+          rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Enable sccache
+        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # `rust-ci.yml` の `wasm-build` job、`deploy-workers.yml` と
+          # 同じ wasm32 sysroot キャッシュ namespace を共有する。
+          shared-key: wasm32
+      # `cargo install` の成果物 (`~/.cargo/bin/worker-build`) は `Swatinem/rust-cache`
+      # の対象外なので、`actions/cache` で明示キャッシュする。`deploy-workers.yml`
+      # と同じキー規約に揃える（バージョン更新時はキー末尾も同時更新）。
+      - name: Cache worker-build binary
+        id: cache-worker-build
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/worker-build
+          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
+      - name: Install worker-build
+        if: steps.cache-worker-build.outputs.cache-hit != 'true'
+        run: cargo install -q worker-build@^0.8 --locked
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: crates/rshogi-csa-server-workers/package.json
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: crates/rshogi-csa-server-workers/.node-version
+          cache: 'pnpm'
+          cache-dependency-path: crates/rshogi-csa-server-workers/pnpm-lock.yaml
+      - name: Install Node deps
+        working-directory: crates/rshogi-csa-server-workers
+        run: pnpm install --frozen-lockfile
+      - name: Build wasm worker
+        working-directory: crates/rshogi-csa-server-workers
+        run: pnpm run build
+      - name: Run smoke E2E
+        working-directory: crates/rshogi-csa-server-workers
+        env:
+          # Vitest の global setup は `worker-build --release` を再度走らせるが、
+          # 直前の `pnpm run build` 成果物を再利用してテスト時間を短縮する。
+          MINIFLARE_SMOKE_SKIP_BUILD: '1'
+        run: pnpm run test:smoke
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/crates/rshogi-csa-server-workers/package.json
+++ b/crates/rshogi-csa-server-workers/package.json
@@ -8,10 +8,24 @@
     "build": "worker-build --release",
     "deploy:prod": "wrangler deploy --config wrangler.production.toml",
     "tail:prod": "wrangler tail --config wrangler.production.toml",
-    "dev": "wrangler dev"
+    "dev": "wrangler dev",
+    "test:smoke": "vitest run --config tests/miniflare_smoke/vitest.config.ts"
   },
   "devDependencies": {
-    "wrangler": "^3.114.17"
+    "@types/node": "^24.12.2",
+    "@types/ws": "^8.18.1",
+    "miniflare": "^4.20260424.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5",
+    "wrangler": "^4.85.0",
+    "ws": "^8.20.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "workerd"
+    ]
   },
   "packageManager": "pnpm@10.33.2"
 }

--- a/crates/rshogi-csa-server-workers/package.json
+++ b/crates/rshogi-csa-server-workers/package.json
@@ -13,12 +13,10 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
-    "@types/ws": "^8.18.1",
     "miniflare": "^4.20260424.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5",
-    "wrangler": "^4.85.0",
-    "ws": "^8.20.0"
+    "wrangler": "^4.85.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/crates/rshogi-csa-server-workers/pnpm-lock.yaml
+++ b/crates/rshogi-csa-server-workers/pnpm-lock.yaml
@@ -8,51 +8,69 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      miniflare:
+        specifier: ^4.20260424.0
+        version: 4.20260424.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3))
       wrangler:
-        specifier: ^3.114.17
-        version: 3.114.17
+        specifier: ^4.85.0
+        version: 4.85.0
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
 packages:
 
-  '@cloudflare/kv-asset-handler@0.3.4':
-    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
-    engines: {node: '>=16.13'}
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
 
-  '@cloudflare/unenv-preset@2.0.2':
-    resolution: {integrity: sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==}
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
-      unenv: 2.0.0-rc.14
-      workerd: ^1.20250124.0
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20250718.0':
-    resolution: {integrity: sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==}
+  '@cloudflare/workerd-darwin-64@1.20260424.1':
+    resolution: {integrity: sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
-    resolution: {integrity: sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==}
+  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
+    resolution: {integrity: sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20250718.0':
-    resolution: {integrity: sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==}
+  '@cloudflare/workerd-linux-64@1.20260424.1':
+    resolution: {integrity: sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20250718.0':
-    resolution: {integrity: sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==}
+  '@cloudflare/workerd-linux-arm64@1.20260424.1':
+    resolution: {integrity: sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20250718.0':
-    resolution: {integrity: sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==}
+  '@cloudflare/workerd-windows-64@1.20260424.1':
+    resolution: {integrity: sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -61,268 +79,320 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3':
-    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
-    peerDependencies:
-      esbuild: '*'
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild-plugins/node-modules-polyfill@0.2.2':
-    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
-    peerDependencies:
-      esbuild: '*'
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
-  '@esbuild/android-arm64@0.17.19':
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.17.19':
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.17.19':
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.17.19':
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.17.19':
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.17.19':
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.17.19':
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.17.19':
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.17.19':
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.17.19':
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.17.19':
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.17.19':
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.17.19':
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.17.19':
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.17.19':
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.17.19':
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.17.19':
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.17.19':
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.17.19':
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
-    engines: {node: '>=12'}
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.17.19':
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.17.19':
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.17.19':
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -337,101 +407,326 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  acorn-walk@8.3.2:
-    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
-    engines: {node: '>=0.4.0'}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  as-table@1.0.55:
-    resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
-  data-uri-to-buffer@2.0.2:
-    resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
-
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
-    engines: {node: '>=12'}
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
     hasBin: true
 
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  estree-walker@0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
-  exit-hook@2.2.1:
-    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
-    engines: {node: '>=6'}
-
-  exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-source@2.0.12:
-    resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
 
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
 
-  magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
 
-  mime@3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  miniflare@4.20260424.0:
+    resolution: {integrity: sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
-  miniflare@3.20250718.3:
-    resolution: {integrity: sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==}
-    engines: {node: '>=16.13'}
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  mustache@4.2.0:
-    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
-    hasBin: true
-
-  ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -439,70 +734,181 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  printable-characters@1.0.42:
-    resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  rollup-plugin-inject@3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
-  rollup-plugin-node-polyfills@0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
 
-  rollup-pluginutils@2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  stacktracey@2.2.0:
-    resolution: {integrity: sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  stoppable@1.1.0:
-    resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
-    engines: {node: '>=4', npm: '>=6'}
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  unenv@2.0.0-rc.14:
-    resolution: {integrity: sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==}
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
 
-  workerd@1.20250718.0:
-    resolution: {integrity: sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==}
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  workerd@1.20260424.1:
+    resolution: {integrity: sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@3.114.17:
-    resolution: {integrity: sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==}
-    engines: {node: '>=16.17.0'}
+  wrangler@4.85.0:
+    resolution: {integrity: sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==}
+    engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20250408.0
+      '@cloudflare/workers-types': ^4.20260424.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -519,199 +925,241 @@ packages:
       utf-8-validate:
         optional: true
 
-  youch@3.3.4:
-    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
-  zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
 snapshots:
 
-  '@cloudflare/kv-asset-handler@0.3.4':
-    dependencies:
-      mime: 3.0.0
+  '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@cloudflare/unenv-preset@2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)':
     dependencies:
-      unenv: 2.0.0-rc.14
+      unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20250718.0
+      workerd: 1.20260424.1
 
-  '@cloudflare/workerd-darwin-64@1.20250718.0':
+  '@cloudflare/workerd-darwin-64@1.20260424.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20250718.0':
+  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20250718.0':
+  '@cloudflare/workerd-linux-64@1.20260424.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20250718.0':
+  '@cloudflare/workerd-linux-arm64@1.20260424.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20250718.0':
+  '@cloudflare/workerd-windows-64@1.20260424.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
-      esbuild: 0.17.19
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
-    dependencies:
-      esbuild: 0.17.19
-      escape-string-regexp: 4.0.0
-      rollup-plugin-node-polyfills: 0.2.1
-
-  '@esbuild/android-arm64@0.17.19':
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm@0.17.19':
+  '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
-  '@esbuild/android-x64@0.17.19':
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
-  '@esbuild/darwin-arm64@0.17.19':
+  '@esbuild/android-arm@0.27.3':
     optional: true
 
-  '@esbuild/darwin-x64@0.17.19':
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.17.19':
+  '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
-  '@esbuild/freebsd-x64@0.17.19':
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
-  '@esbuild/linux-arm64@0.17.19':
+  '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/linux-arm@0.17.19':
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/linux-ia32@0.17.19':
+  '@esbuild/linux-arm64@0.27.3':
     optional: true
 
-  '@esbuild/linux-loong64@0.17.19':
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
-  '@esbuild/linux-mips64el@0.17.19':
+  '@esbuild/linux-ia32@0.27.3':
     optional: true
 
-  '@esbuild/linux-ppc64@0.17.19':
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
-  '@esbuild/linux-riscv64@0.17.19':
+  '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
-  '@esbuild/linux-s390x@0.17.19':
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
-  '@esbuild/linux-x64@0.17.19':
+  '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
-  '@esbuild/netbsd-x64@0.17.19':
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
-  '@esbuild/openbsd-x64@0.17.19':
+  '@esbuild/linux-x64@0.27.3':
     optional: true
 
-  '@esbuild/sunos-x64@0.17.19':
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/win32-arm64@0.17.19':
+  '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
-  '@esbuild/win32-ia32@0.17.19':
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
-  '@esbuild/win32-x64@0.17.19':
+  '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
-  '@fastify/busboy@2.1.1': {}
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
 
-  '@img/sharp-darwin-arm64@0.33.5':
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.33.5':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.33.5':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.33.5':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.33.5':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.10.0
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.33.5':
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -723,234 +1171,459 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  acorn-walk@8.3.2: {}
-
-  acorn@8.14.0: {}
-
-  as-table@1.0.55:
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      printable-characters: 1.0.42
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.12.2
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.3)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
 
   blake3-wasm@2.1.5: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-    optional: true
+  chai@6.2.2: {}
 
-  color-name@1.1.4:
-    optional: true
+  convert-source-map@2.0.0: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-    optional: true
+  cookie@1.1.1: {}
 
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-    optional: true
+  detect-libc@2.1.2: {}
 
-  cookie@0.7.2: {}
+  error-stack-parser-es@1.0.5: {}
 
-  data-uri-to-buffer@2.0.2: {}
+  es-module-lexer@2.1.0: {}
 
-  defu@6.1.7: {}
-
-  detect-libc@2.1.2:
-    optional: true
-
-  esbuild@0.17.19:
+  esbuild@0.27.3:
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
-  escape-string-regexp@4.0.0: {}
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
-  estree-walker@0.6.1: {}
+  expect-type@1.3.0: {}
 
-  exit-hook@2.2.1: {}
-
-  exsolve@1.0.8: {}
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fsevents@2.3.3:
     optional: true
 
-  get-source@2.0.12:
-    dependencies:
-      data-uri-to-buffer: 2.0.2
-      source-map: 0.6.1
+  kleur@4.1.5: {}
 
-  glob-to-regexp@0.4.1: {}
-
-  is-arrayish@0.3.4:
+  lightningcss-android-arm64@1.32.0:
     optional: true
 
-  magic-string@0.25.9:
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
     dependencies:
-      sourcemap-codec: 1.4.8
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
-  mime@3.0.0: {}
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  miniflare@3.20250718.3:
+  miniflare@4.20260424.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.14.0
-      acorn-walk: 8.3.2
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      stoppable: 1.1.0
-      undici: 5.29.0
-      workerd: 1.20250718.0
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260424.1
       ws: 8.18.0
-      youch: 3.3.4
-      zod: 3.22.3
+      youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  mustache@4.2.0: {}
+  nanoid@3.3.11: {}
 
-  ohash@2.0.11: {}
+  obug@2.1.1: {}
 
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
-  printable-characters@1.0.42: {}
+  picocolors@1.1.1: {}
 
-  rollup-plugin-inject@3.0.2:
+  picomatch@4.0.4: {}
+
+  postcss@8.5.12:
     dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
-  rollup-plugin-node-polyfills@0.2.1:
+  rolldown@1.0.0-rc.17:
     dependencies:
-      rollup-plugin-inject: 3.0.2
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rollup-pluginutils@2.8.2:
+  semver@7.7.4: {}
+
+  sharp@0.34.5:
     dependencies:
-      estree-walker: 0.6.1
-
-  semver@7.7.4:
-    optional: true
-
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.7.4
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-    optional: true
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
-  simple-swizzle@0.2.4:
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  supports-color@10.2.2: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
     dependencies:
-      is-arrayish: 0.3.4
-    optional: true
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
-  source-map@0.6.1: {}
-
-  sourcemap-codec@1.4.8: {}
-
-  stacktracey@2.2.0:
-    dependencies:
-      as-table: 1.0.55
-      get-source: 2.0.12
-
-  stoppable@1.1.0: {}
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1:
     optional: true
 
-  ufo@1.6.3: {}
+  typescript@6.0.3: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici-types@7.16.0: {}
 
-  unenv@2.0.0-rc.14:
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
     dependencies:
-      defu: 6.1.7
-      exsolve: 1.0.8
-      ohash: 2.0.11
       pathe: 2.0.3
-      ufo: 1.6.3
 
-  workerd@1.20250718.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20250718.0
-      '@cloudflare/workerd-darwin-arm64': 1.20250718.0
-      '@cloudflare/workerd-linux-64': 1.20250718.0
-      '@cloudflare/workerd-linux-arm64': 1.20250718.0
-      '@cloudflare/workerd-windows-64': 1.20250718.0
-
-  wrangler@3.114.17:
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3):
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/unenv-preset': 2.0.2(unenv@2.0.0-rc.14)(workerd@1.20250718.0)
-      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+
+  vitest@4.1.5(@types/node@24.12.2)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  workerd@1.20260424.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260424.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260424.1
+      '@cloudflare/workerd-linux-64': 1.20260424.1
+      '@cloudflare/workerd-linux-arm64': 1.20260424.1
+      '@cloudflare/workerd-windows-64': 1.20260424.1
+
+  wrangler@4.85.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
       blake3-wasm: 2.1.5
-      esbuild: 0.17.19
-      miniflare: 3.20250718.3
+      esbuild: 0.27.3
+      miniflare: 4.20260424.0
       path-to-regexp: 6.3.0
-      unenv: 2.0.0-rc.14
-      workerd: 1.20250718.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260424.1
     optionalDependencies:
       fsevents: 2.3.3
-      sharp: 0.33.5
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   ws@8.18.0: {}
 
-  youch@3.3.4:
-    dependencies:
-      cookie: 0.7.2
-      mustache: 4.2.0
-      stacktracey: 2.2.0
+  ws@8.20.0: {}
 
-  zod@3.22.3: {}
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3

--- a/crates/rshogi-csa-server-workers/pnpm-lock.yaml
+++ b/crates/rshogi-csa-server-workers/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
       miniflare:
         specifier: ^4.20260424.0
         version: 4.20260424.0
@@ -26,9 +23,6 @@ importers:
       wrangler:
         specifier: ^4.85.0
         version: 4.85.0
-      ws:
-        specifier: ^8.20.0
-        version: 8.20.0
 
 packages:
 
@@ -548,9 +542,6 @@ packages:
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -925,18 +916,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -1266,10 +1245,6 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 24.12.2
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1612,8 +1587,6 @@ snapshots:
       - utf-8-validate
 
   ws@8.18.0: {}
-
-  ws@8.20.0: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/global-setup.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/global-setup.ts
@@ -1,0 +1,31 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const WORKER_ROOT = resolve(import.meta.dirname, "../..");
+const SHIM_PATH = resolve(WORKER_ROOT, "build/worker/shim.mjs");
+
+export default async function setup(): Promise<void> {
+  if (process.env.MINIFLARE_SMOKE_SKIP_BUILD === "1" && existsSync(SHIM_PATH)) {
+    return;
+  }
+  await runWorkerBuild();
+  if (!existsSync(SHIM_PATH)) {
+    throw new Error(`worker-build did not produce ${SHIM_PATH}`);
+  }
+}
+
+function runWorkerBuild(): Promise<void> {
+  return new Promise((resolveBuild, reject) => {
+    const child = spawn("worker-build", ["--release"], {
+      cwd: WORKER_ROOT,
+      stdio: "inherit",
+      env: { ...process.env, RUSTFLAGS: "" },
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolveBuild();
+      else reject(new Error(`worker-build exited with code ${code}`));
+    });
+  });
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/global-setup.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/global-setup.ts
@@ -17,6 +17,13 @@ export default async function setup(): Promise<void> {
 
 function runWorkerBuild(): Promise<void> {
   return new Promise((resolveBuild, reject) => {
+    // `RUSTFLAGS` を空文字で上書きする理由: 開発者ローカルや CI 上位 env で
+    // `-C target-cpu=x86-64-v2` 等の host 用 flag が立っていると、wasm32 では
+    // "not a recognized processor" 警告が大量出力されたり、`cargo` が host
+    // sysroot キャッシュと混在して codegen が壊れることがある。Workers の
+    // wasm32 ビルドは `Swatinem/rust-cache` の `shared-key: wasm32` 経路と
+    // 揃える必要があり、そこも RUSTFLAGS="" で固定済 (workers-smoke.yml /
+    // rust-ci.yml `wasm-build` job / deploy-workers.yml の 3 箇所と同契約)。
     const child = spawn("worker-build", ["--release"], {
       cwd: WORKER_ROOT,
       stdio: "inherit",

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -1,7 +1,27 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { Miniflare, type R2Bucket, type WebSocket } from "miniflare";
+import { Miniflare, type WebSocket } from "miniflare";
+
+/// `mf.getR2Bucket(...)` の戻り値は miniflare 4 が `ReplaceWorkersTypes<R2Bucket>`
+/// (大きな conditional type) として返し、tsc の構造的推論で `Request_2` などに
+/// 潰れる既知のエッジケースがある。`R2Bucket` 自体は miniflare の barrel export
+/// 対象外でもあり、`@cloudflare/workers-types` を別途 devDep に入れたくない
+/// (テスト用途には過剰)。本ハーネスは `list` / `get` の最小サブセットしか
+/// 使わないため、duck-type interface を 1 か所定義して `getKifuBucket` で
+/// キャストを隠蔽する。
+export interface R2BucketLike {
+  list(): Promise<{ objects: Array<{ key: string }> }>;
+  get(key: string): Promise<R2ObjectLike | null>;
+}
+
+export interface R2ObjectLike {
+  text(): Promise<string>;
+}
+
+export async function getKifuBucket(mf: Miniflare): Promise<R2BucketLike> {
+  return (await mf.getR2Bucket("KIFU_BUCKET")) as unknown as R2BucketLike;
+}
 
 const WORKER_ROOT = resolve(import.meta.dirname, "../..");
 const SHIM_PATH = resolve(WORKER_ROOT, "build/worker/shim.mjs");
@@ -72,7 +92,7 @@ export async function makeTempPersistRoot(): Promise<{
 /// 可能性が実質ないため、substring 一致で十分。テスト用途で件数は数件想定、
 /// page 跨ぎ (>1000 件) は視野外。
 export async function pollR2ForGameId(
-  bucket: R2Bucket,
+  bucket: R2BucketLike,
   gameId: string,
   { timeoutMs = 5000, intervalMs = 100 }: { timeoutMs?: number; intervalMs?: number } = {},
 ): Promise<{ key: string }[]> {
@@ -158,11 +178,27 @@ export class CsaClient {
     return lines;
   }
 
-  close(): void {
-    if (!this.closed) {
+  /// クライアント側で WS を閉じ、サーバ側 close ハンドラ (`websocket_close`)
+  /// が走り終わるまで待つ。再接続シナリオでは「サーバが切断を観測してから
+  /// `enter_grace_window` が走る」ことに依存するため、close を fire-and-forget
+  /// すると後続の reconnect リクエストが grace 登録より先に到着して race する。
+  /// `addEventListener("close", ...)` を constructor で予約済みなので、それと
+  /// 同経路の close 通知を await できるよう Promise を返す。サーバ側 close
+  /// ack が来ない異常時は `timeoutMs` で諦める。
+  async close(timeoutMs = 2000): Promise<void> {
+    if (this.closed) return;
+    return await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => resolve(), timeoutMs);
+      this.ws.addEventListener(
+        "close",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
       this.ws.close();
-      this.closed = true;
-    }
+    });
   }
 
   isClosed(): boolean {

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -1,0 +1,198 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Miniflare, type WebSocket } from "miniflare";
+
+const WORKER_ROOT = resolve(import.meta.dirname, "../..");
+const SHIM_PATH = resolve(WORKER_ROOT, "build/worker/shim.mjs");
+
+export interface HarnessOptions {
+  persistRoot?: string;
+  reconnectGraceSeconds?: number;
+  allowFloodgateFeatures?: boolean;
+  totalTimeSec?: number;
+  byoyomiSec?: number;
+  totalTimeMin?: number;
+  byoyomiMin?: number;
+  clockKind?: "countdown" | "fischer" | "stopwatch";
+  corsOrigins?: string;
+  adminHandle?: string;
+}
+
+export async function createMiniflare(opts: HarnessOptions = {}): Promise<Miniflare> {
+  const mf = new Miniflare({
+    scriptPath: SHIM_PATH,
+    modules: true,
+    modulesRules: [
+      { type: "ESModule", include: ["**/*.js", "**/*.mjs"], fallthrough: true },
+      { type: "CompiledWasm", include: ["**/*.wasm"], fallthrough: true },
+    ],
+    compatibilityDate: "2026-04-21",
+    durableObjects: {
+      GAME_ROOM: { className: "GameRoom", useSQLite: true },
+    },
+    r2Buckets: ["KIFU_BUCKET", "FLOODGATE_HISTORY_BUCKET"],
+    bindings: {
+      CLOCK_KIND: opts.clockKind ?? "countdown",
+      TOTAL_TIME_SEC: String(opts.totalTimeSec ?? 600),
+      BYOYOMI_SEC: String(opts.byoyomiSec ?? 10),
+      TOTAL_TIME_MIN: String(opts.totalTimeMin ?? 10),
+      BYOYOMI_MIN: String(opts.byoyomiMin ?? 1),
+      ADMIN_HANDLE: opts.adminHandle ?? "admin",
+      RECONNECT_GRACE_SECONDS: String(opts.reconnectGraceSeconds ?? 0),
+      ALLOW_FLOODGATE_FEATURES: opts.allowFloodgateFeatures ? "true" : "false",
+      CORS_ORIGINS: opts.corsOrigins ?? "https://example.com",
+    },
+    defaultPersistRoot: opts.persistRoot,
+  });
+  await mf.ready;
+  return mf;
+}
+
+export async function makeTempPersistRoot(): Promise<{
+  path: string;
+  cleanup: () => Promise<void>;
+}> {
+  const path = await mkdtemp(join(tmpdir(), "miniflare-smoke-"));
+  return {
+    path,
+    cleanup: async () => {
+      await rm(path, { recursive: true, force: true });
+    },
+  };
+}
+
+export class CsaClient {
+  private readonly buffer = new LineBuffer();
+  private closed = false;
+  private closeReason: { code?: number; reason?: string } | undefined;
+
+  static async connect(mf: Miniflare, roomId: string, origin = "https://example.com"): Promise<CsaClient> {
+    const url = `https://example.com/ws/${encodeURIComponent(roomId)}`;
+    const res = await mf.dispatchFetch(url, {
+      headers: {
+        Upgrade: "websocket",
+        Origin: origin,
+      },
+    });
+    if (res.status !== 101 || !res.webSocket) {
+      throw new Error(`expected 101 with webSocket, got ${res.status}: ${await res.text()}`);
+    }
+    const client = new CsaClient(res.webSocket);
+    res.webSocket.accept();
+    return client;
+  }
+
+  private constructor(private readonly ws: WebSocket) {
+    ws.addEventListener("message", (ev) => {
+      const data =
+        typeof ev.data === "string" ? ev.data : new TextDecoder().decode(ev.data as ArrayBuffer);
+      this.buffer.push(data);
+    });
+    ws.addEventListener("close", (ev) => {
+      this.closed = true;
+      this.closeReason = { code: ev.code, reason: ev.reason };
+      this.buffer.markClosed();
+    });
+  }
+
+  send(line: string): void {
+    if (this.closed) throw new Error("CsaClient: cannot send on closed connection");
+    this.ws.send(`${line}\n`);
+  }
+
+  async recvLine(timeoutMs = 5000): Promise<string> {
+    return this.buffer.takeLine(timeoutMs);
+  }
+
+  async recvUntil(predicate: (line: string) => boolean, timeoutMs = 10_000): Promise<string[]> {
+    const collected: string[] = [];
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`recvUntil timeout; collected so far: ${JSON.stringify(collected)}`);
+      }
+      const line = await this.recvLine(remaining);
+      collected.push(line);
+      if (predicate(line)) return collected;
+    }
+  }
+
+  async drainGameSummary(timeoutMs = 10_000): Promise<string[]> {
+    const lines = await this.recvUntil((l) => l === "END Game_Summary", timeoutMs);
+    if (lines[0] !== "BEGIN Game_Summary") {
+      throw new Error(`expected BEGIN Game_Summary; got ${JSON.stringify(lines)}`);
+    }
+    return lines;
+  }
+
+  close(): void {
+    if (!this.closed) {
+      this.ws.close();
+      this.closed = true;
+    }
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  closeInfo(): { code?: number; reason?: string } | undefined {
+    return this.closeReason;
+  }
+}
+
+class LineBuffer {
+  private text = "";
+  private readonly queue: string[] = [];
+  private readonly waiters: Array<{
+    resolve: (line: string) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private closed = false;
+
+  push(chunk: string): void {
+    this.text += chunk;
+    while (true) {
+      const idx = this.text.indexOf("\n");
+      if (idx < 0) break;
+      const line = this.text.slice(0, idx);
+      this.text = this.text.slice(idx + 1);
+      const w = this.waiters.shift();
+      if (w) w.resolve(line);
+      else this.queue.push(line);
+    }
+  }
+
+  markClosed(): void {
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      const w = this.waiters.shift();
+      w?.reject(new Error("connection closed"));
+    }
+  }
+
+  takeLine(timeoutMs: number): Promise<string> {
+    if (this.queue.length > 0) return Promise.resolve(this.queue.shift()!);
+    if (this.closed) return Promise.reject(new Error("connection closed"));
+    return new Promise<string>((resolve, reject) => {
+      const entry = {
+        resolve: (line: string) => {
+          clearTimeout(timer);
+          resolve(line);
+        },
+        reject: (err: Error) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      };
+      const timer = setTimeout(() => {
+        const idx = this.waiters.indexOf(entry);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        reject(new Error(`recvLine timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.waiters.push(entry);
+    });
+  }
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -1,13 +1,16 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { Miniflare, type WebSocket } from "miniflare";
+import { Miniflare, type R2Bucket, type WebSocket } from "miniflare";
 
 const WORKER_ROOT = resolve(import.meta.dirname, "../..");
 const SHIM_PATH = resolve(WORKER_ROOT, "build/worker/shim.mjs");
 
 export interface HarnessOptions {
-  persistRoot?: string;
+  /// Miniflare の persist 先ディレクトリ。テスト並列実行や 2 回目の `vitest run`
+  /// で R2 / DO storage が交差汚染しないよう、呼び出し側で一時ディレクトリを
+  /// 切って必ず指定する契約。`makeTempPersistRoot()` のヘルパで作るのが基本経路。
+  persistRoot: string;
   reconnectGraceSeconds?: number;
   allowFloodgateFeatures?: boolean;
   totalTimeSec?: number;
@@ -19,7 +22,7 @@ export interface HarnessOptions {
   adminHandle?: string;
 }
 
-export async function createMiniflare(opts: HarnessOptions = {}): Promise<Miniflare> {
+export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> {
   const mf = new Miniflare({
     scriptPath: SHIM_PATH,
     modules: true,
@@ -60,6 +63,34 @@ export async function makeTempPersistRoot(): Promise<{
       await rm(path, { recursive: true, force: true });
     },
   };
+}
+
+/// 棋譜 R2 オブジェクトを `game_id` 部分一致で待機列挙する。`KIFU_BUCKET` の
+/// キー命名規則 (`YYYY/MM/DD/<game_id>.csa` 等) は `game_id` を prefix にしない
+/// 階層形なので `R2.list({ prefix })` は使えず、全件列挙 + 後段 substring 一致で
+/// 拾う。`game_id` は `<room_id>-<epoch_ms>` 形式で偶発的に他キーへ混入する
+/// 可能性が実質ないため、substring 一致で十分。テスト用途で件数は数件想定、
+/// page 跨ぎ (>1000 件) は視野外。
+export async function pollR2ForGameId(
+  bucket: R2Bucket,
+  gameId: string,
+  { timeoutMs = 5000, intervalMs = 100 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<{ key: string }[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const list = await bucket.list();
+    const matched = list.objects
+      .filter((o: { key: string }) => o.key.includes(gameId))
+      .map((o: { key: string }) => ({ key: o.key }));
+    if (matched.length > 0) return matched;
+    if (Date.now() > deadline) {
+      const seen = list.objects.map((o: { key: string }) => o.key);
+      throw new Error(
+        `R2 object for game_id=${gameId} not found within ${timeoutMs}ms; current keys: ${JSON.stringify(seen)}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
 }
 
 export class CsaClient {

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -10,8 +10,24 @@ import { Miniflare, type WebSocket } from "miniflare";
 /// (テスト用途には過剰)。本ハーネスは `list` / `get` の最小サブセットしか
 /// 使わないため、duck-type interface を 1 か所定義して `getKifuBucket` で
 /// キャストを隠蔽する。
+///
+/// 引数 / 戻り値を最小だけ広げてあるのは、将来 miniflare 4 が `list()` の
+/// 既定挙動を変えても (例: page size 規定値変更 / `truncated` 必須化) 局所
+/// 改修で追随できるようにするため。
+export interface R2ListOptions {
+  prefix?: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface R2ListResult {
+  objects: Array<{ key: string }>;
+  truncated?: boolean;
+  cursor?: string;
+}
+
 export interface R2BucketLike {
-  list(): Promise<{ objects: Array<{ key: string }> }>;
+  list(options?: R2ListOptions): Promise<R2ListResult>;
   get(key: string): Promise<R2ObjectLike | null>;
 }
 
@@ -20,7 +36,18 @@ export interface R2ObjectLike {
 }
 
 export async function getKifuBucket(mf: Miniflare): Promise<R2BucketLike> {
-  return (await mf.getR2Bucket("KIFU_BUCKET")) as unknown as R2BucketLike;
+  const raw = (await mf.getR2Bucket("KIFU_BUCKET")) as unknown as R2BucketLike;
+  // 将来 miniflare のメジャーアップで `list` / `get` が rename された場合に
+  // 型崩落で silent に壊れる経路を避けるため、duck-type 違反を runtime で
+  // 早期検出する。型 cast (`as unknown as R2BucketLike`) を使っている以上、
+  // 整合性検証は実装側で持つ責務。
+  if (typeof raw.list !== "function" || typeof raw.get !== "function") {
+    throw new Error(
+      "miniflare R2Bucket API に list/get が見つからない: " +
+        "miniflare メジャーアップで API rename された可能性。harness の duck-type を更新する必要あり",
+    );
+  }
+  return raw;
 }
 
 const WORKER_ROOT = resolve(import.meta.dirname, "../..");
@@ -183,10 +210,25 @@ export class CsaClient {
   /// `enter_grace_window` が走る」ことに依存するため、close を fire-and-forget
   /// すると後続の reconnect リクエストが grace 登録より先に到着して race する。
   /// `addEventListener("close", ...)` を constructor で予約済みなので、それと
-  /// 同経路の close 通知を await できるよう Promise を返す。サーバ側 close
-  /// ack が来ない異常時は `timeoutMs` で諦める。
+  /// 同経路の close 通知を await できるよう Promise を返す。
+  ///
+  /// timeout 時は **resolve** で抜ける (throw しない)。テストの `afterEach` で
+  /// `mf.dispose()` が必ず呼ばれて WS は強制破棄されるため、close ack が
+  /// 帰らない異常経路でも cleanup は別経路で完結する。close を fail-loud に
+  /// すると afterEach 自体が落ちて test の本当の失敗原因が埋もれるので、
+  /// cleanup 側の不確実性は本関数で吸収する設計に倒している。
   async close(timeoutMs = 2000): Promise<void> {
     if (this.closed) return;
+    // server-initiated close (`game_room.rs` の終局時 close 等) と同じ tick で
+    // 呼ばれるケースでは、`addEventListener` を貼る前に WS が CLOSING/CLOSED
+    // へ遷移しており、close event は再 dispatch されずに `Promise` が timeout
+    // 一杯を空待ちすることがある。`readyState` で早期 return して 2000ms の
+    // 浪費を防ぐ。`READY_STATE_CLOSING = 2` / `READY_STATE_CLOSED = 3` は
+    // miniflare 4 の static 定数。
+    const state = this.ws.readyState;
+    if (state === 2 /* CLOSING */ || state === 3 /* CLOSED */) {
+      return;
+    }
     return await new Promise<void>((resolve) => {
       const timer = setTimeout(() => resolve(), timeoutMs);
       this.ws.addEventListener(

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: 再接続プロトコル E2E", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      reconnectGraceSeconds: 30,
+      allowFloodgateFeatures: true,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("黒切断 → 同 token で再接続 → 状態再送 → 対局継続して終局", async () => {
+    const roomId = "reconnect-room-1";
+    const gameName = "fg-60-1";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black0 = await CsaClient.connect(mf, roomId);
+    black0.send(`LOGIN ${blackName} pw`);
+    expect(await black0.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    const blackSummary = await black0.drainGameSummary();
+    const whiteSummary = await white.drainGameSummary();
+    const blackToken = extractReconnectToken(blackSummary);
+    const whiteToken = extractReconnectToken(whiteSummary);
+    expect(blackToken, "Reconnect_Token (black) は Game_Summary に存在する").toBeDefined();
+    expect(whiteToken, "Reconnect_Token (white) は Game_Summary に存在する").toBeDefined();
+    expect(blackToken).not.toBe(whiteToken);
+
+    black0.send("AGREE");
+    white.send("AGREE");
+    const startBlack = await black0.recvLine();
+    await white.recvLine();
+    const gameId = startBlack.slice("START:".length);
+    expect(gameId.length).toBeGreaterThan(0);
+
+    black0.send("+7776FU");
+    await black0.recvUntil((l) => l.startsWith("+7776FU"));
+    await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+    black0.close();
+    await waitFor(() => black0.isClosed(), 2000);
+
+    const black1 = await CsaClient.connect(mf, roomId);
+    black1.send(`LOGIN ${blackName} pw reconnect:${gameId}+${blackToken}`);
+    expect(await black1.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const resumeSummary = await black1.drainGameSummary();
+    const resumedToken = extractReconnectToken(resumeSummary);
+    expect(resumedToken, "再送 Game_Summary にも Reconnect_Token を含む").toBeDefined();
+
+    const reconnectStateOpen = await black1.recvLine();
+    expect(reconnectStateOpen).toBe("BEGIN Reconnect_State");
+    const reconnectStateLines = await black1.recvUntil((l) => l === "END Reconnect_State");
+    const turnLine = reconnectStateLines.find((l) => l.startsWith("Current_Turn:"));
+    expect(turnLine).toBe("Current_Turn:-");
+    expect(reconnectStateLines.some((l) => l.startsWith("Black_Time_Remaining_Ms:"))).toBe(true);
+    expect(reconnectStateLines.some((l) => l.startsWith("White_Time_Remaining_Ms:"))).toBe(true);
+    // `Last_Move` 行は CoreRoom が最終手 token を露出していない現状では省略される。
+    // 将来 last_move 経路が実装されたとき本 assertion を更新する signal になる。
+    expect(reconnectStateLines.some((l) => l.startsWith("Last_Move:"))).toBe(false);
+
+    white.send("-3334FU");
+    await white.recvUntil((l) => l.startsWith("-3334FU"));
+    await black1.recvUntil((l) => l.startsWith("-3334FU"));
+
+    black1.send("%TORYO");
+    const blackEnd = await black1.recvUntil((l) => l === "#LOSE");
+    expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
+
+    black1.close();
+    white.close();
+  });
+
+  it("不正 token での再接続は LOGIN:incorrect reconnect_rejected で拒否される", async () => {
+    const roomId = "reconnect-room-2";
+    const gameName = "fg-60-1";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black0 = await CsaClient.connect(mf, roomId);
+    black0.send(`LOGIN ${blackName} pw`);
+    await black0.recvLine();
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    await white.recvLine();
+    await black0.drainGameSummary();
+    await white.drainGameSummary();
+    black0.send("AGREE");
+    white.send("AGREE");
+    const startBlack = await black0.recvLine();
+    await white.recvLine();
+    const gameId = startBlack.slice("START:".length);
+
+    black0.close();
+    await waitFor(() => black0.isClosed(), 2000);
+
+    const black1 = await CsaClient.connect(mf, roomId);
+    black1.send(`LOGIN ${blackName} pw reconnect:${gameId}+wrong-token-0123abcd`);
+    expect(await black1.recvLine()).toBe("LOGIN:incorrect reconnect_rejected");
+
+    white.close();
+  });
+});
+
+function extractReconnectToken(summaryLines: string[]): string | undefined {
+  const line = summaryLines.find((l) => l.startsWith("Reconnect_Token:"));
+  return line?.slice("Reconnect_Token:".length);
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect.test.ts
@@ -56,8 +56,7 @@ describe("miniflare smoke: 再接続プロトコル E2E", () => {
     await black0.recvUntil((l) => l.startsWith("+7776FU"));
     await white.recvUntil((l) => l.startsWith("+7776FU"));
 
-    black0.close();
-    await waitFor(() => black0.isClosed(), 2000);
+    await black0.close();
 
     const black1 = await CsaClient.connect(mf, roomId);
     black1.send(`LOGIN ${blackName} pw reconnect:${gameId}+${blackToken}`);
@@ -86,8 +85,8 @@ describe("miniflare smoke: 再接続プロトコル E2E", () => {
     const blackEnd = await black1.recvUntil((l) => l === "#LOSE");
     expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
 
-    black1.close();
-    white.close();
+    await black1.close();
+    await white.close();
   });
 
   it("不正 token での再接続は LOGIN:incorrect reconnect_rejected で拒否される", async () => {
@@ -110,26 +109,17 @@ describe("miniflare smoke: 再接続プロトコル E2E", () => {
     await white.recvLine();
     const gameId = startBlack.slice("START:".length);
 
-    black0.close();
-    await waitFor(() => black0.isClosed(), 2000);
+    await black0.close();
 
     const black1 = await CsaClient.connect(mf, roomId);
     black1.send(`LOGIN ${blackName} pw reconnect:${gameId}+wrong-token-0123abcd`);
     expect(await black1.recvLine()).toBe("LOGIN:incorrect reconnect_rejected");
 
-    white.close();
+    await white.close();
   });
 });
 
 function extractReconnectToken(summaryLines: string[]): string | undefined {
   const line = summaryLines.find((l) => l.startsWith("Reconnect_Token:"));
   return line?.slice("Reconnect_Token:".length);
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await new Promise((r) => setTimeout(r, 20));
-  }
 }

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import {
+  CsaClient,
+  createMiniflare,
+  makeTempPersistRoot,
+  pollR2ForGameId,
+} from "./harness.ts";
 import type { Miniflare } from "miniflare";
 
 describe("miniflare smoke: DO restart 永続化", () => {
@@ -95,7 +100,7 @@ async function playOneGame(
   await black.recvUntil((l) => l === "#LOSE");
 
   const r2 = await mf.getR2Bucket("KIFU_BUCKET");
-  const list = await pollR2List(r2, gameId);
+  const list = await pollR2ForGameId(r2, gameId);
   const key = list[0]!.key;
   const body = await (await r2.get(key))!.text();
 
@@ -103,21 +108,4 @@ async function playOneGame(
   white.close();
 
   return { gameId, kifuKey: key, kifuBody: body };
-}
-
-async function pollR2List(
-  r2: Awaited<ReturnType<Miniflare["getR2Bucket"]>>,
-  gameId: string,
-  timeoutMs = 5000,
-): Promise<{ key: string }[]> {
-  const deadline = Date.now() + timeoutMs;
-  while (true) {
-    const res = await r2.list();
-    const matched = res.objects.filter((o: { key: string }) => o.key.includes(gameId));
-    if (matched.length > 0) return matched.map((o: { key: string }) => ({ key: o.key }));
-    if (Date.now() > deadline) {
-      throw new Error(`R2 object for ${gameId} not found within ${timeoutMs}ms`);
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
 }

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CsaClient,
   createMiniflare,
+  getKifuBucket,
   makeTempPersistRoot,
   pollR2ForGameId,
 } from "./harness.ts";
@@ -30,7 +31,7 @@ describe("miniflare smoke: DO restart 永続化", () => {
     const roomId = "restart-room-1";
     const gameName = "fg-60-1";
 
-    const first = await spawn();
+    const first = await spawnMiniflare();
     const { gameId, kifuKey, kifuBody } = await playOneGame(first, roomId, gameName);
 
     expect(kifuBody).toContain("V2.2");
@@ -39,15 +40,17 @@ describe("miniflare smoke: DO restart 永続化", () => {
     await first.dispose();
     instances.length = 0;
 
-    const second = await spawn();
-    const r2 = await second.getR2Bucket("KIFU_BUCKET");
+    const second = await spawnMiniflare();
+    const r2 = await getKifuBucket(second);
     const obj = await r2.get(kifuKey);
     expect(obj, `R2 object ${kifuKey} should survive Miniflare restart`).not.toBeNull();
     const body = await obj!.text();
     expect(body).toBe(kifuBody);
   });
 
-  async function spawn(): Promise<Miniflare> {
+  // `spawn` という名前は Node.js `child_process.spawn` と紛らわしいので
+  // Miniflare instance を生成するヘルパであることを明示する命名に揃える。
+  async function spawnMiniflare(): Promise<Miniflare> {
     const mf = await createMiniflare({
       persistRoot: persistRoot,
       totalTimeSec: 60,
@@ -99,13 +102,13 @@ async function playOneGame(
   black.send("%TORYO");
   await black.recvUntil((l) => l === "#LOSE");
 
-  const r2 = await mf.getR2Bucket("KIFU_BUCKET");
+  const r2 = await getKifuBucket(mf);
   const list = await pollR2ForGameId(r2, gameId);
   const key = list[0]!.key;
   const body = await (await r2.get(key))!.text();
 
-  black.close();
-  white.close();
+  await black.close();
+  await white.close();
 
   return { gameId, kifuKey: key, kifuBody: body };
 }

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/restart.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: DO restart 永続化", () => {
+  let persistRoot: string;
+  let cleanupPersist: () => Promise<void>;
+  const instances: Miniflare[] = [];
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    persistRoot = persist.path;
+    cleanupPersist = persist.cleanup;
+  });
+
+  afterEach(async () => {
+    while (instances.length > 0) {
+      const mf = instances.pop();
+      if (mf) await mf.dispose();
+    }
+    await cleanupPersist();
+  });
+
+  it("1 対局を終局まで進めた後、Miniflare を dispose → 再起動しても R2 棋譜が読める", async () => {
+    const roomId = "restart-room-1";
+    const gameName = "fg-60-1";
+
+    const first = await spawn();
+    const { gameId, kifuKey, kifuBody } = await playOneGame(first, roomId, gameName);
+
+    expect(kifuBody).toContain("V2.2");
+    expect(kifuBody).toContain(gameId);
+
+    await first.dispose();
+    instances.length = 0;
+
+    const second = await spawn();
+    const r2 = await second.getR2Bucket("KIFU_BUCKET");
+    const obj = await r2.get(kifuKey);
+    expect(obj, `R2 object ${kifuKey} should survive Miniflare restart`).not.toBeNull();
+    const body = await obj!.text();
+    expect(body).toBe(kifuBody);
+  });
+
+  async function spawn(): Promise<Miniflare> {
+    const mf = await createMiniflare({
+      persistRoot: persistRoot,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+    instances.push(mf);
+    return mf;
+  }
+});
+
+interface GameOutcome {
+  gameId: string;
+  kifuKey: string;
+  kifuBody: string;
+}
+
+async function playOneGame(
+  mf: Miniflare,
+  roomId: string,
+  gameName: string,
+): Promise<GameOutcome> {
+  const black = await CsaClient.connect(mf, roomId);
+  const blackName = `alice+${gameName}+black`;
+  black.send(`LOGIN ${blackName} pw`);
+  await black.recvLine();
+
+  const white = await CsaClient.connect(mf, roomId);
+  const whiteName = `bob+${gameName}+white`;
+  white.send(`LOGIN ${whiteName} pw`);
+  await white.recvLine();
+
+  await black.drainGameSummary();
+  await white.drainGameSummary();
+
+  black.send("AGREE");
+  white.send("AGREE");
+  const startBlack = await black.recvLine();
+  await white.recvLine();
+  const gameId = startBlack.slice("START:".length);
+
+  black.send("+7776FU");
+  await black.recvUntil((l) => l.startsWith("+7776FU"));
+  await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+  white.send("-3334FU");
+  await black.recvUntil((l) => l.startsWith("-3334FU"));
+  await white.recvUntil((l) => l.startsWith("-3334FU"));
+
+  black.send("%TORYO");
+  await black.recvUntil((l) => l === "#LOSE");
+
+  const r2 = await mf.getR2Bucket("KIFU_BUCKET");
+  const list = await pollR2List(r2, gameId);
+  const key = list[0]!.key;
+  const body = await (await r2.get(key))!.text();
+
+  black.close();
+  white.close();
+
+  return { gameId, kifuKey: key, kifuBody: body };
+}
+
+async function pollR2List(
+  r2: Awaited<ReturnType<Miniflare["getR2Bucket"]>>,
+  gameId: string,
+  timeoutMs = 5000,
+): Promise<{ key: string }[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const res = await r2.list();
+    const matched = res.objects.filter((o: { key: string }) => o.key.includes(gameId));
+    if (matched.length > 0) return matched.map((o: { key: string }) => ({ key: o.key }));
+    if (Date.now() > deadline) {
+      throw new Error(`R2 object for ${gameId} not found within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: 1 対局 E2E", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("LOGIN → AGREE → 数手 → TORYO → R2 棋譜オブジェクトが書かれる", async () => {
+    const roomId = "smoke-room-1";
+    const gameName = "floodgate-60-1";
+
+    const black = await CsaClient.connect(mf, roomId);
+    const blackName = `alice+${gameName}+black`;
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    const whiteName = `bob+${gameName}+white`;
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    const blackSummary = await black.drainGameSummary();
+    const whiteSummary = await white.drainGameSummary();
+    expect(blackSummary.some((l) => l === "Your_Turn:+")).toBe(true);
+    expect(whiteSummary.some((l) => l === "Your_Turn:-")).toBe(true);
+
+    black.send("AGREE");
+    white.send("AGREE");
+    const startBlack = await black.recvLine();
+    const startWhite = await white.recvLine();
+    expect(startBlack.startsWith("START:")).toBe(true);
+    expect(startBlack).toBe(startWhite);
+    const gameId = startBlack.slice("START:".length);
+    expect(gameId.length).toBeGreaterThan(0);
+
+    black.send("+7776FU");
+    await black.recvUntil((l) => l.startsWith("+7776FU"));
+    await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+    white.send("-3334FU");
+    await black.recvUntil((l) => l.startsWith("-3334FU"));
+    await white.recvUntil((l) => l.startsWith("-3334FU"));
+
+    black.send("%TORYO");
+    const blackEnd = await black.recvUntil((l) => l === "#LOSE");
+    expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
+
+    const r2 = await mf.getR2Bucket("KIFU_BUCKET");
+    const list = await pollR2List(r2, gameId);
+    expect(list.length).toBeGreaterThan(0);
+    const key = list[0]!.key;
+    const obj = await r2.get(key);
+    expect(obj).not.toBeNull();
+    const body = await obj!.text();
+    expect(body).toContain("V2.2");
+    expect(body).toContain(gameId);
+
+    black.close();
+    white.close();
+  });
+});
+
+async function pollR2List(
+  r2: Awaited<ReturnType<Miniflare["getR2Bucket"]>>,
+  gameId: string,
+  timeoutMs = 5000,
+): Promise<{ key: string }[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const res = await r2.list();
+    const matched = res.objects.filter((o: { key: string }) => o.key.includes(gameId));
+    if (matched.length > 0) return matched.map((o: { key: string }) => ({ key: o.key }));
+    if (Date.now() > deadline) {
+      throw new Error(`R2 object for ${gameId} not found within ${timeoutMs}ms; keys: ${JSON.stringify(res.objects.map((o: { key: string }) => o.key))}`);
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CsaClient,
   createMiniflare,
+  getKifuBucket,
   makeTempPersistRoot,
   pollR2ForGameId,
 } from "./harness.ts";
@@ -66,7 +67,7 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     const blackEnd = await black.recvUntil((l) => l === "#LOSE");
     expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
 
-    const r2 = await mf.getR2Bucket("KIFU_BUCKET");
+    const r2 = await getKifuBucket(mf);
     const list = await pollR2ForGameId(r2, gameId);
     expect(list.length).toBeGreaterThan(0);
     const key = list[0]!.key;
@@ -76,7 +77,7 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     expect(body).toContain("V2.2");
     expect(body).toContain(gameId);
 
-    black.close();
-    white.close();
+    await black.close();
+    await white.close();
   });
 });

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import {
+  CsaClient,
+  createMiniflare,
+  makeTempPersistRoot,
+  pollR2ForGameId,
+} from "./harness.ts";
 import type { Miniflare } from "miniflare";
 
 describe("miniflare smoke: 1 対局 E2E", () => {
@@ -62,7 +67,7 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
 
     const r2 = await mf.getR2Bucket("KIFU_BUCKET");
-    const list = await pollR2List(r2, gameId);
+    const list = await pollR2ForGameId(r2, gameId);
     expect(list.length).toBeGreaterThan(0);
     const key = list[0]!.key;
     const obj = await r2.get(key);
@@ -75,20 +80,3 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     white.close();
   });
 });
-
-async function pollR2List(
-  r2: Awaited<ReturnType<Miniflare["getR2Bucket"]>>,
-  gameId: string,
-  timeoutMs = 5000,
-): Promise<{ key: string }[]> {
-  const deadline = Date.now() + timeoutMs;
-  while (true) {
-    const res = await r2.list();
-    const matched = res.objects.filter((o: { key: string }) => o.key.includes(gameId));
-    if (matched.length > 0) return matched.map((o: { key: string }) => ({ key: o.key }));
-    if (Date.now() > deadline) {
-      throw new Error(`R2 object for ${gameId} not found within ${timeoutMs}ms; keys: ${JSON.stringify(res.objects.map((o: { key: string }) => o.key))}`);
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/tsconfig.json
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "noEmit": true,
     "types": ["node"]
   },

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/tsconfig.json
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/vitest.config.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    dir: here,
+    globalSetup: [`${here}/global-setup.ts`],
+    include: ["*.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+    pool: "forks",
+  },
+});


### PR DESCRIPTION
## Summary

- worker-build 出力 (`build/worker/shim.mjs` + wasm) を Miniflare 4 から Vitest プロセス内で直接ロードし、wrangler dev を spawn せずに 1 対局を通電する E2E ハーネスを `crates/rshogi-csa-server-workers/tests/miniflare_smoke/` に新設する
- 同ハーネスを `.github/workflows/workers-smoke.yml` から PR 単位で走らせ、Workers crate の wasm32 限定論理 (`game_room.rs` / `router.rs`) を host test で拾えなかった経路まで含めて回帰検出する
- `wrangler` を 3.114 → 4.85 へ更新 (legacy 化回避)、`miniflare` `vitest` `ws` `typescript` `@types/{node,ws}` を新規 pin、`pnpm.onlyBuiltDependencies` に `workerd` `esbuild` `sharp` を allow 登録

## 通電シナリオ (3 ファイル / 4 件)

- **smoke.test.ts**: LOGIN → AGREE → `+7776FU` / `-3334FU` → `%TORYO` → R2 `KIFU_BUCKET` に CSA V2.2 棋譜が書かれる
- **restart.test.ts**: 終局後に `mf.dispose()` → 同 persist root で再 instanciate → R2 棋譜オブジェクトが完全一致で読める (cross-instance 永続化)
- **reconnect.test.ts (正常)**: 黒切断 → 同 `Reconnect_Token` で再接続 → `LOGIN OK` + 状態再送 (Game_Summary 再構築 + `BEGIN Reconnect_State` ブロック with `Current_Turn:-` / `Black/White_Time_Remaining_Ms:`) → 続きの手で終局
- **reconnect.test.ts (異常)**: 不正 token は `LOGIN:incorrect reconnect_rejected` で拒否される (side-channel 防止経路を E2E 固定)

`Last_Move:` 行は CoreRoom が最終手 token を露出していない現状仕様で省略される。assertion で「行が存在しない」を固定し、将来 last_move 経路が実装された時点でテストが failing になって更新シグナルになるよう書く。

## 設計判断

- **Miniflare 4 直接利用** (`@cloudflare/vitest-pool-workers` ではなく)
  - Cloudflare 公式 docs の Rust worker テスト推奨経路 (`scriptPath` + `modulesRules` で worker-build 出力をロード)
  - vitest-pool-workers は WebSocket + DO の per-file storage isolation で公式に未対応 (workaround あり)
  - wrangler dev を spawn しないので port / kill / TTY 管理が不要、DO eviction を `mf.dispose()` で直接駆動できる
- **CI 統合は paths filter 付き push/PR 経路**: Workers crate / `Cargo.toml` / 本 workflow を変更した PR でのみ起動

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rshogi-csa-server-workers --all-targets -- -D warnings`
- [x] `cargo test -p rshogi-csa-server-workers --release` (host test 3 件)
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers`
- [x] ローカル: `pnpm test:smoke` (Vite+/pnpm 経由) で 4 件 / ~4s 全 pass
- [ ] CI 上で `Workers Smoke` workflow が pass することを確認 (本 PR の actions 結果)

🤖 Generated with [Claude Code](https://claude.com/claude-code)