### PR TITLE
docs(csa-server): Workers staging × csa_client 実機 E2E 手順書とサンプル設定を追加する

### DIFF
--- a/crates/tools/examples/README.md
+++ b/crates/tools/examples/README.md
@@ -1,5 +1,27 @@
 # コマンド例
 
+## CSA 対局クライアント (csa_client)
+
+USI エンジンを CSA プロトコル対局サーバーに接続するブリッジ。TCP 経路と
+WebSocket 経路の両方をサポートする。
+
+### Workers staging × csa_client 実機 E2E
+
+`csa_client_staging/` ディレクトリ配下の `*.toml.example` をコピーして
+書き換え、Cloudflare Workers の staging に WebSocket で接続する形で 1 対局
+通電を確認する。手順は [`docs/csa-server/staging-e2e.md`](../../../docs/csa-server/staging-e2e.md)
+を参照。
+
+```bash
+cp crates/tools/examples/csa_client_staging/staging-black.toml.example \
+   /tmp/staging-black.toml
+cp crates/tools/examples/csa_client_staging/staging-white.toml.example \
+   /tmp/staging-white.toml
+# 各 .toml の `engine.path` / `host` URL / `id` を編集してから別ターミナルで起動。
+cargo run -p tools --release --bin csa_client -- /tmp/staging-black.toml
+cargo run -p tools --release --bin csa_client -- /tmp/staging-white.toml
+```
+
 ## トーナメント (tournament)
 
 複数エンジン間の総当たり並列対局を実行し、JSONL形式で結果を出力する。

--- a/crates/tools/examples/csa_client_staging/staging-black.toml.example
+++ b/crates/tools/examples/csa_client_staging/staging-black.toml.example
@@ -1,0 +1,59 @@
+# Workers staging × csa_client (黒番) 用 TOML 例。
+#
+# 詳細手順は docs/csa-server/staging-e2e.md を参照。
+# このファイルは `.example` の suffix 付きで repo に置かれている。実際に使う際は
+# 任意のローカルパス（`/tmp/staging-black.toml` 等）にコピーしてから書き換える。
+
+[server]
+# `wss://` で始まる場合は WebSocket 経路として接続する。
+# `<account>` 部分は Cloudflare アカウント名に置き換え、`<room_id>` は黒・白で
+# 同一の任意文字列を入れる。
+host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>"
+# host が `wss://` を含む場合は `port` は無視されるが、TOML schema 互換のため
+# 値を残しておく。
+port = 0
+id = "csa_e2e_black_<date>"
+password = "anything"
+floodgate = true
+
+# WebSocket Upgrade 時に送る Origin。staging Worker の CORS_ORIGINS allowlist
+# に同じ値を追加してから接続する（§1 参照）。
+ws_origin = "https://csa-client-local"
+
+[server.keepalive]
+# wss は通常 TLS が中間 NAT のタイムアウトを Pong で吸収するため、CSA 空行
+# keep-alive は最低限（60 秒）でよい。
+tcp = false
+ping_interval_sec = 60
+
+[engine]
+# ローカル USI エンジンへの絶対パスを書く。release ビルド推奨。
+path = "/path/to/your/rshogi-usi"
+startup_timeout_sec = 30
+
+[engine.options]
+USI_Hash = 256
+
+[time]
+margin_msec = 2500
+
+[game]
+max_games = 1            # E2E は 1 局回せれば良い
+restart_engine_every_game = false
+ponder = false           # E2E では ponder OFF が単純
+
+[retry]
+initial_delay_sec = 10
+max_delay_sec = 60
+
+[record]
+enabled = true
+dir = "./records/staging-e2e"
+filename_template = "{datetime}_{sente}_vs_{gote}"
+save_csa = true
+save_sfen = true
+
+[log]
+level = "info"
+dir = "./logs/staging-e2e"
+stdout = true

--- a/crates/tools/examples/csa_client_staging/staging-white.toml.example
+++ b/crates/tools/examples/csa_client_staging/staging-white.toml.example
@@ -1,0 +1,49 @@
+# Workers staging × csa_client (白番) 用 TOML 例。
+#
+# 黒番との対 (黒/白で room_id は同じ、id だけ別) で 1 対局を成立させる。
+# 詳細手順は docs/csa-server/staging-e2e.md を参照。
+
+[server]
+# 黒番と同じ `<room_id>` を URL 末尾に入れる（黒・白で完全一致が必須）。
+host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>"
+port = 0
+id = "csa_e2e_white_<date>"
+password = "anything"
+floodgate = true
+
+ws_origin = "https://csa-client-local"
+
+[server.keepalive]
+tcp = false
+ping_interval_sec = 60
+
+[engine]
+path = "/path/to/your/rshogi-usi"
+startup_timeout_sec = 30
+
+[engine.options]
+USI_Hash = 256
+
+[time]
+margin_msec = 2500
+
+[game]
+max_games = 1
+restart_engine_every_game = false
+ponder = false
+
+[retry]
+initial_delay_sec = 10
+max_delay_sec = 60
+
+[record]
+enabled = true
+dir = "./records/staging-e2e"
+filename_template = "{datetime}_{sente}_vs_{gote}"
+save_csa = true
+save_sfen = true
+
+[log]
+level = "info"
+dir = "./logs/staging-e2e"
+stdout = true

--- a/docs/csa-server/staging-e2e.md
+++ b/docs/csa-server/staging-e2e.md
@@ -1,0 +1,160 @@
+# Workers staging × csa_client 実機対局 E2E 手順書
+
+CSA-over-WebSocket で Cloudflare Workers の staging サーバーに `csa_client` ×
+2 セッションを繋ぎ、平手 1 対局を最後まで通電して棋譜が R2 (`rshogi-csa-kifu-staging`)
+に書き出されることを実機で確認する手順をまとめる。
+
+deployment 全体像は [`deployment.md`](deployment.md) を参照。
+
+## 0. 前提
+
+- staging Worker (`rshogi-csa-server-workers-staging.<account>.workers.dev`)
+  が deploy 済みであること。
+- ローカルに USI エンジン（`rshogi-usi` など）の release バイナリがあり、
+  `/path/to/rshogi-usi` で起動できること。
+- `wrangler` CLI（または `vp exec wrangler`）で staging Worker / R2 bucket に
+  操作できる権限があること。
+- `csa_client` の WS 経路（`tungstenite` 依存）が main に取り込まれていること。
+
+## 1. staging Worker の Origin allowlist を一時調整
+
+`csa_client` は WebSocket Upgrade 時に `Origin` ヘッダを送る。staging Worker は
+`CORS_ORIGINS` の allowlist に一致しない Origin を `403 Forbidden Origin` で
+弾くため、E2E 実施時のみ csa_client の Origin を allowlist に追加する。
+
+```bash
+# 既存値を確認
+vp exec wrangler --config crates/rshogi-csa-server-workers/wrangler.staging.toml \
+  whoami
+# secret や var の更新は wrangler.staging.toml 経由でしか入らないため、
+# 一時的に `CORS_ORIGINS` を編集 → deploy → 確認 → 巻き戻す流れになる。
+```
+
+`crates/rshogi-csa-server-workers/wrangler.staging.toml` の `[vars]` セクションで
+`CORS_ORIGINS` を以下のように一時更新（commit せずに手元で書き換えるだけで OK）。
+
+```toml
+[vars]
+CORS_ORIGINS = "https://csa-client-local"
+```
+
+そのまま CI 経由 (`workflow_dispatch` で staging deploy を起動) または手元から
+`vp exec wrangler --config wrangler.staging.toml deploy` で適用する。
+
+E2E が完了したら `CORS_ORIGINS = ""`（または元の値）に戻して再 deploy する。
+
+## 2. ローカル csa_client × 2 を用意する
+
+同一 `room_id` に黒 (`+`) と白 (`-`) で 1 セッションずつログインさせる。
+それぞれ独立の TOML を用意し、別ターミナルから起動する。
+
+### 2-1. 黒番 (`crates/tools/examples/csa_client_staging/staging-black.toml.example`)
+
+`crates/tools/examples/csa_client_staging/` 配下に同梱した
+`staging-black.toml.example` をコピーして使う。
+
+```bash
+cp crates/tools/examples/csa_client_staging/staging-black.toml.example \
+   /tmp/staging-black.toml
+# `/tmp/staging-black.toml` の `engine.path` だけローカルの USI binary パスに合わせて編集。
+```
+
+### 2-2. 白番 (`crates/tools/examples/csa_client_staging/staging-white.toml.example`)
+
+```bash
+cp crates/tools/examples/csa_client_staging/staging-white.toml.example \
+   /tmp/staging-white.toml
+# 同様に engine.path をローカル binary に合わせる。
+```
+
+### 2-3. 黒・白の `id` / `password`
+
+CSA Workers では「ハンドル名 + パスワード」だけで合意成立する（ハンドル名
+照合のみ、パスワードは検証されない）。E2E 用には `id = "csa_e2e_black_<日付>"`
+等の高エントロピー値を双方の TOML に書く。`%%SETBUOY` の操作は不要なので、
+`ADMIN_HANDLE` と被らないユニークな値を使う。
+
+例：
+- `id = "csa_e2e_black_20260427"`、`password = "anything"`
+- `id = "csa_e2e_white_20260427"`、`password = "anything"`
+
+## 3. 同一 room_id で接続して対局を 1 局走らせる
+
+`server.host` に同じ `wss://...workers.dev/ws/<room_id>` を指定して、双方の
+csa_client を別ターミナルで起動する。`room_id` は新規生成する任意の文字列
+（`e2e-20260427-001` など）。
+
+ターミナル A（黒番）:
+
+```bash
+cargo run -p tools --release --bin csa_client -- /tmp/staging-black.toml
+```
+
+ターミナル B（白番）:
+
+```bash
+cargo run -p tools --release --bin csa_client -- /tmp/staging-white.toml
+```
+
+成立すれば双方のログに以下の流れが流れる:
+
+```
+[CSA/WS] 接続中: wss://...workers.dev/ws/e2e-20260427-001
+[CSA/WS] 接続成功: status=101 Switching Protocols
+[CSA] ログイン成功: csa_e2e_black_20260427
+[CSA] 対局待機中...
+[CSA] 対局情報受信: <game_id> ... csa_e2e_black_20260427 vs csa_e2e_white_20260427 ...
+[CSA] 対局開始: START:<game_id>
+...
+```
+
+平手 1 対局を最後まで進めるとどちらか一方が `%TORYO` を送り、Worker が
+`#WIN` / `#LOSE` を返して `END Game_Summary` に到達する。
+
+## 4. R2 棋譜が書き出されたことを確認する
+
+Worker は終局時に `KIFU_BUCKET` (`rshogi-csa-kifu-staging`) に CSA V2 棋譜を
+書き出す。bucket の object 一覧を取得して直近のキーを確認する:
+
+```bash
+vp exec wrangler r2 object list rshogi-csa-kifu-staging \
+  --config crates/rshogi-csa-server-workers/wrangler.staging.toml | head
+```
+
+直近の object キー（例: `2026-04-27/<game_id>.csa`）を取得して中身を確認:
+
+```bash
+vp exec wrangler r2 object get \
+  rshogi-csa-kifu-staging/2026-04-27/<game_id>.csa \
+  --config crates/rshogi-csa-server-workers/wrangler.staging.toml \
+  --file /tmp/<game_id>.csa
+cat /tmp/<game_id>.csa
+```
+
+CSA V2 形式（`'`コメント、`+7776FU,T<sec>` ...、`%TORYO` / `+SUMI` 等の
+終局コマンド）が書かれていれば成功。
+
+加えて、Floodgate 履歴 (`FLOODGATE_HISTORY_BUCKET`) にも 1 オブジェクト
+追加されていることを確認する:
+
+```bash
+vp exec wrangler r2 object list rshogi-csa-floodgate-history-staging \
+  --config crates/rshogi-csa-server-workers/wrangler.staging.toml | head
+```
+
+## 5. 後始末
+
+1. `wrangler.staging.toml` の `CORS_ORIGINS` を元の値（通常は空文字列または運用値）に戻し、再 deploy する。
+2. R2 bucket の `csa_e2e_*` 関連オブジェクトを削除したい場合は
+   `vp exec wrangler r2 object delete` で個別に削除できる（残しておいても害はない）。
+3. ローカルに残った `/tmp/staging-black.toml` / `/tmp/staging-white.toml` /
+   棋譜ファイルを破棄する。
+
+## トラブルシューティング
+
+| 症状 | 原因候補 | 対処 |
+| --- | --- | --- |
+| `CSAサーバー接続失敗: WebSocket Upgrade 失敗` (`403 Forbidden Origin`) | `CORS_ORIGINS` allowlist に csa_client の Origin が無い | §1 で staging に Origin を追加してから再 deploy |
+| `ログイン失敗: LOGIN:INCORRECT` 等 | サーバー側 league で同一ハンドルが既に接続中 | `id` を別値に変えるか、Worker の DO state を `vp exec wrangler ...` で再起動する |
+| 双方接続するも対局が始まらない | `room_id` が一致していない | URL の `/ws/<room_id>` 部分が両 toml で完全一致しているか確認 |
+| 対局終局後も R2 に書き込まれない | DO storage の終局イベントが落ちた可能性 | Worker のログを `vp run tail:staging` で確認 |


### PR DESCRIPTION
## Summary

- `docs/csa-server/staging-e2e.md` を新設し、Cloudflare Workers staging サーバー (`rshogi-csa-server-workers-staging`) に `csa_client` × 2 セッション (黒/白) を WebSocket で接続して平手 1 対局を最後まで通電し、R2 (`rshogi-csa-kifu-staging`) に棋譜が書き出されるところまでを再現可能な 5 ステップ手順として残す。
- `crates/tools/examples/csa_client_staging/staging-{black,white}.toml.example` に黒・白それぞれの最小 TOML サンプルを置く。`engine.path`、`host` URL の `<account>` / `<room_id>` / `<date>`、`ws_origin` を運用者が穴埋めして使う形。
- `crates/tools/examples/README.md` に csa_client セクションを追加し、3 コマンドのクイックスタートを記載。

## 前提

- 前 PR (#518) で追加された `csa_client` の WebSocket transport (host scheme `wss://`) が main に取り込まれていること。
- staging Worker と R2 bucket (kifu / floodgate-history) が deploy 済みであること。

## 設計判断

- 実機通電は本 PR の merge 後にユーザー側で行う想定。本 PR は **手順書と再現用 config までを成果物** とし、再実行可能性を docs に閉じる。これに伴いコード変更はゼロ（`tools/examples/` 以下の追加ファイルのみ）。
- staging Worker の `CORS_ORIGINS` を一時編集 → deploy → 確認 → 巻き戻しの運用は手順書 §1 / §5 に明記。production には影響しない。
- ハンドル名は `csa_e2e_black_<date>` 形式で日付サフィックス + 黒/白 ラベルを付ける形にした。`ADMIN_HANDLE` と被らないユニークな値を使うことで `%%SETBUOY` 系コマンドの誤発火を回避する。

## 受入

- [x] `cargo fmt --all` 適用済み（コード変更なしのため fmt 影響なし）
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test --workspace` 全 pass（無変更）
- [x] 手順書だけを読んで他の運用者が再現できる粒度（5 ステップ + トラブルシューティング表）

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review サイクルで Approve as-is
- [ ] **merge 後にユーザーが実機 E2E を実施し、棋譜が R2 に書かれることを確認**（本 PR の真の検証点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
