### PR TITLE
feat(csa-server-workers): viewer 配信 API に CORS preflight + X-Client クライアント識別を追加

### DIFF
--- a/crates/rshogi-csa-server-workers/src/client_kind.rs
+++ b/crates/rshogi-csa-server-workers/src/client_kind.rs
@@ -1,0 +1,124 @@
+//! `X-Client` ヘッダ値を運用ログ向けに正規化する純粋ロジック。
+//!
+//! Issue #564 設計 v4 §3 に対応。viewer 配信 API のレスポンスログに
+//! `client_kind=<kind>` として埋め込むため、任意文字列が logfmt を破壊しない
+//! よう kebab-case ASCII (`[a-z0-9-]`) のみを許可するホワイトリスト方式で
+//! 正規化する。
+//!
+//! # フォーマット契約
+//! `<client>/<version>` 形式の `<client>` 部分のみを抽出する。`/` を含まない
+//! 場合は全体を `<client>` とみなす。
+//!
+//! # 戻り値
+//! - `Some(raw)` で kebab-case ASCII かつ 1..=64 文字 → 抽出した kind
+//! - `Some(raw)` で正規化規則に違反 → `"invalid"`
+//! - `None` (ヘッダ欠落) → `"unknown"`
+//!
+//! 戻り値はそのまま logfmt の値として埋め込める ASCII 文字列であることを保証
+//! する。`viewer_api.rs` の `extract_client_kind` から呼ばれる。
+//!
+//! Workers ランタイム (`worker::Request`) は wasm32 専用だが、本モジュールは
+//! 純粋関数のためホスト target でもテスト可能。`worker::Request` 依存部分は
+//! `viewer_api::extract_client_kind` 側に留める。
+
+/// `client_kind` の最大長。logfmt にそのまま流すため過大な値を弾く。
+pub const MAX_CLIENT_KIND_LEN: usize = 64;
+
+/// `Some("ramu-shogi-web/0.1.0")` 等の `X-Client` ヘッダ値を `client_kind`
+/// 文字列に正規化する。
+///
+/// - `None` → `"unknown"` (ヘッダ未送信)
+/// - `<kind>` 部分 (`/` までの prefix) が空 / 65 文字以上 / kebab-case ASCII
+///   外を含む → `"invalid"`
+/// - それ以外 → `<kind>` 部分をそのまま返す
+pub fn normalize_client_kind(raw: Option<&str>) -> String {
+    let Some(raw) = raw else {
+        return "unknown".to_owned();
+    };
+    // `<kind>/<version>` の `<kind>` 側のみを抽出。`/` が無い場合は全体が `<kind>`。
+    let kind = raw.split('/').next().unwrap_or("");
+    if kind.is_empty() || kind.len() > MAX_CLIENT_KIND_LEN {
+        return "invalid".to_owned();
+    }
+    // kebab-case ASCII のみ許可。logfmt 破壊文字 (`=` `空白` `\n` `\r` 等) を排除。
+    if !kind.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        return "invalid".to_owned();
+    }
+    kind.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_missing_returns_unknown() {
+        assert_eq!(normalize_client_kind(None), "unknown");
+    }
+
+    #[test]
+    fn lowercase_ascii_kind_is_passed_through() {
+        assert_eq!(normalize_client_kind(Some("ramu-shogi-web")), "ramu-shogi-web");
+        assert_eq!(normalize_client_kind(Some("ramu-shogi-desktop")), "ramu-shogi-desktop");
+        assert_eq!(normalize_client_kind(Some("rshogi-csa-cli")), "rshogi-csa-cli");
+        assert_eq!(normalize_client_kind(Some("client123")), "client123");
+    }
+
+    #[test]
+    fn kind_version_form_extracts_only_kind() {
+        assert_eq!(normalize_client_kind(Some("ramu-shogi-web/0.1.0")), "ramu-shogi-web");
+        assert_eq!(
+            normalize_client_kind(Some("ramu-shogi-desktop/1.2.3-beta")),
+            "ramu-shogi-desktop"
+        );
+        // `/` 直後が空でも kind が有効なら通す。
+        assert_eq!(normalize_client_kind(Some("ramu-shogi-web/")), "ramu-shogi-web");
+    }
+
+    #[test]
+    fn uppercase_letters_are_invalid() {
+        assert_eq!(normalize_client_kind(Some("Ramu-Shogi-Web")), "invalid");
+        assert_eq!(normalize_client_kind(Some("RAMU-SHOGI")), "invalid");
+        assert_eq!(normalize_client_kind(Some("Ramu/0.1.0")), "invalid");
+    }
+
+    #[test]
+    fn whitespace_equals_and_newline_are_invalid() {
+        // logfmt 破壊文字をすべて invalid にする。
+        assert_eq!(normalize_client_kind(Some("ramu shogi")), "invalid");
+        assert_eq!(normalize_client_kind(Some("a=b")), "invalid");
+        assert_eq!(normalize_client_kind(Some("ramu\nshogi")), "invalid");
+        assert_eq!(normalize_client_kind(Some("ramu\rshogi")), "invalid");
+        assert_eq!(normalize_client_kind(Some("ramu\tshogi")), "invalid");
+    }
+
+    #[test]
+    fn over_max_length_is_invalid() {
+        // 65 文字 (MAX_CLIENT_KIND_LEN + 1) は invalid。
+        let too_long = "a".repeat(MAX_CLIENT_KIND_LEN + 1);
+        assert_eq!(normalize_client_kind(Some(&too_long)), "invalid");
+        // ちょうど 64 文字は許可。
+        let just_fit = "a".repeat(MAX_CLIENT_KIND_LEN);
+        assert_eq!(normalize_client_kind(Some(&just_fit)), just_fit);
+        // 65 文字目以降が `/` で切り落とされても kind 側が 65 文字なら invalid。
+        let long_with_version = format!("{}/0.1.0", "a".repeat(MAX_CLIENT_KIND_LEN + 1));
+        assert_eq!(normalize_client_kind(Some(&long_with_version)), "invalid");
+    }
+
+    #[test]
+    fn empty_kind_is_invalid() {
+        // ヘッダ自体は存在するが値が空 / `/` 始まりで kind 部分が空。
+        assert_eq!(normalize_client_kind(Some("")), "invalid");
+        assert_eq!(normalize_client_kind(Some("/0.1.0")), "invalid");
+    }
+
+    #[test]
+    fn non_ascii_or_special_punctuation_is_invalid() {
+        // 日本語やマルチバイトは invalid (logfmt safety)。
+        assert_eq!(normalize_client_kind(Some("らむ将棋")), "invalid");
+        // `_` `.` `:` 等の他の punctuation も kebab-case 外なので invalid。
+        assert_eq!(normalize_client_kind(Some("ramu_shogi")), "invalid");
+        assert_eq!(normalize_client_kind(Some("ramu.shogi")), "invalid");
+        assert_eq!(normalize_client_kind(Some("ramu:shogi")), "invalid");
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -23,6 +23,10 @@ compile_error!(
 );
 
 pub mod attachment;
+// `client_kind` は `X-Client` ヘッダ値を運用ログ向けに正規化する純粋ロジック。
+// `viewer_api` (wasm32 専用) から呼ばれるが、本体は I/O 非依存なのでホスト
+// target でもテストできるよう公開モジュールとして配置する。
+pub mod client_kind;
 // `backfill` は cron trigger (`#[event(scheduled)]`) からのみ消費される。
 // ホスト target で参照する公開 API は Stats / Deserialize 型のみで、IO 関数本体
 // は wasm32 ゲートで切り離している。それでもホスト通常ビルド (cargo build) では

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -33,6 +33,7 @@
 use serde::Serialize;
 use worker::{Env, Headers, Method, Request, Response, Result, Url};
 
+use crate::client_kind::normalize_client_kind;
 use crate::config::{ConfigKeys, OriginAllowList, is_viewer_api_enabled};
 use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
 use crate::live_games_index::LIVE_KEY_PREFIX;
@@ -47,8 +48,25 @@ const MIN_LIMIT: u32 = 1;
 ///
 /// 戻り値 `Some(_)` はマッチしたことを示す。`None` の場合は既存ルーティングに
 /// 引き継ぐ (404 までの fallthrough)。
+///
+/// `OPTIONS` は CORS preflight として viewer API 配下のパスでのみ受理する
+/// (Issue #564 設計 v4 §3)。`X-Client` を custom request header として送る
+/// クライアント (ramu-shogi web / desktop) のために `Access-Control-Allow-Headers`
+/// を返す必要がある。`ALLOW_VIEWER_API` 無効時は GET と同様 404 へフォールスルー
+/// し、preflight の段階で kill-switch を効かせる。
 pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
-    if req.method() != Method::Get {
+    let method = req.method();
+
+    if method == Method::Options {
+        let url = req.url()?;
+        let path = url.path();
+        if !is_viewer_api_path(path) {
+            return Ok(None);
+        }
+        return Ok(Some(handle_options(req, env)?));
+    }
+
+    if method != Method::Get {
         return Ok(None);
     }
     // viewer 配信 API は `ALLOW_VIEWER_API` で opt-in 有効化する。無効化 / 未設定
@@ -77,6 +95,56 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     }
 
     Ok(None)
+}
+
+/// viewer 配信 API 配下のパスかどうかを判定する純粋ロジック。
+///
+/// `OPTIONS` preflight 経路で対象パスをゲートするためにも使用する。
+/// `/api/v1/games` (一覧)、`/api/v1/games/live` (live 一覧)、
+/// `/api/v1/games/<id>` (単局) のみを true とする。
+fn is_viewer_api_path(path: &str) -> bool {
+    if path == "/api/v1/games" || path == "/api/v1/games/live" {
+        return true;
+    }
+    if let Some(rest) = path.strip_prefix("/api/v1/games/") {
+        return !rest.is_empty() && !rest.contains('/');
+    }
+    false
+}
+
+/// CORS preflight (OPTIONS) を返す。
+///
+/// `ALLOW_VIEWER_API` 無効時は viewer API 全体が無効なので preflight も 404 を
+/// 返す (kill-switch を preflight 段階でも効かせる)。`check_origin` は GET と
+/// 同じ経路を踏み、allowlist 未設定 / Origin 非一致は 403。許可された Origin
+/// に対しては `Access-Control-Allow-Methods: GET, OPTIONS`、
+/// `Access-Control-Allow-Headers: X-Client`、`Access-Control-Max-Age: 86400`
+/// を返す。`Access-Control-Allow-Origin` と `Vary` は `with_cors` が共通付与する。
+fn handle_options(req: &Request, env: &Env) -> Result<Response> {
+    if !is_viewer_api_enabled(env) {
+        return Response::error("Not Found", 404);
+    }
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+    let mut resp = Response::empty()?.with_status(204);
+    {
+        let headers: &mut Headers = resp.headers_mut();
+        headers.set("Access-Control-Allow-Methods", "GET, OPTIONS")?;
+        headers.set("Access-Control-Allow-Headers", "X-Client")?;
+        headers.set("Access-Control-Max-Age", "86400")?;
+    }
+    with_cors(resp, req, env)
+}
+
+/// `X-Client` ヘッダを運用ログ用の `client_kind` 文字列に正規化する。
+///
+/// 実装は [`normalize_client_kind`] に委譲する純粋ロジックで、本関数は
+/// `worker::Request` から生のヘッダ値を取り出す薄いラッパに留めている
+/// (ホスト target でユニットテスト可能にするため)。
+fn extract_client_kind(req: &Request) -> String {
+    let raw = req.headers().get("X-Client").ok().flatten();
+    normalize_client_kind(raw.as_deref())
 }
 
 /// 一覧 API (`/api/v1/games`) レスポンスの wire 形状。
@@ -175,6 +243,10 @@ async fn collect_index_page(
         return Ok(CollectOutcome::ErrorResponse(blocked));
     }
 
+    // 失敗ログに付与する `client_kind` をハンドラ冒頭で 1 度だけ正規化する。
+    // 正常系では使わないので、エラー経路でのみ参照する (Issue #564 設計 v4 §3)。
+    let client_kind = extract_client_kind(req);
+
     // クエリパラメータを 1 度だけ走査して `cursor` / `limit` を取り出す。
     let mut cursor: Option<String> = None;
     let mut limit_raw: Option<String> = None;
@@ -204,7 +276,7 @@ async fn collect_index_page(
     let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
         Ok(b) => b,
         Err(e) => {
-            console_log_failed("kifu_bucket_binding", &e.to_string());
+            console_log_failed("kifu_bucket_binding", &client_kind, &e.to_string());
             let err = with_cors(Response::error("Storage unavailable", 503)?, req, env)?;
             return Ok(CollectOutcome::ErrorResponse(err));
         }
@@ -218,7 +290,7 @@ async fn collect_index_page(
     let page = match builder.execute().await {
         Ok(p) => p,
         Err(e) => {
-            console_log_failed(&format!("{event_root}_list"), &e.to_string());
+            console_log_failed(&format!("{event_root}_list"), &client_kind, &e.to_string());
             let err = with_cors(Response::error("Storage error", 502)?, req, env)?;
             return Ok(CollectOutcome::ErrorResponse(err));
         }
@@ -232,7 +304,11 @@ async fn collect_index_page(
         let fetched = match bucket.get(&key).execute().await {
             Ok(o) => o,
             Err(e) => {
-                console_log_failed(&format!("{event_root}_get"), &format!("key={key} err={e}"));
+                console_log_failed(
+                    &format!("{event_root}_get"),
+                    &client_kind,
+                    &format!("key={key} err={e}"),
+                );
                 continue;
             }
         };
@@ -248,14 +324,22 @@ async fn collect_index_page(
         let bytes = match body.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                console_log_failed(&format!("{event_root}_read"), &format!("key={key} err={e}"));
+                console_log_failed(
+                    &format!("{event_root}_read"),
+                    &client_kind,
+                    &format!("key={key} err={e}"),
+                );
                 continue;
             }
         };
         match serde_json::from_slice::<serde_json::Value>(&bytes) {
             Ok(v) => entries.push(v),
             Err(e) => {
-                console_log_failed(&format!("{event_root}_parse"), &format!("key={key} err={e}"));
+                console_log_failed(
+                    &format!("{event_root}_parse"),
+                    &client_kind,
+                    &format!("key={key} err={e}"),
+                );
                 // 1 件壊れても他を返す (best-effort)。
             }
         }
@@ -279,10 +363,14 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
         return Ok(blocked);
     }
 
+    // 失敗ログに付与する `client_kind` をハンドラ冒頭で 1 度だけ正規化する
+    // (Issue #564 設計 v4 §3)。
+    let client_kind = extract_client_kind(req);
+
     let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
         Ok(b) => b,
         Err(e) => {
-            console_log_failed("kifu_bucket_binding", &e.to_string());
+            console_log_failed("kifu_bucket_binding", &client_kind, &e.to_string());
             return with_cors(Response::error("Storage unavailable", 503)?, req, env);
         }
     };
@@ -291,7 +379,7 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
     let csa_obj = match bucket.get(&by_id_key).execute().await {
         Ok(o) => o,
         Err(e) => {
-            console_log_failed("kifu_by_id_get", &format!("key={by_id_key} err={e}"));
+            console_log_failed("kifu_by_id_get", &client_kind, &format!("key={by_id_key} err={e}"));
             return with_cors(Response::error("Storage error", 502)?, req, env);
         }
     };
@@ -304,7 +392,11 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
     let csa_text = match body.text().await {
         Ok(t) => t,
         Err(e) => {
-            console_log_failed("kifu_by_id_read", &format!("key={by_id_key} err={e}"));
+            console_log_failed(
+                "kifu_by_id_read",
+                &client_kind,
+                &format!("key={by_id_key} err={e}"),
+            );
             return with_cors(Response::error("Storage error", 502)?, req, env);
         }
     };
@@ -321,7 +413,11 @@ async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response>
             return with_cors(Response::error("Not Found", 404)?, req, env);
         }
         Err(e) => {
-            console_log_failed("kifu_by_id_meta_lookup", &format!("game_id={game_id} err={e}"));
+            console_log_failed(
+                "kifu_by_id_meta_lookup",
+                &client_kind,
+                &format!("game_id={game_id} err={e}"),
+            );
             return with_cors(Response::error("Storage error", 502)?, req, env);
         }
     };
@@ -390,6 +486,12 @@ fn check_origin(req: &Request, env: &Env) -> Result<Option<Response>> {
 /// Origin そのものに echo back する。`check_origin` が allowlist 未設定 + Origin 付き
 /// を 403 で先に弾いているため、本関数に到達した時点では allowlist は非空かつ
 /// Origin はリストに含まれている (もしくは Origin ヘッダなし)。
+///
+/// `Vary` は `Origin, Access-Control-Request-Headers` を一括して設定する
+/// (Issue #564 設計 v4 §3 review v1 (e))。preflight (OPTIONS) と GET の
+/// 双方に適用することで、CDN / ブラウザキャッシュが Origin あるいは
+/// preflight で送られた `Access-Control-Request-Headers` を取り違えて
+/// レスポンスを共有する事故を防ぐ。
 fn with_cors(mut resp: Response, req: &Request, env: &Env) -> Result<Response> {
     let allow_csv = env
         .var(ConfigKeys::WS_ALLOWED_ORIGINS)
@@ -402,15 +504,24 @@ fn with_cors(mut resp: Response, req: &Request, env: &Env) -> Result<Response> {
         Some(o) if allow_list.iter().any(|allowed| allowed == o) => Some(o.to_owned()),
         _ => None,
     };
-    if let Some(origin) = allow_origin {
+    {
         let headers: &mut Headers = resp.headers_mut();
-        headers.set("Access-Control-Allow-Origin", &origin)?;
-        headers.set("Vary", "Origin")?;
+        if let Some(origin) = allow_origin {
+            headers.set("Access-Control-Allow-Origin", &origin)?;
+        }
+        // GET / OPTIONS いずれの応答にも Vary を付ける。Origin が一致しなかった
+        // (= ACAO を付けない) 場合でも、CDN がキャッシュキーから Origin と
+        // preflight 用の `Access-Control-Request-Headers` を分離するために
+        // 同じヘッダを露出させる。
+        headers.set("Vary", "Origin, Access-Control-Request-Headers")?;
     }
     Ok(resp)
 }
 
-/// 失敗ログを logfmt で出す統一窓口。viewer API の経路別 event 名を持たせる。
-fn console_log_failed(event: &str, detail: &str) {
-    worker::console_log!("[viewer_api] event={event} detail={detail}");
+/// 失敗ログを logfmt で出す統一窓口。viewer API の経路別 event 名と、
+/// 呼出側クライアントを特定する `client_kind` を持たせる
+/// (Issue #564 設計 v4 §3)。`client_kind` は [`normalize_client_kind`] により
+/// `[a-z0-9-]{1,64}` に正規化済みの ASCII 文字列、または `unknown` / `invalid`。
+fn console_log_failed(event: &str, client_kind: &str, detail: &str) {
+    worker::console_log!("[viewer_api] event={event} client_kind={client_kind} detail={detail}");
 }


### PR DESCRIPTION
## 概要

ramu-shogi web/desktop が \`X-Client\` カスタム header 付きで viewer 配信 API を fetch できるよう、CORS preflight (OPTIONS) を実装する。同時にクライアント種を運用ログに残すための識別経路を整える。

詳細設計: SH11235/rshogi#564 設計 v4 §3 (issuecomment-4346010601 等)。

## 変更点

### 新規: \`crates/rshogi-csa-server-workers/src/client_kind.rs\`
- \`normalize_client_kind(raw: Option<&str>) -> String\` 純粋関数
- \`<kind>/<version>\` 形式の \`<kind>\` 部分のみ抽出、kebab-case ASCII (\`[a-z0-9-]{1,64}\`) のホワイトリスト正規化
- ヘッダ未送信は \`unknown\`、正規化違反は \`invalid\`
- ホスト unit test 8 ケース (lowercase / kind-version / uppercase / 空白&改行 / 65 文字超 / 空 / マルチバイト & punctuation / kind-only)

### 改修: \`viewer_api.rs\`
- \`try_handle\` 冒頭に \`Method::Options\` 分岐を追加し、\`/api/v1/games\` / \`/api/v1/games/live\` / \`/api/v1/games/<id>\` のいずれにマッチした OPTIONS のみ \`handle_options\` を呼ぶ
- \`handle_options\`: \`is_viewer_api_enabled = false\` なら 404、Origin allowlist 不通過は 403、許可時は 204 + \`Access-Control-Allow-Methods: GET, OPTIONS\` + \`Access-Control-Allow-Headers: X-Client\` + \`Access-Control-Max-Age: 86400\`
- \`extract_client_kind\` ラッパ + \`collect_index_page\` のエラー logfmt に \`client_kind=<kind>\` を追加
- \`with_cors\` の \`Vary\` を \`Origin, Access-Control-Request-Headers\` に拡張 (GET / OPTIONS 両方適用)

### 改修: \`lib.rs\`
- \`pub mod client_kind;\` を追加

## ALLOW_VIEWER_API gate との整合

\`is_viewer_api_enabled = false\` のときは GET も OPTIONS も 404 を返し、preflight 段階でも kill-switch が効く。

## 検証

- \`cargo fmt --check\`: green
- \`cargo clippy --workspace --tests --all-targets\`: exit 0 (新規警告なし)
- \`cargo test --workspace\`: green (\`client_kind\` 8 tests を含む)
- \`cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers\`: green

## ramu-shogi 側

ramu-shogi 側の \`X-Client\` header 付与は別 PR (本 PR の main merge 後に着手)。merge 順序を逆にするとブラウザ preflight が 404 で fetch 全失敗するため、本 PR 先行が必須。

Refs #564