### PR TITLE
test(csa-server-workers): countdown_msec での 1 対局完走を Miniflare smoke に追加する

### DIFF
--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -70,9 +70,11 @@ export interface HarnessOptions {
   allowFloodgateFeatures?: boolean;
   totalTimeSec?: number;
   byoyomiSec?: number;
+  totalTimeMs?: number;
+  byoyomiMs?: number;
   totalTimeMin?: number;
   byoyomiMin?: number;
-  clockKind?: "countdown" | "fischer" | "stopwatch";
+  clockKind?: "countdown" | "countdown_msec" | "fischer" | "stopwatch";
   wsAllowedOrigins?: string;
   adminHandle?: string;
 }
@@ -94,6 +96,8 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       CLOCK_KIND: opts.clockKind ?? "countdown",
       TOTAL_TIME_SEC: String(opts.totalTimeSec ?? 600),
       BYOYOMI_SEC: String(opts.byoyomiSec ?? 10),
+      TOTAL_TIME_MS: String(opts.totalTimeMs ?? 600_000),
+      BYOYOMI_MS: String(opts.byoyomiMs ?? 10_000),
       TOTAL_TIME_MIN: String(opts.totalTimeMin ?? 10),
       BYOYOMI_MIN: String(opts.byoyomiMin ?? 1),
       ADMIN_HANDLE: opts.adminHandle ?? "admin",

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke_countdown_msec.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke_countdown_msec.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CsaClient,
+  createMiniflare,
+  getKifuBucket,
+  makeTempPersistRoot,
+  pollR2ForGameId,
+} from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+// `CLOCK_KIND = "countdown_msec"` で MillisecondsCountdownClock 経路を通電させ、
+// Game_Summary が `Time_Unit:1msec`、棋譜が CSA V2 で R2 に書かれることを assert
+// する短時間対局 smoke。staging の既定値 (BYOYOMI_MS=100, TOTAL_TIME_MS=10000)
+// に揃え、本番互換でない短 byoyomi の挙動を CI で固定する。
+describe("miniflare smoke: 1 対局 E2E (countdown_msec)", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      clockKind: "countdown_msec",
+      totalTimeMs: 10_000,
+      byoyomiMs: 100,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("Game_Summary に Time_Unit:1msec が出て、TORYO 後 R2 棋譜が書かれる", async () => {
+    const roomId = "smoke-msec-room-1";
+    const gameName = "rapid-10-100ms";
+
+    const black = await CsaClient.connect(mf, roomId);
+    const blackName = `alice+${gameName}+black`;
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    const whiteName = `bob+${gameName}+white`;
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    const blackSummary = await black.drainGameSummary();
+    const whiteSummary = await white.drainGameSummary();
+    // `countdown_msec` バリアントが選択されていれば Time_Unit:1msec が出る。
+    // countdown (sec) 互換のままだと 1sec が出てしまうので、ここで両者を区別できる。
+    expect(blackSummary.some((l) => l === "Time_Unit:1msec")).toBe(true);
+    expect(whiteSummary.some((l) => l === "Time_Unit:1msec")).toBe(true);
+    // ms 値そのままで Total_Time / Byoyomi が出る。
+    expect(blackSummary.some((l) => l === "Total_Time:10000")).toBe(true);
+    expect(blackSummary.some((l) => l === "Byoyomi:100")).toBe(true);
+
+    black.send("AGREE");
+    white.send("AGREE");
+    const startBlack = await black.recvLine();
+    const startWhite = await white.recvLine();
+    expect(startBlack.startsWith("START:")).toBe(true);
+    expect(startBlack).toBe(startWhite);
+    const gameId = startBlack.slice("START:".length);
+
+    black.send("+7776FU");
+    await black.recvUntil((l) => l.startsWith("+7776FU"));
+    await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+    white.send("-3334FU");
+    await black.recvUntil((l) => l.startsWith("-3334FU"));
+    await white.recvUntil((l) => l.startsWith("-3334FU"));
+
+    black.send("%TORYO");
+    const blackEnd = await black.recvUntil((l) => l === "#LOSE");
+    expect(blackEnd.some((l) => l === "#RESIGN")).toBe(true);
+
+    const r2 = await getKifuBucket(mf);
+    const list = await pollR2ForGameId(r2, gameId);
+    expect(list.length).toBeGreaterThan(0);
+    const obj = await r2.get(list[0]!.key);
+    const body = await obj!.text();
+    // 棋譜にも Time_Unit:1msec が入る。
+    expect(body).toContain("V2.2");
+    expect(body).toContain(gameId);
+    expect(body).toContain("Time_Unit:1msec");
+    expect(body).toContain("Total_Time:10000");
+    expect(body).toContain("Byoyomi:100");
+
+    await black.close();
+    await white.close();
+  });
+});


### PR DESCRIPTION
## Summary

PR #523 で導入した `ClockSpec::CountdownMsec` (1ms 粒度、`Time_Unit:1msec`) を CI Miniflare smoke で回帰テストできるようにする。staging の既定値 (`TOTAL_TIME_MS = "10000"` / `BYOYOMI_MS = "100"`) と同じ短時間設定で 1 局完走を assert し、Game_Summary 出力 (`Time_Unit:1msec` / `Total_Time:10000` / `Byoyomi:100`) と R2 棋譜の整合を確認する。

## 主な変更

### `tests/miniflare_smoke/harness.ts`
- `HarnessOptions` に `totalTimeMs` / `byoyomiMs` を追加、`clockKind` 型に `"countdown_msec"` を追加。
- `createMiniflare` の `bindings` で `TOTAL_TIME_MS` / `BYOYOMI_MS` を Miniflare に渡す（default 600_000 / 10_000、既存テストの挙動は無変更）。

### `tests/miniflare_smoke/smoke_countdown_msec.test.ts` (新規)
- `clockKind: "countdown_msec"`、`totalTimeMs: 10_000`、`byoyomiMs: 100` で Miniflare を起動。
- LOGIN → Game_Summary → AGREE → 数手 → `%TORYO` → R2 棋譜書き出しを通電。
- assertions:
  - Game_Summary に `Time_Unit:1msec` / `Total_Time:10000` / `Byoyomi:100` が入る。
  - R2 棋譜にも `Time_Unit:1msec` / `Total_Time:10000` / `Byoyomi:100` + `V2.2` + `<game_id>` が含まれる。

## 検証

- `pnpm test:smoke` をローカルで実行し、5 file / 7 test 全 pass を確認:
  - 既存 smoke (countdown sec) — 無回帰
  - 既存 reconnect / restart / floodgate_history — 無回帰
  - 新 smoke_countdown_msec — green

## 互換性

- 既存テストは `clockKind` 未指定で `"countdown"` (sec) のまま動作。
- 新オプション `totalTimeMs` / `byoyomiMs` も未指定なら default で fallback、`countdown` 経路では参照されない。

## 受入

- [x] `pnpm test:smoke` 全 pass
- [x] 既存テストの挙動は無変更（オプション未指定で従来 binding が出る）

## Test plan

- [ ] PR 作成後 Miniflare smoke E2E ジョブで両 smoke (sec / msec) が green
- [ ] independent Claude review で Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
