### PR TITLE
feat(csa-client): JSONL 出力モードで CLI 解析パイプラインに乗せる

### DIFF
--- a/crates/rshogi-csa-client/examples/README.md
+++ b/crates/rshogi-csa-client/examples/README.md
@@ -78,6 +78,58 @@ cargo run -p rshogi-csa-client --release -- \
 Worker で動かしたい場合は TOML 直書きの host を `wss://<your-subdomain>/ws/lobby` に
 向ける必要があり、現状の `--lobby` モードは未対応 (`--target staging|production` 必須)。
 
+## JSONL 出力モード — `tools::analyze_selfplay` で集計
+
+`--jsonl-out <DIR>` を付けて起動すると、対局完了ごとに analyze_selfplay 互換の JSONL を
+`<DIR>/<datetime>_<sente>_vs_<gote>.jsonl` として書き出す。サーバーへ送信するわけでは
+なく、完全にローカル CLI 解析専用の opt-in 機能 (既定 OFF)。
+
+スキーマは selfplay (`tools/src/bin/tournament.rs`) の出力と同じ `meta` / `move` /
+`result` の 3 種類で、`move.eval` は `score_cp` / `score_mate` / `depth` / `seldepth` /
+`nodes` / `time_ms` / `nps` / `pv` を含む。`engine` フィールドは CSA 上の player 名
+(`sente_name` / `gote_name`) と一致するため、selfplay の per-engine 集計と同じツールを
+そのまま流用できる。
+
+```bash
+# 1. CSA 経由対局を JSONL 付きで実行（--target staging の例）
+mkdir -p runs/csa-jsonl
+cargo run -p rshogi-csa-client --release -- \
+  --target staging \
+  --room-id e2e-jsonl-1 \
+  --handle alice \
+  --color black \
+  --engine /path/to/your/rshogi-usi \
+  --options "EvalFile=/path/to/your-nnue.bin,USI_Hash=256" \
+  --jsonl-out runs/csa-jsonl \
+  --max-games 5
+
+# 2. selfplay と同じツールで集計
+cargo run -p tools --release --bin analyze_selfplay -- runs/csa-jsonl/*.jsonl
+
+# JSON で受け取りたい場合
+cargo run -p tools --release --bin analyze_selfplay -- --json runs/csa-jsonl/*.jsonl
+```
+
+TOML 設定の `[record]` セクションでも指定可能:
+
+```toml
+[record]
+enabled = true
+dir = "./records"
+jsonl_out = "./runs/csa-jsonl"
+```
+
+注意点:
+
+- 1 対局 = 1 JSONL ファイル。複数局を回した場合は glob 展開でまとめて
+  analyze_selfplay に渡す。
+- 相手エンジンのバイナリパス・USI options は CSA プロトコル上で得られないため
+  `path_white` / `path_black` の片側は `remote:<player_name>` 形式の placeholder が入る。
+  per-engine 集計に必要な `label_*` は `sente_name` / `gote_name` を使うので
+  `winner` 判定はそのまま動く。
+- 相手手番の `move` 行は `eval` を持たない（USI info を観測できないため）。
+  集計対象は自エンジンの `engine_timing` のみ意味を持つ。
+
 ## Workers staging × csa_client 実機 E2E
 
 `csa_client_staging/scenarios/<scenario>/` 配下の `*.toml.example` をコピーして

--- a/crates/rshogi-csa-client/src/config.rs
+++ b/crates/rshogi-csa-client/src/config.rs
@@ -149,6 +149,11 @@ pub struct RecordConfig {
     pub filename_template: String,
     pub save_csa: bool,
     pub save_sfen: bool,
+    /// JSONL 出力先ディレクトリ。`None` のとき JSONL は生成しない。
+    /// 指定すると `<datetime>_<sente>_vs_<gote>.jsonl` を出力し、
+    /// `tools::analyze_selfplay` で読み込めるスキーマで meta / move / result 行を書き込む。
+    #[serde(default)]
+    pub jsonl_out: Option<PathBuf>,
 }
 
 impl Default for RecordConfig {
@@ -159,6 +164,7 @@ impl Default for RecordConfig {
             filename_template: "{datetime}_{sente}_vs_{gote}".to_string(),
             save_csa: true,
             save_sfen: true,
+            jsonl_out: None,
         }
     }
 }

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -41,11 +41,19 @@ pub enum SearchOutcome {
 }
 
 /// info 行から抽出した探索情報
+///
+/// `depth` / `score_cp` / `score_mate` / `pv` は CSA Floodgate 拡張コメント生成に使われる。
+/// `seldepth` / `nodes` / `time_ms` / `nps` は JSONL 出力モード（analyze_selfplay 互換）の
+/// `move.eval` フィールドへの転写用。`info` 行から最後に観測した値を保持する。
 #[derive(Clone, Debug, Default)]
 pub struct SearchInfo {
     pub depth: Option<u32>,
+    pub seldepth: Option<u32>,
     pub score_cp: Option<i32>,
     pub score_mate: Option<i32>,
+    pub nodes: Option<u64>,
+    pub time_ms: Option<u64>,
+    pub nps: Option<u64>,
     pub pv: Vec<String>,
 }
 
@@ -432,6 +440,30 @@ fn update_search_info(info: &mut SearchInfo, line: &str) {
             "depth" => {
                 if let Some(v) = tokens.peek().and_then(|s| s.parse().ok()) {
                     info.depth = Some(v);
+                    tokens.next();
+                }
+            }
+            "seldepth" => {
+                if let Some(v) = tokens.peek().and_then(|s| s.parse().ok()) {
+                    info.seldepth = Some(v);
+                    tokens.next();
+                }
+            }
+            "nodes" => {
+                if let Some(v) = tokens.peek().and_then(|s| s.parse().ok()) {
+                    info.nodes = Some(v);
+                    tokens.next();
+                }
+            }
+            "time" => {
+                if let Some(v) = tokens.peek().and_then(|s| s.parse().ok()) {
+                    info.time_ms = Some(v);
+                    tokens.next();
+                }
+            }
+            "nps" => {
+                if let Some(v) = tokens.peek().and_then(|s| s.parse().ok()) {
+                    info.nps = Some(v);
                     tokens.next();
                 }
             }

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -1,0 +1,407 @@
+//! JSONL 出力モード
+//!
+//! 対局完了時に `tools::analyze_selfplay` 互換のスキーマで JSONL を 1 ファイル吐く。
+//! selfplay (`tools/src/bin/tournament.rs`) の出力と同じ `meta` / `move` / `result`
+//! 行構成で、CLI 解析パイプライン（Elo / nElo / 手数分布など）に乗せられる。
+//!
+//! viewer や Cloudflare R2 への送信は行わない。完全にローカル CLI 解析専用。
+//!
+//! ## スキーマ
+//!
+//! - `meta`: `timestamp` / `settings` / `engine_cmd` / `start_positions` / `output`
+//! - `move`: `game_id` / `ply` / `side_to_move` / `sfen_before` / `move_usi` /
+//!   `engine` / `elapsed_ms` / `think_limit_ms` / `timed_out` / `eval`
+//! - `result`: `game_id` / `outcome` / `reason` / `plies` / `winner`
+//!
+//! `eval` フィールドの構造は selfplay 側の `EvalLog` と同じキー集合を持つ
+//! （`score_cp` / `score_mate` / `depth` / `seldepth` / `nodes` / `time_ms` /
+//! `nps` / `pv`）。
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rshogi_csa::Color;
+use serde::Serialize;
+
+use crate::config::CsaClientConfig;
+use crate::protocol::GameResult;
+use crate::record::{GameRecord, JsonlMoveExtra, RecordedMove};
+
+/// CSA 経由対局で 1 局分の JSONL を書き出す。
+///
+/// 既存の `GameRecord` から meta / move / result を組み立てて、`out_dir` 直下に
+/// `<datetime>_<sente>_vs_<gote>.jsonl` を作成する。`out_dir` が無ければ作成する。
+pub fn write_game_jsonl(
+    out_dir: &Path,
+    record: &GameRecord,
+    config: &CsaClientConfig,
+    result: &GameResult,
+) -> Result<PathBuf> {
+    fs::create_dir_all(out_dir).with_context(|| {
+        format!("JSONL 出力ディレクトリを作成できません: {}", out_dir.display())
+    })?;
+
+    let path = out_dir.join(jsonl_filename(record));
+    let file = File::create(&path)
+        .with_context(|| format!("JSONL ファイルを作成できません: {}", path.display()))?;
+    let mut writer = BufWriter::new(file);
+
+    write_meta(&mut writer, record, config, &path)?;
+    let plies = write_moves(&mut writer, record)?;
+    write_result(&mut writer, record, result, plies)?;
+
+    writer.flush().context("JSONL flush に失敗")?;
+    Ok(path)
+}
+
+/// `<datetime>_<sente>_vs_<gote>.jsonl` 形式のファイル名を生成する。
+fn jsonl_filename(record: &GameRecord) -> String {
+    let datetime = record.start_time.format("%Y%m%d_%H%M%S").to_string();
+    let sente = sanitize_for_filename(&record.sente_name);
+    let gote = sanitize_for_filename(&record.gote_name);
+    format!("{datetime}_{sente}_vs_{gote}.jsonl")
+}
+
+fn sanitize_for_filename(name: &str) -> String {
+    if name.is_empty() {
+        return "unknown".to_string();
+    }
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// meta 行
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct MetaLog<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    timestamp: String,
+    settings: MetaSettings,
+    engine_cmd: EngineCommandMeta<'a>,
+    start_positions: Vec<String>,
+    output: String,
+}
+
+#[derive(Serialize)]
+struct MetaSettings {
+    /// JSONL の利用側（analyze_selfplay）が `total_games_expected` の参照に使う。
+    /// CSA 1 対局 = 1 ファイルなので 1 を書く。
+    games: u32,
+    /// CSA 対局では明確な手数上限はサーバ依存だが、analyze 側は 0 でも問題ない。
+    max_moves: u32,
+    /// 先手視点の byoyomi (ms)。`Game_Summary` の値をそのまま入れる。
+    byoyomi: u64,
+    /// 先手視点の持ち時間 (ms)
+    btime: u64,
+    /// 先手視点の increment (ms)
+    binc: u64,
+    /// クライアント側の秒読みマージン (ms)
+    timeout_margin_ms: u64,
+    /// CSA クライアントは USI threads を直接設定しないため 1 を書く。
+    /// USI option として渡された場合は engine_cmd.usi_options 側に出る。
+    threads: u32,
+    /// CSA クライアントは USI_Hash を直接設定しないため 0 を書く。
+    /// USI option として渡された場合は engine_cmd.usi_options 側に出る。
+    hash_mb: u32,
+}
+
+#[derive(Serialize)]
+struct EngineCommandMeta<'a> {
+    /// 先手側のバイナリパス。自分が先手なら自エンジン、後手なら相手の `Name+` を入れる。
+    path_black: String,
+    /// 後手側のバイナリパス。
+    path_white: String,
+    /// 先手側ラベル（analyze_selfplay の集計キー）
+    label_black: String,
+    /// 後手側ラベル
+    label_white: String,
+    /// 自エンジンに渡した USI option 文字列（`Name=Value` 形式）
+    /// 相手側は不明なので空配列。
+    usi_options_black: Vec<String>,
+    usi_options_white: Vec<String>,
+    /// 対戦相手の名前は不明な相手とローカル側を区別するために残しておく。
+    /// `path_*` と冗長だが、analyze_selfplay は無視する追加メタなので OK。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<&'a str>,
+}
+
+fn write_meta<W: Write>(
+    writer: &mut W,
+    record: &GameRecord,
+    config: &CsaClientConfig,
+    output_path: &Path,
+) -> Result<()> {
+    let engine_path = config.engine.path.display().to_string();
+    let usi_options: Vec<String> = config
+        .engine
+        .options
+        .iter()
+        .map(|(k, v)| format!("{k}={}", toml_value_to_string(v)))
+        .collect();
+
+    // analyze_selfplay は `winner` を `label_black` / `label_white` と照合して集計する。
+    // CSA 対局では winner = sente_name または gote_name で送られてくるので、
+    // ラベルを CSA 上のプレイヤー名に揃えておくと analyze 側で素直に集計が動く。
+    // path_* は自エンジン側に実バイナリパス、相手側に `remote:<name>` を入れる。
+    let (path_black, path_white, options_black, options_white) = match record.my_color {
+        Color::Black => (
+            engine_path.clone(),
+            opponent_descriptor(&record.gote_name),
+            usi_options.clone(),
+            Vec::new(),
+        ),
+        Color::White => (
+            opponent_descriptor(&record.sente_name),
+            engine_path.clone(),
+            Vec::new(),
+            usi_options.clone(),
+        ),
+    };
+    let label_black = engine_label_or_fallback(&record.sente_name);
+    let label_white = engine_label_or_fallback(&record.gote_name);
+
+    let initial_sfen = record.initial_position.to_sfen();
+    let start_positions = vec![format!("position sfen {initial_sfen}")];
+
+    let meta = MetaLog {
+        kind: "meta",
+        timestamp: record.start_time.to_rfc3339(),
+        settings: MetaSettings {
+            games: 1,
+            max_moves: 0,
+            byoyomi: u64_or_zero(record.black_time.byoyomi_ms),
+            btime: u64_or_zero(record.black_time.total_time_ms),
+            binc: u64_or_zero(record.black_time.increment_ms),
+            timeout_margin_ms: config.time.margin_msec,
+            threads: 1,
+            hash_mb: 0,
+        },
+        engine_cmd: EngineCommandMeta {
+            path_black,
+            path_white,
+            label_black,
+            label_white,
+            usi_options_black: options_black,
+            usi_options_white: options_white,
+            note: Some(
+                "csa_client: opponent path is reported as remote name; usi_options are for self-engine only",
+            ),
+        },
+        start_positions,
+        output: output_path.display().to_string(),
+    };
+    serde_json::to_writer(&mut *writer, &meta)?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn u64_or_zero(value: i64) -> u64 {
+    if value < 0 { 0 } else { value as u64 }
+}
+
+fn opponent_descriptor(name: &str) -> String {
+    if name.is_empty() {
+        "remote:unknown".to_string()
+    } else {
+        format!("remote:{name}")
+    }
+}
+
+fn engine_label_or_fallback(name: &str) -> String {
+    if name.is_empty() {
+        "unknown".to_string()
+    } else {
+        sanitize_for_filename(name)
+    }
+}
+
+fn toml_value_to_string(value: &toml::Value) -> String {
+    match value {
+        toml::Value::Integer(n) => n.to_string(),
+        toml::Value::Boolean(b) => b.to_string(),
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Float(f) => f.to_string(),
+        other => other.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// move 行
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct MoveLog<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    game_id: u32,
+    ply: u32,
+    side_to_move: char,
+    sfen_before: &'a str,
+    move_usi: &'a str,
+    engine: &'a str,
+    elapsed_ms: u64,
+    think_limit_ms: u64,
+    timed_out: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    eval: Option<EvalLog>,
+}
+
+#[derive(Serialize)]
+struct EvalLog {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score_cp: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score_mate: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    depth: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seldepth: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    time_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nps: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pv: Option<Vec<String>>,
+}
+
+fn write_moves<W: Write>(writer: &mut W, record: &GameRecord) -> Result<u32> {
+    let mut plies: u32 = 0;
+    // RecordedMove と JsonlMoveExtra は session.rs で同時に push されるため、
+    // 一致しないペアは無視する（CSA から流入した手で extra を持たないものなど）。
+    for (idx, (m, extra)) in record.moves.iter().zip(record.jsonl_moves.iter()).enumerate() {
+        let ply = (idx as u32) + 1;
+        plies = ply;
+        let side_char = side_label_char(m.side_to_move);
+        let eval = build_eval_log(m, extra);
+        let entry = MoveLog {
+            kind: "move",
+            game_id: 1,
+            ply,
+            side_to_move: side_char,
+            sfen_before: &extra.sfen_before,
+            move_usi: &extra.move_usi,
+            engine: &extra.engine_label,
+            elapsed_ms: extra.elapsed_ms,
+            think_limit_ms: extra.think_limit_ms,
+            timed_out: false,
+            eval,
+        };
+        serde_json::to_writer(&mut *writer, &entry)?;
+        writer.write_all(b"\n")?;
+    }
+    Ok(plies)
+}
+
+fn side_label_char(color: Color) -> char {
+    match color {
+        Color::Black => 'b',
+        Color::White => 'w',
+    }
+}
+
+fn build_eval_log(m: &RecordedMove, extra: &JsonlMoveExtra) -> Option<EvalLog> {
+    if m.eval_cp.is_none()
+        && m.eval_mate.is_none()
+        && m.depth.is_none()
+        && extra.seldepth.is_none()
+        && extra.nodes.is_none()
+        && extra.time_ms.is_none()
+        && extra.nps.is_none()
+        && m.pv.is_empty()
+    {
+        return None;
+    }
+    Some(EvalLog {
+        score_cp: m.eval_cp,
+        score_mate: m.eval_mate,
+        depth: m.depth,
+        seldepth: extra.seldepth,
+        nodes: extra.nodes,
+        time_ms: extra.time_ms,
+        nps: extra.nps,
+        pv: if m.pv.is_empty() {
+            None
+        } else {
+            Some(m.pv.clone())
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// result 行
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ResultLog<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    game_id: u32,
+    outcome: &'a str,
+    reason: &'a str,
+    plies: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    winner: Option<String>,
+}
+
+fn write_result<W: Write>(
+    writer: &mut W,
+    record: &GameRecord,
+    result: &GameResult,
+    plies: u32,
+) -> Result<()> {
+    let outcome = outcome_label(result, record.my_color);
+    let winner = winner_label(record, result);
+    let reason = if record.result.is_empty() {
+        outcome
+    } else {
+        record.result.as_str()
+    };
+    let entry = ResultLog {
+        kind: "result",
+        game_id: 1,
+        outcome,
+        reason,
+        plies,
+        winner,
+    };
+    serde_json::to_writer(&mut *writer, &entry)?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+fn outcome_label(result: &GameResult, my_color: Color) -> &'static str {
+    match (result, my_color) {
+        (GameResult::Draw, _) => "draw",
+        // 中断は analyze_selfplay 側で集計対象外にしたいケースもあるが、
+        // 現状 outcome=draw としておくと「未決」扱いで wins/losses にカウントされない。
+        (GameResult::Interrupted | GameResult::Censored, _) => "draw",
+        (GameResult::Win, Color::Black) => "black_win",
+        (GameResult::Win, Color::White) => "white_win",
+        (GameResult::Lose, Color::Black) => "white_win",
+        (GameResult::Lose, Color::White) => "black_win",
+    }
+}
+
+fn winner_label(record: &GameRecord, result: &GameResult) -> Option<String> {
+    match (result, record.my_color) {
+        (GameResult::Win, Color::Black) => Some(record.sente_name.clone()),
+        (GameResult::Win, Color::White) => Some(record.gote_name.clone()),
+        (GameResult::Lose, Color::Black) => Some(record.gote_name.clone()),
+        (GameResult::Lose, Color::White) => Some(record.sente_name.clone()),
+        _ => None,
+    }
+}

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod config;
 pub mod engine;
 pub mod event;
+pub mod jsonl;
 pub mod protocol;
 pub mod record;
 pub mod session;

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -23,6 +23,7 @@ use clap::{Parser, ValueEnum};
 
 use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::jsonl::write_game_jsonl;
 use rshogi_csa_client::protocol::{CsaConnection, GameResult};
 use rshogi_csa_client::record::save_record;
 use rshogi_csa_client::session::{run_game_session, run_resumed_session};
@@ -154,6 +155,12 @@ struct Cli {
     #[arg(long)]
     record_dir: Option<PathBuf>,
 
+    /// JSONL 出力ディレクトリ。指定すると対局完了ごとに analyze_selfplay 互換の
+    /// JSONL ファイルを `<datetime>_<sente>_vs_<gote>.jsonl` として書き出す。
+    /// 未指定時は JSONL を出力しない（既定 OFF）。TOML の `record.jsonl_out` でも指定可。
+    #[arg(long)]
+    jsonl_out: Option<PathBuf>,
+
     /// USIエンジンオプション (K=V,K=V,...)
     #[arg(long)]
     options: Option<String>,
@@ -259,6 +266,14 @@ fn main() -> Result<()> {
                 // 棋譜保存
                 if let Err(e) = save_record(&record, &config.record) {
                     log::error!("棋譜保存エラー: {e}");
+                }
+
+                // JSONL 出力（opt-in、--jsonl-out / record.jsonl_out 指定時のみ）
+                if let Some(ref jsonl_dir) = config.record.jsonl_out {
+                    match write_game_jsonl(jsonl_dir, &record, &config, &result) {
+                        Ok(path) => log::info!("[REC] JSONL 保存: {}", path.display()),
+                        Err(e) => log::error!("JSONL 保存エラー: {e}"),
+                    }
                 }
 
                 games_played += 1;
@@ -662,6 +677,9 @@ fn apply_cli_overrides(config: &mut CsaClientConfig, cli: &Cli) {
     if let Some(ref dir) = cli.record_dir {
         config.record.dir = dir.clone();
     }
+    if let Some(ref dir) = cli.jsonl_out {
+        config.record.jsonl_out = Some(dir.clone());
+    }
     if let Some(ref opts) = cli.options {
         for kv in opts.split(',') {
             if let Some((k, v)) = kv.split_once('=') {
@@ -774,6 +792,7 @@ mod tests {
             max_games: None,
             log_level: None,
             record_dir: None,
+            jsonl_out: None,
             options: None,
         }
     }

--- a/crates/rshogi-csa-client/src/record.rs
+++ b/crates/rshogi-csa-client/src/record.rs
@@ -24,6 +24,12 @@ pub struct GameRecord {
     pub moves: Vec<RecordedMove>,
     pub result: String,
     pub start_time: chrono::DateTime<Local>,
+    /// 自エンジンの手番。JSONL 出力モードで `outcome` / `winner` の正規化に使う。
+    pub my_color: Color,
+    /// JSONL 出力モード用に蓄積する手単位の追加情報。CSA / SFEN 棋譜出力には影響しない。
+    /// 各要素は `moves[i]` に対応する。投了 / 勝ち宣言など `apply_csa_move` を経由しない
+    /// 手は含まれず、ply ベースで一致する。
+    pub jsonl_moves: Vec<JsonlMoveExtra>,
 }
 
 #[derive(Clone, Debug)]
@@ -36,6 +42,34 @@ pub struct RecordedMove {
     pub pv: Vec<String>,
     /// この手を指した側の手番（評価値の先手視点正規化に使用）
     pub side_to_move: Color,
+}
+
+/// JSONL 出力モードで `move` 行に書く追加情報。
+///
+/// `analyze_selfplay` が読み取るスキーマ（`tools/src/bin/tournament.rs` 互換）と
+/// 揃えるための転写領域。生成は `session.rs` の対局ループで行う。
+#[derive(Clone, Debug)]
+pub struct JsonlMoveExtra {
+    /// この手を指す前の SFEN（`position` コマンドで送ったのと同じ手前局面）
+    pub sfen_before: String,
+    /// USI 形式の指し手
+    pub move_usi: String,
+    /// この手を指したエンジンのラベル。CSA 上のプレイヤー名 (`sente_name` / `gote_name`)
+    /// と一致させるため、先手手番なら `sente_name`、後手手番なら `gote_name` を入れる。
+    /// analyze_selfplay の per-engine timing 集計でこのラベルがキーになる。
+    pub engine_label: String,
+    /// この手の探索に費やした実時間 (ms)
+    pub elapsed_ms: u64,
+    /// `go` で指示した考慮上限 (ms)。byoyomi+残時間ベースで session.rs が計算した値。
+    pub think_limit_ms: u64,
+    /// USI `info` から最後に観測した seldepth
+    pub seldepth: Option<u32>,
+    /// USI `info` から最後に観測した nodes
+    pub nodes: Option<u64>,
+    /// USI `info` から最後に観測した time
+    pub time_ms: Option<u64>,
+    /// USI `info` から最後に観測した nps
+    pub nps: Option<u64>,
 }
 
 impl RecordedMove {
@@ -66,7 +100,15 @@ impl GameRecord {
             moves: Vec::new(),
             result: String::new(),
             start_time: Local::now(),
+            my_color: summary.my_color,
+            jsonl_moves: Vec::new(),
         }
+    }
+
+    /// JSONL 出力モード向けの追加情報を 1 手分蓄積する。
+    /// CSA 棋譜・SFEN 出力にはこのバッファは使われない。
+    pub fn add_jsonl_move(&mut self, extra: JsonlMoveExtra) {
+        self.jsonl_moves.push(extra);
     }
 
     pub fn add_move(

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -19,7 +19,7 @@ use crate::event::Event;
 use crate::protocol::{
     CsaConnection, GameResult, GameSummary, ReconnectState, parse_game_result, parse_server_move,
 };
-use crate::record::GameRecord;
+use crate::record::{GameRecord, JsonlMoveExtra};
 
 // ────────────────────────────────────────────
 // Clock
@@ -83,6 +83,25 @@ impl Clock {
             format!("btime {} wtime {} byoyomi {}", btime, wtime, byoyomi)
         } else {
             format!("btime {} wtime {}", btime, wtime)
+        }
+    }
+
+    /// JSONL 出力モードの `think_limit_ms` 用に、`side_to_move` の考慮上限を ms で返す。
+    /// byoyomi 指定なら `byoyomi - margin`、Fischer なら残時間 + increment、
+    /// 時間管理が無いなら 0。
+    fn think_limit_ms(&self, margin_msec: u64, side_to_move: Color) -> u64 {
+        let (total_ms, byoyomi_ms, increment_ms) = match side_to_move {
+            Color::Black => (self.black_time_ms, self.black_byoyomi_ms, self.black_increment_ms),
+            Color::White => (self.white_time_ms, self.white_byoyomi_ms, self.white_increment_ms),
+        };
+        if increment_ms > 0 {
+            total_ms.max(0) as u64 + increment_ms.max(0) as u64
+        } else if byoyomi_ms > 0 {
+            (byoyomi_ms - margin_msec as i64).max(0) as u64
+        } else if total_ms > 0 {
+            total_ms as u64
+        } else {
+            0
         }
     }
 
@@ -159,11 +178,17 @@ impl SessionState<'_> {
         &mut self,
         outcome: SearchOutcome,
         turn_start: Instant,
+        sfen_before: String,
+        think_limit_ms: u64,
     ) -> Result<MoveAction> {
         match outcome {
-            SearchOutcome::BestMove(result, info) => {
-                self.send_bestmove_and_wait_echo(&result, &info, turn_start)
-            }
+            SearchOutcome::BestMove(result, info) => self.send_bestmove_and_wait_echo(
+                &result,
+                &info,
+                turn_start,
+                sfen_before,
+                think_limit_ms,
+            ),
             SearchOutcome::ServerInterrupt(lines) => {
                 // サーバーから終局が来た（ponderhit 中等）
                 let (game_result, reason) = parse_server_interrupt_lines(lines);
@@ -180,6 +205,8 @@ impl SessionState<'_> {
         result: &BestMoveResult,
         info: &SearchInfo,
         turn_start: Instant,
+        sfen_before: String,
+        think_limit_ms: u64,
     ) -> Result<MoveAction> {
         if result.bestmove == "resign" {
             self.conn.send_resign()?;
@@ -207,6 +234,19 @@ impl SessionState<'_> {
         self.pos.apply_csa_move(&csa_move)?;
         self.usi_moves.push(result.bestmove.clone());
         self.record.add_move(&csa_move, 0, Some(info), self.my_color);
+        let elapsed_ms = turn_start.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        let engine_label = label_for_color(&self.record, self.my_color);
+        self.record.add_jsonl_move(JsonlMoveExtra {
+            sfen_before,
+            move_usi: result.bestmove.clone(),
+            engine_label,
+            elapsed_ms,
+            think_limit_ms,
+            seldepth: info.seldepth,
+            nodes: info.nodes,
+            time_ms: info.time_ms,
+            nps: info.nps,
+        });
 
         // ponder 開始
         if self.config.game.ponder
@@ -380,12 +420,18 @@ fn run_session_loop(
     let mut move_color = summary.position.side_to_move;
     for cm in &summary.initial_moves {
         let usi = csa_move_to_usi(&cm.mv, &s.pos)?;
+        let initial_sfen_before = s.pos.to_sfen();
         s.pos.apply_csa_move(&cm.mv)?;
-        s.usi_moves.push(usi);
+        s.usi_moves.push(usi.clone());
         if let Some(t) = cm.time_sec {
             s.clock.consume(move_color, t);
         }
-        s.record.add_move(&cm.mv, cm.time_sec.unwrap_or(0), None, move_color);
+        let time_sec = cm.time_sec.unwrap_or(0);
+        s.record.add_move(&cm.mv, time_sec, None, move_color);
+        // 途中再開の手は両方とも「対戦相手の手」相当として extras に記録する。
+        // 自エンジンは新しい session.new_game() でこの局面から開始するため、
+        // この手は自エンジンの探索ログを持たない。
+        push_opponent_jsonl(&mut s.record, initial_sfen_before, usi, move_color, time_sec);
         move_color = opposite(move_color);
     }
 
@@ -393,12 +439,14 @@ fn run_session_loop(
     loop {
         if s.pos.side_to_move == s.my_color {
             let turn_start = Instant::now();
+            let sfen_before = s.pos.to_sfen();
+            let think_limit_ms = s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
             let position_cmd = build_position_cmd(&s.initial_sfen, &s.usi_moves);
             let go_cmd =
                 format!("go {}", s.clock.build_go_args(s.config.time.margin_msec, s.my_color));
             let outcome = s.engine.go(&position_cmd, &go_cmd, s.shutdown, s.server_rx)?;
 
-            match s.handle_search_outcome(outcome, turn_start)? {
+            match s.handle_search_outcome(outcome, turn_start, sfen_before, think_limit_ms)? {
                 MoveAction::Continue => {}
                 MoveAction::GameEnd(result, record_box) => return Ok((result, *record_box)),
             }
@@ -417,15 +465,31 @@ fn run_session_loop(
                             if opponent_usi == ps.expected_usi {
                                 // ponderhit
                                 log::debug!("[PONDER] ponderhit: {}", opponent_usi);
+                                let opponent_sfen_before = s.pos.to_sfen();
                                 s.pos.apply_csa_move(&mv)?;
-                                s.usi_moves.push(opponent_usi);
+                                s.usi_moves.push(opponent_usi.clone());
                                 s.clock.consume(opposite(s.my_color), time_sec);
                                 s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+                                push_opponent_jsonl(
+                                    &mut s.record,
+                                    opponent_sfen_before,
+                                    opponent_usi,
+                                    opposite(s.my_color),
+                                    time_sec,
+                                );
 
                                 let ponderhit_start = Instant::now();
+                                let my_sfen_before = s.pos.to_sfen();
+                                let my_think_limit_ms =
+                                    s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
                                 let outcome = s.engine.ponderhit(s.shutdown, s.server_rx)?;
 
-                                match s.handle_search_outcome(outcome, ponderhit_start)? {
+                                match s.handle_search_outcome(
+                                    outcome,
+                                    ponderhit_start,
+                                    my_sfen_before,
+                                    my_think_limit_ms,
+                                )? {
                                     MoveAction::Continue => break,
                                     MoveAction::GameEnd(result, record_box) => {
                                         return Ok((result, *record_box));
@@ -439,19 +503,35 @@ fn run_session_loop(
                                     opponent_usi
                                 );
                                 s.engine.stop_and_wait()?;
+                                let opponent_sfen_before = s.pos.to_sfen();
                                 s.pos.apply_csa_move(&mv)?;
-                                s.usi_moves.push(opponent_usi);
+                                s.usi_moves.push(opponent_usi.clone());
                                 s.clock.consume(opposite(s.my_color), time_sec);
                                 s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+                                push_opponent_jsonl(
+                                    &mut s.record,
+                                    opponent_sfen_before,
+                                    opponent_usi,
+                                    opposite(s.my_color),
+                                    time_sec,
+                                );
                                 break;
                             }
                         } else {
                             // ponder なし
                             let opponent_usi = csa_move_to_usi(&mv, &s.pos)?;
+                            let opponent_sfen_before = s.pos.to_sfen();
                             s.pos.apply_csa_move(&mv)?;
-                            s.usi_moves.push(opponent_usi);
+                            s.usi_moves.push(opponent_usi.clone());
                             s.clock.consume(opposite(s.my_color), time_sec);
                             s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+                            push_opponent_jsonl(
+                                &mut s.record,
+                                opponent_sfen_before,
+                                opponent_usi,
+                                opposite(s.my_color),
+                                time_sec,
+                            );
                             break;
                         }
                     }
@@ -579,6 +659,43 @@ fn opposite(color: Color) -> Color {
         Color::Black => Color::White,
         Color::White => Color::Black,
     }
+}
+
+/// CSA プレイヤー名から analyze_selfplay の集計キーになる engine label を返す。
+/// `sente_name` / `gote_name` が空なら `"unknown"` を返す。
+fn label_for_color(record: &GameRecord, color: Color) -> String {
+    let raw = match color {
+        Color::Black => &record.sente_name,
+        Color::White => &record.gote_name,
+    };
+    if raw.is_empty() {
+        "unknown".to_string()
+    } else {
+        raw.clone()
+    }
+}
+
+/// 相手 (= 自エンジンでない側) が指した手を JSONL 用バッファに追加する。
+/// `time_sec` はサーバが報告した消費秒。`elapsed_ms` 換算で記録する。
+fn push_opponent_jsonl(
+    record: &mut GameRecord,
+    sfen_before: String,
+    move_usi: String,
+    side: Color,
+    time_sec: u32,
+) {
+    let engine_label = label_for_color(record, side);
+    record.add_jsonl_move(JsonlMoveExtra {
+        sfen_before,
+        move_usi,
+        engine_label,
+        elapsed_ms: u64::from(time_sec) * 1000,
+        think_limit_ms: 0,
+        seldepth: None,
+        nodes: None,
+        time_ms: None,
+        nps: None,
+    });
 }
 
 fn gameover_str(result: &GameResult) -> &'static str {

--- a/crates/rshogi-csa-client/tests/jsonl_output.rs
+++ b/crates/rshogi-csa-client/tests/jsonl_output.rs
@@ -1,0 +1,193 @@
+//! JSONL 出力モードの統合テスト。
+//!
+//! 実 USI / CSA サーバを起動せずに `GameRecord` をプログラムで構築し、
+//! `write_game_jsonl` の出力ファイルが analyze_selfplay 互換のスキーマで
+//! あることを行ごとに検証する。
+
+use std::path::PathBuf;
+
+use rshogi_csa::{Color, initial_position};
+use rshogi_csa_client::config::{CsaClientConfig, EngineConfig, RecordConfig, TimeConfig};
+use rshogi_csa_client::jsonl::write_game_jsonl;
+use rshogi_csa_client::protocol::{GameResult, TimeConfig as ProtoTimeConfig};
+use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra};
+use serde_json::Value;
+
+/// テスト用の minimal な `GameRecord` を作る。
+fn build_record(my_color: Color) -> GameRecord {
+    let pos = initial_position();
+    GameRecord {
+        game_id: "test-game-1".to_string(),
+        sente_name: "alice".to_string(),
+        gote_name: "bob".to_string(),
+        black_time: ProtoTimeConfig {
+            total_time_ms: 60_000,
+            byoyomi_ms: 5_000,
+            increment_ms: 0,
+        },
+        white_time: ProtoTimeConfig {
+            total_time_ms: 60_000,
+            byoyomi_ms: 5_000,
+            increment_ms: 0,
+        },
+        initial_position: pos,
+        moves: Vec::new(),
+        result: String::new(),
+        start_time: chrono::Local::now(),
+        my_color,
+        jsonl_moves: Vec::new(),
+    }
+}
+
+fn build_config() -> CsaClientConfig {
+    let engine = EngineConfig {
+        path: PathBuf::from("/tmp/fake-rshogi-usi"),
+        ..Default::default()
+    };
+    let record = RecordConfig {
+        enabled: true,
+        ..Default::default()
+    };
+    CsaClientConfig {
+        engine,
+        record,
+        time: TimeConfig::default(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn writes_meta_move_result_for_self_engine_black() {
+    let mut record = build_record(Color::Black);
+
+    // 1 手目（自エンジン = 先手）の指し手を 1 手追加
+    let pos = initial_position();
+    let sfen_before = pos.to_sfen();
+    record.moves.push(rshogi_csa_client::record::RecordedMove {
+        csa_move: "+7776FU".to_string(),
+        time_sec: 1,
+        eval_cp: Some(50),
+        eval_mate: None,
+        depth: Some(8),
+        pv: vec!["7g7f".to_string(), "3c3d".to_string()],
+        side_to_move: Color::Black,
+    });
+    record.jsonl_moves.push(JsonlMoveExtra {
+        sfen_before: sfen_before.clone(),
+        move_usi: "7g7f".to_string(),
+        engine_label: "alice".to_string(),
+        elapsed_ms: 1234,
+        think_limit_ms: 5_000,
+        seldepth: Some(10),
+        nodes: Some(12_345),
+        time_ms: Some(1_200),
+        nps: Some(10_287),
+    });
+    record.result = "win".to_string();
+
+    let tmp = tempdir();
+    let config = build_config();
+    let path = write_game_jsonl(&tmp, &record, &config, &GameResult::Win)
+        .expect("write_game_jsonl must succeed");
+
+    let lines = std::fs::read_to_string(&path).expect("read jsonl");
+    let entries: Vec<Value> = lines
+        .lines()
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse json line"))
+        .collect();
+    assert_eq!(entries.len(), 3, "meta + move + result の 3 行");
+
+    // meta
+    let meta = &entries[0];
+    assert_eq!(meta["type"], "meta");
+    assert_eq!(meta["settings"]["games"], 1);
+    assert_eq!(meta["engine_cmd"]["label_black"], "alice");
+    assert_eq!(meta["engine_cmd"]["label_white"], "bob");
+    assert!(meta["engine_cmd"]["path_black"].as_str().unwrap().ends_with("fake-rshogi-usi"));
+
+    // move
+    let mv = &entries[1];
+    assert_eq!(mv["type"], "move");
+    assert_eq!(mv["game_id"], 1);
+    assert_eq!(mv["ply"], 1);
+    assert_eq!(mv["side_to_move"], "b");
+    assert_eq!(mv["sfen_before"], sfen_before);
+    assert_eq!(mv["move_usi"], "7g7f");
+    assert_eq!(mv["engine"], "alice");
+    assert_eq!(mv["elapsed_ms"], 1234);
+    assert_eq!(mv["think_limit_ms"], 5000);
+    assert_eq!(mv["timed_out"], false);
+    assert_eq!(mv["eval"]["depth"], 8);
+    assert_eq!(mv["eval"]["seldepth"], 10);
+    assert_eq!(mv["eval"]["nodes"], 12345);
+    assert_eq!(mv["eval"]["nps"], 10287);
+    assert_eq!(mv["eval"]["score_cp"], 50);
+    assert_eq!(mv["eval"]["pv"][0], "7g7f");
+
+    // result
+    let res = &entries[2];
+    assert_eq!(res["type"], "result");
+    assert_eq!(res["game_id"], 1);
+    assert_eq!(res["outcome"], "black_win");
+    assert_eq!(res["plies"], 1);
+    assert_eq!(res["winner"], "alice");
+}
+
+#[test]
+fn writes_white_win_when_self_engine_white_loses() {
+    let mut record = build_record(Color::White);
+    record.result = "lose".to_string();
+
+    let tmp = tempdir();
+    let config = build_config();
+    let path = write_game_jsonl(&tmp, &record, &config, &GameResult::Lose)
+        .expect("write_game_jsonl must succeed");
+
+    let lines = std::fs::read_to_string(&path).expect("read jsonl");
+    let entries: Vec<Value> = lines
+        .lines()
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse json line"))
+        .collect();
+    let res = entries.last().unwrap();
+    assert_eq!(res["type"], "result");
+    // 自エンジン = 白で負け → 黒（相手）勝ち
+    assert_eq!(res["outcome"], "black_win");
+    assert_eq!(res["winner"], "alice");
+}
+
+#[test]
+fn draws_when_interrupted_regardless_of_side() {
+    let mut record = build_record(Color::Black);
+    record.result = "interrupted".to_string();
+
+    let tmp = tempdir();
+    let config = build_config();
+    let path = write_game_jsonl(&tmp, &record, &config, &GameResult::Interrupted)
+        .expect("write_game_jsonl must succeed");
+
+    let lines = std::fs::read_to_string(&path).expect("read jsonl");
+    let last = lines.lines().last().unwrap();
+    let res: Value = serde_json::from_str(last).unwrap();
+    assert_eq!(res["outcome"], "draw");
+    assert!(res["winner"].is_null());
+}
+
+#[test]
+fn filename_includes_datetime_and_player_names() {
+    let record = build_record(Color::Black);
+    let tmp = tempdir();
+    let config = build_config();
+    let path = write_game_jsonl(&tmp, &record, &config, &GameResult::Draw).expect("write");
+    let name = path.file_name().unwrap().to_string_lossy().to_string();
+    assert!(name.ends_with("_alice_vs_bob.jsonl"), "got: {name}");
+}
+
+/// テスト用に `target/tmp/csa_client_jsonl_<nanos>` を作って返す簡易 tempdir。
+/// 本リポは `tempfile` クレートに依存していないので自前実装する。
+fn tempdir() -> PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let path = std::env::temp_dir().join(format!("rshogi-csa-jsonl-test-{nanos}"));
+    std::fs::create_dir_all(&path).expect("create tempdir");
+    path
+}


### PR DESCRIPTION
## Summary

- `rshogi-csa-client` に opt-in な `--jsonl-out <DIR>` (TOML では `[record].jsonl_out`) を追加し、対局完了ごとに `<datetime>_<sente>_vs_<gote>.jsonl` を 1 ファイル 1 対局で書き出す。サーバ送信は一切無く、完全にローカル CLI 解析専用の機能。
- スキーマは selfplay (`tools/src/bin/tournament.rs`) の出力と互換 (`meta` / `move` / `result` の 3 種類)。`move.eval` には USI `info` から抽出した `score_cp` / `score_mate` / `depth` / `seldepth` / `nodes` / `time_ms` / `nps` / `pv` が入り、`engine` フィールドは CSA 上のプレイヤー名 (`sente_name` / `gote_name`) に揃える。
- 既存 `tools::analyze_selfplay` がそのまま流用でき、Elo / nElo / 手数分布 / per-engine timing 集計が CSA 経由対局でも回るようになる。

## 実装メモ

- `engine.rs` の `SearchInfo` に `seldepth` / `nodes` / `time_ms` / `nps` を追加し、`update_search_info` で `info` 行から抽出。
- `record.rs` に `JsonlMoveExtra` (sfen_before / move_usi / engine_label / elapsed_ms / think_limit_ms / 各 info 値) と `GameRecord.my_color` を追加し、CSA / SFEN 棋譜出力には影響しない並列バッファとして蓄積。
- `session.rs` の対局ループで自エンジン側手番・相手手番・resume 時 `initial_moves` の各経路で `JsonlMoveExtra` を 1 手ごとに push。
- `jsonl.rs` を新設し、`write_game_jsonl` で `meta` / `move` / `result` を組み立てて出力。`label_*` を `sente_name` / `gote_name` に揃えて analyze_selfplay の winner 照合を成立させる。
- `examples/README.md` に CLI 解析手順 (`--jsonl-out` + `analyze_selfplay <生成物>`) を追記。
- 統合テスト (`tests/jsonl_output.rs`) でスキーマと先後別 outcome を検証。実 USI / CSA サーバなしで `GameRecord` をプログラムで構築する形。
- 共通化は YAGNI 原則で見送り。`tools` クレートには依存させず、csa-client 内で完結。

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests` 警告 0
- [x] `cargo test --workspace` グリーン (csa-client 16 件、新規 4 件含む)
- [x] 手書きの最小 JSONL (meta + move + result) を `analyze_selfplay --json` に通して `done=1` / `engine_timing` の集計が成立することを smoke 確認

Closes #543
Refs #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)