### PR TITLE
feat(csa-client): host / id 内の {game_seq} placeholder を局番号で自動展開する

### DIFF
--- a/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/black.toml.example
+++ b/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/black.toml.example
@@ -8,11 +8,18 @@
 # `wss://` で始まる場合は WebSocket 経路として接続する。
 # `<account>` 部分は Cloudflare アカウント名に置き換え、`<room_id>` は黒・白で
 # 同一の任意文字列を入れる。
-host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>"
+#
+# Workers サーバは 1 DO instance = 1 対局 という設計で、終局後の同 room_id への
+# 再 LOGIN は `LOGIN:incorrect` で reject する。連続対局 (max_games > 1) では
+# host / id 内の `{game_seq}` placeholder を csa_client が 0 始まりの局番号に
+# 自動置換するので、room_id 末尾に `-{game_seq}` を入れて毎局新規 DO を立てる。
+host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>-{game_seq}"
 # host が `wss://` を含む場合は `port` は無視されるが、TOML schema 互換のため
 # 値を残しておく。
 port = 0
-id = "csa_e2e_black_<date>_B"
+# id にも `{game_seq}` を入れて、毎局異なる game_name とすることで Workers サーバの
+# slot 衝突を避ける。
+id = "csa_e2e_black_<date>_B+<room_id>-{game_seq}+black"
 password = "anything"
 floodgate = true
 

--- a/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/white.toml.example
+++ b/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/white.toml.example
@@ -5,9 +5,11 @@
 
 [server]
 # 黒番と同じ `<room_id>` を URL 末尾に入れる（黒・白で完全一致が必須）。
-host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>"
+# `{game_seq}` placeholder は csa_client が 0 始まりの局番号に自動置換する
+# （連続対局時の room_id 衝突回避、scenarios/B_consecutive_games/black.toml.example 参照）。
+host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>-{game_seq}"
 port = 0
-id = "csa_e2e_white_<date>_B"
+id = "csa_e2e_white_<date>_B+<room_id>-{game_seq}+white"
 password = "anything"
 floodgate = true
 

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -164,7 +164,7 @@ fn main() -> Result<()> {
             break;
         }
 
-        match run_one_game(&config, &mut engine, &shutdown) {
+        match run_one_game(&config, &mut engine, &shutdown, games_played) {
             Ok((result, record)) => {
                 // 棋譜保存
                 if let Err(e) = save_record(&record, &config.record) {
@@ -222,21 +222,33 @@ fn spawn_engine(config: &CsaClientConfig) -> Result<UsiEngine> {
     )
 }
 
-/// 1回のゲームを実行する（接続〜対局〜切断）
+/// 1回のゲームを実行する（接続〜対局〜切断）。
+///
+/// `games_played` は本起動セッションでの対局完了数（0 開始）。`config.server.host` /
+/// `config.server.id` に `{game_seq}` placeholder が含まれていれば
+/// `games_played` に置換する。Cloudflare Workers サーバは 1 DO instance =
+/// 1 対局という設計のため、連続対局では room_id を毎局変える必要があり、
+/// この placeholder で host URL を局ごとに分岐する運用を提供する。本家 Floodgate の
+/// ように同 server を多対局に使う場合は placeholder を入れず host を固定すればよい。
 fn run_one_game(
     config: &CsaClientConfig,
     engine: &mut UsiEngine,
     shutdown: &AtomicBool,
+    games_played: u32,
 ) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
+    let game_seq_str = games_played.to_string();
+    let host = config.server.host.replace("{game_seq}", &game_seq_str);
+    let id = config.server.id.replace("{game_seq}", &game_seq_str);
+
     // サーバー接続。host に scheme (`ws://` / `wss://` / `tcp://`) があれば
     // それに従い、無ければ既存挙動どおり `host:port` の TCP。
-    let target = TransportTarget::from_host_port(&config.server.host, config.server.port);
+    let target = TransportTarget::from_host_port(&host, config.server.port);
     let opts = ConnectOpts {
         tcp_keepalive: config.server.keepalive.tcp,
         ws_origin: config.server.ws_origin.clone(),
     };
     let mut conn = CsaConnection::connect_with_target(&target, &opts)?;
-    conn.login(&config.server.id, &config.server.password)?;
+    conn.login(&id, &config.server.password)?;
 
     // 対局実行
     let result = run_game_session(&mut conn, engine, config, shutdown);

--- a/docs/csa-server/staging-e2e.md
+++ b/docs/csa-server/staging-e2e.md
@@ -110,21 +110,26 @@ CSA V2 形式（`V2.2`、`N+`、`$GAME_ID:`、`BEGIN Position` 〜 `END Position
 
 ## 4. シナリオ B: 連続 N 対局
 
-`max_games = 5` で同 client が 5 局繰り返す。R2 に 5 件のオブジェクトが追加され、
-`game_id` がすべて異なることを確認する。
+`max_games = 5` で同 client が 5 局繰り返す。Workers サーバは **1 DO instance =
+1 対局** という設計で、終局後の同 room_id への再 LOGIN は `LOGIN:incorrect` で
+reject される。連続対局では host / id 内の `{game_seq}` placeholder を
+csa_client が 0 始まりの局番号で自動置換するので、`<room_id>-{game_seq}` 形式に
+書いて毎局新規 DO を立てる運用にする。
 
 ```bash
 cp crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/black.toml.example /tmp/B-black.toml
 cp crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/white.toml.example /tmp/B-white.toml
-# 同じ <room_id> を両方に入れて起動。
+# 黒・白で同じ <room_id> base を入れて起動。`{game_seq}` は csa_client が
+# 0,1,2,...,(max_games-1) を埋める。
 cargo run -p rshogi-csa-client --release -- /tmp/B-black.toml &
 cargo run -p rshogi-csa-client --release -- /tmp/B-white.toml &
 wait
 ```
 
 期待: 各 client ログに `対局 #1 〜 #5 結果` が並び、`通算: ...勝 ...敗 ...分`
-が出る。R2 list で `<room_id>-<timestamp>.csa` 形式の object が **5 件**
-追加されている。`game_id` は `<room_id>-<n>` で各局異なる timestamp suffix が付く。
+が出る。R2 list で `<room_id>-<n>-<timestamp>.csa` 形式の object が **5 件**
+追加されている。各 object の `game_id` は `<room_id>-<n>-<timestamp>` で
+`<n>` が 0..4 の連番、`<timestamp>` が DO 内で発番される時刻 suffix。
 
 ## 5. シナリオ C: 切断 → 再接続
 


### PR DESCRIPTION
## Summary

Cloudflare Workers サーバは **1 DO instance = 1 対局** という設計で、終局後の同 room_id への再 LOGIN は `handle_login::load_finished` チェック (`game_room.rs:322`) で `LOGIN:incorrect` で reject される。csa_client の `max_games > 1` 連続対局シナリオを成立させるため、`config.server.host` および `config.server.id` 内の `{game_seq}` placeholder を `games_played` (0 始まりの局番号) に置換する仕組みを追加する。

## 背景

直前の PR #524 で B シナリオ (`max_games = 5`) を整備したが、実機 staging で実行すると 1 局目完走後に 2 局目以降が `LOGIN:incorrect` で永続 reject される現象を観測。Workers サーバ側の意図された設計 (1 DO instance = 1 対局) のため、本家 Floodgate のような「1 server で多対局」スタイルでは動かない。サーバ設計を変えるより、client が連続対局のたびに room_id を変える運用が自然。

## 主な変更

### `crates/rshogi-csa-client/src/main.rs::run_one_game`
- 引数に `games_played: u32` を追加。main の対局ループで現在の連番を渡す。
- 関数冒頭で `config.server.host` / `config.server.id` の `"{game_seq}"` を `games_played.to_string()` で置換してから `connect_with_target` / `login` に渡す。
- placeholder を含まない設定 (A / C / E / G シナリオ) は `replace` が no-op なので挙動無変更。

### `examples/csa_client_staging/scenarios/B_consecutive_games/{black,white}.toml.example`
- host を `wss://...workers.dev/ws/<room_id>-{game_seq}` に変更
- id を `<handle>+<room_id>-{game_seq}+<color>` 形式に変更
- 冒頭コメントで `{game_seq}` の意図 (Workers 1 DO=1 対局設計に合わせて毎局新 DO に切替) を説明

### `docs/csa-server/staging-e2e.md`
- シナリオ B セクションに「Workers は 1 DO=1 対局設計で、連続対局では `{game_seq}` で room_id を毎局変える」と挙動を明記

## 互換性

- `{game_seq}` を含まない設定は無変更で動作（本家 Floodgate のような 1 server 多対局サーバ運用も継続可能）
- 既存 A / C / E / G シナリオの sample TOML は touch せず、B のみ template 化

## 実機検証

staging で max_games=5、`<base>-{game_seq}` 展開、`<handle>_B+<base>-{game_seq}+<color>` のセットで実行:

```
対局 #1 結果: Lose | 通算: 0勝 1敗 0分
対局 #2 結果: Lose | 通算: 0勝 2敗 0分
対局 #3 結果: Win | 通算: 1勝 2敗 0分
対局 #4 結果: Lose | 通算: 1勝 3敗 0分
対局 #5 結果: Lose | 通算: 1勝 4敗 0分
最大対局数 (5) に達しました
終了。合計 5 局: 1勝 4敗 0分
```

5 局すべてが別 game_id で完走し、各局 R2 棋譜が書き出されている。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test -p rshogi-csa-client` 全 pass（5 件、無回帰）
- [x] staging 実機で 5 局連続対局完走を確認

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review で Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
