### PR TITLE
GameRoom DO の終局経路で Floodgate 履歴を R2 に永続化する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/datetime.rs
+++ b/crates/rshogi-csa-server-workers/src/datetime.rs
@@ -18,6 +18,13 @@ pub fn format_date_path(epoch_ms: u64) -> String {
     dt.format("%Y/%m/%d").to_string()
 }
 
+/// RFC3339（UTC、秒単位、`Z` サフィックス）に整形する。`FloodgateHistoryEntry`
+/// の `start_time` / `end_time` 契約に揃えるための共通ヘルパで、`R2FloodgateHistoryStorage`
+/// の `entry_key` が `DateTime::parse_from_rfc3339` で読み戻せる書式と一致させる。
+pub fn format_rfc3339_utc(epoch_ms: u64) -> String {
+    to_utc(epoch_ms).to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
 fn to_utc(epoch_ms: u64) -> chrono::DateTime<chrono::Utc> {
     let secs = (epoch_ms / 1000).min(i64::MAX as u64) as i64;
     chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
@@ -61,5 +68,16 @@ mod tests {
         assert_eq!(format_date_path(1_705_363_199_000), "2024/01/15");
         // 2024-01-16 00:00:00 → 2024/01/16
         assert_eq!(format_date_path(1_705_363_200_000), "2024/01/16");
+    }
+
+    #[test]
+    fn format_rfc3339_utc_known_point() {
+        // 2024-01-15 09:30:45 UTC = 1_705_311_045_000 ms
+        assert_eq!(format_rfc3339_utc(1_705_311_045_000), "2024-01-15T09:30:45Z");
+    }
+
+    #[test]
+    fn format_rfc3339_utc_drops_sub_second() {
+        assert_eq!(format_rfc3339_utc(1_705_311_045_999), "2024-01-15T09:30:45Z");
     }
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -54,14 +54,18 @@ use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
 };
-use rshogi_csa_server::record::kifu::{fork_initial_sfen_from_kifu, initial_sfen_from_csa_moves};
+use rshogi_csa_server::record::kifu::{
+    fork_initial_sfen_from_kifu, initial_sfen_from_csa_moves, winner_of,
+};
 use rshogi_csa_server::types::{
     Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken,
 };
+use rshogi_csa_server::{FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor};
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::{ConfigKeys, parse_clock_spec, parse_reconnect_grace_duration};
-use crate::datetime::{format_csa_datetime, format_date_path};
+use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
+use crate::floodgate_history::R2FloodgateHistoryStorage;
 use crate::persistence::{
     FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
 };
@@ -984,6 +988,15 @@ impl GameRoom {
             console_log!("[GameRoom] kifu export failed: {e:?}");
         }
 
+        // Floodgate 履歴の R2 永続化も同じ best-effort 方針。`ALLOW_FLOODGATE_FEATURES`
+        // が立っていなければ何もしない。TCP 側 (`server.rs`) は append 失敗時に
+        // `ServerError::Storage` を伝播するが、Workers DO で Err を返すと alarm /
+        // ws close が抜ける副作用があるため、kifu export と同じ silent log 方針で
+        // 終局処理の前進を優先する。
+        if let Err(e) = self.try_persist_floodgate_history(game_result, &code, ended_at_ms).await {
+            console_log!("[GameRoom] floodgate history persist failed: {e:?}");
+        }
+
         let finished = FinishedState {
             result_code: code,
             ended_at_ms,
@@ -1068,6 +1081,48 @@ impl GameRoom {
         bucket.put(&key, text.as_bytes().to_vec()).execute().await?;
         bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
         console_log!("[GameRoom] kifu exported to R2 key='{key}'");
+        Ok(())
+    }
+
+    /// Floodgate 履歴 1 件を `FLOODGATE_HISTORY_BUCKET` に永続化する。`ALLOW_FLOODGATE_FEATURES`
+    /// が opt-in されており、binding が設定されているときだけ append する。
+    /// 失敗は `console_log!` のみで伝播させない（呼び出し側 `finalize_if_ended` で
+    /// 終局確定の前進を止めない方針）。
+    async fn try_persist_floodgate_history(
+        &self,
+        game_result: &rshogi_csa_server::game::result::GameResult,
+        result_code: &str,
+        ended_at_ms: u64,
+    ) -> Result<()> {
+        let storage = match resolve_floodgate_history_storage(&self.env) {
+            Ok(Some(s)) => s,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                console_log!("[GameRoom] floodgate history disabled: {e}");
+                return Ok(());
+            }
+        };
+
+        let cfg = match self.config.borrow().as_ref() {
+            Some(c) => c.clone(),
+            None => return Ok(()),
+        };
+
+        let start_ms = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
+        let entry = FloodgateHistoryEntry {
+            game_id: cfg.game_id.clone(),
+            game_name: cfg.game_name.clone(),
+            black: cfg.black_handle.clone(),
+            white: cfg.white_handle.clone(),
+            start_time: format_rfc3339_utc(start_ms),
+            end_time: format_rfc3339_utc(ended_at_ms),
+            result_code: result_code.to_owned(),
+            winner: winner_of(game_result).map(HistoryColor::from),
+        };
+
+        if let Err(e) = storage.append(&entry).await {
+            console_log!("[GameRoom] floodgate history append failed: {e:?}");
+        }
         Ok(())
     }
 
@@ -1650,4 +1705,34 @@ fn resolve_reconnect_grace(env: &Env) -> std::result::Result<Duration, String> {
     };
     validate_floodgate_feature_gate(allow, intent)?;
     Ok(grace)
+}
+
+/// `ALLOW_FLOODGATE_FEATURES` env と `FLOODGATE_HISTORY_BUCKET` binding を読み、
+/// 履歴永続化用の `R2FloodgateHistoryStorage` を返す。opt-in されていない、または
+/// dev 環境で binding が宣言されていない場合は `Ok(None)` で skip する。
+///
+/// `validate_floodgate_feature_gate` の `enable_floodgate_history` ブランチに
+/// 対応するため、master switch (`allow`) が立っている前提で intent を組み、
+/// 設定不正は `Err(String)` で呼び出し側 (`finalize_if_ended`) のログ経路に流す。
+fn resolve_floodgate_history_storage(
+    env: &Env,
+) -> std::result::Result<Option<R2FloodgateHistoryStorage>, String> {
+    let allow_raw = env.var(ConfigKeys::ALLOW_FLOODGATE_FEATURES).ok().map(|v| v.to_string());
+    let allow = parse_allow_floodgate_features(allow_raw.as_deref())?;
+    if !allow {
+        return Ok(None);
+    }
+    let intent = FloodgateFeatureIntent {
+        enable_floodgate_history: true,
+        ..FloodgateFeatureIntent::default()
+    };
+    validate_floodgate_feature_gate(allow, intent)?;
+
+    if env.bucket(ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING).is_err() {
+        return Ok(None);
+    }
+    Ok(Some(R2FloodgateHistoryStorage::new(
+        env.clone(),
+        ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING,
+    )))
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -992,10 +992,9 @@ impl GameRoom {
         // が立っていなければ何もしない。TCP 側 (`server.rs`) は append 失敗時に
         // `ServerError::Storage` を伝播するが、Workers DO で Err を返すと alarm /
         // ws close が抜ける副作用があるため、kifu export と同じ silent log 方針で
-        // 終局処理の前進を優先する。
-        if let Err(e) = self.try_persist_floodgate_history(game_result, &code, ended_at_ms).await {
-            console_log!("[GameRoom] floodgate history persist failed: {e:?}");
-        }
+        // 終局処理の前進を優先する。失敗は `try_persist_floodgate_history` 内で
+        // `console_log!` のみで吸収するため呼び出し側は `Result` を待たない。
+        self.try_persist_floodgate_history(game_result, &code, ended_at_ms).await;
 
         let finished = FinishedState {
             result_code: code,
@@ -1086,26 +1085,30 @@ impl GameRoom {
 
     /// Floodgate 履歴 1 件を `FLOODGATE_HISTORY_BUCKET` に永続化する。`ALLOW_FLOODGATE_FEATURES`
     /// が opt-in されており、binding が設定されているときだけ append する。
-    /// 失敗は `console_log!` のみで伝播させない（呼び出し側 `finalize_if_ended` で
-    /// 終局確定の前進を止めない方針）。
+    /// すべての失敗は `console_log!` で握り潰して呼び出し側 `finalize_if_ended` の
+    /// 終局確定の前進を止めない（best-effort）。`Result` を返さないことで
+    /// シグネチャと振る舞いを一致させ、「Err を返し得る」と誤読される余地を消す。
     async fn try_persist_floodgate_history(
         &self,
         game_result: &rshogi_csa_server::game::result::GameResult,
         result_code: &str,
         ended_at_ms: u64,
-    ) -> Result<()> {
+    ) {
         let storage = match resolve_floodgate_history_storage(&self.env) {
             Ok(Some(s)) => s,
-            Ok(None) => return Ok(()),
+            Ok(None) => return,
             Err(e) => {
-                console_log!("[GameRoom] floodgate history disabled: {e}");
-                return Ok(());
+                // `Err` 経路は `parse_allow_floodgate_features` の解析エラーまたは
+                // `validate_floodgate_feature_gate` の opt-in 漏れ等の **設定不正**。
+                // opt-in 未有効 (`Ok(None)`) と区別がつくよう "config error" を明示する。
+                console_log!("[GameRoom] floodgate history config error: {e}");
+                return;
             }
         };
 
         let cfg = match self.config.borrow().as_ref() {
             Some(c) => c.clone(),
-            None => return Ok(()),
+            None => return,
         };
 
         let start_ms = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
@@ -1123,7 +1126,6 @@ impl GameRoom {
         if let Err(e) = storage.append(&entry).await {
             console_log!("[GameRoom] floodgate history append failed: {e:?}");
         }
-        Ok(())
     }
 
     /// マッチ開始直前の致命的条件（buoy 枯渇等）で対局を開始できない場合に、

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/floodgate_history.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/floodgate_history.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CsaClient,
+  createMiniflare,
+  getFloodgateHistoryBucket,
+  makeTempPersistRoot,
+  pollFloodgateHistoryForGameId,
+} from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: Floodgate 履歴 R2 永続化 E2E", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("ALLOW_FLOODGATE_FEATURES=true で 1 対局終局後に floodgate-history/ オブジェクトが書かれる", async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      allowFloodgateFeatures: true,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+
+    const roomId = "floodgate-history-room-1";
+    const gameName = "fg-60-1";
+    const blackHandle = "alice";
+    const whiteHandle = "bob";
+    const blackName = `${blackHandle}+${gameName}+black`;
+    const whiteName = `${whiteHandle}+${gameName}+white`;
+
+    const black = await CsaClient.connect(mf, roomId);
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    await black.drainGameSummary();
+    await white.drainGameSummary();
+
+    black.send("AGREE");
+    white.send("AGREE");
+    const startBlack = await black.recvLine();
+    await white.recvLine();
+    const gameId = startBlack.slice("START:".length);
+    expect(gameId.length).toBeGreaterThan(0);
+
+    black.send("+7776FU");
+    await black.recvUntil((l) => l.startsWith("+7776FU"));
+    await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+    white.send("-3334FU");
+    await black.recvUntil((l) => l.startsWith("-3334FU"));
+    await white.recvUntil((l) => l.startsWith("-3334FU"));
+
+    black.send("%TORYO");
+    await black.recvUntil((l) => l === "#LOSE");
+
+    const r2 = await getFloodgateHistoryBucket(mf);
+    const matched = await pollFloodgateHistoryForGameId(r2, gameId);
+    expect(matched.length).toBe(1);
+    const key = matched[0]!.key;
+    // キー命名規則 `floodgate-history/{YYYY}/{MM}/{DD}/{HHMMSS}-{game_id}.json` の
+    // 全要素が揃っていることを 1 段で固定する。
+    expect(key).toMatch(
+      /^floodgate-history\/\d{4}\/\d{2}\/\d{2}\/\d{6}-[\w-]+\.json$/,
+    );
+    expect(key.endsWith(`-${gameId}.json`)).toBe(true);
+
+    const obj = await r2.get(key);
+    expect(obj).not.toBeNull();
+    const body = await obj!.text();
+    const entry = JSON.parse(body) as {
+      game_id: string;
+      game_name: string;
+      black: string;
+      white: string;
+      start_time: string;
+      end_time: string;
+      result_code: string;
+      winner?: "Black" | "White";
+    };
+    expect(entry.game_id).toBe(gameId);
+    expect(entry.game_name).toBe(gameName);
+    // entry の black / white は CSA LOGIN ハンドルの末尾 `+game_name+color` を
+    // 落とした handle 部分（TCP `JsonlFloodgateHistoryStorage::append` と同じ
+    // 契約）。
+    expect(entry.black).toBe(blackHandle);
+    expect(entry.white).toBe(whiteHandle);
+    expect(entry.result_code).toBe("#RESIGN");
+    expect(entry.winner).toBe("White");
+    // RFC3339 (UTC, `Z` サフィックス、秒精度) を `format_rfc3339_utc` 経由で出すため
+    // タイムゾーン ofset 表記は混入しない契約。
+    expect(entry.start_time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(entry.end_time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+
+    await black.close();
+    await white.close();
+  });
+
+  it("ALLOW_FLOODGATE_FEATURES=false では floodgate-history/ オブジェクトが書かれない", async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    // opt-in しない構成では履歴永続化を skip する契約を回帰防止する。
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      allowFloodgateFeatures: false,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+
+    const roomId = "floodgate-history-room-2";
+    const gameName = "fg-60-1";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black = await CsaClient.connect(mf, roomId);
+    black.send(`LOGIN ${blackName} pw`);
+    await black.recvLine();
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    await white.recvLine();
+    await black.drainGameSummary();
+    await white.drainGameSummary();
+    black.send("AGREE");
+    white.send("AGREE");
+    await black.recvLine();
+    await white.recvLine();
+
+    black.send("%TORYO");
+    await black.recvUntil((l) => l === "#LOSE");
+
+    const r2 = await getFloodgateHistoryBucket(mf);
+    // 終局直後に DO put が走り得るので、書かれないことを観測するには append 経路が
+    // 走る期間を一定時間 wait する必要がある。`pollFloodgateHistoryForGameId` の
+    // 既定 5000ms より短い 1500ms で確定させ、念のため list 結果が空であることを assert。
+    await new Promise((r) => setTimeout(r, 1500));
+    const list = await r2.list({ prefix: "floodgate-history/" });
+    expect(list.objects.length).toBe(0);
+
+    await black.close();
+    await white.close();
+  });
+});

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -36,14 +36,22 @@ export interface R2ObjectLike {
 }
 
 export async function getKifuBucket(mf: Miniflare): Promise<R2BucketLike> {
-  const raw = (await mf.getR2Bucket("KIFU_BUCKET")) as unknown as R2BucketLike;
+  return getR2BucketByBinding(mf, "KIFU_BUCKET");
+}
+
+export async function getFloodgateHistoryBucket(mf: Miniflare): Promise<R2BucketLike> {
+  return getR2BucketByBinding(mf, "FLOODGATE_HISTORY_BUCKET");
+}
+
+async function getR2BucketByBinding(mf: Miniflare, binding: string): Promise<R2BucketLike> {
+  const raw = (await mf.getR2Bucket(binding)) as unknown as R2BucketLike;
   // 将来 miniflare のメジャーアップで `list` / `get` が rename された場合に
   // 型崩落で silent に壊れる経路を避けるため、duck-type 違反を runtime で
   // 早期検出する。型 cast (`as unknown as R2BucketLike`) を使っている以上、
   // 整合性検証は実装側で持つ責務。
   if (typeof raw.list !== "function" || typeof raw.get !== "function") {
     throw new Error(
-      "miniflare R2Bucket API に list/get が見つからない: " +
+      `miniflare R2Bucket API (${binding}) に list/get が見つからない: ` +
         "miniflare メジャーアップで API rename された可能性。harness の duck-type を更新する必要あり",
     );
   }
@@ -134,6 +142,34 @@ export async function pollR2ForGameId(
       const seen = list.objects.map((o: { key: string }) => o.key);
       throw new Error(
         `R2 object for game_id=${gameId} not found within ${timeoutMs}ms; current keys: ${JSON.stringify(seen)}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+/// `FLOODGATE_HISTORY_BUCKET` 配下を `floodgate-history/` prefix で列挙し、
+/// `game_id` を含むキーを待機列挙する。終局確定後に DO の `try_persist_floodgate_history`
+/// が put を完了するまでの race を吸収するため、polling の deadline / interval を
+/// 設ける。`pollR2ForGameId` (`KIFU_BUCKET`) と分離しているのは、prefix を絞った
+/// list をデフォルトにして他テストの kifu キーが混ざらないようにするため。
+export async function pollFloodgateHistoryForGameId(
+  bucket: R2BucketLike,
+  gameId: string,
+  { timeoutMs = 5000, intervalMs = 100 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<{ key: string }[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const list = await bucket.list({ prefix: "floodgate-history/" });
+    const matched = list.objects
+      .filter((o: { key: string }) => o.key.includes(gameId))
+      .map((o: { key: string }) => ({ key: o.key }));
+    if (matched.length > 0) return matched;
+    if (Date.now() > deadline) {
+      const seen = list.objects.map((o: { key: string }) => o.key);
+      throw new Error(
+        `floodgate history object for game_id=${gameId} not found within ${timeoutMs}ms; ` +
+          `current keys under floodgate-history/: ${JSON.stringify(seen)}`,
       );
     }
     await new Promise((r) => setTimeout(r, intervalMs));


### PR DESCRIPTION
## Summary
- `finalize_if_ended` で `export_kifu_to_r2` 直後に `R2FloodgateHistoryStorage::append` を呼ぶ経路を追加。`ALLOW_FLOODGATE_FEATURES` opt-in + `FLOODGATE_HISTORY_BUCKET` binding 設定済みの場合のみ 1 対局 = 1 R2 オブジェクトを書き出す
- `resolve_floodgate_history_storage` ヘルパを `resolve_reconnect_grace` 隣に追加し、env 解析と feature gate 判定を 1 か所に集約
- 失敗は `console_log!` のみで終局前進を止めない (TCP `server.rs` の `Err(ServerError::Storage)` 伝播と意図的に非対称、kifu export と同じ best-effort 方針)
- `format_rfc3339_utc(epoch_ms)` を `datetime` に追加。`FloodgateHistoryEntry` の RFC3339 契約と round-trip する書式 (UTC / 秒精度 / `Z` サフィックス)
- Miniflare smoke E2E に `floodgate_history.test.ts` を新設し、opt-in / opt-out 両経路を回帰防止

## 設計判断
- TCP `server.rs:2931-2952` は `state.history_storage.as_ref()` 単一 gate で全 match を append、game_name フィルタ無し。Workers 側もこの仕様に揃えた
- `SharedState<R, K, P, H>` の `H` 経路は採用せず flat helper で抽象化を抑える (YAGNI)。trait は将来差し替え用に export 維持
- TCP との Err 伝播 vs Workers best-effort log 非対称は、Workers DO が Err を返すと alarm/ws close 側 step が抜けて部屋が中途半端な状態で残る副作用を回避するための意図的選択

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p rshogi-csa-server-workers --all-targets -- -D warnings`
- [x] `cargo test -p rshogi-csa-server-workers` (lib + integration 全 pass、新規 `format_rfc3339_utc_*` 2 件含む)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- [x] `vp run build` (worker-build) 成功
- [x] `MINIFLARE_SMOKE_SKIP_BUILD=1 vp run test:smoke` (4 ファイル / 6 件 pass、新規 floodgate_history.test.ts 2 件含む)
- [x] `vp exec tsc -p tests/miniflare_smoke/tsconfig.json` 型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)