### PR TITLE
chore(csa-server): MillisecondsCountdownClock 会計モデル明記と staging-e2e 手順書補強

### DIFF
--- a/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/G_clock_variants/black.toml.example
+++ b/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/G_clock_variants/black.toml.example
@@ -1,8 +1,11 @@
-# Workers staging × csa_client (黒番) 用 TOML 例。
+# Workers staging × csa_client (黒番) 用 TOML 例 — シナリオ G (時計違い)。
 #
-# 詳細手順は docs/csa-server/staging-e2e.md を参照。
-# このファイルは `.example` の suffix 付きで repo に置かれている。実際に使う際は
-# 任意のローカルパス（`/tmp/G-black.toml` 等）にコピーしてから書き換える。
+# シナリオ G では client 側の設定はシナリオ A と同形で、`CLOCK_KIND` の切替は
+# `wrangler.staging.toml` 側で行う (詳細は docs/csa-server/staging-e2e.md §9)。
+# 本ファイルは A と同一の id 形式だと並行/同日実行時に衝突するので `_G` suffix を
+# 付けて区別する。
+#
+# 実際に使う際は任意のローカルパス（`/tmp/G-black.toml` 等）にコピーしてから書き換える。
 
 [server]
 # `wss://` で始まる場合は WebSocket 経路として接続する。
@@ -12,7 +15,7 @@ host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_i
 # host が `wss://` を含む場合は `port` は無視されるが、TOML schema 互換のため
 # 値を残しておく。
 port = 0
-id = "csa_e2e_black_<date>"
+id = "csa_e2e_black_<date>_G"
 password = "anything"
 floodgate = true
 

--- a/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/G_clock_variants/white.toml.example
+++ b/crates/rshogi-csa-client/examples/csa_client_staging/scenarios/G_clock_variants/white.toml.example
@@ -1,13 +1,15 @@
-# Workers staging × csa_client (白番) 用 TOML 例。
+# Workers staging × csa_client (白番) 用 TOML 例 — シナリオ G (時計違い)。
 #
 # 黒番との対 (黒/白で room_id は同じ、id だけ別) で 1 対局を成立させる。
-# 詳細手順は docs/csa-server/staging-e2e.md を参照。
+# シナリオ G では client 側の設定は A と同形で、`CLOCK_KIND` の切替は
+# `wrangler.staging.toml` 側で行う (詳細は docs/csa-server/staging-e2e.md §9)。
+# A と同一 id だと並行/同日実行時に衝突するので `_G` suffix を付けて区別する。
 
 [server]
 # 黒番と同じ `<room_id>` を URL 末尾に入れる（黒・白で完全一致が必須）。
 host = "wss://rshogi-csa-server-workers-staging.<account>.workers.dev/ws/<room_id>"
 port = 0
-id = "csa_e2e_white_<date>"
+id = "csa_e2e_white_<date>_G"
 password = "anything"
 floodgate = true
 

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -279,6 +279,11 @@ impl MillisecondsCountdownClock {
 
 impl TimeClock for MillisecondsCountdownClock {
     fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
+        // 秒読み (`byoyomi_ms`) は **毎手リセット型** で累積しない。本体時間
+        // (`slot`) を使い切ったあとは、各手で独立に `byoyomi_ms` まで使えて、
+        // 超過した瞬間に `TimeUp` を返す。`SecondsCountdownClock::consume` と
+        // 同じ会計モデル (CSA 2014 改訂)。
+        //
         // ms 粒度では切り捨てを行わない。`elapsed_ms` の上限は対局想定時間内に
         // 収まる（数十秒〜数分）ので i64 cast で問題ない。
         let elapsed = elapsed_ms as i64;

--- a/docs/csa-server/staging-e2e.md
+++ b/docs/csa-server/staging-e2e.md
@@ -108,13 +108,26 @@ cat /tmp/<game_id>.csa
 CSA V2 形式（`V2.2`、`N+`、`$GAME_ID:`、`BEGIN Position` 〜 `END Position`、
 指し手 `+7776FU,T<sec>` 等、終局コマンド `%TORYO` / `+SUMI` 等）が含まれていれば成功。
 
+> ※ Floodgate 履歴バケット (`rshogi-csa-floodgate-history-staging`) への
+> 書き込みは staging では既定 (`ALLOW_FLOODGATE_FEATURES = "false"`) で
+> 無効化されているため、本シナリオの必須確認項目には含めない。Floodgate
+> 機能 opt-in 環境で動作確認する場合は別途
+> `vp exec wrangler r2 object list rshogi-csa-floodgate-history-staging` で
+> 確認する。
+
 ## 4. シナリオ B: 連続 N 対局
 
-`max_games = 5` で同 client が 5 局繰り返す。Workers サーバは **1 DO instance =
-1 対局** という設計で、終局後の同 room_id への再 LOGIN は `LOGIN:incorrect` で
-reject される。連続対局では host / id 内の `{game_seq}` placeholder を
-csa_client が 0 始まりの局番号で自動置換するので、`<room_id>-{game_seq}` 形式に
-書いて毎局新規 DO を立てる運用にする。
+`max_games = 5` で同 client が 5 局繰り返す。**Workers 版 (`rshogi-csa-server-workers`)**
+は 1 DO instance = 1 対局 という設計で、終局後の同 room_id への再 LOGIN は
+`LOGIN:incorrect` で reject される (`game_room.rs::handle_login::load_finished`)。
+連続対局では host / id 内の `{game_seq}` placeholder を csa_client が
+0 始まりの局番号で自動置換するので、`<room_id>-{game_seq}` 形式に書いて
+毎局新規 DO を立てる運用にする。
+
+> 補足: TCP 版 (`rshogi-csa-server-tcp`) は本家 Floodgate 互換で 1 server に
+> 多対局が成立するため、`{game_seq}` placeholder は不要 (むしろ host が
+> DNS 名のため `tcp://host-0:4081` のような展開は不正な host になる)。
+> TCP 経路で連続対局するときは host を固定し、game_name を毎局変えれば良い。
 
 ```bash
 cp crates/rshogi-csa-client/examples/csa_client_staging/scenarios/B_consecutive_games/black.toml.example /tmp/B-black.toml
@@ -150,6 +163,12 @@ wait
 5. 黒 client が `LOGIN:<name> OK` を受けて対局が継続する（指し手の続きから）。
 6. 終局後に R2 棋譜を確認すると、**1 つの game_id** に黒の disconnect 前後の
    指し手が連続している。
+
+> 注意: `RECONNECT_GRACE_SECONDS` で指定した秒数 (例: 30 秒) 以内に
+> step 3 → 4 を完走する必要がある。手元で `id` 文字列を組み立てる作業を含む
+> ため時間的余裕は少ない。事前に `<game_id>` と `<token>` を埋めた reconnect
+> 用 id 文字列を別ターミナルに貼り付けておき、step 3 で kill した直後に
+> step 4 の `id` だけ書き換えて再起動できるよう準備しておくのが安全。
 
 ## 6. シナリオ D: 観戦 (`%%MONITOR2ON`)
 
@@ -251,6 +270,18 @@ gh workflow run "Deploy Workers" -f target=staging
 
 各 kind で R2 棋譜の `BEGIN Time` セクションが想定通りの `Time_Unit` /
 `Total_Time` / `Byoyomi`/`Increment` を含むことを確認する。
+
+> ⚠️ `sed -i` は **追跡対象** の `wrangler.staging.toml` を直接書き換える。
+> 検証を中断して工程を中座した場合、ファイルが意図せぬ kind のまま残り
+> 後続のコミットに混入する事故が起こり得る。各 sed の直後と最後の戻し sed
+> の後で必ず以下を実行し、`countdown_msec` に戻っていることを目視確認する:
+>
+> ```bash
+> git diff crates/rshogi-csa-server-workers/wrangler.staging.toml
+> ```
+>
+> 戻ってない場合は `git checkout -- crates/rshogi-csa-server-workers/wrangler.staging.toml`
+> で復元してから再 deploy する。
 
 ## 10. 後始末
 


### PR DESCRIPTION
## Summary

直近 merge した 2 つの PR で claude[bot] レビューが残した Nice-to-have 指摘のうち、軽微で別 PR にする価値が薄い 5 件をまとめて吸収する。実装挙動の変更はなく、コメント追加 / docs 補足 / sample TOML の id suffix 整合のみ。

## 取り込んだ指摘

### `MillisecondsCountdownClock::consume` の会計モデル明記
- 「秒読みは毎手リセット型で累積しない」「`SecondsCountdownClock` と同じ会計」という会計モデルがコードから読み取りにくいという指摘 → 関数冒頭に 1 段落で明記。

### `scenarios/G_clock_variants/` の id suffix
- A シナリオと同じ id placeholder `csa_e2e_<color>_<date>` だと並行/同日実行で衝突するため `_G` suffix を追加。
- ヘッダコメントに「シナリオ G では client 設定は A と同形、CLOCK_KIND の切替は wrangler.staging.toml 側で行う (§9)」と意図を明記。

### `docs/csa-server/staging-e2e.md`
- §3-3 末尾: Floodgate 履歴バケットは staging 既定 (`ALLOW_FLOODGATE_FEATURES = "false"`) で書き込み無し、必須確認項目に含めない旨。
- §4 (B): **Workers 版固有の制約** であることを明記。**TCP 版 (`rshogi-csa-server-tcp`)** は本家 Floodgate 互換で 1 server 多対局成立、`{game_seq}` placeholder は不要 (むしろ TCP host に展開すると DNS 解決失敗になる)。
- §5 (C): `RECONNECT_GRACE_SECONDS` 秒以内に kill→ 再起動が必要、reconnect 用 id 文字列を事前に用意しておく安全策。
- §9 (G): `sed -i` で `wrangler.staging.toml` を直接書き換える手順に対し、中断時の混入を防ぐため `git diff` 目視確認 + `git checkout --` での復元手順を追記。

## 採用しなかった指摘

- PR #523 の `push_str(&format!(...))` → `write!` 置換: 既存 `SecondsCountdownClock::format_summary` と同パターンなので統一性のため現状維持 (reviewer も「現状維持可」と明示)。
- PR #523 の `MillisecondsCountdownClock` / `SecondsCountdownClock` 型パラメータ化: YAGNI に抵触するため見送り (reviewer も今回不要と明示)。
- PR #523 の `parse_clock_spec` 引数 7 → 構造体化: 将来案として記録のみ、現スコープでは見送り (reviewer も今回許容と明示)。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test -p rshogi-csa-server --lib game::clock` 33 件 pass (無回帰)

## Test plan

- [ ] PR 作成後 CI 通過
- [ ] independent Claude review で Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
