### PR TITLE
feat(csa-server): 1ms 粒度の秒読み (CountdownMsec) を一級バリアントとして追加する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -37,12 +37,16 @@ impl ConfigKeys {
     /// （単一行 JSON）を `floodgate-history/YYYY/MM/DD/HHMMSS-<game_id>.json` キーで
     /// 保存し、`list_recent` は day shard を新しい順に走査して N 件取得する。
     pub const FLOODGATE_HISTORY_BUCKET_BINDING: &'static str = "FLOODGATE_HISTORY_BUCKET";
-    /// 時計方式。`countdown` / `fischer` / `stopwatch`。
+    /// 時計方式。`countdown` / `countdown_msec` / `fischer` / `stopwatch`。
     pub const CLOCK_KIND: &'static str = "CLOCK_KIND";
-    /// 秒読み / Fischer 用の持ち時間（秒）。
+    /// `countdown` / Fischer 用の持ち時間（秒）。
     pub const TOTAL_TIME_SEC: &'static str = "TOTAL_TIME_SEC";
-    /// 秒読みの秒読み、または Fischer の増分（秒）。
+    /// `countdown` の秒読み、または Fischer の増分（秒）。
     pub const BYOYOMI_SEC: &'static str = "BYOYOMI_SEC";
+    /// `countdown_msec` 用の持ち時間（ms）。短時間対局（Floodgate 互換ではない拡張）。
+    pub const TOTAL_TIME_MS: &'static str = "TOTAL_TIME_MS";
+    /// `countdown_msec` の秒読み（ms）。
+    pub const BYOYOMI_MS: &'static str = "BYOYOMI_MS";
     /// StopWatch 用の持ち時間（分）。
     pub const TOTAL_TIME_MIN: &'static str = "TOTAL_TIME_MIN";
     /// StopWatch 用の秒読み（分）。
@@ -101,6 +105,8 @@ impl ConfigKeys {
         Self::CLOCK_KIND,
         Self::TOTAL_TIME_SEC,
         Self::BYOYOMI_SEC,
+        Self::TOTAL_TIME_MS,
+        Self::BYOYOMI_MS,
         Self::TOTAL_TIME_MIN,
         Self::BYOYOMI_MIN,
         Self::RECONNECT_GRACE_SECONDS,
@@ -132,10 +138,18 @@ pub fn parse_reconnect_grace_duration(raw: Option<&str>) -> Result<std::time::Du
 }
 
 /// Workers `[vars]` 文字列群から時計設定を解決する。
+///
+/// `CLOCK_KIND` のバリアント別に参照する env 変数:
+/// - `countdown`: `TOTAL_TIME_SEC` / `BYOYOMI_SEC` (秒、Floodgate 互換)
+/// - `countdown_msec`: `TOTAL_TIME_MS` / `BYOYOMI_MS` (ms、短時間対局向け拡張)
+/// - `fischer`: `TOTAL_TIME_SEC` / `BYOYOMI_SEC` (秒、`BYOYOMI_SEC` は Fischer increment)
+/// - `stopwatch`: `TOTAL_TIME_MIN` / `BYOYOMI_MIN` (分)
 pub fn parse_clock_spec(
     clock_kind: Option<&str>,
     total_time_sec: Option<&str>,
     byoyomi_sec: Option<&str>,
+    total_time_ms: Option<&str>,
+    byoyomi_ms: Option<&str>,
     total_time_min: Option<&str>,
     byoyomi_min: Option<&str>,
 ) -> Result<ClockSpec, String> {
@@ -151,6 +165,10 @@ pub fn parse_clock_spec(
             total_time_sec: parse_u32("TOTAL_TIME_SEC", total_time_sec, 600)?,
             byoyomi_sec: parse_u32("BYOYOMI_SEC", byoyomi_sec, 10)?,
         }),
+        "countdown_msec" => Ok(ClockSpec::CountdownMsec {
+            total_time_ms: parse_u32("TOTAL_TIME_MS", total_time_ms, 600_000)?,
+            byoyomi_ms: parse_u32("BYOYOMI_MS", byoyomi_ms, 10_000)?,
+        }),
         "fischer" => Ok(ClockSpec::Fischer {
             total_time_sec: parse_u32("TOTAL_TIME_SEC", total_time_sec, 600)?,
             increment_sec: parse_u32("BYOYOMI_SEC", byoyomi_sec, 10)?,
@@ -159,7 +177,9 @@ pub fn parse_clock_spec(
             total_time_min: parse_u32("TOTAL_TIME_MIN", total_time_min, 10)?,
             byoyomi_min: parse_u32("BYOYOMI_MIN", byoyomi_min, 1)?,
         }),
-        other => Err(format!("CLOCK_KIND: expected countdown|fischer|stopwatch, got {other:?}")),
+        other => Err(format!(
+            "CLOCK_KIND: expected countdown|countdown_msec|fischer|stopwatch, got {other:?}"
+        )),
     }
 }
 
@@ -208,7 +228,7 @@ mod tests {
     #[test]
     fn parse_clock_spec_defaults_to_countdown() {
         assert_eq!(
-            parse_clock_spec(None, None, None, None, None).unwrap(),
+            parse_clock_spec(None, None, None, None, None, None, None).unwrap(),
             ClockSpec::Countdown {
                 total_time_sec: 600,
                 byoyomi_sec: 10,
@@ -217,9 +237,43 @@ mod tests {
     }
 
     #[test]
+    fn parse_clock_spec_accepts_countdown_msec() {
+        assert_eq!(
+            parse_clock_spec(
+                Some("countdown_msec"),
+                None,
+                None,
+                Some("10000"),
+                Some("100"),
+                None,
+                None,
+            )
+            .unwrap(),
+            ClockSpec::CountdownMsec {
+                total_time_ms: 10_000,
+                byoyomi_ms: 100,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_clock_spec_countdown_msec_uses_defaults_when_unset() {
+        // CLOCK_KIND=countdown_msec で値未指定なら 600_000 / 10_000 (= 600s / 10s 相当) で
+        // production の挙動と整合する。
+        assert_eq!(
+            parse_clock_spec(Some("countdown_msec"), None, None, None, None, None, None).unwrap(),
+            ClockSpec::CountdownMsec {
+                total_time_ms: 600_000,
+                byoyomi_ms: 10_000,
+            }
+        );
+    }
+
+    #[test]
     fn parse_clock_spec_accepts_fischer() {
         assert_eq!(
-            parse_clock_spec(Some("fischer"), Some("300"), Some("5"), None, None).unwrap(),
+            parse_clock_spec(Some("fischer"), Some("300"), Some("5"), None, None, None, None)
+                .unwrap(),
             ClockSpec::Fischer {
                 total_time_sec: 300,
                 increment_sec: 5,
@@ -230,7 +284,8 @@ mod tests {
     #[test]
     fn parse_clock_spec_accepts_stopwatch() {
         assert_eq!(
-            parse_clock_spec(Some("stopwatch"), None, None, Some("15"), Some("2")).unwrap(),
+            parse_clock_spec(Some("stopwatch"), None, None, None, None, Some("15"), Some("2"))
+                .unwrap(),
             ClockSpec::StopWatch {
                 total_time_min: 15,
                 byoyomi_min: 2,
@@ -240,8 +295,8 @@ mod tests {
 
     #[test]
     fn parse_clock_spec_rejects_unknown_kind() {
-        let err = parse_clock_spec(Some("weird"), None, None, None, None).unwrap_err();
-        assert!(err.contains("countdown|fischer|stopwatch"));
+        let err = parse_clock_spec(Some("weird"), None, None, None, None, None, None).unwrap_err();
+        assert!(err.contains("countdown|countdown_msec|fischer|stopwatch"));
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1673,12 +1673,16 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
     let clock_kind = env.var(ConfigKeys::CLOCK_KIND).ok().map(|v| v.to_string());
     let total_time_sec = env.var(ConfigKeys::TOTAL_TIME_SEC).ok().map(|v| v.to_string());
     let byoyomi_sec = env.var(ConfigKeys::BYOYOMI_SEC).ok().map(|v| v.to_string());
+    let total_time_ms = env.var(ConfigKeys::TOTAL_TIME_MS).ok().map(|v| v.to_string());
+    let byoyomi_ms = env.var(ConfigKeys::BYOYOMI_MS).ok().map(|v| v.to_string());
     let total_time_min = env.var(ConfigKeys::TOTAL_TIME_MIN).ok().map(|v| v.to_string());
     let byoyomi_min = env.var(ConfigKeys::BYOYOMI_MIN).ok().map(|v| v.to_string());
     parse_clock_spec(
         clock_kind.as_deref(),
         total_time_sec.as_deref(),
         byoyomi_sec.as_deref(),
+        total_time_ms.as_deref(),
+        byoyomi_ms.as_deref(),
         total_time_min.as_deref(),
         byoyomi_min.as_deref(),
     )

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -73,11 +73,17 @@ bucket_name = "rshogi-csa-floodgate-history-prod"
 # 例: "https://rshogi.example.com,https://www.rshogi.example.com"
 WS_ALLOWED_ORIGINS = ""
 
-# 対局時計。`countdown` (CSA 2014 改訂秒読み) / `fischer` (増分加算) / `stopwatch` (分単位)。
+# 対局時計。`countdown` (CSA 2014 改訂秒読み、Floodgate 互換) / `countdown_msec`
+# (ms 粒度の短時間対局向け拡張) / `fischer` (増分加算) / `stopwatch` (分単位)。
+# production は本家 Floodgate と互換の `countdown` (Time_Unit:1sec) を既定値とする。
 CLOCK_KIND = "countdown"
 # countdown / fischer 用（秒）。
 TOTAL_TIME_SEC = "600"
 BYOYOMI_SEC = "10"
+# countdown_msec 用（ms）。CLOCK_KIND=countdown_msec のときのみ参照。
+# production は countdown (sec) で運用するため、ここは整合性確保のための placeholder。
+TOTAL_TIME_MS = "600000"
+BYOYOMI_MS = "10000"
 # stopwatch 用（分）。CLOCK_KIND=stopwatch のときのみ参照。
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -68,11 +68,28 @@ bucket_name = "rshogi-csa-floodgate-history-staging"
 # 入れておく。本番 client URL が確定したら追記/差し替えする。
 WS_ALLOWED_ORIGINS = "https://csa-client-local"
 
-# 対局時計。`countdown` (CSA 2014 改訂秒読み) / `fischer` (増分加算) / `stopwatch` (分単位)。
-# production と同値にして staging で時計挙動の regression を素直に検出する。
-CLOCK_KIND = "countdown"
+# 対局時計の方式と値。
+# - `countdown`: CSA 2014 改訂互換、整数秒切り捨て、Floodgate 互換 (`Time_Unit:1sec`)。
+# - `countdown_msec`: ms 粒度の短時間対局向け拡張 (`Time_Unit:1msec`)。
+#   本リポ独自で本家 Floodgate には無い。staging では実機 E2E と CI E2E を素早く回す
+#   ために CountdownMsec で `byoyomi=100ms` 程度に短縮する運用。
+# - `fischer`: 秒単位の増分加算。
+# - `stopwatch`: 分単位切り捨ての shogi-server 旧挙動。
+#
+# 各バリアントが参照する env 変数:
+#   countdown      → TOTAL_TIME_SEC / BYOYOMI_SEC
+#   countdown_msec → TOTAL_TIME_MS  / BYOYOMI_MS
+#   fischer        → TOTAL_TIME_SEC / BYOYOMI_SEC (BYOYOMI_SEC は increment)
+#   stopwatch      → TOTAL_TIME_MIN / BYOYOMI_MIN
+CLOCK_KIND = "countdown_msec"
+# countdown 系（参照されない側も SHARED_PUBLIC_VARS_KEYS の整合性のため宣言する）。
 TOTAL_TIME_SEC = "600"
 BYOYOMI_SEC = "10"
+# countdown_msec で使う実値: 持ち時間 10 秒、秒読み 100ms（実機 E2E と CI E2E で
+# 1 局を数秒〜十数秒で完走させる速度を狙う）。
+TOTAL_TIME_MS = "10000"
+BYOYOMI_MS = "100"
+# stopwatch 系（参照されない）。
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
 

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -55,11 +55,15 @@ preview_bucket_name = "local-floodgate-history-dev"
 # 空文字列・未設定時は全 Upgrade 要求を 403 で拒否する（安全側の既定）。
 [vars]
 WS_ALLOWED_ORIGINS = ""
-# 対局時計。`countdown` / `fischer` / `stopwatch`。
+# 対局時計。`countdown` / `countdown_msec` / `fischer` / `stopwatch`。
+# countdown は Floodgate 互換の整数秒切り捨て、countdown_msec は ms 粒度の短時間対局向け拡張。
 CLOCK_KIND = "countdown"
 # countdown / fischer 用（秒）。
 TOTAL_TIME_SEC = "600"
 BYOYOMI_SEC = "10"
+# countdown_msec 用（ms）。CLOCK_KIND=countdown_msec のときのみ使う。
+TOTAL_TIME_MS = "600000"
+BYOYOMI_MS = "10000"
 # stopwatch 用（分）。CLOCK_KIND=stopwatch のときのみ使う。
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -56,14 +56,22 @@ pub trait TimeClock {
 }
 
 /// フロントエンド設定から選択する時計方式。
+///
+/// `Countdown` (整数秒切り捨て、Floodgate 互換) と `CountdownMsec` (1ms 粒度、
+/// 短時間対局向け拡張) は **別バリアント** として並列に持つ。
+/// 1 つの Worker / TCP server インスタンスは config で指定された 1 種類だけを
+/// 使う（バリアントを混在させない）。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ClockSpec {
-    /// CSA 2014 改訂互換の秒読み。
+    /// CSA 2014 改訂互換の秒読み（整数秒切り捨て、`Time_Unit:1sec`）。
     Countdown {
         total_time_sec: u32,
         byoyomi_sec: u32,
     },
+    /// 1ms 粒度の秒読み（短時間対局向け、`Time_Unit:1msec`）。
+    /// 本家 Floodgate には無い拡張で、`byoyomi_ms = 100` のような端数値を許す。
+    CountdownMsec { total_time_ms: u32, byoyomi_ms: u32 },
     /// Fischer 方式（秒単位）。
     Fischer {
         total_time_sec: u32,
@@ -93,6 +101,10 @@ impl ClockSpec {
                 total_time_sec,
                 byoyomi_sec,
             } => Box::new(SecondsCountdownClock::new(*total_time_sec, *byoyomi_sec)),
+            Self::CountdownMsec {
+                total_time_ms,
+                byoyomi_ms,
+            } => Box::new(MillisecondsCountdownClock::new(*total_time_ms, *byoyomi_ms)),
             Self::Fischer {
                 total_time_sec,
                 increment_sec,
@@ -216,6 +228,97 @@ impl TimeClock for SecondsCountdownClock {
 const SECOND_GRAIN_MS: i64 = 1_000;
 /// 1 分分のミリ秒。StopWatch の grain (最小単位)。
 const MINUTE_GRAIN_MS: i64 = 60 * 1_000;
+
+/// 1ms 粒度の秒読み方式（短時間対局向け、Floodgate 互換ではない拡張）。
+///
+/// - `total_time_ms`: 持ち時間本体（ms）。使い切ると秒読みへ移行。
+/// - `byoyomi_ms`: 1 手あたりの秒読み時間（ms）。使い切ると時間切れ。
+/// - 経過時間の切り捨ては行わない（`elapsed_ms` をそのまま差し引く）。
+/// - Game_Summary は `Time_Unit:1msec` を出力。
+///
+/// `SecondsCountdownClock` との違いは grain (1ms vs 1sec) のみで、
+/// turn_budget や本体→秒読み移行のロジックは同型。
+#[derive(Debug, Clone)]
+pub struct MillisecondsCountdownClock {
+    total_time_ms: u32,
+    byoyomi_ms: u32,
+    remaining_black_ms: i64,
+    remaining_white_ms: i64,
+}
+
+impl MillisecondsCountdownClock {
+    /// 新しい ms 粒度秒読み時計を作る。
+    pub fn new(total_time_ms: u32, byoyomi_ms: u32) -> Self {
+        let initial = total_time_ms as i64;
+        Self {
+            total_time_ms,
+            byoyomi_ms,
+            remaining_black_ms: initial,
+            remaining_white_ms: initial,
+        }
+    }
+
+    fn slot_mut(&mut self, color: Color) -> &mut i64 {
+        match color {
+            Color::Black => &mut self.remaining_black_ms,
+            Color::White => &mut self.remaining_white_ms,
+        }
+    }
+
+    fn slot(&self, color: Color) -> i64 {
+        match color {
+            Color::Black => self.remaining_black_ms,
+            Color::White => self.remaining_white_ms,
+        }
+    }
+
+    fn byoyomi_ms_i64(&self) -> i64 {
+        self.byoyomi_ms as i64
+    }
+}
+
+impl TimeClock for MillisecondsCountdownClock {
+    fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
+        // ms 粒度では切り捨てを行わない。`elapsed_ms` の上限は対局想定時間内に
+        // 収まる（数十秒〜数分）ので i64 cast で問題ない。
+        let elapsed = elapsed_ms as i64;
+        let byoyomi = self.byoyomi_ms_i64();
+        let slot = self.slot_mut(color);
+
+        if elapsed <= *slot {
+            *slot -= elapsed;
+            return ClockResult::Continue;
+        }
+
+        let over = elapsed - *slot;
+        *slot = 0;
+        if over > byoyomi {
+            ClockResult::TimeUp
+        } else {
+            ClockResult::Continue
+        }
+    }
+
+    fn format_summary(&self) -> String {
+        let mut out = String::new();
+        out.push_str("BEGIN Time\n");
+        out.push_str("Time_Unit:1msec\n");
+        out.push_str(&format!("Total_Time:{}\n", self.total_time_ms));
+        out.push_str(&format!("Byoyomi:{}\n", self.byoyomi_ms));
+        out.push_str("Least_Time_Per_Move:0\n");
+        out.push_str("END Time\n");
+        out
+    }
+
+    fn remaining_main_ms(&self, color: Color) -> i64 {
+        self.slot(color)
+    }
+
+    fn turn_budget_ms(&self, color: Color) -> i64 {
+        // ms 粒度では切り捨てが無いので grain offset (秒粒度の 999ms 等) は不要。
+        self.slot(color) + self.byoyomi_ms_i64()
+    }
+}
 
 /// Fischer 方式の時計（増分加算、**CSA client の会計規則に合わせた init+post hybrid**）。
 ///
@@ -697,6 +800,67 @@ mod tests {
             spec.format_time_section(),
             SecondsCountdownClock::new(600, 10).format_summary()
         );
+    }
+
+    #[test]
+    fn clock_spec_builds_matching_summary_for_countdown_msec() {
+        let spec = ClockSpec::CountdownMsec {
+            total_time_ms: 10_000,
+            byoyomi_ms: 100,
+        };
+        assert_eq!(
+            spec.format_time_section(),
+            MillisecondsCountdownClock::new(10_000, 100).format_summary()
+        );
+    }
+
+    // ---- MillisecondsCountdownClock ----
+
+    #[test]
+    fn ms_clock_consumes_exact_elapsed_ms() {
+        let mut c = MillisecondsCountdownClock::new(10_000, 100);
+        assert_eq!(c.consume(Color::Black, 250), ClockResult::Continue);
+        // 切り捨て無し: 10_000 - 250 = 9_750ms。
+        assert_eq!(c.remaining_main_ms(Color::Black), 9_750);
+    }
+
+    #[test]
+    fn ms_clock_enters_byoyomi_when_main_exhausted() {
+        let mut c = MillisecondsCountdownClock::new(500, 100);
+        assert_eq!(c.consume(Color::Black, 500), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::Black), 0);
+        // 100ms 以内なら byoyomi で受理。
+        assert_eq!(c.consume(Color::Black, 100), ClockResult::Continue);
+    }
+
+    #[test]
+    fn ms_clock_time_up_when_over_byoyomi() {
+        let mut c = MillisecondsCountdownClock::new(500, 100);
+        // 500 + 101 = 601ms 消費 → byoyomi 1ms 超過で TimeUp。
+        assert_eq!(c.consume(Color::Black, 601), ClockResult::TimeUp);
+    }
+
+    #[test]
+    fn ms_clock_format_summary_uses_msec_unit() {
+        let c = MillisecondsCountdownClock::new(10_000, 100);
+        let s = c.format_summary();
+        assert!(s.contains("Time_Unit:1msec"));
+        assert!(s.contains("Total_Time:10000"));
+        assert!(s.contains("Byoyomi:100"));
+    }
+
+    #[test]
+    fn ms_clock_turn_budget_has_no_grain_offset() {
+        // ms 粒度では切り捨てが無いので grain offset (秒粒度の 999ms) は不要。
+        let c = MillisecondsCountdownClock::new(10_000, 100);
+        assert_eq!(c.turn_budget_ms(Color::Black), 10_100);
+    }
+
+    #[test]
+    fn ms_clock_black_and_white_are_independent() {
+        let mut c = MillisecondsCountdownClock::new(10_000, 100);
+        assert_eq!(c.consume(Color::Black, 5_000), ClockResult::Continue);
+        assert_eq!(c.remaining_main_ms(Color::White), 10_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

短時間対局を本リポ独自機能として提供できるよう、`ClockSpec` に `CountdownMsec { total_time_ms, byoyomi_ms }` バリアントを追加。本家 Floodgate は秒単位のみだが、CSA プロトコル v1.2.1 の `Time_Unit:1msec` を素直に出すことで client 側 (`parse_time_unit` で msec/min/sec 三方向対応済み) も無変更で通電する。production は `CLOCK_KIND = "countdown"` のまま無変更で Floodgate 互換維持。staging を `countdown_msec / BYOYOMI_MS = "100"` に切り替えて、実機 E2E と将来の CI E2E を高速化する。

## なぜ別バリアント?

- 既存 `ClockSpec::Countdown { total_time_sec, byoyomi_sec }` を ms 化すると 100 件超の参照を機械的に rename する必要があり、persistence schema の serde 互換性も破る。
- `Countdown` (秒、Floodgate 互換) と `CountdownMsec` (ms、独自拡張) を別バリアントで並列に持つことで、production の挙動は完全無変更、staging は単に `CLOCK_KIND` を切り替えるだけで短時間対局へ移行できる。

## 主な変更

### `crates/rshogi-csa-server/src/game/clock.rs`
- `MillisecondsCountdownClock` を新設。1ms 粒度、`elapsed_ms` の切り捨てなし、`Time_Unit:1msec` 出力、`turn_budget_ms` は `slot + byoyomi`（grain offset 不要）。
- `ClockSpec::CountdownMsec { total_time_ms, byoyomi_ms }` バリアントを追加。`build_clock` / `format_time_section` / `Default` 等は CountdownMsec を扱う分岐を増やすだけ。
- 既存 Countdown / Fischer / StopWatch は **無変更**。serde tag は `kind` で `countdown_msec` (`#[serde(rename_all = "snake_case")]` 通り) を持つ。
- 新クロックの consume / format_summary / turn_budget / 独立性を unit test 6 件で固定。

### `crates/rshogi-csa-server-workers/src/config.rs`
- `ConfigKeys::TOTAL_TIME_MS` / `BYOYOMI_MS` を追加し `SHARED_PUBLIC_VARS_KEYS` に含める（template / staging / production 全 toml で宣言を要求する整合性チェック対象）。
- `parse_clock_spec` に `countdown_msec` 分岐を追加。default 値 600_000ms / 10_000ms (= 600s / 10s) で production countdown と同じ意味。

### `crates/rshogi-csa-server-workers/src/game_room.rs::load_clock_spec_from_env`
- `TOTAL_TIME_MS` / `BYOYOMI_MS` を env から読み込んで `parse_clock_spec` に渡す。`CLOCK_KIND` で実際に参照される変数群が分岐する。

### `wrangler.{staging,production,toml.example}.toml`
- staging: `CLOCK_KIND = "countdown_msec"`、`TOTAL_TIME_MS = "10000"`、`BYOYOMI_MS = "100"`。1 局を数秒〜十数秒で完走させる。
- production: `CLOCK_KIND = "countdown"` のまま無変更、`TOTAL_TIME_MS = "600000"` / `BYOYOMI_MS = "10000"` は SHARED_PUBLIC_VARS_KEYS 整合性のための placeholder。
- toml.example: `TOTAL_TIME_MS` / `BYOYOMI_MS` の説明と既定値を local dev 用に追加。

## 互換性

- **本家 Floodgate**: production は `CLOCK_KIND = "countdown"` 据え置きで挙動完全無変更。`Time_Unit:1sec` 出力もそのまま。
- **本家 client が staging に繋ぐ場合**: Game_Summary に `Time_Unit:1msec` が出る。Floodgate 仕様には `1msec` も spec に含まれるので read 可能なはずだが、本家 client が古ければ未対応の可能性 → staging のみで限定的に許容（運用上 production には影響なし）。
- **本リポ csa_client (`crates/rshogi-csa-client/`)**: `parse_time_unit` で `msec`/`min`/`sec` 三方向対応済み = **無変更で通電**。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test --workspace` 全 pass（lib + integration + Miniflare smoke）
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 成功
- [x] production の挙動が完全無変更（`CLOCK_KIND = "countdown"` のまま `SecondsCountdownClock` 経路）

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review サイクルで Approve as-is
- [ ] **merge 後の staging 自動 deploy で `BYOYOMI_MS = "100"` が反映され、実機 csa_client × 2 で 1 局完走するところまで動作確認**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
