### PR TITLE
fix(tools): psv_dedup_partition の warn_fd_limit を Windows で cfg 分岐する

### DIFF
--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -679,6 +679,7 @@ fn deduplicate_partitions(
     Ok((total_ref, total_seen, total_unique))
 }
 
+#[cfg(unix)]
 fn warn_fd_limit(num_partitions: usize) {
     let mut limit = libc::rlimit {
         rlim_cur: 0,
@@ -700,6 +701,11 @@ fn warn_fd_limit(num_partitions: usize) {
         );
     }
 }
+
+// Windows 等の非 Unix 環境には `RLIMIT_NOFILE` 相当のソフトリミットが存在しないため、
+// fd 上限の事前警告は no-op とする（CRT の `_setmaxstdio` はストリーム上限で別概念）。
+#[cfg(not(unix))]
+fn warn_fd_limit(_: usize) {}
 
 /// temp_dir を掃除する（空ディレクトリなら削除）。
 fn cleanup_if_empty(dir: &Path) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- PR #476 のフォローアップ。`warn_fd_limit` に残っていた Unix 専用 API 直書きを `#[cfg(unix)]` で分岐し、Windows ビルドを通す。
- 非 Unix では no-op スタブを追加（Windows に `RLIMIT_NOFILE` 相当のソフトリミット概念がないため）。

## Why
PR #476 では `crates/tools/src/common/dedup.rs` の Unix 専用 API は OS 分岐したが、呼び出し側の `crates/tools/src/bin/psv_dedup_partition.rs::warn_fd_limit` に `libc::rlimit` / `libc::getrlimit` / `libc::RLIMIT_NOFILE` の直接利用が残っており、Windows でコンパイル不能のままだった（本環境で `cargo check -p tools --bin psv_dedup_partition` が E0422/E0425 で失敗するのを確認）。

## Changes
- `bin/psv_dedup_partition.rs::warn_fd_limit` を `#[cfg(unix)]` でガードし従来実装を維持
- `#[cfg(not(unix))]` 用に no-op 実装 `fn warn_fd_limit(_: usize) {}` を追加
- WHY コメントに「Windows には `RLIMIT_NOFILE` 相当が存在しない」「`_setmaxstdio` は CRT のストリーム上限で別概念」を明記

## Impact
- Unix/Linux: 挙動・パフォーマンス変化なし（既存実装をそのまま `#[cfg(unix)]` で維持）
- Windows: `psv_dedup_partition` がビルド可能になり、Phase 1 の fd 上限事前警告は省略される（Windows ではソフトリミット概念がないため失われるシグナルなし）

## Validation
- `cargo fmt -p tools`
- `cargo check -p tools --bin psv_dedup_partition` (Windows / 1.95.0-x86_64-pc-windows-msvc): 通過確認
- `cargo clippy --fix --allow-dirty --tests -p tools`: 警告ゼロ
- ローカル独立レビューで以下を確認:
  - `crates/tools/` 配下の他の Unix 専用 API 利用箇所（`merge_psv.rs`, `selfplay/engine.rs`, `search_only_ab.rs`, `rescore_psv.rs`, `common/dedup.rs`）はすべて既に `#[cfg(unix)]` で gate 済み
  - `_: usize` の引数完全省略は `crates/rshogi-core/src/nnue/network_halfkp.rs` の既存 `fn _check_*(_: T) {}` パターンと整合

## Out of Scope
- `tools/Cargo.toml` の `libc = "0.2"` を `[target.'cfg(unix)'.dependencies]` に移行する案: 性能影響ゼロ・依存意図の明示という軽微な改善のみで、`rshogi-core` / `rshogi-csa-client` も同様に持つため別の単発リファクタ PR で扱うのが妥当。

## Test plan
- [x] CI で Linux/macOS 側のビルド・テストが従来通りパスすること
- [x] Windows でのビルド検証（手元で `cargo check -p tools --bin psv_dedup_partition` 通過済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)