### PR TITLE
feat(csa-server-workers): staging で Floodgate 系 opt-in 機能を有効化する

### DIFF
--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -96,8 +96,10 @@ BYOYOMI_MIN = "1"
 
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
-RECONNECT_GRACE_SECONDS = "0"
-ALLOW_FLOODGATE_FEATURES = "false"
+# staging では reconnect protocol / history bucket / rating 応答などの Floodgate 系
+# 拡張機能を実機通電させるため 30 秒に設定する。production は引き続き 0 で運用。
+RECONNECT_GRACE_SECONDS = "30"
+ALLOW_FLOODGATE_FEATURES = "true"
 
 # --- secret として設定する値 ---
 # staging で必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -97,7 +97,10 @@ BYOYOMI_MIN = "1"
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 # staging では reconnect protocol / history bucket / rating 応答などの Floodgate 系
-# 拡張機能を実機通電させるため 30 秒に設定する。production は引き続き 0 で運用。
+# 拡張機能を実機通電させるため 30 秒に設定する。値の根拠: 手動 kill→再起動で
+# `id` 文字列を組み立て直す operator 余裕 (10〜15 秒) と短時間ネットワーク blip の
+# 吸収を兼ねる経験的下限。production 昇格時は実運用 client の再接続所要時間を
+# 計測してから再評価する。
 RECONNECT_GRACE_SECONDS = "30"
 ALLOW_FLOODGATE_FEATURES = "true"
 

--- a/docs/csa-server/staging-e2e.md
+++ b/docs/csa-server/staging-e2e.md
@@ -109,11 +109,10 @@ CSA V2 形式（`V2.2`、`N+`、`$GAME_ID:`、`BEGIN Position` 〜 `END Position
 指し手 `+7776FU,T<sec>` 等、終局コマンド `%TORYO` / `+SUMI` 等）が含まれていれば成功。
 
 > ※ Floodgate 履歴バケット (`rshogi-csa-floodgate-history-staging`) への
-> 書き込みは staging では既定 (`ALLOW_FLOODGATE_FEATURES = "false"`) で
-> 無効化されているため、本シナリオの必須確認項目には含めない。Floodgate
-> 機能 opt-in 環境で動作確認する場合は別途
+> 書き込みは `ALLOW_FLOODGATE_FEATURES = "true"` opt-in 環境で有効になる。
+> staging は本既定で運用中なので、終局後に
 > `vp exec wrangler r2 object list rshogi-csa-floodgate-history-staging` で
-> 確認する。
+> 該当 game_id の object が増えていることを確認する。
 
 ## 4. シナリオ B: 連続 N 対局
 
@@ -146,12 +145,11 @@ wait
 
 ## 5. シナリオ C: 切断 → 再接続
 
-> **前提**: staging で `ALLOW_FLOODGATE_FEATURES = "true"` と
-> `RECONNECT_GRACE_SECONDS = "30"` 等を設定して再 deploy する必要がある。
-> 現在の staging は `false` / `0` で disabled。Floodgate features を有効化する
-> 別 PR を merge してから本シナリオを実機検証する。
+> **前提**: staging で `ALLOW_FLOODGATE_FEATURES = "true"` /
+> `RECONNECT_GRACE_SECONDS = "30"` の opt-in 設定で運用中なので、本シナリオは
+> 追加 deploy 無しでそのまま実機通電できる。
 
-設定後の手順:
+手順:
 
 1. シナリオ A を起動して対局を進める。
 2. Game_Summary 末尾の拡張行 `Reconnect_Token:<token>` を黒/白それぞれの


### PR DESCRIPTION
## Summary

staging で reconnect protocol / floodgate-history bucket 書き込み / rating 応答などの Floodgate 系 opt-in 機能を実機通電できるよう、`wrangler.staging.toml` の 2 値を有効化する:

- `RECONNECT_GRACE_SECONDS = "0"` → `"30"`
- `ALLOW_FLOODGATE_FEATURES = "false"` → `"true"`

production の `wrangler.production.toml` は引き続き保守的既定 (`"0"` / `"false"`) のまま維持し、staging で実機通電してから将来 production に展開する。

## 背景

`game_room.rs::resolve_reconnect_grace` の fail-fast 制約 (`grace > 0 && ALLOW_FLOODGATE_FEATURES = false` で起動失敗) を両値を同時に有効化することで回避。`validate_floodgate_feature_gate` を通る最小構成。

これでシナリオ C (切断 → 再接続) や Floodgate 履歴バケット書き込みを staging で実機通電できるようになる (それまでは server-side 機能 disabled で client が `Reconnect_Token` を受け取れなかった)。

## 主要変更

### `crates/rshogi-csa-server-workers/wrangler.staging.toml`
2 値を有効化し、コメントで「production は引き続き 0 で運用」と差分目的を明記。

### `docs/csa-server/staging-e2e.md`
- §3-3 末尾の Floodgate 履歴注記を「無効」→「opt-in で有効、終局後に R2 list 確認」に書き換え。
- §5 シナリオ C 切断 → 再接続の前提文言を「別 PR 必要」→「追加 deploy 無しで実機通電できる」に書き換え。

## 互換性

- production の `wrangler.production.toml` は無変更 (`"0"` / `"false"` のまま)。
- Miniflare smoke は harness が `RECONNECT_GRACE_SECONDS` / `ALLOW_FLOODGATE_FEATURES` を opts 経由でテストごとに注入する構造なので、wrangler.staging.toml の値変更は smoke 6 ファイル / 12 テストに無回帰。
- `tests/wrangler_environment_toml_consistency.rs` は key 集合のみを gate しているため、値変更のみで無回帰。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test -p rshogi-csa-server-workers` 全 pass (consistency tests 含む)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` クリーン
- [x] `pnpm test:smoke` 全 pass (6 ファイル / 12 テスト、無回帰)
- [x] independent Claude review で Approve as-is

## Test plan

- [ ] PR 作成後 CI 全 SUCCESS
- [ ] independent claude-review (CI 内) で Approve as-is
- [ ] **merge 後にユーザーが staging で以下を実機通電確認**:
  - シナリオ C (切断 → 再接続) で `Reconnect_Token` を受信し、kill → grace 内に同一 token で再 LOGIN → 対局継続
  - シナリオ A 終局後に `vp exec wrangler r2 object list rshogi-csa-floodgate-history-staging` で該当 game_id の history object 存在確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)