### PR TITLE
feat(csa-client): WS 切断時に Reconnect_Token で同一対局へ自動再接続する

### DIFF
--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -25,7 +25,7 @@ use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::UsiEngine;
 use rshogi_csa_client::protocol::{CsaConnection, GameResult};
 use rshogi_csa_client::record::save_record;
-use rshogi_csa_client::session::run_game_session;
+use rshogi_csa_client::session::{run_game_session, run_resumed_session};
 use rshogi_csa_client::transport::{ConnectOpts, TransportTarget};
 
 /// `--target` プリセット。本リポ単一 Cloudflare アカウント (`sh11235.workers.dev`) の
@@ -317,6 +317,47 @@ fn run_one_game(
     // 対局実行
     let result = run_game_session(&mut conn, engine, config, shutdown);
 
+    // 中断 (= サーバ切断) でかつ Reconnect_Token を保持している場合は 1 度だけ
+    // 再接続を試みる。Workers の `RECONNECT_GRACE_SECONDS` 内に到達できれば
+    // 同一対局を継続できる。reconnect 試行前に元 conn は drop / logout する。
+    let reconnect_request = match result.as_ref() {
+        Ok((GameResult::Interrupted, _, Some(summary)))
+            if summary.reconnect_token.is_some() && !shutdown.load(Ordering::SeqCst) =>
+        {
+            Some((summary.game_id.clone(), summary.reconnect_token.clone().unwrap()))
+        }
+        _ => None,
+    };
+
+    if let Some((game_id, token)) = reconnect_request {
+        log::warn!(
+            "[CSA] サーバ切断を検出。Reconnect_Token を持つので grace 内に再接続を試みます: game_id={game_id}"
+        );
+        let _ = conn.logout();
+        drop(conn);
+        match attempt_reconnect(
+            &target,
+            &opts,
+            &id,
+            &config.server.password,
+            &game_id,
+            &token,
+            engine,
+            config,
+            shutdown,
+        ) {
+            Ok((reconnect_result, reconnect_record)) => {
+                log::info!("[CSA] 再接続成功: 対局を継続して終局: {:?}", reconnect_result);
+                return Ok((reconnect_result, reconnect_record));
+            }
+            Err(e) => {
+                log::warn!("[CSA] 再接続失敗: {e}。元の Interrupted 結果で終了します。");
+                let _ = engine.stop_and_wait();
+                return result.map(|(r, rec, _)| (r, rec));
+            }
+        }
+    }
+
     // エラー時は投了を試みる（NF2: 対局中のエラーは投了してから再接続）
     if result.is_err() {
         // ponder 中の場合は stop して bestmove を待ってからクリーンアップ
@@ -326,7 +367,29 @@ fn run_one_game(
     }
 
     let _ = conn.logout();
-    result
+    // (result, record, _summary) → 既存呼び出し互換 (result, record) に縮約
+    result.map(|(r, rec, _)| (r, rec))
+}
+
+/// 切断検出後の自動再接続。新規 transport で接続 → `LOGIN ... reconnect:<game_id>+<token>`
+/// → resume 用 Game_Summary + Reconnect_State 受信 → セッションループ継続。
+#[allow(clippy::too_many_arguments)]
+fn attempt_reconnect(
+    target: &TransportTarget,
+    opts: &ConnectOpts,
+    id: &str,
+    password: &str,
+    game_id: &str,
+    token: &str,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
+    let mut conn = CsaConnection::connect_with_target(target, opts)?;
+    conn.login_reconnect(id, password, game_id, token)?;
+    let (r, rec, _) = run_resumed_session(&mut conn, engine, config, shutdown)?;
+    let _ = conn.logout();
+    Ok((r, rec))
 }
 
 /// `--target` プリセット適用時に password が空のときに埋める placeholder 値。

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -335,22 +335,23 @@ fn run_one_game(
         );
         let _ = conn.logout();
         drop(conn);
-        match attempt_reconnect(
-            &target,
-            &opts,
-            &id,
-            &config.server.password,
-            &game_id,
-            &token,
-            engine,
-            config,
-            shutdown,
-        ) {
+        let credentials = ReconnectCredentials {
+            id: &id,
+            password: &config.server.password,
+            game_id: &game_id,
+            token: &token,
+        };
+        match attempt_reconnect(&target, &opts, &credentials, engine, config, shutdown) {
             Ok((reconnect_result, reconnect_record)) => {
                 log::info!("[CSA] 再接続成功: 対局を継続して終局: {:?}", reconnect_result);
                 return Ok((reconnect_result, reconnect_record));
             }
             Err(e) => {
+                // engine は元 disconnect 経路で `gameover("lose")` 発射済み。
+                // `attempt_reconnect` 中に `engine.new_game()` が成功した後で失敗
+                // するケースではエンジンが「新局面待ち」状態のまま残るが、
+                // `stop_and_wait()` は探索中でない場合は no-op として通過する
+                // ことを期待する (rshogi-usi 含む主要 USI engine の挙動)。
                 log::warn!("[CSA] 再接続失敗: {e}。元の Interrupted 結果で終了します。");
                 let _ = engine.stop_and_wait();
                 return result.map(|(r, rec, _)| (r, rec));
@@ -371,22 +372,26 @@ fn run_one_game(
     result.map(|(r, rec, _)| (r, rec))
 }
 
+/// 切断検出後の再接続に必要な認証情報。多引数化を避けるためまとめる。
+struct ReconnectCredentials<'a> {
+    id: &'a str,
+    password: &'a str,
+    game_id: &'a str,
+    token: &'a str,
+}
+
 /// 切断検出後の自動再接続。新規 transport で接続 → `LOGIN ... reconnect:<game_id>+<token>`
 /// → resume 用 Game_Summary + Reconnect_State 受信 → セッションループ継続。
-#[allow(clippy::too_many_arguments)]
 fn attempt_reconnect(
     target: &TransportTarget,
     opts: &ConnectOpts,
-    id: &str,
-    password: &str,
-    game_id: &str,
-    token: &str,
+    creds: &ReconnectCredentials<'_>,
     engine: &mut UsiEngine,
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
 ) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
     let mut conn = CsaConnection::connect_with_target(target, opts)?;
-    conn.login_reconnect(id, password, game_id, token)?;
+    conn.login_reconnect(creds.id, creds.password, creds.game_id, creds.token)?;
     let (r, rec, _) = run_resumed_session(&mut conn, engine, config, shutdown)?;
     let _ = conn.logout();
     Ok((r, rec))

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -11,7 +11,7 @@ use anyhow::{Result, bail};
 
 use rshogi_csa::{Color, CsaMove, ParsedMove, Position, parse_csa_full};
 use rshogi_csa_server::protocol::command::{ClientCommand, serialize_client_command};
-use rshogi_csa_server::types::{CsaMoveToken, GameId, PlayerName, Secret};
+use rshogi_csa_server::types::{CsaMoveToken, GameId, PlayerName, ReconnectToken, Secret};
 
 use crate::event::Event;
 use crate::transport::{ConnectOpts, CsaTransport, TransportTarget};
@@ -44,6 +44,26 @@ pub struct GameSummary {
     pub black_time: TimeConfig,
     /// 後手の時間設定
     pub white_time: TimeConfig,
+    /// `Reconnect_Token:<token>` 拡張行で受信した自色用 token。`None` のとき
+    /// サーバが reconnect protocol を提供していない（`ALLOW_FLOODGATE_FEATURES = false`
+    /// 等）か、相手色用 token のみが送られて自色には付与されていない。
+    /// `Some(token)` の場合、WS 切断時に `LOGIN <id> <pw> reconnect:<game_id>+<token>`
+    /// で同一対局へ復帰できる (Workers の `RECONNECT_GRACE_SECONDS` 以内)。
+    pub reconnect_token: Option<String>,
+}
+
+/// 再接続成立時にサーバから送られる `BEGIN Reconnect_State` ブロックの
+/// パース結果。`Current_Turn` / `Black_Time_Remaining_Ms` / `White_Time_Remaining_Ms`
+/// / `Last_Move` を保持する。
+#[derive(Clone, Debug, Default)]
+pub struct ReconnectState {
+    /// 切断時点の手番。`+` を `Color::Black`、`-` を `Color::White` で表現。
+    /// `None` の場合は不正フォーマットで安全側に倒す（実機サーバは必ず送信）。
+    pub current_turn: Option<Color>,
+    pub black_remaining_ms: i64,
+    pub white_remaining_ms: i64,
+    /// 直前手 (例: `+7776FU`)。`None` のときは初期局面で再接続が走った経路。
+    pub last_move: Option<String>,
 }
 
 /// サーバーから受信した指し手
@@ -121,6 +141,75 @@ impl CsaConnection {
         }
     }
 
+    /// 再接続ログイン: `LOGIN <id> <pw> reconnect:<game_id>+<token>`。
+    ///
+    /// 切断前の `GameSummary.reconnect_token` と `game_id` を使う。サーバが
+    /// 受理すると `LOGIN:<name> OK` を返し、続いて `BEGIN Game_Summary` ...
+    /// `BEGIN Reconnect_State` ... の resume メッセージを送出する。本関数は
+    /// `LOGIN:` 行までのみを処理し、resume 内容の読み取りは
+    /// [`recv_game_summary`][Self::recv_game_summary] と
+    /// [`recv_reconnect_state`][Self::recv_reconnect_state] の組合わせで行う。
+    pub fn login_reconnect(
+        &mut self,
+        id: &str,
+        password: &str,
+        game_id: &str,
+        token: &str,
+    ) -> Result<()> {
+        use rshogi_csa_server::protocol::command::ReconnectRequest;
+        self.password = password.to_string();
+        let cmd = serialize_client_command(&ClientCommand::Login {
+            name: PlayerName::new(id),
+            password: Secret::new(password),
+            x1: false,
+            reconnect: Some(ReconnectRequest {
+                game_id: GameId::new(game_id),
+                token: ReconnectToken::new(token),
+            }),
+        });
+        self.send_line(&cmd)?;
+        let response = self.recv_line_blocking(Duration::from_secs(15))?;
+        if response.starts_with("LOGIN:") && response.contains("OK") {
+            log::info!("[CSA] 再接続ログイン成功: {id} (game_id={game_id})");
+            Ok(())
+        } else {
+            bail!("再接続失敗: {response}");
+        }
+    }
+
+    /// 再接続後の `BEGIN Reconnect_State` ... `END Reconnect_State` ブロックを
+    /// 読み取る。`recv_game_summary` 直後に呼ぶ。各キー (`Current_Turn`,
+    /// `Black_Time_Remaining_Ms`, `White_Time_Remaining_Ms`, `Last_Move`) を
+    /// パースして返す。
+    pub fn recv_reconnect_state(&mut self) -> Result<ReconnectState> {
+        loop {
+            let line = self.recv_line_blocking(Duration::from_secs(30))?;
+            if line == "BEGIN Reconnect_State" {
+                break;
+            }
+        }
+        let mut state = ReconnectState::default();
+        loop {
+            let line = self.recv_line_blocking(Duration::from_secs(30))?;
+            if line == "END Reconnect_State" {
+                return Ok(state);
+            }
+            if let Some(val) = line.strip_prefix("Current_Turn:") {
+                state.current_turn = match val.trim() {
+                    "+" => Some(Color::Black),
+                    "-" => Some(Color::White),
+                    _ => None,
+                };
+            } else if let Some(val) = line.strip_prefix("Black_Time_Remaining_Ms:") {
+                state.black_remaining_ms = val.trim().parse().unwrap_or(0);
+            } else if let Some(val) = line.strip_prefix("White_Time_Remaining_Ms:") {
+                state.white_remaining_ms = val.trim().parse().unwrap_or(0);
+            } else if let Some(val) = line.strip_prefix("Last_Move:") {
+                state.last_move = Some(val.trim().to_owned());
+            }
+        }
+    }
+
     /// Game_Summary を受信して解析する
     pub fn recv_game_summary(&mut self, keepalive_interval_sec: u64) -> Result<GameSummary> {
         log::info!("[CSA] 対局待機中...");
@@ -142,6 +231,7 @@ impl CsaConnection {
         let mut gote_name = String::new();
         let mut position_lines = Vec::new();
         let mut in_position = false;
+        let mut reconnect_token: Option<String> = None;
 
         // 時間設定: 共通 / 先手別 / 後手別の3レイヤー
         // Time_Unit のデフォルトは秒 (1000ms)
@@ -240,6 +330,10 @@ impl CsaConnection {
             } else if let Some(val) = line.strip_prefix("Increment:") {
                 let v: i64 = val.trim().parse().unwrap_or(0);
                 common_time.increment_ms = v * header_time_unit_ms;
+            } else if let Some(val) = line.strip_prefix("Reconnect_Token:") {
+                // 自色用 token は `END Game_Summary` 直前に 1 行だけ届く拡張行。
+                // 相手色 token は届かない（サーバ側 `build_for(my_color)` で除外）。
+                reconnect_token = Some(val.trim().to_owned());
             }
         }
 
@@ -267,6 +361,7 @@ impl CsaConnection {
             initial_moves,
             black_time: final_black_time,
             white_time: final_white_time,
+            reconnect_token,
         };
         log::info!(
             "[CSA] 対局情報受信: {} ({}手目から) {}vs{} 先手:{}ms+{}ms+{}ms 後手:{}ms+{}ms+{}ms",

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -54,7 +54,8 @@ pub struct GameSummary {
 
 /// 再接続成立時にサーバから送られる `BEGIN Reconnect_State` ブロックの
 /// パース結果。`Current_Turn` / `Black_Time_Remaining_Ms` / `White_Time_Remaining_Ms`
-/// / `Last_Move` を保持する。
+/// を保持する。`Last_Move:` 行は受信時にスキップする (resume 時の局面は
+/// `Game_Summary.position_section` から完全復元できるため client は参照不要)。
 #[derive(Clone, Debug, Default)]
 pub struct ReconnectState {
     /// 切断時点の手番。`+` を `Color::Black`、`-` を `Color::White` で表現。
@@ -62,8 +63,6 @@ pub struct ReconnectState {
     pub current_turn: Option<Color>,
     pub black_remaining_ms: i64,
     pub white_remaining_ms: i64,
-    /// 直前手 (例: `+7776FU`)。`None` のときは初期局面で再接続が走った経路。
-    pub last_move: Option<String>,
 }
 
 /// サーバーから受信した指し手
@@ -133,7 +132,7 @@ impl CsaConnection {
         });
         self.send_line(&cmd)?;
         let response = self.recv_line_blocking(Duration::from_secs(15))?;
-        if response.starts_with("LOGIN:") && response.contains("OK") {
+        if is_login_ok(&response) {
             log::info!("[CSA] ログイン成功: {id}");
             Ok(())
         } else {
@@ -169,7 +168,7 @@ impl CsaConnection {
         });
         self.send_line(&cmd)?;
         let response = self.recv_line_blocking(Duration::from_secs(15))?;
-        if response.starts_with("LOGIN:") && response.contains("OK") {
+        if is_login_ok(&response) {
             log::info!("[CSA] 再接続ログイン成功: {id} (game_id={game_id})");
             Ok(())
         } else {
@@ -178,11 +177,23 @@ impl CsaConnection {
     }
 
     /// 再接続後の `BEGIN Reconnect_State` ... `END Reconnect_State` ブロックを
-    /// 読み取る。`recv_game_summary` 直後に呼ぶ。各キー (`Current_Turn`,
-    /// `Black_Time_Remaining_Ms`, `White_Time_Remaining_Ms`, `Last_Move`) を
-    /// パースして返す。
+    /// 読み取る。`recv_game_summary` 直後に呼ぶ。`Current_Turn` /
+    /// `Black_Time_Remaining_Ms` / `White_Time_Remaining_Ms` をパースして返す。
+    /// `Last_Move:` 行は局面復元に不要なため破棄する (resume 時の局面は
+    /// `Game_Summary.position_section` から完全復元できる)。
+    ///
+    /// `BEGIN Reconnect_State` を待つループには **最大 50 行** の終了保護を入れる。
+    /// 古いサーバや誤接続でこのブロックが届かない場合に無限ループするのを防ぐ。
     pub fn recv_reconnect_state(&mut self) -> Result<ReconnectState> {
+        const MAX_PRELUDE_LINES: usize = 50;
+        let mut tries = 0usize;
         loop {
+            tries += 1;
+            if tries > MAX_PRELUDE_LINES {
+                bail!(
+                    "BEGIN Reconnect_State が届かないまま {tries} 行受信、再接続応答が不正と判断して中止"
+                );
+            }
             let line = self.recv_line_blocking(Duration::from_secs(30))?;
             if line == "BEGIN Reconnect_State" {
                 break;
@@ -204,9 +215,8 @@ impl CsaConnection {
                 state.black_remaining_ms = val.trim().parse().unwrap_or(0);
             } else if let Some(val) = line.strip_prefix("White_Time_Remaining_Ms:") {
                 state.white_remaining_ms = val.trim().parse().unwrap_or(0);
-            } else if let Some(val) = line.strip_prefix("Last_Move:") {
-                state.last_move = Some(val.trim().to_owned());
             }
+            // `Last_Move:` を含む他の拡張行は黙って破棄する (前方互換)。
         }
     }
 
@@ -556,4 +566,12 @@ pub(crate) fn parse_game_result(line: &str) -> Option<GameResult> {
     } else {
         None // #TIME_UP, #ILLEGAL_MOVE, #SENNICHITE 等は中間行
     }
+}
+
+/// LOGIN 応答が成功 (`LOGIN:<name> OK` 形式) であるかを判定する。
+///
+/// 単純な `contains("OK")` 判定だと `LOGIN:incorrect OKAZ_NG` のような偽陽性を
+/// 通してしまうため、`LOGIN:` プレフィックスと末尾の ` OK` をセットで要求する。
+fn is_login_ok(response: &str) -> bool {
+    response.starts_with("LOGIN:") && response.ends_with(" OK")
 }

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -16,7 +16,9 @@ use rshogi_csa::{Color, Position, csa_move_to_usi, usi_move_to_csa};
 use crate::config::CsaClientConfig;
 use crate::engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
 use crate::event::Event;
-use crate::protocol::{CsaConnection, GameResult, parse_game_result, parse_server_move};
+use crate::protocol::{
+    CsaConnection, GameResult, GameSummary, ReconnectState, parse_game_result, parse_server_move,
+};
 use crate::record::GameRecord;
 
 // ────────────────────────────────────────────
@@ -293,20 +295,77 @@ pub fn run_game_session(
     engine: &mut UsiEngine,
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
-) -> Result<(GameResult, GameRecord)> {
+) -> Result<(GameResult, GameRecord, Option<GameSummary>)> {
     let summary = conn.recv_game_summary(config.server.keepalive.ping_interval_sec)?;
     conn.agree_and_wait_start(&summary.game_id)?;
     engine.new_game()?;
 
+    let summary_for_caller = summary.clone();
+    let (result, record) = run_session_loop(conn, engine, config, shutdown, summary, None)?;
+    Ok((result, record, Some(summary_for_caller)))
+}
+
+/// 再接続成立後の resume セッションを駆動する。
+///
+/// `login_reconnect` が成功した直後の `conn` を受け取り、サーバが続けて送出する
+/// `BEGIN Game_Summary` ... `END Game_Summary` ブロック (新 `Reconnect_Token` 付き)
+/// と `BEGIN Reconnect_State` ... `END Reconnect_State` ブロックを読み取る。
+/// その後、AGREE 経路は **スキップ** して（対局はサーバ側 `Playing` 状態のまま）
+/// 対局ループに戻る。前 session で `gameover("lose")` を発射済みのエンジンに対し
+/// 新 session の `position` / `go` を許可するため、冒頭で `engine.new_game()` を
+/// 呼んで USI 状態をリセットする (hash の温存は後段の最適化として別 PR)。
+pub fn run_resumed_session(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+) -> Result<(GameResult, GameRecord, Option<GameSummary>)> {
+    // resume 時の Game_Summary は切断時点の局面が `position_section` に焼き込まれて
+    // いるため、`initial_moves` は通常空。新 `Reconnect_Token` も含まれる。
+    let summary = conn.recv_game_summary(config.server.keepalive.ping_interval_sec)?;
+    let state = conn.recv_reconnect_state()?;
+    log::info!(
+        "[CSA] 再接続セッション開始: my_color={:?} 残時間 黒:{}ms 白:{}ms",
+        summary.my_color,
+        state.black_remaining_ms,
+        state.white_remaining_ms
+    );
+
+    engine.new_game()?;
+    let summary_for_caller = summary.clone();
+    let (result, record) = run_session_loop(conn, engine, config, shutdown, summary, Some(state))?;
+    Ok((result, record, Some(summary_for_caller)))
+}
+
+/// `run_game_session` / `run_resumed_session` 共通の対局メインループ。
+///
+/// `resume_state` が `Some` のときは Reconnect_State 由来の残時間で `Clock` を
+/// 上書きし、AGREE / `engine.new_game()` のスキップを前提とする。
+fn run_session_loop(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+    summary: GameSummary,
+    resume_state: Option<ReconnectState>,
+) -> Result<(GameResult, GameRecord)> {
     // サーバー受信スレッドを起動
     let (server_tx, server_rx) = mpsc::channel();
     conn.start_reader_thread(server_tx)?;
+
+    let mut clock = Clock::from_summary(&summary);
+    if let Some(state) = &resume_state {
+        // resume の Reconnect_State から残時間を復元する。秒読み / increment 設定は
+        // Game_Summary 側を信用し、本体時間だけ上書き。
+        clock.black_time_ms = state.black_remaining_ms.max(0);
+        clock.white_time_ms = state.white_remaining_ms.max(0);
+    }
 
     let mut s = SessionState {
         pos: summary.position.clone(),
         initial_sfen: summary.position.to_sfen(),
         usi_moves: Vec::new(),
-        clock: Clock::from_summary(&summary),
+        clock,
         record: GameRecord::new(&summary),
         ponder_state: None,
         my_color: summary.my_color,
@@ -317,7 +376,7 @@ pub fn run_game_session(
         server_rx: &server_rx,
     };
 
-    // 途中局面の手順を適用
+    // 途中局面の手順を適用 (resume では通常空)
     let mut move_color = summary.position.side_to_move;
     for cm in &summary.initial_moves {
         let usi = csa_move_to_usi(&cm.mv, &s.pos)?;

--- a/crates/rshogi-csa-client/tests/csa_reconnect_protocol.rs
+++ b/crates/rshogi-csa-client/tests/csa_reconnect_protocol.rs
@@ -152,7 +152,7 @@ fn recv_game_summary_handles_missing_reconnect_token() {
 }
 
 #[test]
-fn recv_reconnect_state_parses_all_fields() {
+fn recv_reconnect_state_parses_known_fields_and_drops_unknown() {
     let port = spawn_mock_tcp_server(|reader, writer| {
         let _ = read_line(reader);
         write_lines(writer, &["LOGIN:alice OK"]);
@@ -163,7 +163,9 @@ fn recv_reconnect_state_parses_all_fields() {
                 "Current_Turn:-",
                 "Black_Time_Remaining_Ms:599500",
                 "White_Time_Remaining_Ms:600000",
+                // 既知フィールドではない行はサイレントに破棄される (前方互換)。
                 "Last_Move:+7776FU",
+                "Custom_Future_Field:foobar",
                 "END Reconnect_State",
             ],
         );
@@ -174,12 +176,11 @@ fn recv_reconnect_state_parses_all_fields() {
     let state = conn.recv_reconnect_state().expect("recv_reconnect_state");
     assert_eq!(state.black_remaining_ms, 599_500);
     assert_eq!(state.white_remaining_ms, 600_000);
-    assert_eq!(state.last_move.as_deref(), Some("+7776FU"));
     assert_eq!(state.current_turn, Some(rshogi_csa::Color::White));
 }
 
 #[test]
-fn recv_reconnect_state_handles_missing_last_move() {
+fn recv_reconnect_state_handles_minimal_block() {
     let port = spawn_mock_tcp_server(|reader, writer| {
         let _ = read_line(reader);
         write_lines(writer, &["LOGIN:alice OK"]);
@@ -198,6 +199,22 @@ fn recv_reconnect_state_handles_missing_last_move() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
     let state = conn.recv_reconnect_state().expect("recv_reconnect_state");
-    assert!(state.last_move.is_none());
     assert_eq!(state.current_turn, Some(rshogi_csa::Color::Black));
+}
+
+#[test]
+fn recv_reconnect_state_aborts_when_begin_marker_missing() {
+    // BEGIN Reconnect_State が来ないまま大量の行が届く異常応答で無限ループしない
+    // ことを確認する (50 行で abort)。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let noise: Vec<&str> = (0..60).map(|_| "noise_line_no_begin_marker").collect();
+        write_lines(writer, &noise);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let err = conn.recv_reconnect_state().expect_err("expected abort");
+    assert!(err.to_string().contains("BEGIN Reconnect_State"));
 }

--- a/crates/rshogi-csa-client/tests/csa_reconnect_protocol.rs
+++ b/crates/rshogi-csa-client/tests/csa_reconnect_protocol.rs
@@ -1,0 +1,203 @@
+//! CSA 再接続プロトコル (`Reconnect_Token` / `LOGIN ... reconnect:` /
+//! `BEGIN Reconnect_State`) の client 側 parse / 送出ロジックを TCP loopback で
+//! 確認する。
+//!
+//! `tungstenite` の WS スタックは別スレッドで mock サーバを立てる手間が大きい
+//! ため、本テストは TCP 経路を使う。`CsaConnection::login_reconnect` /
+//! `recv_reconnect_state` / `recv_game_summary` の `Reconnect_Token` 拡張行は
+//! transport 種別非依存で実装されているため TCP / WS 共通の挙動として
+//! 妥当に確認できる。
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+use rshogi_csa_client::protocol::CsaConnection;
+
+/// 1 接続を受け取り、与えた `handler` を別スレッドで実行する mock CSA TCP サーバ。
+fn spawn_mock_tcp_server<F>(handler: F) -> u16
+where
+    F: FnOnce(&mut BufReader<std::net::TcpStream>, &mut std::net::TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    thread::Builder::new()
+        .name("mock-csa-server".to_string())
+        .spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+            let mut writer = stream.try_clone().expect("clone stream");
+            let mut reader = BufReader::new(stream);
+            handler(&mut reader, &mut writer);
+        })
+        .expect("spawn");
+    port
+}
+
+fn read_line(reader: &mut BufReader<std::net::TcpStream>) -> String {
+    let mut buf = String::new();
+    reader.read_line(&mut buf).expect("read line");
+    buf.trim_end_matches(['\r', '\n']).to_owned()
+}
+
+fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
+    for line in lines {
+        writeln!(writer, "{}", line).expect("write line");
+    }
+    writer.flush().expect("flush");
+}
+
+#[test]
+fn login_reconnect_sends_correct_token_format() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let line = read_line(reader);
+        // LOGIN行の reconnect:<game_id>+<token> 形式が期待通りか確認
+        assert!(
+            line.contains("reconnect:game-42+abc1234"),
+            "LOGIN line should contain reconnect:<game_id>+<token>: got {}",
+            line
+        );
+        write_lines(writer, &["LOGIN:alice OK"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login_reconnect("alice", "pw", "game-42", "abc1234")
+        .expect("login_reconnect");
+}
+
+#[test]
+fn login_reconnect_propagates_incorrect_response() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:incorrect reconnect_rejected"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    let err = conn
+        .login_reconnect("alice", "pw", "game-42", "bad-token")
+        .expect_err("expected reconnect failure");
+    assert!(err.to_string().contains("再接続失敗"));
+}
+
+#[test]
+fn recv_game_summary_extracts_reconnect_token() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        // LOGIN受信→OK応答
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        // Game_Summary送出 (Reconnect_Token拡張行付き)
+        write_lines(
+            writer,
+            &[
+                "BEGIN Game_Summary",
+                "Protocol_Version:1.2",
+                "Game_ID:game-42",
+                "Name+:black",
+                "Name-:white",
+                "Your_Turn:+",
+                "To_Move:+",
+                "Time_Unit:1sec",
+                "Total_Time:600",
+                "Byoyomi:10",
+                "BEGIN Position",
+                "PI",
+                "+",
+                "END Position",
+                "Reconnect_Token:black-token-xyz",
+                "END Game_Summary",
+            ],
+        );
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let summary = conn.recv_game_summary(0).expect("recv_game_summary");
+    assert_eq!(summary.game_id, "game-42");
+    assert_eq!(summary.reconnect_token.as_deref(), Some("black-token-xyz"));
+}
+
+#[test]
+fn recv_game_summary_handles_missing_reconnect_token() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Game_Summary",
+                "Protocol_Version:1.2",
+                "Game_ID:game-no-token",
+                "Name+:black",
+                "Name-:white",
+                "Your_Turn:+",
+                "To_Move:+",
+                "Time_Unit:1sec",
+                "Total_Time:600",
+                "Byoyomi:10",
+                "BEGIN Position",
+                "PI",
+                "+",
+                "END Position",
+                "END Game_Summary",
+            ],
+        );
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let summary = conn.recv_game_summary(0).expect("recv_game_summary");
+    assert!(summary.reconnect_token.is_none());
+}
+
+#[test]
+fn recv_reconnect_state_parses_all_fields() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:-",
+                "Black_Time_Remaining_Ms:599500",
+                "White_Time_Remaining_Ms:600000",
+                "Last_Move:+7776FU",
+                "END Reconnect_State",
+            ],
+        );
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let state = conn.recv_reconnect_state().expect("recv_reconnect_state");
+    assert_eq!(state.black_remaining_ms, 599_500);
+    assert_eq!(state.white_remaining_ms, 600_000);
+    assert_eq!(state.last_move.as_deref(), Some("+7776FU"));
+    assert_eq!(state.current_turn, Some(rshogi_csa::Color::White));
+}
+
+#[test]
+fn recv_reconnect_state_handles_missing_last_move() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:+",
+                "Black_Time_Remaining_Ms:600000",
+                "White_Time_Remaining_Ms:600000",
+                "END Reconnect_State",
+            ],
+        );
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let state = conn.recv_reconnect_state().expect("recv_reconnect_state");
+    assert!(state.last_move.is_none());
+    assert_eq!(state.current_turn, Some(rshogi_csa::Color::Black));
+}


### PR DESCRIPTION
## Summary

Workers staging の Floodgate features 有効化 (PR #534) で受信できる `Reconnect_Token:<token>` 拡張行を csa_client が解釈し、サーバ切断検出時に **1 度だけ自動再接続** を試みる。`RECONNECT_GRACE_SECONDS` 内に到達できれば同一対局を継続できる。

## 主要変更

### `crates/rshogi-csa-client/src/protocol.rs`
- `GameSummary.reconnect_token: Option<String>` フィールドを追加し、`recv_game_summary` で `Reconnect_Token:` 拡張行をパース。
- `CsaConnection::login_reconnect(id, password, game_id, token)`: `LOGIN <id> <pw> reconnect:<game_id>+<token>` を送出して LOGIN OK を待つ。
- `CsaConnection::recv_reconnect_state()`: `BEGIN Reconnect_State ... END Reconnect_State` ブロックを `Current_Turn` / `Black_Time_Remaining_Ms` / `White_Time_Remaining_Ms` / `Last_Move` に分解。
- `ReconnectState` 型を新設。

### `crates/rshogi-csa-client/src/session.rs`
- `run_game_session` の戻り値を `(GameResult, GameRecord, Option<GameSummary>)` 3 タプルに変更（呼び出し側で reconnect_token を取得するため）。
- `run_resumed_session()` を新設: login_reconnect 直後の resume 用 Game_Summary + Reconnect_State を読み取り、`engine.new_game()` で USI 状態をリセットしてから対局ループに合流。
- `run_session_loop()` を共通ヘルパとして抽出 (run_game_session / run_resumed_session 両方から再利用)。
- resume 時は Reconnect_State 由来の残時間で `Clock` の本体時間を上書き、秒読み / increment は Game_Summary 由来を維持。

### `crates/rshogi-csa-client/src/main.rs`
- `run_one_game` で `Interrupted + reconnect_token + !shutdown` 検出時に `attempt_reconnect()` で 1 回再接続を試みる。
- 再接続失敗時は元の Interrupted 結果で終了 (元 disconnect 経路で既に `gameover("lose")` 発射済みのため main.rs では `stop_and_wait` のみ)。

### `crates/rshogi-csa-client/tests/csa_reconnect_protocol.rs` (新規)
TCP loopback で 6 件のテスト:
1. `login_reconnect` の LOGIN 行に `reconnect:<game_id>+<token>` が含まれる
2. `login_reconnect` が `LOGIN:incorrect ...` で適切にエラーを伝播する
3. `recv_game_summary` が `Reconnect_Token:` 拡張行を抽出する
4. `recv_game_summary` が `Reconnect_Token` 欠落でも壊れない
5. `recv_reconnect_state` が全フィールドを正しくパース (`Current_Turn:-` / 残時間 / Last_Move)
6. `recv_reconnect_state` が Last_Move 欠落でも壊れない

## 互換性

- TOML 経路 / `--target` プリセット (PR #532) は無回帰。`Reconnect_Token` を持たない server との接続では再接続経路に入らず従来どおり Interrupted で終了。
- Workers / TCP server 共通の経路で実装、transport 種別非依存。
- `Reconnect_Token:` パース位置は server 側 `summary.rs::build_for` の出力位置 (`END Position` 後・`END Game_Summary` 直前) と一致。
- LOGIN reconnect format / `BEGIN Reconnect_State` ブロックの key 名は server 側 (`reconnect.rs::build_resume_message` / `command.rs::ClientCommand::Login`) と一致。

## 受入

- [x] `cargo fmt --all` 適用済み
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test -p rshogi-csa-client` 23 件全 pass (lib 3 / main 9 / ws_transport 5 / 新規 reconnect 6)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` クリーン (server 側無変更)
- [x] independent Claude review 2 周で Approve as-is に到達
  - 1 周目: USI プロトコル不整合 (reconnect 後の `engine.new_game()` 抜け) と未使用 `_prior_record` 引数の YAGNI 違反を指摘 → 解消
  - 2 周目: Approve as-is

## Test plan

- [ ] PR 作成後 CI 全 SUCCESS
- [ ] independent claude-review (CI 内) で Approve as-is
- [ ] **merge 後にユーザーが staging で実機通電確認**:
  - シナリオ A 開始 → 対局途中で client 側から WS を強制切断 (kill -9 不可、ネットワーク切断 or process 一時停止)
  - 30 秒以内に grace 内自動再接続が成立して対局継続
  - 終局後 R2 棋譜に切断前後の指し手が連続して保存されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)