### PR TITLE
chore(csa-server-workers): production/staging の WS_ALLOWED_ORIGINS に ramu-shogi web と Tauri Origin を登録

### DIFF
--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -94,8 +94,11 @@ crons = ["0 */1 * * *"]
 # では allowlist が **必須**: 空・未設定時は Origin の有無にかかわらず 403。
 # 無認可公開を防ぐ fail-closed 既定で、`ALLOW_VIEWER_API` と組で運用する。
 # 実運用では web client URL を実値に書き換えること。
-# 例: "https://rshogi.example.com,https://www.rshogi.example.com"
-WS_ALLOWED_ORIGINS = "https://rshogi.example.com"
+# Tauri desktop は webview から fetch するときに OS 別の Origin を付与する:
+#   - macOS / Linux: tauri://localhost
+#   - Windows: https://tauri.localhost
+# 両方を allowlist に登録して desktop からの request も通す。
+WS_ALLOWED_ORIGINS = "https://ramu-shogi.sh11235.com,tauri://localhost,https://tauri.localhost"
 
 # 対局時計。`countdown` (CSA 2014 改訂秒読み、Floodgate 互換) / `countdown_msec`
 # (ms 粒度の短時間対局向け拡張) / `fischer` (増分加算) / `stopwatch` (分単位)。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -86,9 +86,11 @@ crons = ["0 */1 * * *"]
 # （Origin ヘッダ付き）に対する CSRF 防御として機能する。
 # 空文字列・未設定時はブラウザ経由を全 403、Origin ヘッダを送らない
 # ネイティブ CSA クライアントは素通し。
-# staging では本リポ csa_client の `ws_origin` 既定値と合わせ、Origin 付きで
-# 実機 E2E が通電できる値を入れておく。web client URL が確定したら追記する。
-WS_ALLOWED_ORIGINS = "https://csa-client-local"
+# staging では本リポ csa_client の `ws_origin` 既定値 (`https://csa-client-local`)
+# と staging web client + Tauri desktop の Origin を併記する。
+# Tauri desktop は OS 別 Origin (`tauri://localhost` / `https://tauri.localhost`)
+# を webview から自動付与するため、両方を登録する。
+WS_ALLOWED_ORIGINS = "https://stg.ramu-shogi.sh11235.com,https://csa-client-local,tauri://localhost,https://tauri.localhost"
 
 # 対局時計の方式と値。
 # - `countdown`: CSA 2014 改訂互換、整数秒切り捨て、Floodgate 互換 (`Time_Unit:1sec`)。


### PR DESCRIPTION
## 概要

ramu-shogi 本番/staging から viewer 配信 API + spectate WS を通すため、`wrangler.{production,staging}.toml` の `WS_ALLOWED_ORIGINS` を実値に更新する。

## 変更点

### production (`wrangler.production.toml`)
- 旧: `"https://rshogi.example.com"` (placeholder)
- 新: `"https://ramu-shogi.sh11235.com,tauri://localhost,https://tauri.localhost"`

### staging (`wrangler.staging.toml`)
- 旧: `"https://csa-client-local"` (csa_client E2E 用のみ)
- 新: `"https://stg.ramu-shogi.sh11235.com,https://csa-client-local,tauri://localhost,https://tauri.localhost"`
  - 既存 `csa-client-local` を保持し、staging web origin と Tauri origin を追加

## Tauri Origin の取扱い

Tauri 2.0 の webview は fetch 時に OS 別の Origin を自動付与する:
- macOS / Linux: `tauri://localhost`
- Windows: `https://tauri.localhost`

両 origin を allowlist に並記することで、desktop アプリからの viewer 利用も 403 で弾かれないようにする。

ネイティブ CSA クライアント (`rshogi-csa-client` 等) は Origin ヘッダを送らないため、`origin.rs::evaluate` の `None → Allow` semantics により従来どおり素通し。

## 検証

- `cargo test -p rshogi-csa-server-workers --test wrangler_environment_toml_consistency --test wrangler_template_consistency`: 16 tests passed
- merge 後 deploy が走ったら curl smoke で確認 (production: `curl -sI -H 'Origin: https://ramu-shogi.sh11235.com' https://rshogi-csa-server.sh11235.com/api/v1/games` → 200 + `Access-Control-Allow-Origin` echo back)

## Non-goals

- ramu-shogi 側 `.env.production` / `.env.staging` の `VITE_RSHOGI_API_BASE` 配線 (別 PR、ramu-shogi リポ側)
- viewer/spectate API への CORS preflight (OPTIONS) 対応 (要観測)
- クライアント種識別 (User-Agent / X-Client header 経由) の導入は別 issue