### PR TITLE
fix(deploy-workers): smoke job の job-level if を撤去し step 内 gate に変更する

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -15,7 +15,8 @@
 # (`rshogi-csa-server-workers-staging` / `rshogi-csa-server-workers-production`)
 # ごとに登録する設計:
 #   - secrets   : `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
-#   - variables : `WORKERS_HEALTH_URL` (`/health` endpoint URL、未設定なら smoke skip)
+#   - variables : `WORKERS_HEALTH_URL` (`/health` endpoint URL、未設定なら smoke step が
+#                 warning を出して即 exit 0 で済ませる）
 # 各 job が `environment:` を宣言することで、その環境に紐付いた値だけが
 # 注入される（staging job が production token を取れない gating になる）。
 # Environment 名に crate prefix (`rshogi-csa-server-workers-`) を付けるのは、
@@ -179,11 +180,14 @@ jobs:
     name: Smoke check deployed worker (staging)
     runs-on: ubuntu-latest
     needs: deploy-staging
-    # `vars.WORKERS_HEALTH_URL` は本 job が `environment: rshogi-csa-server-workers-staging`
-    # を宣言しているため、staging Environment の variable から自動解決される。
-    # production Environment 側に同名の variable を登録していても、staging 側 URL が
-    # 取り違えられて curl される心配はない（GitHub Actions の environment binding 仕様）。
-    if: ${{ vars.WORKERS_HEALTH_URL != '' }}
+    # `environment:` 宣言により staging Environment の variables / secrets が
+    # step 実行時に注入される（production との取り違えは発生しない）。
+    #
+    # 注意: GitHub Actions の job-level `if:` は environment 解決の **前** に
+    # 評価されるため、`if: ${{ vars.WORKERS_HEALTH_URL != '' }}` のような形で
+    # gate すると Environment variable が見えず常に false になる。job 自体は
+    # 必ず起動させ、step 内の env で `vars.WORKERS_HEALTH_URL` を解決して
+    # 空ならその場で warning + exit 0 で skip 相当にする。
     environment: rshogi-csa-server-workers-staging
     timeout-minutes: 5
     steps:
@@ -191,6 +195,10 @@ jobs:
         env:
           HEALTH_URL: ${{ vars.WORKERS_HEALTH_URL }}
         run: |
+          if [ -z "$HEALTH_URL" ]; then
+            echo "::warning ::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-staging Environment; skipping smoke check"
+            exit 0
+          fi
           # Cloudflare 側の rollout は数秒〜数十秒の伝播時間がある。
           # 短い間隔で 5 回までリトライする。
           for attempt in 1 2 3 4 5; do
@@ -313,10 +321,10 @@ jobs:
     name: Smoke check deployed worker (production)
     runs-on: ubuntu-latest
     needs: deploy-production
-    # `vars.WORKERS_HEALTH_URL` は本 job が `environment: rshogi-csa-server-workers-production`
-    # を宣言しているため、production Environment の variable から自動解決される。
-    # staging 側との取り違えは発生しない（同 smoke-staging のコメント参照）。
-    if: ${{ vars.WORKERS_HEALTH_URL != '' }}
+    # `environment:` 宣言により production Environment の variables / secrets が
+    # step 実行時に注入される（staging との取り違えは発生しない、同 smoke-staging
+    # のコメント参照）。job-level `if:` での gate は environment 解決前に評価されて
+    # しまい Environment variable が見えないため、step 内 env 経由で gate する。
     environment: rshogi-csa-server-workers-production
     timeout-minutes: 5
     steps:
@@ -324,6 +332,10 @@ jobs:
         env:
           HEALTH_URL: ${{ vars.WORKERS_HEALTH_URL }}
         run: |
+          if [ -z "$HEALTH_URL" ]; then
+            echo "::warning ::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-production Environment; skipping smoke check"
+            exit 0
+          fi
           for attempt in 1 2 3 4 5; do
             echo "[attempt $attempt] curl $HEALTH_URL"
             if curl -fsS --max-time 10 "$HEALTH_URL"; then

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -94,7 +94,7 @@ jobs:
               echo
               echo "See \`docs/csa-server/deployment.md\` for initial setup."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning ::staging deploy skipped (environment secrets not configured)."
+            echo "::warning::staging deploy skipped (environment secrets not configured)."
           fi
 
   deploy-staging:
@@ -128,8 +128,8 @@ jobs:
       - name: Verify wrangler.staging.toml exists
         run: |
           test -f crates/rshogi-csa-server-workers/wrangler.staging.toml || {
-            echo "::error ::crates/rshogi-csa-server-workers/wrangler.staging.toml not found."
-            echo "::error ::Run from main branch with the file committed (see docs/csa-server/deployment.md)."
+            echo "::error::crates/rshogi-csa-server-workers/wrangler.staging.toml not found."
+            echo "::error::Run from main branch with the file committed (see docs/csa-server/deployment.md)."
             exit 1
           }
       # `cargo install` の成果物 (`~/.cargo/bin/worker-build`) は `Swatinem/rust-cache`
@@ -196,7 +196,7 @@ jobs:
           HEALTH_URL: ${{ vars.WORKERS_HEALTH_URL }}
         run: |
           if [ -z "$HEALTH_URL" ]; then
-            echo "::warning ::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-staging Environment; skipping smoke check"
+            echo "::warning::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-staging Environment; skipping smoke check"
             exit 0
           fi
           # Cloudflare 側の rollout は数秒〜数十秒の伝播時間がある。
@@ -210,7 +210,7 @@ jobs:
             fi
             sleep 5
           done
-          echo "::error ::Health check failed after 5 attempts. Investigate via 'cd crates/rshogi-csa-server-workers && vp run tail:staging'."
+          echo "::error::Health check failed after 5 attempts. Investigate via 'cd crates/rshogi-csa-server-workers && vp run tail:staging'."
           exit 1
 
   # ---------- production -----------------------------------------------------
@@ -243,7 +243,7 @@ jobs:
               echo
               echo "See \`docs/csa-server/deployment.md\` for initial setup."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning ::production deploy skipped (environment secrets not configured)."
+            echo "::warning::production deploy skipped (environment secrets not configured)."
           fi
 
   deploy-production:
@@ -273,8 +273,8 @@ jobs:
       - name: Verify wrangler.production.toml exists
         run: |
           test -f crates/rshogi-csa-server-workers/wrangler.production.toml || {
-            echo "::error ::crates/rshogi-csa-server-workers/wrangler.production.toml not found."
-            echo "::error ::Run from main branch with the file committed (see docs/csa-server/deployment.md)."
+            echo "::error::crates/rshogi-csa-server-workers/wrangler.production.toml not found."
+            echo "::error::Run from main branch with the file committed (see docs/csa-server/deployment.md)."
             exit 1
           }
       # ⚠️ バージョン更新時の二重管理に注意:
@@ -333,7 +333,7 @@ jobs:
           HEALTH_URL: ${{ vars.WORKERS_HEALTH_URL }}
         run: |
           if [ -z "$HEALTH_URL" ]; then
-            echo "::warning ::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-production Environment; skipping smoke check"
+            echo "::warning::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-production Environment; skipping smoke check"
             exit 0
           fi
           for attempt in 1 2 3 4 5; do
@@ -345,5 +345,5 @@ jobs:
             fi
             sleep 5
           done
-          echo "::error ::Health check failed after 5 attempts. Investigate via 'cd crates/rshogi-csa-server-workers && vp run tail:prod'."
+          echo "::error::Health check failed after 5 attempts. Investigate via 'cd crates/rshogi-csa-server-workers && vp run tail:prod'."
           exit 1

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -338,9 +338,17 @@ fail させる契約。
 [Cloudflare Dashboard → Workers & Pages → 各 worker → Triggers → Routes] でも
 確認できる。
 
-これを設定すると、deploy 完了後に CI が `/health` を curl で叩いて smoke check
-する step が起動する。値未設定なら smoke step は skip されるだけで deploy 自体
-は成功扱い。**§3 の初回 deploy が成功してから設定する** こと。
+これを設定すると、deploy 完了後に CI が `/health` を curl で叩いて 200 を確認する
+smoke step が走る。値未設定でも smoke job は起動するが、step 内で
+`::warning ::WORKERS_HEALTH_URL not set on <Environment> Environment; skipping smoke check`
+を出して `exit 0` で終わるため、CI 全体は成功扱いを維持したまま deploy 健全性
+チェックだけ skip される。**§3 の初回 deploy が成功してから設定する** こと。
+
+> ℹ️ 実装メモ: GitHub Actions の job-level `if:` は `environment:` 宣言の
+> 解決 **前** に評価されるため、`if: ${{ vars.WORKERS_HEALTH_URL != '' }}`
+> のような形では Environment variable が見えず常に false と評価される。
+> このため smoke job は job レベルで gate せず、必ず起動して step 内 env で
+> 解決した値を見て分岐する設計にしている。
 
 ## 3. 初回手動 deploy
 

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -340,7 +340,7 @@ fail させる契約。
 
 これを設定すると、deploy 完了後に CI が `/health` を curl で叩いて 200 を確認する
 smoke step が走る。値未設定でも smoke job は起動するが、step 内で
-`::warning ::WORKERS_HEALTH_URL not set on <Environment> Environment; skipping smoke check`
+`::warning::WORKERS_HEALTH_URL not set on <Environment> Environment; skipping smoke check`
 を出して `exit 0` で終わるため、CI 全体は成功扱いを維持したまま deploy 健全性
 チェックだけ skip される。**§3 の初回 deploy が成功してから設定する** こと。
 


### PR DESCRIPTION
## Summary

- `.github/workflows/deploy-workers.yml` の `smoke-staging` / `smoke-production` から `if: ${{ vars.WORKERS_HEALTH_URL != '' }}` を削除し、step 内 env 経由で `[ -z "$HEALTH_URL" ]` 判定する gate に変える。
- これにより、`environment:` 宣言で注入される Environment variable (`WORKERS_HEALTH_URL`) が step 実行時に解決されるようになり、登録済み URL に対して `/health` curl が走る。
- `docs/csa-server/deployment.md` §2.6 の挙動説明と workflow 冒頭コメントを新仕様に合わせて補正。
- 加えて、`.github/workflows/deploy-workers.yml` の `::warning ::` / `::error ::` (スペースあり) 全 10 箇所を GitHub Actions 正式仕様 `::warning::` / `::error::` (スペースなし) に sweep。スペースありの形式はパーサーに workflow command として認識されず、注釈として機能しないため。本 PR で追加した 2 箇所と、PR #511 由来の既存 8 箇所をまとめて修正。

## なぜ前 PR で動かなかったか

PR #511 で導入した smoke job は次の構造だった:

```yaml
smoke-staging:
  if: ${{ vars.WORKERS_HEALTH_URL != '' }}    # ← ここで弾かれる
  environment: rshogi-csa-server-workers-staging
```

GitHub Actions の仕様上、**job-level の `if:` は `environment:` 宣言の解決の前に評価される**。`vars.*` context は repository / organization variables だけが見え、Environment variable は environment 解決後に注入されるため、`if:` の評価時点では空文字と等価になる。結果として両 smoke job が常に skip 状態になり、実機で `gh workflow run -f target=production` を回しても `smoke-production` が `conclusion=skipped` のまま終わっていた。

## 修正後の構造

```yaml
smoke-staging:
  needs: deploy-staging
  environment: rshogi-csa-server-workers-staging
  steps:
    - name: Curl /health endpoint
      env:
        HEALTH_URL: ${{ vars.WORKERS_HEALTH_URL }}    # ← step 実行時に解決
      run: |
        if [ -z "$HEALTH_URL" ]; then
          echo "::warning ::WORKERS_HEALTH_URL not set on rshogi-csa-server-workers-staging Environment; skipping smoke check"
          exit 0
        fi
        # 既存の curl リトライロジック
```

job 自体は必ず起動するが、空なら warning 出して即 exit 0 で終わるので、CI 全体は成功扱いを維持する。`vars.WORKERS_HEALTH_URL` は step 実行時には Environment binding 経由で正しく解決される。

## 実機での顕在化と検証経路

PR #511 merge 直後の検証で次の事象を確認した:

1. main push trigger → staging auto deploy 成功、`smoke-staging` は skipped (variable 未登録のため意図通りに見えていた)
2. staging Environment に `WORKERS_HEALTH_URL = https://rshogi-csa-server-workers-staging.sh11235.workers.dev/health` を登録
3. production Environment に同様に登録 + 初回 dispatch deploy 成功
4. **production を再 dispatch しても `smoke-production` が `conclusion=skipped`** のまま
5. ログ追跡で `if:` の job-level 評価タイミング問題に着地 → 本 PR で gate を step 内に移動

本 PR merge 後、次の dispatch (`gh workflow run deploy-workers.yml --ref main -f target=staging` or `target=production`) で smoke job が実際に curl を実行し `conclusion=success` で終わることで動作確認が完結する。

## 主な変更ファイル

| ファイル | 内容 |
|---|---|
| `.github/workflows/deploy-workers.yml` | smoke-staging / smoke-production の job-level `if:` 削除、step 内 env gate 追加、関連コメントの追従。preflight / deploy 系の `if:` (event_name / inputs.target / needs ベース) は無変更 |
| `docs/csa-server/deployment.md` | §2.6 の挙動説明を新 gate 設計に合わせて書き換え。実装メモとして「job-level `if:` が environment 解決前に評価される」事実を 1 ブロック追記 |

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-workers.yml'))"` で YAML が valid、6 jobs 構成維持を確認
- [x] smoke-staging / smoke-production から job-level `if:` が消え、preflight / deploy 系の `if:` は無変更であることを確認
- [ ] **post-merge**: `gh workflow run deploy-workers.yml --ref main -f target=staging` を回して `smoke-staging` が success で終わることを確認
- [ ] **post-merge**: `gh workflow run deploy-workers.yml --ref main -f target=production` を回して `smoke-production` が success で終わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
