### PR TITLE
feat(csa-client): lib/bin 分割と feature gate 導入

### DIFF
--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -7,14 +7,45 @@ description = "CSA protocol client (CLI bridge) that wires a USI engine to a CSA
 license = "GPL-3.0-only"
 repository = "https://github.com/SH11235/rshogi"
 
+# crate を library + binary 構成に分割。consumer (Tauri 等) は lib を取り込み、
+# `--no-default-features --features tcp` 等で WS / CLI 依存を切り落とせる。
+[lib]
+name = "rshogi_csa_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "csa_client"
+path = "src/main.rs"
+# CLI 用 dep (clap / ctrlc / env_logger 等) は `cli` feature で gate 済みのため、
+# bin の build にも `cli` feature を要求する。consumer が `default-features = false`
+# で取り込むと bin はビルド対象から除外される。
+required-features = ["cli"]
+
+[features]
+# default は CLI binary をそのまま動かすためのフルセット。
+default = ["tcp", "websocket", "cli"]
+
+# TCP transport は std::net のみで実装されているため常時有効に近いが、
+# 「明示的に opt-out したい consumer はいない」という意味で feature flag は提供する。
+# 中身は空 (=切り替える dep がない)。
+tcp = []
+
+# CSA-over-WebSocket transport。tungstenite + rustls を pull する。
+websocket = ["dep:tungstenite", "dep:rustls"]
+
+# CLI (`csa_client` バイナリ) を組み立てるための feature。clap / ctrlc /
+# env_logger を pull する。consumer から取り込むときは無効化することで
+# これら CLI 系依存を切れる。
+cli = ["dep:clap", "dep:ctrlc", "dep:env_logger"]
+
 [dependencies]
 anyhow.workspace = true
-clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
-env_logger.workspace = true
 log.workspace = true
+# `toml::Value` は EngineConfig.options の公開フィールド型として library API の
+# 一部になっているため、feature gate 不可 (consumer から見える型のため常時必須)。
 toml.workspace = true
 
 rshogi-core = { path = "../rshogi-core" }
@@ -24,13 +55,20 @@ rshogi-csa = { path = "../rshogi-csa" }
 # protocol モジュールが必要とする pure な型 / 関数のみを取り込む。
 rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 
+# `libc` は engine.rs の `pre_exec` で `setpgid` を呼ぶ unix 経路、および
+# transport.rs の TCP keepalive (`SO_KEEPALIVE`) で使われる。両方とも library
+# コード側のため feature gate せず常時必須。
+libc = "0.2"
+
 # CSA-over-WebSocket 用の sync ハンドシェイク + フレーミング。
 # rustls + webpki ルートで TLS を実装し、native-tls 経由の OpenSSL 依存を避ける。
-tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
+tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"], optional = true }
 # rustls 0.23 は process-level の `CryptoProvider` を起動時に明示登録する必要がある
 # （`tungstenite` の rustls feature は cert source だけを切り替え、provider は選ばない）。
 # `ring` provider を `main()` 冒頭で `install_default()` 経由で登録する。
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 
-ctrlc = "3.4"
-libc = "0.2"
+# CLI 専用 dep。`cli` feature でのみ pull する。
+clap = { workspace = true, optional = true }
+ctrlc = { version = "3.4", optional = true }
+env_logger = { workspace = true, optional = true }

--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -27,7 +27,8 @@ default = ["tcp", "websocket", "cli"]
 
 # TCP transport は std::net のみで実装されているため常時有効に近いが、
 # 「明示的に opt-out したい consumer はいない」という意味で feature flag は提供する。
-# 中身は空 (=切り替える dep がない)。
+# 中身は空 (=切り替える dep がない) で、無効化しても TcpTransport 本体は常に
+# ビルド対象に残る（feature の役割は依存切り替えではなく将来の opt-in 用 marker）。
 tcp = []
 
 # CSA-over-WebSocket transport。tungstenite + rustls を pull する。

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -19,11 +19,12 @@
 //! # rustls CryptoProvider に関する注意
 //!
 //! `websocket` feature を有効化した場合、`rustls 0.23` は process-level の
-//! `CryptoProvider` が起動時に明示登録されていることを要求する（未登録だと TLS
-//! ハンドシェイク時に panic する）。**本 crate からは provider を install しない**
-//! （複数 consumer が同 process に同居したときに二重 install を避けるため）。
+//! `CryptoProvider` が起動時に明示登録されていることを要求する。**呼び忘れた
+//! 状態で `wss://` 接続を試みると TLS ハンドシェイク時に panic する**。
 //!
-//! consumer 側 `main()` 起動時に 1 度だけ次のいずれかを呼ぶこと:
+//! **本 crate からは provider を install しない**（複数 consumer が同 process
+//! に同居したときに二重 install を避けるため）。consumer 側 `main()` 起動時に
+//! 1 度だけ次のいずれかを呼ぶこと:
 //!
 //! ```ignore
 //! let _ = rustls::crypto::ring::default_provider().install_default();
@@ -31,6 +32,12 @@
 //!
 //! 本 crate 同梱の `csa_client` バイナリ (`src/main.rs`) はこれを行っているが、
 //! library として取り込む consumer は自分で同等の初期化を行う必要がある。
+//!
+//! # Panics
+//!
+//! `websocket` feature 有効時、上記 `CryptoProvider` の install を行わずに
+//! `wss://` 経路で `CsaConnection::connect_with_target` 等を呼ぶと `rustls`
+//! 内部で panic する。consumer 側で起動時 install を必ず行うこと。
 
 pub mod config;
 pub mod engine;

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -1,8 +1,36 @@
 //! `rshogi-csa-client` — USI エンジンを CSA プロトコル対局サーバー
-//! （Floodgate / 自リポの Workers 版 / TCP 版など）に接続する CLI ブリッジ。
+//! （Floodgate / 自リポの Workers 版 / TCP 版など）に接続する library + CLI。
 //!
-//! `cargo run -p rshogi-csa-client -- <config.toml>` で利用する。
-//! TCP / WebSocket transport を `host` 設定文字列の scheme で切り替える。
+//! `cargo run -p rshogi-csa-client -- <config.toml>` で CLI として利用するほか、
+//! 別 crate (例: Tauri 製デスクトップ frontend) から library として組み込むこと
+//! もできる。`host` 設定文字列の scheme で TCP / WebSocket transport を切り替える。
+//!
+//! # Features
+//!
+//! - `tcp` (既定有効): `std::net` ベースの TCP transport。常時利用可能。
+//! - `websocket` (既定有効): `tungstenite` + `rustls` の sync WebSocket transport。
+//!   無効化すると `WsTransport` / `CsaTransport::WebSocket` / `TransportTarget::WebSocket`
+//!   が消え、`TransportTarget::from_host_port` に `ws://` / `wss://` URL を渡すと
+//!   `Err` を返す。
+//! - `cli` (既定有効): `csa_client` バイナリと clap / ctrlc / env_logger を pull
+//!   する。library として取り込む consumer は `default-features = false` で
+//!   無効化することで CLI 系依存を切り落とせる。
+//!
+//! # rustls CryptoProvider に関する注意
+//!
+//! `websocket` feature を有効化した場合、`rustls 0.23` は process-level の
+//! `CryptoProvider` が起動時に明示登録されていることを要求する（未登録だと TLS
+//! ハンドシェイク時に panic する）。**本 crate からは provider を install しない**
+//! （複数 consumer が同 process に同居したときに二重 install を避けるため）。
+//!
+//! consumer 側 `main()` 起動時に 1 度だけ次のいずれかを呼ぶこと:
+//!
+//! ```ignore
+//! let _ = rustls::crypto::ring::default_provider().install_default();
+//! ```
+//!
+//! 本 crate 同梱の `csa_client` バイナリ (`src/main.rs`) はこれを行っているが、
+//! library として取り込む consumer は自分で同等の初期化を行う必要がある。
 
 pub mod config;
 pub mod engine;
@@ -12,3 +40,14 @@ pub mod protocol;
 pub mod record;
 pub mod session;
 pub mod transport;
+
+// crate root に主要 API を再エクスポート。consumer は
+// `use rshogi_csa_client::{CsaClientConfig, UsiEngine, ...}` で参照できる。
+// 型名は実装側に合わせており、別名は付与しない。
+pub use config::CsaClientConfig;
+pub use engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
+pub use event::Event;
+pub use protocol::{CsaConnection, GameResult, GameSummary};
+pub use record::{GameRecord, RecordedMove};
+pub use session::{run_game_session, run_resumed_session};
+pub use transport::{ConnectOpts, CsaTransport, TransportTarget};

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -347,7 +347,7 @@ fn run_one_game(
 
     // サーバー接続。host に scheme (`ws://` / `wss://` / `tcp://`) があれば
     // それに従い、無ければ既存挙動どおり `host:port` の TCP。
-    let target = TransportTarget::from_host_port(&host, config.server.port);
+    let target = TransportTarget::from_host_port(&host, config.server.port)?;
     let opts = ConnectOpts {
         tcp_keepalive: config.server.keepalive.tcp,
         ws_origin: config.server.ws_origin.clone(),
@@ -477,7 +477,7 @@ fn acquire_lobby_match(
         );
     }
 
-    let target = TransportTarget::from_host_port(&config.server.host, config.server.port);
+    let target = TransportTarget::from_host_port(&config.server.host, config.server.port)?;
     let opts = ConnectOpts {
         tcp_keepalive: config.server.keepalive.tcp,
         ws_origin: config.server.ws_origin.clone(),

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -100,7 +100,7 @@ impl CsaConnection {
     /// 既存呼び出し互換: TCP 経路に絞った接続。
     pub fn connect(host: &str, port: u16, tcp_keepalive: bool) -> Result<Self> {
         Self::connect_with_target(
-            &TransportTarget::from_host_port(host, port),
+            &TransportTarget::from_host_port(host, port)?,
             &ConnectOpts {
                 tcp_keepalive,
                 ws_origin: None,

--- a/crates/rshogi-csa-client/src/transport.rs
+++ b/crates/rshogi-csa-client/src/transport.rs
@@ -54,6 +54,8 @@ impl TransportTarget {
     /// `websocket` feature OFF で `ws://` / `wss://` を渡した場合は `Err` を返す。
     pub fn from_host_port(host: &str, port: u16) -> Result<Self> {
         if host.starts_with("ws://") || host.starts_with("wss://") {
+            // 片方の cfg block だけがコンパイルされる: feature ON で `WebSocket`
+            // バリアントを返し、OFF では明示エラーで bail する。
             #[cfg(feature = "websocket")]
             {
                 return Ok(Self::WebSocket {

--- a/crates/rshogi-csa-client/src/transport.rs
+++ b/crates/rshogi-csa-client/src/transport.rs
@@ -11,49 +11,72 @@
 //! は文字列スライスで扱う。改行コードは TCP 経路では `write_line` 内部で
 //! `\n` を付加し、WS 経路では text frame の境界そのものが行境界になる。
 
-use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
+
+#[cfg(feature = "websocket")]
+use std::collections::VecDeque;
+#[cfg(feature = "websocket")]
+use std::sync::{Arc, Mutex};
+
+#[cfg(feature = "websocket")]
 use tungstenite::client::IntoClientRequest;
+#[cfg(feature = "websocket")]
 use tungstenite::handshake::client::Request;
+#[cfg(feature = "websocket")]
 use tungstenite::stream::MaybeTlsStream;
+#[cfg(feature = "websocket")]
 use tungstenite::{Message, WebSocket};
 
 use crate::event::Event;
 
 /// 接続先のスキーム解析結果。`host` 設定文字列から `from_host_port` で生成する。
+///
+/// `WebSocket` バリアントは `websocket` feature 有効時のみ存在する。feature OFF で
+/// `ws://` / `wss://` URL を渡すと `from_host_port` が `Err` を返す。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransportTarget {
     /// `tcp://host:port` または scheme なし `host` + `port`。
     Tcp { host: String, port: u16 },
     /// `ws://host[:port]/path` または `wss://host[:port]/path`。`port` 設定は無視される。
+    #[cfg(feature = "websocket")]
     WebSocket { url: String },
 }
 
 impl TransportTarget {
     /// `server.host` 設定文字列に scheme が含まれていれば優先し、そうでなければ
     /// 既存の `host:port` 形式として TCP 接続先に解釈する。
-    pub fn from_host_port(host: &str, port: u16) -> Self {
+    ///
+    /// `websocket` feature OFF で `ws://` / `wss://` を渡した場合は `Err` を返す。
+    pub fn from_host_port(host: &str, port: u16) -> Result<Self> {
         if host.starts_with("ws://") || host.starts_with("wss://") {
-            Self::WebSocket {
-                url: host.to_owned(),
+            #[cfg(feature = "websocket")]
+            {
+                return Ok(Self::WebSocket {
+                    url: host.to_owned(),
+                });
             }
-        } else if let Some(rest) = host.strip_prefix("tcp://") {
-            Self::Tcp {
-                host: rest.to_owned(),
-                port,
-            }
-        } else {
-            Self::Tcp {
-                host: host.to_owned(),
-                port,
+            #[cfg(not(feature = "websocket"))]
+            {
+                bail!(
+                    "WebSocket scheme `{host}` was provided but the `websocket` feature is disabled"
+                );
             }
         }
+        if let Some(rest) = host.strip_prefix("tcp://") {
+            return Ok(Self::Tcp {
+                host: rest.to_owned(),
+                port,
+            });
+        }
+        Ok(Self::Tcp {
+            host: host.to_owned(),
+            port,
+        })
     }
 }
 
@@ -73,8 +96,11 @@ pub struct ConnectOpts {
 /// `start_reader_thread` を呼ぶまでは inline で `read_line_*` / `write_line` を
 /// 使い、対局開始後は reader thread に reader 部分を移して main thread が
 /// `write_line` のみを使う運用を想定する。
+///
+/// `WebSocket` バリアントは `websocket` feature 有効時のみ存在する。
 pub enum CsaTransport {
     Tcp(TcpTransport),
+    #[cfg(feature = "websocket")]
     WebSocket(WsTransport),
 }
 
@@ -85,6 +111,7 @@ impl CsaTransport {
             TransportTarget::Tcp { host, port } => {
                 Ok(Self::Tcp(TcpTransport::connect(host, *port, opts.tcp_keepalive)?))
             }
+            #[cfg(feature = "websocket")]
             TransportTarget::WebSocket { url } => {
                 Ok(Self::WebSocket(WsTransport::connect(url, opts.ws_origin.as_deref())?))
             }
@@ -96,6 +123,7 @@ impl CsaTransport {
     pub fn read_line_blocking(&mut self, timeout: Duration) -> Result<String> {
         match self {
             Self::Tcp(t) => t.read_line_blocking(timeout),
+            #[cfg(feature = "websocket")]
             Self::WebSocket(w) => w.read_line_blocking(timeout),
         }
     }
@@ -104,6 +132,7 @@ impl CsaTransport {
     pub fn read_line_nonblocking(&mut self) -> Result<Option<String>> {
         match self {
             Self::Tcp(t) => t.read_line_nonblocking(),
+            #[cfg(feature = "websocket")]
             Self::WebSocket(w) => w.read_line_nonblocking(),
         }
     }
@@ -112,6 +141,7 @@ impl CsaTransport {
     pub fn write_line(&mut self, line: &str) -> Result<()> {
         match self {
             Self::Tcp(t) => t.write_line(line),
+            #[cfg(feature = "websocket")]
             Self::WebSocket(w) => w.write_line(line),
         }
     }
@@ -120,6 +150,7 @@ impl CsaTransport {
     pub fn write_keepalive(&mut self) -> Result<()> {
         match self {
             Self::Tcp(t) => t.write_raw(b"\n"),
+            #[cfg(feature = "websocket")]
             Self::WebSocket(w) => w.write_line(""),
         }
     }
@@ -129,6 +160,7 @@ impl CsaTransport {
     pub fn start_reader_thread(&mut self, tx: mpsc::Sender<Event>) -> Result<()> {
         match self {
             Self::Tcp(t) => t.start_reader_thread(tx),
+            #[cfg(feature = "websocket")]
             Self::WebSocket(w) => w.start_reader_thread(tx),
         }
     }
@@ -298,7 +330,8 @@ impl TcpTransport {
     }
 }
 
-/// WebSocket 経路の transport。
+/// WebSocket 経路の transport。`websocket` feature 有効時のみ提供。
+#[cfg(feature = "websocket")]
 pub struct WsTransport {
     ws: Arc<Mutex<WebSocket<MaybeTlsStream<TcpStream>>>>,
     /// `start_reader_thread` 後は reader が thread 内で動作する。inline 操作禁止フラグ。
@@ -310,6 +343,7 @@ pub struct WsTransport {
     pending_lines: VecDeque<String>,
 }
 
+#[cfg(feature = "websocket")]
 impl WsTransport {
     fn connect(url: &str, origin: Option<&str>) -> Result<Self> {
         log::info!("[CSA/WS] 接続中: {url}");
@@ -508,6 +542,7 @@ impl WsTransport {
 }
 
 /// `WsTransport::try_read_one_frame` の戻り値。
+#[cfg(feature = "websocket")]
 enum FrameOutcome {
     /// text frame を 1 つ受信した（複数行を含み得る）。
     Text(String),
@@ -517,6 +552,7 @@ enum FrameOutcome {
 
 /// `tungstenite::WebSocket` 内部の `TcpStream` に到達して read_timeout を設定する
 /// ためのヘルパ。`MaybeTlsStream` の variant に応じて適切な参照を返す。
+#[cfg(feature = "websocket")]
 fn stream_of_ws(ws: &WebSocket<MaybeTlsStream<TcpStream>>) -> Option<&TcpStream> {
     match ws.get_ref() {
         MaybeTlsStream::Plain(s) => Some(s),
@@ -558,7 +594,7 @@ mod tests {
 
     #[test]
     fn target_parses_tcp_default() {
-        let t = TransportTarget::from_host_port("wdoor.c.u-tokyo.ac.jp", 4081);
+        let t = TransportTarget::from_host_port("wdoor.c.u-tokyo.ac.jp", 4081).unwrap();
         assert_eq!(
             t,
             TransportTarget::Tcp {
@@ -570,7 +606,7 @@ mod tests {
 
     #[test]
     fn target_parses_explicit_tcp_scheme() {
-        let t = TransportTarget::from_host_port("tcp://floodgate.example", 4081);
+        let t = TransportTarget::from_host_port("tcp://floodgate.example", 4081).unwrap();
         assert_eq!(
             t,
             TransportTarget::Tcp {
@@ -580,9 +616,10 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "websocket")]
     #[test]
     fn target_parses_ws_and_wss() {
-        let t = TransportTarget::from_host_port("ws://localhost:8787/ws/room1", 0);
+        let t = TransportTarget::from_host_port("ws://localhost:8787/ws/room1", 0).unwrap();
         assert_eq!(
             t,
             TransportTarget::WebSocket {
@@ -593,7 +630,8 @@ mod tests {
         let t = TransportTarget::from_host_port(
             "wss://rshogi-csa-server-workers-staging.example.workers.dev/ws/room1",
             0,
-        );
+        )
+        .unwrap();
         assert_eq!(
             t,
             TransportTarget::WebSocket {
@@ -601,5 +639,13 @@ mod tests {
                     .to_owned()
             }
         );
+    }
+
+    #[cfg(not(feature = "websocket"))]
+    #[test]
+    fn target_rejects_ws_without_feature() {
+        let err = TransportTarget::from_host_port("ws://localhost:8787/ws/room1", 0).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("websocket"), "expected websocket-related error, got: {msg}");
     }
 }

--- a/crates/rshogi-csa-client/tests/csa_ws_transport.rs
+++ b/crates/rshogi-csa-client/tests/csa_ws_transport.rs
@@ -2,6 +2,12 @@
 //!
 //! `tungstenite` の sync server を loopback ポートで立て、`CsaTransport` の
 //! WebSocket 経路が 1 line = 1 text frame の対応で送受信できることを確認する。
+//!
+//! `websocket` feature OFF 時はファイル全体を build 対象から外す
+//! (`tungstenite` を直接利用しているため、feature OFF では依存が pull されず
+//! テスト build が通らない)。
+
+#![cfg(feature = "websocket")]
 
 use std::net::TcpListener;
 use std::sync::mpsc;
@@ -45,7 +51,8 @@ fn ws_transport_send_then_recv_line() {
         ws.send(Message::Text("LOGIN:OK".into())).expect("send response");
     });
 
-    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let target =
+        TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0).expect("ws target");
     let mut transport = CsaTransport::connect(
         &target,
         &ConnectOpts {
@@ -75,7 +82,8 @@ fn ws_transport_reader_thread_delivers_multiple_lines() {
         thread::sleep(Duration::from_millis(50));
     });
 
-    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let target =
+        TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0).expect("ws target");
     let mut transport = CsaTransport::connect(
         &target,
         &ConnectOpts {
@@ -117,7 +125,8 @@ fn ws_transport_splits_multiline_frame_into_lines() {
         thread::sleep(Duration::from_millis(50));
     });
 
-    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let target =
+        TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0).expect("ws target");
     let mut transport = CsaTransport::connect(
         &target,
         &ConnectOpts {
@@ -160,7 +169,8 @@ fn ws_transport_reader_thread_splits_multiline_frame() {
         thread::sleep(Duration::from_millis(50));
     });
 
-    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let target =
+        TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0).expect("ws target");
     let mut transport = CsaTransport::connect(
         &target,
         &ConnectOpts {
@@ -196,7 +206,8 @@ fn ws_transport_empty_text_frame_treated_as_keepalive() {
         ws.send(Message::Text("AFTER_KEEPALIVE".into())).expect("after");
     });
 
-    let target = TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0);
+    let target =
+        TransportTarget::from_host_port(&format!("ws://127.0.0.1:{port}/"), 0).expect("ws target");
     let mut transport = CsaTransport::connect(
         &target,
         &ConnectOpts {

--- a/crates/rshogi-csa-client/tests/lib_consumer.rs
+++ b/crates/rshogi-csa-client/tests/lib_consumer.rs
@@ -1,0 +1,45 @@
+//! crate root の `pub use` シンボルが build target として壊れていないことを保証する
+//! build-only smoke test。
+//!
+//! consumer (例: Tauri 製 frontend) から `use rshogi_csa_client::{...};` で参照
+//! することを想定しているシンボルを 1 箇所で名前解決させ、`cargo build --tests`
+//! の段階で壊れたら検出する。実 IO や engine spawn は行わない。
+//!
+//! TCP only / WebSocket only など複数 feature 構成でも build pass させたいので、
+//! WS 専用シンボル (`CsaTransport::WebSocket` バリアント等) は参照しない。
+
+use rshogi_csa_client::{
+    BestMoveResult, ConnectOpts, CsaClientConfig, CsaConnection, CsaTransport, Event, GameRecord,
+    GameResult, GameSummary, RecordedMove, SearchInfo, SearchOutcome, TransportTarget, UsiEngine,
+    run_game_session, run_resumed_session,
+};
+
+/// build only: 上の `use` がそのまま resolve できれば pass。型を実体化したり
+/// 関数を呼んだりはしない。pub 型 / 関数を `&dyn`-相当の参照位置に並べることで
+/// 未使用警告を防ぎつつシンボル名前解決を強制する。
+#[test]
+fn build_only() {
+    // 型を引数として要求するクロージャを式値として `let _ = ...;` 経由で
+    // 評価することで、上の `use` で取り込んだ型がコンパイル単位に組み込まれる
+    // ことを保証する。クロージャ自体は呼ばない。
+    let consume_types = |_: CsaClientConfig,
+                         _: UsiEngine,
+                         _: BestMoveResult,
+                         _: SearchOutcome,
+                         _: SearchInfo,
+                         _: Event,
+                         _: CsaConnection,
+                         _: GameSummary,
+                         _: GameRecord,
+                         _: RecordedMove,
+                         _: GameResult,
+                         _: CsaTransport,
+                         _: TransportTarget,
+                         _: ConnectOpts| {};
+    // 関数ポインタとしての参照を取得して値として捨てる (call はしない)。
+    let consume_funcs: (fn(_, _, _, _) -> _, fn(_, _, _, _) -> _) =
+        (run_game_session, run_resumed_session);
+
+    // どちらも `_var` で未使用警告抑止せず、`let _ = ...` で値を消費する。
+    let _ = (consume_types, consume_funcs);
+}


### PR DESCRIPTION
## Summary

- `rshogi-csa-client` を library + binary 構成に分割し、`tcp` / `websocket` / `cli` feature で consumer 取り込み時の依存 (clap, ctrlc, env_logger, tungstenite, rustls) を最小化
- `[[bin]] required-features = ["cli"]` で `cargo build --no-default-features --features tcp` 等の library 取り込みでは bin がビルド対象から外れる
- `transport.rs` の WS 関連 (`WsTransport`, `CsaTransport::WebSocket`, `TransportTarget::WebSocket`, `tungstenite` 依存コード) を `#[cfg(feature = "websocket")]` でガード。`from_host_port` を `Result<Self>` 化し、feature OFF 時に `ws://` / `wss://` を渡すと明示エラー
- crate root に主要型 (`CsaClientConfig`, `UsiEngine`, `Event`, `CsaConnection`, `GameRecord`, `RecordedMove` 他) を pub use 再エクスポート、型名は実装に合わせて変更なし
- `lib.rs` に `tcp` / `websocket` / `cli` feature 説明 + rustls `CryptoProvider` 初期化責任 (consumer 側で `install_default()` を呼ぶ旨) の crate-level doc を追記
- `tests/csa_ws_transport.rs` に `#![cfg(feature = "websocket")]` 追加で feature OFF skip
- `tests/lib_consumer.rs` 新規: crate root pub use シンボルが build target として壊れていないことの build-only smoke

設計 v2 からの差分:
- `MoveRecord` (設計 v2 記載) は実コードに存在しないため `RecordedMove` (実型名) を再エクスポート
- `CsaConnectionError` (設計 v2 記載) は実コードに存在しない (`anyhow::Result` を使用) ため再エクスポート対象から除外
- `toml` / `libc` は library API (`EngineConfig.options: HashMap<String, toml::Value>`, `engine.rs::setpgid`, `transport.rs::SO_KEEPALIVE`) に組み込まれているため CLI feature ではなく非 optional 依存として保持

Closes #568

## Test plan

- [x] `cargo build -p rshogi-csa-client` (default features) 成功
- [x] `cargo build -p rshogi-csa-client --no-default-features --features tcp` 成功
- [x] `cargo build -p rshogi-csa-client --no-default-features --features websocket` 成功
- [x] `cargo build -p rshogi-csa-client --no-default-features` (no features) 成功
- [x] `cargo test -p rshogi-csa-client` 全 green (default + WS test 走行)
- [x] `cargo test -p rshogi-csa-client --no-default-features --features tcp` で WS test がスキップ (`tungstenite` 直接依存のため file-level cfg) されることを確認
- [x] `cargo clippy -p rshogi-csa-client --all-targets --tests` 警告ゼロ (default / TCP only / WS only 全て確認)
- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` 成功

ローカルで観測した `cargo test --workspace` の `rshogi-csa-server-tcp::tcp_session` の 3 件の失敗 (graceful_shutdown_*, kifu_and_zerozero_list_match_format_contract) は本ブランチ・main 双方で再現する concurrent 実行下の flake で、本 PR の変更とは無関係 (個別実行では main / 本ブランチとも green を確認)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)