### PR TITLE
fix(csa-client): wss 接続を実機通電させる rustls provider と複数行 frame の split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ data/
 logs/
 *.log
 
+# csa_client local output (棋譜 / sfen) for staging E2E or local runs
+records/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "rshogi-core",
  "rshogi-csa",
  "rshogi-csa-server",
+ "rustls",
  "serde",
  "serde_json",
  "toml",
@@ -1920,6 +1921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -27,6 +27,10 @@ rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 # CSA-over-WebSocket 用の sync ハンドシェイク + フレーミング。
 # rustls + webpki ルートで TLS を実装し、native-tls 経由の OpenSSL 依存を避ける。
 tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
+# rustls 0.23 は process-level の `CryptoProvider` を起動時に明示登録する必要がある
+# （`tungstenite` の rustls feature は cert source だけを切り替え、provider は選ばない）。
+# `ring` provider を `main()` 冒頭で `install_default()` 経由で登録する。
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 ctrlc = "3.4"
 libc = "0.2"

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -100,6 +100,12 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
+    // tungstenite が wss を扱う際、rustls 0.23 は process-level の CryptoProvider が
+    // 明示的に登録されていないと panic する。aws-lc-rs より導入が軽い `ring` を選択し、
+    // 起動時に 1 度だけ install する。`set_default` は同 process で既に install されて
+    // いれば `Err` を返すので無視する。
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = Cli::parse();
 
     // 設定ファイル読み込み

--- a/crates/rshogi-csa-client/src/transport.rs
+++ b/crates/rshogi-csa-client/src/transport.rs
@@ -11,6 +11,7 @@
 //! は文字列スライスで扱う。改行コードは TCP 経路では `write_line` 内部で
 //! `\n` を付加し、WS 経路では text frame の境界そのものが行境界になる。
 
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
@@ -302,6 +303,11 @@ pub struct WsTransport {
     ws: Arc<Mutex<WebSocket<MaybeTlsStream<TcpStream>>>>,
     /// `start_reader_thread` 後は reader が thread 内で動作する。inline 操作禁止フラグ。
     reader_moved: bool,
+    /// CSA サーバ実装は `Game_Summary` のように `\n` 区切りの複数行を 1 つの
+    /// text frame で送ってくる（TCP 互換のため文字列全体を `send_with_str` する）。
+    /// inline モードではここに 1 frame 分を行ごとに分割して push し、
+    /// `read_line_*` が 1 行ずつ pop する。空行 (CSA keep-alive) は捨てる。
+    pending_lines: VecDeque<String>,
 }
 
 impl WsTransport {
@@ -331,6 +337,7 @@ impl WsTransport {
         Ok(Self {
             ws: Arc::new(Mutex::new(ws)),
             reader_moved: false,
+            pending_lines: VecDeque::new(),
         })
     }
 
@@ -345,20 +352,18 @@ impl WsTransport {
         self.ensure_inline()?;
         let deadline = Instant::now() + timeout;
         loop {
+            if let Some(line) = self.pop_pending_line() {
+                log::debug!("[CSA] < {line}");
+                return Ok(line);
+            }
             let remaining =
                 deadline.checked_duration_since(Instant::now()).unwrap_or(Duration::ZERO);
             if remaining.is_zero() {
                 bail!("サーバー応答タイムアウト");
             }
-            match self.try_read_one_message()? {
-                Some(line) => {
-                    if !line.is_empty() {
-                        log::debug!("[CSA] < {line}");
-                        return Ok(line);
-                    }
-                    // 空 text frame は keep-alive 扱いで読み飛ばす。
-                }
-                None => {
+            match self.try_read_one_frame()? {
+                FrameOutcome::Text(payload) => self.enqueue_frame(&payload),
+                FrameOutcome::None => {
                     // 50ms 単位でリトライしつつ deadline まで待つ（内部 TcpStream の
                     // read_timeout が 100ms なので、その半分でリトライ間隔を取る）。
                     std::thread::sleep(Duration::from_millis(50).min(remaining));
@@ -369,28 +374,48 @@ impl WsTransport {
 
     fn read_line_nonblocking(&mut self) -> Result<Option<String>> {
         self.ensure_inline()?;
-        match self.try_read_one_message()? {
-            Some(line) if !line.is_empty() => {
-                log::debug!("[CSA] < {line}");
-                Ok(Some(line))
+        if let Some(line) = self.pop_pending_line() {
+            log::debug!("[CSA] < {line}");
+            return Ok(Some(line));
+        }
+        match self.try_read_one_frame()? {
+            FrameOutcome::Text(payload) => {
+                self.enqueue_frame(&payload);
+                Ok(self.pop_pending_line().inspect(|line| {
+                    log::debug!("[CSA] < {line}");
+                }))
             }
-            _ => Ok(None),
+            FrameOutcome::None => Ok(None),
         }
     }
 
-    /// `WebSocket::read` を 1 回だけ非ブロッキングで試行する。
-    /// `Ok(Some(line))`: text frame を 1 つ受信した（空文字含む）。
-    /// `Ok(None)`: WouldBlock / Pong / Ping をハンドリング後にデータなし。
-    /// `Err(_)`: 切断 / プロトコル違反など回復不能。
-    fn try_read_one_message(&mut self) -> Result<Option<String>> {
+    /// 受信した 1 frame の text を `\n` で分割して `pending_lines` に積む。
+    /// 末尾の空行は CSA の keep-alive 慣習に従って捨てる（`split` の最後の要素は
+    /// `\n` 終端時に必ず空文字になるため）。中間に来る空行も同様に捨てる。
+    fn enqueue_frame(&mut self, payload: &str) {
+        for line in payload.split('\n') {
+            let trimmed = line.trim_end_matches('\r');
+            if !trimmed.is_empty() {
+                self.pending_lines.push_back(trimmed.to_owned());
+            }
+        }
+    }
+
+    fn pop_pending_line(&mut self) -> Option<String> {
+        self.pending_lines.pop_front()
+    }
+
+    /// `WebSocket::read` を 1 回だけ非ブロッキングで試行し、得られた text frame
+    /// を生のまま返す（`\n` 分割は呼び出し側）。
+    fn try_read_one_frame(&mut self) -> Result<FrameOutcome> {
         let mut guard = self.ws.lock().map_err(|_| anyhow!("WS lock poisoned"))?;
         match guard.read() {
-            Ok(Message::Text(payload)) => Ok(Some(payload.to_string())),
+            Ok(Message::Text(payload)) => Ok(FrameOutcome::Text(payload.to_string())),
             Ok(Message::Binary(_)) => {
                 log::warn!("[CSA/WS] 想定外の binary frame を破棄");
-                Ok(None)
+                Ok(FrameOutcome::None)
             }
-            Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => Ok(None),
+            Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => Ok(FrameOutcome::None),
             Ok(Message::Close(frame)) => {
                 log::info!("[CSA/WS] サーバーから Close frame 受信: {frame:?}");
                 bail!("サーバー切断");
@@ -398,7 +423,7 @@ impl WsTransport {
             Err(tungstenite::Error::Io(e))
                 if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
             {
-                Ok(None)
+                Ok(FrameOutcome::None)
             }
             Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
                 bail!("サーバー切断");
@@ -421,7 +446,15 @@ impl WsTransport {
         }
         self.reader_moved = true;
         let ws = Arc::clone(&self.ws);
+        // 既に inline で受信して queue に溜まっている行も先に流してから loop に入る。
+        let pending = std::mem::take(&mut self.pending_lines);
         std::thread::Builder::new().name("csa-ws-reader".to_string()).spawn(move || {
+            for line in pending {
+                log::debug!("[CSA] < {line}");
+                if tx.send(Event::ServerLine(line)).is_err() {
+                    return;
+                }
+            }
             loop {
                 let next = {
                     let mut guard = match ws.lock() {
@@ -435,11 +468,16 @@ impl WsTransport {
                 };
                 match next {
                     Ok(Message::Text(payload)) => {
-                        let line = payload.to_string();
-                        if !line.is_empty() {
-                            log::debug!("[CSA] < {line}");
-                            if tx.send(Event::ServerLine(line)).is_err() {
-                                break;
+                        // 1 frame に複数行 (`\n` 区切り) が入りうる。CSA は
+                        // 行 stream protocol なので、frame を line 単位に展開する。
+                        for raw_line in payload.as_str().split('\n') {
+                            let trimmed = raw_line.trim_end_matches('\r');
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            log::debug!("[CSA] < {trimmed}");
+                            if tx.send(Event::ServerLine(trimmed.to_owned())).is_err() {
+                                return;
                             }
                         }
                     }
@@ -467,6 +505,14 @@ impl WsTransport {
         })?;
         Ok(())
     }
+}
+
+/// `WsTransport::try_read_one_frame` の戻り値。
+enum FrameOutcome {
+    /// text frame を 1 つ受信した（複数行を含み得る）。
+    Text(String),
+    /// データなし（WouldBlock / Ping / Pong / Binary 廃棄）。
+    None,
 }
 
 /// `tungstenite::WebSocket` 内部の `TcpStream` に到達して read_timeout を設定する

--- a/crates/rshogi-csa-client/tests/csa_ws_transport.rs
+++ b/crates/rshogi-csa-client/tests/csa_ws_transport.rs
@@ -105,6 +105,90 @@ fn ws_transport_reader_thread_delivers_multiple_lines() {
 }
 
 #[test]
+fn ws_transport_splits_multiline_frame_into_lines() {
+    // CSA サーバは Game_Summary のように `\n` 区切りの複数行を 1 frame で送る。
+    // client 側は frame を行単位に split して 1 行ずつ消費できなければならない。
+    let (port, join) = spawn_mock_ws_server(|ws| {
+        let _ = ws.read(); // wait for "READY"
+        ws.send(Message::Text(
+            "BEGIN Game_Summary\nName+:black\nName-:white\nEND Game_Summary\n".into(),
+        ))
+        .expect("send multiline");
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let mut transport = CsaTransport::connect(
+        &target,
+        &ConnectOpts {
+            tcp_keepalive: false,
+            ws_origin: Some("http://localhost".to_owned()),
+        },
+    )
+    .expect("connect");
+
+    transport.write_line("READY").expect("write ready");
+
+    let mut received = Vec::new();
+    while received.len() < 4 {
+        match transport.read_line_blocking(Duration::from_secs(5)) {
+            Ok(line) => received.push(line),
+            Err(e) => panic!("read failed: {e}"),
+        }
+    }
+    assert_eq!(
+        received,
+        vec![
+            "BEGIN Game_Summary".to_owned(),
+            "Name+:black".to_owned(),
+            "Name-:white".to_owned(),
+            "END Game_Summary".to_owned(),
+        ]
+    );
+
+    drop(transport);
+    join.join().expect("server thread");
+}
+
+#[test]
+fn ws_transport_reader_thread_splits_multiline_frame() {
+    // start_reader_thread 経路でも multi-line frame を 1 行ずつ Event::ServerLine で
+    // 配信できる。
+    let (port, join) = spawn_mock_ws_server(|ws| {
+        let _ = ws.read();
+        ws.send(Message::Text("LINE_X\nLINE_Y\nLINE_Z\n".into())).expect("send");
+        thread::sleep(Duration::from_millis(50));
+    });
+
+    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let mut transport = CsaTransport::connect(
+        &target,
+        &ConnectOpts {
+            tcp_keepalive: false,
+            ws_origin: Some("http://localhost".to_owned()),
+        },
+    )
+    .expect("connect");
+    transport.write_line("READY").expect("write");
+
+    let (tx, rx) = mpsc::channel::<Event>();
+    transport.start_reader_thread(tx).expect("reader thread");
+
+    let mut received = Vec::new();
+    while received.len() < 3 {
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Event::ServerLine(s)) => received.push(s),
+            Ok(Event::ServerDisconnected) => break,
+            Err(e) => panic!("recv timeout: {e:?}"),
+        }
+    }
+    assert_eq!(received, vec!["LINE_X".to_owned(), "LINE_Y".into(), "LINE_Z".into()]);
+
+    drop(transport);
+    join.join().expect("server thread");
+}
+
+#[test]
 fn ws_transport_empty_text_frame_treated_as_keepalive() {
     let (port, join) = spawn_mock_ws_server(|ws| {
         let _ = ws.read(); // wait for "PING"


### PR DESCRIPTION
## Summary

PR #518 で導入した CSA-over-WebSocket transport を Cloudflare Workers staging に対して実機通電させたところ、対局成立まで届かない 2 つの実装ギャップが判明したのでまとめて直す。さらに csa_client のローカル出力ディレクトリを `.gitignore` する。

## 1. rustls 0.23 の CryptoProvider 未登録で wss が panic

- 症状: `cargo run -p rshogi-csa-client -- staging.toml` で wss 接続を試みた瞬間に rustls が以下の panic を起こす。
  ```
  Could not automatically determine the process-level CryptoProvider from Rustls crate features.
  Call CryptoProvider::install_default() before this point to select a provider manually,
  or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
  ```
- 原因: tungstenite 0.27 の `rustls-tls-webpki-roots` feature は cert source の切り替えだけで、rustls 0.23 の process-level `CryptoProvider` を選ばない。
- 修正: `rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }` を追加し、`main()` 冒頭で `rustls::crypto::ring::default_provider().install_default()` を 1 度だけ登録する。`set_default` は重複で `Err` を返すので無視する。

## 2. WebSocket text frame に複数行が乗ったとき先頭行で全文を比較してしまう

- 症状: LOGIN は通るが Game_Summary 受信ループから抜けず client が無限待機。
- 原因: サーバ側 (Workers) は `Game_Summary` を `BEGIN Game_Summary\n...\nEND Game_Summary\n` の 1 frame にまとめて送る (TCP との `send_line` 互換)。client 側は `WsTransport::try_read_one_message` で 1 frame = 1 line として読んでしまい、`line == "BEGIN Game_Summary"` 等の完全一致比較が永遠に成立しない。
- 修正:
  - `WsTransport` に `pending_lines: VecDeque<String>` を持たせ、受信した text frame を `\n` で split して 1 行ずつ enqueue → `read_line_*` が 1 行ずつ pop する形に変更。`\r` 末尾は trim する。空行は CSA keep-alive 扱いで捨てる。
  - `start_reader_thread` 経路でも frame split を行い、inline で先行受信した queue は thread 起動時に `mem::take` してから loop に流すことで順序を保つ。
  - `tests/csa_ws_transport.rs` に inline / reader-thread 経路それぞれの multi-line frame 分解テストを追加。

## 3. csa_client のローカル出力ディレクトリを `.gitignore` 対象にする

- `records/` を `.gitignore` に追加。csa_client は対局終了後 `./records/<run-dir>/<datetime>_<sente>_vs_<gote>.csa` を書き出すため、E2E や手元検証で worktree が dirty になるのを防ぐ。

## 実機検証

staging Worker (`https://rshogi-csa-server-workers-staging.sh11235.workers.dev`) に csa_client × 2 (黒/白) を接続し、平手で `+7776FU` 等 6 手を相互送信した状態で途中切断 (`%CHUDAN`) としたところ、R2 (`rshogi-csa-kifu-staging`) に CSA V2 形式の棋譜 (`2026/04/27/e2e-20260427144531-1777268750262.csa`) が正しく書き出されることまで確認。LOGIN→Game_Summary→START→指し手交換→終局→R2 export のフルパスが通電するようになった。

R2 から取得した棋譜の冒頭:

```
V2.2
N+csa_e2e_black_20260427
N-csa_e2e_white_20260427
$GAME_ID:e2e-20260427144531-1777268750262
$START_TIME:2026/04/27 05:45:50
$END_TIME:2026/04/27 05:47:55
BEGIN Time
Time_Unit:1sec
Total_Time:600
Byoyomi:10
...
+7776FU,T32
-8384FU,T42
+6978KI,T8
-7172GI,T11
+2726FU,T16
-4132KI,T5
%CHUDAN
```

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test -p rshogi-csa-client` 5 件全 pass（multi-line frame テスト 2 件追加含む）
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 成功
- [x] staging Worker (`rshogi-csa-server-workers-staging.sh11235.workers.dev`) で **wss 接続 → 対局通電 → R2 棋譜書き出し** を実機確認

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review サイクルで Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
