### PR TITLE
feat(csa-server): viewer 配信 API (/api/v1/games) を実装する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/floodgate_history.rs
+++ b/crates/rshogi-csa-server-workers/src/floodgate_history.rs
@@ -88,7 +88,10 @@ pub fn entry_key(entry: &FloodgateHistoryEntry) -> Result<String, StorageError> 
 /// 壊れる。空文字や R2 が拒否する制御文字も同様に弾く。CSA プロトコル上 `game_id`
 /// は ASCII 英数 + `-` `_` のみを生成するサーバ前提なので、想定外の文字種は
 /// バグとして上位に伝える。
-fn validate_key_component(s: &str) -> Result<&str, StorageError> {
+///
+/// 本関数は `games_index` モジュール (viewer 配信 API) からも参照されるため
+/// `pub` で公開する。許可文字集合と空文字拒否のセマンティクスは両者で共有する。
+pub fn validate_key_component(s: &str) -> Result<&str, StorageError> {
     if s.is_empty() {
         return Err(StorageError::Malformed("empty game_id in history entry".to_owned()));
     }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -66,6 +66,9 @@ use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::{ConfigKeys, parse_clock_spec, parse_reconnect_grace_duration};
 use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
 use crate::floodgate_history::R2FloodgateHistoryStorage;
+use crate::games_index::{
+    ClockSpec as IndexClockSpec, GamesIndexEntry, classify_result, games_index_key,
+};
 use crate::persistence::{
     FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
 };
@@ -1046,6 +1049,10 @@ impl GameRoom {
             });
         }
 
+        // 後続の `KifuRecord::moves` で `kifu_moves` を move する前に手数を退避する。
+        // `moves_count` は viewer 配信 API 用 index entry に埋め込む。
+        let moves_count_for_index: u32 = kifu_moves.len() as u32;
+
         // `time_section` は clock の初期設定値に依存し、持ち時間の残量には
         // 左右されないので cfg から再構築しても同じ出力になる。
         let time_section = cfg.clock.format_time_section();
@@ -1080,6 +1087,73 @@ impl GameRoom {
         bucket.put(&key, text.as_bytes().to_vec()).execute().await?;
         bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
         console_log!("[GameRoom] kifu exported to R2 key='{key}'");
+
+        // viewer 配信 API 用の補助インデックス (`games-index/...`) を 1 件 put する。
+        // 本文 + by-id put は既に成功しているため、index put のいかなる失敗も
+        // `finalize_if_ended` を Err にしてはならない (best-effort)。validation /
+        // serialize / put すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。
+        // `?` は意図的に使わない。
+        //
+        // `source` は `resolve_floodgate_history_storage` が `Some` を返せる構成
+        // (= Floodgate gating opt-in & binding 解決可) かどうかで事前判定する。
+        // `floodgate-history/` への put 成否ではなく「Floodgate 環境設定下で起きた
+        // 終局」を表す semantics (v3 設計の `source` field 定義に従う)。
+        let source = if resolve_floodgate_history_storage(&self.env).ok().flatten().is_some() {
+            "floodgate"
+        } else {
+            "kifu"
+        };
+
+        let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
+            Ok(k) => k,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=games_index_skip game_id={} reason=key:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return Ok(());
+            }
+        };
+
+        let (result_kind, end_reason) = classify_result(game_result);
+        let entry = GamesIndexEntry {
+            game_id: &cfg.game_id,
+            started_at_ms: cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms),
+            ended_at_ms,
+            black_handle: &cfg.black_handle,
+            white_handle: &cfg.white_handle,
+            result_kind,
+            end_reason,
+            // CSA は理論上 0..=u32::MAX 手は到達しないが、API contract は
+            // 整数手数を要求するため u32 に正規化する。`DEFAULT_MAX_MOVES = 256`
+            // 上限のため通常は 0..=256 に収まる。
+            moves_count: moves_count_for_index,
+            clock: IndexClockSpec::from_server(&cfg.clock),
+            source,
+        };
+
+        let body = match serde_json::to_vec(&entry) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=games_index_skip game_id={} reason=serialize:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return Ok(());
+            }
+        };
+
+        if let Err(e) = bucket.put(&index_key, body).execute().await {
+            console_log!(
+                "[GameRoom] event=games_index_put_failed game_id={} inv_key={} err={:?}",
+                cfg.game_id,
+                index_key,
+                e,
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/rshogi-csa-server-workers/src/games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_index.rs
@@ -1,0 +1,448 @@
+//! viewer 配信 API 用の R2 補助インデックス (`games-index/...`)。
+//!
+//! 終局時に [`crate::game_room::GameRoom::export_kifu_to_r2`] が CSA 本文を
+//! `KIFU_BUCKET` に書き込んだ直後、本モジュールのキー生成 + JSON 直列化を
+//! 経由して `games-index/<inv_ended_at_ms>-<game_id>.json` を 1 件追加する。
+//!
+//! # キー設計
+//!
+//! - prefix: `games-index/`
+//! - 並び順軸: `ended_at_ms` (Floodgate 履歴と同じ軸。長時間対局が古いキーになる
+//!   start_time 軸の問題を回避)
+//! - lex 順 = 数値降順を成立させるため、`inv_ms = INV_BASE - ended_at_ms` を
+//!   `{:014}` でゼロパディングして key 先頭に置く。`INV_BASE = 99_999_999_999_999`
+//!   (= `10^14 - 1`) で `ended_at_ms ∈ [0, INV_BASE]` を仮定し、書式上は常に 14 桁。
+//! - `<game_id>` は [`crate::floodgate_history::validate_key_component`] で
+//!   ASCII 英数 + `-` `_` のみを許可する。それ以外は `StorageError::Malformed`。
+//!
+//! # 不変条件
+//!
+//! - 1 対局 = 1 オブジェクト、本文は単一 JSON entry。
+//! - 並行書き込み中の pagination 整合: 新着 entry は既存 cursor より前に挿入
+//!   される (cursor 位置で見落とされる) が、これは仕様として明示的に許容する。
+//! - 同一 ms に同一 `game_id` の終局は DO の単一 finalize で 1 度しか起きない
+//!   (room_id ごとに DO 一意) ため、key は `room_id × ended_at_ms × game_id`
+//!   の積で一意。
+//!
+//! # ホスト側ユニットテスト
+//!
+//! `inv_ms` のゼロパディング、key formatter、`validate_key_component` の
+//! disallowed char 系を host target で検証する。R2 アダプタ固有の経路 (list /
+//! pagination) は `wrangler dev` で別途確認する。
+
+use rshogi_csa_server::error::StorageError;
+use serde::Serialize;
+
+use crate::floodgate_history::validate_key_component;
+
+/// `inv_ms = INV_BASE - ended_at_ms` の基準値。`10^14 - 1` を u64 で表現。
+///
+/// `ended_at_ms` が西暦 5138 年 (= INV_BASE 直前) を超える場合は overflow で減算が
+/// 失敗するが、本コードベース運用上ここに到達することは想定しない。仮に到達した
+/// 場合は `validate_inv_ms` 経由で `Err` を返し、index put は best-effort で skip
+/// する経路に乗せる。
+pub const INV_BASE: u64 = 99_999_999_999_999;
+
+/// `games-index/` prefix。一覧 API はこの prefix に対して R2 list を発行する。
+pub const KEY_PREFIX: &str = "games-index/";
+
+/// 1 対局 1 オブジェクトの index key を構築する。
+///
+/// `ended_at_ms` が `INV_BASE` を超える場合は `StorageError::Malformed` を返す
+/// (write 経路で best-effort 失敗として観測ログに残す)。
+pub fn games_index_key(ended_at_ms: u64, game_id: &str) -> Result<String, StorageError> {
+    let validated = validate_key_component(game_id)?;
+    if ended_at_ms > INV_BASE {
+        return Err(StorageError::Malformed(format!(
+            "ended_at_ms {ended_at_ms} exceeds INV_BASE {INV_BASE}"
+        )));
+    }
+    let inv = INV_BASE - ended_at_ms;
+    Ok(format!("{KEY_PREFIX}{inv:014}-{validated}.json"))
+}
+
+/// games-index に書き込む 1 entry の wire format。
+///
+/// API contract A (Issue #542 issuecomment-4338125621) に準拠し、`result_kind` /
+/// `end_reason` を **2 フィールドに分離** する。client 側 (ramu-shogi viewer)
+/// は両者を合わせて UI 表示用の構造化結果に変換する。
+///
+/// `source` は `"kifu"` / `"floodgate"` の 2 値 enum。`"floodgate"` は
+/// 「Floodgate gating が opt-in された worker (`ALLOW_FLOODGATE_FEATURES`
+/// 立ち + `FLOODGATE_HISTORY_BUCKET` binding 解決可) で起きた終局」を意味し、
+/// `floodgate-history/` への put 成否は反映しない。
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct GamesIndexEntry<'a> {
+    pub game_id: &'a str,
+    pub started_at_ms: u64,
+    pub ended_at_ms: u64,
+    pub black_handle: &'a str,
+    pub white_handle: &'a str,
+    pub result_kind: &'static str,
+    pub end_reason: &'static str,
+    pub moves_count: u32,
+    pub clock: ClockSpec<'a>,
+    pub source: &'static str,
+}
+
+/// `clock` field の wire 形状。`kind` は `wrangler.toml::CLOCK_KIND` と同一の
+/// snake_case 値域 (`countdown` / `countdown_msec` / `fischer` / `stopwatch`)。
+///
+/// 各時計方式で意味のある field は限定されるため、未使用 field は `None` で省略する
+/// (serde の `skip_serializing_if`)。
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ClockSpec<'a> {
+    pub kind: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_sec: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byoyomi_sec: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byoyomi_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub increment_sec: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_min: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byoyomi_min: Option<u32>,
+}
+
+impl<'a> ClockSpec<'a> {
+    /// `rshogi_csa_server::ClockSpec` から wire 表現を構築する。各時計方式の
+    /// 専用フィールドのみを埋め、それ以外は `None` で省略する。
+    pub fn from_server(spec: &'a rshogi_csa_server::ClockSpec) -> Self {
+        match spec {
+            rshogi_csa_server::ClockSpec::Countdown {
+                total_time_sec,
+                byoyomi_sec,
+            } => Self {
+                kind: "countdown",
+                total_sec: Some(*total_time_sec),
+                byoyomi_sec: Some(*byoyomi_sec),
+                byoyomi_ms: None,
+                increment_sec: None,
+                total_ms: None,
+                total_min: None,
+                byoyomi_min: None,
+            },
+            rshogi_csa_server::ClockSpec::CountdownMsec {
+                total_time_ms,
+                byoyomi_ms,
+            } => Self {
+                kind: "countdown_msec",
+                total_sec: None,
+                byoyomi_sec: None,
+                byoyomi_ms: Some(*byoyomi_ms),
+                increment_sec: None,
+                total_ms: Some(*total_time_ms),
+                total_min: None,
+                byoyomi_min: None,
+            },
+            rshogi_csa_server::ClockSpec::Fischer {
+                total_time_sec,
+                increment_sec,
+            } => Self {
+                kind: "fischer",
+                total_sec: Some(*total_time_sec),
+                byoyomi_sec: None,
+                byoyomi_ms: None,
+                increment_sec: Some(*increment_sec),
+                total_ms: None,
+                total_min: None,
+                byoyomi_min: None,
+            },
+            rshogi_csa_server::ClockSpec::StopWatch {
+                total_time_min,
+                byoyomi_min,
+            } => Self {
+                kind: "stopwatch",
+                total_sec: None,
+                byoyomi_sec: None,
+                byoyomi_ms: None,
+                increment_sec: None,
+                total_ms: None,
+                total_min: Some(*total_time_min),
+                byoyomi_min: Some(*byoyomi_min),
+            },
+        }
+    }
+}
+
+/// `GameResult` から `(result_kind, end_reason)` を導出する。
+///
+/// API contract A の値域:
+/// - `result_kind ∈ {"WIN_BLACK", "WIN_WHITE", "DRAW", "ABORT"}`
+/// - `end_reason ∈ {"RESIGN", "TIME_UP", "ILLEGAL", "JISHOGI", "OUTE_SENNICHITE",
+///   "SENNICHITE", "MAX_MOVES", "ABNORMAL"}`
+///
+/// `Abnormal { winner: None }` だけは結果が不確定なので `result_kind = "ABORT"`
+/// で表現する。それ以外は勝者または引き分けが確定しているため `WIN_*` / `DRAW`
+/// に分類する。
+pub fn classify_result(
+    result: &rshogi_csa_server::game::result::GameResult,
+) -> (&'static str, &'static str) {
+    use rshogi_csa_server::game::result::GameResult;
+    use rshogi_csa_server::types::Color;
+
+    fn winner_kind(c: Color) -> &'static str {
+        match c {
+            Color::Black => "WIN_BLACK",
+            Color::White => "WIN_WHITE",
+        }
+    }
+
+    match result {
+        GameResult::Toryo { winner } => (winner_kind(*winner), "RESIGN"),
+        GameResult::TimeUp { loser } => (winner_kind(loser.opposite()), "TIME_UP"),
+        GameResult::IllegalMove { loser, .. } => (winner_kind(loser.opposite()), "ILLEGAL"),
+        GameResult::Kachi { winner } => (winner_kind(*winner), "JISHOGI"),
+        GameResult::OuteSennichite { loser } => (winner_kind(loser.opposite()), "OUTE_SENNICHITE"),
+        GameResult::Sennichite => ("DRAW", "SENNICHITE"),
+        GameResult::MaxMoves => ("DRAW", "MAX_MOVES"),
+        GameResult::Abnormal { winner } => match winner {
+            Some(c) => (winner_kind(*c), "ABNORMAL"),
+            None => ("ABORT", "ABNORMAL"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rshogi_csa_server::game::result::{GameResult, IllegalReason};
+    use rshogi_csa_server::types::Color;
+
+    #[test]
+    fn games_index_key_pads_inv_ms_to_14_digits() {
+        // ended_at_ms = 1 → inv = INV_BASE - 1 = 99_999_999_999_998 (14 桁)
+        let key = games_index_key(1, "g1").unwrap();
+        assert_eq!(key, "games-index/99999999999998-g1.json");
+    }
+
+    #[test]
+    fn games_index_key_inv_ms_zero_pads_for_recent_timestamp() {
+        // 2026-04-29 頃の epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
+        let ended = 1_777_392_877_244_u64;
+        let key = games_index_key(ended, "lobby-cross-fischer-1777391025209").unwrap();
+        // INV_BASE - 1_777_392_877_244 = 98_222_607_122_755 (14 桁)
+        assert_eq!(key, "games-index/98222607122755-lobby-cross-fischer-1777391025209.json");
+    }
+
+    #[test]
+    fn games_index_key_lex_order_matches_descending_ended_at() {
+        // 早い終局のほうが古い → inv が大きい → key が lex 後ろ。
+        // 遅い終局のほうが新しい → inv が小さい → key が lex 前。
+        let early = games_index_key(1_000_000_000_000, "g1").unwrap();
+        let late = games_index_key(2_000_000_000_000, "g2").unwrap();
+        assert!(late < early, "late {late} should sort before early {early}");
+    }
+
+    #[test]
+    fn games_index_key_inv_zero_when_ended_at_eq_inv_base() {
+        let key = games_index_key(INV_BASE, "g1").unwrap();
+        assert_eq!(key, "games-index/00000000000000-g1.json");
+    }
+
+    #[test]
+    fn games_index_key_rejects_overflowing_ended_at() {
+        let err = games_index_key(INV_BASE + 1, "g1").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn games_index_key_rejects_game_id_with_slash() {
+        // `/` は R2 の階層区切り。validate_key_component 経由で弾かれる。
+        let err = games_index_key(1_000, "g1/evil").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn games_index_key_rejects_empty_game_id() {
+        let err = games_index_key(1_000, "").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn games_index_key_rejects_non_ascii_game_id() {
+        let err = games_index_key(1_000, "g\u{3042}").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn games_index_key_rejects_disallowed_punctuation() {
+        // `.` / 空白 / `?` 等 ASCII でも英数 + `-` `_` 以外は拒否。
+        for bad in ["g.1", "g 1", "g?1", "g+1", "g/1"] {
+            let err = games_index_key(1_000, bad).unwrap_err();
+            assert!(
+                matches!(err, StorageError::Malformed(_)),
+                "input={bad:?} expected Malformed, got: {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn games_index_key_accepts_underscore_and_dash() {
+        let key = games_index_key(1_000, "g_1-abc").unwrap();
+        assert!(key.ends_with("-g_1-abc.json"), "got: {key}");
+    }
+
+    #[test]
+    fn classify_result_maps_toryo_to_winner_and_resign() {
+        let r = GameResult::Toryo {
+            winner: Color::Black,
+        };
+        assert_eq!(classify_result(&r), ("WIN_BLACK", "RESIGN"));
+
+        let r = GameResult::Toryo {
+            winner: Color::White,
+        };
+        assert_eq!(classify_result(&r), ("WIN_WHITE", "RESIGN"));
+    }
+
+    #[test]
+    fn classify_result_maps_time_up_to_opponent_winner() {
+        // 黒が時間切れ → 白勝ち
+        let r = GameResult::TimeUp {
+            loser: Color::Black,
+        };
+        assert_eq!(classify_result(&r), ("WIN_WHITE", "TIME_UP"));
+    }
+
+    #[test]
+    fn classify_result_maps_illegal_move_to_opponent_winner() {
+        let r = GameResult::IllegalMove {
+            loser: Color::White,
+            reason: IllegalReason::Generic,
+        };
+        assert_eq!(classify_result(&r), ("WIN_BLACK", "ILLEGAL"));
+    }
+
+    #[test]
+    fn classify_result_maps_kachi_to_winner_and_jishogi() {
+        let r = GameResult::Kachi {
+            winner: Color::Black,
+        };
+        assert_eq!(classify_result(&r), ("WIN_BLACK", "JISHOGI"));
+    }
+
+    #[test]
+    fn classify_result_maps_oute_sennichite_to_opponent_winner() {
+        let r = GameResult::OuteSennichite {
+            loser: Color::Black,
+        };
+        assert_eq!(classify_result(&r), ("WIN_WHITE", "OUTE_SENNICHITE"));
+    }
+
+    #[test]
+    fn classify_result_maps_sennichite_to_draw() {
+        assert_eq!(classify_result(&GameResult::Sennichite), ("DRAW", "SENNICHITE"));
+    }
+
+    #[test]
+    fn classify_result_maps_max_moves_to_draw() {
+        assert_eq!(classify_result(&GameResult::MaxMoves), ("DRAW", "MAX_MOVES"));
+    }
+
+    #[test]
+    fn classify_result_maps_abnormal_with_winner_to_winner_kind() {
+        let r = GameResult::Abnormal {
+            winner: Some(Color::Black),
+        };
+        assert_eq!(classify_result(&r), ("WIN_BLACK", "ABNORMAL"));
+    }
+
+    #[test]
+    fn classify_result_maps_abnormal_without_winner_to_abort() {
+        let r = GameResult::Abnormal { winner: None };
+        assert_eq!(classify_result(&r), ("ABORT", "ABNORMAL"));
+    }
+
+    #[test]
+    fn clock_spec_from_server_countdown_emits_only_seconds() {
+        let spec = rshogi_csa_server::ClockSpec::Countdown {
+            total_time_sec: 600,
+            byoyomi_sec: 10,
+        };
+        let wire = ClockSpec::from_server(&spec);
+        assert_eq!(wire.kind, "countdown");
+        assert_eq!(wire.total_sec, Some(600));
+        assert_eq!(wire.byoyomi_sec, Some(10));
+        assert_eq!(wire.byoyomi_ms, None);
+        assert_eq!(wire.increment_sec, None);
+    }
+
+    #[test]
+    fn clock_spec_from_server_fischer_emits_increment() {
+        let spec = rshogi_csa_server::ClockSpec::Fischer {
+            total_time_sec: 300,
+            increment_sec: 5,
+        };
+        let wire = ClockSpec::from_server(&spec);
+        assert_eq!(wire.kind, "fischer");
+        assert_eq!(wire.total_sec, Some(300));
+        assert_eq!(wire.increment_sec, Some(5));
+        assert_eq!(wire.byoyomi_sec, None);
+    }
+
+    #[test]
+    fn clock_spec_from_server_countdown_msec_emits_ms_fields() {
+        let spec = rshogi_csa_server::ClockSpec::CountdownMsec {
+            total_time_ms: 60_000,
+            byoyomi_ms: 100,
+        };
+        let wire = ClockSpec::from_server(&spec);
+        assert_eq!(wire.kind, "countdown_msec");
+        assert_eq!(wire.total_ms, Some(60_000));
+        assert_eq!(wire.byoyomi_ms, Some(100));
+        assert_eq!(wire.total_sec, None);
+        assert_eq!(wire.byoyomi_sec, None);
+    }
+
+    #[test]
+    fn clock_spec_from_server_stopwatch_emits_minute_fields() {
+        let spec = rshogi_csa_server::ClockSpec::StopWatch {
+            total_time_min: 15,
+            byoyomi_min: 2,
+        };
+        let wire = ClockSpec::from_server(&spec);
+        assert_eq!(wire.kind, "stopwatch");
+        assert_eq!(wire.total_min, Some(15));
+        assert_eq!(wire.byoyomi_min, Some(2));
+        assert_eq!(wire.total_sec, None);
+    }
+
+    #[test]
+    fn entry_serializes_with_split_result_fields() {
+        let entry = GamesIndexEntry {
+            game_id: "g1",
+            started_at_ms: 1_777_391_025_209,
+            ended_at_ms: 1_777_392_877_244,
+            black_handle: "alice",
+            white_handle: "bob",
+            result_kind: "WIN_BLACK",
+            end_reason: "RESIGN",
+            moves_count: 142,
+            clock: ClockSpec {
+                kind: "fischer",
+                total_sec: Some(300),
+                byoyomi_sec: None,
+                byoyomi_ms: None,
+                increment_sec: Some(5),
+                total_ms: None,
+                total_min: None,
+                byoyomi_min: None,
+            },
+            source: "kifu",
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        // result_kind / end_reason が独立 field として直列化されることを固定。
+        assert!(json.contains("\"result_kind\":\"WIN_BLACK\""), "json={json}");
+        assert!(json.contains("\"end_reason\":\"RESIGN\""), "json={json}");
+        assert!(json.contains("\"source\":\"kifu\""), "json={json}");
+        // 未使用 clock field は省略される。
+        assert!(!json.contains("byoyomi_sec"), "json={json}");
+        assert!(!json.contains("total_ms"), "json={json}");
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -26,6 +26,7 @@ pub mod attachment;
 pub mod config;
 pub mod datetime;
 pub mod floodgate_history;
+pub mod games_index;
 pub mod lobby_protocol;
 pub mod origin;
 // `persistence` は DO ランタイム (`game_room`) からのみ消費される I/O 非依存の
@@ -52,6 +53,8 @@ mod game_room;
 mod lobby;
 #[cfg(target_arch = "wasm32")]
 mod router;
+#[cfg(target_arch = "wasm32")]
+mod viewer_api;
 
 #[cfg(target_arch = "wasm32")]
 pub use game_room::GameRoom;

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -10,6 +10,7 @@ use worker::{Env, Method, Request, Response, Result};
 
 use crate::config::{ConfigKeys, OriginAllowList};
 use crate::origin::{OriginDecision, evaluate};
+use crate::viewer_api;
 use crate::ws_route::parse_ws_route;
 
 /// `#[event(fetch)]` から委譲されるディスパッチ。
@@ -20,6 +21,13 @@ pub async fn handle_fetch(req: Request, env: Env) -> Result<Response> {
 
     if method == Method::Get && (path == "/" || path == "/health") {
         return Response::ok(format!("rshogi-csa-server-workers v{}", env!("CARGO_PKG_VERSION")));
+    }
+
+    // viewer 配信 API (`/api/v1/games[/...]`) は GameRoom DO を経由せず
+    // R2 直 fetch のみで完結する。本ルートに該当しない場合のみ既存の
+    // WebSocket ルーティングへ落ちる。
+    if let Some(resp) = viewer_api::try_handle(&req, &env).await? {
+        return Ok(resp);
     }
 
     if method == Method::Get && path == "/ws/lobby" {

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -1,0 +1,341 @@
+//! viewer 配信 HTTP API (`/api/v1/games`) のルーティングと R2 アクセス。
+//!
+//! v3 設計 (Issue #542 issuecomment-4338088406) に準拠する 2 エンドポイント:
+//!
+//! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧
+//!   `KIFU_BUCKET.list({prefix: "games-index/", cursor, limit})` を 1 回呼び、
+//!   各オブジェクト本文 (= [`crate::games_index::GamesIndexEntry`] の JSON) を
+//!   そのまま `games[]` に詰めて返す。`next_cursor` は R2 list の cursor を
+//!   opaque 転送する。
+//! - `GET /api/v1/games/<game_id>` 単局
+//!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
+//!   `games-index/` から取得した meta を合わせて返す。
+//!
+//! いずれも GameRoom DO を経由せず、Worker 直 fetch のみで完結する (R2 read
+//! 1 ホップ)。CORS は staging では `WS_ALLOWED_ORIGINS` をそのまま流用して
+//! ramu-shogi origin に絞る (実装の柔軟性で OK)。
+
+use serde::Serialize;
+use worker::{Env, Headers, Method, Request, Response, Result, Url};
+
+use crate::config::{ConfigKeys, OriginAllowList};
+use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
+use crate::origin::{OriginDecision, evaluate};
+use crate::x1_paths::kifu_by_id_object_key;
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 100;
+const MIN_LIMIT: u32 = 1;
+
+/// `/api/v1/games[/...]` 配下のリクエストを判定して該当ハンドラに振り分ける。
+///
+/// 戻り値 `Some(_)` はマッチしたことを示す。`None` の場合は既存ルーティングに
+/// 引き継ぐ (404 までの fallthrough)。
+pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
+    if req.method() != Method::Get {
+        return Ok(None);
+    }
+    let url = req.url()?;
+    let path = url.path().to_owned();
+
+    if path == "/api/v1/games" {
+        return Ok(Some(handle_list(req, env, &url).await?));
+    }
+    if let Some(rest) = path.strip_prefix("/api/v1/games/") {
+        if rest.is_empty() || rest.contains('/') {
+            // 余分な階層 (`/api/v1/games/x/y`) や末尾 `/` は 404 で扱う。
+            return Ok(Some(Response::error("Not Found", 404)?));
+        }
+        return Ok(Some(handle_get(req, env, rest).await?));
+    }
+
+    Ok(None)
+}
+
+/// 一覧 API レスポンスの wire 形状。
+#[derive(Debug, Serialize)]
+struct ListResponse {
+    /// `games-index/` のオブジェクト本文をそのまま吐き出すのが契約 (本モジュールでは
+    /// meta の再構築をしない)。MVP では `serde_json::Value` でラウンドトリップ parse
+    /// する素朴実装。要素数 1 ページ最大 100 件のため性能影響は許容。`RawValue` 化は
+    /// レイテンシが顕在化したときの将来拡張で検討する。
+    games: Vec<serde_json::Value>,
+    next_cursor: Option<String>,
+}
+
+/// 単局 API レスポンスの wire 形状。
+#[derive(Debug, Serialize)]
+struct GameResponse<'a> {
+    game_id: &'a str,
+    csa: String,
+    /// `games-index/` から取得した meta。MVP では index に entry が無い場合
+    /// 404 を返す前提で、ここは常に `Some` だが、JSON 上は serde 既定で field
+    /// として出る。
+    meta: serde_json::Value,
+}
+
+/// 一覧ハンドラ。
+async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+
+    // クエリパラメータを 1 度だけ走査して `cursor` / `limit` を取り出す。
+    let mut cursor: Option<String> = None;
+    let mut limit_raw: Option<String> = None;
+    for (k, v) in url.query_pairs() {
+        match k.as_ref() {
+            "cursor" => cursor = Some(v.into_owned()),
+            "limit" => limit_raw = Some(v.into_owned()),
+            _ => {}
+        }
+    }
+
+    let limit = match limit_raw.as_deref() {
+        None => DEFAULT_LIMIT,
+        Some(s) => match s.parse::<u32>() {
+            Ok(n) if (MIN_LIMIT..=MAX_LIMIT).contains(&n) => n,
+            _ => {
+                return with_cors(
+                    Response::error(format!("limit must be {MIN_LIMIT}..={MAX_LIMIT}"), 400)?,
+                    req,
+                    env,
+                );
+            }
+        },
+    };
+
+    let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+        Ok(b) => b,
+        Err(e) => {
+            console_log_failed("kifu_bucket_binding", &e.to_string());
+            return with_cors(Response::error("Storage unavailable", 503)?, req, env);
+        }
+    };
+
+    let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX).limit(limit);
+    if let Some(c) = cursor.as_deref() {
+        builder = builder.cursor(c);
+    }
+
+    let page = match builder.execute().await {
+        Ok(p) => p,
+        Err(e) => {
+            console_log_failed("games_index_list", &e.to_string());
+            return with_cors(Response::error("Storage error", 502)?, req, env);
+        }
+    };
+
+    let mut games: Vec<serde_json::Value> = Vec::with_capacity(page.objects().len());
+    for obj in page.objects() {
+        let key = obj.key();
+        // 各 entry を取得 → bytes → JSON value。bytes 経由なのは
+        // 本文がそのまま `GamesIndexEntry` の JSON 形式である契約のため。
+        let fetched = match bucket.get(&key).execute().await {
+            Ok(o) => o,
+            Err(e) => {
+                console_log_failed("games_index_get", &format!("key={key} err={e}"));
+                continue;
+            }
+        };
+        let Some(fetched) = fetched else {
+            // list と get の間に削除されたケース。pagination 整合の観点で
+            // 落としても問題ない。
+            continue;
+        };
+        let Some(body) = fetched.body() else {
+            continue;
+        };
+        let bytes = match body.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                console_log_failed("games_index_read", &format!("key={key} err={e}"));
+                continue;
+            }
+        };
+        match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(v) => games.push(v),
+            Err(e) => {
+                console_log_failed("games_index_parse", &format!("key={key} err={e}"));
+                // 1 件壊れても他を返す (best-effort)。
+            }
+        }
+    }
+
+    let next_cursor = if page.truncated() {
+        page.cursor()
+    } else {
+        None
+    };
+    let payload = ListResponse { games, next_cursor };
+    let resp = Response::from_json(&payload)?;
+    with_cors(resp, req, env)
+}
+
+/// 単局ハンドラ。`<game_id>` (URL-decoded path 残部) を受け取り、kifu-by-id を
+/// 直接 get する。
+async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response> {
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+
+    let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+        Ok(b) => b,
+        Err(e) => {
+            console_log_failed("kifu_bucket_binding", &e.to_string());
+            return with_cors(Response::error("Storage unavailable", 503)?, req, env);
+        }
+    };
+
+    let by_id_key = kifu_by_id_object_key(game_id);
+    let csa_obj = match bucket.get(&by_id_key).execute().await {
+        Ok(o) => o,
+        Err(e) => {
+            console_log_failed("kifu_by_id_get", &format!("key={by_id_key} err={e}"));
+            return with_cors(Response::error("Storage error", 502)?, req, env);
+        }
+    };
+    let Some(csa_obj) = csa_obj else {
+        return with_cors(Response::error("Not Found", 404)?, req, env);
+    };
+    let Some(body) = csa_obj.body() else {
+        return with_cors(Response::error("Not Found", 404)?, req, env);
+    };
+    let csa_text = match body.text().await {
+        Ok(t) => t,
+        Err(e) => {
+            console_log_failed("kifu_by_id_read", &format!("key={by_id_key} err={e}"));
+            return with_cors(Response::error("Storage error", 502)?, req, env);
+        }
+    };
+
+    // meta は `games-index/` を prefix list で 1 件だけ走査して見つける。
+    // index key は `<inv_ms>-<game_id>.json` 形式なので game_id 単独では
+    // 完全な key を再構築できない (inv_ms が分からない)。MVP では list で
+    // 1 件目を見つけ次第 break する単純戦略を採る (per game_id で 1 件のみ
+    // 存在する不変条件下では効率より簡潔さを優先)。
+    let meta = match find_meta_for(&bucket, game_id).await {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            // CSA 本文はあるが index に entry が無い (backfill 未実施 or
+            // index put 失敗)。MVP 仕様として 404 を返す (本文表示には
+            // meta が必須なため)。
+            return with_cors(Response::error("Not Found", 404)?, req, env);
+        }
+        Err(e) => {
+            console_log_failed("games_index_lookup", &format!("game_id={game_id} err={e}"));
+            return with_cors(Response::error("Storage error", 502)?, req, env);
+        }
+    };
+
+    let payload = GameResponse {
+        game_id,
+        csa: csa_text,
+        meta,
+    };
+    let resp = Response::from_json(&payload)?;
+    with_cors(resp, req, env)
+}
+
+/// `games-index/` を走査して `game_id` に対応する meta を 1 件取得する。
+///
+/// pagination で `truncated` の間ループするが、ヒット時点で打ち切る。
+/// 1 game_id あたり 1 entry の不変条件を活用し、見つかった瞬間返す。
+async fn find_meta_for(
+    bucket: &worker::Bucket,
+    game_id: &str,
+) -> std::result::Result<Option<serde_json::Value>, String> {
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX);
+        if let Some(c) = cursor.as_deref() {
+            builder = builder.cursor(c);
+        }
+        let page = builder.execute().await.map_err(|e| e.to_string())?;
+        for obj in page.objects() {
+            let key = obj.key();
+            // key 形式: `games-index/<inv_ms:14>-<game_id>.json`
+            // 末尾 `.json` を除去 → 先頭 `games-index/<inv_ms>-` を除去 → game_id
+            let Some(stripped) = key.strip_prefix(GAMES_INDEX_PREFIX) else {
+                continue;
+            };
+            let Some(without_ext) = stripped.strip_suffix(".json") else {
+                continue;
+            };
+            // `<inv_ms:14>-<game_id>` から `-` 1 個目以降を game_id として取り出す。
+            let Some(dash_idx) = without_ext.find('-') else {
+                continue;
+            };
+            let key_game_id = &without_ext[dash_idx + 1..];
+            if key_game_id != game_id {
+                continue;
+            }
+            let fetched = bucket.get(&key).execute().await.map_err(|e| e.to_string())?;
+            let Some(fetched) = fetched else {
+                continue;
+            };
+            let Some(body) = fetched.body() else {
+                continue;
+            };
+            let bytes = body.bytes().await.map_err(|e| e.to_string())?;
+            let value: serde_json::Value =
+                serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+            return Ok(Some(value));
+        }
+        if !page.truncated() {
+            return Ok(None);
+        }
+        cursor = page.cursor();
+        if cursor.is_none() {
+            return Ok(None);
+        }
+    }
+}
+
+/// CORS / Origin チェック。リクエスト Origin が許可リストに含まれる場合のみ
+/// 通す。Origin ヘッダ未送信のクライアント (curl 等) は許可リスト未設定時のみ
+/// 通す ([`evaluate`] と同じ semantics)。
+fn check_origin(req: &Request, env: &Env) -> Result<Option<Response>> {
+    let allow_csv = env
+        .var(ConfigKeys::WS_ALLOWED_ORIGINS)
+        .ok()
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let allow_list = OriginAllowList::from_csv(&allow_csv);
+    let origin_header = req.headers().get("Origin")?;
+    match evaluate(origin_header.as_deref(), allow_list.iter()) {
+        OriginDecision::Allow => Ok(None),
+        OriginDecision::NotAllowed => Ok(Some(Response::error("Forbidden Origin", 403)?)),
+    }
+}
+
+/// 既存レスポンスに CORS ヘッダを乗せ直す。
+///
+/// `Origin` が許可済みの場合のみ `Access-Control-Allow-Origin` をリクエスト
+/// Origin そのものに echo back する。`check_origin` が allowlist 未設定 + Origin 付き
+/// を 403 で先に弾いているため、本関数に到達した時点では allowlist は非空かつ
+/// Origin はリストに含まれている (もしくは Origin ヘッダなし)。
+fn with_cors(mut resp: Response, req: &Request, env: &Env) -> Result<Response> {
+    let allow_csv = env
+        .var(ConfigKeys::WS_ALLOWED_ORIGINS)
+        .ok()
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let allow_list = OriginAllowList::from_csv(&allow_csv);
+    let origin_header = req.headers().get("Origin")?;
+    let allow_origin = match origin_header.as_deref() {
+        Some(o) if allow_list.iter().any(|allowed| allowed == o) => Some(o.to_owned()),
+        _ => None,
+    };
+    if let Some(origin) = allow_origin {
+        let headers: &mut Headers = resp.headers_mut();
+        headers.set("Access-Control-Allow-Origin", &origin)?;
+        headers.set("Vary", "Origin")?;
+    }
+    Ok(resp)
+}
+
+/// 失敗ログを logfmt で出す統一窓口。viewer API の経路別 event 名を持たせる。
+fn console_log_failed(event: &str, detail: &str) {
+    worker::console_log!("[viewer_api] event={event} detail={detail}");
+}


### PR DESCRIPTION
親 Issue: #542
親 Epic: #541

## Summary

ramu-shogi viewer から CSA 棋譜を再生するための配信経路をサーバ側に追加する。Issue #542 コメントの v3 設計と API contract A に従う。

## 主な変更

- **新 module `games_index.rs`** (host + wasm 共有): `inv_ms` 14 桁ゼロ埋めキー (`games-index/<inv_ms>-<game_id>.json`) 形式の R2 索引と `GamesIndexEntry` 型。snake_case wire / `result_kind` + `end_reason` 分離 / `clock.kind` enum (`countdown` / `countdown_msec` / `fischer` / `stopwatch`) を実装。host-side ユニットテストで `inv_ms` ゼロパディング・disallowed char・`-`/`_`受理・lex 順=降順・全 GameResult variant・全 ClockKind variant・JSON シリアライズ shape を網羅。
- **`floodgate_history.rs::validate_key_component` を `pub` 化** して新 module から再利用。
- **`game_room.rs::export_kifu_to_r2`** の本文 + by-id put 成功直後に index put を追加。validation / serialize / put のすべての失敗を `?` 不使用で `if let Err / match` に吸収し `finalize_if_ended` を Err にしない (best-effort)。失敗時は logfmt 形式の構造化ログ (`event=games_index_put_failed game_id=… inv_key=… err=…`) を出す。`source` は `resolve_floodgate_history_storage(...).ok().flatten().is_some()` で事前判定し Floodgate 経路には index put を追加しない (二重 put 排除)。
- **新 module `viewer_api.rs`** (wasm32 限定):
  - `GET /api/v1/games?cursor=&limit=` 一覧 (limit 1〜100, default 50)。`KIFU_BUCKET.list({prefix: "games-index/"})` を昇順のまま 1 回呼び、結果がそのまま新着順 (新→旧)。`next_cursor` は R2 list の cursor を opaque 転送。
  - `GET /api/v1/games/<game_id>` 単局 (404 / 502 / 503 を適切に区別)。
  - Origin allowlist 経由の CORS 制御 (`WS_ALLOWED_ORIGINS` を再利用)。
- **`router.rs`** から `viewer_api::try_handle` を最優先で振り分け、既存 ws / health ルーティングを温存。

## ローカル検証

- `cargo fmt --check` / `cargo clippy --tests` (警告 0) / `cargo test -p rshogi-csa-server-workers` (140 + 1 + 10 + 3 = 154 件 pass) / `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` (success)
- ローカル agent review で `APPROVE` (nitpick 3 件解消済: doc/code 一致 / 定数重複排除 / dead branch 整理)

## Non-goals (別 Issue)

- live spectator 観戦 WebSocket (#26)
- 棋譜一覧 UI (ramu-shogi#25)
- 認証 / private 棋譜
- backfill ジョブ (新規対局のみ index 化、既存は viewer 表示対象外で割り切り)

## 設計/contract コメント参照

- v3 設計: https://github.com/SH11235/rshogi/issues/542#issuecomment-4338088406
- API contract A: https://github.com/SH11235/rshogi/issues/542#issuecomment-4338125621

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)