### PR TITLE
docs(csa-server): Workers LobbyDO + マッチング設計書を整備する

### DIFF
--- a/docs/csa-server/lobby_design.md
+++ b/docs/csa-server/lobby_design.md
@@ -1,0 +1,264 @@
+# Workers LobbyDO + マッチング設計書
+
+本リポ `rshogi-csa-client` を立ち上げっぱなしで複数局を別 AI と自動マッチング
+対局させる体験を提供するための設計書。Cloudflare Workers に LobbyDO を新設し、
+既存 `GameRoom` DO と組み合わせて Floodgate 相当のマッチングロビーを構築する。
+
+## 1. 背景と目的
+
+現状 (Origin 緩和 / `--target` プリセット / `RECONNECT_GRACE_SECONDS` 有効化 /
+auto-reconnect 機能の合流後):
+
+- `rshogi-csa-server-workers` は **1 DO instance = 1 対局** という設計で、`/ws/<room_id>`
+  に黒白 2 client が同時接続することで対局成立。
+- `rshogi-csa-client` は `--target {staging,production} --room-id <id> --handle <name> --color <black|white>`
+  でクイック接続できるが、**room_id を黒白で人手合わせする** 運用が必要。
+- 本家 Floodgate (TCP) は 1 server で待機プレイヤをキューに入れ、`game_name`
+  が一致した瞬間にペアリング → game_id 発番 → Game_Summary 配布で自動成立する。
+
+これを Workers でも提供したい。設計のキーは **本家 Floodgate のマッチング処理を
+LobbyDO 1 個に閉じ込め、ペアリング成立時に既存 GameRoom DO へ handoff** する形。
+
+## 2. アーキテクチャ概要
+
+```
+            ┌──────────────────────┐
+ csa_client │    /ws/lobby         │   ← LobbyDO (1 個固定 ID = "default")
+   ────────▶│   (LOGIN_LOBBY 待機) │
+            └──────────────────────┘
+                      │
+              MATCHED <room_id> <color>
+                      ▼
+            ┌──────────────────────┐
+ csa_client │    /ws/<room_id>     │   ← 既存 GameRoom DO (1 instance = 1 対局)
+   ────────▶│  (Game_Summary 配布) │
+            └──────────────────────┘
+                      │
+                 終局 / 切断 / reconnect 不可
+                      │
+                      └──── csa_client は再度 /ws/lobby に LOGIN_LOBBY して
+                            queue に戻る → 次のマッチング待ち
+```
+
+- **LobbyDO** (新設、本 PR で scaffold のみ): プレイヤ待機キュー + ペアリング判定 +
+  GameRoom DO への引き渡し通知を担当。1 instance 固定 (id_from_name("default"))。
+  queue 自体は **メモリのみ** で永続化しない。Hibernation 復帰時は client が
+  再 LOGIN_LOBBY して queue を再構成する想定 (queue は揮発でよい)。
+- **GameRoom DO** (既存、無変更): 1 対局を駆動。LobbyDO から流入してくる
+  client は通常の LOGIN フローでこの DO に接続する。
+- **csa_client** (`--lobby` モード追加): ロビーで queue 待機 → MATCHED 通知で
+  指定された GameRoom DO に再接続 → 1 局完走 → 再度ロビー queue に戻る、を
+  shutdown まで繰り返す。
+
+## 3. プロトコル設計
+
+### 3.1 `/ws/lobby` route
+
+LobbyDO への接続経路。Origin 検査は既存 `forward_ws_to_room` と同じ allowlist を
+利用 (Origin 欠落 = 素通し / Origin 付き = allowlist 完全一致)。
+
+### 3.2 LobbyDO 受信プロトコル (client → LobbyDO)
+
+| line | 役割 |
+|---|---|
+| `LOGIN_LOBBY <handle>+<game_name>+<color> <password>` | queue へエントリ。`<game_name>` がマッチング対象タグ、`<color>` は手番希望 (`black`/`white`/`any`)。 |
+| `LOGOUT_LOBBY` | queue から離脱。 |
+| `LOBBY_PONG` | LobbyDO が送る `LOBBY_PING` への応答 (双方向 keep-alive)。 |
+
+**`<game_name>` の文字種制限**: `[A-Za-z0-9_-]` のみ許可、長さ 1〜32 文字。これは
+`MATCHED <room_id> <color>` の room_id 文字列に `<game_name>` を組み込むため、
+区切り曖昧性を排除する目的。形式違反は `LOGIN_LOBBY:incorrect format` で reject。
+
+`game_name` の意味: 本家 Floodgate と同じく「同 `game_name` 同士でしかマッチング
+しない」。`game_name` をユーザ任意の自由 string にすることで、複数のマッチング
+pool を 1 LobbyDO 内で同時稼働できる。
+
+### 3.3 LobbyDO 送信プロトコル (LobbyDO → client)
+
+| line | 役割 |
+|---|---|
+| `LOGIN_LOBBY:<handle> OK` | queue 登録成功 (`<handle>` は LOGIN_LOBBY で送られた handle 部分をそのまま echo)。 |
+| `LOGIN_LOBBY:incorrect <reason>` | 登録失敗 (重複ハンドル / フォーマット不正等)。 |
+| `LOGIN_LOBBY:expired` | queue 滞留時間 (TTL) を超過した。client は再度 `LOGIN_LOBBY` を送るか shutdown する。 |
+| `MATCHED <room_id> <color>` | ペアリング成立。`<room_id>` と `<color>` は **半角スペース区切り**。client は LobbyDO を close してから `/ws/<room_id>` に `<handle>+<game_name>+<color>` で LOGIN し、対局を開始する。 |
+| `LOBBY_PING` | DO Hibernation 復帰時の生存確認。client は `LOBBY_PONG` を返す。 |
+
+`<room_id>` のフォーマット: `lobby-<game_name>-<128bit-rand-hex>` (rand 部分は 32 文字 hex
+= 128 bit、衝突確率は事実上ゼロ)。`<game_name>` は §3.2 の文字種制限により
+`-` 以外の特殊文字が混入しないため、`-` で区切っても曖昧性なし。
+
+### 3.4 マッチング戦略
+
+ペアリング戦略は **直接マッチのみ** (本設計の最低限ゴール)。同 `game_name` で
+`preferred_color` が競合しない先着 2 名を順次ペアリングする。
+
+実装は既存 `rshogi-csa-server::matching::DirectMatchStrategy` を Workers crate
+から再利用したいが、**`rshogi-csa-server` crate の wasm32 互換性確認** が前提
+となる (実装ロードマップ §6 の (0) 段で実施)。
+
+レート差最小ペアリング等の戦略拡張は本設計のスコープ外 (将来必要になったら
+別設計を起こす)。
+
+### 3.5 GameRoom DO への引き渡し
+
+ペアリング成立時、LobbyDO は:
+
+1. `<room_id> = "lobby-<game_name>-<128bit-rand-hex>"` を発番
+   (DO storage に既存 room_id 集合を持たない最初の発番でも、128 bit rand により
+   GameRoom DO が `id_from_name(<room_id>)` で同名 DO に当たる確率は実質ゼロ)。
+2. 黒/白 client それぞれに `MATCHED <room_id> <color>` を送信。
+3. LobbyDO 自体の WS は close し、client が `/ws/<room_id>` に再接続するのを
+   ある時間 (`LOBBY_HANDOFF_DEADLINE_SECONDS`) 内に完了することを期待する。
+4. GameRoom DO は通常の LOGIN フローでこの 2 client を受け入れて Game_Summary
+   配布 → 対局開始。
+
+#### handoff 片側失敗時の整合性
+
+両 client が `/ws/<room_id>` に LOGIN するまでに片側が失敗 (例: 黒は接続成功、
+白は失敗) するシナリオがある。これを処理するため:
+
+- **GameRoom DO 側**: `GAME_ROOM_LOGIN_DEADLINE_SECONDS` (既定 60 秒) 内に
+  両者 LOGIN が揃わない場合、対局を破棄し DO を空状態に戻す。LOGIN 済み単側
+  client には `#CHUDAN handoff_timeout` を送って close。これは GameRoom DO 側の
+  既存「対局成立前の片側不在」処理を拡張する形 (実装は本設計のスコープ外、
+  実装ロードマップ §6 の (2) 段でカバー)。
+- **LobbyDO 側**: handoff 後は GameRoom の状態を関知しない (片側不在の検出は
+  GameRoom DO 側が行う)。失敗で戻された client は LobbyDO に再 LOGIN_LOBBY して
+  queue に戻る運用 (csa_client が状態機械で実装、§4.1)。
+
+## 4. csa_client `--lobby` モード
+
+```bash
+cargo run -p rshogi-csa-client --release -- \
+  --target staging \
+  --lobby \
+  --game-name "rshogi-eval" \
+  --handle alice \
+  --color any \
+  --simple-engine \
+  --engine /path/to/your/rshogi-usi
+```
+
+`--lobby` 指定時は `--room-id` 不要 (LobbyDO が発番)。`--color any` は
+`preferred_color = None` で送信される。
+
+### 4.1 状態機械
+
+```
+ ┌─────────┐
+ │  Init   │
+ └─────────┘
+      │ ロビー接続
+      ▼
+ ┌─────────┐
+ │ Queued  │← LOGIN_LOBBY:OK 受信
+ └─────────┘
+      │ MATCHED <room_id> <color> 受信
+      ▼
+ ┌──────────┐
+ │Connecting│ /ws/<room_id> へ LOGIN
+ └──────────┘
+   │     │
+   │     │ LOGIN 失敗 / GameRoom timeout (#CHUDAN handoff_timeout)
+   │     └──→ Init に戻る (再 LOGIN_LOBBY)
+   │
+   │ LOGIN OK
+   ▼
+ ┌─────────┐
+ │ Playing │ 通常の対局ループ (auto-reconnect 機能も適用される)
+ └─────────┘
+   │     │
+   │     │ 対局中切断 → auto-reconnect 失敗 (Reconnect_Token expired 等)
+   │     └──→ Init に戻る (再 LOGIN_LOBBY)
+   │
+   │ 終局 / shutdown
+   ▼
+ ┌─────────┐
+ │  Init   │ → Queued に戻る (shutdown なら終了)
+ └─────────┘
+```
+
+`Queued` 状態で `LOGIN_LOBBY:expired` を受けた場合は `Init` に戻り再 LOGIN_LOBBY
+を試みる (TTL 超過は LobbyDO 側のリソース防衛で発生)。
+
+`shutdown` (Ctrl+C) で `Queued` / `Connecting` / `Playing` から離脱して終了。
+`Connecting` 失敗時は backoff してから `Init` に戻る (既存 retry ロジック流用)。
+
+### 4.2 lobby と auto-reconnect (Reconnect_Token 機能) の関係
+
+- `Playing` 状態中に WS 切断 → 既存 auto-reconnect (Reconnect_Token) が走る。
+  これは GameRoom DO 内で完結し、LobbyDO は関与しない。
+- `Connecting` 状態の失敗 (LobbyDO のペアリング後に GameRoom 接続が失敗) は
+  lobby レベルで「マッチング無効」とみなして Queued (再 LOGIN_LOBBY) に戻る。
+- `Playing` 中の auto-reconnect が **最終的に失敗** (grace 超過や reconnect token
+  reject) した場合も `Init` に戻り、ロビーで次のマッチングを待つ。
+
+## 5. セキュリティと運用
+
+### 5.1 認証
+
+LobbyDO の LOGIN_LOBBY 受け入れ条件:
+
+- `<handle>+<game_name>+<color>` のフォーマットが正しい (既存 GameRoom と同じ)。
+- `<game_name>` は §3.2 の文字種制限を満たす。
+- `<password>` は Workers 設定 secret と照合する経路は持たない (本家 Floodgate と
+  同じく「ハンドル名は self-claim」運用)。
+- 重複ハンドルは別セッションを EvictOld (既存 League 実装と同じ挙動)。
+
+### 5.2 Origin 検査
+
+`/ws/lobby` も `/ws/<room_id>` と同じ Origin 検査を通す
+(`router.rs::forward_ws_to_lobby` を新設、`evaluate(origin, allow_list)` を流用)。
+
+### 5.3 リソース上限
+
+各 config 値は `[vars]` の追加キーとして wrangler.toml.example に追加し、CI 整合
+チェック (`tests/wrangler_template_consistency.rs`) で固定する:
+
+| Config キー | 既定値 | 役割 |
+|---|---|---|
+| `LOBBY_QUEUE_SIZE_LIMIT` | `100` | 1 LobbyDO 内の queue 総数上限 (`game_name` 別ではなく合計)。超過時 LOGIN_LOBBY を reject。 |
+| `LOBBY_QUEUE_TTL_SECONDS` | `300` | LOGIN_LOBBY からのエントリ有効期限。expire 時 `LOGIN_LOBBY:expired` で client を起こす。 |
+| `LOBBY_HANDOFF_DEADLINE_SECONDS` | `30` | `MATCHED` 送信後、両 client が GameRoom DO に LOGIN するまでの猶予 (実装は GameRoom DO 側で実施、§3.5)。 |
+| `GAME_ROOM_LOGIN_DEADLINE_SECONDS` | `60` | GameRoom DO で両者 LOGIN が揃うまでの猶予 (handoff 失敗検知用)。 |
+
+### 5.4 metrics / observability
+
+- `wrangler tail` ログに `[Lobby] queue=<n> matched=<m>` を 30 秒ごとに出力。
+  Hibernation 中は Worker code が走らないため、`state.alarm()` API で 30 秒後の
+  alarm を仕掛けて起床する経路にする (LobbyDO は queue 保持中は idle になりにくいが、
+  queue 空時は Hibernation に入りうるので保険)。
+- DO storage に `total_matches_made` を増分 (運用観測用、実装ロードマップ §6 (5) 段)。
+
+## 6. 実装ロードマップ (本設計後の follow-up PR)
+
+各段は独立 PR として merge 可能で、依存関係は (0) → (1) → (2) → (3) → (4) → (5)
+の直線的な順序を想定する。
+
+| 段 | 概要 | スコープ |
+|---|---|---|
+| (0) wasm32 互換確認 | `rshogi-csa-server::matching` の wasm32 ビルド確認 | `cargo check --target wasm32-unknown-unknown` で互換確認。非互換 API (tokio / std::time::Instant 等) があれば matching 部分を no_std 互換 sub-crate に切り出す前段作業 |
+| (1) LobbyDO 骨格 + `/ws/lobby` route | 空 DO + LOGIN_LOBBY 受信のみ | in-memory queue、ペアリング無し、`<game_name>` 文字種検証 |
+| (2) DirectMatch ペアリング + handoff | 既存 `DirectMatchStrategy` を Workers crate に wrap、`MATCHED` 送信、GameRoom DO 側の login deadline | queue が 2 件揃ったらペアを発番、`MATCHED` 送信。GameRoom DO 側に `GAME_ROOM_LOGIN_DEADLINE_SECONDS` 経過で破棄経路を追加 |
+| (3) csa_client `--lobby` mode | 状態機械 (Init / Queued / Connecting / Playing) を実装 | `--lobby` フラグ、shutdown 経路、再 LOGIN、auto-reconnect 機能と整合 |
+| (4) Miniflare smoke | 2 client 同時接続 → 1 ペア成立 → handoff → 1 局完走 | CI E2E。auto-reconnect 機能後の GameRoom 新規 LOGIN パスが壊れていないことの回帰確認も含む |
+| (5) metrics / Hibernation 対応 + queue TTL | 30 秒 keep-alive、queue TTL、storage カウンタ | 信頼性向上 |
+
+(0)〜(4) まで揃えばゴール「本リポ csa_client が立ち上げっぱなしで複数局を
+マッチング対局する」が最低限達成できる。(5) は queue 滞留 / 観測性の本番運用前
+強化 PR。queue TTL に依存する `LOGIN_LOBBY:expired` は (5) で初めて実装可能。
+
+## 7. 既存設計との比較
+
+| 観点 | 本家 Floodgate (TCP) | rshogi Workers (LobbyDO 設計後) |
+|---|---|---|
+| プロセス境界 | 1 プロセス内に League + 全対局 | LobbyDO + N 個の GameRoom DO |
+| マッチング | League::confirm_match で内部即時 | LobbyDO で発番 → MATCHED 通知 → client が GameRoom に再接続 |
+| 対局並行度 | 1 server = N 対局 | 1 GameRoom DO = 1 対局 (Cloudflare account-level の concurrent instance 数上限内で実用上ほぼ制約なし) |
+| 切断後再接続 | 同 server に reconnect | 元 GameRoom DO に reconnect (Reconnect_Token 機能) |
+| 休止 | 常時実行 | GameRoom DO は Hibernation で対局 idle 時 0 課金 (LobbyDO は queue 保持中は idle になりにくく、空時のみ Hibernation 対象) |
+
+設計上の妥協点: client は **マッチング成立後に新規 WS 接続を 1 回張り直す** 必要がある。
+本家 Floodgate は同 TCP 接続上で対局が始まるので 1 hop だが、Workers の DO 境界を
+跨ぐため 2 hop (Lobby → GameRoom) になる。レイテンシ観点では数百 ms 増だが、
+1 game の総対局時間に対して無視できる。


### PR DESCRIPTION
## Summary

本リポ `rshogi-csa-client` を立ち上げっぱなしで複数局を別 AI とマッチング対局させる体験を提供するため、Cloudflare Workers に LobbyDO を新設して既存 GameRoom DO と組み合わせる構成の設計書を `docs/csa-server/lobby_design.md` に追加する。

**本 PR は設計書のみ**。実装は段階別の follow-up PR (5 段、(0)〜(4) で最低限ゴール達成、(5) で信頼性向上) に分割する案を提示する。

## 設計の核

- **LobbyDO** (1 instance 固定): プレイヤ待機キュー + 既存 `rshogi-csa-server::matching::DirectMatchStrategy` 再利用ペアリング + GameRoom DO への handoff 通知。
- **GameRoom DO** (既存無変更を最大限維持、login deadline のみ追加): 1 対局を駆動。LobbyDO から流入してくる client は通常の LOGIN フローでこの DO に接続。
- **csa_client `--lobby` mode**: ロビー → MATCHED 受信 → GameRoom 接続 → 対局 → 再ロビー、を shutdown まで繰り返す状態機械。

## プロトコル

- `/ws/lobby` route に line ベースで LOGIN_LOBBY / LOGOUT_LOBBY / LOBBY_PING/PONG。
- `MATCHED <room_id> <color>` (半角スペース区切り)。`<room_id>` は `lobby-<game_name>-<128bit-rand-hex>`。
- `<game_name>` は `[A-Za-z0-9_-]` / 1〜32 文字に制限してパース曖昧性を排除。

## handoff 整合性

両 client が GameRoom に LOGIN するまでに片側が失敗するシナリオを処理するため、GameRoom DO 側に `GAME_ROOM_LOGIN_DEADLINE_SECONDS` (60 秒) の login timeout を導入し、片側不在で `#CHUDAN handoff_timeout` 送出 → DO 破棄。csa_client 側は状態機械で `Connecting → Init` に戻して再 LOGIN_LOBBY する。

## 実装ロードマップ (本 PR 後の follow-up)

| 段 | 概要 |
|---|---|
| (0) | `rshogi-csa-server::matching` の wasm32 互換確認 (pre-step) |
| (1) | LobbyDO 骨格 + `/ws/lobby` route (in-memory queue、ペアリング無し) |
| (2) | DirectMatch ペアリング + GameRoom DO login deadline |
| (3) | csa_client `--lobby` mode (状態機械実装) |
| (4) | Miniflare smoke (2 client → ペア成立 → handoff → 1 局完走) |
| (5) | metrics / Hibernation 対応 + queue TTL (信頼性向上) |

(0)〜(4) でゴール最低限達成。

## 受入

- [x] `cargo fmt --all` 適用済み (doc-only なので影響なし)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン (無回帰)
- [x] independent Claude review 2 周で Approve as-is
  - 1 周目: 8 件の Must 指摘 (PR # 参照削除 / handoff 整合性 / wasm32 互換 pre-step / MATCHED パース曖昧性 / LOGIN_LOBBY OK の `<name>` 定義 / YAGNI 抵触 / room_id 衝突回避 / auto-reconnect 失敗経路)
  - 2 周目: 全 8 件解消、Approve as-is

## Test plan

- [ ] PR 作成後 CI 全 SUCCESS (doc-only なので Test / Clippy / smoke は無回帰確認のみ)
- [ ] independent claude-review (CI 内) で Approve as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)