### PR TITLE
feat(csa-server): viewer/spectate API access control を実装する (#550)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -73,6 +73,14 @@ impl ConfigKeys {
     /// Floodgate 機能群を opt-in 有効化するブール変数。`true` / `1` / `yes` / `on`
     /// で有効。`reconnect_protocol` 等の Floodgate 系を要求する構成で必須。
     pub const ALLOW_FLOODGATE_FEATURES: &'static str = "ALLOW_FLOODGATE_FEATURES";
+    /// viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in
+    /// 有効化するブール変数。`true` / `1` / `yes` / `on` で有効、`false` / `0`
+    /// / `no` / `off` または未設定で無効（= 該当 endpoint は 404 で既存ルーティング
+    /// にフォールスルー）。production rollout 時の kill-switch を兼ね、本値を
+    /// `"0"` に切り替えて redeploy することで viewer API を即時無効化できる。
+    /// 設定不正値は安全側に倒し（無効化）、`worker::console_log!` で警告ログを
+    /// 出す。
+    pub const ALLOW_VIEWER_API: &'static str = "ALLOW_VIEWER_API";
 
     /// `wrangler.toml` の `[[r2_buckets]] binding = "..."` で宣言されるべき名前の
     /// 網羅列挙。新規 R2 binding 定数を追加したら必ず本配列にも追加する。
@@ -117,6 +125,7 @@ impl ConfigKeys {
         Self::BYOYOMI_MIN,
         Self::RECONNECT_GRACE_SECONDS,
         Self::ALLOW_FLOODGATE_FEATURES,
+        Self::ALLOW_VIEWER_API,
         Self::LOBBY_QUEUE_SIZE_LIMIT,
     ];
 
@@ -187,6 +196,26 @@ pub fn parse_clock_spec(
         other => Err(format!(
             "CLOCK_KIND: expected countdown|countdown_msec|fischer|stopwatch, got {other:?}"
         )),
+    }
+}
+
+/// viewer 配信 API (HTTP `/api/v1/games*` および WS `/ws/<id>/spectate`) が
+/// 有効化されているかを `[vars]` `ALLOW_VIEWER_API` から判定する。
+///
+/// 値の解釈は [`rshogi_csa_server::config::parse_truthy_bool_env`] に委ねる。
+/// 設定不正値（`true` / `false` / 数字 / yes/no/on/off 以外）は安全側に倒し
+/// （= viewer API 無効化）、`worker::console_log!` で警告ログを 1 回だけ出す。
+/// production rollout 時の kill-switch を兼ねる: 値を `"0"` に切り替えて
+/// redeploy することで該当 endpoint を即時 404 化できる。
+#[cfg(target_arch = "wasm32")]
+pub fn is_viewer_api_enabled(env: &worker::Env) -> bool {
+    let raw = env.var(ConfigKeys::ALLOW_VIEWER_API).ok().map(|v| v.to_string());
+    match rshogi_csa_server::config::parse_truthy_bool_env(raw.as_deref()) {
+        Ok(v) => v,
+        Err(e) => {
+            worker::console_log!("[viewer_api] event=invalid_allow_viewer_api err={e}");
+            false
+        }
     }
 }
 

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -8,10 +8,10 @@
 
 use worker::{Env, Method, Request, Response, Result};
 
-use crate::config::{ConfigKeys, OriginAllowList};
+use crate::config::{ConfigKeys, OriginAllowList, is_viewer_api_enabled};
 use crate::origin::{OriginDecision, evaluate};
 use crate::viewer_api;
-use crate::ws_route::parse_ws_route;
+use crate::ws_route::{WsRoute, parse_ws_route};
 
 /// `#[event(fetch)]` から委譲されるディスパッチ。
 pub async fn handle_fetch(req: Request, env: Env) -> Result<Response> {
@@ -38,7 +38,7 @@ pub async fn handle_fetch(req: Request, env: Env) -> Result<Response> {
         let Some(route) = parse_ws_route(&path) else {
             return Response::error("Invalid room_id", 400);
         };
-        return forward_ws_to_room(req, env, &path, route.room_id()).await;
+        return forward_ws_to_room(req, env, &path, &route).await;
     }
 
     Response::error("Not Found", 404)
@@ -87,21 +87,39 @@ async fn forward_ws_to_lobby(req: Request, env: Env) -> Result<Response> {
 }
 
 /// `/ws/:room_id` を Origin 検査し、許可された場合のみ GameRoom DO に転送する。
+///
+/// Spectator 経路 (`/ws/<id>/spectate`) は viewer 配信 API と同列の access
+/// control を適用する: `ALLOW_VIEWER_API` 無効 → 404、allowlist 未設定 → 403。
+/// Player 経路 (`/ws/<room_id>`) は対局者ネイティブクライアントが Origin を
+/// 送らない経路を温存する必要があるため、既存の Origin 検査 semantics を
+/// 維持する（allowlist 未設定 + Origin 付きのみ 403）。
 async fn forward_ws_to_room(
     req: Request,
     env: Env,
     request_path: &str,
-    room_id: &str,
+    route: &WsRoute,
 ) -> Result<Response> {
+    // Spectator 経路では viewer API gate を通す。無効化されている場合は
+    // 404 を返し、`/api/v1/games*` と挙動を揃える。
+    if route.is_spectator() && !is_viewer_api_enabled(&env) {
+        return Response::error("Not Found", 404);
+    }
+
     // Origin 許可リストは `[vars] WS_ALLOWED_ORIGINS = "<csv>"` から取得する。
-    // 値が空や未設定なら `OriginAllowList` は空 = ブラウザ経由（Origin 付き）は全拒否。
-    // ネイティブ CSA クライアント等 Origin ヘッダを送らない経路は素通し（[`evaluate`] の仕様）。
+    // Player 経路: 値が空や未設定なら `OriginAllowList` は空 = ブラウザ経由
+    // （Origin 付き）は全拒否。ネイティブ CSA クライアント等 Origin ヘッダを
+    // 送らない経路は素通し（[`evaluate`] の仕様）。
+    // Spectator 経路: allowlist 未設定は fail-closed で 403（無認可公開を防ぐ）。
     let allow_csv = env
         .var(ConfigKeys::WS_ALLOWED_ORIGINS)
         .ok()
         .map(|v| v.to_string())
         .unwrap_or_default();
     let allow_list = OriginAllowList::from_csv(&allow_csv);
+
+    if route.is_spectator() && allow_list.is_empty() {
+        return Response::error("Forbidden Origin", 403);
+    }
 
     let origin_header = req.headers().get("Origin")?;
     match evaluate(origin_header.as_deref(), allow_list.iter()) {
@@ -118,7 +136,7 @@ async fn forward_ws_to_room(
     // room_id から決定論的に DO インスタンスを解決する。`id_from_name` は
     // 文字列ハッシュを ID に写像するため、同じ room_id は常に同一 DO に到達する。
     let namespace = env.durable_object(ConfigKeys::GAME_ROOM_BINDING)?;
-    let stub = namespace.id_from_name(room_id)?.get_stub()?;
+    let stub = namespace.id_from_name(route.room_id())?.get_stub()?;
 
     // DO 側 fetch は完全な URL を要求する仕様。転送用のダミー host を立て、
     // path をそのまま DO 側へ引き継ぐ（`/spectate` を含む route 判定に使う）。

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -32,7 +32,7 @@
 use serde::Serialize;
 use worker::{Env, Headers, Method, Request, Response, Result, Url};
 
-use crate::config::{ConfigKeys, OriginAllowList};
+use crate::config::{ConfigKeys, OriginAllowList, is_viewer_api_enabled};
 use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
 use crate::live_games_index::LIVE_KEY_PREFIX;
 use crate::origin::{OriginDecision, evaluate};
@@ -48,6 +48,12 @@ const MIN_LIMIT: u32 = 1;
 /// 引き継ぐ (404 までの fallthrough)。
 pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     if req.method() != Method::Get {
+        return Ok(None);
+    }
+    // viewer 配信 API は `ALLOW_VIEWER_API` で opt-in 有効化する。無効化 / 未設定
+    // / 値不正のいずれも `Ok(None)` を返して既存ルーティングへフォールスルー
+    // させる（最終的に 404 になる）。production rollout 中の kill-switch も同経路。
+    if !is_viewer_api_enabled(env) {
         return Ok(None);
     }
     let url = req.url()?;
@@ -385,9 +391,14 @@ async fn find_meta_for(
     }
 }
 
-/// CORS / Origin チェック。リクエスト Origin が許可リストに含まれる場合のみ
-/// 通す。Origin ヘッダ未送信のクライアント (curl 等) は許可リスト未設定時のみ
-/// 通す ([`evaluate`] と同じ semantics)。
+/// CORS / Origin チェック。viewer 配信 API では allowlist の設定が **必須**
+/// であり、`WS_ALLOWED_ORIGINS` が空 / 未設定の場合は Origin の有無にかかわらず
+/// 403 を返す（ブラウザ・ネイティブ問わず CSRF / 無認可公開を防ぐ）。
+///
+/// allowlist が非空の場合は [`evaluate`] と同じ semantics で判定する: Origin が
+/// 許可リストに含まれていれば通し、含まれない場合は 403。Origin ヘッダ未送信の
+/// クライアント (curl 等) は allowlist 非空のときのみ素通しする
+/// （[`evaluate`] の仕様）。
 fn check_origin(req: &Request, env: &Env) -> Result<Option<Response>> {
     let allow_csv = env
         .var(ConfigKeys::WS_ALLOWED_ORIGINS)
@@ -395,6 +406,11 @@ fn check_origin(req: &Request, env: &Env) -> Result<Option<Response>> {
         .map(|v| v.to_string())
         .unwrap_or_default();
     let allow_list = OriginAllowList::from_csv(&allow_csv);
+    if allow_list.is_empty() {
+        // allowlist 未設定は viewer API では fail-closed。設定漏れを 403 で
+        // 顕在化させ、無認可公開を防ぐ。
+        return Ok(Some(Response::error("Forbidden Origin", 403)?));
+    }
     let origin_header = req.headers().get("Origin")?;
     match evaluate(origin_header.as_deref(), allow_list.iter()) {
         OriginDecision::Allow => Ok(None),

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -79,13 +79,15 @@ bucket_name = "rshogi-csa-floodgate-history-prod"
 [vars]
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。ブラウザ経由
 # （Origin ヘッダ付き）のリクエストに対する CSRF 防御として機能する。
-# 空文字列・未設定時はブラウザ経由を全 403、Origin ヘッダを送らない
-# ネイティブ CSA クライアント（`rshogi-csa-client` 等）は素通し。
-# production では web client が確定するまで空のままで運用してよい。
-# native CSA クライアントは LOGIN ハンドル / パスワード等の別レイヤで認可する。
-# web client 化したときに deployment.md §3.4 の手順で Origin を追加する。
+# Player 経路（`/ws/<room_id>`、ネイティブ CSA クライアント想定）では
+# 空文字列・未設定時に Origin ヘッダ付きリクエストを 403 で弾き、Origin ヘッダ
+# を送らないネイティブ CSA クライアント（`rshogi-csa-client` 等）は素通し。
+# Spectator 経路（`/ws/<id>/spectate`）と viewer 配信 API（`/api/v1/games*`）
+# では allowlist が **必須**: 空・未設定時は Origin の有無にかかわらず 403。
+# 無認可公開を防ぐ fail-closed 既定で、`ALLOW_VIEWER_API` と組で運用する。
+# 実運用では web client URL を実値に書き換えること。
 # 例: "https://rshogi.example.com,https://www.rshogi.example.com"
-WS_ALLOWED_ORIGINS = ""
+WS_ALLOWED_ORIGINS = "https://rshogi.example.com"
 
 # 対局時計。`countdown` (CSA 2014 改訂秒読み、Floodgate 互換) / `countdown_msec`
 # (ms 粒度の短時間対局向け拡張) / `fischer` (増分加算) / `stopwatch` (分単位)。
@@ -108,6 +110,13 @@ RECONNECT_GRACE_SECONDS = "0"
 # Floodgate 系運用機能（再接続プロトコル等）を opt-in 有効化する。`true` / `1` /
 # `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
 ALLOW_FLOODGATE_FEATURES = "false"
+# viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in 有効化する。
+# `true` / `1` / `yes` / `on` で有効、`false` / `0` / `no` / `off` または
+# 未設定で無効化（該当 endpoint は 404）。本値は production rollout の kill-switch
+# も兼ねる: 即時無効化が必要な場合は本値を `"0"` に切り替えて redeploy することで
+# viewer / spectate を 404 化できる。Origin 制限は `WS_ALLOWED_ORIGINS` 側で
+# 必須化される（allowlist 未設定時は 403）。
+ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。100 件を超える同時待機は LOGIN_LOBBY を
 # queue_full で reject する保守的既定。負荷に応じて引き上げ可。
 LOBBY_QUEUE_SIZE_LIMIT = "100"

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -116,6 +116,10 @@ BYOYOMI_MIN = "1"
 # 計測してから再評価する。
 RECONNECT_GRACE_SECONDS = "30"
 ALLOW_FLOODGATE_FEATURES = "true"
+# viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in 有効化する。
+# staging は実機通電 (web client / spectator E2E) を回す前提で `"1"` を既定とする。
+# 即時無効化したい場合は本値を `"0"` に切り替えて redeploy する（kill-switch）。
+ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。staging では小規模通電向けに 100 で運用。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
 

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -70,7 +70,10 @@ preview_bucket_name = "local-floodgate-history-dev"
 # Origin ヘッダを送らないネイティブ CSA クライアント等は本リストに関係なく素通し
 # （LOGIN ハンドル / パスワード等の別レイヤで認可する想定）。
 [vars]
-WS_ALLOWED_ORIGINS = ""
+# local dev では Vite dev server (5173/5174) と Tauri ネイティブの両方から
+# 通電できる Origin を既定値として置く。production / staging では
+# `wrangler.<env>.toml` 側で本番 / staging の URL に書き換える。
+WS_ALLOWED_ORIGINS = "http://localhost:5173,http://localhost:5174,tauri://localhost"
 # 対局時計。`countdown` / `countdown_msec` / `fischer` / `stopwatch`。
 # countdown は Floodgate 互換の整数秒切り捨て、countdown_msec は ms 粒度の短時間対局向け拡張。
 CLOCK_KIND = "countdown"
@@ -91,5 +94,10 @@ RECONNECT_GRACE_SECONDS = "0"
 # Floodgate 系運用機能（再接続プロトコル等）を opt-in で有効化する。`true` / `1` /
 # `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
 ALLOW_FLOODGATE_FEATURES = "false"
+# viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in 有効化する。
+# `true` / `1` / `yes` / `on` で有効、`false` / `0` / `no` / `off` または
+# 未設定で無効化（該当 endpoint は 404）。production rollout 時の kill-switch も
+# 兼ねるため、即時無効化したい場合は本値を `"0"` にして redeploy する。
+ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。超過時 LOGIN_LOBBY を queue_full で reject。
 LOBBY_QUEUE_SIZE_LIMIT = "100"

--- a/crates/rshogi-csa-server/src/config.rs
+++ b/crates/rshogi-csa-server/src/config.rs
@@ -33,13 +33,18 @@ pub struct FloodgateFeatureIntent {
     pub enable_reconnect_protocol: bool,
 }
 
-/// 真偽文字列から Floodgate 機能 gate を解決する。
+/// 真偽文字列を `bool` に解決する汎用パーサ。
 ///
-/// TCP frontend は clap が直接 `bool` にパースするため本関数を経由しない。
-/// 環境変数など文字列経由で読む経路（Workers frontend など）で利用する。
-/// 入力は前後空白を `trim` してから判定するため、`"true\n"` や `" 1 "` も
-/// 許容する。
-pub fn parse_allow_floodgate_features(raw: Option<&str>) -> Result<bool, String> {
+/// 環境変数など文字列経由で `bool` を受け取る経路（Workers frontend など）で
+/// 利用する。`true` / `1` / `yes` / `on` を `true`、`false` / `0` / `no` /
+/// `off` を `false` として受理する。case-insensitive かつ前後空白を `trim`
+/// してから判定するため、`"true\n"` や `" 1 "` も許容する。`None` または空白
+/// のみの入力は **`false` 既定**で扱う（個別フラグの保守的既定値）。
+///
+/// エラーメッセージは特定の環境変数名や CLI フラグ名に依存しない汎用形で
+/// 返す。呼び出し側で `ALLOW_FLOODGATE_FEATURES` / `--allow-floodgate-features`
+/// 等のフラグ名 prefix を `map_err` で付加する想定。
+pub fn parse_truthy_bool_env(raw: Option<&str>) -> Result<bool, String> {
     let normalized = raw.unwrap_or("false").trim();
     if normalized.eq_ignore_ascii_case("true")
         || normalized.eq_ignore_ascii_case("yes")
@@ -55,9 +60,21 @@ pub fn parse_allow_floodgate_features(raw: Option<&str>) -> Result<bool, String>
     {
         return Ok(false);
     }
-    Err(format!(
-        "allow_floodgate_features: expected true|false|1|0|yes|no|on|off, got {normalized:?}"
-    ))
+    Err(format!("expected true|false|1|0|yes|no|on|off, got {normalized:?}"))
+}
+
+/// 真偽文字列から Floodgate 機能 gate を解決する。
+///
+/// TCP frontend は clap が直接 `bool` にパースするため本関数を経由しない。
+/// 環境変数など文字列経由で読む経路（Workers frontend など）で利用する。
+/// 入力は前後空白を `trim` してから判定するため、`"true\n"` や `" 1 "` も
+/// 許容する。
+///
+/// 実装は [`parse_truthy_bool_env`] を呼び出し、エラー時は
+/// `"allow_floodgate_features: "` prefix を付与した文字列を返す。既存呼び出し
+/// 側（`?` 伝播 / Err 分岐）の semantics を完全に保持する。
+pub fn parse_allow_floodgate_features(raw: Option<&str>) -> Result<bool, String> {
+    parse_truthy_bool_env(raw).map_err(|e| format!("allow_floodgate_features: {e}"))
 }
 
 /// Floodgate 機能が要求されているかを検証する。
@@ -101,6 +118,34 @@ pub fn validate_floodgate_feature_gate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_truthy_bool_env_defaults_to_false() {
+        assert!(!parse_truthy_bool_env(None).unwrap());
+    }
+
+    #[test]
+    fn parse_truthy_bool_env_accepts_truthy_variants() {
+        for raw in ["true", "TRUE", "yes", "YES", "on", "ON", "1", " true\n"] {
+            assert!(parse_truthy_bool_env(Some(raw)).unwrap(), "expected truthy: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn parse_truthy_bool_env_accepts_falsy_variants() {
+        for raw in ["false", "FALSE", "no", "NO", "off", "OFF", "0", " false\t"] {
+            assert!(!parse_truthy_bool_env(Some(raw)).unwrap(), "expected falsy: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn parse_truthy_bool_env_rejects_unknown_value_with_generic_prefix() {
+        // 汎用パーサ単独の Err は wrapper 側で prefix を付ける契約。本関数自身は
+        // 特定 frontend 名（"allow_floodgate_features" 等）を含めない。
+        let err = parse_truthy_bool_env(Some("weird")).unwrap_err();
+        assert!(err.contains("expected true|false"), "unexpected err: {err}");
+        assert!(!err.contains("allow_floodgate_features"), "unexpected prefix leaked: {err}");
+    }
 
     #[test]
     fn parse_allow_floodgate_features_defaults_to_false() {

--- a/docs/csa-server/viewer_access_control.md
+++ b/docs/csa-server/viewer_access_control.md
@@ -1,0 +1,132 @@
+# viewer 配信 / spectate API access control 運用 Runbook
+
+`rshogi-csa-server-workers` が提供する viewer / spectate 系 endpoint に対する
+production / staging 環境のアクセス制御方針と、rollout / kill-switch 手順を
+まとめる。基本的な deploy 手順は [`deployment.md`](deployment.md)、staging 実機
+通電は [`staging-e2e.md`](staging-e2e.md) を参照。
+
+## 1. access control が及ぶ endpoint
+
+以下はすべて同一の access control（`ALLOW_VIEWER_API` opt-in と
+`WS_ALLOWED_ORIGINS` の必須化）を共有する:
+
+| Endpoint | 用途 |
+| --- | --- |
+| `GET /api/v1/games` | 終局済対局の一覧（pagination） |
+| `GET /api/v1/games/live` | 進行中対局の一覧（pagination） |
+| `GET /api/v1/games/<game_id>` | 終局済対局の単局取得（CSA 本文 + meta） |
+| `GET /ws/<id>/spectate` | 観戦 WebSocket 接続（progress broadcast 受信） |
+
+Player 経路（`/ws/<room_id>`、ネイティブ CSA クライアントが LOGIN する経路）は
+本 access control の対象外で、既存の Origin 検査 semantics を維持する
+（Origin ヘッダを送らないネイティブクライアントを温存）。
+
+## 2. 環境変数の責任分界
+
+| 変数 | 役割 | 既定値（fail-closed） |
+| --- | --- | --- |
+| `ALLOW_VIEWER_API` | viewer / spectate endpoint の有効化 / 無効化フラグ。`true` / `1` / `yes` / `on` で有効、それ以外（空 / `false` / 不正値）は無効。 | 不正値 → 無効 + `console_log` に警告 |
+| `WS_ALLOWED_ORIGINS` | viewer / spectate へのアクセス可能 Origin 集合（CSV）。viewer / spectate では **必須**。Player 経路は空でもネイティブクライアントを許可（既存 semantics）。 | 空 → viewer / spectate を 403 |
+
+挙動マトリクス（viewer / spectate 経路）:
+
+| `ALLOW_VIEWER_API` | `WS_ALLOWED_ORIGINS` | 結果 |
+| --- | --- | --- |
+| 無効・未設定・不正値 | * | **404**（kill-switch、既存ルーティングへフォールスルー） |
+| 有効 | 空 | **403**（fail-closed） |
+| 有効 | 非空、Origin 不一致 | **403** |
+| 有効 | 非空、Origin 一致 / Origin 未送信（curl 等） | **通過** |
+
+## 3. rollout チェックリスト
+
+新環境への初回 rollout、もしくは既存環境で viewer / spectate を有効化する際に
+順に実施する。実 deploy の確認結果は本 runbook ではなく PR / Issue / 運用監視
+の責務で残すこと。
+
+1. `wrangler.<env>.toml` に以下が **両方** 揃っていることを PR で確認する:
+   - `[vars] ALLOW_VIEWER_API = "1"`（kill-switch 時は `"0"` に切替）
+   - `[vars] WS_ALLOWED_ORIGINS = "https://<client-origin>[,...]"`（非空、最終 client URL）
+2. staging 環境に deploy し、smoke チェック（§5）を通過させる。
+3. production 環境に deploy する前に `WS_ALLOWED_ORIGINS` の値が production
+   client の実 URL と一致していることを再確認する（staging 値が混入していないか）。
+4. production deploy 後、smoke チェック（§5）の各 curl パターンを通電させ、
+   想定通りのステータス遷移であることを確認する。
+5. 一定期間 access log を観察し、想定外 Origin からの 403 が連続していないか
+   モニタリングする。
+
+## 4. kill-switch 手順
+
+production 中に viewer / spectate を即時無効化する必要が生じた場合:
+
+1. `wrangler.production.toml` で `ALLOW_VIEWER_API = "0"` に書き換える PR を作成。
+2. merge → 自動 deploy or `workflow_dispatch` で再 deploy。
+3. deploy 完了後、§5 の smoke check で 4 endpoint すべてが **404** を返すことを
+   確認する。404 で揃うことが kill-switch 成立のシグナル。
+
+`WS_ALLOWED_ORIGINS = ""` でも fail-closed で 403 を返すが、404 と比べて運用上の
+意図（無効化したのか設定漏れか）が判別しづらいため、kill-switch には
+`ALLOW_VIEWER_API` を使うこと。
+
+## 5. smoke 確認 curl コマンド例
+
+`<host>` は `rshogi-csa-server-workers.<account>.workers.dev`、
+`<allowed-origin>` は `WS_ALLOWED_ORIGINS` に登録した Origin、
+`<other-origin>` は登録していない Origin に置き換える。
+
+### 5-1. viewer API 無効時（`ALLOW_VIEWER_API="0"`）
+
+```bash
+# 404 を期待
+curl -sS -o /dev/null -w "%{http_code}\n" "https://<host>/api/v1/games"
+curl -sS -o /dev/null -w "%{http_code}\n" "https://<host>/api/v1/games/live"
+curl -sS -o /dev/null -w "%{http_code}\n" "https://<host>/api/v1/games/sample-id"
+```
+
+### 5-2. viewer API 有効時 + Origin allowlist 未設定
+
+```bash
+# 403 を期待（fail-closed）
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  -H "Origin: https://<other-origin>" \
+  "https://<host>/api/v1/games"
+```
+
+### 5-3. viewer API 有効時 + Origin 一致
+
+```bash
+# 200 を期待
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  -H "Origin: https://<allowed-origin>" \
+  "https://<host>/api/v1/games?limit=1"
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  -H "Origin: https://<allowed-origin>" \
+  "https://<host>/api/v1/games/live?limit=1"
+```
+
+### 5-4. viewer API 有効時 + Origin 不一致
+
+```bash
+# 403 を期待
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  -H "Origin: https://<other-origin>" \
+  "https://<host>/api/v1/games"
+```
+
+### 5-5. spectate WS（参考）
+
+WebSocket Upgrade を curl で完結させるのは難しいため、Origin 付き接続テストは
+[`staging-e2e.md`](staging-e2e.md) §6 の `wscat` 手順に従う。viewer API 無効時は
+`/ws/<id>/spectate` も 404 で揃うことだけ smoke チェックで担保する:
+
+```bash
+# Upgrade なしの GET でも 404 / 403 / 426 が状況に応じて返る
+curl -sS -o /dev/null -w "%{http_code}\n" "https://<host>/ws/<room>/spectate"
+```
+
+## 6. 将来計画
+
+- private 棋譜（個人対局）と public 棋譜（Floodgate 経由等）の分離は、本
+  access control の上位レイヤとして別 Issue で扱う。本 runbook は public 棋譜
+  のみを viewer 配信する前提に立つ。
+- API token / shared secret 経由の認可は現時点では未導入。Origin allowlist で
+  必要な防御を担保する設計に閉じている。


### PR DESCRIPTION
## Summary

- `/api/v1/games*` (HTTP) と `/ws/<id>/spectate` (WS) を production rollout 前に無認可公開しないため、`ALLOW_VIEWER_API` opt-in gate と `WS_ALLOWED_ORIGINS` 必須化を導入。
- core crate `rshogi-csa-server` に汎用 truthy 文字列パーサ `parse_truthy_bool_env` を新設。既存 `parse_allow_floodgate_features` は薄い wrapper に変更し、Err prefix 維持で 3 callers (`game_room.rs:2201/2221`, `games_index.rs:257`) の semantics を完全保持。
- workers crate `is_viewer_api_enabled(&Env)` で設定不正は安全側に倒し (`false`) console_log で警告出力。viewer_api / router (Spectator 経路) を共通制御に統一、Player 経路は既存 Origin 検査 semantics を維持。
- `wrangler.toml.example` / `wrangler.staging.toml` / `wrangler.production.toml` に `ALLOW_VIEWER_API` を追加し、toml.example は Vite + Tauri 用の dev 既定 Origin を持たせる。
- 一般化された rollout / kill-switch 手順を `docs/csa-server/viewer_access_control.md` に追加 (特定 deploy evidence は含めない)。

設計は Issue #550 v3 (APPROVE 取得済) を踏襲。

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --tests --all-targets` 警告なし
- [x] `cargo test --workspace` 全 pass (新規 `parse_truthy_bool_env_*` 4 本含む)
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` 通過
- [x] `tests/wrangler_template_consistency.rs` / `tests/wrangler_environment_toml_consistency.rs` で `ALLOW_VIEWER_API` 整合性が自動検出されることを確認

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)