### PR TITLE
feat(csa-server): live spectate snapshot 送信と broadcast queue を実装する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -82,6 +82,39 @@ pub enum WsAttachment {
     Spectator {
         /// 観戦対象の部屋 ID。
         room_id: String,
+        /// snapshot 送信中かどうか (`Monitor2On` Accept 経路に入ると `true`、
+        /// `##[MONITOR2] END` 送出後に `false`)。`true` の間はこの ws への
+        /// 指し手 broadcast を per-ws pending queue に積み、snapshot 完了後に
+        /// flush する race-resolution 用フラグ。
+        ///
+        /// 設計上は in-memory のみ扱いだが、DO の WebSocket Hibernation 経由で
+        /// 異なる handler 呼び出し間で参照する必要があるため attachment 経由で
+        /// 永続化する (= `serialize_attachment` に乗る)。Hibernation 後に「snapshot
+        /// 送信中」状態が復帰してしまうのを防ぐため、`#[serde(default)]` で
+        /// `false` を既定値として復元する規則 (= 万一 hibernation 中に snapshot
+        /// 送信処理が中断したら、復帰後の DO は queue を空 / フラグ false で
+        /// 開始する)。
+        #[serde(default)]
+        snapshot_in_progress: bool,
+        /// snapshot に含めた最終 ply (1 始まり、初手前なら 0)。
+        ///
+        /// snapshot 完了後に pending queue を flush する際、`ply > last_ply_in_snapshot`
+        /// の broadcast 行のみ送出して重複を排除する。`snapshot_in_progress = false`
+        /// に戻った後も値は保持する (queue 経由で挙動を共有しないため副作用は無いが、
+        /// 攻撃的に reset しないことで race の窓を狭くする)。
+        #[serde(default)]
+        last_ply_in_snapshot: u32,
+        /// snapshot 送信中に到着した broadcast 行を「行 + その手の ply」の形で
+        /// 保持する pending queue。snapshot 完了後に順次 flush する。
+        ///
+        /// `Vec<(String, Option<u32>)>`: 第 1 要素が CSA 行、第 2 要素が手数
+        /// (`None` は START / 終局通知 / CHAT 等の非指し手 broadcast で、queue
+        /// 経由でも常に flush 対象)。
+        ///
+        /// MVP では上限を設けない (1 局 ≤ 512 手のため pending queue は数十行
+        /// 程度に収まる想定)。性能課題が顕在化したら別 Issue で gating する。
+        #[serde(default)]
+        pending_queue: Vec<(String, Option<u32>)>,
     },
 }
 
@@ -96,9 +129,17 @@ impl WsAttachment {
     }
 
     /// 観戦者 attachment を構築する補助関数。
+    ///
+    /// `snapshot_in_progress` / `last_ply_in_snapshot` / `pending_queue` は
+    /// すべて default 値で初期化する。snapshot 送信経路に入る際に DO 側で
+    /// `snapshot_in_progress = true` に切り替え、`##[MONITOR2] END` 送出後に
+    /// `false` に戻す契約。
     pub fn spectator(room_id: impl Into<String>) -> Self {
         Self::Spectator {
             room_id: room_id.into(),
+            snapshot_in_progress: false,
+            last_ply_in_snapshot: 0,
+            pending_queue: Vec::new(),
         }
     }
 }
@@ -210,6 +251,49 @@ mod tests {
         // `#[serde(tag = "type")]` の下では variant 名が `type` 値に入る。
         assert!(s.contains("\"type\":\"Spectator\""));
         assert!(s.contains("\"room_id\":\"room-xyz\""));
+    }
+
+    #[test]
+    fn spectator_snapshot_state_round_trips_via_serde() {
+        // snapshot 送信中の attachment が serialize → deserialize で完全復元
+        // されること。in-memory 値だが Hibernation 経由で他 handler から見える
+        // 必要があるため永続化する設計。
+        let att = WsAttachment::Spectator {
+            room_id: "room-xyz".to_owned(),
+            snapshot_in_progress: true,
+            last_ply_in_snapshot: 7,
+            pending_queue: vec![
+                ("+5756FU,T2".to_owned(), Some(8)),
+                ("##[CHAT] alice: hi".to_owned(), None),
+            ],
+        };
+        let s = serde_json::to_string(&att).unwrap();
+        let restored: WsAttachment = serde_json::from_str(&s).unwrap();
+        assert_eq!(att, restored);
+    }
+
+    #[test]
+    fn spectator_legacy_attachment_defaults_snapshot_fields() {
+        // 旧 schema (snapshot_in_progress / last_ply_in_snapshot / pending_queue
+        // 導入前) で永続化された attachment を deserialize した場合に、新 field
+        // が default (false / 0 / Vec::new()) で復元されること。Hibernation 復帰時
+        // の互換性として固定する。
+        let legacy = r#"{"type":"Spectator","room_id":"room-xyz"}"#;
+        let restored: WsAttachment = serde_json::from_str(legacy).unwrap();
+        match restored {
+            WsAttachment::Spectator {
+                room_id,
+                snapshot_in_progress,
+                last_ply_in_snapshot,
+                pending_queue,
+            } => {
+                assert_eq!(room_id, "room-xyz");
+                assert!(!snapshot_in_progress);
+                assert_eq!(last_ply_in_snapshot, 0);
+                assert!(pending_queue.is_empty());
+            }
+            other => panic!("expected Spectator, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -77,12 +77,22 @@ use crate::reconnect::{
     build_resume_message, color_from_str, color_to_str,
 };
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
-use crate::spectator_control::{MonitorDecision, resolve_monitor_target};
+use crate::spectator_control::{
+    MonitorDecision, resolve_monitor_target, resolve_monitor_target_with_finished,
+};
+use crate::spectator_snapshot::{
+    SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot,
+};
 use crate::ws_route::{WsRoute, parse_ws_route};
 use crate::x1_paths::{buoy_object_key, default_fork_buoy_name, kifu_by_id_object_key};
 
 const DEFAULT_MAX_MOVES: u32 = 256;
 const DEFAULT_TIME_MARGIN_MS: u64 = 1000;
+
+/// 1 部屋あたりの観戦者同時接続上限。`fetch` で `/ws/<id>/spectate` の upgrade
+/// 時にカウントし、上限に達していたら 503 を返す。MVP の DDoS 防御として最低限
+/// の gating であり、ベンチで上限を見直す際は環境変数化を検討する (現状は const)。
+const MAX_SPECTATORS_PER_ROOM: usize = 50;
 
 /// Alarm 発火時刻に上乗せする安全側マージン（ミリ秒）。Cloudflare Alarm API
 /// のジッタと `Date::now()` ↔ `handle_line` の now_ms 伝搬遅延を吸収する。
@@ -166,6 +176,26 @@ impl DurableObject for GameRoom {
             self.state.storage().put(KEY_ROOM_ID, room_id.to_owned()).await?;
         }
 
+        // 観戦者の上限チェック (MVP の DDoS 防御)。room あたり同時接続
+        // `MAX_SPECTATORS_PER_ROOM` を超える spectator upgrade は 503 で拒否。
+        // 対局者経路 (`WsRoute::Player`) には影響しない。
+        if route.is_spectator() {
+            let count = self
+                .state
+                .get_websockets()
+                .iter()
+                .filter(|ws| {
+                    matches!(
+                        ws.deserialize_attachment::<WsAttachment>().ok().flatten(),
+                        Some(WsAttachment::Spectator { .. })
+                    )
+                })
+                .count();
+            if count >= MAX_SPECTATORS_PER_ROOM {
+                return Response::error("spectator capacity exceeded", 503);
+            }
+        }
+
         let pair = WebSocketPair::new()?;
         let server = pair.server;
         self.state.accept_web_socket(&server);
@@ -200,7 +230,7 @@ impl DurableObject for GameRoom {
             WsAttachment::Player { role, handle, .. } => {
                 self.handle_game_line(&ws, role, &handle, &line).await
             }
-            WsAttachment::Spectator { room_id } => {
+            WsAttachment::Spectator { room_id, .. } => {
                 self.handle_spectator_line(&ws, &room_id, &line).await
             }
         }
@@ -591,7 +621,8 @@ impl GameRoom {
     }
 
     /// 観戦者からの制御行。`%%CHAT` を同一 room の全参加者へ relay し、
-    /// `%%MONITOR2OFF` は確認応答後に socket を閉じる。
+    /// `%%MONITOR2OFF` は確認応答後に socket を閉じる。`%%MONITOR2ON` は
+    /// snapshot (= Game_Summary + 既存指し手 + 終局結果) を 1 回送出する。
     async fn handle_spectator_line(&self, ws: &WebSocket, room_id: &str, line: &str) -> Result<()> {
         let csa = CsaLine::new(line);
         let Ok(cmd) = parse_command(&csa) else {
@@ -622,19 +653,195 @@ impl GameRoom {
                 Ok(())
             }
             ClientCommand::Monitor2On { game_id } => {
-                match resolve_monitor_target(room_id, active_game_id.as_deref(), game_id.as_str()) {
+                let finished = self.load_finished().await?;
+                let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
+                let finished_game_id =
+                    finished.as_ref().and(cfg_opt.as_ref().map(|c| c.game_id.as_str()));
+                let decision = resolve_monitor_target_with_finished(
+                    room_id,
+                    active_game_id.as_deref(),
+                    finished_game_id,
+                    game_id.as_str(),
+                );
+                match decision {
                     MonitorDecision::Accept { monitor_id } => {
                         send_line(ws, &format!("##[MONITOR2] BEGIN {monitor_id}"))?;
+                        self.send_spectator_snapshot(ws, &finished, cfg_opt.as_ref()).await?;
+                        send_line(ws, "##[MONITOR2] END")?;
+                        // 終局済 DO は snapshot を流したあとで close する。client 側は
+                        // `onEnd` 発火後の reconnect 経路を停止するため、normal close
+                        // (code 1000) で終了通知するだけで十分。
+                        if finished.is_some() {
+                            let _ = ws.close(Some(1000), Some("spectate finished".to_owned()));
+                        }
                     }
                     MonitorDecision::NotFound { requested } => {
                         send_line(ws, &format!("##[MONITOR2] NOT_FOUND {requested}"))?;
+                        send_line(ws, "##[MONITOR2] END")?;
                     }
                 }
-                send_line(ws, "##[MONITOR2] END")?;
                 Ok(())
             }
             _ => Ok(()),
         }
+    }
+
+    /// `Monitor2On Accept` 経路で snapshot を送る本体。
+    ///
+    /// 流れ:
+    /// 1. attachment の `snapshot_in_progress = true` をセット (= 以降この ws 宛
+    ///    の broadcast は `send_to_spectators` で per-ws pending queue に積まれる)
+    /// 2. `ensure_core_loaded()` 後に `core` 参照スコープを最小化して
+    ///    `SpectatorClocks` を組み、`load_moves()` で snapshot 用の指し手列を確定
+    /// 3. `build_spectator_snapshot` の wire 行を順次 send
+    /// 4. attachment の queue を flush (`ply > last_ply_in_snapshot` のみ送る) し、
+    ///    `snapshot_in_progress = false` に戻して通常 broadcast 経路へ復帰
+    ///
+    /// 例外経路: `cfg` が無いケース (= LOGIN 前の DO に観戦者だけが入ってきた
+    /// case)。snapshot は組まずに END を返してそのまま通常 broadcast 経路に
+    /// 載せる (player から手が指されるまで配信は無いので queue 不要)。
+    async fn send_spectator_snapshot(
+        &self,
+        ws: &WebSocket,
+        finished: &Option<FinishedState>,
+        cfg_opt: Option<&PersistedConfig>,
+    ) -> Result<()> {
+        let Some(cfg) = cfg_opt else {
+            // 対局未開始 (LOGIN 前) の DO に観戦者が入ったケース。snapshot は
+            // 出さずそのまま終了する (Game_Summary に必要な game_id すら無いため)。
+            return Ok(());
+        };
+
+        // attachment の snapshot 状態を「送信中」に更新する。queue / last_ply は
+        // ここで初期化し、過去 invocation の残骸が混ざらないようにする。
+        self.set_spectator_snapshot_state(ws, true, 0, Vec::new())?;
+
+        // CoreRoom を確保し、clock / current_turn から `SpectatorClocks` を組む。
+        // borrow scope は最小化し、await を伴う `load_moves` は borrow 外で呼ぶ。
+        self.ensure_core_loaded().await?;
+        let clocks_opt = {
+            let borrow = self.core.borrow();
+            borrow.as_ref().map(|core| SpectatorClocks {
+                black_remaining_ms: core.clock_remaining_main_ms(Color::Black).max(0) as u64,
+                white_remaining_ms: core.clock_remaining_main_ms(Color::White).max(0) as u64,
+                side_to_move: core.current_turn(),
+            })
+        };
+        // CoreRoom が `replay_core_room` の InvalidSfen 等で復元できなかった場合
+        // (storage が破損した稀なケース)、安全側に snapshot を諦めて END だけ返す。
+        let Some(clocks) = clocks_opt else {
+            self.flush_spectator_snapshot_queue(ws).await?;
+            return Ok(());
+        };
+
+        let moves = self.load_moves().await?;
+        let last_ply_in_snapshot = u32::try_from(moves.len()).unwrap_or(u32::MAX);
+
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: cfg,
+            moves: &moves,
+            clocks: &clocks,
+            finalized: finished.as_ref(),
+        });
+        for line in &lines {
+            send_line(ws, line)?;
+        }
+
+        // snapshot 完了。attachment の last_ply を更新し、queue を flush する。
+        // queue 内の手は `ply > last_ply_in_snapshot` のみ送る (= snapshot に
+        // 含まれた手と重複しない broadcast のみ)。
+        self.set_spectator_snapshot_last_ply(ws, last_ply_in_snapshot)?;
+        self.flush_spectator_snapshot_queue(ws).await?;
+        Ok(())
+    }
+
+    /// snapshot 完了後に attachment の pending queue を順次 flush する。
+    ///
+    /// `ply > last_ply_in_snapshot` の broadcast 行のみ送出し (重複手の二重表示を
+    /// 防ぐ)、`ply == None` の non-move broadcast (START / 終局通知 / CHAT 等) は
+    /// 常に送る。flush 後は `snapshot_in_progress = false` / `pending_queue = []`
+    /// に戻して通常 broadcast 経路へ復帰させる。
+    async fn flush_spectator_snapshot_queue(&self, ws: &WebSocket) -> Result<()> {
+        let (last_ply, queue) = match ws
+            .deserialize_attachment::<WsAttachment>()
+            .map_err(|e| Error::RustError(format!("deserialize_attachment: {e}")))?
+        {
+            Some(WsAttachment::Spectator {
+                last_ply_in_snapshot,
+                pending_queue,
+                ..
+            }) => (last_ply_in_snapshot, pending_queue),
+            // attachment が Spectator でない / 無いケースは flush 不要。
+            _ => return Ok(()),
+        };
+        for (line, ply) in &queue {
+            // 指し手 broadcast (`ply == Some(n)`) は snapshot 含有分を skip。
+            // 非指し手 broadcast (`ply == None`) は常に送る。
+            match ply {
+                Some(n) if *n <= last_ply => continue,
+                _ => {}
+            }
+            if let Err(e) = send_line(ws, line) {
+                console_log!("[GameRoom] spectator queue flush failed (ignored): {e:?}");
+            }
+        }
+        // snapshot 終了状態へ戻す (`snapshot_in_progress = false`, queue は空)。
+        // last_ply_in_snapshot は保持してもしなくても以後の挙動には影響しない
+        // (= queue 経路に乗らないため) が、再度 Monitor2On が来たときのために
+        // そのまま置いておく。
+        self.set_spectator_snapshot_state(ws, false, last_ply, Vec::new())?;
+        Ok(())
+    }
+
+    /// `WsAttachment::Spectator` の snapshot 関連 3 フィールドを一括更新する。
+    ///
+    /// `room_id` は既存値を保持する (上書きしない)。Spectator でない場合は no-op。
+    fn set_spectator_snapshot_state(
+        &self,
+        ws: &WebSocket,
+        snapshot_in_progress: bool,
+        last_ply_in_snapshot: u32,
+        pending_queue: Vec<(String, Option<u32>)>,
+    ) -> Result<()> {
+        let att = ws
+            .deserialize_attachment::<WsAttachment>()
+            .map_err(|e| Error::RustError(format!("deserialize_attachment: {e}")))?;
+        let Some(WsAttachment::Spectator { room_id, .. }) = att else {
+            return Ok(());
+        };
+        let updated = WsAttachment::Spectator {
+            room_id,
+            snapshot_in_progress,
+            last_ply_in_snapshot,
+            pending_queue,
+        };
+        ws.serialize_attachment(&updated)
+            .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))
+    }
+
+    /// snapshot 構築完了時に `last_ply_in_snapshot` のみ更新する補助関数。
+    /// `snapshot_in_progress` / `pending_queue` は queue が積まれていれば残す。
+    fn set_spectator_snapshot_last_ply(&self, ws: &WebSocket, last_ply: u32) -> Result<()> {
+        let att = ws
+            .deserialize_attachment::<WsAttachment>()
+            .map_err(|e| Error::RustError(format!("deserialize_attachment: {e}")))?;
+        let Some(WsAttachment::Spectator {
+            room_id,
+            snapshot_in_progress,
+            pending_queue,
+            ..
+        }) = att
+        else {
+            return Ok(());
+        };
+        let updated = WsAttachment::Spectator {
+            room_id,
+            snapshot_in_progress,
+            last_ply_in_snapshot: last_ply,
+            pending_queue,
+        };
+        ws.serialize_attachment(&updated)
+            .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))
     }
 
     /// プレイヤー接続から受け付ける制御系コマンドを処理する。
@@ -958,11 +1165,11 @@ impl GameRoom {
                     self.send_to_role(Role::White, entry.line.as_str()).await?;
                 }
                 BroadcastTarget::Spectators => {
-                    self.send_to_spectators(entry.line.as_str()).await?;
+                    self.send_to_spectators(entry.line.as_str(), entry.ply).await?;
                 }
             }
             if matches!(entry.target, BroadcastTarget::All) {
-                self.send_to_spectators(entry.line.as_str()).await?;
+                self.send_to_spectators(entry.line.as_str(), entry.ply).await?;
             }
         }
         Ok(())
@@ -973,7 +1180,9 @@ impl GameRoom {
         let line = format!("##[CHAT] {sender}: {message}");
         self.send_to_role(Role::Black, &line).await?;
         self.send_to_role(Role::White, &line).await?;
-        self.send_to_spectators(&line).await
+        // chat は指し手では無いので ply = None (= snapshot 中の queue でも常に
+        // flush される非指し手 broadcast)。
+        self.send_to_spectators(&line, None).await
     }
 
     /// 終局したなら R2 に棋譜を書き出し、finished フラグを立てて両 ws を close する。
@@ -1237,14 +1446,41 @@ impl GameRoom {
     /// 全観戦者へ 1 行送出する。
     ///
     /// 観戦者は best-effort 配信。特定の WS への書き込みが失敗しても他の
-    /// 観戦者や対局進行を止めず、エラーは log に落として継続する (Copilot
-    /// レビュー指摘)。観戦者 1 人の切断が DO を不安定化させないようにする。
-    async fn send_to_spectators(&self, line: &str) -> Result<()> {
+    /// 観戦者や対局進行を止めず、エラーは log に落として継続する。観戦者 1 人の
+    /// 切断が DO を不安定化させないようにする。
+    ///
+    /// `ply` は指し手 broadcast の場合の手数 (1 始まり)。指し手以外
+    /// (START / 終局通知 / CHAT 等) では `None` を渡す。snapshot 送信中の ws へは
+    /// この行を per-ws pending queue に積み、send は飛ばす (= snapshot 完了後に
+    /// flush 経路で `ply > last_ply_in_snapshot` のみ送出される)。
+    async fn send_to_spectators(&self, line: &str, ply: Option<u32>) -> Result<()> {
         for ws in self.state.get_websockets() {
-            let att: Option<WsAttachment> = ws.deserialize_attachment().ok().flatten();
-            if let Some(WsAttachment::Spectator { .. }) = att
-                && let Err(e) = send_line(&ws, line)
-            {
+            let att: Option<WsAttachment> =
+                ws.deserialize_attachment::<WsAttachment>().ok().flatten();
+            let Some(WsAttachment::Spectator {
+                room_id,
+                snapshot_in_progress,
+                last_ply_in_snapshot,
+                mut pending_queue,
+            }) = att
+            else {
+                continue;
+            };
+            if snapshot_in_progress {
+                // snapshot 送信中は queue に積むだけ。flush 経路で重複手は弾く。
+                pending_queue.push((line.to_owned(), ply));
+                let updated = WsAttachment::Spectator {
+                    room_id,
+                    snapshot_in_progress,
+                    last_ply_in_snapshot,
+                    pending_queue,
+                };
+                if let Err(e) = ws.serialize_attachment(&updated) {
+                    console_log!("[GameRoom] spectator queue serialize failed (ignored): {e:?}");
+                }
+                continue;
+            }
+            if let Err(e) = send_line(&ws, line) {
                 console_log!("[GameRoom] spectator send failed (ignored): {e:?}");
             }
         }

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -44,6 +44,12 @@ pub(crate) mod reconnect;
 pub mod room_id;
 pub mod session_state;
 pub mod spectator_control;
+// `spectator_snapshot` は DO ランタイムから消費される I/O 非依存の純粋関数で、
+// `persistence` モジュール (`PersistedConfig` / `MoveRow` / `FinishedState`) を
+// 参照する。`persistence` と同じ wasm32 + test ゲーティングで揃え、ホスト
+// target の `cargo test` から到達可能にする。
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) mod spectator_snapshot;
 pub mod ws_route;
 pub mod x1_paths;
 

--- a/crates/rshogi-csa-server-workers/src/spectator_control.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_control.rs
@@ -35,6 +35,34 @@ pub fn resolve_monitor_target<'a>(
     }
 }
 
+/// 終局済 DO への観戦アクセスを許可する拡張ラッパー。
+///
+/// `active_game_id` のみを参照する [`resolve_monitor_target`] に対し、終局済
+/// (`KEY_FINISHED` set) DO の `cfg.game_id` も `Accept` 対象として加える。
+///
+/// 引数:
+/// - `finished_game_id`: 終局済 DO の場合の `cfg.game_id` を `Some` で渡す。
+///   active な対局が無く finished も無い (そもそも対局していない) DO では `None`。
+///
+/// monitor_id の優先順位は `active_game_id` → `finished_game_id` → `room_id`。
+pub fn resolve_monitor_target_with_finished<'a>(
+    room_id: &'a str,
+    active_game_id: Option<&'a str>,
+    finished_game_id: Option<&'a str>,
+    requested: &'a str,
+) -> MonitorDecision<'a> {
+    if requested == room_id
+        || active_game_id == Some(requested)
+        || finished_game_id == Some(requested)
+    {
+        MonitorDecision::Accept {
+            monitor_id: active_game_id.or(finished_game_id).unwrap_or(room_id),
+        }
+    } else {
+        MonitorDecision::NotFound { requested }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,6 +92,83 @@ mod tests {
         assert_eq!(
             resolve_monitor_target("room-1", Some("room-1-1712345678"), "other"),
             MonitorDecision::NotFound { requested: "other" }
+        );
+    }
+
+    #[test]
+    fn with_finished_accepts_finished_game_id() {
+        // active が無くなっても finished_game_id にマッチすれば Accept。
+        // monitor_id はフォールバックチェイン (active → finished → room) で
+        // finished の値が採用される。
+        assert_eq!(
+            resolve_monitor_target_with_finished(
+                "room-1",
+                None,
+                Some("room-1-1712345678"),
+                "room-1-1712345678",
+            ),
+            MonitorDecision::Accept {
+                monitor_id: "room-1-1712345678",
+            }
+        );
+    }
+
+    #[test]
+    fn with_finished_active_takes_precedence_when_both_match() {
+        // active と finished の両方が設定されている特異ケース (実運用では起きない
+        // が、API 契約として優先順位を固定する)。
+        assert_eq!(
+            resolve_monitor_target_with_finished(
+                "room-1",
+                Some("active-id"),
+                Some("finished-id"),
+                "active-id",
+            ),
+            MonitorDecision::Accept {
+                monitor_id: "active-id",
+            }
+        );
+    }
+
+    #[test]
+    fn with_finished_room_id_match_returns_active_when_present() {
+        // room_id 一致の Accept でも monitor_id は active を優先する。これは
+        // 既存 `resolve_monitor_target` と同じ意味論を踏襲する。
+        assert_eq!(
+            resolve_monitor_target_with_finished(
+                "room-1",
+                Some("room-1-1712345678"),
+                None,
+                "room-1",
+            ),
+            MonitorDecision::Accept {
+                monitor_id: "room-1-1712345678",
+            }
+        );
+    }
+
+    #[test]
+    fn with_finished_unrelated_id_is_rejected() {
+        assert_eq!(
+            resolve_monitor_target_with_finished(
+                "room-1",
+                None,
+                Some("room-1-1712345678"),
+                "other",
+            ),
+            MonitorDecision::NotFound { requested: "other" }
+        );
+    }
+
+    #[test]
+    fn with_finished_no_active_no_finished_only_room_match() {
+        // active も finished も無い (fetch だけ通って LOGIN 前の DO) で room_id
+        // 直指定された場合、monitor_id は room_id にフォールバックする。
+        assert_eq!(
+            resolve_monitor_target_with_finished("room-1", None, None, "room-1"),
+            MonitorDecision::Accept {
+                monitor_id: "room-1",
+            }
         );
     }
 }

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -1,0 +1,340 @@
+//! 観戦者向け snapshot の構築（純粋関数）。
+//!
+//! `%%MONITOR2ON <gameId>` 受理時に、対局の現状を CSA wire に流すための行列を
+//! 組み立てる。本モジュールは I/O を持たず DO state にも依存しないため、ホスト
+//! target の単体テストで wire 出力を pin する。
+//!
+//! wire 順序 (`build_spectator_snapshot` の戻り値):
+//!
+//! 1. 観戦者向け `BEGIN Game_Summary` ブロック（`Black/White_Time_Remaining_Ms:`
+//!    末尾拡張行を含む、player 経路の `Your_Turn:` / `Reconnect_Token:` は含まない）
+//! 2. これまでの move 行 (1 行 1 手): `<token>,T<elapsed_sec>` 形式
+//!    （broadcast の通常形式と一致）
+//! 3. （終局済 DO の場合のみ）終局結果コード行 (`#RESIGN` / `#TIME_UP` 等)
+//!
+//! `BEGIN Position` / `END Position` は Game_Summary の `position_section` 内部に
+//! 含まれており、本モジュールが別途出力することはない。
+//!
+//! クライアント側は `##[MONITOR2] BEGIN <id>` と `##[MONITOR2] END` の間で本関数の
+//! 戻り値を順次受信し、`END` 受信を hard delimiter として state を全置換する。
+
+use rshogi_csa_server::protocol::summary::{
+    GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
+    standard_initial_position_block,
+};
+use rshogi_csa_server::types::{Color, GameId, PlayerName};
+
+use crate::persistence::{FinishedState, MoveRow, PersistedConfig};
+
+/// 観戦者用の残り時間スナップショット。
+///
+/// `core.clock_remaining_main_ms(Color)` と `CoreRoom::current_turn()` から構築
+/// する純粋データで、storage には永続化しない。`Color` は
+/// `rshogi_csa_server::types::Color` を使う (`rshogi_csa_server` crate を直接
+/// 参照する点に注意)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpectatorClocks {
+    /// 先手の本体残時間 (ms 粒度、秒読みは含まない)。
+    pub black_remaining_ms: u64,
+    /// 後手の本体残時間 (ms 粒度、秒読みは含まない)。
+    pub white_remaining_ms: u64,
+    /// wire 上は手番側を示す。`CoreRoom::current_turn()` の戻り値をそのまま
+    /// 入れる契約 (`SpectatorClocks::side_to_move` は wire 上の意味を表す
+    /// field 名で、source 側は `current_turn()`)。
+    pub side_to_move: Color,
+}
+
+/// `build_spectator_snapshot` への入力。
+pub struct SpectatorSnapshotInput<'a> {
+    /// 永続化済み対局設定（クロック設定 / 初期 SFEN / プレイヤ名 / game_id 等）。
+    pub config: &'a PersistedConfig,
+    /// `moves` テーブルを ply 昇順で読み出した結果。空なら初手前。
+    pub moves: &'a [MoveRow],
+    /// snapshot 取得時点の clock 残時間スナップショット (= `ensure_core_loaded`
+    /// 直後に `CoreRoom` から取得した値)。
+    pub clocks: &'a SpectatorClocks,
+    /// 終局済の場合のみ `Some`。snapshot 末尾に `result_code` 行を 1 行追加する。
+    pub finalized: Option<&'a FinishedState>,
+}
+
+/// 観戦者向け snapshot の wire 行を組み立てる純粋関数。
+///
+/// 戻り値は CSA 行の `Vec<String>`。各行は末尾改行を含まないため、呼び出し側
+/// (DO 側 `send_line`) で改行を付与する契約。
+pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    let position_section = match input.config.initial_sfen.as_deref() {
+        Some(sfen) => position_section_from_sfen(sfen).unwrap_or_else(|_| {
+            // SFEN 不正は本来 `start_match` で検出済みのはずだが、永続化レイヤから
+            // 想定外の SFEN が読み出された場合の安全側フォールバックとして平手
+            // ブロックを返す。観戦者は state 全置換のため、この場合でも UI は
+            // 平手で復元できる。
+            standard_initial_position_block()
+        }),
+        None => standard_initial_position_block(),
+    };
+
+    let to_move = match input.config.initial_sfen.as_deref() {
+        Some(sfen) => side_to_move_from_sfen(sfen).unwrap_or(Color::Black),
+        None => Color::Black,
+    };
+
+    let time_section = input.config.clock.format_time_section();
+
+    let builder = GameSummaryBuilder {
+        game_id: GameId::new(input.config.game_id.clone()),
+        black: PlayerName::new(input.config.black_handle.clone()),
+        white: PlayerName::new(input.config.white_handle.clone()),
+        time_section,
+        position_section,
+        rematch_on_draw: false,
+        to_move,
+        declaration: String::new(),
+        // 観戦者向け builder は token を出力しないため、`None` 固定で渡す
+        // (関数内部でも player 経路と異なり token 行は出さない契約)。
+        black_reconnect_token: None,
+        white_reconnect_token: None,
+    };
+
+    let summary = builder
+        .build_for_spectator(input.clocks.black_remaining_ms, input.clocks.white_remaining_ms);
+    // build_for_spectator は内部で複数行を改行区切りで返すため、行単位に分解して
+    // 末尾改行を取り除いた個別行として lines に追加する。
+    for raw_line in summary.lines() {
+        lines.push(raw_line.to_owned());
+    }
+
+    // 既存の指し手 (broadcast move 行と完全に同一書式)。`MoveRow::line` は
+    // `+7776FU,T3` のような raw CSA 行をそのまま保持しているため、改行除去
+    // だけ済ませて push する。
+    for m in input.moves {
+        let trimmed = m.line.trim_end_matches(['\r', '\n']);
+        lines.push(trimmed.to_owned());
+    }
+
+    // 終局済 DO の場合は最終結果コード行を追加。終局時に CoreRoom 側で broadcast
+    // した詳細メッセージ (`#WIN` / `#LOSE` 等) は永続化していないため、ここで
+    // 復元するのは集約済の `result_code` のみ。client 側は `#RESIGN` / `#TIME_UP`
+    // 等を見て onEnd 経路に乗る。
+    if let Some(state) = input.finalized {
+        lines.push(state.result_code.clone());
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use rshogi_csa_server::ClockSpec;
+
+    use super::*;
+
+    fn baseline_config() -> PersistedConfig {
+        PersistedConfig {
+            game_id: "room-1-test".to_owned(),
+            black_handle: "alice".to_owned(),
+            white_handle: "bob".to_owned(),
+            game_name: "g1".to_owned(),
+            clock: ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+            max_moves: 256,
+            time_margin_ms: 0,
+            matched_at_ms: 1_000_000,
+            play_started_at_ms: Some(1_000_000),
+            initial_sfen: None,
+            black_reconnect_token: Some("blk-token".to_owned()),
+            white_reconnect_token: Some("wht-token".to_owned()),
+        }
+    }
+
+    fn move_row(ply: i64, color: &str, line: &str) -> MoveRow {
+        MoveRow {
+            ply,
+            color: color.to_owned(),
+            line: line.to_owned(),
+            at_ms: 1_000_000 + ply * 1_000,
+        }
+    }
+
+    fn clocks(black: u64, white: u64, side: Color) -> SpectatorClocks {
+        SpectatorClocks {
+            black_remaining_ms: black,
+            white_remaining_ms: white,
+            side_to_move: side,
+        }
+    }
+
+    /// シナリオ 1: 初手前 (= moves 空、終局なし)。
+    #[test]
+    fn snapshot_before_first_move_emits_summary_only() {
+        let cfg = baseline_config();
+        let cl = clocks(600_000, 600_000, Color::Black);
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: &cfg,
+            moves: &[],
+            clocks: &cl,
+            finalized: None,
+        });
+
+        // Game_Summary block の始終端と残時間行・初期局面行が含まれる。
+        assert!(
+            lines.contains(&"BEGIN Game_Summary".to_owned()),
+            "missing BEGIN Game_Summary: {lines:?}"
+        );
+        assert!(
+            lines.contains(&"END Game_Summary".to_owned()),
+            "missing END Game_Summary: {lines:?}"
+        );
+        assert!(
+            lines.contains(&"Black_Time_Remaining_Ms:600000".to_owned()),
+            "missing black remaining: {lines:?}"
+        );
+        assert!(
+            lines.contains(&"White_Time_Remaining_Ms:600000".to_owned()),
+            "missing white remaining: {lines:?}"
+        );
+        // player 専用フィールドが漏れていない。
+        assert!(
+            !lines.iter().any(|l| l.starts_with("Your_Turn:")),
+            "spectator must not emit Your_Turn: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.starts_with("Reconnect_Token:")),
+            "spectator must not leak Reconnect_Token: {lines:?}"
+        );
+        // 終局行は出ない。
+        assert!(
+            !lines.iter().any(|l| l.starts_with('#')),
+            "no result code line expected: {lines:?}"
+        );
+    }
+
+    /// シナリオ 2: 数手後 (= moves 3 件、進行中)。
+    #[test]
+    fn snapshot_after_three_moves_appends_move_lines_in_order() {
+        let cfg = baseline_config();
+        let moves = vec![
+            move_row(1, "black", "+7776FU,T3"),
+            move_row(2, "white", "-3334FU,T2"),
+            move_row(3, "black", "+8833UM,T4"),
+        ];
+        let cl = clocks(597_000, 598_000, Color::White);
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: &cfg,
+            moves: &moves,
+            clocks: &cl,
+            finalized: None,
+        });
+
+        // 全 move 行が順序通り含まれる。
+        let move_indices: Vec<usize> = ["+7776FU,T3", "-3334FU,T2", "+8833UM,T4"]
+            .iter()
+            .map(|m| {
+                lines
+                    .iter()
+                    .position(|l| l == m)
+                    .unwrap_or_else(|| panic!("missing move line {m}: {lines:?}"))
+            })
+            .collect();
+        assert!(
+            move_indices.windows(2).all(|w| w[0] < w[1]),
+            "move lines must be ply-ascending: {move_indices:?}"
+        );
+        // 全 move 行は END Game_Summary より後に来る。
+        let end_idx = lines.iter().position(|l| l == "END Game_Summary").unwrap();
+        assert!(move_indices.iter().all(|&i| i > end_idx));
+        // 終局行は出ない。
+        assert!(!lines.iter().any(|l| l.starts_with('#')));
+    }
+
+    /// シナリオ 3: 終局直後 (= moves に %TORYO が含まれる + finalized も Some)。
+    /// 一見すると move 行重複 (`%TORYO`) と result code (`#RESIGN`) の二重記録に
+    /// 見えるが、クライアントは onEnd を `#RESIGN` 等で確定する仕様で、`%TORYO`
+    /// は通常の move stream と同じ位置で再生されるだけ (UI 側は idempotent)。
+    #[test]
+    fn snapshot_after_toryo_with_finalized_appends_result_code_line() {
+        let cfg = baseline_config();
+        let moves = vec![
+            move_row(1, "black", "+7776FU,T3"),
+            move_row(2, "white", "-3334FU,T2"),
+            move_row(3, "black", "%TORYO,T1"),
+        ];
+        let cl = clocks(596_000, 598_000, Color::Black);
+        let finished = FinishedState {
+            result_code: "#RESIGN".to_owned(),
+            ended_at_ms: 1_010_000,
+        };
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: &cfg,
+            moves: &moves,
+            clocks: &cl,
+            finalized: Some(&finished),
+        });
+
+        // `%TORYO` 行と `#RESIGN` 行が両方入り、`#RESIGN` は最終位置。
+        let toryo_idx = lines
+            .iter()
+            .position(|l| l == "%TORYO,T1")
+            .unwrap_or_else(|| panic!("missing %TORYO,T1: {lines:?}"));
+        let resign_idx = lines
+            .iter()
+            .position(|l| l == "#RESIGN")
+            .unwrap_or_else(|| panic!("missing #RESIGN: {lines:?}"));
+        assert!(toryo_idx < resign_idx);
+        assert_eq!(resign_idx, lines.len() - 1, "result code must be last: {lines:?}");
+    }
+
+    /// シナリオ 4: 終局済 DO 接続経路 (moves 全部 + finalized で snapshot を 1 回送る)。
+    /// シナリオ 3 と入力は似るが、観戦者が「new connection した時点で既に finished」
+    /// だったケース。snapshot は 1 回送って close する経路 (DO 側) なので、本関数の
+    /// 戻り値としてはシナリオ 3 と同じ「全 moves + 結果コード」になる。
+    #[test]
+    fn snapshot_for_finished_do_emits_full_history_with_result_code() {
+        let cfg = baseline_config();
+        let moves = vec![
+            move_row(1, "black", "+7776FU,T3"),
+            move_row(2, "white", "-3334FU,T2"),
+        ];
+        let cl = clocks(594_000, 597_000, Color::Black);
+        let finished = FinishedState {
+            result_code: "#TIME_UP".to_owned(),
+            ended_at_ms: 1_010_000,
+        };
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: &cfg,
+            moves: &moves,
+            clocks: &cl,
+            finalized: Some(&finished),
+        });
+
+        // `#TIME_UP` で終端する。
+        assert_eq!(lines.last().map(String::as_str), Some("#TIME_UP"));
+        // 全 moves が含まれる (順序保証は他テストで確認済みのため、ここでは含有のみ)。
+        for m in &moves {
+            assert!(
+                lines.iter().any(|l| l == &m.line),
+                "missing move line {:?}: {lines:?}",
+                m.line
+            );
+        }
+    }
+
+    /// `Game_ID:` / `Name+:` / `Name-:` は config 由来で snapshot に乗る。
+    #[test]
+    fn snapshot_summary_includes_game_id_and_player_names() {
+        let cfg = baseline_config();
+        let cl = clocks(600_000, 600_000, Color::Black);
+        let lines = build_spectator_snapshot(SpectatorSnapshotInput {
+            config: &cfg,
+            moves: &[],
+            clocks: &cl,
+            finalized: None,
+        });
+        assert!(lines.iter().any(|l| l == "Game_ID:room-1-test"));
+        assert!(lines.iter().any(|l| l == "Name+:alice"));
+        assert!(lines.iter().any(|l| l == "Name-:bob"));
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/ws_route.rs
+++ b/crates/rshogi-csa-server-workers/src/ws_route.rs
@@ -31,27 +31,61 @@ impl WsRoute {
 
 /// path 文字列から WebSocket route を解釈する。
 ///
-/// `/ws/<room_id>` と `/ws/<room_id>/spectate` だけを受け付ける。`room_id` は
+/// `/ws/<room_id>` と `/ws/<id>/spectate` だけを受け付ける。`room_id` は
 /// [`is_valid_room_id`] を満たす必要がある。
+///
+/// 観戦経路の `<id>` は room_id でも game_id 形式 (= `lobby-<game_name>-<32hex>-<13桁以上epoch_ms>`)
+/// でも受理する。game_id 形式と判別したら [`extract_room_id_for_spectate`] で
+/// suffix の epoch_ms 部を剥がして DO ルーティング用の room_id だけを採用する。
+/// 対局者経路 (`/ws/<room_id>`) はこの suffix 剥がしを通さない (URL 由来の値を
+/// そのまま使う既存挙動を維持する)。
 pub fn parse_ws_route(path: &str) -> Option<WsRoute> {
     let tail = path.strip_prefix("/ws/")?;
-    let (room_id, spectator) = match tail.split_once('/') {
+    let (id, spectator) = match tail.split_once('/') {
         None => (tail, false),
         Some((room_id, "spectate")) => (room_id, true),
         Some(_) => return None,
     };
-    if !is_valid_room_id(room_id) {
-        return None;
-    }
-    Some(if spectator {
-        WsRoute::Spectator {
-            room_id: room_id.to_owned(),
+    if spectator {
+        let room_id = extract_room_id_for_spectate(id);
+        if !is_valid_room_id(room_id) {
+            return None;
         }
+        Some(WsRoute::Spectator {
+            room_id: room_id.to_owned(),
+        })
     } else {
-        WsRoute::Player {
-            room_id: room_id.to_owned(),
+        if !is_valid_room_id(id) {
+            return None;
         }
-    })
+        Some(WsRoute::Player {
+            room_id: id.to_owned(),
+        })
+    }
+}
+
+/// spectate 経路 `<id>` から DO ルーティング用の `room_id` を返す。
+///
+/// game_id 形式 (= 末尾 `-<13 桁以上の 10 進数字>` で、prefix も
+/// `is_valid_room_id` を満たす) と判別したら prefix のみを返す。それ以外は
+/// `<id>` 全体をそのまま返す。
+///
+/// 13 桁以上を採用するのは epoch ミリ秒の桁数 (現代では 13 桁、長期運用で 14
+/// 桁も想定) を許容するためで、上限は設けない。room_id 形式の `lobby-<name>-<32 hex>`
+/// は末尾 32 hex で a-f を含み得るため、本ヒューリスティックでは判別しない
+/// (= 全体を採用する) ことで衝突しない。
+fn extract_room_id_for_spectate(id: &str) -> &str {
+    if let Some(idx) = id.rfind('-') {
+        let suffix = &id[idx + 1..];
+        let prefix = &id[..idx];
+        if suffix.len() >= 13
+            && suffix.chars().all(|c| c.is_ascii_digit())
+            && is_valid_room_id(prefix)
+        {
+            return prefix;
+        }
+    }
+    id
 }
 
 #[cfg(test)]
@@ -83,5 +117,74 @@ mod tests {
         assert_eq!(parse_ws_route("/ws/room-1/extra"), None);
         assert_eq!(parse_ws_route("/ws/room/1"), None);
         assert_eq!(parse_ws_route("/health"), None);
+    }
+
+    #[test]
+    fn extract_room_id_room_only() {
+        // game_id 形式ではない (suffix が短い / 数字でない) ので `<id>` 全体を
+        // そのまま room_id として返す。
+        assert_eq!(extract_room_id_for_spectate("lobby-foo-bar"), "lobby-foo-bar");
+    }
+
+    #[test]
+    fn extract_room_id_game_form() {
+        // 13 桁の epoch ms suffix を剥がして prefix を採用する。
+        assert_eq!(extract_room_id_for_spectate("lobby-foo-1777391025209"), "lobby-foo");
+    }
+
+    #[test]
+    fn extract_room_id_short_suffix() {
+        // 12 桁では epoch ms と判別しない (= room_id 全体を保持)。
+        assert_eq!(
+            extract_room_id_for_spectate("lobby-foo-123456789012"),
+            "lobby-foo-123456789012"
+        );
+    }
+
+    #[test]
+    fn extract_room_id_15_digit() {
+        // 15 桁 epoch (将来拡張) も上限なしルールで剥がす。
+        assert_eq!(extract_room_id_for_spectate("lobby-foo-123456789012345"), "lobby-foo");
+    }
+
+    #[test]
+    fn extract_room_id_non_digit_suffix() {
+        // 数字でない suffix (例: `abc`) は剥がさず room_id 全体を保持。
+        assert_eq!(extract_room_id_for_spectate("lobby-foo-abc"), "lobby-foo-abc");
+    }
+
+    #[test]
+    fn extract_room_id_room_id_with_dash_only() {
+        // 内部 `-` を保持する room_id (`lobby-cross-fischer-v2-...`) でも、
+        // 最後の `-` が数字 13 桁以上でなければ全体を保持する。
+        assert_eq!(
+            extract_room_id_for_spectate("lobby-cross-fischer-v2-deadbeef"),
+            "lobby-cross-fischer-v2-deadbeef"
+        );
+    }
+
+    #[test]
+    fn parses_spectator_route_with_game_id_form_strips_suffix() {
+        // 統合: parse_ws_route の spectate 経路に game_id 形式を渡しても
+        // 戻り値は既存形 `WsRoute::Spectator { room_id }`。
+        assert_eq!(
+            parse_ws_route("/ws/lobby-foo-1777391025209/spectate"),
+            Some(WsRoute::Spectator {
+                room_id: "lobby-foo".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_player_route_does_not_strip_suffix() {
+        // player 経路は suffix 剥がしを通さない (= 既存挙動完全維持)。
+        // ただし `id_from_name` のキー一致が前提なので、URL に書いたままを
+        // room_id として採用する。
+        assert_eq!(
+            parse_ws_route("/ws/lobby-foo-1777391025209"),
+            Some(WsRoute::Player {
+                room_id: "lobby-foo-1777391025209".to_owned(),
+            })
+        );
     }
 }

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -63,6 +63,14 @@ pub struct BroadcastEntry {
     pub target: BroadcastTarget,
     /// 送る生 CSA テキスト（末尾改行はフロントエンドで付ける）。
     pub line: CsaLine,
+    /// 行が指し手 broadcast の場合の手数（1 始まり）。
+    ///
+    /// `Some(n)` は「この行が n 手目の指し手」を意味する。観戦者向けの
+    /// snapshot 送信中に到着した broadcast を「snapshot に含めた最終 ply
+    /// より大きい行のみ」flush するための識別子として用いる。`None` は
+    /// 指し手以外（START、終局通知、CHAT 等）であり queue 経由でも常に
+    /// flush 対象となる。
+    pub ply: Option<u32>,
 }
 
 /// `GameRoom::handle_line` の 1 件分の戻り値。
@@ -364,6 +372,7 @@ impl GameRoom {
                     broadcasts: vec![BroadcastEntry {
                         target: BroadcastTarget::Players,
                         line,
+                        ply: None,
                     }],
                 })
             }
@@ -393,6 +402,7 @@ impl GameRoom {
                 broadcasts: vec![BroadcastEntry {
                     target: BroadcastTarget::Players,
                     line,
+                    ply: None,
                 }],
             })
         } else {
@@ -473,10 +483,14 @@ impl GameRoom {
         self.moves_played += 1;
         let elapsed_sec = elapsed_ms / 1000;
 
-        // 4. 関係者に `<token>,T<sec>` を配信。
+        // 4. 関係者に `<token>,T<sec>` を配信。手数は 1 始まりで、本手の
+        //    `do_move` 後 (= `moves_played` インクリメント後) の値をそのまま
+        //    乗せる。観戦者 snapshot 送信中に到着した broadcast を「snapshot
+        //    に含めた最終 ply より大きい行のみ」flush する判定で使う。
         let mut broadcasts = vec![BroadcastEntry {
             target: BroadcastTarget::All,
             line: CsaLine::new(format!("{},T{}", token.as_str(), elapsed_sec)),
+            ply: Some(self.moves_played),
         }];
 
         // 5. 千日手・連続王手千日手判定。
@@ -607,6 +621,7 @@ impl GameRoom {
                 broadcasts.push(BroadcastEntry {
                     target,
                     line: CsaLine::new(line.clone()),
+                    ply: None,
                 });
             }
         }

--- a/crates/rshogi-csa-server/src/protocol/summary.rs
+++ b/crates/rshogi-csa-server/src/protocol/summary.rs
@@ -42,6 +42,49 @@ pub struct GameSummaryBuilder {
 }
 
 impl GameSummaryBuilder {
+    /// 観戦者向け Game_Summary を組み立てる。
+    ///
+    /// 対局者向け [`Self::build_for`] との差分:
+    /// - `Your_Turn:` 行を出さない（観戦者は手を指せないため player 専用フィールドを除外）
+    /// - `Reconnect_Token:` 拡張行を出さない（観戦者は再接続トークンを保有しない）
+    /// - `END Game_Summary` 直前に `Black_Time_Remaining_Ms:` /
+    ///   `White_Time_Remaining_Ms:` 拡張行を追加（reconnect.rs と同形式）
+    ///
+    /// `black_remaining_ms` / `white_remaining_ms` は wire 上の残時間 (`u64`)。
+    /// `core.clock_remaining_main_ms()` を `max(0) as u64` で正規化した値を渡す
+    /// 契約。
+    pub fn build_for_spectator(&self, black_remaining_ms: u64, white_remaining_ms: u64) -> String {
+        let mut out = String::with_capacity(512);
+        out.push_str("BEGIN Game_Summary\n");
+        out.push_str("Protocol_Version:1.2\n");
+        out.push_str("Protocol_Mode:Server\n");
+        out.push_str("Format:Shogi 1.0\n");
+        if !self.declaration.is_empty() {
+            let _ = writeln!(out, "Declaration:{}", self.declaration);
+        }
+        let _ = writeln!(out, "Game_ID:{}", self.game_id);
+        let _ = writeln!(out, "Name+:{}", self.black);
+        let _ = writeln!(out, "Name-:{}", self.white);
+        let _ =
+            writeln!(out, "Rematch_On_Draw:{}", if self.rematch_on_draw { "YES" } else { "NO" });
+        let _ = writeln!(out, "To_Move:{}", color_char(self.to_move));
+        // 持ち時間セクションは TimeClock 由来の文字列をそのまま埋め込む。
+        out.push_str(&self.time_section);
+        if !self.time_section.ends_with('\n') {
+            out.push('\n');
+        }
+        // 初期局面セクション（`BEGIN Position`...`END Position` 全体）。
+        out.push_str(&self.position_section);
+        if !self.position_section.ends_with('\n') {
+            out.push('\n');
+        }
+        // 観戦者向け拡張行: 残時間 (ms 粒度)。reconnect.rs:148-149 と同形式。
+        let _ = writeln!(out, "Black_Time_Remaining_Ms:{black_remaining_ms}");
+        let _ = writeln!(out, "White_Time_Remaining_Ms:{white_remaining_ms}");
+        out.push_str("END Game_Summary\n");
+        out
+    }
+
     /// `you` 宛ての Game_Summary 文字列を組み立てる。
     ///
     /// `Your_Turn:` は `you` の色に応じて `+`/`-` を出力する。
@@ -402,6 +445,59 @@ mod tests {
         assert!(!white_out.contains("Reconnect_Token:"), "white must omit token: {white_out}");
         let black_out = b.build_for(Color::Black);
         assert!(black_out.contains("\nReconnect_Token:only-black\n"));
+    }
+
+    #[test]
+    fn build_for_spectator_omits_your_turn_and_reconnect_token() {
+        let mut b = skeleton();
+        b.black_reconnect_token = Some(ReconnectToken::new("blk-token"));
+        b.white_reconnect_token = Some(ReconnectToken::new("wht-token"));
+        let txt = b.build_for_spectator(540_000, 600_000);
+        assert!(txt.starts_with("BEGIN Game_Summary\n"));
+        assert!(txt.ends_with("END Game_Summary\n"));
+        assert!(!txt.contains("Your_Turn:"), "spectator must not have Your_Turn: {txt}");
+        assert!(
+            !txt.contains("Reconnect_Token:"),
+            "spectator must not leak Reconnect_Token: {txt}"
+        );
+    }
+
+    #[test]
+    fn build_for_spectator_appends_remaining_ms_lines_before_end() {
+        let txt = skeleton().build_for_spectator(123_456, 654_321);
+        let black = txt
+            .find("Black_Time_Remaining_Ms:123456\n")
+            .unwrap_or_else(|| panic!("missing black remaining: {txt}"));
+        let white = txt
+            .find("White_Time_Remaining_Ms:654321\n")
+            .unwrap_or_else(|| panic!("missing white remaining: {txt}"));
+        let end_pos = txt.find("END Position\n").unwrap();
+        let end_summary = txt.find("END Game_Summary\n").unwrap();
+        assert!(end_pos < black, "Black_Time_Remaining_Ms must follow END Position");
+        assert!(black < white, "Black before White");
+        assert!(white < end_summary, "remaining lines must precede END Game_Summary");
+    }
+
+    #[test]
+    fn build_for_spectator_includes_time_section_and_position() {
+        let txt = skeleton().build_for_spectator(1_000, 2_000);
+        assert!(txt.contains("BEGIN Time"));
+        assert!(txt.contains("END Time"));
+        assert!(txt.contains("BEGIN Position"));
+        assert!(txt.contains("END Position"));
+        assert!(txt.contains("To_Move:+"));
+    }
+
+    #[test]
+    fn build_for_player_is_unchanged_after_spectator_addition() {
+        // 既存 player 経路の挙動が壊れていないことを spectator builder 追加前後で
+        // 直接照合する。`Your_Turn:` が出る、`Reconnect_Token:` が None なら出ない、
+        // `Black_Time_Remaining_Ms:` は player 経路には出ない。
+        let txt = skeleton().build_for(Color::Black);
+        assert!(txt.contains("Your_Turn:+"));
+        assert!(!txt.contains("Reconnect_Token:"));
+        assert!(!txt.contains("Black_Time_Remaining_Ms:"));
+        assert!(!txt.contains("White_Time_Remaining_Ms:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

ramu-shogi viewer から進行中対局を観戦するための MVP サーバ機能を追加する。
`/ws/<id>/spectate` 経路で `%%MONITOR2ON <gameId>` を受けたとき、
`Game_Summary` ブロック + 既存指し手 + (終局済なら) 結果コードを 1 回 send する
snapshot replay 機能を実装。snapshot 送信中に到着した broadcast は per-ws pending
queue で退避 → 完了直後に `ply > last_ply_in_snapshot` のみ flush することで
重複指し手の二重表示を排除する。

設計コメント (v5): https://github.com/SH11235/ramu-shogi/issues/26#issuecomment-4341224281

## 主な変更

- `crates/rshogi-csa-server-workers/src/spectator_snapshot.rs` 新設: `build_spectator_snapshot` 純粋関数 (4 シナリオの host-side テスト pin)
- `crates/rshogi-csa-server/src/protocol/summary.rs::GameSummaryBuilder::build_for_spectator` 追加 (`Your_Turn:` / `Reconnect_Token:` を出さず、末尾に `Black/White_Time_Remaining_Ms:` 拡張行を追加)
- `crates/rshogi-csa-server-workers/src/spectator_control.rs::resolve_monitor_target_with_finished` 追加 (終局済 DO の game_id も accept、優先順 active > finished > room)
- `crates/rshogi-csa-server-workers/src/attachment.rs::WsAttachment::Spectator` に `snapshot_in_progress` / `last_ply_in_snapshot` / `pending_queue` を追加 (旧 schema は `serde(default)` で互換維持)
- `crates/rshogi-csa-server-workers/src/ws_route.rs::extract_room_id_for_spectate` 追加 (spectate 経路のみ末尾 `-<13 桁以上 epoch_ms>` を剥がして DO ルーティング、player 経路は不変)
- `crates/rshogi-csa-server/src/game/room.rs::BroadcastEntry` に `ply: Option<u32>` field 追加 (指し手 broadcast のみ `Some(moves_played)`、START / 終局通知は `None`)
- `crates/rshogi-csa-server-workers/src/game_room.rs`:
  - `handle_spectator_line` の Monitor2On Accept に snapshot 送信を組込
  - `send_to_spectators(line, ply)` で snapshot 送信中の ws へは queue へ退避し send は飛ばす
  - `fetch` で観戦経路のみ `MAX_SPECTATORS_PER_ROOM = 50` 超過時に 503 を返す

## 既存 player 経路への影響

- `GameSummaryBuilder::build_for(color)` は無変更 (新規ヘルパとして並立)
- player route の `parse_ws_route` 挙動は変更なし (`extract_room_id_for_spectate` は spectate 経路のみ通る)
- `BroadcastEntry::ply` 追加は構造体拡張のみで、player 配信経路ではフィールドを参照しない

## Test plan

- [x] `cargo fmt --check` PASS
- [x] `cargo clippy --workspace --tests` 警告 0
- [x] `cargo test --workspace` 全 760+ tests 緑
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` 緑
- [x] 新規ユニットテスト:
  - `build_spectator_snapshot`: 初手前 / 数手後 / 終局直後 / 終局済 DO の 4 シナリオ
  - `resolve_monitor_target_with_finished`: room/active/finished 各組合せ 5 ケース
  - `extract_room_id_for_spectate`: 6 ケース + parse_ws_route 統合 2 ケース
  - `build_for_spectator`: Your_Turn/Reconnect_Token 除外、残時間行配置、player builder 不変性
  - `WsAttachment::Spectator`: round-trip + 旧 schema からのデフォルト復元
- [ ] 別 PR (ramu-shogi#26 client side) と組み合わせた staging E2E 確認

## Closes / Refs

Closes ramu-shogi#26 (server side)
Refs #541 (Epic)