### PR TITLE
feat(csa-client): CSA-over-WebSocket transport を追加し host scheme で TCP/WS を切り替える

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,10 +385,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dispatch2"
@@ -579,6 +623,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2067,6 +2121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2485,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "toml",
+ "tungstenite",
  "url",
  "walkdir",
 ]
@@ -2536,6 +2602,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+ "utf-8",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2674,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2785,6 +2883,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -46,6 +46,11 @@ rshogi-csa = { path = "../rshogi-csa" }
 # protocol モジュールが必要とする pure な型 / 関数のみを取り込む。
 rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 
+# CSA-over-WebSocket 用の sync ハンドシェイク + フレーミング。
+# rustls + webpki ルートで TLS を実装し、native-tls 経由の OpenSSL 依存を避ける。
+# Cloudflare Workers は Let's Encrypt 証明書なので webpki ルートで疎通する。
+tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
+
 # Additional dependencies
 sysinfo = "0.37"
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/crates/tools/src/bin/csa_client.rs
+++ b/crates/tools/src/bin/csa_client.rs
@@ -26,6 +26,7 @@ use tools::csa_client::engine::UsiEngine;
 use tools::csa_client::protocol::{CsaConnection, GameResult};
 use tools::csa_client::record::save_record;
 use tools::csa_client::session::run_game_session;
+use tools::csa_client::transport::{ConnectOpts, TransportTarget};
 
 #[derive(Parser)]
 #[command(
@@ -67,6 +68,11 @@ struct Cli {
     /// Floodgate モード
     #[arg(long, default_missing_value = "true", num_args = 0..=1)]
     floodgate: Option<bool>,
+
+    /// WebSocket Upgrade 時の Origin ヘッダ値（`wss://` 接続時のみ意味あり）。
+    /// 例: `https://csa-client.example.local`
+    #[arg(long)]
+    ws_origin: Option<String>,
 
     /// Keep-alive 間隔 (秒)
     #[arg(long)]
@@ -216,12 +222,14 @@ fn run_one_game(
     engine: &mut UsiEngine,
     shutdown: &AtomicBool,
 ) -> Result<(GameResult, tools::csa_client::record::GameRecord)> {
-    // サーバー接続
-    let mut conn = CsaConnection::connect(
-        &config.server.host,
-        config.server.port,
-        config.server.keepalive.tcp,
-    )?;
+    // サーバー接続。host に scheme (`ws://` / `wss://` / `tcp://`) があれば
+    // それに従い、無ければ既存挙動どおり `host:port` の TCP。
+    let target = TransportTarget::from_host_port(&config.server.host, config.server.port);
+    let opts = ConnectOpts {
+        tcp_keepalive: config.server.keepalive.tcp,
+        ws_origin: config.server.ws_origin.clone(),
+    };
+    let mut conn = CsaConnection::connect_with_target(&target, &opts)?;
     conn.login(&config.server.id, &config.server.password)?;
 
     // 対局実行
@@ -263,6 +271,9 @@ fn apply_cli_overrides(config: &mut CsaClientConfig, cli: &Cli) {
     }
     if let Some(fg) = cli.floodgate {
         config.server.floodgate = fg;
+    }
+    if let Some(ref origin) = cli.ws_origin {
+        config.server.ws_origin = Some(origin.clone());
     }
     if let Some(ka) = cli.keep_alive {
         config.server.keepalive.ping_interval_sec = ka;

--- a/crates/tools/src/csa_client/config.rs
+++ b/crates/tools/src/csa_client/config.rs
@@ -23,12 +23,20 @@ pub struct CsaClientConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct ServerConfig {
+    /// 接続先。`host:port` 直書き、`tcp://host`、`ws://host[:port]/ws/<room>`、
+    /// `wss://host[:port]/ws/<room>` のいずれか。`ws://` / `wss://` の場合は
+    /// `port` 設定は無視される（URL に含めること）。
     pub host: String,
     pub port: u16,
     pub id: String,
     pub password: String,
     pub floodgate: bool,
     pub keepalive: KeepaliveConfig,
+    /// WebSocket Upgrade 時に送る `Origin` ヘッダ値。`None` のとき
+    /// `tungstenite` の既定値（URL から導出）に任せる。Cloudflare Workers の
+    /// `CORS_ORIGINS` allowlist 通過のため、運用時は明示する。
+    #[serde(default)]
+    pub ws_origin: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -40,6 +48,7 @@ impl Default for ServerConfig {
             password: String::new(),
             floodgate: true,
             keepalive: KeepaliveConfig::default(),
+            ws_origin: None,
         }
     }
 }

--- a/crates/tools/src/csa_client/mod.rs
+++ b/crates/tools/src/csa_client/mod.rs
@@ -8,3 +8,4 @@ pub mod event;
 pub mod protocol;
 pub mod record;
 pub mod session;
+pub mod transport;

--- a/crates/tools/src/csa_client/protocol.rs
+++ b/crates/tools/src/csa_client/protocol.rs
@@ -1,19 +1,20 @@
 //! CSAプロトコル通信層
 //!
-//! TCP接続によるCSAサーバーとのテキスト行ベース通信を管理する。
+//! `transport` モジュール（TCP / WebSocket）の上にテキスト行ベースの
+//! CSA プロトコルを乗せる。送信側は `serialize_client_command` 経由で
+//! `ClientCommand` バリアントから 1 行を組み立てる。
 
-use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::net::TcpStream;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 
 use rshogi_csa::{Color, CsaMove, ParsedMove, Position, parse_csa_full};
 use rshogi_csa_server::protocol::command::{ClientCommand, serialize_client_command};
 use rshogi_csa_server::types::{CsaMoveToken, GameId, PlayerName, Secret};
 
 use super::event::Event;
+use super::transport::{ConnectOpts, CsaTransport, TransportTarget};
 
 /// 先後共通または個別の時間設定
 #[derive(Clone, Debug, Default)]
@@ -67,9 +68,8 @@ pub enum GameResult {
 
 /// CSAプロトコルクライアント
 pub struct CsaConnection {
-    /// 対局開始前はブロッキング読み取りに使用。`start_reader_thread` 後は None。
-    reader: Option<BufReader<TcpStream>>,
-    writer: BufWriter<TcpStream>,
+    /// 下層 transport（TCP / WebSocket）。
+    transport: CsaTransport,
     last_activity_time: Instant,
     /// パスワードマスク用
     password: String,
@@ -78,56 +78,24 @@ pub struct CsaConnection {
 }
 
 impl CsaConnection {
-    /// CSAサーバーに接続する
+    /// 既存呼び出し互換: TCP 経路に絞った接続。
     pub fn connect(host: &str, port: u16, tcp_keepalive: bool) -> Result<Self> {
-        let addr_str = format!("{host}:{port}");
-        log::info!("[CSA] 接続中: {addr_str}");
-        // DNS名を解決し、解決済みアドレスを順に試す（IPv6/IPv4 両対応）
-        use std::net::ToSocketAddrs;
-        let addrs: Vec<_> = addr_str
-            .to_socket_addrs()
-            .with_context(|| format!("名前解決失敗: {addr_str}"))?
-            .collect();
-        if addrs.is_empty() {
-            bail!("アドレスが見つかりません: {addr_str}");
-        }
-        let mut last_err = None;
-        let mut stream_opt = None;
-        for addr in &addrs {
-            log::debug!("[CSA] 接続試行: {addr}");
-            match TcpStream::connect_timeout(addr, Duration::from_secs(15)) {
-                Ok(s) => {
-                    stream_opt = Some(s);
-                    break;
-                }
-                Err(e) => {
-                    log::debug!("[CSA] {addr} 接続失敗: {e}");
-                    last_err = Some(e);
-                }
-            }
-        }
-        let stream = stream_opt.ok_or_else(|| {
-            anyhow::anyhow!(
-                "CSAサーバー接続失敗: {addr_str} ({}アドレス試行済み): {}",
-                addrs.len(),
-                last_err.map_or("unknown".to_string(), |e| e.to_string())
-            )
-        })?;
+        Self::connect_with_target(
+            &TransportTarget::from_host_port(host, port),
+            &ConnectOpts {
+                tcp_keepalive,
+                ws_origin: None,
+            },
+        )
+    }
 
-        if tcp_keepalive {
-            set_tcp_keepalive(&stream)?;
-        }
-        // Nagle 無効化（低遅延のため）
-        let _ = stream.set_nodelay(true);
-        // 読み取りタイムアウト: keep-alive チェック用に30秒
-        stream.set_read_timeout(Some(Duration::from_secs(30)))?;
-
-        let reader = BufReader::new(stream.try_clone()?);
-        let writer = BufWriter::new(stream);
-
+    /// 解析済み `TransportTarget` と接続オプションから接続する。WebSocket 経路は
+    /// 必ず本関数経由で開く（`host` に `ws://` / `wss://` を含めれば
+    /// `connect()` でも転送される）。
+    pub fn connect_with_target(target: &TransportTarget, opts: &ConnectOpts) -> Result<Self> {
+        let transport = CsaTransport::connect(target, opts)?;
         Ok(Self {
-            reader: Some(reader),
-            writer,
+            transport,
             last_activity_time: Instant::now(),
             password: String::new(),
             pending_end_reason: None,
@@ -410,144 +378,42 @@ impl CsaConnection {
             return Ok(());
         }
         if self.last_activity_time.elapsed() >= Duration::from_secs(interval_sec) {
-            self.send_raw(b"\n")?;
+            self.transport.write_keepalive()?;
             self.last_activity_time = Instant::now();
         }
         Ok(())
     }
 
     fn send_line(&mut self, line: &str) -> Result<()> {
-        // パスワードをマスクしてログ出力（非パスワード行ではアロケーション不要）
         if !self.password.is_empty() && line.contains(&self.password) {
             let masked = line.replace(&self.password, "*****");
             log::debug!("[CSA] > {masked}");
         } else {
             log::debug!("[CSA] > {line}");
         }
-        self.writer.write_all(line.as_bytes())?;
-        self.writer.write_all(b"\n")?;
-        self.writer.flush()?;
+        self.transport.write_line(line)?;
         self.last_activity_time = Instant::now();
         Ok(())
     }
 
-    fn send_raw(&mut self, data: &[u8]) -> Result<()> {
-        self.writer.write_all(data)?;
-        self.writer.flush()?;
-        Ok(())
-    }
-
-    /// reader への可変参照を取得。start_reader_thread 後は使用不可。
-    fn reader_mut(&mut self) -> Result<&mut BufReader<TcpStream>> {
-        self.reader
-            .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("reader は start_reader_thread で移動済み"))
-    }
-
     /// サーバー受信を別スレッドに移し、共通チャネルに `Event::ServerLine` を送信する。
-    /// 対局開始後に呼ぶ。以降、`recv_move` / `recv_line_*` は使用不可。
+    /// 対局開始後に呼ぶ。以降、`recv_move` / 内部 `recv_line_*` は使用不可。
     pub fn start_reader_thread(&mut self, tx: mpsc::Sender<Event>) -> Result<()> {
-        let mut reader =
-            self.reader.take().ok_or_else(|| anyhow::anyhow!("reader は既に移動済み"))?;
-        // 読み取りタイムアウトを短くして keep-alive のタイミングを確保
-        reader.get_ref().set_read_timeout(Some(Duration::from_millis(500)))?;
-        std::thread::Builder::new()
-            .name("csa-server-reader".to_string())
-            .spawn(move || {
-                loop {
-                    let mut line = String::new();
-                    match reader.read_line(&mut line) {
-                        Ok(0) => {
-                            let _ = tx.send(Event::ServerDisconnected);
-                            break;
-                        }
-                        Ok(_) => {
-                            let trimmed = line.trim_end().to_string();
-                            if !trimmed.is_empty() {
-                                log::debug!("[CSA] < {trimmed}");
-                                if tx.send(Event::ServerLine(trimmed)).is_err() {
-                                    break;
-                                }
-                            }
-                            // 空行: keep-alive ping — チャネルには送らない
-                        }
-                        Err(ref e)
-                            if e.kind() == std::io::ErrorKind::WouldBlock
-                                || e.kind() == std::io::ErrorKind::TimedOut =>
-                        {
-                            // タイムアウト: 正常、次のループへ
-                        }
-                        Err(_) => {
-                            let _ = tx.send(Event::ServerDisconnected);
-                            break;
-                        }
-                    }
-                }
-            })?;
-        Ok(())
+        self.transport.start_reader_thread(tx)
     }
 
-    /// ブロッキング読み取り（タイムアウト付き）。start_reader_thread 前のみ使用可。
     fn recv_line_blocking(&mut self, timeout: Duration) -> Result<String> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            let remaining =
-                deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
-            if remaining.is_zero() {
-                bail!("サーバー応答タイムアウト");
-            }
-            let reader = self.reader_mut()?;
-            reader.get_ref().set_read_timeout(Some(remaining.min(Duration::from_secs(5))))?;
-            let mut line = String::new();
-            match reader.read_line(&mut line) {
-                Ok(0) => bail!("サーバー切断"),
-                Ok(n) if n > 0 => {
-                    // 空行でもデータ受信なので activity 更新（相手の blank ping 等）
-                    self.last_activity_time = Instant::now();
-                    let trimmed = line.trim_end().to_string();
-                    if !trimmed.is_empty() {
-                        log::debug!("[CSA] < {trimmed}");
-                        return Ok(trimmed);
-                    }
-                }
-                Ok(_) => bail!("サーバー切断"),
-                Err(ref e)
-                    if e.kind() == std::io::ErrorKind::WouldBlock
-                        || e.kind() == std::io::ErrorKind::TimedOut =>
-                {
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-            }
-        }
+        let line = self.transport.read_line_blocking(timeout)?;
+        self.last_activity_time = Instant::now();
+        Ok(line)
     }
 
-    /// ノンブロッキング読み取り。データがなければ Ok(None)。start_reader_thread 前のみ。
     fn recv_line_nonblocking(&mut self) -> Result<Option<String>> {
-        let reader = self.reader_mut()?;
-        reader.get_ref().set_read_timeout(Some(Duration::from_millis(100)))?;
-        let mut line = String::new();
-        match reader.read_line(&mut line) {
-            Ok(0) => bail!("サーバー切断"),
-            Ok(_) => {
-                // 空行でもデータ受信なので activity 更新
-                self.last_activity_time = Instant::now();
-                let trimmed = line.trim_end().to_string();
-                if trimmed.is_empty() {
-                    Ok(None)
-                } else {
-                    log::debug!("[CSA] < {trimmed}");
-                    Ok(Some(trimmed))
-                }
-            }
-            Err(ref e)
-                if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut =>
-            {
-                Ok(None)
-            }
-            Err(e) => Err(e.into()),
+        let opt = self.transport.read_line_nonblocking()?;
+        if opt.is_some() {
+            self.last_activity_time = Instant::now();
         }
+        Ok(opt)
     }
 }
 
@@ -595,31 +461,4 @@ pub(crate) fn parse_game_result(line: &str) -> Option<GameResult> {
     } else {
         None // #TIME_UP, #ILLEGAL_MOVE, #SENNICHITE 等は中間行
     }
-}
-
-/// TCP SO_KEEPALIVE を有効化する
-#[cfg(unix)]
-fn set_tcp_keepalive(stream: &TcpStream) -> Result<()> {
-    use std::os::unix::io::AsRawFd;
-    let fd = stream.as_raw_fd();
-    let optval: libc::c_int = 1;
-    // SAFETY: fd は有効なソケット。optval は有効なポインタ。
-    let ret = unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_KEEPALIVE,
-            &optval as *const _ as *const libc::c_void,
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        )
-    };
-    if ret != 0 {
-        log::warn!("SO_KEEPALIVE 設定失敗: {}", std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_tcp_keepalive(_stream: &TcpStream) -> Result<()> {
-    Ok(())
 }

--- a/crates/tools/src/csa_client/transport.rs
+++ b/crates/tools/src/csa_client/transport.rs
@@ -1,0 +1,559 @@
+//! CSA プロトコル下層 transport（TCP / WebSocket）。
+//!
+//! - TCP: `host:port` への TcpStream を `BufReader` / `BufWriter` で 1 行ずつ
+//!   読み書きする既存実装。同一 socket を `try_clone()` で reader thread に
+//!   分配する。
+//! - WebSocket: `tungstenite` の sync API で `ws://` / `wss://` URL に接続
+//!   し、1 line = 1 text frame の対応で扱う。`Arc<Mutex<WebSocket>>` を共有
+//!   して reader thread と writer thread の双方が同じ socket を見る。
+//!
+//! どちらの経路でも CSA プロトコル本体（行末改行は呼び出し側で除去済み）
+//! は文字列スライスで扱う。改行コードは TCP 経路では `write_line` 内部で
+//! `\n` を付加し、WS 経路では text frame の境界そのものが行境界になる。
+
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow, bail};
+use tungstenite::client::IntoClientRequest;
+use tungstenite::handshake::client::Request;
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{Message, WebSocket};
+
+use super::event::Event;
+
+/// 接続先のスキーム解析結果。`host` 設定文字列から `from_host_port` で生成する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransportTarget {
+    /// `tcp://host:port` または scheme なし `host` + `port`。
+    Tcp { host: String, port: u16 },
+    /// `ws://host[:port]/path` または `wss://host[:port]/path`。`port` 設定は無視される。
+    WebSocket { url: String },
+}
+
+impl TransportTarget {
+    /// `server.host` 設定文字列に scheme が含まれていれば優先し、そうでなければ
+    /// 既存の `host:port` 形式として TCP 接続先に解釈する。
+    pub fn from_host_port(host: &str, port: u16) -> Self {
+        if host.starts_with("ws://") || host.starts_with("wss://") {
+            Self::WebSocket {
+                url: host.to_owned(),
+            }
+        } else if let Some(rest) = host.strip_prefix("tcp://") {
+            Self::Tcp {
+                host: rest.to_owned(),
+                port,
+            }
+        } else {
+            Self::Tcp {
+                host: host.to_owned(),
+                port,
+            }
+        }
+    }
+}
+
+/// 接続オプション。CLI / TOML から渡される設定をひとまとめにする。
+#[derive(Debug, Clone, Default)]
+pub struct ConnectOpts {
+    /// TCP SO_KEEPALIVE を有効化する（TCP 経路でのみ参照）。
+    pub tcp_keepalive: bool,
+    /// WebSocket Upgrade 時の Origin ヘッダ値。`None` なら tungstenite の既定値
+    /// （`url::Url::origin()`）に任せる。Cloudflare Workers の `CORS_ORIGINS`
+    /// allowlist 通過のため、運用時は明示指定する想定。
+    pub ws_origin: Option<String>,
+}
+
+/// CSA 行を 1 line = 1 message として扱う transport の統一インタフェース。
+///
+/// `start_reader_thread` を呼ぶまでは inline で `read_line_*` / `write_line` を
+/// 使い、対局開始後は reader thread に reader 部分を移して main thread が
+/// `write_line` のみを使う運用を想定する。
+pub enum CsaTransport {
+    Tcp(TcpTransport),
+    WebSocket(WsTransport),
+}
+
+impl CsaTransport {
+    /// 解析済みの `TransportTarget` に対して接続する。
+    pub fn connect(target: &TransportTarget, opts: &ConnectOpts) -> Result<Self> {
+        match target {
+            TransportTarget::Tcp { host, port } => {
+                Ok(Self::Tcp(TcpTransport::connect(host, *port, opts.tcp_keepalive)?))
+            }
+            TransportTarget::WebSocket { url } => {
+                Ok(Self::WebSocket(WsTransport::connect(url, opts.ws_origin.as_deref())?))
+            }
+        }
+    }
+
+    /// `timeout` 内に 1 行受信する。空行（keep-alive）は呼び出し側に空文字列で
+    /// 上げず、内部でログ更新だけ行ってから次行を待つ。タイムアウト時は `bail!`。
+    pub fn read_line_blocking(&mut self, timeout: Duration) -> Result<String> {
+        match self {
+            Self::Tcp(t) => t.read_line_blocking(timeout),
+            Self::WebSocket(w) => w.read_line_blocking(timeout),
+        }
+    }
+
+    /// 受信データがなければ `Ok(None)`（keep-alive チェック用）。
+    pub fn read_line_nonblocking(&mut self) -> Result<Option<String>> {
+        match self {
+            Self::Tcp(t) => t.read_line_nonblocking(),
+            Self::WebSocket(w) => w.read_line_nonblocking(),
+        }
+    }
+
+    /// 1 行送信する。改行コードは transport 側で適切に付加する。
+    pub fn write_line(&mut self, line: &str) -> Result<()> {
+        match self {
+            Self::Tcp(t) => t.write_line(line),
+            Self::WebSocket(w) => w.write_line(line),
+        }
+    }
+
+    /// CSA の空行 keep-alive。TCP では `\n` 単独、WS では空 text frame を送る。
+    pub fn write_keepalive(&mut self) -> Result<()> {
+        match self {
+            Self::Tcp(t) => t.write_raw(b"\n"),
+            Self::WebSocket(w) => w.write_line(""),
+        }
+    }
+
+    /// 受信ループを別スレッドで起動する。同 transport インスタンスでの
+    /// `read_line_*` 呼び出しは以降不可（reader が thread に移動するため）。
+    pub fn start_reader_thread(&mut self, tx: mpsc::Sender<Event>) -> Result<()> {
+        match self {
+            Self::Tcp(t) => t.start_reader_thread(tx),
+            Self::WebSocket(w) => w.start_reader_thread(tx),
+        }
+    }
+}
+
+/// TCP 経路の transport。
+pub struct TcpTransport {
+    /// 対局開始前はブロッキング読み取りに使用。`start_reader_thread` 後は `None`。
+    reader: Option<BufReader<TcpStream>>,
+    writer: BufWriter<TcpStream>,
+}
+
+impl TcpTransport {
+    fn connect(host: &str, port: u16, tcp_keepalive: bool) -> Result<Self> {
+        let addr_str = format!("{host}:{port}");
+        log::info!("[CSA/TCP] 接続中: {addr_str}");
+        let addrs: Vec<_> = addr_str
+            .to_socket_addrs()
+            .with_context(|| format!("名前解決失敗: {addr_str}"))?
+            .collect();
+        if addrs.is_empty() {
+            bail!("アドレスが見つかりません: {addr_str}");
+        }
+        let mut last_err = None;
+        let mut stream_opt = None;
+        for addr in &addrs {
+            log::debug!("[CSA/TCP] 接続試行: {addr}");
+            match TcpStream::connect_timeout(addr, Duration::from_secs(15)) {
+                Ok(s) => {
+                    stream_opt = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    log::debug!("[CSA/TCP] {addr} 接続失敗: {e}");
+                    last_err = Some(e);
+                }
+            }
+        }
+        let stream = stream_opt.ok_or_else(|| {
+            anyhow!(
+                "CSAサーバー接続失敗: {addr_str} ({}アドレス試行済み): {}",
+                addrs.len(),
+                last_err.map_or("unknown".to_string(), |e| e.to_string())
+            )
+        })?;
+
+        if tcp_keepalive {
+            set_tcp_keepalive(&stream)?;
+        }
+        let _ = stream.set_nodelay(true);
+        stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+
+        let reader = BufReader::new(stream.try_clone()?);
+        let writer = BufWriter::new(stream);
+
+        Ok(Self {
+            reader: Some(reader),
+            writer,
+        })
+    }
+
+    fn reader_mut(&mut self) -> Result<&mut BufReader<TcpStream>> {
+        self.reader
+            .as_mut()
+            .ok_or_else(|| anyhow!("reader は start_reader_thread で移動済み"))
+    }
+
+    fn read_line_blocking(&mut self, timeout: Duration) -> Result<String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining =
+                deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                bail!("サーバー応答タイムアウト");
+            }
+            let reader = self.reader_mut()?;
+            reader.get_ref().set_read_timeout(Some(remaining.min(Duration::from_secs(5))))?;
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => bail!("サーバー切断"),
+                Ok(n) if n > 0 => {
+                    let trimmed = line.trim_end().to_string();
+                    if !trimmed.is_empty() {
+                        log::debug!("[CSA] < {trimmed}");
+                        return Ok(trimmed);
+                    }
+                }
+                Ok(_) => bail!("サーバー切断"),
+                Err(ref e)
+                    if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+                {
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    fn read_line_nonblocking(&mut self) -> Result<Option<String>> {
+        let reader = self.reader_mut()?;
+        reader.get_ref().set_read_timeout(Some(Duration::from_millis(100)))?;
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => bail!("サーバー切断"),
+            Ok(_) => {
+                let trimmed = line.trim_end().to_string();
+                if trimmed.is_empty() {
+                    Ok(None)
+                } else {
+                    log::debug!("[CSA] < {trimmed}");
+                    Ok(Some(trimmed))
+                }
+            }
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut => {
+                Ok(None)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn write_line(&mut self, line: &str) -> Result<()> {
+        self.writer.write_all(line.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn write_raw(&mut self, data: &[u8]) -> Result<()> {
+        self.writer.write_all(data)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn start_reader_thread(&mut self, tx: mpsc::Sender<Event>) -> Result<()> {
+        let mut reader = self.reader.take().ok_or_else(|| anyhow!("reader は既に移動済み"))?;
+        reader.get_ref().set_read_timeout(Some(Duration::from_millis(500)))?;
+        std::thread::Builder::new().name("csa-tcp-reader".to_string()).spawn(move || {
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => {
+                        let _ = tx.send(Event::ServerDisconnected);
+                        break;
+                    }
+                    Ok(_) => {
+                        let trimmed = line.trim_end().to_string();
+                        if !trimmed.is_empty() {
+                            log::debug!("[CSA] < {trimmed}");
+                            if tx.send(Event::ServerLine(trimmed)).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Err(ref e)
+                        if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+                    {
+                        // タイムアウト: 正常、次のループへ
+                    }
+                    Err(_) => {
+                        let _ = tx.send(Event::ServerDisconnected);
+                        break;
+                    }
+                }
+            }
+        })?;
+        Ok(())
+    }
+}
+
+/// WebSocket 経路の transport。
+pub struct WsTransport {
+    ws: Arc<Mutex<WebSocket<MaybeTlsStream<TcpStream>>>>,
+    /// `start_reader_thread` 後は reader が thread 内で動作する。inline 操作禁止フラグ。
+    reader_moved: bool,
+}
+
+impl WsTransport {
+    fn connect(url: &str, origin: Option<&str>) -> Result<Self> {
+        log::info!("[CSA/WS] 接続中: {url}");
+        let mut request: Request = url
+            .into_client_request()
+            .with_context(|| format!("WebSocket URL のパース失敗: {url}"))?;
+        if let Some(origin_value) = origin {
+            let header_value = origin_value
+                .parse()
+                .with_context(|| format!("Origin ヘッダ値が不正: {origin_value}"))?;
+            request.headers_mut().insert("Origin", header_value);
+        }
+
+        let (ws, response) = tungstenite::connect(request)
+            .with_context(|| format!("WebSocket Upgrade 失敗: {url}"))?;
+        log::info!("[CSA/WS] 接続成功: status={}", response.status());
+
+        // 内部 TcpStream に短い read_timeout を設定し、reader thread でも main
+        // thread でも read_message が long-block しないようにする。
+        if let Some(stream) = stream_of_ws(&ws) {
+            let _ = stream.set_nodelay(true);
+            stream.set_read_timeout(Some(Duration::from_millis(100)))?;
+        }
+
+        Ok(Self {
+            ws: Arc::new(Mutex::new(ws)),
+            reader_moved: false,
+        })
+    }
+
+    fn ensure_inline(&self) -> Result<()> {
+        if self.reader_moved {
+            bail!("WS reader は start_reader_thread で thread に移動済み");
+        }
+        Ok(())
+    }
+
+    fn read_line_blocking(&mut self, timeout: Duration) -> Result<String> {
+        self.ensure_inline()?;
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining =
+                deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                bail!("サーバー応答タイムアウト");
+            }
+            match self.try_read_one_message()? {
+                Some(line) => {
+                    if !line.is_empty() {
+                        log::debug!("[CSA] < {line}");
+                        return Ok(line);
+                    }
+                    // 空 text frame は keep-alive 扱いで読み飛ばす。
+                }
+                None => {
+                    // 50ms 単位でリトライしつつ deadline まで待つ（内部 TcpStream の
+                    // read_timeout が 100ms なので、その半分でリトライ間隔を取る）。
+                    std::thread::sleep(Duration::from_millis(50).min(remaining));
+                }
+            }
+        }
+    }
+
+    fn read_line_nonblocking(&mut self) -> Result<Option<String>> {
+        self.ensure_inline()?;
+        match self.try_read_one_message()? {
+            Some(line) if !line.is_empty() => {
+                log::debug!("[CSA] < {line}");
+                Ok(Some(line))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// `WebSocket::read` を 1 回だけ非ブロッキングで試行する。
+    /// `Ok(Some(line))`: text frame を 1 つ受信した（空文字含む）。
+    /// `Ok(None)`: WouldBlock / Pong / Ping をハンドリング後にデータなし。
+    /// `Err(_)`: 切断 / プロトコル違反など回復不能。
+    fn try_read_one_message(&mut self) -> Result<Option<String>> {
+        let mut guard = self.ws.lock().map_err(|_| anyhow!("WS lock poisoned"))?;
+        match guard.read() {
+            Ok(Message::Text(payload)) => Ok(Some(payload.to_string())),
+            Ok(Message::Binary(_)) => {
+                log::warn!("[CSA/WS] 想定外の binary frame を破棄");
+                Ok(None)
+            }
+            Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => Ok(None),
+            Ok(Message::Close(frame)) => {
+                log::info!("[CSA/WS] サーバーから Close frame 受信: {frame:?}");
+                bail!("サーバー切断");
+            }
+            Err(tungstenite::Error::Io(e))
+                if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+            {
+                Ok(None)
+            }
+            Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                bail!("サーバー切断");
+            }
+            Err(e) => Err(anyhow!("WebSocket read error: {e}")),
+        }
+    }
+
+    fn write_line(&mut self, line: &str) -> Result<()> {
+        let mut guard = self.ws.lock().map_err(|_| anyhow!("WS lock poisoned"))?;
+        guard
+            .send(Message::Text(line.to_owned().into()))
+            .with_context(|| "WebSocket text frame 送信失敗")?;
+        Ok(())
+    }
+
+    fn start_reader_thread(&mut self, tx: mpsc::Sender<Event>) -> Result<()> {
+        if self.reader_moved {
+            bail!("WS reader は既に thread に移動済み");
+        }
+        self.reader_moved = true;
+        let ws = Arc::clone(&self.ws);
+        std::thread::Builder::new().name("csa-ws-reader".to_string()).spawn(move || {
+            loop {
+                let next = {
+                    let mut guard = match ws.lock() {
+                        Ok(g) => g,
+                        Err(_) => {
+                            let _ = tx.send(Event::ServerDisconnected);
+                            break;
+                        }
+                    };
+                    guard.read()
+                };
+                match next {
+                    Ok(Message::Text(payload)) => {
+                        let line = payload.to_string();
+                        if !line.is_empty() {
+                            log::debug!("[CSA] < {line}");
+                            if tx.send(Event::ServerLine(line)).is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    Ok(Message::Binary(_)) => {
+                        log::warn!("[CSA/WS] 想定外の binary frame を破棄");
+                    }
+                    Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => {}
+                    Ok(Message::Close(_)) => {
+                        let _ = tx.send(Event::ServerDisconnected);
+                        break;
+                    }
+                    Err(tungstenite::Error::Io(e))
+                        if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+                    {
+                        // 短 timeout で抜けて lock を release し、writer に
+                        // 進行のチャンスを与える。
+                        std::thread::sleep(Duration::from_millis(20));
+                    }
+                    Err(_) => {
+                        let _ = tx.send(Event::ServerDisconnected);
+                        break;
+                    }
+                }
+            }
+        })?;
+        Ok(())
+    }
+}
+
+/// `tungstenite::WebSocket` 内部の `TcpStream` に到達して read_timeout を設定する
+/// ためのヘルパ。`MaybeTlsStream` の variant に応じて適切な参照を返す。
+fn stream_of_ws(ws: &WebSocket<MaybeTlsStream<TcpStream>>) -> Option<&TcpStream> {
+    match ws.get_ref() {
+        MaybeTlsStream::Plain(s) => Some(s),
+        MaybeTlsStream::Rustls(s) => Some(s.get_ref()),
+        _ => None,
+    }
+}
+
+/// TCP SO_KEEPALIVE を有効化する（既存実装と同等）。
+#[cfg(unix)]
+fn set_tcp_keepalive(stream: &TcpStream) -> Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let fd = stream.as_raw_fd();
+    let optval: libc::c_int = 1;
+    // SAFETY: fd は有効なソケット。optval は有効なポインタ。
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_KEEPALIVE,
+            &optval as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        log::warn!("SO_KEEPALIVE 設定失敗: {}", std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_tcp_keepalive(_stream: &TcpStream) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_parses_tcp_default() {
+        let t = TransportTarget::from_host_port("wdoor.c.u-tokyo.ac.jp", 4081);
+        assert_eq!(
+            t,
+            TransportTarget::Tcp {
+                host: "wdoor.c.u-tokyo.ac.jp".to_owned(),
+                port: 4081
+            }
+        );
+    }
+
+    #[test]
+    fn target_parses_explicit_tcp_scheme() {
+        let t = TransportTarget::from_host_port("tcp://floodgate.example", 4081);
+        assert_eq!(
+            t,
+            TransportTarget::Tcp {
+                host: "floodgate.example".to_owned(),
+                port: 4081
+            }
+        );
+    }
+
+    #[test]
+    fn target_parses_ws_and_wss() {
+        let t = TransportTarget::from_host_port("ws://localhost:8787/ws/room1", 0);
+        assert_eq!(
+            t,
+            TransportTarget::WebSocket {
+                url: "ws://localhost:8787/ws/room1".to_owned()
+            }
+        );
+
+        let t = TransportTarget::from_host_port(
+            "wss://rshogi-csa-server-workers-staging.example.workers.dev/ws/room1",
+            0,
+        );
+        assert_eq!(
+            t,
+            TransportTarget::WebSocket {
+                url: "wss://rshogi-csa-server-workers-staging.example.workers.dev/ws/room1"
+                    .to_owned()
+            }
+        );
+    }
+}

--- a/crates/tools/tests/csa_ws_transport.rs
+++ b/crates/tools/tests/csa_ws_transport.rs
@@ -1,0 +1,131 @@
+//! CSA-over-WebSocket transport の疎通テスト。
+//!
+//! `tungstenite` の sync server を loopback ポートで立て、`CsaTransport` の
+//! WebSocket 経路が 1 line = 1 text frame の対応で送受信できることを確認する。
+
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use tools::csa_client::event::Event;
+use tools::csa_client::transport::{ConnectOpts, CsaTransport, TransportTarget};
+use tungstenite::{Message, accept};
+
+/// 1 接続を受け取り、与えた `script` のスクリプトを順次実行する mock WebSocket
+/// サーバを別スレッドで起動して、選んだポートと join handle を返す。
+fn spawn_mock_ws_server<F>(handler: F) -> (u16, thread::JoinHandle<()>)
+where
+    F: FnOnce(&mut tungstenite::WebSocket<std::net::TcpStream>) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let port = listener.local_addr().unwrap().port();
+    let join = thread::Builder::new()
+        .name("mock-ws-server".to_string())
+        .spawn(move || {
+            let (stream, _) = listener.accept().expect("mock accept");
+            let mut ws = accept(stream).expect("mock ws handshake");
+            handler(&mut ws);
+            // Close は呼び出し側が自身で投げるので、ここではフレーム close まで実行。
+            let _ = ws.close(None);
+            let _ = ws.flush();
+        })
+        .expect("spawn mock");
+    (port, join)
+}
+
+#[test]
+fn ws_transport_send_then_recv_line() {
+    let (port, join) = spawn_mock_ws_server(|ws| {
+        let msg = ws.read().expect("read text");
+        match msg {
+            Message::Text(t) => assert_eq!(t.as_str(), "LOGIN alice pw"),
+            other => panic!("expected text, got {other:?}"),
+        }
+        ws.send(Message::Text("LOGIN:OK".into())).expect("send response");
+    });
+
+    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let mut transport = CsaTransport::connect(
+        &target,
+        &ConnectOpts {
+            tcp_keepalive: false,
+            ws_origin: Some("http://localhost".to_owned()),
+        },
+    )
+    .expect("connect");
+
+    transport.write_line("LOGIN alice pw").expect("write");
+    let line = transport.read_line_blocking(Duration::from_secs(5)).expect("read response");
+    assert_eq!(line, "LOGIN:OK");
+
+    drop(transport);
+    join.join().expect("server thread");
+}
+
+#[test]
+fn ws_transport_reader_thread_delivers_multiple_lines() {
+    let (port, join) = spawn_mock_ws_server(|ws| {
+        // クライアントの「READY」を待ってから 3 行 push する。
+        let _ = ws.read();
+        for line in ["LINE_A", "LINE_B", "LINE_C"] {
+            ws.send(Message::Text(line.into())).expect("send");
+        }
+        // 0.5 秒余裕を持って close 前に flush。
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let mut transport = CsaTransport::connect(
+        &target,
+        &ConnectOpts {
+            tcp_keepalive: false,
+            ws_origin: Some("http://localhost".to_owned()),
+        },
+    )
+    .expect("connect");
+
+    transport.write_line("READY").expect("write ready");
+
+    let (tx, rx) = mpsc::channel::<Event>();
+    transport.start_reader_thread(tx).expect("reader thread");
+
+    let mut received = Vec::new();
+    while received.len() < 3 {
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Event::ServerLine(s)) => received.push(s),
+            Ok(Event::ServerDisconnected) => break,
+            Err(e) => panic!("recv timeout: {e:?}"),
+        }
+    }
+    assert_eq!(received, vec!["LINE_A".to_string(), "LINE_B".into(), "LINE_C".into()]);
+
+    drop(transport);
+    join.join().expect("server thread");
+}
+
+#[test]
+fn ws_transport_empty_text_frame_treated_as_keepalive() {
+    let (port, join) = spawn_mock_ws_server(|ws| {
+        let _ = ws.read(); // wait for "PING"
+        ws.send(Message::Text("".into())).expect("empty");
+        ws.send(Message::Text("AFTER_KEEPALIVE".into())).expect("after");
+    });
+
+    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let mut transport = CsaTransport::connect(
+        &target,
+        &ConnectOpts {
+            tcp_keepalive: false,
+            ws_origin: Some("http://localhost".to_owned()),
+        },
+    )
+    .expect("connect");
+
+    transport.write_line("PING").expect("write ping");
+    let line = transport.read_line_blocking(Duration::from_secs(5)).expect("read");
+    assert_eq!(line, "AFTER_KEEPALIVE");
+
+    drop(transport);
+    join.join().expect("server thread");
+}


### PR DESCRIPTION
## Summary

- `crates/tools/src/csa_client/transport.rs` を新設し、CSA プロトコルの 1 line = 1 message を TCP / WebSocket の双方で扱える `CsaTransport` enum を提供する。
- `server.host` 設定文字列の scheme で transport を判別する: `ws://` / `wss://` → WebSocket、`tcp://` 付き or 無印 → TCP。`port` は WebSocket 経路では無視（URL に含めるため）。
- `CsaConnection::connect_with_target(&TransportTarget, &ConnectOpts)` を追加し、bin csa_client.rs から transport 経路を選んで接続する。既存の `CsaConnection::connect(host, port, tcp_keepalive)` は内部で `connect_with_target` に委譲する互換 wrapper として残す。
- `--ws-origin <ORIGIN>` CLI / `[server] ws_origin` TOML フィールドで WebSocket Upgrade 時の `Origin` ヘッダを指定可能にする（Cloudflare Workers の `CORS_ORIGINS` allowlist 通過用）。
- `tools/Cargo.toml` に `tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }` を追加。OpenSSL を引き込まず webpki ルートで wss を扱う。
- `tools/tests/csa_ws_transport.rs` を新規追加。loopback mock WebSocket server を立てて 1 往復送受信 / reader thread 経由の複数行配信 / 空 text frame keep-alive の 3 ケースを検証。

## 設計判断

- WebSocket は `Arc<Mutex<tungstenite::WebSocket<MaybeTlsStream<TcpStream>>>>` を共有して reader thread と writer thread が同じ socket を見る形にした。tungstenite の sync API は `WebSocket` を split できないため。
- 内部 TcpStream に短い `read_timeout` (100ms) を設定し、reader thread が lock を握り続けないようにした。これで writer の `write_line` 呼び出しが blocking されない。
- CSA の空行 keep-alive は TCP では `\n` 単独、WS では空 text frame (`""`) で表現する。既存サーバー側 `parse_command` は空行を `ClientCommand::KeepAlive` として認識するので両経路で互換。
- `ClientCommand::Move::comment` の serialize 規約 (`'` 抜き本体) は前 PR (#517) で定まっている。本 PR は transport 抽象だけが対象で、protocol 仕様には触らない。
- `tungstenite` の TLS feature に `rustls-tls-webpki-roots` を選んだ理由: native-tls 経由の OpenSSL 依存を避け、Cloudflare Workers の Let's Encrypt 証明書とも互換。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test --workspace` 全 pass（lib + integration + doc）。新規 `csa_ws_transport` 3 ケースも green。
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 成功
- [x] 既存 TCP 経路は `CsaConnection::connect` の互換 wrapper として残し、無回帰

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review サイクルで Approve as-is
- [ ] 後続 PR (task 23.15) で staging Workers への wss 実機接続を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
