### PR TITLE
feat(csa-server): game_name 別の持ち時間プリセットを TCP/Workers で実装する

### DIFF
--- a/crates/rshogi-csa-server-tcp/config-examples/clock_presets.toml
+++ b/crates/rshogi-csa-server-tcp/config-examples/clock_presets.toml
@@ -1,0 +1,31 @@
+# 持ち時間プリセット宣言例。
+#
+# `--clock-presets-toml <path>` で読み込ませると strict mode が有効になり、
+# 未登録 `game_name` での LOGIN は `LOGIN:incorrect unknown_game_name` で
+# 拒否される。`game_name` は CSA LOGIN の `<handle>+<game_name>+<color>` の
+# 中央トークンと一致する必要がある。
+#
+# 命名規則（推奨）:
+# - `byoyomi-<total_sec>-<byoyomi_sec>` 秒読み方式
+# - `fischer-<total_sec>-<increment_sec>F` Fischer 方式（末尾 F 必須）
+
+# 通常対局: 10 分 + 10 秒秒読み
+[[preset]]
+game_name = "byoyomi-600-10"
+kind = "countdown"
+total_time_sec = 600
+byoyomi_sec = 10
+
+# 早指し: 1 分 + 5 秒秒読み
+[[preset]]
+game_name = "byoyomi-60-5"
+kind = "countdown"
+total_time_sec = 60
+byoyomi_sec = 5
+
+# Fischer: 5 分 + 1 手 10 秒加算
+[[preset]]
+game_name = "fischer-300-10F"
+kind = "fischer"
+total_time_sec = 300
+increment_sec = 10

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -72,6 +72,14 @@ struct Cli {
     /// を複数指定できる。指定すると当該 `game_name` の対局が SFEN 開始になる。
     #[arg(long, value_name = "PATH")]
     handicap_toml: Option<PathBuf>,
+    /// 持ち時間プリセット TOML のパス。`[[preset]]` 配列で `game_name` と
+    /// `kind` (`countdown` / `countdown_msec` / `fischer` / `stopwatch`) と
+    /// 各方式のパラメータを宣言する。指定するとサーバーは strict mode となり、
+    /// 未登録 `game_name` での LOGIN は `LOGIN:incorrect unknown_game_name` で
+    /// 拒否される。未指定時は `--clock-kind` / `--total-time-*` で指定した
+    /// global clock を全 `game_name` で使用する（後方互換）。
+    #[arg(long, value_name = "PATH")]
+    clock_presets_toml: Option<PathBuf>,
     /// 同名ログイン重複時に旧セッションを evict する（既定は新接続を拒否）。
     /// `--allow-floodgate-features` opt-in が必須。`AgreeWaiting` 以降の
     /// 対局進行中セッションは evict されず新接続を拒否する。
@@ -218,6 +226,16 @@ fn main() -> anyhow::Result<()> {
         HashMap::new()
     };
 
+    // 持ち時間プリセット TOML を読み込む（指定時のみ）。空 HashMap は「プリセット
+    // 未宣言」で fallback global clock 動作。
+    let clock_presets: HashMap<rshogi_csa_server::types::GameName, ClockSpec> =
+        if let Some(path) = cli.clock_presets_toml.as_ref() {
+            load_clock_presets_toml(path)
+                .with_context(|| format!("failed to load clock presets TOML at {path:?}"))?
+        } else {
+            HashMap::new()
+        };
+
     // 2. ServerConfig を構築。
     let config = ServerConfig {
         bind_addr,
@@ -244,6 +262,7 @@ fn main() -> anyhow::Result<()> {
         floodgate_schedules,
         floodgate_history_path: cli.floodgate_history_jsonl.clone(),
         handicap_initial_sfens: handicap_map,
+        clock_presets,
         duplicate_login_policy: if cli.duplicate_login_evict_old {
             DuplicateLoginPolicy::EvictOld
         } else {
@@ -580,22 +599,114 @@ fn validate_handicap_sfen(game_name: &str, sfen: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// 持ち時間プリセット TOML を読む。
+///
+/// 期待する形式（`ClockSpec` の `#[serde(tag = "kind")]` をフラット展開する）:
+/// ```toml
+/// [[preset]]
+/// game_name = "byoyomi-600-10"
+/// kind = "countdown"
+/// total_time_sec = 600
+/// byoyomi_sec = 10
+///
+/// [[preset]]
+/// game_name = "fischer-300-10F"
+/// kind = "fischer"
+/// total_time_sec = 300
+/// increment_sec = 10
+/// ```
+///
+/// バリデーション:
+/// - `game_name` 重複は起動時 Err。
+/// - `total_time_*` が 0 の preset は Err（少なくとも 1 ms 以上の本体時間を要求）。
+///   `byoyomi_*` / `increment_sec` の 0 は sudden death として許容。
+fn load_clock_presets_toml(
+    path: &std::path::Path,
+) -> anyhow::Result<HashMap<rshogi_csa_server::types::GameName, ClockSpec>> {
+    let raw = std::fs::read_to_string(path)?;
+    parse_clock_presets_toml_str(&raw)
+}
+
+/// `load_clock_presets_toml` の入力 TOML 文字列パース部分。テストから直接呼べる
+/// よう disk IO を切り離している。
+fn parse_clock_presets_toml_str(
+    raw: &str,
+) -> anyhow::Result<HashMap<rshogi_csa_server::types::GameName, ClockSpec>> {
+    use serde::Deserialize;
+    #[derive(Debug, Deserialize)]
+    struct Entry {
+        game_name: String,
+        #[serde(flatten)]
+        spec: ClockSpec,
+    }
+    #[derive(Debug, Deserialize)]
+    struct Root {
+        #[serde(default)]
+        preset: Vec<Entry>,
+    }
+    let root: Root = toml::from_str(raw)?;
+    let mut out: HashMap<rshogi_csa_server::types::GameName, ClockSpec> =
+        HashMap::with_capacity(root.preset.len());
+    for entry in root.preset {
+        validate_clock_spec(&entry.game_name, &entry.spec)?;
+        let key = rshogi_csa_server::types::GameName::new(&entry.game_name);
+        anyhow::ensure!(
+            !out.contains_key(&key),
+            "duplicate clock preset entry for game_name {:?}",
+            entry.game_name
+        );
+        out.insert(key, entry.spec);
+    }
+    Ok(out)
+}
+
+/// `ClockSpec` の最小限バリデーション。`total_time_*` が 0 の preset を弾く。
+fn validate_clock_spec(game_name: &str, spec: &ClockSpec) -> anyhow::Result<()> {
+    match spec {
+        ClockSpec::Countdown { total_time_sec, .. } => {
+            anyhow::ensure!(
+                *total_time_sec > 0,
+                "clock preset {game_name:?}: total_time_sec must be > 0"
+            );
+        }
+        ClockSpec::CountdownMsec { total_time_ms, .. } => {
+            anyhow::ensure!(
+                *total_time_ms > 0,
+                "clock preset {game_name:?}: total_time_ms must be > 0"
+            );
+        }
+        ClockSpec::Fischer { total_time_sec, .. } => {
+            anyhow::ensure!(
+                *total_time_sec > 0,
+                "clock preset {game_name:?}: total_time_sec must be > 0"
+            );
+        }
+        ClockSpec::StopWatch { total_time_min, .. } => {
+            anyhow::ensure!(
+                *total_time_min > 0,
+                "clock preset {game_name:?}: total_time_min must be > 0"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Floodgate スケジュール TOML を読む。
 ///
 /// 期待する形式:
 /// ```toml
 /// [[schedules]]
-/// game_name = "floodgate-600-10"
+/// game_name = "byoyomi-600-10"
 /// weekday = "Mon"
 /// hour = 13
 /// minute = 0
 /// pairing_strategy = "direct"
-///
-/// [schedules.clock]
-/// kind = "countdown"
-/// total_time_sec = 600
-/// byoyomi_sec = 10
 /// ```
+///
+/// 各スケジュールが使う持ち時間は `--clock-presets-toml` で `game_name` 別に
+/// 宣言する（per-game_name）。同 `game_name` で曜日別に時計を変える運用は
+/// 意図的に非対応 — 同じ持ち時間を複数曜日で出したい場合は同一 `game_name` を
+/// 参照する複数 `[[schedules]]` を並べる。
 fn load_floodgate_schedule_toml(
     path: &std::path::Path,
 ) -> anyhow::Result<Vec<rshogi_csa_server::FloodgateSchedule>> {
@@ -699,5 +810,132 @@ mod tests {
             "lnsgkgsnl/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1",
         )
         .unwrap();
+    }
+
+    /// `parse_clock_presets_toml_str` が 3 種類の preset を全て正しく逆シリアライズ
+    /// する。`#[serde(flatten)]` で `kind = "..."` が `ClockSpec` enum の正しい
+    /// variant に落ちることを明示確認する（タグ付き enum の flatten 経由展開の
+    /// 回帰検知）。
+    #[test]
+    fn load_clock_presets_accepts_three_variants() {
+        let raw = r#"
+[[preset]]
+game_name = "byoyomi-600-10"
+kind = "countdown"
+total_time_sec = 600
+byoyomi_sec = 10
+
+[[preset]]
+game_name = "byoyomi-60-5"
+kind = "countdown"
+total_time_sec = 60
+byoyomi_sec = 5
+
+[[preset]]
+game_name = "fischer-300-10F"
+kind = "fischer"
+total_time_sec = 300
+increment_sec = 10
+"#;
+        let map = parse_clock_presets_toml_str(raw).unwrap();
+        assert_eq!(map.len(), 3);
+        assert!(matches!(
+            map.get(&rshogi_csa_server::types::GameName::new("byoyomi-600-10")),
+            Some(ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10
+            })
+        ));
+        assert!(matches!(
+            map.get(&rshogi_csa_server::types::GameName::new("byoyomi-60-5")),
+            Some(ClockSpec::Countdown {
+                total_time_sec: 60,
+                byoyomi_sec: 5
+            })
+        ));
+        assert!(matches!(
+            map.get(&rshogi_csa_server::types::GameName::new("fischer-300-10F")),
+            Some(ClockSpec::Fischer {
+                total_time_sec: 300,
+                increment_sec: 10
+            })
+        ));
+    }
+
+    /// プリセット宣言なし (= 空 TOML) は空 HashMap が返る (= fallback モード)。
+    #[test]
+    fn load_clock_presets_empty_file_returns_empty_map() {
+        let map = parse_clock_presets_toml_str("").unwrap();
+        assert!(map.is_empty());
+    }
+
+    /// 同一 `game_name` を 2 度宣言した TOML は起動時に弾く。
+    #[test]
+    fn load_clock_presets_rejects_duplicate_game_name() {
+        let raw = r#"
+[[preset]]
+game_name = "byoyomi-600-10"
+kind = "countdown"
+total_time_sec = 600
+byoyomi_sec = 10
+
+[[preset]]
+game_name = "byoyomi-600-10"
+kind = "fischer"
+total_time_sec = 60
+increment_sec = 5
+"#;
+        let err = parse_clock_presets_toml_str(raw).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("duplicate"), "error must mention duplicate: {msg}");
+        assert!(msg.contains("byoyomi-600-10"), "error must mention game_name: {msg}");
+    }
+
+    /// `total_time_sec = 0` は `validate_clock_spec` で弾く。
+    #[test]
+    fn load_clock_presets_rejects_zero_total_time() {
+        let raw = r#"
+[[preset]]
+game_name = "broken"
+kind = "countdown"
+total_time_sec = 0
+byoyomi_sec = 10
+"#;
+        let err = parse_clock_presets_toml_str(raw).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("total_time_sec"), "error must mention field: {msg}");
+        assert!(msg.contains("broken"), "error must mention game_name: {msg}");
+    }
+
+    /// 未知の `kind` を持つ preset は serde の untagged で Err になる。
+    #[test]
+    fn load_clock_presets_rejects_unknown_kind() {
+        let raw = r#"
+[[preset]]
+game_name = "broken"
+kind = "exotic-kind"
+total_time_sec = 60
+"#;
+        let err = parse_clock_presets_toml_str(raw).unwrap_err();
+        let msg = format!("{err:#}");
+        // toml/serde からのエラーメッセージは実装依存のためキーワードだけ確認
+        assert!(
+            msg.contains("kind") || msg.contains("variant"),
+            "error must reference invalid kind: {msg}"
+        );
+    }
+
+    /// `byoyomi_sec = 0` (sudden death) は許容する。
+    #[test]
+    fn load_clock_presets_allows_zero_byoyomi() {
+        let raw = r#"
+[[preset]]
+game_name = "byoyomi-600-0"
+kind = "countdown"
+total_time_sec = 600
+byoyomi_sec = 0
+"#;
+        let map = parse_clock_presets_toml_str(raw).unwrap();
+        assert_eq!(map.len(), 1);
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -23,12 +23,19 @@
 //!    吸い上げ、`drive_game` を `spawn_local` で起動
 //! 4. ペア化されなかった slot は WaitingPool に再 push（次回まで待機）
 //!
+//! # 時計の決定
+//!
+//! - 各スケジュールの対局は `schedule.game_name` をキーに
+//!   `state.config.clock_presets` から `ClockSpec` を引いて使う。preset 未登録 (or
+//!   `clock_presets` 空 = 後方互換モード) のときは `state.config.clock` (global)
+//!   が fallback として使われる。
+//! - 同一 `game_name` で曜日別に時計を変える運用 (per-schedule clock) は意図的に
+//!   非対応 — `game_name` をアイデンティティと見なすことで preset map の単一窓口
+//!   で時計を一元管理する設計。同じ持ち時間で複数曜日の枠を作りたい場合は同一
+//!   `game_name` の `[[schedules]]` を曜日違いで並べる。
+//!
 //! # 既知の制約
 //!
-//! - **per-schedule clock**: 現状は `state.config.clock`（global）を使う。
-//!   スケジュール毎に異なる時計（`floodgate-600-10` と `floodgate-180-3` 等）
-//!   をサポートするには `drive_game` のシグネチャに `ClockSpec` 引数を足して
-//!   呼び出し側で上書きする必要がある。
 //! - **buoy / 駒落ち**: スケジューラ起動の対局は常に平手（`initial_sfen = None`）。
 //!   buoy 予約消費や駒落ち初期局面のマッピングは matchmaking 経路（LOGIN ハンドラ
 //!   からの `reserve_match_initial_position`）でのみ作用する。

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -84,6 +84,19 @@ pub fn parse_handle(raw: &str) -> Option<(String, GameName, Color)> {
     Some((handle, GameName::new(game_name), color))
 }
 
+/// `clock_presets` が登録されていれば該当 spec を、無ければ `fallback` を返す。
+///
+/// `drive_game_inner` と `build_game_summary` の双方から呼ぶ単一窓口。
+/// preset hit/miss の挙動を 1 か所に集約することで、両経路の clock 解決を
+/// 必ず一致させる。
+fn resolve_clock_spec<'a>(
+    presets: &'a HashMap<GameName, ClockSpec>,
+    fallback: &'a ClockSpec,
+    game_name: &GameName,
+) -> &'a ClockSpec {
+    presets.get(game_name).unwrap_or(fallback)
+}
+
 /// 受信ループで「実質無限」として扱うタイムアウト（10 年）。
 /// 実際の対局終了は持ち時間 deadline で駆動するため、`recv_line` 側は
 /// この長さで貼り付けておく（`rshogi_csa_server::game::run_loop` と揃える）。
@@ -95,8 +108,15 @@ pub struct ServerConfig {
     pub bind_addr: SocketAddr,
     /// CSA V2 棋譜と 00LIST の保存先ルート。
     pub kifu_topdir: std::path::PathBuf,
-    /// 対局で使う時計方式とパラメータ。
+    /// 対局で使う時計方式とパラメータ。`clock_presets` が空（未宣言）のとき、
+    /// または LOGIN の `game_name` が `clock_presets` に登録されていないときの
+    /// fallback 値として参照する。
     pub clock: ClockSpec,
+    /// `game_name` 別の時計プリセット。空 `HashMap` のときは「プリセット未宣言」
+    /// で、全対局が `clock` フィールド (global) を使う（後方互換）。1 件以上
+    /// 登録されたときは strict mode となり、未登録の `game_name` で LOGIN した
+    /// 接続は `LOGIN:incorrect unknown_game_name` で拒否される。
+    pub clock_presets: HashMap<GameName, ClockSpec>,
     /// 通信マージン (ミリ秒)。`GameRoom` の `consume` 前に差し引かれる。
     pub time_margin_ms: u64,
     /// 最大手数。
@@ -199,6 +219,7 @@ impl ServerConfig {
             bind_addr: "127.0.0.1:4081".parse().unwrap(),
             kifu_topdir: std::path::PathBuf::from("./kifu"),
             clock: ClockSpec::default(),
+            clock_presets: HashMap::new(),
             time_margin_ms: 1_500,
             max_moves: 256,
             login_timeout: Duration::from_secs(30),
@@ -878,6 +899,16 @@ where
             full_name
         ))));
     };
+
+    // 3.5. clock_presets が宣言済みなら、未登録 game_name は strict mode で拒否。
+    //      `is_empty()` のときは presets 未宣言扱いで fallback (state.config.clock)
+    //      を全 game_name に当てる後方互換モードに留まり、ここでは拒否しない。
+    if !state.config.clock_presets.is_empty()
+        && !state.config.clock_presets.contains_key(&game_name)
+    {
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect unknown_game_name")).await;
+        return Ok(());
+    }
 
     // 4. パスワード照合。PasswordStore は handle 単位、RateStorage も handle で登録。
     let handle_player = PlayerName::new(&handle);
@@ -2114,9 +2145,12 @@ where
     P: PasswordStore + 'static,
     H: FloodgateHistoryStorage + 'static,
 {
-    // Game_Summary を両対局者に送信。
-    let clock = state.config.clock.build_clock();
-    let time_section = state.config.clock.format_time_section();
+    // Game_Summary を両対局者に送信。clock は game_name に紐付くプリセットを
+    // 優先し、未登録 (or presets 空) なら global fallback を使う。
+    let clock_spec =
+        resolve_clock_spec(&state.config.clock_presets, &state.config.clock, &game_name);
+    let clock = clock_spec.build_clock();
+    let time_section = clock_spec.format_time_section();
     // `initial_sfen` が設定されていればそれから派生、無ければ平手固定のブロックを使う。
     // GameRoom / Game_Summary / 棋譜 の三点一致契約 (GameRoomConfig::initial_sfen の
     // doc を参照) を満たすため、同じ SFEN を複数入口で再利用する。
@@ -2898,7 +2932,12 @@ where
         start_time: start_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         end_time: end_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         event: "rshogi-csa-server-tcp".to_owned(),
-        time_section: state.config.clock.format_time_section(),
+        time_section: resolve_clock_spec(
+            &state.config.clock_presets,
+            &state.config.clock,
+            game_name,
+        )
+        .format_time_section(),
         initial_position,
         moves: moves.to_vec(),
         result: result.clone(),

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -177,8 +177,32 @@ async fn spawn_server(tag: &str) -> (std::net::SocketAddr, PathBuf) {
     .await
 }
 
+/// `clock_presets` 付きでテストサーバーを立ち上げる。strict mode 検証用。
+async fn spawn_server_with_clock_presets(
+    tag: &str,
+    presets: std::collections::HashMap<rshogi_csa_server::types::GameName, ClockSpec>,
+) -> (std::net::SocketAddr, PathBuf) {
+    spawn_server_inner(
+        tag,
+        ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
+        presets,
+    )
+    .await
+}
+
 /// テストシナリオ 1 件分のサーバーを指定時計で立ち上げる。
 async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::SocketAddr, PathBuf) {
+    spawn_server_inner(tag, clock, std::collections::HashMap::new()).await
+}
+
+async fn spawn_server_inner(
+    tag: &str,
+    clock: ClockSpec,
+    clock_presets: std::collections::HashMap<rshogi_csa_server::types::GameName, ClockSpec>,
+) -> (std::net::SocketAddr, PathBuf) {
     let topdir = unique_topdir(tag);
     let mut password_map = HashMap::new();
     password_map.insert("alice".to_owned(), "pw".to_owned());
@@ -223,6 +247,7 @@ async fn spawn_server_with_clock(tag: &str, clock: ClockSpec) -> (std::net::Sock
         bind_addr: actual_addr,
         kifu_topdir: topdir.clone(),
         clock,
+        clock_presets,
         login_timeout: Duration::from_secs(10),
         agree_timeout: Duration::from_secs(30),
         ..ServerConfig::sensible_defaults()
@@ -368,6 +393,93 @@ fn login_auth_failure_on_bad_password() {
         send_line(&mut w, "LOGIN alice+g1+black badpw").await;
         let resp = read_line_raw(&mut r).await.unwrap();
         assert_eq!(resp, "LOGIN:incorrect");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// `clock_presets` が宣言済みかつ未登録 `game_name` の LOGIN は
+/// `LOGIN:incorrect unknown_game_name` で拒否される（strict mode）。
+#[test]
+fn login_rejected_when_game_name_is_not_in_clock_presets() {
+    run_local(|| async {
+        let mut presets = std::collections::HashMap::new();
+        presets.insert(
+            rshogi_csa_server::types::GameName::new("byoyomi-600-10"),
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+        );
+        let (addr, topdir) = spawn_server_with_clock_presets("preset_strict", presets).await;
+        let (mut r, mut w) = connect(addr).await;
+        // `g1` は presets 未登録 → strict 拒否
+        send_line(&mut w, "LOGIN alice+g1+black pw").await;
+        let resp = read_line_raw(&mut r).await.unwrap();
+        assert_eq!(resp, "LOGIN:incorrect unknown_game_name");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// 登録済 `game_name` の LOGIN は通常成立する（strict mode は registered preset
+/// だけは透過させる契約）。
+#[test]
+fn login_succeeds_when_game_name_is_in_clock_presets() {
+    run_local(|| async {
+        let mut presets = std::collections::HashMap::new();
+        presets.insert(
+            rshogi_csa_server::types::GameName::new("byoyomi-60-5"),
+            ClockSpec::Countdown {
+                total_time_sec: 60,
+                byoyomi_sec: 5,
+            },
+        );
+        let (addr, topdir) = spawn_server_with_clock_presets("preset_ok", presets).await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+byoyomi-60-5+black pw").await;
+        let resp = read_line_raw(&mut r).await.unwrap();
+        assert_eq!(resp, "LOGIN:alice OK");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// 登録済 `game_name` のマッチ成立時、Game_Summary の `Total_Time` / `Byoyomi`
+/// が global clock ではなく preset 由来の値になることを確認する。
+/// （preset = byoyomi-600-10、global clock fallback = 60s/10s なので差異が出る）
+#[test]
+fn matched_game_summary_uses_preset_clock_not_global() {
+    run_local(|| async {
+        let mut presets = std::collections::HashMap::new();
+        presets.insert(
+            rshogi_csa_server::types::GameName::new("byoyomi-600-10"),
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+        );
+        let (addr, topdir) = spawn_server_with_clock_presets("preset_summary", presets).await;
+
+        let (mut rb, mut wb) = connect(addr).await;
+        send_line(&mut wb, "LOGIN alice+byoyomi-600-10+black pw").await;
+        assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:alice OK");
+        let (mut rw, mut ww) = connect(addr).await;
+        send_line(&mut ww, "LOGIN bob+byoyomi-600-10+white pw").await;
+        assert_eq!(read_line_raw(&mut rw).await.unwrap(), "LOGIN:bob OK");
+
+        let s_black = drain_game_summary(&mut rb).await;
+        let s_white = drain_game_summary(&mut rw).await;
+        assert!(
+            s_black.iter().any(|l| l == "Total_Time:600"),
+            "black summary must reflect preset Total_Time: {s_black:?}"
+        );
+        assert!(
+            s_black.iter().any(|l| l == "Byoyomi:10"),
+            "black summary must reflect preset Byoyomi: {s_black:?}"
+        );
+        assert!(
+            s_white.iter().any(|l| l == "Total_Time:600"),
+            "white summary must reflect preset Total_Time: {s_white:?}"
+        );
+        let _ = (wb, ww);
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -56,6 +56,19 @@ impl ConfigKeys {
     pub const TOTAL_TIME_MIN: &'static str = "TOTAL_TIME_MIN";
     /// StopWatch 用の秒読み（分）。
     pub const BYOYOMI_MIN: &'static str = "BYOYOMI_MIN";
+    /// 持ち時間プリセット宣言（JSON 配列文字列）。`game_name` 別に `ClockSpec` を
+    /// 切り替えるために使う。値の例:
+    /// ```jsonc
+    /// [
+    ///   {"game_name":"byoyomi-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},
+    ///   {"game_name":"fischer-300-10F","kind":"fischer","total_time_sec":300,"increment_sec":10}
+    /// ]
+    /// ```
+    /// 未設定 / 空文字 / 空配列のときは「プリセット未宣言」となり、`CLOCK_KIND`
+    /// 等から導出する global clock を全 `game_name` に適用する後方互換動作にとどまる。
+    /// 1 件以上登録された場合は strict mode となり、未登録 `game_name` の LOGIN は
+    /// `LOGIN_LOBBY:incorrect unknown_game_name` で拒否される。
+    pub const CLOCK_PRESETS: &'static str = "CLOCK_PRESETS";
     /// 運営権限を持つハンドル名（`%%SETBUOY` / `%%DELETEBUOY`）。
     ///
     /// **production**: Cloudflare secret として `wrangler secret put ADMIN_HANDLE`
@@ -123,6 +136,7 @@ impl ConfigKeys {
         Self::BYOYOMI_MS,
         Self::TOTAL_TIME_MIN,
         Self::BYOYOMI_MIN,
+        Self::CLOCK_PRESETS,
         Self::RECONNECT_GRACE_SECONDS,
         Self::ALLOW_FLOODGATE_FEATURES,
         Self::ALLOW_VIEWER_API,
@@ -197,6 +211,112 @@ pub fn parse_clock_spec(
             "CLOCK_KIND: expected countdown|countdown_msec|fischer|stopwatch, got {other:?}"
         )),
     }
+}
+
+/// `CLOCK_PRESETS` 環境変数 (JSON 配列文字列) から `game_name → ClockSpec` の
+/// マップを構築する。
+///
+/// `None` / 空文字 / `[]` は空 HashMap を返す（プリセット未宣言モード）。
+/// 1 件以上を含む場合は呼び出し側 (lobby / game_room) が strict mode に切り替わり、
+/// 未登録 `game_name` の LOGIN を拒否する。
+///
+/// バリデーション:
+/// - JSON パース失敗は `Err`。
+/// - 同一 `game_name` の重複は `Err`。
+/// - `total_time_*` が 0 の preset は `Err`（少なくとも 1 単位以上の本体時間を要求）。
+///   `byoyomi_*` / `increment_sec` の 0 は sudden death として許容。
+pub fn parse_clock_presets(
+    raw: Option<&str>,
+) -> Result<std::collections::HashMap<String, ClockSpec>, String> {
+    use serde::Deserialize;
+    let trimmed = raw.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    #[derive(Deserialize)]
+    struct Entry {
+        game_name: String,
+        #[serde(flatten)]
+        spec: ClockSpec,
+    }
+    let entries: Vec<Entry> =
+        serde_json::from_str(trimmed).map_err(|e| format!("CLOCK_PRESETS: invalid JSON: {e}"))?;
+    let mut out: std::collections::HashMap<String, ClockSpec> =
+        std::collections::HashMap::with_capacity(entries.len());
+    for entry in entries {
+        validate_clock_spec_value(&entry.game_name, &entry.spec)?;
+        if out.contains_key(&entry.game_name) {
+            return Err(format!(
+                "CLOCK_PRESETS: duplicate clock preset entry for game_name {:?}",
+                entry.game_name
+            ));
+        }
+        out.insert(entry.game_name, entry.spec);
+    }
+    Ok(out)
+}
+
+/// `resolve_clock_spec_from_presets_map` の戻り値。
+/// `parse_clock_presets` の結果から `game_name` の解決結果を 3 状態で表現する。
+#[derive(Debug, PartialEq, Eq)]
+pub enum PresetResolution {
+    /// presets 空 → 呼び出し側が `load_clock_spec_from_env` 等で fallback 解決する
+    /// （後方互換モード）。
+    Fallback,
+    /// 該当 `game_name` の preset を返す。
+    Hit(ClockSpec),
+    /// presets 宣言済みかつ未登録 → strict mode で `Err` 化されるべき。
+    Unknown,
+}
+
+/// `parse_clock_presets` で得たマップと `game_name` から `PresetResolution` を返す
+/// 純粋ロジック部。env-fetch を持たないため、host target テストから直接呼べる。
+pub fn resolve_clock_spec_from_presets_map(
+    presets: &std::collections::HashMap<String, ClockSpec>,
+    game_name: &str,
+) -> PresetResolution {
+    if presets.is_empty() {
+        return PresetResolution::Fallback;
+    }
+    match presets.get(game_name) {
+        Some(spec) => PresetResolution::Hit(spec.clone()),
+        None => PresetResolution::Unknown,
+    }
+}
+
+/// `parse_clock_presets` の preset 値検証。`total_time_*` が 0 の preset を弾く。
+fn validate_clock_spec_value(game_name: &str, spec: &ClockSpec) -> Result<(), String> {
+    match spec {
+        ClockSpec::Countdown { total_time_sec, .. } => {
+            if *total_time_sec == 0 {
+                return Err(format!(
+                    "CLOCK_PRESETS: clock preset {game_name:?}: total_time_sec must be > 0"
+                ));
+            }
+        }
+        ClockSpec::CountdownMsec { total_time_ms, .. } => {
+            if *total_time_ms == 0 {
+                return Err(format!(
+                    "CLOCK_PRESETS: clock preset {game_name:?}: total_time_ms must be > 0"
+                ));
+            }
+        }
+        ClockSpec::Fischer { total_time_sec, .. } => {
+            if *total_time_sec == 0 {
+                return Err(format!(
+                    "CLOCK_PRESETS: clock preset {game_name:?}: total_time_sec must be > 0"
+                ));
+            }
+        }
+        ClockSpec::StopWatch { total_time_min, .. } => {
+            if *total_time_min == 0 {
+                return Err(format!(
+                    "CLOCK_PRESETS: clock preset {game_name:?}: total_time_min must be > 0"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// viewer 配信 API (HTTP `/api/v1/games*` および WS `/ws/<id>/spectate`) が
@@ -362,5 +482,124 @@ mod tests {
     fn parse_reconnect_grace_duration_rejects_non_numeric() {
         let err = parse_reconnect_grace_duration(Some("forever")).unwrap_err();
         assert!(err.contains("RECONNECT_GRACE_SECONDS"));
+    }
+
+    #[test]
+    fn parse_clock_presets_empty_inputs_return_empty_map() {
+        assert!(parse_clock_presets(None).unwrap().is_empty());
+        assert!(parse_clock_presets(Some("")).unwrap().is_empty());
+        assert!(parse_clock_presets(Some("   \n  ")).unwrap().is_empty());
+        assert!(parse_clock_presets(Some("[]")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_clock_presets_accepts_three_variants() {
+        let raw = r#"[
+            {"game_name":"byoyomi-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},
+            {"game_name":"byoyomi-60-5","kind":"countdown","total_time_sec":60,"byoyomi_sec":5},
+            {"game_name":"fischer-300-10F","kind":"fischer","total_time_sec":300,"increment_sec":10}
+        ]"#;
+        let map = parse_clock_presets(Some(raw)).unwrap();
+        assert_eq!(map.len(), 3);
+        assert!(matches!(
+            map.get("byoyomi-600-10"),
+            Some(ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10
+            })
+        ));
+        assert!(matches!(
+            map.get("fischer-300-10F"),
+            Some(ClockSpec::Fischer {
+                total_time_sec: 300,
+                increment_sec: 10
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_clock_presets_rejects_duplicate_game_name() {
+        let raw = r#"[
+            {"game_name":"x","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},
+            {"game_name":"x","kind":"fischer","total_time_sec":60,"increment_sec":5}
+        ]"#;
+        let err = parse_clock_presets(Some(raw)).unwrap_err();
+        assert!(err.contains("duplicate"), "error must mention duplicate: {err}");
+        assert!(err.contains("\"x\""), "error must mention game_name: {err}");
+    }
+
+    #[test]
+    fn parse_clock_presets_rejects_zero_total_time() {
+        let raw = r#"[
+            {"game_name":"broken","kind":"countdown","total_time_sec":0,"byoyomi_sec":10}
+        ]"#;
+        let err = parse_clock_presets(Some(raw)).unwrap_err();
+        assert!(err.contains("total_time_sec"), "error must mention field: {err}");
+        assert!(err.contains("broken"), "error must mention game_name: {err}");
+    }
+
+    #[test]
+    fn parse_clock_presets_rejects_invalid_json() {
+        let err = parse_clock_presets(Some("not json")).unwrap_err();
+        assert!(err.contains("CLOCK_PRESETS"), "error must mention env name: {err}");
+    }
+
+    #[test]
+    fn parse_clock_presets_allows_zero_byoyomi() {
+        let raw = r#"[
+            {"game_name":"sd","kind":"countdown","total_time_sec":600,"byoyomi_sec":0}
+        ]"#;
+        let map = parse_clock_presets(Some(raw)).unwrap();
+        assert_eq!(map.len(), 1);
+    }
+
+    /// presets が空 (= 未宣言モード) のとき `Fallback` を返し、呼び出し側に
+    /// global clock 解決を委ねる。
+    #[test]
+    fn resolve_returns_fallback_when_presets_empty() {
+        let presets: std::collections::HashMap<String, ClockSpec> =
+            std::collections::HashMap::new();
+        assert_eq!(
+            resolve_clock_spec_from_presets_map(&presets, "anything"),
+            PresetResolution::Fallback
+        );
+    }
+
+    /// 登録済 `game_name` は該当 spec を `Hit` で返す。
+    #[test]
+    fn resolve_hits_registered_game_name() {
+        let mut presets = std::collections::HashMap::new();
+        presets.insert(
+            "byoyomi-600-10".to_owned(),
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+        );
+        assert_eq!(
+            resolve_clock_spec_from_presets_map(&presets, "byoyomi-600-10"),
+            PresetResolution::Hit(ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10
+            })
+        );
+    }
+
+    /// presets 宣言済みかつ未登録 `game_name` は `Unknown` を返し、
+    /// `resolve_clock_spec_for_game` 側で strict mode の Err に変換される。
+    #[test]
+    fn resolve_unknown_game_name_when_presets_declared() {
+        let mut presets = std::collections::HashMap::new();
+        presets.insert(
+            "byoyomi-600-10".to_owned(),
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            },
+        );
+        assert_eq!(
+            resolve_clock_spec_from_presets_map(&presets, "unregistered"),
+            PresetResolution::Unknown
+        );
     }
 }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -63,7 +63,9 @@ use rshogi_csa_server::types::{
 use rshogi_csa_server::{FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor};
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
-use crate::config::{ConfigKeys, parse_clock_spec, parse_reconnect_grace_duration};
+use crate::config::{
+    ConfigKeys, parse_clock_presets, parse_clock_spec, parse_reconnect_grace_duration,
+};
 use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
 use crate::floodgate_history::R2FloodgateHistoryStorage;
 use crate::games_index::{
@@ -464,7 +466,7 @@ impl GameRoom {
             .await?
             .unwrap_or_else(|| "unknown".to_owned());
         let game_id = format!("{room_id}-{started}");
-        let clock_spec = load_clock_spec_from_env(&self.env)?;
+        let clock_spec = resolve_clock_spec_for_game(&self.env, game_name)?;
         // 双方の LOGIN は既に OK を返しているので、予約で失敗したまま早期
         // return するとスロットが永久に詰まる。Exhausted に加え、CAS リトライ
         // 上限到達などの Err も pending match abort 経路に落として部屋を
@@ -1945,12 +1947,13 @@ impl GameRoom {
 
         // 切断側宛の Game_Summary を「切断時点の現在局面」で再構築する。再接続
         // クライアントは初接続時と同じ `Reconnect_Token:` 拡張行を再受信できる。
-        let clock_spec = load_clock_spec_from_env(&self.env)?;
+        // `cfg.clock` (= 対局開始時に確定した preset 由来 ClockSpec) を使うことで、
+        // `CLOCK_PRESETS` 配下では再接続時の `Time:` セクションが対局開始時と一致する。
         let summary = GameSummaryBuilder {
             game_id: GameId::new(cfg.game_id.clone()),
             black: PlayerName::new(cfg.black_handle.clone()),
             white: PlayerName::new(cfg.white_handle.clone()),
-            time_section: clock_spec.format_time_section(),
+            time_section: cfg.clock.format_time_section(),
             position_section,
             rematch_on_draw: false,
             to_move: core.current_turn(),
@@ -2207,6 +2210,36 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
         byoyomi_min.as_deref(),
     )
     .map_err(Error::RustError)
+}
+
+/// `game_name` 別の時計プリセットを解決する。
+///
+/// - `CLOCK_PRESETS` が宣言済み (= 1 件以上 entry を持つ) で `game_name` がヒット
+///   → 該当 `ClockSpec` を返す。
+/// - `CLOCK_PRESETS` が未宣言 / 空配列
+///   → `load_clock_spec_from_env` で global clock を返す（後方互換）。
+/// - `CLOCK_PRESETS` 宣言済みかつ `game_name` 未登録
+///   → `Err`（strict mode）。Lobby 側 (`handle_login_lobby`) は同じプリセット表で
+///   事前に弾いており Err はクライアントに届かない（DO ログにのみ出る）。本経路に
+///   到達するのは Lobby を経由しない単体テスト経路、もしくはプリセット書き換え直後の
+///   race など限定的なケース。
+///
+/// **キャッシュなし設計**: Lobby DO は LOGIN ごとに `clock_presets()` を呼ぶため
+/// `OnceCell` キャッシュを持たせるが、GameRoom DO は 1 対局 = 1 インスタンスで
+/// `start_match` のたった 1 回でしか評価しないため、env 再パースのコストが無視できる。
+/// 各 DO のライフサイクルに合わせ計算を最小化することで設計の対称性より局所最適を
+/// 優先している。
+fn resolve_clock_spec_for_game(env: &Env, game_name: &str) -> Result<ClockSpec> {
+    use crate::config::{PresetResolution, resolve_clock_spec_from_presets_map};
+    let raw = env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
+    let presets = parse_clock_presets(raw.as_deref()).map_err(Error::RustError)?;
+    match resolve_clock_spec_from_presets_map(&presets, game_name) {
+        PresetResolution::Fallback => load_clock_spec_from_env(env),
+        PresetResolution::Hit(spec) => Ok(spec),
+        PresetResolution::Unknown => Err(Error::RustError(format!(
+            "CLOCK_PRESETS: unknown game_name {game_name:?}; configure preset or remove strict mode"
+        ))),
+    }
 }
 
 /// `RECONNECT_GRACE_SECONDS` env を読み、Floodgate features の opt-in

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -16,7 +16,8 @@
 //!
 //! 認証は self-claim (`<password>` 値検証なし)、本家 Floodgate と同じ扱い。
 
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use worker::{
@@ -24,11 +25,12 @@ use worker::{
     WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
 };
 
-use crate::config::ConfigKeys;
+use crate::config::{ConfigKeys, parse_clock_presets};
 use crate::lobby_protocol::{
     LobbyQueue, LoginLobbyError, MatchedEntries, QueueEntry, build_login_incorrect_line,
     build_login_ok_line, build_matched_line, build_room_id, parse_login_lobby,
 };
+use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::types::{Color, ReconnectToken};
 
 /// LobbyDO 内 in-memory queue 上限の既定値 (`LOBBY_QUEUE_SIZE_LIMIT` 未設定時)。
@@ -77,6 +79,10 @@ pub struct Lobby {
     state: State,
     env: Env,
     queue: RefCell<LobbyQueue>,
+    /// `CLOCK_PRESETS` 環境変数を 1 度だけパースして保持するキャッシュ。
+    /// 起動中に env vars は不変のため、初回 LOGIN_LOBBY のたびに JSON パースを
+    /// 走らせる無駄を避ける。空 HashMap = preset 未宣言 = strict mode 無効。
+    clock_presets: OnceCell<HashMap<String, ClockSpec>>,
 }
 
 impl DurableObject for Lobby {
@@ -85,6 +91,7 @@ impl DurableObject for Lobby {
             state,
             env,
             queue: RefCell::new(LobbyQueue::new()),
+            clock_presets: OnceCell::new(),
         }
     }
 
@@ -157,12 +164,38 @@ impl Lobby {
             .unwrap_or(DEFAULT_LOBBY_QUEUE_SIZE_LIMIT)
     }
 
+    /// `CLOCK_PRESETS` 環境変数をパースして得たマップを返す（OnceCell キャッシュ）。
+    /// パース失敗時は空 HashMap として扱い、`console_log!` で警告を残して strict
+    /// mode を無効化する（preset 設定不正で全 LOGIN がブロックされる事態を避ける
+    /// 安全側挙動。`CLOCK_PRESETS` 値そのものは `parse_clock_presets` の起動時
+    /// テストでカバーする）。
+    fn clock_presets(&self) -> &HashMap<String, ClockSpec> {
+        self.clock_presets.get_or_init(|| {
+            let raw = self.env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
+            match parse_clock_presets(raw.as_deref()) {
+                Ok(map) => map,
+                Err(e) => {
+                    console_log!("[Lobby] event=invalid_clock_presets err={e}");
+                    HashMap::new()
+                }
+            }
+        })
+    }
+
     /// LOGIN_LOBBY 受信時の処理。
     async fn handle_login_lobby(&self, ws: &WebSocket, line: &str) -> Result<()> {
         let req = match parse_login_lobby(line) {
             Ok(r) => r,
             Err(e) => return self.send_login_error(ws, e).await,
         };
+
+        // strict mode: `CLOCK_PRESETS` が宣言済みかつ未登録 `game_name` は拒否。
+        // 空 (= preset 未宣言) のときは strict mode 自体を無効化し全 game_name を
+        // 通す後方互換動作にとどまる。
+        let presets = self.clock_presets();
+        if !presets.is_empty() && !presets.contains_key(&req.game_name) {
+            return self.send_login_error(ws, LoginLobbyError::UnknownGameName).await;
+        }
 
         let entry = QueueEntry {
             handle: req.handle.clone(),

--- a/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
@@ -36,6 +36,10 @@ pub enum LoginLobbyError {
     BadColor,
     /// `<game_name>` が `[A-Za-z0-9_-]` の文字種または 1〜32 文字長制限に違反。
     BadGameName,
+    /// `<game_name>` が `CLOCK_PRESETS` で宣言されたいずれの preset にも一致しない
+    /// （strict mode）。`CLOCK_PRESETS` 未設定 / 空配列のときは strict mode 自体が
+    /// 無効化されているため、本エラーは発生しない。
+    UnknownGameName,
 }
 
 impl LoginLobbyError {
@@ -47,6 +51,7 @@ impl LoginLobbyError {
             Self::BadIdFormat => "bad_id_format",
             Self::BadColor => "bad_color",
             Self::BadGameName => "bad_game_name",
+            Self::UnknownGameName => "unknown_game_name",
         }
     }
 }
@@ -291,6 +296,13 @@ mod tests {
         let too_long = "x".repeat(33);
         let line = format!("LOGIN_LOBBY alice+{too_long}+black pw");
         assert_eq!(parse_login_lobby(&line), Err(LoginLobbyError::BadGameName));
+    }
+
+    /// `UnknownGameName` の reason は `"unknown_game_name"` を返す（lobby が
+    /// `LOGIN_LOBBY:incorrect unknown_game_name` を組み立てるためのキー）。
+    #[test]
+    fn unknown_game_name_reason_is_stable() {
+        assert_eq!(LoginLobbyError::UnknownGameName.reason(), "unknown_game_name");
     }
 
     fn entry(h: &str, g: &str, c: Color) -> QueueEntry {

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -115,6 +115,13 @@ BYOYOMI_MS = "10000"
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
 
+# `game_name` 別の時計プリセット（JSON 配列文字列）。空配列 / 空文字 / 未設定で
+# 「プリセット未宣言」となり、CLOCK_KIND 等から導出する global clock を全 game_name に
+# 適用する後方互換動作にとどまる。1 件以上登録した場合は strict mode となり、
+# 未登録 game_name の LOGIN_LOBBY は `LOGIN_LOBBY:incorrect unknown_game_name` で拒否。
+# 命名規則: `byoyomi-<total_sec>-<byoyomi_sec>` / `fischer-<total_sec>-<increment_sec>F`
+CLOCK_PRESETS = "[]"
+
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "0"

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -117,6 +117,12 @@ BYOYOMI_MS = "100"
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
 
+# `game_name` 別の時計プリセット（JSON 配列文字列）。空配列で「プリセット未宣言」、
+# 1 件以上登録すると strict mode（未登録 game_name は LOGIN_LOBBY:incorrect
+# unknown_game_name で拒否）。命名規則: `byoyomi-<total_sec>-<byoyomi_sec>` /
+# `fischer-<total_sec>-<increment_sec>F`。staging は通電確認用に空配列で出荷する。
+CLOCK_PRESETS = "[]"
+
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 # staging では reconnect protocol / history bucket / rating 応答などの Floodgate 系

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -94,6 +94,13 @@ BYOYOMI_MS = "10000"
 # stopwatch 用（分）。CLOCK_KIND=stopwatch のときのみ使う。
 TOTAL_TIME_MIN = "10"
 BYOYOMI_MIN = "1"
+# `game_name` 別の時計プリセット（JSON 配列文字列）。空配列で「プリセット未宣言」、
+# 1 件以上登録すると strict mode (未登録 game_name は LOGIN_LOBBY:incorrect
+# unknown_game_name で拒否)。サンプル運用例（インライン JSON 文字列）:
+#   CLOCK_PRESETS = '[{"game_name":"byoyomi-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},{"game_name":"byoyomi-60-5","kind":"countdown","total_time_sec":60,"byoyomi_sec":5},{"game_name":"fischer-300-10F","kind":"fischer","total_time_sec":300,"increment_sec":10}]'
+# TOML の literal string (`'...'`) を使うと内部の `"` をエスケープせずに済む。
+# 改行を入れたい場合は TOML の multi-line literal string (`'''...'''`) も可。
+CLOCK_PRESETS = "[]"
 # `%%SETBUOY` / `%%DELETEBUOY` を許可する運営ハンドル（LOGIN の handle 部分）。
 ADMIN_HANDLE = "admin"
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。

--- a/crates/rshogi-csa-server/src/scheduler.rs
+++ b/crates/rshogi-csa-server/src/scheduler.rs
@@ -93,12 +93,12 @@ pub struct FloodgateSchedule {
     /// ペアリング戦略名。`"direct"` をフロントエンドが認識し、Floodgate 系の
     /// 追加戦略は別タスクで配線する。未知の名前は起動時 `Err`。
     pub pairing_strategy: String,
-    // NOTE: per-schedule の時計（`ClockSpec`）は本タスクの範囲外。スケジュール
-    // 起動の対局は `state.config.clock`（global）を使う。スケジュール毎に異なる
-    // 時計を実現するには `drive_game` のシグネチャに `ClockSpec` を追加する
-    // 侵襲的な改修が必要になるため、必要になった時点で別タスクで対応する。
-    // 不要なフィールドを「parse はするけど無視する」silent drop は YAGNI 違反な
-    // ので意図的に省く（field を持たないことで利用者の誤解を防ぐ）。
+    // 持ち時間は `state.config.clock_presets` の `game_name` 別 lookup で解決される
+    // （per-game_name clock）。本構造体に `ClockSpec` を持たせない理由は、同一
+    // `game_name` で曜日別に時計を変える運用 (per-schedule clock) を意図的に
+    // 非対応にしているため: 同じ持ち時間を複数曜日で出したい場合は同一 `game_name`
+    // を参照する複数 `[[schedules]]` を並べる。`game_name` をアイデンティティと
+    // 見なすことで、preset map の単一窓口で時計を一元管理できる。
 }
 
 impl FloodgateSchedule {


### PR DESCRIPTION
## Summary

- `game_name` 文字列をキーにした `ClockSpec` プリセットを TCP/Workers の CSA サーバー両方で宣言可能にし、1 サーバーで複数の持ち時間 (例: `byoyomi-600-10`, `byoyomi-60-5`, `fischer-300-10F`) を並行運用できるようにした。
- プリセット 1 件以上宣言時は strict mode となり、未登録 `game_name` の LOGIN は `LOGIN:incorrect unknown_game_name` で拒否。プリセット未宣言時は従来通り global clock を fallback として使う後方互換挙動を維持。
- Workers の reconnect 経路 (`game_room.rs:1948`) で env 再パースしていた潜在バグも併せて修正し、対局開始時と再接続時の `Time:` セクションが preset 配下で一致するようにした。

設計詳細・受け入れ基準は #565 を参照。

## 変更ファイル

| 領域 | ファイル | 内容 |
|---|---|---|
| TCP | `crates/rshogi-csa-server-tcp/src/server.rs` | `ServerConfig.clock_presets`、LOGIN strict mode、`resolve_clock_spec` |
| TCP | `crates/rshogi-csa-server-tcp/src/bin/main.rs` | `--clock-presets-toml` CLI、`load_clock_presets_toml` ローダー、`validate_clock_spec` |
| TCP | `crates/rshogi-csa-server-tcp/src/scheduler.rs` | NOTE 書き換え |
| TCP | `crates/rshogi-csa-server-tcp/tests/tcp_session.rs` | strict 拒否 / 受理 / preset Time セクション統合テスト |
| TCP | `crates/rshogi-csa-server-tcp/config-examples/clock_presets.toml` | 3 プリセットのサンプル |
| Workers | `crates/rshogi-csa-server-workers/src/config.rs` | `CLOCK_PRESETS` 定数、`parse_clock_presets`、`PresetResolution` |
| Workers | `crates/rshogi-csa-server-workers/src/lobby.rs` | OnceCell キャッシュ、`handle_login_lobby` strict 分岐 |
| Workers | `crates/rshogi-csa-server-workers/src/lobby_protocol.rs` | `LoginLobbyError::UnknownGameName` |
| Workers | `crates/rshogi-csa-server-workers/src/game_room.rs` | `resolve_clock_spec_for_game`、reconnect 経路の `cfg.clock` 統一 |
| Workers | `wrangler.production.toml` / `wrangler.staging.toml` / `wrangler.toml.example` | `CLOCK_PRESETS = "[]"` 追加 |
| Core | `crates/rshogi-csa-server/src/scheduler.rs` | `FloodgateSchedule` の NOTE 書き換え |

## 命名規則 (推奨)

サンプル設定で採用した命名:
- `byoyomi-<total_sec>-<byoyomi_sec>` 秒読み方式
- `fischer-<total_sec>-<increment_sec>F` Fischer 方式（末尾 `F` 必須）

実体と一致させた命名にすることで、`Time:` セクションを参照せずとも持ち時間方式が判別できる。Floodgate 慣習 (`floodgate-600-10`) は接続先サーバーが異なる以上 protocol interop ではないため踏襲しない。

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --tests -- -D warnings` 通過 (TCP/Workers/core)
- [x] `cargo test -p rshogi-csa-server-tcp` 全 pass (含む新規 6 件のローダーテスト + 3 件の LOGIN 統合テスト)
- [x] `cargo test -p rshogi-csa-server-workers` 全 pass (含む新規 6 件の `parse_clock_presets` テスト + 3 件の `resolve_clock_spec_from_presets_map` テスト + 1 件の `UnknownGameName.reason()` テスト)
- [x] `cargo test -p rshogi-csa-server` 全 pass (scheduler.rs コメント変更のみ)
- [x] `wrangler_environment_toml_consistency` / `wrangler_template_consistency` 両テストが新 `CLOCK_PRESETS` 定数と環境 toml の対応を検証
- [ ] staging 環境で `CLOCK_PRESETS = '[...]'` を設定して E2E 通電確認 (deploy 時に運用側で実施)

## 移行手順

- 既存デプロイは `CLOCK_PRESETS = "[]"` のまま挙動変化なし (global clock fallback)
- プリセットを宣言したい場合の手順:
  1. `wrangler secret put` でなく `[vars]` で `CLOCK_PRESETS` の JSON 配列を設定
  2. 既存 client 設定の `game_name` を確認し、`LOGIN_LOBBY:incorrect unknown_game_name` が出ないことを確認

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
