### PR TITLE
feat(csa-server): ClientCommand 直列化関数を pub 公開し csa_client 送信側を集約する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ dependencies = [
  "reqwest",
  "rshogi-core",
  "rshogi-csa",
+ "rshogi-csa-server",
  "serde",
  "serde_json",
  "sysinfo",

--- a/crates/rshogi-csa-server/src/lib.rs
+++ b/crates/rshogi-csa-server/src/lib.rs
@@ -36,7 +36,9 @@ pub use matching::registry::{GameListing, GameRegistry};
 pub use port::{
     BroadcastTag, Broadcaster, BuoyStorage, ClientTransport, KifuStorage, RateDecision, RateStorage,
 };
-pub use protocol::command::{ClientCommand, parse_command};
+pub use protocol::command::{
+    ClientCommand, ReconnectRequest, color_of_move, parse_command, serialize_client_command,
+};
 pub use protocol::info::{help_lines, list_lines, show_lines, version_lines, who_lines};
 pub use protocol::summary::{GameSummaryBuilder, standard_initial_position_block};
 pub use record::kifu::{

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -421,6 +421,110 @@ pub fn color_of_move(token: &CsaMoveToken) -> Option<Color> {
     }
 }
 
+/// [`ClientCommand`] を CSA プロトコル 1 行に直列化する（行末改行は含めない）。
+///
+/// クライアント → サーバー方向の送信側で、`format!("LOGIN {id} {pw}")` のような
+/// 散在する文字列組み立てを 1 関数に集約するためのヘルパ。サーバー側の
+/// [`parse_command`] と組で動き、roundtrip プロパティ
+/// `parse_command(serialize_client_command(c))` が等値性を満たすことを
+/// テストで担保する（標準コマンド・x1 拡張コマンドそれぞれに対し）。
+///
+/// 注意:
+/// - [`ClientCommand::KeepAlive`] は空文字列を返す（呼び出し側で改行のみを送る運用）。
+/// - [`ClientCommand::Move::comment`] の値は CSA `'` プレフィックス**抜き**の本体を期待し、
+///   出力では `,'<comment>` の形に整える（[`parse_command`] と対称）。
+pub fn serialize_client_command(cmd: &ClientCommand) -> String {
+    match cmd {
+        ClientCommand::Login {
+            name,
+            password,
+            x1,
+            reconnect,
+        } => {
+            let mut s = format!("LOGIN {} {}", name.as_str(), password.expose());
+            if *x1 {
+                s.push_str(" x1");
+            } else if let Some(rec) = reconnect {
+                s.push_str(" reconnect:");
+                s.push_str(rec.game_id.as_str());
+                s.push('+');
+                s.push_str(rec.token.as_str());
+            }
+            s
+        }
+        ClientCommand::Logout => "LOGOUT".to_owned(),
+        ClientCommand::Agree { game_id } => match game_id {
+            Some(g) => format!("AGREE {}", g.as_str()),
+            None => "AGREE".to_owned(),
+        },
+        ClientCommand::Reject { game_id } => match game_id {
+            Some(g) => format!("REJECT {}", g.as_str()),
+            None => "REJECT".to_owned(),
+        },
+        ClientCommand::Move { token, comment } => match comment {
+            Some(c) => format!("{},'{}", token.as_str(), c),
+            None => token.as_str().to_owned(),
+        },
+        ClientCommand::Toryo => "%TORYO".to_owned(),
+        ClientCommand::Kachi => "%KACHI".to_owned(),
+        ClientCommand::Chudan => "%CHUDAN".to_owned(),
+        ClientCommand::KeepAlive => String::new(),
+        ClientCommand::Who => "%%WHO".to_owned(),
+        ClientCommand::List => "%%LIST".to_owned(),
+        ClientCommand::Show { game_id } => format!("%%SHOW {}", game_id.as_str()),
+        ClientCommand::Monitor2On { game_id } => format!("%%MONITOR2ON {}", game_id.as_str()),
+        ClientCommand::Monitor2Off { game_id } => format!("%%MONITOR2OFF {}", game_id.as_str()),
+        ClientCommand::Chat { message } => format!("%%CHAT {message}"),
+        ClientCommand::Version => "%%VERSION".to_owned(),
+        ClientCommand::Help => "%%HELP".to_owned(),
+        ClientCommand::SetBuoy {
+            game_name,
+            moves,
+            count,
+        } => {
+            let mut s = format!("%%SETBUOY {}", game_name.as_str());
+            for m in moves {
+                s.push(' ');
+                s.push_str(m.as_str());
+            }
+            s.push(' ');
+            s.push_str(&count.to_string());
+            s
+        }
+        ClientCommand::DeleteBuoy { game_name } => {
+            format!("%%DELETEBUOY {}", game_name.as_str())
+        }
+        ClientCommand::GetBuoyCount { game_name } => {
+            format!("%%GETBUOYCOUNT {}", game_name.as_str())
+        }
+        ClientCommand::Fork {
+            source_game,
+            new_buoy,
+            nth_move,
+        } => {
+            let mut s = format!("%%FORK {}", source_game.as_str());
+            match (new_buoy, nth_move) {
+                (Some(b), Some(n)) => {
+                    s.push(' ');
+                    s.push_str(b.as_str());
+                    s.push(' ');
+                    s.push_str(&n.to_string());
+                }
+                (Some(b), None) => {
+                    s.push(' ');
+                    s.push_str(b.as_str());
+                }
+                (None, Some(n)) => {
+                    s.push(' ');
+                    s.push_str(&n.to_string());
+                }
+                (None, None) => {}
+            }
+            s
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -698,5 +802,215 @@ mod tests {
         assert_eq!(color_of_move(&CsaMoveToken::new("+7776FU")), Some(Color::Black));
         assert_eq!(color_of_move(&CsaMoveToken::new("-3334FU")), Some(Color::White));
         assert_eq!(color_of_move(&CsaMoveToken::new("7776FU")), None);
+    }
+
+    #[test]
+    fn serialize_login_basic_and_x1_and_reconnect() {
+        let basic = ClientCommand::Login {
+            name: PlayerName::new("alice"),
+            password: Secret::new("pw"),
+            x1: false,
+            reconnect: None,
+        };
+        assert_eq!(serialize_client_command(&basic), "LOGIN alice pw");
+
+        let x1 = ClientCommand::Login {
+            name: PlayerName::new("bob"),
+            password: Secret::new("secret"),
+            x1: true,
+            reconnect: None,
+        };
+        assert_eq!(serialize_client_command(&x1), "LOGIN bob secret x1");
+
+        let rec = ClientCommand::Login {
+            name: PlayerName::new("carol"),
+            password: Secret::new("p"),
+            x1: false,
+            reconnect: Some(ReconnectRequest {
+                game_id: GameId::new("20260427120000"),
+                token: ReconnectToken::new("abcd1234"),
+            }),
+        };
+        assert_eq!(
+            serialize_client_command(&rec),
+            "LOGIN carol p reconnect:20260427120000+abcd1234"
+        );
+    }
+
+    #[test]
+    fn serialize_move_with_and_without_comment() {
+        let bare = ClientCommand::Move {
+            token: CsaMoveToken::new("+7776FU"),
+            comment: None,
+        };
+        assert_eq!(serialize_client_command(&bare), "+7776FU");
+
+        let with = ClientCommand::Move {
+            token: CsaMoveToken::new("+7776FU"),
+            comment: Some("* 123 +7776FU -3334FU".to_owned()),
+        };
+        assert_eq!(serialize_client_command(&with), "+7776FU,'* 123 +7776FU -3334FU");
+    }
+
+    #[test]
+    fn serialize_special_and_x1_simple_commands() {
+        assert_eq!(serialize_client_command(&ClientCommand::Logout), "LOGOUT");
+        assert_eq!(serialize_client_command(&ClientCommand::Toryo), "%TORYO");
+        assert_eq!(serialize_client_command(&ClientCommand::Kachi), "%KACHI");
+        assert_eq!(serialize_client_command(&ClientCommand::Chudan), "%CHUDAN");
+        assert_eq!(serialize_client_command(&ClientCommand::KeepAlive), "");
+        assert_eq!(serialize_client_command(&ClientCommand::Who), "%%WHO");
+        assert_eq!(serialize_client_command(&ClientCommand::List), "%%LIST");
+        assert_eq!(serialize_client_command(&ClientCommand::Version), "%%VERSION");
+        assert_eq!(serialize_client_command(&ClientCommand::Help), "%%HELP");
+    }
+
+    #[test]
+    fn serialize_agree_reject_with_optional_id() {
+        assert_eq!(serialize_client_command(&ClientCommand::Agree { game_id: None }), "AGREE");
+        assert_eq!(
+            serialize_client_command(&ClientCommand::Agree {
+                game_id: Some(GameId::new("g1"))
+            }),
+            "AGREE g1"
+        );
+        assert_eq!(serialize_client_command(&ClientCommand::Reject { game_id: None }), "REJECT");
+    }
+
+    #[test]
+    fn serialize_buoy_and_fork() {
+        let setbuoy = ClientCommand::SetBuoy {
+            game_name: GameName::new("buoy1"),
+            moves: vec![CsaMoveToken::new("+7776FU"), CsaMoveToken::new("-3334FU")],
+            count: 5,
+        };
+        assert_eq!(serialize_client_command(&setbuoy), "%%SETBUOY buoy1 +7776FU -3334FU 5");
+
+        let del = ClientCommand::DeleteBuoy {
+            game_name: GameName::new("buoy1"),
+        };
+        assert_eq!(serialize_client_command(&del), "%%DELETEBUOY buoy1");
+
+        let count = ClientCommand::GetBuoyCount {
+            game_name: GameName::new("buoy1"),
+        };
+        assert_eq!(serialize_client_command(&count), "%%GETBUOYCOUNT buoy1");
+
+        let f0 = ClientCommand::Fork {
+            source_game: GameId::new("g"),
+            new_buoy: None,
+            nth_move: None,
+        };
+        assert_eq!(serialize_client_command(&f0), "%%FORK g");
+
+        let f1 = ClientCommand::Fork {
+            source_game: GameId::new("g"),
+            new_buoy: Some(GameName::new("forked")),
+            nth_move: None,
+        };
+        assert_eq!(serialize_client_command(&f1), "%%FORK g forked");
+
+        let f2 = ClientCommand::Fork {
+            source_game: GameId::new("g"),
+            new_buoy: None,
+            nth_move: Some(24),
+        };
+        assert_eq!(serialize_client_command(&f2), "%%FORK g 24");
+
+        let f3 = ClientCommand::Fork {
+            source_game: GameId::new("g"),
+            new_buoy: Some(GameName::new("forked")),
+            nth_move: Some(24),
+        };
+        assert_eq!(serialize_client_command(&f3), "%%FORK g forked 24");
+    }
+
+    #[test]
+    fn parse_then_serialize_then_parse_is_stable_for_all_variants() {
+        // parse_command(serialize(cmd)) == cmd を主要バリアントに対して確認する
+        // (Secret は PartialEq 実装で expose 値に基づくので Login も等価判定可能)。
+        let samples = vec![
+            ClientCommand::Login {
+                name: PlayerName::new("alice"),
+                password: Secret::new("pw"),
+                x1: false,
+                reconnect: None,
+            },
+            ClientCommand::Login {
+                name: PlayerName::new("bob"),
+                password: Secret::new("s"),
+                x1: true,
+                reconnect: None,
+            },
+            ClientCommand::Login {
+                name: PlayerName::new("carol"),
+                password: Secret::new("p"),
+                x1: false,
+                reconnect: Some(ReconnectRequest {
+                    game_id: GameId::new("20260427120000"),
+                    token: ReconnectToken::new("abcd1234"),
+                }),
+            },
+            ClientCommand::Logout,
+            ClientCommand::Agree { game_id: None },
+            ClientCommand::Agree {
+                game_id: Some(GameId::new("g1")),
+            },
+            ClientCommand::Reject { game_id: None },
+            ClientCommand::Move {
+                token: CsaMoveToken::new("+7776FU"),
+                comment: None,
+            },
+            ClientCommand::Move {
+                token: CsaMoveToken::new("+7776FU"),
+                comment: Some("* 100 +7776FU -3334FU".to_owned()),
+            },
+            ClientCommand::Toryo,
+            ClientCommand::Kachi,
+            ClientCommand::Chudan,
+            ClientCommand::KeepAlive,
+            ClientCommand::Who,
+            ClientCommand::List,
+            ClientCommand::Show {
+                game_id: GameId::new("g1"),
+            },
+            ClientCommand::Monitor2On {
+                game_id: GameId::new("g1"),
+            },
+            ClientCommand::Monitor2Off {
+                game_id: GameId::new("g1"),
+            },
+            ClientCommand::Version,
+            ClientCommand::Help,
+            ClientCommand::SetBuoy {
+                game_name: GameName::new("buoy1"),
+                moves: vec![CsaMoveToken::new("+7776FU"), CsaMoveToken::new("-3334FU")],
+                count: 5,
+            },
+            ClientCommand::DeleteBuoy {
+                game_name: GameName::new("buoy1"),
+            },
+            ClientCommand::GetBuoyCount {
+                game_name: GameName::new("buoy1"),
+            },
+            ClientCommand::Fork {
+                source_game: GameId::new("g"),
+                new_buoy: None,
+                nth_move: None,
+            },
+            ClientCommand::Fork {
+                source_game: GameId::new("g"),
+                new_buoy: Some(GameName::new("forked")),
+                nth_move: Some(24),
+            },
+        ];
+
+        for cmd in samples {
+            let line = serialize_client_command(&cmd);
+            let parsed = parse_command(&CsaLine::new(&line)).unwrap_or_else(|e| {
+                panic!("parse failed for serialized `{line}` ({cmd:?}): {e:?}")
+            });
+            assert_eq!(parsed, cmd, "roundtrip mismatch for {cmd:?} => `{line}`");
+        }
     }
 }

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -1003,6 +1003,14 @@ mod tests {
                 new_buoy: Some(GameName::new("forked")),
                 nth_move: Some(24),
             },
+            ClientCommand::Fork {
+                source_game: GameId::new("g"),
+                new_buoy: None,
+                nth_move: Some(24),
+            },
+            ClientCommand::Chat {
+                message: "hello world".to_owned(),
+            },
         ];
 
         for cmd in samples {

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -41,6 +41,10 @@ log.workspace = true
 # Local dependencies
 rshogi-core = { path = "../rshogi-core" }
 rshogi-csa = { path = "../rshogi-csa" }
+# CSA プロトコル送信側 serialize / 受信側 parse の単一ソース。
+# `default-features=false` で `tokio-transport` (tokio + serde_yaml) を切り、
+# protocol モジュールが必要とする pure な型 / 関数のみを取り込む。
+rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 
 # Additional dependencies
 sysinfo = "0.37"

--- a/crates/tools/src/csa_client/protocol.rs
+++ b/crates/tools/src/csa_client/protocol.rs
@@ -10,6 +10,8 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 
 use rshogi_csa::{Color, CsaMove, ParsedMove, Position, parse_csa_full};
+use rshogi_csa_server::protocol::command::{ClientCommand, serialize_client_command};
+use rshogi_csa_server::types::{CsaMoveToken, GameId, PlayerName, Secret};
 
 use super::event::Event;
 
@@ -135,7 +137,12 @@ impl CsaConnection {
     /// ログイン
     pub fn login(&mut self, id: &str, password: &str) -> Result<()> {
         self.password = password.to_string();
-        let cmd = format!("LOGIN {id} {password}");
+        let cmd = serialize_client_command(&ClientCommand::Login {
+            name: PlayerName::new(id),
+            password: Secret::new(password),
+            x1: false,
+            reconnect: None,
+        });
         self.send_line(&cmd)?;
         let response = self.recv_line_blocking(Duration::from_secs(15))?;
         if response.starts_with("LOGIN:") && response.contains("OK") {
@@ -311,7 +318,10 @@ impl CsaConnection {
 
     /// AGREE を送信して START を待つ
     pub fn agree_and_wait_start(&mut self, game_id: &str) -> Result<()> {
-        self.send_line(&format!("AGREE {game_id}"))?;
+        let cmd = serialize_client_command(&ClientCommand::Agree {
+            game_id: Some(GameId::new(game_id)),
+        });
+        self.send_line(&cmd)?;
         loop {
             let line = self.recv_line_blocking(Duration::from_secs(60))?;
             if line.starts_with("START:") {
@@ -360,33 +370,37 @@ impl CsaConnection {
 
     /// 指し手をサーバーに送信する
     pub fn send_move(&mut self, csa_move: &str) -> Result<()> {
-        self.send_line(csa_move)
+        let cmd = serialize_client_command(&ClientCommand::Move {
+            token: CsaMoveToken::new(csa_move),
+            comment: None,
+        });
+        self.send_line(&cmd)
     }
 
     /// 指し手 + floodgate コメント（評価値・PV）を送信する。
-    /// コメントは `+7776FU,'* 123 +7776FU -3334FU` のようにカンマ区切りで同一行に付加する。
+    /// `comment` には `'` プレフィックスを含まない本体（例: `* 123 +7776FU -3334FU`）を渡す。
+    /// 送信時は `+7776FU,'* 123 +7776FU -3334FU` のように `,'<comment>` 形式で付加される。
     pub fn send_move_with_comment(&mut self, csa_move: &str, comment: Option<&str>) -> Result<()> {
-        if let Some(c) = comment {
-            let line = format!("{csa_move},{c}");
-            self.send_line(&line)
-        } else {
-            self.send_line(csa_move)
-        }
+        let cmd = serialize_client_command(&ClientCommand::Move {
+            token: CsaMoveToken::new(csa_move),
+            comment: comment.map(|c| c.to_owned()),
+        });
+        self.send_line(&cmd)
     }
 
     /// 投了を送信
     pub fn send_resign(&mut self) -> Result<()> {
-        self.send_line("%TORYO")
+        self.send_line(&serialize_client_command(&ClientCommand::Toryo))
     }
 
     /// 入玉宣言勝ちを送信
     pub fn send_win(&mut self) -> Result<()> {
-        self.send_line("%KACHI")
+        self.send_line(&serialize_client_command(&ClientCommand::Kachi))
     }
 
     /// ログアウト
     pub fn logout(&mut self) -> Result<()> {
-        let _ = self.send_line("LOGOUT");
+        let _ = self.send_line(&serialize_client_command(&ClientCommand::Logout));
         Ok(())
     }
 

--- a/crates/tools/src/csa_client/session.rs
+++ b/crates/tools/src/csa_client/session.rs
@@ -608,7 +608,9 @@ fn build_floodgate_comment(
         0
     };
 
-    let mut comment = format!("'* {score}");
+    // CSA Floodgate の追記コメント本体（`'` プレフィックス抜き）。
+    // 送信時は CsaConnection::send_move_with_comment 側で `,'<comment>` 形に整形される。
+    let mut comment = format!("* {score}");
     if !info.pv.is_empty() {
         let mut pv_pos = pos.clone();
         let pv_start = if info.pv.first().map(|s| s.as_str()) == Some(last_bestmove) {


### PR DESCRIPTION
## Summary

- `rshogi-csa-server::protocol::command::serialize_client_command(&ClientCommand) -> String` を新設し、CSA クライアントが送信する 1 行のテキスト生成を server crate 側に集約する。
- `crates/tools/src/csa_client/protocol.rs` の `format!("LOGIN {id} {pw}")` などの直書き文字列組み立てを `ClientCommand::*` を組み立てて `serialize_client_command` 経由で送る形に書き換える。サーバー側 `parse_command` と対称な唯一の serialize 経路にすることで、CSA v1.2.1 仕様の解釈が server / client で乖離するリスクを排する。
- `parse_command(serialize_client_command(c)) == c` を主要バリアントについて確認する roundtrip テストを追加。

## 設計判断

- 受信側 (`Game_Summary` parse / 指し手受信 / `#WIN` 判定 等) は CSA プロトコルの方向が逆で、サーバー側に対称な実装がない（サーバー側は同じ情報を「送る」builder/sink を持つ）。今回は **クライアント → サーバー方向の送信ロジックの一本化** に絞り、`csa_client::protocol::{GameSummary, ServerMove, RecvEvent, GameResult, TimeConfig, CsaConnection}` はクライアント専用構造体として残置する。
- `ClientCommand::Move::comment` の意味論は CSA `'` プレフィックス**抜き**の本体である（既存 `parse_command::parse_move` の comment 抽出と一貫）。これに合わせて `csa_client::session::build_floodgate_comment` の出力先頭の `'` を削除し、`,'<comment>` 形成は `serialize_client_command` のみが担う形に整理した。
- `tools/Cargo.toml` に `rshogi-csa-server` を `default-features = false` で path 依存追加。`tokio-transport` は不要なので tokio / serde_yaml は引き込まない。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test --workspace` 全 pass（lib + integration + doc）
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 成功
- [x] `tools::csa_client::protocol` の送信側コードが独自文字列組み立てを持たず、すべて `serialize_client_command` 経由になった
- [x] roundtrip テストで Login / Move(comment あり/なし) / Agree / x1 拡張 / SetBuoy / Fork 等を網羅

## Test plan

- [ ] PR 作成後 CI チェック成功
- [ ] independent Claude review サイクルで Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
