### PR TITLE
feat(spsa): NetworkDelay=0/MinimumThinkingTime を自動注入する

### DIFF
--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -1521,6 +1521,32 @@ fn main() -> Result<()> {
         }
     }
 
+    // 公平な対局条件のため、tournament と同様に NetworkDelay=0 と
+    // MinimumThinkingTime をデフォルトで注入する。ユーザーが明示的に
+    // --usi-option で指定した場合はそちらを優先。
+    // - NetworkDelay: 0 以外だと秒境界切り上げで思考時間が短縮され、
+    //   時間切れ・思考時間の偏りの原因になる。
+    // - MinimumThinkingTime: byoyomi 時は byoyomi と一致させることで秒読み全体を使い切れる。
+    //   フィッシャー/ノード数モードでは 0（エンジンの時間管理に委ねる）。
+    let min_think = if cli.nodes.is_none() && cli.btime.is_none() && cli.byoyomi > 0 {
+        cli.byoyomi.to_string()
+    } else {
+        "0".to_string()
+    };
+    let time_defaults: [(&str, &str); 3] = [
+        ("NetworkDelay", "0"),
+        ("NetworkDelay2", "0"),
+        ("MinimumThinkingTime", min_think.as_str()),
+    ];
+    let mut usi_options = cli.usi_options.clone().unwrap_or_default();
+    for (name, default_value) in &time_defaults {
+        let already_set =
+            usi_options.iter().any(|o| o.split_once('=').is_some_and(|(k, _)| k == *name));
+        if !already_set {
+            usi_options.push(format!("{name}={default_value}"));
+        }
+    }
+
     let base_cfg = EngineConfig {
         path: engine_path,
         args: engine_args,
@@ -1531,7 +1557,7 @@ fn main() -> Result<()> {
         minimum_thinking_time: None,
         slowmover: None,
         ponder: false,
-        usi_options: cli.usi_options.clone().unwrap_or_default(),
+        usi_options,
     };
 
     let game_cfg = GameConfig {


### PR DESCRIPTION
## Summary
- SPSA ツールでも tournament と同じく `NetworkDelay=0` / `NetworkDelay2=0` / `MinimumThinkingTime` を usi_options にデフォルト注入し、公平な時間条件で自己対局できるようにする。
- 明示的に `--usi-option NetworkDelay=...` 等で指定された場合は尊重（`split_once('=')` で既存検出）。
- `MinimumThinkingTime` は byoyomi モード時のみ byoyomi と一致させ、フィッシャー/`--nodes` モードでは 0（エンジンの時間管理に委ねる）。

## 背景
- 直近 30 ラン (50,984 局) の tournament/SPRT ログでは `reason="timeout"` が 0 件だった。これは `tournament.rs:861` で同オプションが自動注入されているおかげ。
- 一方で `spsa.rs` には自動注入がなく、YO のデフォルト `NetworkDelay=120` / `NetworkDelay2=1120` がそのまま効いて秒境界切り上げで思考時間が縮み、時間切れや思考時間の偏りの原因になり得る。
- tournament と spsa で挙動を揃え、SPSA チューニング時の時間管理ノイズを抑える。

## 注意点
- `EngineConfig.network_delay` 等の専用フィールドではなく `usi_options` 経由で渡している。`engine.rs:109` の専用フィールド経路は `None` のまま、`set_option_if_available` 側で対応するため非対応エンジンでは黙ってスキップされ安全。
- spsa では byoyomi のデフォルトが 1000ms あるため、tournament と異なり `min_think` を `nodes.is_none() && btime.is_none() && byoyomi > 0` の条件付きで設定している（フィッシャー時の誤注入防止）。

## Test plan
- [x] `cargo build --bin spsa`
- [x] `cargo clippy --bin spsa --tests`
- [x] `cargo fmt --check`
- [ ] 実機での SPSA 短時間ラン後、出力 JSONL に `"reason":"timeout"` が増えていないことを確認
- [ ] `--usi-option NetworkDelay=120` を明示指定した場合に上書きされず尊重されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)