### PR TITLE
feat(csa-server): /api/v1/games/live と live-games-index R2 prefix を実装する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -29,7 +29,7 @@
 //!    CSA V2 形式で組み立て、R2 の `YYYY/MM/DD/<game_id>.csa` に書き出す。
 //!    TCP 側 `FileKifuStorage` と同一キー体系で Ruby 系バッチとの互換性を保つ。
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,9 @@ use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc}
 use crate::floodgate_history::R2FloodgateHistoryStorage;
 use crate::games_index::{
     ClockSpec as IndexClockSpec, GamesIndexEntry, classify_result, games_index_key,
+    resolve_index_source,
 };
+use crate::live_games_index::{LiveGamesIndexEntry, live_games_index_key};
 use crate::persistence::{
     FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
 };
@@ -145,6 +147,17 @@ pub struct GameRoom {
     env: Env,
     core: RefCell<Option<CoreRoom>>,
     config: RefCell<Option<PersistedConfig>>,
+    /// この isolate 寿命中に `live-games-index/<inv>-<id>.json` の put が成功
+    /// 済みかどうか (Issue #549)。hibernation で isolate が破棄されると
+    /// `false` に戻るため、cold start 後の最初の `ensure_core_loaded` で 1 回
+    /// だけ retry が走る。`mark_play_started` 経路で put 成功した直後にも
+    /// `true` を立て、同 isolate 内の後続 `ensure_core_loaded` で冗長 put が
+    /// 走らないようにする。
+    ///
+    /// put 失敗時はあえて `false` のまま残す (= 次回 `ensure_core_loaded` で
+    /// retry させる)。R2 put は同一キーで上書きしても idempotent なので
+    /// 重複 put は安全。
+    live_index_put_done: Cell<bool>,
 }
 
 impl DurableObject for GameRoom {
@@ -156,6 +169,7 @@ impl DurableObject for GameRoom {
             env,
             core: RefCell::new(None),
             config: RefCell::new(None),
+            live_index_put_done: Cell::new(false),
         }
     }
 
@@ -1214,6 +1228,22 @@ impl GameRoom {
         };
         self.state.storage().put(KEY_FINISHED, &finished).await?;
 
+        // KEY_FINISHED が確定した後に live-games-index entry を best-effort で
+        // 削除する (Issue #549 §4)。「終局 entry も live entry も無い」矛盾
+        // 状態を最小化するため、`KEY_FINISHED` put より後に delete を置く。
+        // delete 失敗時は orphan として残るが、cron sweep (Issue #551) が
+        // 後追い掃除する契約。`play_started_at_ms` が None のまま終局した
+        // (= AGREE 前 abnormal 等) ケースは live entry を put していないので
+        // delete も skip する。
+        let live_delete_target = self
+            .config
+            .borrow()
+            .as_ref()
+            .and_then(|c| c.play_started_at_ms.map(|ts| (c.clone(), ts)));
+        if let Some((cfg_snapshot, started_at_ms)) = live_delete_target {
+            self.try_delete_live_games_index(&cfg_snapshot, started_at_ms).await;
+        }
+
         // CoreRoom を落とす。再度 ensure_core_loaded しても finished ガードで戻る。
         self.core.borrow_mut().take();
 
@@ -1303,15 +1333,11 @@ impl GameRoom {
         // serialize / put すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。
         // `?` は意図的に使わない。
         //
-        // `source` は `resolve_floodgate_history_storage` が `Some` を返せる構成
-        // (= Floodgate gating opt-in & binding 解決可) かどうかで事前判定する。
-        // `floodgate-history/` への put 成否ではなく「Floodgate 環境設定下で起きた
-        // 終局」を表す semantics (v3 設計の `source` field 定義に従う)。
-        let source = if resolve_floodgate_history_storage(&self.env).ok().flatten().is_some() {
-            "floodgate"
-        } else {
-            "kifu"
-        };
+        // `source` 判定は `live-games-index/` の対局開始時 entry と完全に揃える
+        // ため、`games_index::resolve_index_source` 共通 helper に集約済 (Issue
+        // #549 設計 v3 §3)。`floodgate-history/` への put 成否ではなく「Floodgate
+        // 環境設定下で起きた終局」を表す semantics は同 helper の契約に従う。
+        let source = resolve_index_source(&self.env);
 
         let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
             Ok(k) => k,
@@ -1524,7 +1550,11 @@ impl GameRoom {
     /// - 復元中の `handle_line` 失敗（`AgreeReplayFailed` / `MoveReplayFailed` 等）
     ///   ではコアを生成せず、以降の着手受理を拒絶する。
     async fn ensure_core_loaded(&self) -> Result<()> {
+        // core が既に組み立て済の場合でも、live-games-index 未 put のまま
+        // hibernation を跨いで再 attach した場合に retry が必要なので、
+        // 早期 return ではなく `live_index_put_done` の照合を先に行う。
         if self.core.borrow().is_some() {
+            self.retry_live_games_index_if_needed().await?;
             return Ok(());
         }
         if self.load_finished().await?.is_some() {
@@ -1561,11 +1591,48 @@ impl GameRoom {
                 console_log!("[GameRoom] replay move ply={ply} line='{line}' failed: {reason}");
             }
         }
+
+        // live-games-index put が抜けたまま hibernation で isolate が落ちた
+        // ケースを救済する (Issue #549 §5)。
+        self.retry_live_games_index_if_needed().await?;
+        Ok(())
+    }
+
+    /// `live-games-index/<inv>-<id>.json` の put が `mark_play_started` 経路で
+    /// 抜けた／hibernation で isolate が落ちた場合のリカバリ。
+    ///
+    /// 条件: 同 isolate 寿命中に未 put (`live_index_put_done == false`) かつ
+    /// `play_started_at_ms.is_some()` (= 対局開始済) かつ未終局
+    /// (`load_finished == None`)。3 つすべて満たすときに 1 回だけ
+    /// `try_put_live_games_index` を呼ぶ。put 成功で flag が立つので、同
+    /// isolate 内の後続 `ensure_core_loaded` では re-entry しない。
+    async fn retry_live_games_index_if_needed(&self) -> Result<()> {
+        if self.live_index_put_done.get() {
+            return Ok(());
+        }
+        if self.load_finished().await?.is_some() {
+            return Ok(());
+        }
+        let cfg_for_put: Option<PersistedConfig> = self
+            .config
+            .borrow()
+            .as_ref()
+            .filter(|c| c.play_started_at_ms.is_some())
+            .cloned();
+        if let Some(c) = cfg_for_put {
+            self.try_put_live_games_index(&c).await;
+        }
         Ok(())
     }
 
     /// 初めて `HandleOutcome::GameStarted` を観測した時刻を cfg に書き込む。
     /// 2 手目以降は冪等に no-op として扱い、storage への再書き込みを避ける。
+    ///
+    /// `KEY_CONFIG` の put 成功後にのみ live-games-index entry の put を
+    /// best-effort で試みる。put 成功時のみ `live_index_put_done` を立てて、
+    /// 同 isolate 内で `ensure_core_loaded` 経由の retry が走らないようにする。
+    /// put 失敗時は flag を立てず、次回の `ensure_core_loaded` 呼び出しで
+    /// retry させる (R2 put は同一キーで idempotent)。
     async fn mark_play_started(&self, ts: u64) -> Result<()> {
         let new_cfg = {
             let mut borrow = self.config.borrow_mut();
@@ -1579,8 +1646,125 @@ impl GameRoom {
         };
         if let Some(c) = new_cfg {
             self.state.storage().put(KEY_CONFIG, &c).await?;
+            // KEY_CONFIG put 成功後にのみ live index put を試みる。これが
+            // Err を返しても finalize 経路ではないので最終的な動作には影響
+            // しない (best-effort)。
+            self.try_put_live_games_index(&c).await;
         }
         Ok(())
+    }
+
+    /// `live-games-index/<inv>-<id>.json` を best-effort で put する。
+    ///
+    /// `cfg.play_started_at_ms` が `None` の場合は live index put が成立しない
+    /// (= mark_play_started 前) ため早期 return する。すべての失敗 (key
+    /// validation / serialize / R2 put) を `console_log!` で吸収し、`Result`
+    /// は返さない。put 成功時のみ `live_index_put_done` を `true` にセットする。
+    async fn try_put_live_games_index(&self, cfg: &PersistedConfig) {
+        let Some(started_at_ms) = cfg.play_started_at_ms else {
+            return;
+        };
+
+        let key = match live_games_index_key(started_at_ms, &cfg.game_id) {
+            Ok(k) => k,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_skip game_id={} reason=key:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        let source = resolve_index_source(&self.env);
+        let entry = LiveGamesIndexEntry {
+            game_id: &cfg.game_id,
+            started_at_ms,
+            black_handle: &cfg.black_handle,
+            white_handle: &cfg.white_handle,
+            clock: IndexClockSpec::from_server(&cfg.clock),
+            source,
+        };
+
+        let body = match serde_json::to_vec(&entry) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_skip game_id={} reason=serialize:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_skip game_id={} reason=bucket:{}",
+                    cfg.game_id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        match bucket.put(&key, body).execute().await {
+            Ok(_) => {
+                self.live_index_put_done.set(true);
+            }
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_put_failed game_id={} key={} err={:?}",
+                    cfg.game_id,
+                    key,
+                    e,
+                );
+            }
+        }
+    }
+
+    /// `live-games-index/<inv>-<id>.json` を best-effort で delete する。
+    ///
+    /// 終局確定 (`KEY_FINISHED` put 成功) 直後に呼び、live 一覧から進行中
+    /// 表示を消す。失敗 (R2 一時障害 / key 生成失敗) は `console_log!` で
+    /// 吸収して `Result` を返さない。残った orphan は Issue #551 の sweep
+    /// ジョブで掃除する契約。
+    async fn try_delete_live_games_index(&self, cfg: &PersistedConfig, started_at_ms: u64) {
+        let key = match live_games_index_key(started_at_ms, &cfg.game_id) {
+            Ok(k) => k,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_delete_skip game_id={} reason=key:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=live_games_index_delete_skip game_id={} reason=bucket:{}",
+                    cfg.game_id,
+                    e,
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = bucket.delete(&key).await {
+            console_log!(
+                "[GameRoom] event=live_games_index_delete_failed game_id={} key={} err={:?}",
+                cfg.game_id,
+                key,
+                e,
+            );
+        }
     }
 
     /// `moves` テーブルを ply 昇順で読み出す。

--- a/crates/rshogi-csa-server-workers/src/games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_index.rs
@@ -30,9 +30,14 @@
 //! disallowed char 系を host target で検証する。R2 アダプタ固有の経路 (list /
 //! pagination) は `wrangler dev` で別途確認する。
 
+use rshogi_csa_server::config::{
+    FloodgateFeatureIntent, parse_allow_floodgate_features, validate_floodgate_feature_gate,
+};
 use rshogi_csa_server::error::StorageError;
 use serde::Serialize;
 
+#[cfg(target_arch = "wasm32")]
+use crate::config::ConfigKeys;
 use crate::floodgate_history::validate_key_component;
 
 /// `inv_ms = INV_BASE - ended_at_ms` の基準値。`10^14 - 1` を u64 で表現。
@@ -206,6 +211,67 @@ pub fn classify_result(
             None => ("ABORT", "ABNORMAL"),
         },
     }
+}
+
+/// `source` フィールド (`"kifu"` / `"floodgate"`) を env から導出する。
+///
+/// 「Floodgate gating が opt-in されており (`ALLOW_FLOODGATE_FEATURES`)、
+/// `FLOODGATE_HISTORY_BUCKET` binding も解決可能」な構成を `"floodgate"` と
+/// 表現する。それ以外はすべて `"kifu"`。`floodgate-history/` への put 成否は
+/// 判定材料にしない (= live entry put 時点では終局していない / floodgate-history
+/// は終局時にしか書かない、という非対称性を吸収する)。
+///
+/// games-index の終局時 entry 経路と live-games-index の対局開始時 entry 経路
+/// の双方から呼び出して `source` の値を完全に揃えるための共通 helper。
+///
+/// `Env` 依存は `worker::Env` の var / bucket 取得だけに閉じており、純粋判定
+/// ロジック自体は [`classify_index_source_from_inputs`] に切り出してホスト
+/// target でも単体テストできるようにしてある。
+///
+/// `worker` クレートは `cfg(target_arch = "wasm32")` でのみ依存に含まれるため、
+/// 本関数も wasm32 ビルドに限定する。ホスト target の単体テストは
+/// [`classify_index_source_from_inputs`] 経由で網羅する。
+#[cfg(target_arch = "wasm32")]
+pub fn resolve_index_source(env: &worker::Env) -> &'static str {
+    let allow_raw = env.var(ConfigKeys::ALLOW_FLOODGATE_FEATURES).ok().map(|v| v.to_string());
+    let bucket_resolves = env.bucket(ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING).is_ok();
+    classify_index_source_from_inputs(allow_raw.as_deref(), bucket_resolves)
+}
+
+/// [`resolve_index_source`] の純粋関数版。
+///
+/// `allow_raw`: `ALLOW_FLOODGATE_FEATURES` env の生文字列 (未設定なら `None`)。
+/// `bucket_resolves`: `FLOODGATE_HISTORY_BUCKET` binding が解決できたか。
+///
+/// `parse_allow_floodgate_features` と `validate_floodgate_feature_gate`
+/// を経由して "Floodgate 履歴 opt-in が成立する構成" を判定し、binding まで
+/// 揃っている場合に限り `"floodgate"` を返す。それ以外 (opt-in 未成立、
+/// gate 不整合、binding 未解決) はすべて `"kifu"` に倒す。
+pub fn classify_index_source_from_inputs(
+    allow_raw: Option<&str>,
+    bucket_resolves: bool,
+) -> &'static str {
+    // env 値の読み取り失敗 (parse error / gate 不整合) は kifu 側に倒す。
+    // viewer 配信 API 用 index は best-effort なので、設定不正で `floodgate`
+    // を誤って付けるよりは保守的に "kifu" を返すほうが矛盾が少ない。
+    let allow = match parse_allow_floodgate_features(allow_raw) {
+        Ok(v) => v,
+        Err(_) => return "kifu",
+    };
+    if !allow {
+        return "kifu";
+    }
+    let intent = FloodgateFeatureIntent {
+        enable_floodgate_history: true,
+        ..FloodgateFeatureIntent::default()
+    };
+    if validate_floodgate_feature_gate(allow, intent).is_err() {
+        return "kifu";
+    }
+    if !bucket_resolves {
+        return "kifu";
+    }
+    "floodgate"
 }
 
 #[cfg(test)]
@@ -411,6 +477,37 @@ mod tests {
         assert_eq!(wire.total_min, Some(15));
         assert_eq!(wire.byoyomi_min, Some(2));
         assert_eq!(wire.total_sec, None);
+    }
+
+    #[test]
+    fn classify_index_source_returns_kifu_when_allow_unset() {
+        assert_eq!(classify_index_source_from_inputs(None, false), "kifu");
+        assert_eq!(classify_index_source_from_inputs(None, true), "kifu");
+    }
+
+    #[test]
+    fn classify_index_source_returns_kifu_when_allow_false() {
+        assert_eq!(classify_index_source_from_inputs(Some("0"), true), "kifu",);
+        assert_eq!(classify_index_source_from_inputs(Some("false"), true), "kifu",);
+    }
+
+    #[test]
+    fn classify_index_source_returns_kifu_when_bucket_missing() {
+        // opt-in は成立するが binding が解決できない (= dev で binding 未宣言)。
+        assert_eq!(classify_index_source_from_inputs(Some("1"), false), "kifu",);
+    }
+
+    #[test]
+    fn classify_index_source_returns_floodgate_when_opt_in_and_bucket() {
+        assert_eq!(classify_index_source_from_inputs(Some("1"), true), "floodgate",);
+        assert_eq!(classify_index_source_from_inputs(Some("true"), true), "floodgate",);
+    }
+
+    #[test]
+    fn classify_index_source_returns_kifu_for_unparseable_allow() {
+        // `parse_allow_floodgate_features` が Err を返す入力。設定不正は
+        // 保守的に kifu に倒す (live / games index の `source` は best-effort)。
+        assert_eq!(classify_index_source_from_inputs(Some("maybe"), true), "kifu",);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -27,6 +27,7 @@ pub mod config;
 pub mod datetime;
 pub mod floodgate_history;
 pub mod games_index;
+pub mod live_games_index;
 pub mod lobby_protocol;
 pub mod origin;
 // `persistence` は DO ランタイム (`game_room`) からのみ消費される I/O 非依存の

--- a/crates/rshogi-csa-server-workers/src/live_games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/live_games_index.rs
@@ -1,0 +1,184 @@
+//! viewer 配信 API 用の R2 補助インデックス (`live-games-index/...`)。
+//!
+//! 進行中対局の発見手段として、`GameRoom` DO の対局開始時に
+//! `live-games-index/<inv_started_ms>-<game_id>.json` を 1 件 put し、
+//! 終局時に同 key を delete する。`/api/v1/games/live` ハンドラはこの prefix を
+//! R2 list することで現在 active な対局一覧を返す。
+//!
+//! `games_index` (`games-index/`、終局時 entry) と対称設計。違いは並び順軸が
+//! `started_at_ms` 降順 (= 開始が新しい順) であることと、終局後に消える点のみ。
+//! `INV_BASE` と `validate_key_component` は `games_index` / `floodgate_history`
+//! から再利用する (重複定義しない)。
+//!
+//! # 整合性モデル (best-effort, eventual)
+//!
+//! - 対局開始 → R2 put までの数百 ms ～ 数秒は live に出てこない
+//! - 終局 → R2 delete までは live に残る (viewer の click 時に既に終局済 cfg)
+//! - DO crash で put 済だが delete されない orphan が残るリスクあり
+//!   (orphan sweep は Issue #551 で扱う backfill ジョブに統合する)
+//!
+//! pagination 中に entry が追加・削除されうるため、同じ cursor で 2 回 list を
+//! 呼んでも結果集合が一致しない。viewer 側は live entry を **発見手段** として
+//! 扱い、行クリック時に WS spectate 接続で実状態を確認する前提。
+
+use rshogi_csa_server::error::StorageError;
+use serde::Serialize;
+
+use crate::floodgate_history::validate_key_component;
+use crate::games_index::{ClockSpec, INV_BASE};
+
+/// `live-games-index/` prefix。`/api/v1/games/live` ハンドラはこの prefix に対して
+/// R2 list を発行する。
+pub const LIVE_KEY_PREFIX: &str = "live-games-index/";
+
+/// 1 対局 1 オブジェクトの live index key を構築する。
+///
+/// `started_at_ms` が `INV_BASE` を超える場合は `StorageError::Malformed` を返す
+/// (write 経路で best-effort 失敗として観測ログに残す)。
+pub fn live_games_index_key(started_at_ms: u64, game_id: &str) -> Result<String, StorageError> {
+    let validated = validate_key_component(game_id)?;
+    if started_at_ms > INV_BASE {
+        return Err(StorageError::Malformed(format!(
+            "started_at_ms {started_at_ms} exceeds INV_BASE {INV_BASE}"
+        )));
+    }
+    let inv = INV_BASE - started_at_ms;
+    Ok(format!("{LIVE_KEY_PREFIX}{inv:014}-{validated}.json"))
+}
+
+/// live-games-index に書き込む 1 entry の wire format。
+///
+/// `started_at_ms` は **常に `play_started_at_ms`** (= `mark_play_started`
+/// 観測時刻)。`matched_at_ms` への fallback は意図的に不採用 (live put は
+/// `mark_play_started` 経路でしか発火しない契約)。
+///
+/// `source` は `"kifu"` / `"floodgate"` の 2 値。判定は
+/// [`crate::games_index::resolve_index_source`] 共通 helper に集約しており、
+/// 本モジュールでは事前に解決済みの値を受け取る。
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct LiveGamesIndexEntry<'a> {
+    pub game_id: &'a str,
+    pub started_at_ms: u64,
+    pub black_handle: &'a str,
+    pub white_handle: &'a str,
+    pub clock: ClockSpec<'a>,
+    pub source: &'static str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_games_index_key_pads_inv_ms_to_14_digits() {
+        // started_at_ms = 1 → inv = INV_BASE - 1 = 99_999_999_999_998 (14 桁)
+        let key = live_games_index_key(1, "g1").unwrap();
+        assert_eq!(key, "live-games-index/99999999999998-g1.json");
+    }
+
+    #[test]
+    fn live_games_index_key_inv_ms_zero_pads_for_recent_timestamp() {
+        // 2026-04-29 頃の epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
+        let started = 1_777_391_025_209_u64;
+        let key = live_games_index_key(started, "lobby-cross-fischer-1777391025209").unwrap();
+        // INV_BASE - 1_777_391_025_209 = 98_222_608_974_790 (14 桁)
+        assert_eq!(key, "live-games-index/98222608974790-lobby-cross-fischer-1777391025209.json");
+    }
+
+    #[test]
+    fn live_games_index_key_lex_order_matches_descending_started_at() {
+        // 早い開始 → 古い → inv が大きい → key が lex 後ろ。
+        // 遅い開始 → 新しい → inv が小さい → key が lex 前。
+        let early = live_games_index_key(1_000_000_000_000, "g1").unwrap();
+        let late = live_games_index_key(2_000_000_000_000, "g2").unwrap();
+        assert!(late < early, "late {late} should sort before early {early}");
+    }
+
+    #[test]
+    fn live_games_index_key_inv_zero_when_started_at_eq_inv_base() {
+        let key = live_games_index_key(INV_BASE, "g1").unwrap();
+        assert_eq!(key, "live-games-index/00000000000000-g1.json");
+    }
+
+    #[test]
+    fn live_games_index_key_rejects_overflowing_started_at() {
+        let err = live_games_index_key(INV_BASE + 1, "g1").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn live_games_index_key_rejects_game_id_with_slash() {
+        // `/` は R2 の階層区切り。validate_key_component 経由で弾かれる。
+        let err = live_games_index_key(1_000, "g1/evil").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn live_games_index_key_rejects_empty_game_id() {
+        let err = live_games_index_key(1_000, "").unwrap_err();
+        assert!(matches!(err, StorageError::Malformed(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn live_games_index_key_rejects_disallowed_punctuation() {
+        // `.` / 空白 / `?` 等 ASCII でも英数 + `-` `_` 以外は拒否。
+        for bad in ["g.1", "g 1", "g?1", "g+1", "g/1"] {
+            let err = live_games_index_key(1_000, bad).unwrap_err();
+            assert!(
+                matches!(err, StorageError::Malformed(_)),
+                "input={bad:?} expected Malformed, got: {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn live_games_index_key_accepts_underscore_and_dash() {
+        let key = live_games_index_key(1_000, "g_1-abc").unwrap();
+        assert!(key.ends_with("-g_1-abc.json"), "got: {key}");
+    }
+
+    #[test]
+    fn live_entry_serializes_with_expected_fields() {
+        let entry = LiveGamesIndexEntry {
+            game_id: "g1",
+            started_at_ms: 1_777_391_025_209,
+            black_handle: "alice",
+            white_handle: "bob",
+            clock: ClockSpec {
+                kind: "fischer",
+                total_sec: Some(300),
+                byoyomi_sec: None,
+                byoyomi_ms: None,
+                increment_sec: Some(5),
+                total_ms: None,
+                total_min: None,
+                byoyomi_min: None,
+            },
+            source: "kifu",
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"game_id\":\"g1\""), "json={json}");
+        assert!(json.contains("\"started_at_ms\":1777391025209"), "json={json}");
+        assert!(json.contains("\"black_handle\":\"alice\""), "json={json}");
+        assert!(json.contains("\"white_handle\":\"bob\""), "json={json}");
+        assert!(json.contains("\"source\":\"kifu\""), "json={json}");
+        // 未使用 clock field は省略される。
+        assert!(!json.contains("byoyomi_sec"), "json={json}");
+        assert!(!json.contains("total_ms"), "json={json}");
+        // ended_at_ms / result_kind / moves_count は live entry の wire には出ない。
+        assert!(!json.contains("ended_at_ms"), "json={json}");
+        assert!(!json.contains("result_kind"), "json={json}");
+        assert!(!json.contains("moves_count"), "json={json}");
+    }
+
+    #[test]
+    fn live_key_prefix_matches_expected_string() {
+        // viewer_api ハンドラと R2 list でしか参照されない契約値を固定。
+        assert_eq!(LIVE_KEY_PREFIX, "live-games-index/");
+    }
+
+    // `source` の env 切替判定は `games_index::resolve_index_source` (wasm32
+    // 限定) に集約済み。ホスト target からは純粋関数
+    // `games_index::classify_index_source_from_inputs` のテスト
+    // (`games_index::tests`) で網羅する。
+}

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -1,25 +1,40 @@
 //! viewer 配信 HTTP API (`/api/v1/games`) のルーティングと R2 アクセス。
 //!
-//! v3 設計 (Issue #542 issuecomment-4338088406) に準拠する 2 エンドポイント:
+//! v3 設計 (Issue #542 issuecomment-4338088406) に準拠する 3 エンドポイント:
 //!
-//! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧
+//! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧 (終局済)
 //!   `KIFU_BUCKET.list({prefix: "games-index/", cursor, limit})` を 1 回呼び、
 //!   各オブジェクト本文 (= [`crate::games_index::GamesIndexEntry`] の JSON) を
 //!   そのまま `games[]` に詰めて返す。`next_cursor` は R2 list の cursor を
 //!   opaque 転送する。
-//! - `GET /api/v1/games/<game_id>` 単局
+//! - `GET /api/v1/games/live?cursor=<opaque>&limit=<N>` 一覧 (進行中)
+//!   `KIFU_BUCKET.list({prefix: "live-games-index/", cursor, limit})` を 1 回呼び、
+//!   各オブジェクト本文 (= [`crate::live_games_index::LiveGamesIndexEntry`] の JSON)
+//!   を `live_games[]` に詰めて返す (Issue #549)。終局済 list と同じ pagination
+//!   semantics、`/api/v1/games/<id>` のような単局エンドポイントは進行中対局には
+//!   設けない (= viewer 側は live entry を **発見手段** として扱い、行クリック時に
+//!   WS spectate 接続で実状態を確認する)。
+//! - `GET /api/v1/games/<game_id>` 単局 (終局済)
 //!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
 //!   `games-index/` から取得した meta を合わせて返す。
 //!
 //! いずれも GameRoom DO を経由せず、Worker 直 fetch のみで完結する (R2 read
 //! 1 ホップ)。CORS は staging では `WS_ALLOWED_ORIGINS` をそのまま流用して
 //! ramu-shogi origin に絞る (実装の柔軟性で OK)。
+//!
+//! # access control レビュー必須
+//!
+//! `try_handle` 配下に新しい `/api/v1/*` エンドポイントを追加する場合は、
+//! `check_origin` / `with_cors` の通過と `WS_ALLOWED_ORIGINS` allowlist 体系
+//! (Issue #550 で強化予定) に確実に乗ることを必ずレビューする。allowlist 未設定
+//! 環境での挙動 (= Origin ヘッダなしで通る) も含めて回帰させない。
 
 use serde::Serialize;
 use worker::{Env, Headers, Method, Request, Response, Result, Url};
 
 use crate::config::{ConfigKeys, OriginAllowList};
 use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
+use crate::live_games_index::LIVE_KEY_PREFIX;
 use crate::origin::{OriginDecision, evaluate};
 use crate::x1_paths::kifu_by_id_object_key;
 
@@ -41,6 +56,11 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     if path == "/api/v1/games" {
         return Ok(Some(handle_list(req, env, &url).await?));
     }
+    // `/api/v1/games/live` は `/api/v1/games/<game_id>` より先にマッチさせる
+    // (`live` という ID の単局取得を 1 件目で誤って受けないため)。
+    if path == "/api/v1/games/live" {
+        return Ok(Some(handle_list_live(req, env, &url).await?));
+    }
     if let Some(rest) = path.strip_prefix("/api/v1/games/") {
         if rest.is_empty() || rest.contains('/') {
             // 余分な階層 (`/api/v1/games/x/y`) や末尾 `/` は 404 で扱う。
@@ -52,7 +72,7 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     Ok(None)
 }
 
-/// 一覧 API レスポンスの wire 形状。
+/// 一覧 API (`/api/v1/games`) レスポンスの wire 形状。
 #[derive(Debug, Serialize)]
 struct ListResponse {
     /// `games-index/` のオブジェクト本文をそのまま吐き出すのが契約 (本モジュールでは
@@ -60,6 +80,17 @@ struct ListResponse {
     /// する素朴実装。要素数 1 ページ最大 100 件のため性能影響は許容。`RawValue` 化は
     /// レイテンシが顕在化したときの将来拡張で検討する。
     games: Vec<serde_json::Value>,
+    next_cursor: Option<String>,
+}
+
+/// 進行中対局一覧 API (`/api/v1/games/live`) レスポンスの wire 形状。
+///
+/// `games` ではなく `live_games` をキーに使うことで、終局済一覧との混在を
+/// client 側で取り違えないように分離する (viewer 側は配列キー名を見て描画
+/// ルートを切り替えられる)。
+#[derive(Debug, Serialize)]
+struct LiveListResponse {
+    live_games: Vec<serde_json::Value>,
     next_cursor: Option<String>,
 }
 
@@ -74,10 +105,67 @@ struct GameResponse<'a> {
     meta: serde_json::Value,
 }
 
-/// 一覧ハンドラ。
+/// 終局済一覧ハンドラ。`games-index/` を 1 ページ list する。
 async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
+    let entries = match collect_index_page(req, env, url, GAMES_INDEX_PREFIX, "games_index").await?
+    {
+        CollectOutcome::Page(p) => p,
+        CollectOutcome::ErrorResponse(r) => return Ok(r),
+    };
+    let payload = ListResponse {
+        games: entries.entries,
+        next_cursor: entries.next_cursor,
+    };
+    let resp = Response::from_json(&payload)?;
+    with_cors(resp, req, env)
+}
+
+/// 進行中対局一覧ハンドラ。`live-games-index/` を 1 ページ list する。
+///
+/// 終局済の `handle_list` と同じ pagination semantics を持ち、prefix と
+/// レスポンス key (`live_games`) のみが異なる。
+async fn handle_list_live(req: &Request, env: &Env, url: &Url) -> Result<Response> {
+    let entries =
+        match collect_index_page(req, env, url, LIVE_KEY_PREFIX, "live_games_index").await? {
+            CollectOutcome::Page(p) => p,
+            CollectOutcome::ErrorResponse(r) => return Ok(r),
+        };
+    let payload = LiveListResponse {
+        live_games: entries.entries,
+        next_cursor: entries.next_cursor,
+    };
+    let resp = Response::from_json(&payload)?;
+    with_cors(resp, req, env)
+}
+
+/// `collect_index_page` の戻り値。原則 [`Self::Page`] を返すが、early return が
+/// 必要なエラー (Origin 拒否 / limit パース失敗 / R2 binding 失敗 / R2 list 失敗)
+/// は完成済 `Response` を [`Self::ErrorResponse`] に詰めて返す。
+enum CollectOutcome {
+    Page(IndexPage),
+    ErrorResponse(Response),
+}
+
+/// 1 ページぶんの index entry を bytes get → JSON value 化したもの。
+struct IndexPage {
+    entries: Vec<serde_json::Value>,
+    next_cursor: Option<String>,
+}
+
+/// `games-index/` / `live-games-index/` 共通の 1 ページ走査ロジック。
+///
+/// `event_root` はログ event 名の prefix (`games_index` / `live_games_index`)。
+/// 失敗時の logfmt event はこれを土台に `<root>_list` / `<root>_get` /
+/// `<root>_read` / `<root>_parse` を組み立てる。
+async fn collect_index_page(
+    req: &Request,
+    env: &Env,
+    url: &Url,
+    prefix: &str,
+    event_root: &str,
+) -> Result<CollectOutcome> {
     if let Some(blocked) = check_origin(req, env)? {
-        return Ok(blocked);
+        return Ok(CollectOutcome::ErrorResponse(blocked));
     }
 
     // クエリパラメータを 1 度だけ走査して `cursor` / `limit` を取り出す。
@@ -96,11 +184,12 @@ async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
         Some(s) => match s.parse::<u32>() {
             Ok(n) if (MIN_LIMIT..=MAX_LIMIT).contains(&n) => n,
             _ => {
-                return with_cors(
+                let err = with_cors(
                     Response::error(format!("limit must be {MIN_LIMIT}..={MAX_LIMIT}"), 400)?,
                     req,
                     env,
-                );
+                )?;
+                return Ok(CollectOutcome::ErrorResponse(err));
             }
         },
     };
@@ -109,11 +198,12 @@ async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
         Ok(b) => b,
         Err(e) => {
             console_log_failed("kifu_bucket_binding", &e.to_string());
-            return with_cors(Response::error("Storage unavailable", 503)?, req, env);
+            let err = with_cors(Response::error("Storage unavailable", 503)?, req, env)?;
+            return Ok(CollectOutcome::ErrorResponse(err));
         }
     };
 
-    let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX).limit(limit);
+    let mut builder = bucket.list().prefix(prefix).limit(limit);
     if let Some(c) = cursor.as_deref() {
         builder = builder.cursor(c);
     }
@@ -121,26 +211,28 @@ async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
     let page = match builder.execute().await {
         Ok(p) => p,
         Err(e) => {
-            console_log_failed("games_index_list", &e.to_string());
-            return with_cors(Response::error("Storage error", 502)?, req, env);
+            console_log_failed(&format!("{event_root}_list"), &e.to_string());
+            let err = with_cors(Response::error("Storage error", 502)?, req, env)?;
+            return Ok(CollectOutcome::ErrorResponse(err));
         }
     };
 
-    let mut games: Vec<serde_json::Value> = Vec::with_capacity(page.objects().len());
+    let mut entries: Vec<serde_json::Value> = Vec::with_capacity(page.objects().len());
     for obj in page.objects() {
         let key = obj.key();
-        // 各 entry を取得 → bytes → JSON value。bytes 経由なのは
-        // 本文がそのまま `GamesIndexEntry` の JSON 形式である契約のため。
+        // 各 entry を取得 → bytes → JSON value。bytes 経由なのは本文が
+        // そのまま `*IndexEntry` の JSON 形式である契約のため。
         let fetched = match bucket.get(&key).execute().await {
             Ok(o) => o,
             Err(e) => {
-                console_log_failed("games_index_get", &format!("key={key} err={e}"));
+                console_log_failed(&format!("{event_root}_get"), &format!("key={key} err={e}"));
                 continue;
             }
         };
         let Some(fetched) = fetched else {
-            // list と get の間に削除されたケース。pagination 整合の観点で
-            // 落としても問題ない。
+            // list と get の間に削除されたケース。live entry の場合は終局
+            // (delete) と list のレースに該当する。pagination 整合の観点で
+            // 落としても問題ない (= live は entry が瞬間的に消えうる契約)。
             continue;
         };
         let Some(body) = fetched.body() else {
@@ -149,14 +241,14 @@ async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
         let bytes = match body.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                console_log_failed("games_index_read", &format!("key={key} err={e}"));
+                console_log_failed(&format!("{event_root}_read"), &format!("key={key} err={e}"));
                 continue;
             }
         };
         match serde_json::from_slice::<serde_json::Value>(&bytes) {
-            Ok(v) => games.push(v),
+            Ok(v) => entries.push(v),
             Err(e) => {
-                console_log_failed("games_index_parse", &format!("key={key} err={e}"));
+                console_log_failed(&format!("{event_root}_parse"), &format!("key={key} err={e}"));
                 // 1 件壊れても他を返す (best-effort)。
             }
         }
@@ -167,9 +259,10 @@ async fn handle_list(req: &Request, env: &Env, url: &Url) -> Result<Response> {
     } else {
         None
     };
-    let payload = ListResponse { games, next_cursor };
-    let resp = Response::from_json(&payload)?;
-    with_cors(resp, req, env)
+    Ok(CollectOutcome::Page(IndexPage {
+        entries,
+        next_cursor,
+    }))
 }
 
 /// 単局ハンドラ。`<game_id>` (URL-decoded path 残部) を受け取り、kifu-by-id を


### PR DESCRIPTION
## 概要

Issue #549 設計 v3 (APPROVE 済) を実装。GameRoom DO の対局開始時に `live-games-index/<inv_started_ms>-<game_id>.json` を best-effort で put し、終局時に delete することで viewer が `GET /api/v1/games/live` で進行中対局を発見できる。

## 変更点

- **新規** `crates/rshogi-csa-server-workers/src/live_games_index.rs`
  - `LIVE_KEY_PREFIX`, `LiveGamesIndexEntry`, `live_games_index_key` (inv padding `{:014}`)
  - `INV_BASE` / `validate_key_component` は既存 `games_index` / `floodgate_history` から再利用
- **改修** `games_index.rs`: `resolve_index_source` (wasm32) と純粋関数版 `classify_index_source_from_inputs` (host テスト用) を追加し、`export_kifu_to_r2` の `source` 判定を共通化
- **改修** `viewer_api.rs`: `/api/v1/games/live` ルートを追加 (`/api/v1/games/<game_id>` より先にマッチ)。`collect_index_page` 共通 helper に list/get ループを切り出し。レスポンス key は `live_games`。access control レビュー必須の旨を module doc に追記
- **改修** `game_room.rs`:
  - `GameRoom::live_index_put_done: Cell<bool>` を追加 (DO ctor で `Cell::new(false)`)
  - `mark_play_started` 内で `KEY_CONFIG` put 後に `try_put_live_games_index` (best-effort)、**put 成功時のみ** flag set
  - `ensure_core_loaded` (および core が既に Some の早期 return 経路) で `retry_live_games_index_if_needed` を呼ぶ。flag 未立ちかつ未終局かつ `play_started_at_ms.is_some()` のときに 1 回だけ retry
  - `finalize_if_ended` で `KEY_FINISHED` put 後に `try_delete_live_games_index` (best-effort)

## ホストユニットテスト

- `live_games_index::tests`: inv padding / lex order / validate_key_component disallowed char / entry serialize (`source`/`game_id`/`started_at_ms`/handles を含み、`ended_at_ms`/`result_kind`/`moves_count` は出ない) / `LIVE_KEY_PREFIX` 値固定
- `games_index::tests`: `classify_index_source_from_inputs` の env 切替網羅 (allow 未設定 / false / 解析不能 / opt-in だが binding なし / opt-in + binding)

## CI チェック

- `cargo fmt && cargo clippy --workspace --tests --all-targets` clean
- `cargo test --workspace` all green (workers crate: 187 passed)
- `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` clean

## Non-goals (本 PR スコープ外)

- viewer 側 UI 変更 (ramu-shogi 別 issue)
- spectator_count / current_moves_count
- production access control 強化 (#550)
- live entry orphan sweep cron (Issue #551 に統合)

## Test plan

- [x] cargo fmt / clippy / test 全 green (host)
- [x] cargo check wasm32 green
- [ ] staging で `wrangler dev` smoke (対局 1 件開始 → /api/v1/games/live で確認 → 終局 → 消える) — merge 後の手動検証

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)