### PR TITLE
feat(csa-server-workers): kifu meta primary + games-index backfill cron + live orphan sweep

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -1,0 +1,450 @@
+//! viewer 配信用 R2 prefix の補完 / orphan 掃除を担う cron ジョブ群。
+//!
+//! Issue #551 設計 v3 に従い、以下 2 つの best-effort ジョブを実装する:
+//!
+//! - [`run_games_index_backfill`]: `kifu-by-id/<id>.meta.json` を 1 ページ
+//!   (1000 件) 単位で list し、各 meta 本文から `games-index/<inv>-<id>.json`
+//!   key を再生成して上書き put する (派生 index 補完)。
+//! - [`run_live_orphan_sweep`]: `live-games-index/` を 1 ページ単位で list し、
+//!   対応する `kifu-by-id/<id>.meta.json` (= 終局済 primary 判定キー、設計 v3
+//!   §3) が存在する live entry を delete する (orphan 掃除)。
+//!
+//! いずれも 1 page (1000 件) のみ処理し、cursor の持ち越しは行わない (= 次回
+//! cron で続行する eventual semantics)。本実装範囲では admin invoke endpoint
+//! や 1 万件超の bulk 並列化は Non-goals (設計 v3 §10)。
+//!
+//! 進捗ログは logfmt 構造化 (`event=…_progress listed=… elapsed_ms=…`) で
+//! `console_log!` に流す。Cloudflare Workers の Logs / tail で grep 可能。
+//! いかなる失敗 (R2 binding 解決失敗 / list 失敗 / get 失敗 / put 失敗 /
+//! parse 失敗) も `Err` を返さず ログのみ残して `Ok` で抜ける契約。
+//! `scheduled` handler が次回 cron 起動を妨げないようにするため、伝播禁止。
+//!
+//! # ホスト target でのテスト境界
+//!
+//! `worker` クレートは wasm32 限定なので、IO 本体 ([`run_games_index_backfill`]
+//! / [`run_live_orphan_sweep`]) は `cfg(target_arch = "wasm32")` でゲートする。
+//! 純粋ロジック (Stats 構造体 / `MetaForIndexKey` deserialize) はホスト target
+//! でも参照可能で、`cargo test` でこれらの形状契約を検証する。
+
+use serde::Deserialize;
+
+/// `kifu-by-id/` prefix。`<id>.csa` と `<id>.meta.json` が同居するため、
+/// `.meta.json` で suffix 判定する側で本 prefix を再利用する。
+pub(crate) const KIFU_BY_ID_PREFIX: &str = "kifu-by-id/";
+
+/// `kifu-by-id/<id>.meta.json` の suffix。list 結果から meta だけを抽出する。
+pub(crate) const META_SUFFIX: &str = ".meta.json";
+
+/// 1 cron run あたりの list page size (= R2 list の最大値)。
+///
+/// 1000 を超える backfill 対象が常時残る運用に到達したら admin invoke endpoint
+/// 経由で複数ページ一気に処理する案 (設計 v2 §5 (a)) を別 issue で検討する。
+pub(crate) const PAGE_SIZE: u32 = 1000;
+
+/// `run_games_index_backfill` の進捗統計。テスト容易性のため値型で返す。
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BackfillStats {
+    /// list で観測した meta オブジェクトの総数。
+    pub listed: u64,
+    /// `games-index/` への put が成功した件数 (上書き含む)。
+    pub put: u64,
+    /// key 生成失敗 / parse 失敗 / 必須フィールド欠如等で put を skip した件数。
+    pub skipped: u64,
+}
+
+/// `run_live_orphan_sweep` の進捗統計。
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SweepStats {
+    /// list で観測した live-games-index entry の総数。
+    pub listed: u64,
+    /// `kifu-by-id/<id>.meta.json` が存在する (= 終局済) ため delete した件数。
+    pub deleted: u64,
+}
+
+/// `kifu-by-id/<id>.meta.json` の本文を deserialize する最小 view。
+///
+/// `GamesIndexEntry` は `&'a str` 借用ベースなので Deserialize できない。
+/// backfill 経路では `ended_at_ms` と `game_id` だけが key 再構築に必要なので、
+/// 必要 field だけを持つ owned 型を別に置く (将来 meta 形式が拡張されても、
+/// ここで参照する 2 field の wire 名が安定している限り影響を受けない)。
+#[derive(Debug, Deserialize)]
+pub(crate) struct MetaForIndexKey {
+    pub game_id: String,
+    pub ended_at_ms: u64,
+}
+
+/// `live-games-index/<inv>-<id>.json` の本文から `game_id` field のみ取り出す
+/// 最小 view。orphan sweep 判定に必要なのは `game_id` のみなので、それ以外の
+/// 形式 (clock 等) には依存しない。
+#[derive(Debug, Deserialize)]
+pub(crate) struct LiveEntryGameId {
+    pub game_id: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use super::{
+        BackfillStats, KIFU_BY_ID_PREFIX, LiveEntryGameId, META_SUFFIX, MetaForIndexKey, PAGE_SIZE,
+        SweepStats,
+    };
+    use worker::{Date, Env, Result, console_log};
+
+    use crate::config::ConfigKeys;
+    use crate::games_index::games_index_key;
+    use crate::live_games_index::LIVE_KEY_PREFIX;
+    use crate::x1_paths::kifu_by_id_meta_key;
+
+    /// `kifu-by-id/*.meta.json` を 1 ページ list し、各 meta 本文から
+    /// `games-index/<inv>-<id>.json` を再生成して上書き put する。
+    ///
+    /// 上書き put は冪等 (R2 strongly consistent 上書き、設計 v2 §2)。head
+    /// による存在チェックは行わない。cursor の持ち越しは「次回 cron で続行」
+    /// する eventual semantics (設計 v2 §5)。
+    ///
+    /// 各失敗 (binding 失敗 / list 失敗 / get 失敗 / parse 失敗 / key 生成失敗
+    /// / put 失敗) は logfmt で記録し `Err` を伝播しない。集計結果のみを返す。
+    pub async fn run_games_index_backfill(env: &Env) -> Result<BackfillStats> {
+        let started_at_ms = Date::now().as_millis();
+        let mut stats = BackfillStats::default();
+
+        let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!("[backfill] event=games_index_backfill_bucket_failed err={:?}", e);
+                return Ok(stats);
+            }
+        };
+
+        let page = match bucket.list().prefix(KIFU_BY_ID_PREFIX).limit(PAGE_SIZE).execute().await {
+            Ok(p) => p,
+            Err(e) => {
+                console_log!("[backfill] event=games_index_backfill_list_failed err={:?}", e);
+                return Ok(stats);
+            }
+        };
+
+        for obj in page.objects() {
+            let key = obj.key();
+            // `kifu-by-id/<id>.csa` も同 prefix に出るため、`.meta.json` 拡張子で
+            // 絞り込む。`.csa` は無視 (legacy fallback は本 issue Non-goals)。
+            if !key.ends_with(META_SUFFIX) {
+                continue;
+            }
+            stats.listed = stats.listed.saturating_add(1);
+
+            let fetched = match bucket.get(&key).execute().await {
+                Ok(o) => o,
+                Err(e) => {
+                    console_log!(
+                        "[backfill] event=games_index_backfill_get_failed key={} err={:?}",
+                        key,
+                        e,
+                    );
+                    stats.skipped = stats.skipped.saturating_add(1);
+                    continue;
+                }
+            };
+            let Some(fetched) = fetched else {
+                // list と get の間に削除されたケース。skip 集計。
+                stats.skipped = stats.skipped.saturating_add(1);
+                continue;
+            };
+            let Some(body) = fetched.body() else {
+                stats.skipped = stats.skipped.saturating_add(1);
+                continue;
+            };
+            let bytes = match body.bytes().await {
+                Ok(b) => b,
+                Err(e) => {
+                    console_log!(
+                        "[backfill] event=games_index_backfill_read_failed key={} err={:?}",
+                        key,
+                        e,
+                    );
+                    stats.skipped = stats.skipped.saturating_add(1);
+                    continue;
+                }
+            };
+            let meta: MetaForIndexKey = match serde_json::from_slice(&bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    console_log!(
+                        "[backfill] event=games_index_backfill_parse_failed key={} err={:?}",
+                        key,
+                        e,
+                    );
+                    stats.skipped = stats.skipped.saturating_add(1);
+                    continue;
+                }
+            };
+
+            let index_key = match games_index_key(meta.ended_at_ms, &meta.game_id) {
+                Ok(k) => k,
+                Err(e) => {
+                    console_log!(
+                        "[backfill] event=games_index_backfill_key_failed game_id={} err={:?}",
+                        meta.game_id,
+                        e,
+                    );
+                    stats.skipped = stats.skipped.saturating_add(1);
+                    continue;
+                }
+            };
+
+            // body は meta の wire そのまま。`GamesIndexEntry` の wire と等価
+            // (両方とも export_kifu_to_r2 で同一 JSON を put している)。
+            if let Err(e) = bucket.put(&index_key, bytes).execute().await {
+                console_log!(
+                    "[backfill] event=games_index_backfill_put_failed game_id={} index_key={} err={:?}",
+                    meta.game_id,
+                    index_key,
+                    e,
+                );
+                stats.skipped = stats.skipped.saturating_add(1);
+                continue;
+            }
+            stats.put = stats.put.saturating_add(1);
+        }
+
+        let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
+        console_log!(
+            "[backfill] event=games_index_backfill_progress listed={} put={} skipped={} elapsed_ms={}",
+            stats.listed,
+            stats.put,
+            stats.skipped,
+            elapsed_ms,
+        );
+        Ok(stats)
+    }
+
+    /// `live-games-index/<inv>-<id>.json` の各 entry について、対応する終局済
+    /// meta (`kifu-by-id/<id>.meta.json`) が存在する live entry を delete する。
+    ///
+    /// 設計 v3 §3 に従い、判定キーは `kifu-by-id/<id>.csa` ではなく `.meta.json`。
+    /// CSA 本体 put は失敗していても meta が書かれていれば終局確定 +
+    /// finalize_if_ended 経路を通った証拠になる。逆もまた然りで、両方失敗した
+    /// orphan は本 sweep では消さない (= eventual に live 一覧に残るが、次回
+    /// cron で finalize 経路の副作用で meta が put された後に消える、または
+    /// 手動オペレーションで対処)。
+    ///
+    /// 各失敗は logfmt で記録し `Err` を伝播しない。
+    pub async fn run_live_orphan_sweep(env: &Env) -> Result<SweepStats> {
+        let started_at_ms = Date::now().as_millis();
+        let mut stats = SweepStats::default();
+
+        let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!("[backfill] event=live_orphan_sweep_bucket_failed err={:?}", e);
+                return Ok(stats);
+            }
+        };
+
+        let page = match bucket.list().prefix(LIVE_KEY_PREFIX).limit(PAGE_SIZE).execute().await {
+            Ok(p) => p,
+            Err(e) => {
+                console_log!("[backfill] event=live_orphan_sweep_list_failed err={:?}", e);
+                return Ok(stats);
+            }
+        };
+
+        for obj in page.objects() {
+            let live_key = obj.key();
+            stats.listed = stats.listed.saturating_add(1);
+
+            // live entry 本文から game_id を取り出す。key 文字列パースより本文
+            // の `game_id` field を信頼するほうが、key 形式の将来変更に対して
+            // 頑健。
+            let game_id = match read_live_entry_game_id(&bucket, &live_key).await {
+                Some(id) => id,
+                None => continue,
+            };
+
+            // primary meta が存在 = 終局済 → live は orphan として delete 対象。
+            let meta_key = kifu_by_id_meta_key(&game_id);
+            let head_result = match bucket.head(&meta_key).await {
+                Ok(o) => o,
+                Err(e) => {
+                    console_log!(
+                        "[backfill] event=live_orphan_sweep_head_failed game_id={} meta_key={} err={:?}",
+                        game_id,
+                        meta_key,
+                        e,
+                    );
+                    continue;
+                }
+            };
+            if head_result.is_none() {
+                // meta が無い = まだ進行中 (or 終局時 meta put 失敗)。前者は
+                // 正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的な保守)。
+                continue;
+            }
+
+            if let Err(e) = bucket.delete(&live_key).await {
+                console_log!(
+                    "[backfill] event=live_orphan_sweep_delete_failed game_id={} live_key={} err={:?}",
+                    game_id,
+                    live_key,
+                    e,
+                );
+                continue;
+            }
+            stats.deleted = stats.deleted.saturating_add(1);
+        }
+
+        let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
+        console_log!(
+            "[backfill] event=live_orphan_sweep_progress listed={} deleted={} elapsed_ms={}",
+            stats.listed,
+            stats.deleted,
+            elapsed_ms,
+        );
+        Ok(stats)
+    }
+
+    /// `live-games-index/<key>` の本文を読んで `game_id` field を返す。
+    ///
+    /// 失敗はすべて logfmt で記録した上で `None` を返し、呼び出し側で entry
+    /// を skip させる (sweep 全体を停止しない)。
+    async fn read_live_entry_game_id(bucket: &worker::Bucket, key: &str) -> Option<String> {
+        let fetched = match bucket.get(key).execute().await {
+            Ok(o) => o,
+            Err(e) => {
+                console_log!(
+                    "[backfill] event=live_orphan_sweep_get_failed key={} err={:?}",
+                    key,
+                    e,
+                );
+                return None;
+            }
+        };
+        let fetched = fetched?;
+        let body = fetched.body()?;
+        let bytes = match body.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[backfill] event=live_orphan_sweep_read_failed key={} err={:?}",
+                    key,
+                    e,
+                );
+                return None;
+            }
+        };
+        match serde_json::from_slice::<LiveEntryGameId>(&bytes) {
+            Ok(v) => Some(v.game_id),
+            Err(e) => {
+                console_log!(
+                    "[backfill] event=live_orphan_sweep_parse_failed key={} err={:?}",
+                    key,
+                    e,
+                );
+                None
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use imp::{run_games_index_backfill, run_live_orphan_sweep};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::x1_paths::kifu_by_id_meta_key;
+
+    #[test]
+    fn meta_for_index_key_deserializes_subset_of_games_index_entry() {
+        // `GamesIndexEntry` の wire と互換であることを確認する。
+        let json = r#"{
+            "game_id": "lobby-cross-fischer-1777391025209",
+            "started_at_ms": 1777391025209,
+            "ended_at_ms": 1777392877244,
+            "black_handle": "alice",
+            "white_handle": "bob",
+            "result_kind": "WIN_BLACK",
+            "end_reason": "RESIGN",
+            "moves_count": 142,
+            "clock": {"kind": "fischer", "total_sec": 300, "increment_sec": 5},
+            "source": "kifu"
+        }"#;
+        let parsed: MetaForIndexKey = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.game_id, "lobby-cross-fischer-1777391025209");
+        assert_eq!(parsed.ended_at_ms, 1_777_392_877_244);
+    }
+
+    #[test]
+    fn meta_for_index_key_rejects_missing_required_fields() {
+        // `game_id` 欠落は parse error → backfill 経路で skip。
+        let json = r#"{"ended_at_ms": 1}"#;
+        assert!(serde_json::from_str::<MetaForIndexKey>(json).is_err());
+
+        // `ended_at_ms` 欠落も同様。
+        let json = r#"{"game_id": "g1"}"#;
+        assert!(serde_json::from_str::<MetaForIndexKey>(json).is_err());
+    }
+
+    #[test]
+    fn live_entry_game_id_deserializes_from_live_entry_wire() {
+        // `LiveGamesIndexEntry` の wire (`live_games_index::tests::live_entry_serializes_with_expected_fields`
+        // と整合) から `game_id` のみ抽出できる。
+        let json = r#"{
+            "game_id": "g1",
+            "started_at_ms": 1777391025209,
+            "black_handle": "alice",
+            "white_handle": "bob",
+            "clock": {"kind": "fischer", "total_sec": 300, "increment_sec": 5},
+            "source": "kifu"
+        }"#;
+        let parsed: LiveEntryGameId = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.game_id, "g1");
+    }
+
+    #[test]
+    fn backfill_stats_default_is_zero() {
+        let stats = BackfillStats::default();
+        assert_eq!(
+            stats,
+            BackfillStats {
+                listed: 0,
+                put: 0,
+                skipped: 0
+            }
+        );
+    }
+
+    #[test]
+    fn sweep_stats_default_is_zero() {
+        let stats = SweepStats::default();
+        assert_eq!(
+            stats,
+            SweepStats {
+                listed: 0,
+                deleted: 0
+            }
+        );
+    }
+
+    #[test]
+    fn meta_suffix_matches_kifu_by_id_meta_key_layout() {
+        // `kifu_by_id_meta_key` 生成キーの拡張子と本モジュールの list filter で
+        // 使う suffix が必ず揃っていること (片方だけ変わると backfill が空振り)。
+        let key = kifu_by_id_meta_key("g1");
+        assert!(key.ends_with(META_SUFFIX), "key={key} suffix={META_SUFFIX}");
+    }
+
+    #[test]
+    fn kifu_by_id_meta_key_starts_with_backfill_prefix() {
+        // backfill list 走査の prefix と meta key の先頭は揃っていること。
+        let key = kifu_by_id_meta_key("g1");
+        assert!(key.starts_with(KIFU_BY_ID_PREFIX), "key={key} prefix={KIFU_BY_ID_PREFIX}");
+    }
+
+    #[test]
+    fn page_size_does_not_exceed_r2_list_limit() {
+        // R2 list の上限 = 1000 (Cloudflare 仕様)。本値を勝手に上げると runtime
+        // 失敗するため、定数の不変条件として固定。const block で生成時に検査
+        // させる (clippy::assertions_on_constants 回避)。
+        const _: () = assert!(PAGE_SIZE <= 1000, "PAGE_SIZE must not exceed R2 list limit");
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -86,7 +86,9 @@ use crate::spectator_snapshot::{
     SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot,
 };
 use crate::ws_route::{WsRoute, parse_ws_route};
-use crate::x1_paths::{buoy_object_key, default_fork_buoy_name, kifu_by_id_object_key};
+use crate::x1_paths::{
+    buoy_object_key, default_fork_buoy_name, kifu_by_id_meta_key, kifu_by_id_object_key,
+};
 
 const DEFAULT_MAX_MOVES: u32 = 256;
 const DEFAULT_TIME_MARGIN_MS: u64 = 1000;
@@ -1327,29 +1329,25 @@ impl GameRoom {
         bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
         console_log!("[GameRoom] kifu exported to R2 key='{key}'");
 
-        // viewer 配信 API 用の補助インデックス (`games-index/...`) を 1 件 put する。
-        // 本文 + by-id put は既に成功しているため、index put のいかなる失敗も
-        // `finalize_if_ended` を Err にしてはならない (best-effort)。validation /
-        // serialize / put すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。
-        // `?` は意図的に使わない。
+        // viewer 配信 API 用の正準メタ (`kifu-by-id/<id>.meta.json`) と派生
+        // インデックス (`games-index/<inv>-<id>.json`) を続けて put する。
+        // CSA 本文 + by-id put は既に成功しているため、以降の put のいかなる
+        // 失敗も `finalize_if_ended` を Err にしてはならない (best-effort)。
+        // すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。`?` は意図的
+        // に使わない。
+        //
+        // 書き込み順序 (Issue #551 設計 v3 §1):
+        //   1. csa 本文 / by-id (上で完了)
+        //   2. `kifu-by-id/<id>.meta.json` — backfill / orphan sweep の真の判定
+        //      キー (primary)。csa 成功直後に書く。
+        //   3. `games-index/<inv>-<id>.json` — meta から派生する一覧索引
+        //      (secondary)。failure 時は backfill cron が meta を起点に再生成する。
         //
         // `source` 判定は `live-games-index/` の対局開始時 entry と完全に揃える
         // ため、`games_index::resolve_index_source` 共通 helper に集約済 (Issue
         // #549 設計 v3 §3)。`floodgate-history/` への put 成否ではなく「Floodgate
         // 環境設定下で起きた終局」を表す semantics は同 helper の契約に従う。
         let source = resolve_index_source(&self.env);
-
-        let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
-            Ok(k) => k,
-            Err(e) => {
-                console_log!(
-                    "[GameRoom] event=games_index_skip game_id={} reason=key:{:?}",
-                    cfg.game_id,
-                    e,
-                );
-                return Ok(());
-            }
-        };
 
         let (result_kind, end_reason) = classify_result(game_result);
         let entry = GamesIndexEntry {
@@ -1368,6 +1366,9 @@ impl GameRoom {
             source,
         };
 
+        // 1 度シリアライズして meta primary / games-index secondary の双方に
+        // 流用する。serialize 失敗は両 put を skip して終了する (どちらも meta
+        // 起点なので片方だけ書く意味がない)。
         let body = match serde_json::to_vec(&entry) {
             Ok(b) => b,
             Err(e) => {
@@ -1380,6 +1381,31 @@ impl GameRoom {
             }
         };
 
+        // (2) `kifu-by-id/<id>.meta.json` — primary。failure は backfill 経路で
+        // 復元できないので observable に log は残すが、後段の games-index put は
+        // 引き続き試行する (現行 best-effort 一連 put 方針を維持。設計 v2 §1)。
+        let meta_key = kifu_by_id_meta_key(&cfg.game_id);
+        if let Err(e) = bucket.put(&meta_key, body.clone()).execute().await {
+            console_log!(
+                "[GameRoom] event=kifu_by_id_meta_put_failed game_id={} meta_key={} err={:?}",
+                cfg.game_id,
+                meta_key,
+                e,
+            );
+        }
+
+        // (3) `games-index/<inv>-<id>.json` — secondary。
+        let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
+            Ok(k) => k,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=games_index_skip game_id={} reason=key:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return Ok(());
+            }
+        };
         if let Err(e) = bucket.put(&index_key, body).execute().await {
             console_log!(
                 "[GameRoom] event=games_index_put_failed game_id={} inv_key={} err={:?}",

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -23,6 +23,13 @@ compile_error!(
 );
 
 pub mod attachment;
+// `backfill` は cron trigger (`#[event(scheduled)]`) からのみ消費される。
+// ホスト target で参照する公開 API は Stats / Deserialize 型のみで、IO 関数本体
+// は wasm32 ゲートで切り離している。それでもホスト通常ビルド (cargo build) では
+// 消費者が無くなり dead_code 警告が出るため、`persistence` 等と同様に
+// wasm32 + test ゲーティングで揃える。
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) mod backfill;
 pub mod config;
 pub mod datetime;
 pub mod floodgate_history;
@@ -80,4 +87,38 @@ pub async fn fetch(
     _ctx: worker::Context,
 ) -> worker::Result<worker::Response> {
     router::handle_fetch(req, env).await
+}
+
+/// Workers ランタイムの scheduled イベント (cron trigger)。
+///
+/// `wrangler.toml` の `[triggers] crons = ["0 */1 * * *"]` (毎時 0 分) で起動し、
+/// 順次 `run_games_index_backfill` → `run_live_orphan_sweep` を呼ぶ
+/// (Issue #551 設計 v3 §11)。
+///
+/// 各ジョブは内部的に best-effort で失敗を握り潰し `Result::Ok` で返すため、
+/// scheduled handler 側ではさらに伝播禁止 (cron の継続可用性を最優先する) で
+/// `Err` も logfmt のみ記録する。`env` は `&env` 経由で渡し `Env: Clone` 前提
+/// を作らない (設計 v2 §4)。
+#[cfg(target_arch = "wasm32")]
+#[worker::event(scheduled)]
+pub async fn scheduled(
+    event: worker::ScheduledEvent,
+    env: worker::Env,
+    _ctx: worker::ScheduleContext,
+) {
+    let cron = event.cron();
+    if let Err(e) = backfill::run_games_index_backfill(&env).await {
+        worker::console_log!(
+            "[scheduled] event=games_index_backfill_failed cron={} err={:?}",
+            cron,
+            e,
+        );
+    }
+    if let Err(e) = backfill::run_live_orphan_sweep(&env).await {
+        worker::console_log!(
+            "[scheduled] event=live_orphan_sweep_failed cron={} err={:?}",
+            cron,
+            e,
+        );
+    }
 }

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -16,7 +16,8 @@
 //!   WS spectate 接続で実状態を確認する)。
 //! - `GET /api/v1/games/<game_id>` 単局 (終局済)
 //!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
-//!   `games-index/` から取得した meta を合わせて返す。
+//!   `kifu-by-id/<encoded_game_id>.meta.json` から取得した正準メタ (Issue #551
+//!   設計 v3 §12) を合わせて返す。
 //!
 //! いずれも GameRoom DO を経由せず、Worker 直 fetch のみで完結する (R2 read
 //! 1 ホップ)。CORS は staging では `WS_ALLOWED_ORIGINS` をそのまま流用して
@@ -36,7 +37,7 @@ use crate::config::{ConfigKeys, OriginAllowList};
 use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
 use crate::live_games_index::LIVE_KEY_PREFIX;
 use crate::origin::{OriginDecision, evaluate};
-use crate::x1_paths::kifu_by_id_object_key;
+use crate::x1_paths::{kifu_by_id_meta_key, kifu_by_id_object_key};
 
 const DEFAULT_LIMIT: u32 = 50;
 const MAX_LIMIT: u32 = 100;
@@ -99,9 +100,9 @@ struct LiveListResponse {
 struct GameResponse<'a> {
     game_id: &'a str,
     csa: String,
-    /// `games-index/` から取得した meta。MVP では index に entry が無い場合
-    /// 404 を返す前提で、ここは常に `Some` だが、JSON 上は serde 既定で field
-    /// として出る。
+    /// `kifu-by-id/<id>.meta.json` から取得した正準メタ (Issue #551 設計 v3 §12)。
+    /// meta 不在時は 404 を返す前提なので、ここは常に `Some` 相当だが JSON 上は
+    /// serde 既定で field として出る。
     meta: serde_json::Value,
 }
 
@@ -302,21 +303,19 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
         }
     };
 
-    // meta は `games-index/` を prefix list で 1 件だけ走査して見つける。
-    // index key は `<inv_ms>-<game_id>.json` 形式なので game_id 単独では
-    // 完全な key を再構築できない (inv_ms が分からない)。MVP では list で
-    // 1 件目を見つけ次第 break する単純戦略を採る (per game_id で 1 件のみ
-    // 存在する不変条件下では効率より簡潔さを優先)。
+    // meta は `kifu-by-id/<id>.meta.json` を直接 get で取得する (Issue #551
+    // 設計 v3 §12)。primary meta が常設される契約なので、`games-index/` を
+    // prefix list で走査する旧経路 (O(N) コスト) は廃止し、O(1) get に置換した。
     let meta = match find_meta_for(&bucket, game_id).await {
         Ok(Some(m)) => m,
         Ok(None) => {
-            // CSA 本文はあるが index に entry が無い (backfill 未実施 or
-            // index put 失敗)。MVP 仕様として 404 を返す (本文表示には
-            // meta が必須なため)。
+            // primary meta が無い (backfill 未実施 or meta put 失敗)。本 issue
+            // scope では legacy fallback を行わず 404 を返す (Non-goals 設計
+            // v3 §10)。
             return with_cors(Response::error("Not Found", 404)?, req, env);
         }
         Err(e) => {
-            console_log_failed("games_index_lookup", &format!("game_id={game_id} err={e}"));
+            console_log_failed("kifu_by_id_meta_lookup", &format!("game_id={game_id} err={e}"));
             return with_cors(Response::error("Storage error", 502)?, req, env);
         }
     };
@@ -330,59 +329,26 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
     with_cors(resp, req, env)
 }
 
-/// `games-index/` を走査して `game_id` に対応する meta を 1 件取得する。
+/// `kifu-by-id/<id>.meta.json` を直接 get して `game_id` の meta を返す。
 ///
-/// pagination で `truncated` の間ループするが、ヒット時点で打ち切る。
-/// 1 game_id あたり 1 entry の不変条件を活用し、見つかった瞬間返す。
+/// Issue #551 設計 v3 §12 で meta primary 化したことにより、`games-index/`
+/// を prefix list で走査する旧経路 (O(N)) は廃止し O(1) get に統一した。
+/// meta が存在しない場合は `Ok(None)` を返し、呼び出し側で 404 を返す。
 async fn find_meta_for(
     bucket: &worker::Bucket,
     game_id: &str,
 ) -> std::result::Result<Option<serde_json::Value>, String> {
-    let mut cursor: Option<String> = None;
-    loop {
-        let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX);
-        if let Some(c) = cursor.as_deref() {
-            builder = builder.cursor(c);
-        }
-        let page = builder.execute().await.map_err(|e| e.to_string())?;
-        for obj in page.objects() {
-            let key = obj.key();
-            // key 形式: `games-index/<inv_ms:14>-<game_id>.json`
-            // 末尾 `.json` を除去 → 先頭 `games-index/<inv_ms>-` を除去 → game_id
-            let Some(stripped) = key.strip_prefix(GAMES_INDEX_PREFIX) else {
-                continue;
-            };
-            let Some(without_ext) = stripped.strip_suffix(".json") else {
-                continue;
-            };
-            // `<inv_ms:14>-<game_id>` から `-` 1 個目以降を game_id として取り出す。
-            let Some(dash_idx) = without_ext.find('-') else {
-                continue;
-            };
-            let key_game_id = &without_ext[dash_idx + 1..];
-            if key_game_id != game_id {
-                continue;
-            }
-            let fetched = bucket.get(&key).execute().await.map_err(|e| e.to_string())?;
-            let Some(fetched) = fetched else {
-                continue;
-            };
-            let Some(body) = fetched.body() else {
-                continue;
-            };
-            let bytes = body.bytes().await.map_err(|e| e.to_string())?;
-            let value: serde_json::Value =
-                serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
-            return Ok(Some(value));
-        }
-        if !page.truncated() {
-            return Ok(None);
-        }
-        cursor = page.cursor();
-        if cursor.is_none() {
-            return Ok(None);
-        }
-    }
+    let meta_key = kifu_by_id_meta_key(game_id);
+    let fetched = bucket.get(&meta_key).execute().await.map_err(|e| e.to_string())?;
+    let Some(fetched) = fetched else {
+        return Ok(None);
+    };
+    let Some(body) = fetched.body() else {
+        return Ok(None);
+    };
+    let bytes = body.bytes().await.map_err(|e| e.to_string())?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    Ok(Some(value))
 }
 
 /// CORS / Origin チェック。リクエスト Origin が許可リストに含まれる場合のみ

--- a/crates/rshogi-csa-server-workers/src/x1_paths.rs
+++ b/crates/rshogi-csa-server-workers/src/x1_paths.rs
@@ -33,6 +33,16 @@ pub fn kifu_by_id_object_key(game_id: &str) -> String {
     format!("kifu-by-id/{}.csa", encode_component(game_id))
 }
 
+/// game_id から逆引きする棋譜メタ (`<id>.meta.json`) キー。
+///
+/// `kifu_by_id_object_key` と同じ `encode_component(game_id)` を通すことで、
+/// CSA 本体キーと完全に同じエンコーディング規約に揃える (Issue #551 v3 §12)。
+/// reader (viewer_api) と writer (game_room / backfill) で生成キーが乖離しない
+/// ように、本ヘルパを必ず経由して `<game_id>.meta.json` を構築する。
+pub fn kifu_by_id_meta_key(game_id: &str) -> String {
+    format!("kifu-by-id/{}.meta.json", encode_component(game_id))
+}
+
 /// `%%FORK` で省略時に使う既定の buoy 名。
 pub fn default_fork_buoy_name(source_game: &str, nth_move: Option<u32>) -> String {
     let suffix = nth_move.map_or_else(|| "final".to_owned(), |n| n.to_string());
@@ -58,5 +68,27 @@ mod tests {
     fn fork_default_name_uses_final_when_nth_missing() {
         assert_eq!(default_fork_buoy_name("20260417120000", None), "20260417120000-fork-final");
         assert_eq!(default_fork_buoy_name("20260417120000", Some(24)), "20260417120000-fork-24");
+    }
+
+    #[test]
+    fn kifu_by_id_meta_key_uses_meta_json_suffix() {
+        // ASCII 安全な game_id はそのまま埋まる + 末尾は `.meta.json`。
+        assert_eq!(
+            kifu_by_id_meta_key("lobby-cross-fischer-1777391025209"),
+            "kifu-by-id/lobby-cross-fischer-1777391025209.meta.json",
+        );
+    }
+
+    #[test]
+    fn kifu_by_id_meta_key_encodes_unsafe_chars_consistently_with_object_key() {
+        // CSA 本体キーと meta キーは「encode_component を通したあと拡張子だけ
+        // 異なる」という不変条件が崩れていないこと。これにより writer/reader が
+        // 同一 game_id について常に対応するペアを参照できる。
+        let game_id = "../weird id/対局";
+        let object = kifu_by_id_object_key(game_id);
+        let meta = kifu_by_id_meta_key(game_id);
+        let object_stem = object.strip_suffix(".csa").expect("object key ends with .csa");
+        let meta_stem = meta.strip_suffix(".meta.json").expect("meta key ends with .meta.json");
+        assert_eq!(object_stem, meta_stem, "encoded stem must match between object and meta");
     }
 }

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -32,6 +32,8 @@ struct EnvironmentBindings {
     /// `[[migrations]]` 配列を生のまま保持する。`new_sqlite_classes` 等を
     /// 各 test が独自に検査するため、`Vec<toml::Value>` のまま持つ。
     migrations: Vec<toml::Value>,
+    /// `[triggers] crons = [...]` の値 (Issue #551)。空配列は未宣言。
+    crons: Vec<String>,
 }
 
 static PRODUCTION: LazyLock<EnvironmentBindings> =
@@ -77,6 +79,13 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
 
     let migrations = doc.get("migrations").and_then(|v| v.as_array()).cloned().unwrap_or_default();
 
+    let crons = doc
+        .get("triggers")
+        .and_then(|v| v.get("crons"))
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|t| t.as_str().map(str::to_owned)).collect())
+        .unwrap_or_default();
+
     EnvironmentBindings {
         label,
         file_name,
@@ -84,6 +93,7 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
         do_bindings,
         vars_keys,
         migrations,
+        crons,
     }
 }
 
@@ -151,6 +161,20 @@ fn assert_no_local_dev_only_keys(env: &EnvironmentBindings) {
     );
 }
 
+/// Issue #551 で追加した `[triggers] crons` が各 deploy 環境に宣言されていることを
+/// 固定する。`[event(scheduled)]` ハンドラは production / staging 両方で稼働させる
+/// 契約 (片方だけ宣言だと backfill / orphan sweep が動かず orphan が滞留する)。
+fn assert_declares_backfill_cron_trigger(env: &EnvironmentBindings) {
+    assert!(
+        !env.crons.is_empty(),
+        "{file} ({label}) must declare [triggers] crons = [...] for the backfill scheduled handler; \
+         got: {crons:?}",
+        file = env.file_name,
+        label = env.label,
+        crons = env.crons,
+    );
+}
+
 fn assert_declares_sqlite_migration_for_game_room(env: &EnvironmentBindings) {
     assert!(
         !env.migrations.is_empty(),
@@ -201,6 +225,11 @@ fn wrangler_production_declares_sqlite_migration_for_game_room() {
     assert_declares_sqlite_migration_for_game_room(&PRODUCTION);
 }
 
+#[test]
+fn wrangler_production_declares_backfill_cron_trigger() {
+    assert_declares_backfill_cron_trigger(&PRODUCTION);
+}
+
 // --- staging -------------------------------------------------------------
 
 #[test]
@@ -226,4 +255,9 @@ fn wrangler_staging_vars_must_not_contain_local_dev_only_keys() {
 #[test]
 fn wrangler_staging_declares_sqlite_migration_for_game_room() {
     assert_declares_sqlite_migration_for_game_room(&STAGING);
+}
+
+#[test]
+fn wrangler_staging_declares_backfill_cron_trigger() {
+    assert_declares_backfill_cron_trigger(&STAGING);
 }

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -29,6 +29,8 @@ struct TemplateBindings {
     r2_bindings: Vec<String>,
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
+    /// `[triggers] crons = [...]` の値を保持する (Issue #551)。空配列は未宣言。
+    crons: Vec<String>,
 }
 
 /// テスト 1 本ごとに file I/O + parse を繰り返さないため `LazyLock` で 1 回化する。
@@ -75,10 +77,19 @@ fn load_template_bindings() -> TemplateBindings {
         .map(|t| t.keys().cloned().collect())
         .unwrap_or_default();
 
+    // `[triggers] crons = [...]` を集める。
+    let crons = doc
+        .get("triggers")
+        .and_then(|v| v.get("crons"))
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|t| t.as_str().map(str::to_owned)).collect())
+        .unwrap_or_default();
+
     TemplateBindings {
         r2_bindings,
         do_bindings,
         vars_keys,
+        crons,
     }
 }
 
@@ -148,4 +159,16 @@ fn wrangler_template_vars_keys_match_config_keys() {
         .copied()
         .collect();
     assert_bidirectional("vars_keys", &expected, &TEMPLATE.vars_keys);
+}
+
+/// Issue #551 で追加した `[triggers] crons` が template に宣言されていることを
+/// 固定する。`[event(scheduled)]` ハンドラと cron trigger は同 PR で導入したので、
+/// 片方だけが残ったまま運用者が `cp wrangler.toml.example wrangler.toml` した場合
+/// に handler が永久 dormant にならないよう、template 側で必須化する。
+#[test]
+fn wrangler_template_declares_backfill_cron_trigger() {
+    assert!(
+        !TEMPLATE.crons.is_empty(),
+        "wrangler.toml.example must declare [triggers] crons = [...] for the backfill scheduled handler",
+    );
 }

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -73,6 +73,14 @@ bucket_name = "rshogi-csa-kifu-prod"
 binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-prod"
 
+# --- Cron triggers ---
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
+# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
+# のみ処理する eventual semantics。
+[triggers]
+crons = ["0 */1 * * *"]
+
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、本番 client URL に応じて運用者が更新する。
 # 値変更は通常の PR で行い、merge → dispatch deploy で反映される。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -70,6 +70,14 @@ bucket_name = "rshogi-csa-kifu-staging"
 binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-staging"
 
+# --- Cron triggers ---
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
+# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
+# のみ処理する eventual semantics。
+[triggers]
+crons = ["0 */1 * * *"]
+
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、staging client の Origin に応じて運用者が更新する。
 # 値変更は通常の PR で行い、merge → 自動 deploy で反映される。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -63,6 +63,14 @@ binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "local-floodgate-history-dev"
 preview_bucket_name = "local-floodgate-history-dev"
 
+# --- Cron triggers ---
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
+# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
+# のみ処理する eventual semantics。bulk 1 万件超は admin invoke 経路を別途検討。
+[triggers]
+crons = ["0 */1 * * *"]
+
 # --- 変数 ---
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。ブラウザ経由
 # （Origin ヘッダ付き）のリクエストに対する CSRF 防御に使う。


### PR DESCRIPTION
## Summary

Issue #551 設計 v3 を実装。

- `kifu-by-id/<id>.meta.json` を **正準メタ (primary)** として書き、`games-index/` を派生 secondary に位置付ける (設計 v3 §1)
- viewer_api::find_meta_for を `games-index/` list 走査 (O(N)) → `kifu-by-id/<id>.meta.json` 直 get (O(1)) に置換 (設計 v3 §12)
- `backfill.rs` 新規: meta から games-index を再生成する backfill cron + live entry の orphan sweep を実装 (設計 v3 §3)
- `#[event(scheduled)]` handler + `[triggers] crons = ["0 */1 * * *"]` を 3 wrangler*.toml に追加

## 主要ファイル

- 新規 `crates/rshogi-csa-server-workers/src/backfill.rs` (run_games_index_backfill / run_live_orphan_sweep + Stats / Deserialize 型)
- 改修 `crates/rshogi-csa-server-workers/src/game_room.rs` (csa → meta → games-index の順 put)
- 改修 `crates/rshogi-csa-server-workers/src/viewer_api.rs` (find_meta_for を 直 get 化)
- 改修 `crates/rshogi-csa-server-workers/src/x1_paths.rs` (kifu_by_id_meta_key helper + tests)
- 改修 `crates/rshogi-csa-server-workers/src/lib.rs` (scheduled handler 追加)
- 改修 `crates/rshogi-csa-server-workers/wrangler.toml.example` / `wrangler.staging.toml` / `wrangler.production.toml` (cron trigger)
- 改修 `crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs` / `tests/wrangler_environment_toml_consistency.rs` (cron 必須化アサーション)

Closes #551

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --tests --all-targets` (warning 0)
- [x] `cargo test --workspace` (新規 backfill / x1_paths テスト + cron 整合テスト全 pass)
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers`
- [ ] staging で `wrangler dev` smoke (1 局完走 → meta が R2 に書かれる、`/api/v1/games/<id>` が meta 経由で 200、cron 手動 trigger で games-index 補完、live entry が終局後 sweep される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)