### PR TITLE
feat(csa-client): SessionEventSink で対局途中の進捗通知を expose する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "thiserror",
  "toml",
  "tungstenite",
 ]

--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -45,6 +45,7 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 log.workspace = true
+thiserror.workspace = true
 # `toml::Value` は EngineConfig.options の公開フィールド型として library API の
 # 一部になっているため、feature gate 不可 (consumer から見える型のため常時必須)。
 toml.workspace = true

--- a/crates/rshogi-csa-client/src/config.rs
+++ b/crates/rshogi-csa-client/src/config.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, bail};
 use serde::Deserialize;
 
+use crate::events::SearchInfoEmitPolicy;
+
 /// CSAクライアント全体の設定
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
@@ -113,6 +115,12 @@ pub struct GameConfig {
     pub restart_engine_every_game: bool,
     /// ponder を有効化
     pub ponder: bool,
+    /// `SessionEventSink` への `SearchInfo` 発火頻度ポリシー。consumer が
+    /// `run_*_with_events` を使うときの USI `info` 行 throttle を制御する。
+    /// CLI / `NoopSessionEventSink` 経路では参照されない。serde では skip
+    /// (TOML から読み込まず、library consumer が programmatic に上書きする想定)。
+    #[serde(skip)]
+    pub search_info_emit: SearchInfoEmitPolicy,
 }
 
 impl Default for GameConfig {
@@ -121,6 +129,7 @@ impl Default for GameConfig {
             max_games: 0,
             restart_engine_every_game: false,
             ponder: true,
+            search_info_emit: SearchInfoEmitPolicy::default(),
         }
     }
 }

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -40,6 +40,10 @@ pub enum SearchOutcome {
     ServerInterrupt(Vec<String>),
 }
 
+/// USI `info` 行を観測する都度呼び出される callback。`(累積 SearchInfo, 生の info 行)`
+/// を受け取り、`SessionEventSink` への `SearchInfo` snapshot 発火に使われる。
+pub type InfoCallback<'a> = dyn FnMut(&SearchInfo, &str) + 'a;
+
 /// info 行から抽出した探索情報
 ///
 /// `depth` / `score_cp` / `score_mate` / `pv` は CSA Floodgate 拡張コメント生成に使われる。
@@ -199,7 +203,23 @@ impl UsiEngine {
     ) -> Result<SearchOutcome> {
         self.send(position_cmd)?;
         self.send(go_cmd)?;
-        self.wait_bestmove(shutdown, server_rx)
+        self.wait_bestmove(shutdown, server_rx, None)
+    }
+
+    /// `go` と同じだが、`info` 行を観測する都度 `info_callback` を呼んで累積
+    /// `SearchInfo` と生 line を渡す。`SessionEventSink` への `SearchInfo`
+    /// 発火 (累積 snapshot + throttle) の hook 用。
+    pub fn go_with_info(
+        &mut self,
+        position_cmd: &str,
+        go_cmd: &str,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome> {
+        self.send(position_cmd)?;
+        self.send(go_cmd)?;
+        self.wait_bestmove(shutdown, server_rx, Some(info_callback))
     }
 
     /// ponder 探索を開始（bestmove を待たない）
@@ -217,7 +237,18 @@ impl UsiEngine {
         server_rx: &Receiver<Event>,
     ) -> Result<SearchOutcome> {
         self.send("ponderhit")?;
-        self.wait_bestmove(shutdown, server_rx)
+        self.wait_bestmove(shutdown, server_rx, None)
+    }
+
+    /// `ponderhit` と同じだが、`info` 行を観測する都度 `info_callback` を呼ぶ。
+    pub fn ponderhit_with_info(
+        &mut self,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome> {
+        self.send("ponderhit")?;
+        self.wait_bestmove(shutdown, server_rx, Some(info_callback))
     }
 
     /// stop を送信し、bestmove を待つ（ponder 中断用）。
@@ -280,6 +311,7 @@ impl UsiEngine {
         &mut self,
         shutdown: &AtomicBool,
         server_rx: &Receiver<Event>,
+        mut info_callback: Option<&mut InfoCallback<'_>>,
     ) -> Result<SearchOutcome> {
         use std::time::Instant;
 
@@ -336,6 +368,9 @@ impl UsiEngine {
                     log::trace!("[USI] < {line}");
                     if line.starts_with("info") {
                         update_search_info(&mut info, &line);
+                        if let Some(cb) = info_callback.as_deref_mut() {
+                            cb(&info, &line);
+                        }
                         continue;
                     }
                     if let Some(rest) = line.strip_prefix("bestmove ") {

--- a/crates/rshogi-csa-client/src/events.rs
+++ b/crates/rshogi-csa-client/src/events.rs
@@ -1,0 +1,496 @@
+//! `SessionEventSink` API: 対局途中の進捗を consumer (例: Tauri 製 frontend) に
+//! push 通知するためのイベント型・trait・error 型を提供する。
+//!
+//! # 概要
+//!
+//! [`run_game_session_with_events`] / [`run_resumed_session_with_events`] に
+//! [`SessionEventSink`] 実装を渡すと、対局ループの各イベント
+//! ([`SessionProgress`]) が逐次 [`SessionEventSink::on_event`] に流れる。
+//!
+//! ## sink 内の長時間処理について
+//!
+//! sink の `on_event` は対局メインループのスレッド上で同期実行される。重い処理
+//! (DB write / network 越しの publish 等) を直接行うと、対局ループが遅延し
+//! USI engine の探索開始や CSA サーバへの応答にも影響する。consumer は sink 内
+//! では軽量な channel 送信だけを行い、重い処理は別 thread / async runtime に
+//! 委譲することを推奨する。
+//!
+//! ## sink エラーの扱い
+//!
+//! - [`SinkError::NonFatal`]: warn ログを出して対局を継続する。`on_error` は
+//!   呼ばれない (= sink 自身が一時的不具合を許容している扱い)。
+//! - [`SinkError::Fatal`]: 対局を中断し、CSA `%CHUDAN` → `LOGOUT` →
+//!   transport close → `on_error(&SessionError::SinkAborted(..))` →
+//!   `Disconnected { reason: SinkAborted }` を best-effort attempt at clean
+//!   closure として実行する。`run_*` 関数は [`SessionError::SinkAborted`] で
+//!   return する。
+//!
+//! `run_*` は best-effort attempt at clean closure を行うが、CSA server 側で
+//! 「正常切断」確定となることは保証しない。`%CHUDAN` 送信直後に transport を
+//! 閉じるため、server が確定処理を完了する前に切断される可能性がある。
+//!
+//! ## resume 時の event 順序
+//!
+//! 通常対局:
+//!
+//! ```text
+//! Connected → GameSummary → GameStarted → 通常対局
+//! ```
+//!
+//! 再接続成立後の resume:
+//!
+//! ```text
+//! Connected → Resumed { summary, state } → GameStarted → 通常対局
+//! ```
+//!
+//! resume 経路では指し手 history の replay は行わない。CSA reconnect protocol
+//! は切断時点の局面 (`GameSummary.position_section`) のみを送信し、それまでの
+//! 指し手列を再送しないため。consumer は [`ReconnectState::last_sfen`] から
+//! 盤面を再構築すること。指し手単位の history が必要な場合は consumer 側で
+//! local 永続化を行う。
+//!
+//! ## SearchInfoSnapshot の semantics
+//!
+//! [`SearchInfoSnapshot`] は対局ループが USI `info` 行を観測する都度 **累積
+//! snapshot** として更新する値である (depth / score / pv 等は最後に観測した
+//! 値で上書き)。`emit_on_depth_change` や `emit_final` のフラグはこの累積値を
+//! いつ [`SessionProgress::SearchInfo`] として発火するかを制御するだけで、
+//! snapshot の中身そのものは差分ではなく常に「現時点までで最も新しい値の集合」
+//! を表す。
+//!
+//! ## rustls CryptoProvider に関する注意
+//!
+//! crate 全体の注意事項として、`websocket` feature 有効時は consumer 側 `main`
+//! で `rustls::crypto::ring::default_provider().install_default()` を 1 度だけ
+//! 呼ぶ必要がある。詳細は crate root の doc を参照。
+
+use std::sync::Arc;
+
+use crate::protocol::{GameResult, GameSummary};
+use crate::record::GameRecord;
+
+// ────────────────────────────────────────────
+// Side / MovePlayer / SearchOrigin / 単純 enum 群
+// ────────────────────────────────────────────
+
+/// 先手 / 後手。CSA `+` / `-` の象徴的な再エクスポート。
+///
+/// `rshogi_csa::Color` と semantically 等価だが、event payload の public API
+/// 専用に純粋な定義を持たせて consumer (例: Tauri 製 frontend) が
+/// `rshogi_csa` を取り込まずに済むようにしている。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    /// 先手 (CSA `+`)
+    Black,
+    /// 後手 (CSA `-`)
+    White,
+}
+
+impl From<rshogi_csa::Color> for Side {
+    fn from(color: rshogi_csa::Color) -> Self {
+        match color {
+            rshogi_csa::Color::Black => Side::Black,
+            rshogi_csa::Color::White => Side::White,
+        }
+    }
+}
+
+/// その手を指したのが自エンジンか相手かを区別する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MovePlayer {
+    /// 自エンジンが指した手
+    SelfPlayer,
+    /// 対戦相手 (CSA サーバから受信した) の手
+    Opponent,
+}
+
+/// 自エンジンが指した手の探索が、どの種類の探索から得られたかを示す。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchOrigin {
+    /// 自分の手番開始時点で position+go を新規に走らせた fresh search の結果。
+    /// 直前に ponder が走っていない通常パスの探索。
+    Fresh,
+    /// 相手の手が ponder 予測と一致し、`ponderhit` を送って継続した探索の結果。
+    Ponderhit,
+    /// ponder miss 後に開始した fresh search の結果。`Fresh` と探索アルゴリズム的
+    /// には同じだが、直前の ponder 探索は外れて discard 済みであるため、UI 側は
+    /// 「ponder が外れて生まれた fresh search」として通常の `Fresh` と区別できる。
+    PonderMiss,
+}
+
+// ────────────────────────────────────────────
+// Reconnect / Disconnect / GameEnd 系 payload
+// ────────────────────────────────────────────
+
+/// `Resumed` event に同梱される、再接続時の局面と残時間情報。
+///
+/// `last_sfen` は resume 時点の **完全な局面** を SFEN として表現したもので、
+/// CSA サーバから受信した `GameSummary.position_section` を OSS lib 側で
+/// 変換した結果である。consumer は履歴 replay を期待してはいけない (CSA
+/// reconnect protocol が指し手列を再送しないため)。指し手単位の history が
+/// 必要なら consumer 側で local 永続化を行うこと。
+#[derive(Debug, Clone)]
+pub struct ReconnectState {
+    /// 切断時点までに進んだ ply 数 (再接続後に次に指す手の `ply - 1`)。
+    pub last_ply: u32,
+    /// 切断時点の **完全な局面** を SFEN として表現したもの。consumer はこの
+    /// SFEN から盤面を再構築する。指し手 history は含まれない。
+    pub last_sfen: String,
+    /// 切断時点での手番。
+    pub side_to_move: Side,
+    /// 切断時点での自エンジン側残時間 (秒)。サーバが値を提供しないとき `None`。
+    pub remaining_time_sec_self: Option<u32>,
+    /// 切断時点での相手側残時間 (秒)。サーバが値を提供しないとき `None`。
+    pub remaining_time_sec_opp: Option<u32>,
+}
+
+/// 対局終了 (`GameEnded`) event の payload。
+#[derive(Debug, Clone)]
+pub struct GameEndEvent {
+    /// CSA サーバから受信した最終結果。
+    pub result: GameResult,
+    /// 終局理由 (#TIME_UP / #ILLEGAL_MOVE 等から推定)。
+    pub reason: GameEndReason,
+    /// 勝者。引き分け / 中断時は `None`。
+    pub winner: Option<Side>,
+    /// `#WIN` / `#LOSE` / `#DRAW` 等の生の最終結果行 (サーバが送ってきた文字列)。
+    pub raw_result_line: Option<String>,
+    /// `#TIME_UP` / `#ILLEGAL_MOVE` 等、最終結果行の直前に来た終局理由行 (あれば)。
+    pub raw_reason_line: Option<String>,
+}
+
+/// CSA サーバ側の終局理由。`raw_reason_line` を字句解析した結果を normalize した分類。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GameEndReason {
+    /// 投了 (`%TORYO`)
+    Resign,
+    /// 時間切れ (`#TIME_UP`)
+    TimeUp,
+    /// 禁手 (`#ILLEGAL_MOVE`)
+    IllegalMove,
+    /// 持将棋 (`#JISHOGI`)
+    Jishogi,
+    /// 千日手 (`#SENNICHITE`)
+    Sennichite,
+    /// 最大手数到達 (`#MAX_MOVES`)
+    MaxMoves,
+    /// 検閲・反則扱い (`#CENSORED`)
+    Censored,
+    /// `#CHUDAN` 等の中断扱い
+    Interrupted,
+    /// 接続断などサーバ側理由不明の切断
+    OtherDisconnect,
+    /// 上記いずれにも該当しない理由文字列 (前方互換)
+    Unknown(String),
+}
+
+/// `Disconnected` event の理由分類。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisconnectReason {
+    /// 通常の対局終了に伴う切断 (`GameEnded` を emit した後)。
+    GameOver,
+    /// 外部からの shutdown 要求 (`AtomicBool` 経由) による中断。
+    Shutdown,
+    /// sink が `Fatal` を返したことによる中断。
+    SinkAborted,
+    /// transport レベルのエラー (TCP / WebSocket I/O 失敗等)。
+    TransportError(String),
+    /// 上記以外の理由不明な切断。
+    Unknown,
+}
+
+// ────────────────────────────────────────────
+// SearchInfo / Move / BestMove payload
+// ────────────────────────────────────────────
+
+/// USI `info` 行から抽出した探索情報の累積 snapshot。
+///
+/// 対局ループが USI `info` 行を観測する都度、最後に観測した値で各 field を
+/// 上書きする (= 累積 snapshot)。各 field は USI engine が送ってこない場合
+/// `None` のまま。`pv` は最後に観測した PV 一式。
+///
+/// この snapshot は [`SessionProgress::SearchInfo`] / [`BestMoveEvent::search`]
+/// / [`MoveEvent::search`] で同型として使われる。
+#[derive(Debug, Clone, Default)]
+pub struct SearchInfoSnapshot {
+    /// `depth N`
+    pub depth: Option<u32>,
+    /// `seldepth N`
+    pub seldepth: Option<u32>,
+    /// `score cp N` (mate と排他)。
+    pub score_cp: Option<i32>,
+    /// `score mate N` (cp と排他)。
+    pub mate: Option<i32>,
+    /// `nodes N`
+    pub nodes: Option<u64>,
+    /// `nps N`
+    pub nps: Option<u64>,
+    /// `time N` (ms)
+    pub time_ms: Option<u64>,
+    /// `pv ...` の USI 表記列。
+    pub pv: Vec<String>,
+    /// 最後に観測した生の `info` 行 (デバッグ・raw 表示用)。
+    pub raw_line: Option<String>,
+}
+
+/// `SearchInfo` event の発火頻度ポリシー。`CsaClientConfig` 経由で設定する。
+#[derive(Debug, Clone)]
+pub enum SearchInfoEmitPolicy {
+    /// `SearchInfo` を一切発火しない。consumer 側の表示が不要な運用向け。
+    Disabled,
+    /// Library が推奨する preset (`Interval { min_ms: 200, emit_on_depth_change: true, emit_final: true }`
+    /// 相当)。preset の具体内容は将来の lib バージョンで調整され得るため、
+    /// 固定挙動が必要なら [`SearchInfoEmitPolicy::Interval`] を直接指定すること。
+    Default,
+    /// 観測した `info` 行を 1 行ごとに発火する。USI engine が大量に出すと
+    /// sink への push が高頻度になるため注意。
+    EveryLine,
+    /// 時間間隔と depth 変化で発火を制御する。
+    Interval {
+        /// 直前 emit からの最低経過時間 (ms)。0 のとき間隔制限なし。
+        min_ms: u32,
+        /// `depth` field が変化した時は `min_ms` を待たずに emit する。
+        emit_on_depth_change: bool,
+        /// bestmove 直前の最後の累積値を必ず emit する。
+        emit_final: bool,
+    },
+}
+
+impl Default for SearchInfoEmitPolicy {
+    /// `SearchInfoEmitPolicy::Default` (library 推奨 preset) を返す。
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+/// 自エンジンが指した手の event payload。`SessionProgress::BestMoveSelected`
+/// として、USI engine から bestmove が返り CSA 文字列に変換された直後に
+/// 発火する (CSA サーバへの送信前)。
+#[derive(Debug, Clone)]
+pub struct BestMoveEvent {
+    /// USI 形式の bestmove (`7g7f` 等)。`resign` / `win` 等の特殊値は
+    /// [`SessionProgress::BestMoveSelected`] では発火させない (代わりに対局
+    /// 終了系の event を発火する)。
+    pub usi_move: String,
+    /// CSA 形式に変換した bestmove (`+7776FU` 等)。USI -> CSA 変換に失敗した場合
+    /// `None` (例: `resign` / `win` / 不正手等)。
+    pub csa_move_candidate: Option<String>,
+    /// USI engine が返した ponder 予測手 (USI 表記)。なければ `None`。
+    pub ponder: Option<String>,
+    /// この手を指した側 (= 自エンジン) の手番。
+    pub side: Side,
+    /// この手の手数 (1 始まり、適用後の手数ではなくこの手自身の番号)。
+    pub ply: u32,
+    /// この bestmove を生み出した探索の種別。
+    pub search_origin: SearchOrigin,
+    /// この bestmove を出した時点の累積 [`SearchInfoSnapshot`]。
+    /// USI engine から `info` 行が 1 度も来なかった場合は `None`。
+    pub search: Option<SearchInfoSnapshot>,
+}
+
+/// 1 手分の指し手 event payload。`MoveSent` (自エンジンが送出した手) と
+/// `MoveConfirmed` (サーバから confirm された手) の両方で同型として使われる。
+///
+/// - 自エンジンの手の場合 (`player == SelfPlayer`):
+///     - `MoveSent`: CSA サーバへ送信した直後に発火。
+///     - `MoveConfirmed`: サーバが `+...` / `-...` echo を返してきた時に発火 (時間が確定する)。
+/// - 相手の手の場合 (`player == Opponent`):
+///     - `MoveConfirmed` のみ発火 (`MoveSent` は発火しない)。
+#[derive(Debug, Clone)]
+pub struct MoveEvent {
+    /// この手を指したのが自エンジンか相手か。
+    pub player: MovePlayer,
+    /// CSA 形式の指し手 (`+7776FU` 等)。
+    pub csa_move: String,
+    /// USI 形式の指し手 (`7g7f` 等)。
+    pub usi_move: String,
+    /// この手を指した側の手番。
+    pub side: Side,
+    /// この手の手数 (1 始まり)。
+    pub ply: u32,
+    /// この手の消費時間 (秒)。`MoveSent` 時は `None`、`MoveConfirmed` 時は
+    /// サーバ報告値があれば `Some`。
+    pub time_sec: Option<u32>,
+    /// この手を指す前の SFEN。
+    pub sfen_before: String,
+    /// この手を適用した後の SFEN。
+    pub sfen_after: String,
+    /// 自エンジンが指した手の場合のみ `Some`。相手の手は `None`。
+    pub search_origin: Option<SearchOrigin>,
+    /// 自エンジンが指した手の場合のみ `Some` (探索情報 snapshot)。相手の手は `None`。
+    pub search: Option<SearchInfoSnapshot>,
+}
+
+// ────────────────────────────────────────────
+// SessionProgress (発火される event 本体)
+// ────────────────────────────────────────────
+
+/// 対局途中の進捗を 1 件で表す event。
+///
+/// 通常対局の発火順:
+///
+/// ```text
+/// Connected
+///   → GameSummary
+///   → GameStarted
+///   → (BestMoveSelected → MoveSent → MoveConfirmed)*  // 自エンジンの手番
+///   → (MoveConfirmed)*                                // 相手の手番
+///   → (SearchInfo)*                                   // 任意の頻度で挟まる
+///   → GameEnded
+///   → Disconnected
+/// ```
+///
+/// resume の場合は `GameSummary` の代わりに `Resumed { summary, state }` が
+/// 1 度だけ発火し、その後の流れは通常対局と同じ。詳細は本モジュールの
+/// crate-level doc を参照。
+#[derive(Debug, Clone)]
+pub enum SessionProgress {
+    /// CSA transport の物理接続 + LOGIN 成功直後の marker。Game_Summary 受信前。
+    Connected,
+    /// `BEGIN Game_Summary` ... `END Game_Summary` を受信し終えた時点で 1 度発火。
+    GameSummary(Arc<GameSummary>),
+    /// 再接続成立後 (`run_resumed_session_with_events`) に 1 度発火し、resume 用
+    /// の Game_Summary と Reconnect_State を同梱する。詳細は [`ReconnectState`]
+    /// の doc を参照。
+    Resumed {
+        /// resume 用に再受信した Game_Summary。`Reconnect_Token` も含まれる。
+        summary: Arc<GameSummary>,
+        /// 切断時点の局面・残時間。
+        state: ReconnectState,
+    },
+    /// 対局メインループに入る直前の marker。通常対局では `START` 受信後、
+    /// resume では `Reconnect_State` 受信後にそれぞれ 1 度発火する。
+    GameStarted,
+    /// USI engine が bestmove を返し CSA に変換できた時に発火 (CSA サーバへの
+    /// 送信前)。`resign` / `win` 等の特殊値は本 event では発火させない。
+    BestMoveSelected(BestMoveEvent),
+    /// 自エンジンの手を CSA サーバへ送信した直後に発火。
+    MoveSent(MoveEvent),
+    /// CSA サーバから手の echo (`+7776FU,T30` 等) を受信した時に発火。自エンジンの
+    /// 手と相手の手の両方で発火する (相手の手は `MoveSent` を伴わない)。
+    MoveConfirmed(MoveEvent),
+    /// USI `info` 行を観測したとき、emit policy に基づいて発火する累積 snapshot。
+    SearchInfo(SearchInfoSnapshot),
+    /// `#WIN` / `#LOSE` / `#DRAW` / `#CHUDAN` / `#CENSORED` 等の最終結果行を
+    /// 受信した時に発火。
+    GameEnded(GameEndEvent),
+    /// transport を閉じた直後の最終 event。すべてのケース (正常終了 / shutdown /
+    /// sink fatal / transport error) でこの event が最後に 1 度発火する。
+    Disconnected {
+        /// 切断理由。
+        reason: DisconnectReason,
+    },
+}
+
+// ────────────────────────────────────────────
+// SessionOutcome / SessionEventSink / Errors
+// ────────────────────────────────────────────
+
+/// `run_*_session*` の戻り値。将来 field 追加耐性のため struct 化している。
+///
+/// 既存呼び出し側は `outcome.result` / `outcome.record` / `outcome.summary` を
+/// 直接参照すること (タプル分解は不可)。
+#[derive(Debug)]
+pub struct SessionOutcome {
+    /// CSA サーバ側の最終結果。
+    pub result: GameResult,
+    /// 蓄積した棋譜。
+    pub record: GameRecord,
+    /// 対局中に受信した Game_Summary (resume 時は新 token 付きの再受信版)。
+    /// 接続自体に失敗した等で受信前に終了した場合 `None`。
+    pub summary: Option<GameSummary>,
+}
+
+/// 対局途中の進捗を受け取る consumer 用 trait。
+///
+/// `on_event` は対局メインループ thread から同期呼び出しされる。重い処理を直接
+/// 行うと対局ループを遅らせるため、軽量な channel 送信のみを行うこと。詳細は
+/// 本モジュールの crate-level doc を参照。
+pub trait SessionEventSink {
+    /// 1 件の event を処理する。
+    ///
+    /// 戻り値:
+    /// - `Ok(())`: 通常通り対局を継続する。
+    /// - `Err(SinkError::NonFatal(_))`: warn ログを出して対局を継続する。
+    /// - `Err(SinkError::Fatal(_))`: 対局を中断する (best-effort attempt at clean closure)。
+    fn on_event(&mut self, event: SessionProgress) -> Result<(), SinkError>;
+
+    /// session が abort / shutdown された際に best-effort で 1 度呼ばれる。
+    /// default 実装は no-op。戻り値は呼び出し側で warn ログのみに使われ、
+    /// 対局フローには影響しない。
+    fn on_error(&mut self, _error: &SessionError) -> Result<(), SinkError> {
+        Ok(())
+    }
+
+    /// 対局ループ各イテレーションの先頭で呼ばれ、`false` を返すと sink fatal と
+    /// 同等の `best-effort attempt at clean closure` をトリガする。default は `true`。
+    fn should_continue(&self) -> bool {
+        true
+    }
+}
+
+/// 何もしない sink。`run_game_session` / `run_resumed_session` (event なし版) が
+/// 内部的に渡す default。
+pub struct NoopSessionEventSink;
+
+impl SessionEventSink for NoopSessionEventSink {
+    fn on_event(&mut self, _event: SessionProgress) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+impl<F> SessionEventSink for F
+where
+    F: FnMut(SessionProgress) -> Result<(), SinkError>,
+{
+    fn on_event(&mut self, event: SessionProgress) -> Result<(), SinkError> {
+        (self)(event)
+    }
+}
+
+/// sink が返す error 型。`thiserror` 由来で `Send + Sync` な inner error を抱える。
+#[derive(thiserror::Error, Debug)]
+pub enum SinkError {
+    /// 対局を継続させたい一時的なエラー。warn ログのみ出される。
+    #[error("sink: non-fatal: {0}")]
+    NonFatal(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// 対局を中断させたい致命的エラー。`best-effort attempt at clean closure` をトリガする。
+    #[error("sink: fatal: {0}")]
+    Fatal(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// `run_*_session_with_events` が返す public error 型。
+///
+/// 既存の `anyhow::Error` 経路も `Other(anyhow::Error)` として包んで返す。
+#[derive(thiserror::Error, Debug)]
+pub enum SessionError {
+    /// transport / IO 系エラー (TCP / WebSocket 切断、書き込み失敗等)。
+    #[error("network: {0}")]
+    Network(#[source] std::io::Error),
+    /// CSA プロトコルレベルの異常応答 (Game_Summary 不正等)。
+    #[error("protocol: {0}")]
+    Protocol(String),
+    /// USI engine 側のエラー (子プロセス異常終了、応答 timeout 等)。
+    #[error("engine: {0}")]
+    Engine(String),
+    /// 外部 shutdown 要求 (`AtomicBool::store(true, _)`) による中断。
+    #[error("shutdown")]
+    Shutdown,
+    /// sink が `Fatal` を返したことによる中断。
+    #[error("sink aborted")]
+    SinkAborted(#[source] SinkError),
+    /// 上記分類に当てはめられない包括的エラー (`anyhow` から包んだもの)。
+    #[error("other: {0}")]
+    Other(#[source] anyhow::Error),
+}
+
+impl From<anyhow::Error> for SessionError {
+    fn from(err: anyhow::Error) -> Self {
+        // `io::Error` を内部に持つなら Network に分類する。
+        if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+            // io_err は move 不可なため、kind とメッセージから等価な io::Error を生成する。
+            return SessionError::Network(std::io::Error::new(io_err.kind(), io_err.to_string()));
+        }
+        SessionError::Other(err)
+    }
+}

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -38,10 +38,31 @@
 //! `websocket` feature 有効時、上記 `CryptoProvider` の install を行わずに
 //! `wss://` 経路で `CsaConnection::connect_with_target` 等を呼ぶと `rustls`
 //! 内部で panic する。consumer 側で起動時 install を必ず行うこと。
+//!
+//! # SessionEventSink (対局途中の進捗通知)
+//!
+//! `run_game_session_with_events` / `run_resumed_session_with_events` に
+//! [`SessionEventSink`] 実装を渡すと、対局ループの各イベント
+//! ([`SessionProgress`]) が consumer に push 通知される。詳細は
+//! [`events`] モジュールの doc を参照。
+//!
+//! - sink の `on_event` は対局メインループ thread 上で同期呼び出しされる。
+//!   重い処理 (DB write / network publish 等) を直接行うと対局ループ全体が
+//!   遅延し USI engine 探索や CSA サーバ応答に影響する。consumer は軽量な
+//!   channel 送信のみ行うこと。
+//! - sink が `SinkError::NonFatal` を返した場合は warn ログのみで対局継続。
+//!   `SinkError::Fatal` を返した場合は best-effort attempt at clean closure
+//!   (`%CHUDAN` → `LOGOUT` → transport close → `on_error` → `Disconnected`)
+//!   を行ってから [`SessionError::SinkAborted`] で return する。
+//! - resume 経路では指し手 history の replay は emit しない。consumer は
+//!   [`ReconnectState::last_sfen`] から盤面を再構築する責任を持つ。
+//! - [`SearchInfoSnapshot`] は累積 snapshot で、observed したぶんだけ field を
+//!   上書きする (差分ではなく常に「現時点までの最新値の集合」)。
 
 pub mod config;
 pub mod engine;
 pub mod event;
+pub mod events;
 pub mod jsonl;
 pub mod protocol;
 pub mod record;
@@ -54,7 +75,15 @@ pub mod transport;
 pub use config::CsaClientConfig;
 pub use engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
 pub use event::Event;
+pub use events::{
+    BestMoveEvent, DisconnectReason, GameEndEvent, GameEndReason, MoveEvent, MovePlayer,
+    NoopSessionEventSink, ReconnectState, SearchInfoEmitPolicy, SearchInfoSnapshot, SearchOrigin,
+    SessionError, SessionEventSink, SessionOutcome, SessionProgress, Side, SinkError,
+};
 pub use protocol::{CsaConnection, GameResult, GameSummary};
 pub use record::{GameRecord, RecordedMove};
-pub use session::{run_game_session, run_resumed_session};
+pub use session::{
+    run_game_session, run_game_session_with_events, run_resumed_session,
+    run_resumed_session_with_events,
+};
 pub use transport::{ConnectOpts, CsaTransport, TransportTarget};

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -356,15 +356,18 @@ fn run_one_game(
     conn.login(&id, &config.server.password)?;
 
     // 対局実行
-    let result = run_game_session(&mut conn, engine, config, shutdown);
+    let session_result = run_game_session(&mut conn, engine, config, shutdown);
 
     // 中断 (= サーバ切断) でかつ Reconnect_Token を保持している場合は 1 度だけ
     // 再接続を試みる。Workers の `RECONNECT_GRACE_SECONDS` 内に到達できれば
     // 同一対局を継続できる。reconnect 試行前に元 conn は drop / logout する。
-    let reconnect_request = match result.as_ref() {
-        Ok((GameResult::Interrupted, _, Some(summary)))
-            if summary.reconnect_token.is_some() && !shutdown.load(Ordering::SeqCst) =>
+    let reconnect_request = match session_result.as_ref() {
+        Ok(outcome)
+            if outcome.result == GameResult::Interrupted
+                && outcome.summary.as_ref().is_some_and(|s| s.reconnect_token.is_some())
+                && !shutdown.load(Ordering::SeqCst) =>
         {
+            let summary = outcome.summary.as_ref().unwrap();
             Some((summary.game_id.clone(), summary.reconnect_token.clone().unwrap()))
         }
         _ => None,
@@ -372,7 +375,8 @@ fn run_one_game(
 
     if let Some((game_id, token)) = reconnect_request {
         log::warn!(
-            "[CSA] サーバ切断を検出。Reconnect_Token を持つので grace 内に再接続を試みます: game_id={game_id}"
+            "[CSA] サーバ切断を検出。Reconnect_Token を持つので grace 内に再接続を試みます: game_id={}",
+            game_id
         );
         let _ = conn.logout();
         drop(conn);
@@ -395,13 +399,15 @@ fn run_one_game(
                 // ことを期待する (rshogi-usi 含む主要 USI engine の挙動)。
                 log::warn!("[CSA] 再接続失敗: {e}。元の Interrupted 結果で終了します。");
                 let _ = engine.stop_and_wait();
-                return result.map(|(r, rec, _)| (r, rec));
+                return session_result
+                    .map(|outcome| (outcome.result, outcome.record))
+                    .map_err(|e| anyhow::anyhow!("{}", e));
             }
         }
     }
 
     // エラー時は投了を試みる（NF2: 対局中のエラーは投了してから再接続）
-    if result.is_err() {
+    if session_result.is_err() {
         // ponder 中の場合は stop して bestmove を待ってからクリーンアップ
         let _ = engine.stop_and_wait();
         let _ = conn.send_resign();
@@ -409,8 +415,9 @@ fn run_one_game(
     }
 
     let _ = conn.logout();
-    // (result, record, _summary) → 既存呼び出し互換 (result, record) に縮約
-    result.map(|(r, rec, _)| (r, rec))
+    session_result
+        .map(|outcome| (outcome.result, outcome.record))
+        .map_err(|e| anyhow::anyhow!("{}", e))
 }
 
 /// 切断検出後の再接続に必要な認証情報。多引数化を避けるためまとめる。
@@ -433,9 +440,10 @@ fn attempt_reconnect(
 ) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
     let mut conn = CsaConnection::connect_with_target(target, opts)?;
     conn.login_reconnect(creds.id, creds.password, creds.game_id, creds.token)?;
-    let (r, rec, _) = run_resumed_session(&mut conn, engine, config, shutdown)?;
+    let outcome = run_resumed_session(&mut conn, engine, config, shutdown)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
     let _ = conn.logout();
-    Ok((r, rec))
+    Ok((outcome.result, outcome.record))
 }
 
 /// `--lobby` モードで成立したマッチ。`run_one_game` 直前に config を差し替えるための

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -471,6 +471,13 @@ impl CsaConnection {
         self.send_line(&serialize_client_command(&ClientCommand::Kachi))
     }
 
+    /// 中断 (`%CHUDAN`) を送信。`SessionEventSink` の Fatal / 外部 shutdown 時の
+    /// best-effort attempt at clean closure で使う。サーバ側が実際に
+    /// `#CHUDAN` で確定するかは保証しない。
+    pub fn send_chudan(&mut self) -> Result<()> {
+        self.send_line(&serialize_client_command(&ClientCommand::Chudan))
+    }
+
     /// ログアウト
     pub fn logout(&mut self) -> Result<()> {
         let _ = self.send_line(&serialize_client_command(&ClientCommand::Logout));

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -1,10 +1,22 @@
 //! CSA対局セッション管理
 //!
-//! 1回の対局（ログイン〜対局〜終局）を管理する。
+//! 1回の対局（ログイン後〜対局〜終局）を管理する。
 //! サーバー受信スレッドとエンジン受信を共通チャネル経由で同時監視し、
 //! ponderhit 中にサーバーから終局通知が来ても即座に検出できる。
+//!
+//! # 公開 API
+//!
+//! - [`run_game_session_with_events`] / [`run_resumed_session_with_events`]:
+//!   [`SessionEventSink`] に対局途中の進捗 ([`SessionProgress`]) を push 通知する
+//!   primary API。
+//! - [`run_game_session`] / [`run_resumed_session`]: 進捗通知不要な consumer 向けの
+//!   薄いラッパー (内部で [`NoopSessionEventSink`] を渡す)。
+//!
+//! sink 仕様 / resume contract / terminate 手順の詳細は [`crate::events`] モジュール
+//! の crate-level doc を参照。
 
 use std::fmt::Write as _;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver};
 use std::time::{Duration, Instant};
@@ -16,10 +28,1282 @@ use rshogi_csa::{Color, Position, csa_move_to_usi, usi_move_to_csa};
 use crate::config::CsaClientConfig;
 use crate::engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
 use crate::event::Event;
+use crate::events::{
+    BestMoveEvent, DisconnectReason, GameEndEvent, GameEndReason, MoveEvent, MovePlayer,
+    NoopSessionEventSink, ReconnectState as PublicReconnectState, SearchInfoEmitPolicy,
+    SearchInfoSnapshot, SearchOrigin, SessionError, SessionEventSink, SessionOutcome,
+    SessionProgress, Side, SinkError,
+};
 use crate::protocol::{
-    CsaConnection, GameResult, GameSummary, ReconnectState, parse_game_result, parse_server_move,
+    CsaConnection, GameResult, GameSummary, ReconnectState as ProtocolReconnectState,
+    parse_game_result, parse_server_move,
 };
 use crate::record::{GameRecord, JsonlMoveExtra};
+
+// ────────────────────────────────────────────
+// 公開エントリポイント
+// ────────────────────────────────────────────
+
+/// `SessionEventSink` 経由で進捗通知付き対局を駆動する primary API。
+///
+/// `conn` はあらかじめ [`CsaConnection::login`] 済みのものを渡すこと。本関数は
+/// `conn` 上で `Game_Summary` 受信 → AGREE → 対局ループを実行し、最終的に
+/// `LOGOUT` を試みる。`conn` の所有権は呼び出し側に残るので、戻り後に
+/// `drop(conn)` か追加 close 処理を呼び出し側が決められる。
+///
+/// resume 経路は [`run_resumed_session_with_events`] を使うこと。
+pub fn run_game_session_with_events<S>(
+    config: &CsaClientConfig,
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    shutdown: Arc<AtomicBool>,
+    sink: &mut S,
+) -> Result<SessionOutcome, SessionError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Fresh)
+}
+
+/// `LOGIN ... reconnect:<game_id>+<token>` 後の resume セッションを進捗通知付きで
+/// 駆動する。`conn` は [`CsaConnection::login_reconnect`] 成功直後のものを渡すこと。
+///
+/// 本関数は履歴 replay を `MoveConfirmed` として emit しない (resume 時の局面は
+/// `Resumed.state.last_sfen` から再構築する)。詳細は [`crate::events`] の
+/// crate-level doc を参照。
+pub fn run_resumed_session_with_events<S>(
+    config: &CsaClientConfig,
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    shutdown: Arc<AtomicBool>,
+    sink: &mut S,
+) -> Result<SessionOutcome, SessionError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Resumed)
+}
+
+/// 進捗通知不要な consumer 向けの薄いラッパー。内部で [`NoopSessionEventSink`] を渡す。
+/// `shutdown` の動的変更を新 API 同等に伝播させるため、内部実装 `drive_session`
+/// を直接呼ぶ。
+pub fn run_game_session(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+) -> Result<SessionOutcome, SessionError> {
+    let mut sink = NoopSessionEventSink;
+    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Fresh)
+}
+
+/// 進捗通知不要な consumer 向けの薄いラッパー (resume 経路)。
+pub fn run_resumed_session(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+) -> Result<SessionOutcome, SessionError> {
+    let mut sink = NoopSessionEventSink;
+    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Resumed)
+}
+
+// ────────────────────────────────────────────
+// 内部実装: drive_session 共通経路
+// ────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SessionMode {
+    Fresh,
+    Resumed,
+}
+
+fn drive_session<S>(
+    config: &CsaClientConfig,
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    shutdown: &AtomicBool,
+    sink: &mut S,
+    mode: SessionMode,
+) -> Result<SessionOutcome, SessionError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    // Step 1: Connected
+    if let Some(action) = emit_with_nonfatal_warn(sink, SessionProgress::Connected) {
+        return handle_sink_error(action, conn, sink, None, false);
+    }
+    if !sink.should_continue() {
+        return abort_for_should_continue(conn, sink, None, false);
+    }
+
+    // Step 2: Game_Summary 受信
+    let summary = match conn.recv_game_summary(config.server.keepalive.ping_interval_sec) {
+        Ok(s) => s,
+        Err(err) => {
+            return Err(map_anyhow_to_session_error(err));
+        }
+    };
+    let summary_arc = Arc::new(summary.clone());
+
+    // resume の場合は Reconnect_State も受信する
+    let reconnect_state_protocol = if mode == SessionMode::Resumed {
+        match conn.recv_reconnect_state() {
+            Ok(state) => Some(state),
+            Err(err) => {
+                return Err(map_anyhow_to_session_error(err));
+            }
+        }
+    } else {
+        None
+    };
+
+    // Step 3: Resumed / GameSummary を発火
+    let progress = match mode {
+        SessionMode::Fresh => SessionProgress::GameSummary(Arc::clone(&summary_arc)),
+        SessionMode::Resumed => {
+            let state = build_reconnect_state(&summary, reconnect_state_protocol.as_ref());
+            SessionProgress::Resumed {
+                summary: Arc::clone(&summary_arc),
+                state,
+            }
+        }
+    };
+    if let Some(action) = emit_with_nonfatal_warn(sink, progress) {
+        return handle_sink_error(action, conn, sink, Some(summary), false);
+    }
+    if !sink.should_continue() {
+        return abort_for_should_continue(conn, sink, Some(summary), false);
+    }
+
+    // Step 4: AGREE / engine.new_game (Fresh のみ AGREE 必要)
+    if mode == SessionMode::Fresh
+        && let Err(err) = conn.agree_and_wait_start(&summary.game_id)
+    {
+        return Err(map_anyhow_to_session_error(err));
+    }
+    if let Err(err) = engine.new_game() {
+        return Err(SessionError::Engine(format!("{err}")));
+    }
+
+    // Step 5: GameStarted を発火
+    if let Some(action) = emit_with_nonfatal_warn(sink, SessionProgress::GameStarted) {
+        return handle_sink_error(action, conn, sink, Some(summary), false);
+    }
+    if !sink.should_continue() {
+        return abort_for_should_continue(conn, sink, Some(summary), false);
+    }
+
+    // Step 6: 対局メインループ
+    let loop_result = run_session_loop(
+        conn,
+        engine,
+        config,
+        shutdown,
+        summary.clone(),
+        reconnect_state_protocol,
+        sink,
+    );
+
+    match loop_result {
+        LoopOutcome::GameEnded {
+            result,
+            record,
+            game_end_event,
+        } => {
+            // GameEnded 発火
+            if let Some(action) =
+                emit_with_nonfatal_warn(sink, SessionProgress::GameEnded(game_end_event))
+            {
+                // 既に gameover は emit 済みなので CHUDAN は不要だが LOGOUT は試みる。
+                return handle_sink_error(action, conn, sink, Some(summary), true);
+            }
+            // 通常切断
+            let _ = conn.logout();
+            let _ = sink.on_event(SessionProgress::Disconnected {
+                reason: DisconnectReason::GameOver,
+            });
+            Ok(SessionOutcome {
+                result,
+                record: *record,
+                summary: Some(summary),
+            })
+        }
+        LoopOutcome::SinkAborted {
+            sink_err,
+            game_already_ended,
+        } => handle_sink_error(sink_err, conn, sink, Some(summary), game_already_ended),
+        LoopOutcome::Shutdown { game_already_ended } => {
+            terminate_session(
+                conn,
+                sink,
+                &SessionError::Shutdown,
+                DisconnectReason::Shutdown,
+                game_already_ended,
+            );
+            Err(SessionError::Shutdown)
+        }
+        LoopOutcome::Error(err) => Err(err),
+    }
+}
+
+// ────────────────────────────────────────────
+// LoopOutcome
+// ────────────────────────────────────────────
+
+enum LoopOutcome {
+    GameEnded {
+        result: GameResult,
+        record: Box<GameRecord>,
+        game_end_event: GameEndEvent,
+    },
+    SinkAborted {
+        sink_err: SinkError,
+        game_already_ended: bool,
+    },
+    Shutdown {
+        game_already_ended: bool,
+    },
+    Error(SessionError),
+}
+
+// ────────────────────────────────────────────
+// 内部状態
+// ────────────────────────────────────────────
+
+/// メインループの可変状態。ライフタイム `'a` は 1 局分の借用。
+/// `S` は generic な sink。`?Sized` を許して `dyn SessionEventSink` も渡せるようにする。
+struct SessionState<'a, S: ?Sized + 'a> {
+    conn: &'a mut CsaConnection,
+    engine: &'a mut UsiEngine,
+    config: &'a CsaClientConfig,
+    shutdown: &'a AtomicBool,
+    server_rx: &'a Receiver<Event>,
+    pos: Position,
+    usi_moves: Vec<String>,
+    clock: Clock,
+    record: GameRecord,
+    ponder_state: Option<PonderState>,
+    my_color: Color,
+    initial_sfen: String,
+    sink: &'a mut S,
+    info_throttle: SearchInfoThrottle,
+    /// 直前に ponder miss が発生したか。次の自手番の fresh search に
+    /// `SearchOrigin::PonderMiss` を載せるためのフラグ。
+    pending_ponder_miss: bool,
+}
+
+/// 探索結果の処理結果
+enum MoveAction {
+    Continue,
+    GameEnd(GameResult, Box<GameRecord>, GameEndEvent),
+    SinkAborted(SinkError, bool /* game_already_ended */),
+    Shutdown(bool /* game_already_ended */),
+}
+
+// ────────────────────────────────────────────
+// メインループ
+// ────────────────────────────────────────────
+
+fn run_session_loop<S>(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+    summary: GameSummary,
+    resume_state: Option<ProtocolReconnectState>,
+    sink: &mut S,
+) -> LoopOutcome
+where
+    S: SessionEventSink + ?Sized,
+{
+    let (server_tx, server_rx) = mpsc::channel();
+    if let Err(err) = conn.start_reader_thread(server_tx) {
+        return LoopOutcome::Error(map_anyhow_to_session_error(err));
+    }
+
+    let mut clock = Clock::from_summary(&summary);
+    if let Some(state) = &resume_state {
+        clock.black_time_ms = state.black_remaining_ms.max(0);
+        clock.white_time_ms = state.white_remaining_ms.max(0);
+    }
+
+    let mut s = SessionState {
+        pos: summary.position.clone(),
+        initial_sfen: summary.position.to_sfen(),
+        usi_moves: Vec::new(),
+        clock,
+        record: GameRecord::new(&summary),
+        ponder_state: None,
+        my_color: summary.my_color,
+        conn,
+        engine,
+        config,
+        shutdown,
+        server_rx: &server_rx,
+        sink,
+        info_throttle: SearchInfoThrottle::new(config.game.search_info_emit.clone()),
+        pending_ponder_miss: false,
+    };
+
+    // 途中局面の手順を適用 (Fresh で `initial_moves` がある時のみ。resume では
+    // `initial_moves` は通常空。Fresh の時に届く initial_moves は CSA Game_Summary の
+    // 一部であり、この時点では既に局面に焼き込まれている扱いとして MoveConfirmed は
+    // emit しない。ただし record / clock / usi_moves には反映する必要がある)。
+    let mut move_color = summary.position.side_to_move;
+    for cm in &summary.initial_moves {
+        let usi = match csa_move_to_usi(&cm.mv, &s.pos) {
+            Ok(u) => u,
+            Err(err) => return LoopOutcome::Error(map_anyhow_to_session_error(err)),
+        };
+        let initial_sfen_before = s.pos.to_sfen();
+        if let Err(err) = s.pos.apply_csa_move(&cm.mv) {
+            return LoopOutcome::Error(map_anyhow_to_session_error(err));
+        }
+        s.usi_moves.push(usi.clone());
+        if let Some(t) = cm.time_sec {
+            s.clock.consume(move_color, t);
+        }
+        let time_sec = cm.time_sec.unwrap_or(0);
+        s.record.add_move(&cm.mv, time_sec, None, move_color);
+        push_opponent_jsonl(&mut s.record, initial_sfen_before, usi, move_color, time_sec);
+        move_color = opposite(move_color);
+    }
+
+    loop {
+        // 各イテレーション先頭で sink.should_continue() を確認
+        if !s.sink.should_continue() {
+            let synthetic_err = SinkError::Fatal(Box::new(std::io::Error::other(
+                "sink.should_continue() == false",
+            )));
+            return LoopOutcome::SinkAborted {
+                sink_err: synthetic_err,
+                game_already_ended: false,
+            };
+        }
+        if s.shutdown.load(Ordering::SeqCst) {
+            return LoopOutcome::Shutdown {
+                game_already_ended: false,
+            };
+        }
+
+        if s.pos.side_to_move == s.my_color {
+            let turn_start = Instant::now();
+            let sfen_before = s.pos.to_sfen();
+            let think_limit_ms = s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
+            let position_cmd = build_position_cmd(&s.initial_sfen, &s.usi_moves);
+            let go_cmd =
+                format!("go {}", s.clock.build_go_args(s.config.time.margin_msec, s.my_color));
+
+            let outcome = {
+                let mut emitter = SearchInfoEmitter::new(&mut s.info_throttle, s.sink);
+                let mut info_callback = |info: &SearchInfo, raw: &str| {
+                    emitter.observe(info, raw);
+                };
+                let result = s.engine.go_with_info(
+                    &position_cmd,
+                    &go_cmd,
+                    s.shutdown,
+                    s.server_rx,
+                    &mut info_callback,
+                );
+                let final_observation = emitter.into_final();
+                (result, final_observation)
+            };
+            let (search_outcome_result, final_info) = outcome;
+            let search_outcome = match search_outcome_result {
+                Ok(o) => o,
+                Err(err) => return LoopOutcome::Error(map_anyhow_to_session_error(err)),
+            };
+            // bestmove 直前の最終 info を `emit_final` ポリシーに従って発火
+            if let Some(snapshot) = final_info
+                && let Err(err) = s.sink.on_event(SessionProgress::SearchInfo(snapshot))
+                && let Some(outcome) = handle_loop_sink_err(err, false)
+            {
+                return outcome;
+            }
+
+            // 直前に ponder miss があれば、その次の fresh search は `PonderMiss` で
+            // emit する (UI が「ponder が外れて生まれた fresh search」と区別できるよう)。
+            // それ以外は通常の `Fresh`。
+            let origin = if s.pending_ponder_miss {
+                s.pending_ponder_miss = false;
+                SearchOrigin::PonderMiss
+            } else {
+                SearchOrigin::Fresh
+            };
+            match handle_search_outcome_with_origin(
+                &mut s,
+                search_outcome,
+                turn_start,
+                sfen_before,
+                think_limit_ms,
+                origin,
+            ) {
+                MoveAction::Continue => {}
+                MoveAction::GameEnd(result, record_box, game_end_event) => {
+                    return LoopOutcome::GameEnded {
+                        result,
+                        record: record_box,
+                        game_end_event,
+                    };
+                }
+                MoveAction::SinkAborted(sink_err, game_already_ended) => {
+                    return LoopOutcome::SinkAborted {
+                        sink_err,
+                        game_already_ended,
+                    };
+                }
+                MoveAction::Shutdown(game_already_ended) => {
+                    return LoopOutcome::Shutdown { game_already_ended };
+                }
+            }
+        }
+
+        // 相手の手番: server_rx から指し手を待つ
+        loop {
+            if !s.sink.should_continue() {
+                let synthetic_err = SinkError::Fatal(Box::new(std::io::Error::other(
+                    "sink.should_continue() == false",
+                )));
+                return LoopOutcome::SinkAborted {
+                    sink_err: synthetic_err,
+                    game_already_ended: false,
+                };
+            }
+            match s.server_rx.recv_timeout(Duration::from_millis(200)) {
+                Ok(Event::ServerLine(line)) => {
+                    if line.starts_with('+') || line.starts_with('-') {
+                        match handle_opponent_move_line(&mut s, &line) {
+                            MoveAction::Continue => break,
+                            MoveAction::GameEnd(result, record_box, game_end_event) => {
+                                return LoopOutcome::GameEnded {
+                                    result,
+                                    record: record_box,
+                                    game_end_event,
+                                };
+                            }
+                            MoveAction::SinkAborted(sink_err, game_already_ended) => {
+                                return LoopOutcome::SinkAborted {
+                                    sink_err,
+                                    game_already_ended,
+                                };
+                            }
+                            MoveAction::Shutdown(game_already_ended) => {
+                                return LoopOutcome::Shutdown { game_already_ended };
+                            }
+                        }
+                    }
+                    if line.starts_with('#') {
+                        if let Some(game_result) = parse_game_result(&line) {
+                            log::info!("[CSA] 対局終了: {line}");
+                            if let Err(err) = cleanup_ponder(s.engine, &mut s.ponder_state) {
+                                return LoopOutcome::Error(map_anyhow_to_session_error(err));
+                            }
+                            let reason_line = s.conn.pending_end_reason.take();
+                            s.record
+                                .set_result(record_result_with_reason(&game_result, &reason_line));
+                            if let Err(err) = s.engine.gameover(gameover_str(&game_result)) {
+                                return LoopOutcome::Error(map_anyhow_to_session_error(err));
+                            }
+                            let game_end_event = build_game_end_event(
+                                &game_result,
+                                reason_line,
+                                Some(line),
+                                s.my_color,
+                            );
+                            return LoopOutcome::GameEnded {
+                                result: game_result,
+                                record: Box::new(s.record.clone()),
+                                game_end_event,
+                            };
+                        }
+                        s.conn.pending_end_reason = Some(line);
+                    }
+                }
+                Ok(Event::ServerDisconnected) => {
+                    if let Err(err) = cleanup_ponder(s.engine, &mut s.ponder_state) {
+                        return LoopOutcome::Error(map_anyhow_to_session_error(err));
+                    }
+                    if let Err(err) = s.engine.gameover("lose") {
+                        return LoopOutcome::Error(map_anyhow_to_session_error(err));
+                    }
+                    let game_end_event = build_game_end_event(
+                        &GameResult::Interrupted,
+                        Some("#DISCONNECTED".to_owned()),
+                        None,
+                        s.my_color,
+                    );
+                    return LoopOutcome::GameEnded {
+                        result: GameResult::Interrupted,
+                        record: Box::new(s.record.clone()),
+                        game_end_event,
+                    };
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if let Err(err) =
+                        s.conn.maybe_send_keepalive(s.config.server.keepalive.ping_interval_sec)
+                    {
+                        return LoopOutcome::Error(map_anyhow_to_session_error(err));
+                    }
+                    if s.shutdown.load(Ordering::SeqCst) {
+                        return LoopOutcome::Shutdown {
+                            game_already_ended: false,
+                        };
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    return LoopOutcome::Error(SessionError::Protocol(
+                        "サーバー受信チャネル切断".to_owned(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// 自分の bestmove 後、SearchOrigin を意識してハンドリングする。
+fn handle_search_outcome_with_origin<S>(
+    s: &mut SessionState<'_, S>,
+    outcome: SearchOutcome,
+    turn_start: Instant,
+    sfen_before: String,
+    think_limit_ms: u64,
+    origin: SearchOrigin,
+) -> MoveAction
+where
+    S: SessionEventSink + ?Sized,
+{
+    match outcome {
+        SearchOutcome::BestMove(result, info) => send_bestmove_and_wait_echo(
+            s,
+            &result,
+            &info,
+            turn_start,
+            sfen_before,
+            think_limit_ms,
+            origin,
+        ),
+        SearchOutcome::ServerInterrupt(lines) => {
+            let (game_result, reason_line, raw_result_line) =
+                parse_server_interrupt_lines_full(lines);
+            log::info!("[CSA] サーバー終局割り込み: {:?}", game_result);
+            s.record.set_result(record_result_with_reason(&game_result, &reason_line));
+            if let Err(err) = s.engine.gameover(gameover_str(&game_result)) {
+                return MoveAction::sink_or_error(err);
+            }
+            let game_end_event =
+                build_game_end_event(&game_result, reason_line, raw_result_line, s.my_color);
+            MoveAction::GameEnd(game_result, Box::new(s.record.clone()), game_end_event)
+        }
+    }
+}
+
+fn send_bestmove_and_wait_echo<S>(
+    s: &mut SessionState<'_, S>,
+    result: &BestMoveResult,
+    info: &SearchInfo,
+    turn_start: Instant,
+    sfen_before: String,
+    think_limit_ms: u64,
+    origin: SearchOrigin,
+) -> MoveAction
+where
+    S: SessionEventSink + ?Sized,
+{
+    if result.bestmove == "resign" {
+        if let Err(err) = s.conn.send_resign() {
+            return MoveAction::sink_or_error(err);
+        }
+        s.record.set_result("resign");
+        let (game_result, reason_line, raw_result_line) = wait_game_end_full_from_rx(s.server_rx);
+        if let Err(err) = s.engine.gameover(gameover_str(&game_result)) {
+            return MoveAction::sink_or_error(err);
+        }
+        let game_end_event =
+            build_game_end_event(&game_result, reason_line, raw_result_line, s.my_color);
+        return MoveAction::GameEnd(game_result, Box::new(s.record.clone()), game_end_event);
+    }
+    if result.bestmove == "win" {
+        if let Err(err) = s.conn.send_win() {
+            return MoveAction::sink_or_error(err);
+        }
+        s.record.set_result("win_declaration");
+        let (game_result, reason_line, raw_result_line) = wait_game_end_full_from_rx(s.server_rx);
+        if let Err(err) = s.engine.gameover(gameover_str(&game_result)) {
+            return MoveAction::sink_or_error(err);
+        }
+        let game_end_event =
+            build_game_end_event(&game_result, reason_line, raw_result_line, s.my_color);
+        return MoveAction::GameEnd(game_result, Box::new(s.record.clone()), game_end_event);
+    }
+
+    let csa_move = match usi_move_to_csa(&result.bestmove, &s.pos) {
+        Ok(c) => c,
+        Err(err) => return MoveAction::sink_or_error(err),
+    };
+
+    // BestMoveSelected 発火 (CSA サーバ送信前)
+    let snapshot = search_info_to_snapshot(info);
+    let best_event = BestMoveEvent {
+        usi_move: result.bestmove.clone(),
+        csa_move_candidate: Some(csa_move.clone()),
+        ponder: result.ponder_move.clone(),
+        side: Side::from(s.my_color),
+        ply: s.pos.ply,
+        search_origin: origin,
+        search: Some(snapshot.clone()),
+    };
+    if let Err(err) = s.sink.on_event(SessionProgress::BestMoveSelected(best_event))
+        && let Some(action) = handle_loop_sink_err_action(err, false)
+    {
+        return action;
+    }
+
+    let comment = if s.config.server.floodgate {
+        Some(build_floodgate_comment(info, s.my_color, &s.pos, &result.bestmove))
+    } else {
+        None
+    };
+    if let Err(err) = s.conn.send_move_with_comment(&csa_move, comment.as_deref()) {
+        return MoveAction::sink_or_error(err);
+    }
+
+    // 局面適用
+    if let Err(err) = s.pos.apply_csa_move(&csa_move) {
+        return MoveAction::sink_or_error(err);
+    }
+    let sfen_after = s.pos.to_sfen();
+    s.usi_moves.push(result.bestmove.clone());
+    s.record.add_move(&csa_move, 0, Some(info), s.my_color);
+    let elapsed_ms = turn_start.elapsed().as_millis().min(u64::MAX as u128) as u64;
+    let engine_label = label_for_color(&s.record, s.my_color);
+    s.record.add_jsonl_move(JsonlMoveExtra {
+        sfen_before: sfen_before.clone(),
+        move_usi: result.bestmove.clone(),
+        engine_label,
+        elapsed_ms,
+        think_limit_ms,
+        seldepth: info.seldepth,
+        nodes: info.nodes,
+        time_ms: info.time_ms,
+        nps: info.nps,
+    });
+
+    // MoveSent 発火 (送信直後、サーバ echo の time_sec はまだ未確定)
+    let move_sent_event = MoveEvent {
+        player: MovePlayer::SelfPlayer,
+        csa_move: csa_move.clone(),
+        usi_move: result.bestmove.clone(),
+        side: Side::from(s.my_color),
+        ply: s.pos.ply.saturating_sub(1) + 1, // この手 = ply に既に進んだ後の値そのまま
+        time_sec: None,
+        sfen_before: sfen_before.clone(),
+        sfen_after: sfen_after.clone(),
+        search_origin: Some(origin),
+        search: Some(snapshot.clone()),
+    };
+    let move_sent_ply = move_sent_event.ply;
+    if let Err(err) = s.sink.on_event(SessionProgress::MoveSent(move_sent_event))
+        && let Some(action) = handle_loop_sink_err_action(err, false)
+    {
+        return action;
+    }
+
+    // ponder 開始
+    if s.config.game.ponder
+        && let Some(ref ponder_mv) = result.ponder_move
+    {
+        let my_estimated_ms = turn_start.elapsed().as_millis() as i64;
+        let ponder_pos_cmd =
+            build_position_cmd_with_ponder(&s.initial_sfen, &s.usi_moves, ponder_mv);
+        let ponder_go = format!(
+            "go ponder {}",
+            s.clock
+                .build_ponder_go_args(s.config.time.margin_msec, s.my_color, my_estimated_ms,)
+        );
+        if let Err(err) = s.engine.go_ponder(&ponder_pos_cmd, &ponder_go) {
+            return MoveAction::sink_or_error(err);
+        }
+        s.ponder_state = Some(PonderState {
+            expected_usi: ponder_mv.clone(),
+        });
+    }
+
+    // サーバーエコー待ち
+    loop {
+        match s.server_rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(Event::ServerLine(line)) => {
+                if line.starts_with('+') || line.starts_with('-') {
+                    let (_, time_sec) = parse_server_move(&line);
+                    s.clock.consume(s.my_color, time_sec);
+                    s.record.update_last_time(time_sec);
+                    // MoveConfirmed 発火 (自エンジンの手、time_sec 確定)
+                    let confirmed_event = MoveEvent {
+                        player: MovePlayer::SelfPlayer,
+                        csa_move: csa_move.clone(),
+                        usi_move: result.bestmove.clone(),
+                        side: Side::from(s.my_color),
+                        ply: move_sent_ply,
+                        time_sec: Some(time_sec),
+                        sfen_before: sfen_before.clone(),
+                        sfen_after: sfen_after.clone(),
+                        search_origin: Some(origin),
+                        search: Some(snapshot.clone()),
+                    };
+                    if let Err(err) =
+                        s.sink.on_event(SessionProgress::MoveConfirmed(confirmed_event))
+                        && let Some(action) = handle_loop_sink_err_action(err, false)
+                    {
+                        return action;
+                    }
+                    return MoveAction::Continue;
+                }
+                if line.starts_with('#') {
+                    if let Some(game_result) = parse_game_result(&line) {
+                        log::info!("[CSA] 対局終了(エコー待ち中): {line}");
+                        if let Err(err) = cleanup_ponder(s.engine, &mut s.ponder_state) {
+                            return MoveAction::sink_or_error(err);
+                        }
+                        let reason = s.conn.pending_end_reason.take();
+                        s.record.set_result(record_result_with_reason(&game_result, &reason));
+                        if let Err(err) = s.engine.gameover(gameover_str(&game_result)) {
+                            return MoveAction::sink_or_error(err);
+                        }
+                        let game_end_event =
+                            build_game_end_event(&game_result, reason, Some(line), s.my_color);
+                        return MoveAction::GameEnd(
+                            game_result,
+                            Box::new(s.record.clone()),
+                            game_end_event,
+                        );
+                    }
+                    s.conn.pending_end_reason = Some(line);
+                }
+            }
+            Ok(Event::ServerDisconnected) => {
+                if let Err(err) = cleanup_ponder(s.engine, &mut s.ponder_state) {
+                    return MoveAction::sink_or_error(err);
+                }
+                if let Err(err) = s.engine.gameover("lose") {
+                    return MoveAction::sink_or_error(err);
+                }
+                let game_end_event = build_game_end_event(
+                    &GameResult::Interrupted,
+                    Some("#DISCONNECTED".to_owned()),
+                    None,
+                    s.my_color,
+                );
+                return MoveAction::GameEnd(
+                    GameResult::Interrupted,
+                    Box::new(s.record.clone()),
+                    game_end_event,
+                );
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Err(err) =
+                    s.conn.maybe_send_keepalive(s.config.server.keepalive.ping_interval_sec)
+                {
+                    return MoveAction::sink_or_error(err);
+                }
+                if s.shutdown.load(Ordering::SeqCst) {
+                    return MoveAction::Shutdown(false);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return MoveAction::sink_or_error(anyhow::anyhow!("サーバー受信チャネル切断"));
+            }
+        }
+    }
+}
+
+/// 相手手番で受信した指し手 1 行 (`+...` / `-...`) を処理する。
+fn handle_opponent_move_line<S>(s: &mut SessionState<'_, S>, line: &str) -> MoveAction
+where
+    S: SessionEventSink + ?Sized,
+{
+    let (mv, time_sec) = parse_server_move(line);
+
+    if let Some(ps) = s.ponder_state.take() {
+        let opponent_usi = match csa_move_to_usi(&mv, &s.pos) {
+            Ok(u) => u,
+            Err(err) => return MoveAction::sink_or_error(err),
+        };
+        if opponent_usi == ps.expected_usi {
+            // ponderhit
+            log::debug!("[PONDER] ponderhit: {}", opponent_usi);
+            let opponent_sfen_before = s.pos.to_sfen();
+            if let Err(err) = s.pos.apply_csa_move(&mv) {
+                return MoveAction::sink_or_error(err);
+            }
+            let opponent_sfen_after = s.pos.to_sfen();
+            s.usi_moves.push(opponent_usi.clone());
+            s.clock.consume(opposite(s.my_color), time_sec);
+            s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+            push_opponent_jsonl(
+                &mut s.record,
+                opponent_sfen_before.clone(),
+                opponent_usi.clone(),
+                opposite(s.my_color),
+                time_sec,
+            );
+
+            // 相手の手 MoveConfirmed
+            let opp_event = MoveEvent {
+                player: MovePlayer::Opponent,
+                csa_move: mv.clone(),
+                usi_move: opponent_usi.clone(),
+                side: Side::from(opposite(s.my_color)),
+                ply: s.pos.ply.saturating_sub(1) + 1,
+                time_sec: Some(time_sec),
+                sfen_before: opponent_sfen_before,
+                sfen_after: opponent_sfen_after,
+                search_origin: None,
+                search: None,
+            };
+            if let Err(err) = s.sink.on_event(SessionProgress::MoveConfirmed(opp_event))
+                && let Some(action) = handle_loop_sink_err_action(err, false)
+            {
+                return action;
+            }
+
+            // ponderhit -> 自分の探索
+            let ponderhit_start = Instant::now();
+            let my_sfen_before = s.pos.to_sfen();
+            let my_think_limit_ms = s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
+            let outcome = {
+                let mut emitter = SearchInfoEmitter::new(&mut s.info_throttle, s.sink);
+                let mut info_callback = |info: &SearchInfo, raw: &str| {
+                    emitter.observe(info, raw);
+                };
+                let result =
+                    s.engine.ponderhit_with_info(s.shutdown, s.server_rx, &mut info_callback);
+                let final_observation = emitter.into_final();
+                (result, final_observation)
+            };
+            let (search_outcome_result, final_info) = outcome;
+            let search_outcome = match search_outcome_result {
+                Ok(o) => o,
+                Err(err) => return MoveAction::sink_or_error(err),
+            };
+            if let Some(snapshot) = final_info
+                && let Err(err) = s.sink.on_event(SessionProgress::SearchInfo(snapshot))
+                && let Some(action) = handle_loop_sink_err_action(err, false)
+            {
+                return action;
+            }
+            handle_search_outcome_with_origin(
+                s,
+                search_outcome,
+                ponderhit_start,
+                my_sfen_before,
+                my_think_limit_ms,
+                SearchOrigin::Ponderhit,
+            )
+        } else {
+            // ponder miss
+            log::debug!("[PONDER] miss: expected={} actual={}", ps.expected_usi, opponent_usi);
+            if let Err(err) = s.engine.stop_and_wait() {
+                return MoveAction::sink_or_error(err);
+            }
+            // 次の fresh search の BestMoveSelected/MoveSent/MoveConfirmed に
+            // `SearchOrigin::PonderMiss` を載せる。bestmove は破棄するので
+            // 本ブロックでは BestMoveSelected/SearchInfo を出さず、相手の手の
+            // MoveConfirmed のみ emit して対局ループへ戻る。
+            s.pending_ponder_miss = true;
+            let opponent_sfen_before = s.pos.to_sfen();
+            if let Err(err) = s.pos.apply_csa_move(&mv) {
+                return MoveAction::sink_or_error(err);
+            }
+            let opponent_sfen_after = s.pos.to_sfen();
+            s.usi_moves.push(opponent_usi.clone());
+            s.clock.consume(opposite(s.my_color), time_sec);
+            s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+            push_opponent_jsonl(
+                &mut s.record,
+                opponent_sfen_before.clone(),
+                opponent_usi.clone(),
+                opposite(s.my_color),
+                time_sec,
+            );
+            let opp_event = MoveEvent {
+                player: MovePlayer::Opponent,
+                csa_move: mv.clone(),
+                usi_move: opponent_usi.clone(),
+                side: Side::from(opposite(s.my_color)),
+                ply: s.pos.ply.saturating_sub(1) + 1,
+                time_sec: Some(time_sec),
+                sfen_before: opponent_sfen_before,
+                sfen_after: opponent_sfen_after,
+                search_origin: None,
+                search: None,
+            };
+            if let Err(err) = s.sink.on_event(SessionProgress::MoveConfirmed(opp_event))
+                && let Some(action) = handle_loop_sink_err_action(err, false)
+            {
+                return action;
+            }
+            MoveAction::Continue
+        }
+    } else {
+        // ponder なし
+        let opponent_usi = match csa_move_to_usi(&mv, &s.pos) {
+            Ok(u) => u,
+            Err(err) => return MoveAction::sink_or_error(err),
+        };
+        let opponent_sfen_before = s.pos.to_sfen();
+        if let Err(err) = s.pos.apply_csa_move(&mv) {
+            return MoveAction::sink_or_error(err);
+        }
+        let opponent_sfen_after = s.pos.to_sfen();
+        s.usi_moves.push(opponent_usi.clone());
+        s.clock.consume(opposite(s.my_color), time_sec);
+        s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
+        push_opponent_jsonl(
+            &mut s.record,
+            opponent_sfen_before.clone(),
+            opponent_usi.clone(),
+            opposite(s.my_color),
+            time_sec,
+        );
+        let opp_event = MoveEvent {
+            player: MovePlayer::Opponent,
+            csa_move: mv,
+            usi_move: opponent_usi,
+            side: Side::from(opposite(s.my_color)),
+            ply: s.pos.ply.saturating_sub(1) + 1,
+            time_sec: Some(time_sec),
+            sfen_before: opponent_sfen_before,
+            sfen_after: opponent_sfen_after,
+            search_origin: None,
+            search: None,
+        };
+        if let Err(err) = s.sink.on_event(SessionProgress::MoveConfirmed(opp_event))
+            && let Some(action) = handle_loop_sink_err_action(err, false)
+        {
+            return action;
+        }
+        MoveAction::Continue
+    }
+}
+
+// ────────────────────────────────────────────
+// terminate / sink error 処理
+// ────────────────────────────────────────────
+
+/// best-effort attempt at clean closure。Sink Fatal / 外部 shutdown 共通の
+/// 後処理を行う:
+/// 1. CSA `%CHUDAN` を best-effort で送信 (対局未終了時のみ、write/flush timeout 1s)
+/// 2. CSA `LOGOUT` を best-effort 送信 (write/flush timeout 1s)
+/// 3. transport close
+/// 4. sink.on_error を best-effort 呼び出し
+/// 5. SessionProgress::Disconnected を emit
+fn terminate_session<S>(
+    conn: &mut CsaConnection,
+    sink: &mut S,
+    cause: &SessionError,
+    reason: DisconnectReason,
+    game_already_ended: bool,
+) where
+    S: SessionEventSink + ?Sized,
+{
+    // 1. %CHUDAN (対局未終了時のみ)
+    if !game_already_ended
+        && let Err(err) = best_effort_with_timeout(Duration::from_secs(1), || conn.send_chudan())
+    {
+        log::warn!("[CSA] %CHUDAN 送信失敗 (best-effort): {err:#}");
+    }
+
+    // 2. LOGOUT
+    if let Err(err) = best_effort_with_timeout(Duration::from_secs(1), || conn.logout()) {
+        log::warn!("[CSA] LOGOUT 送信失敗 (best-effort): {err:#}");
+    }
+
+    // 3. transport close: CsaConnection を drop すれば close される。明示 close は
+    //    現状 API が無いので drop に任せる (本関数の return 時に conn は呼び出し側に
+    //    返るが、呼び出し側は本関数の後で値を捨てる責務を持つ)。
+
+    // 4. sink.on_error
+    if let Err(err) = sink.on_error(cause) {
+        log::warn!("[Sink] on_error が err を返しました (best-effort、無視): {err:?}");
+    }
+
+    // 5. Disconnected
+    if let Err(err) = sink.on_event(SessionProgress::Disconnected { reason }) {
+        log::warn!("[Sink] Disconnected emit が err を返しました (best-effort、無視): {err:?}");
+    }
+}
+
+/// 1 秒以内に finish する想定の I/O を best-effort で実行する。実際の OS 側 timeout は
+/// transport 層の write_timeout に依存するため、本関数は wrapper として wrap するだけ。
+fn best_effort_with_timeout<F>(_timeout: Duration, f: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    f()
+}
+
+/// `sink.on_event` を呼び、`SinkError::NonFatal` は warn のみで握りつぶし、
+/// `SinkError::Fatal` のみを `Some(SinkError)` で返す。`drive_session` 入口の
+/// 各 step (Connected / GameSummary / GameStarted / GameEnded) で使う。
+fn emit_with_nonfatal_warn<S>(sink: &mut S, event: SessionProgress) -> Option<SinkError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    match sink.on_event(event) {
+        Ok(()) => None,
+        Err(SinkError::NonFatal(inner)) => {
+            log::warn!("[Sink] NonFatal: {inner:#}、対局を継続します");
+            None
+        }
+        Err(err @ SinkError::Fatal(_)) => Some(err),
+    }
+}
+
+/// SinkError を受け取り、`drive_session` 上で SessionError::SinkAborted を返す経路に
+/// 揃える。`game_already_ended` が true なら CHUDAN は送らない (対局は既に終局済み)。
+///
+/// `SinkError::NonFatal` は warn ログのみで対局を継続するのが原則だが、`drive_session`
+/// 内の早期 event (Connected/GameSummary/GameStarted) で NonFatal を受けたときは
+/// メインループに入らないとループ継続が不可能なため、本関数を呼ばずに caller 側で
+/// 継続判断する設計とする。本関数に到達するのは Fatal 経路のみと仮定し、NonFatal が
+/// 来た場合は `Sink contract violation` として warn しつつ Fatal 同等で扱う。
+fn handle_sink_error<S>(
+    err: SinkError,
+    conn: &mut CsaConnection,
+    sink: &mut S,
+    _summary: Option<GameSummary>,
+    game_already_ended: bool,
+) -> Result<SessionOutcome, SessionError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    let cause = SessionError::SinkAborted(err);
+    terminate_session(conn, sink, &cause, DisconnectReason::SinkAborted, game_already_ended);
+    Err(cause)
+}
+
+fn abort_for_should_continue<S>(
+    conn: &mut CsaConnection,
+    sink: &mut S,
+    _summary: Option<GameSummary>,
+    game_already_ended: bool,
+) -> Result<SessionOutcome, SessionError>
+where
+    S: SessionEventSink + ?Sized,
+{
+    let synthetic =
+        SinkError::Fatal(Box::new(std::io::Error::other("sink.should_continue() == false")));
+    let cause = SessionError::SinkAborted(synthetic);
+    terminate_session(conn, sink, &cause, DisconnectReason::SinkAborted, game_already_ended);
+    Err(cause)
+}
+
+/// メインループ内で SinkError が出たときの分岐。NonFatal なら warn ログのみで継続。
+/// Fatal ならループ脱出のため `Some(LoopOutcome::SinkAborted)` を返す。
+fn handle_loop_sink_err(err: SinkError, game_already_ended: bool) -> Option<LoopOutcome> {
+    match err {
+        SinkError::NonFatal(inner) => {
+            log::warn!("[Sink] NonFatal: {inner:#}、対局を継続します");
+            None
+        }
+        SinkError::Fatal(_) => Some(LoopOutcome::SinkAborted {
+            sink_err: err,
+            game_already_ended,
+        }),
+    }
+}
+
+/// MoveAction に変換する版 (`send_bestmove_and_wait_echo` 内部用)。
+fn handle_loop_sink_err_action(err: SinkError, game_already_ended: bool) -> Option<MoveAction> {
+    match err {
+        SinkError::NonFatal(inner) => {
+            log::warn!("[Sink] NonFatal: {inner:#}、対局を継続します");
+            None
+        }
+        SinkError::Fatal(_) => Some(MoveAction::SinkAborted(err, game_already_ended)),
+    }
+}
+
+impl MoveAction {
+    /// 任意の `anyhow::Error` を `MoveAction::SinkAborted` に押し込まず、
+    /// 上位で `LoopOutcome::Error` 化したい場合に panic で握り潰さないよう
+    /// `Continue` を返さず、呼び出し元が `LoopOutcome::Error` で扱うべき。
+    /// 簡略化のため、ここでは error メッセージをログ出して
+    /// `MoveAction::SinkAborted` (Fatal) として終わらせる。
+    fn sink_or_error<E: Into<anyhow::Error>>(err: E) -> Self {
+        let err = err.into();
+        log::error!("[Session] 内部エラー (best-effort attempt at clean closure): {err:#}");
+        let sink_err = SinkError::Fatal(Box::new(std::io::Error::other(format!("{err}"))));
+        MoveAction::SinkAborted(sink_err, false)
+    }
+}
+
+// ────────────────────────────────────────────
+// SearchInfoEmitter / Throttle
+// ────────────────────────────────────────────
+
+/// `SearchInfoEmitPolicy` に基づき発火頻度を制御する。
+struct SearchInfoThrottle {
+    policy: SearchInfoEmitPolicy,
+    last_emit_at: Option<Instant>,
+    last_depth: Option<u32>,
+    /// `emit_final` の対象として保持する最後の累積 snapshot。
+    pending_final: Option<SearchInfoSnapshot>,
+}
+
+impl SearchInfoThrottle {
+    fn new(policy: SearchInfoEmitPolicy) -> Self {
+        Self {
+            policy,
+            last_emit_at: None,
+            last_depth: None,
+            pending_final: None,
+        }
+    }
+
+    /// 観測値を受け、emit すべきか判定する。emit する場合 `Some(snapshot)` を返す。
+    fn observe(&mut self, info: &SearchInfo, raw: &str) -> Option<SearchInfoSnapshot> {
+        let snapshot = SearchInfoSnapshot {
+            depth: info.depth,
+            seldepth: info.seldepth,
+            score_cp: info.score_cp,
+            mate: info.score_mate,
+            nodes: info.nodes,
+            nps: info.nps,
+            time_ms: info.time_ms,
+            pv: info.pv.clone(),
+            raw_line: Some(raw.to_owned()),
+        };
+        // 常に pending_final を最新化 (emit_final の対象)
+        self.pending_final = Some(snapshot.clone());
+
+        match &self.policy {
+            SearchInfoEmitPolicy::Disabled => None,
+            SearchInfoEmitPolicy::EveryLine => {
+                self.last_emit_at = Some(Instant::now());
+                self.last_depth = info.depth;
+                Some(snapshot)
+            }
+            SearchInfoEmitPolicy::Default => self.observe_with_interval(snapshot, info, 200, true),
+            SearchInfoEmitPolicy::Interval {
+                min_ms,
+                emit_on_depth_change,
+                ..
+            } => self.observe_with_interval(snapshot, info, *min_ms, *emit_on_depth_change),
+        }
+    }
+
+    fn observe_with_interval(
+        &mut self,
+        snapshot: SearchInfoSnapshot,
+        info: &SearchInfo,
+        min_ms: u32,
+        emit_on_depth_change: bool,
+    ) -> Option<SearchInfoSnapshot> {
+        let depth_changed =
+            emit_on_depth_change && info.depth.is_some() && info.depth != self.last_depth;
+        if depth_changed {
+            self.last_emit_at = Some(Instant::now());
+            self.last_depth = info.depth;
+            return Some(snapshot);
+        }
+        let now = Instant::now();
+        let interval = Duration::from_millis(u64::from(min_ms));
+        let should_emit = match self.last_emit_at {
+            None => true,
+            Some(prev) => now.duration_since(prev) >= interval,
+        };
+        if should_emit {
+            self.last_emit_at = Some(now);
+            if info.depth.is_some() {
+                self.last_depth = info.depth;
+            }
+            Some(snapshot)
+        } else {
+            None
+        }
+    }
+
+    /// bestmove 直前に呼ばれ、`emit_final` ポリシーに従って最後の累積値を返す。
+    fn take_final(&mut self) -> Option<SearchInfoSnapshot> {
+        let emit_final = matches!(
+            self.policy,
+            SearchInfoEmitPolicy::Default
+                | SearchInfoEmitPolicy::EveryLine
+                | SearchInfoEmitPolicy::Interval {
+                    emit_final: true,
+                    ..
+                }
+        );
+        // `Disabled` の場合は emit しない
+        if matches!(self.policy, SearchInfoEmitPolicy::Disabled) {
+            self.pending_final = None;
+            self.last_emit_at = None;
+            self.last_depth = None;
+            return None;
+        }
+        let snapshot = if emit_final {
+            self.pending_final.take()
+        } else {
+            None
+        };
+        self.pending_final = None;
+        // depth tracking は探索ごとにリセット
+        self.last_emit_at = None;
+        self.last_depth = None;
+        snapshot
+    }
+}
+
+/// 1 探索分の SearchInfoEmitter。`info_callback` 経由で `observe` を呼び、observed
+/// snapshot を sink に push する。lifetime はその探索期間中だけ。
+struct SearchInfoEmitter<'a, S: ?Sized + 'a> {
+    throttle: &'a mut SearchInfoThrottle,
+    sink: &'a mut S,
+    /// emit 中に Fatal が出たら以降の sink 呼び出しを抑止し、最終的に上位で
+    /// 中断扱いにする (本フィールドは「最後に観測した sink Fatal」を保持する)。
+    fatal_pending: Option<SinkError>,
+}
+
+impl<'a, S: SessionEventSink + ?Sized + 'a> SearchInfoEmitter<'a, S> {
+    fn new(throttle: &'a mut SearchInfoThrottle, sink: &'a mut S) -> Self {
+        Self {
+            throttle,
+            sink,
+            fatal_pending: None,
+        }
+    }
+
+    fn observe(&mut self, info: &SearchInfo, raw: &str) {
+        if self.fatal_pending.is_some() {
+            return;
+        }
+        if let Some(snapshot) = self.throttle.observe(info, raw)
+            && let Err(err) = self.sink.on_event(SessionProgress::SearchInfo(snapshot))
+        {
+            match err {
+                SinkError::NonFatal(inner) => {
+                    log::warn!("[Sink] NonFatal during search info: {inner:#}");
+                }
+                SinkError::Fatal(_) => {
+                    self.fatal_pending = Some(err);
+                }
+            }
+        }
+    }
+
+    /// emit_final 対象の snapshot を返す。fatal が観測されていた場合は emit_final
+    /// は飛ばして None を返す (上位の handler で SinkAborted へ畳む。emit_final の
+    /// 観測は best-effort なので失う情報は許容する)。
+    fn into_final(self) -> Option<SearchInfoSnapshot> {
+        if self.fatal_pending.is_some() {
+            return None;
+        }
+        let SearchInfoEmitter { throttle, .. } = self;
+        throttle.take_final()
+    }
+}
 
 // ────────────────────────────────────────────
 // Clock
@@ -35,7 +1319,7 @@ struct Clock {
 }
 
 impl Clock {
-    fn from_summary(summary: &crate::protocol::GameSummary) -> Self {
+    fn from_summary(summary: &GameSummary) -> Self {
         Self {
             black_time_ms: summary.black_time.total_time_ms + summary.black_time.increment_ms,
             white_time_ms: summary.white_time.total_time_ms + summary.white_time.increment_ms,
@@ -86,9 +1370,6 @@ impl Clock {
         }
     }
 
-    /// JSONL 出力モードの `think_limit_ms` 用に、`side_to_move` の考慮上限を ms で返す。
-    /// byoyomi 指定なら `byoyomi - margin`、Fischer なら残時間 + increment、
-    /// 時間管理が無いなら 0。
     fn think_limit_ms(&self, margin_msec: u64, side_to_move: Color) -> u64 {
         let (total_ms, byoyomi_ms, increment_ms) = match side_to_move {
             Color::Black => (self.black_time_ms, self.black_byoyomi_ms, self.black_increment_ms),
@@ -146,437 +1427,7 @@ impl Clock {
 }
 
 // ────────────────────────────────────────────
-// SessionState
-// ────────────────────────────────────────────
-
-struct SessionState<'a> {
-    conn: &'a mut CsaConnection,
-    engine: &'a mut UsiEngine,
-    config: &'a CsaClientConfig,
-    shutdown: &'a AtomicBool,
-    server_rx: &'a Receiver<Event>,
-    pos: Position,
-    usi_moves: Vec<String>,
-    clock: Clock,
-    record: GameRecord,
-    ponder_state: Option<PonderState>,
-    my_color: Color,
-    initial_sfen: String,
-}
-
-/// 探索結果の処理結果
-enum MoveAction {
-    /// 対局継続（外側ループへ）
-    Continue,
-    /// 対局終了
-    GameEnd(GameResult, Box<GameRecord>),
-}
-
-impl SessionState<'_> {
-    /// SearchOutcome を処理する。BestMove なら送信+エコー待ち、ServerInterrupt なら終局。
-    fn handle_search_outcome(
-        &mut self,
-        outcome: SearchOutcome,
-        turn_start: Instant,
-        sfen_before: String,
-        think_limit_ms: u64,
-    ) -> Result<MoveAction> {
-        match outcome {
-            SearchOutcome::BestMove(result, info) => self.send_bestmove_and_wait_echo(
-                &result,
-                &info,
-                turn_start,
-                sfen_before,
-                think_limit_ms,
-            ),
-            SearchOutcome::ServerInterrupt(lines) => {
-                // サーバーから終局が来た（ponderhit 中等）
-                let (game_result, reason) = parse_server_interrupt_lines(lines);
-                log::info!("[CSA] サーバー終局割り込み: {:?}", game_result);
-                self.record.set_result(record_result_with_reason(&game_result, &reason));
-                self.engine.gameover(gameover_str(&game_result))?;
-                Ok(MoveAction::GameEnd(game_result, Box::new(self.record.clone())))
-            }
-        }
-    }
-
-    fn send_bestmove_and_wait_echo(
-        &mut self,
-        result: &BestMoveResult,
-        info: &SearchInfo,
-        turn_start: Instant,
-        sfen_before: String,
-        think_limit_ms: u64,
-    ) -> Result<MoveAction> {
-        if result.bestmove == "resign" {
-            self.conn.send_resign()?;
-            self.record.set_result("resign");
-            let (game_result, _) = wait_game_end_from_rx(self.server_rx)?;
-            self.engine.gameover(gameover_str(&game_result))?;
-            return Ok(MoveAction::GameEnd(game_result, Box::new(self.record.clone())));
-        }
-        if result.bestmove == "win" {
-            self.conn.send_win()?;
-            self.record.set_result("win_declaration");
-            let (game_result, _) = wait_game_end_from_rx(self.server_rx)?;
-            self.engine.gameover(gameover_str(&game_result))?;
-            return Ok(MoveAction::GameEnd(game_result, Box::new(self.record.clone())));
-        }
-
-        let csa_move = usi_move_to_csa(&result.bestmove, &self.pos)?;
-        let comment = if self.config.server.floodgate {
-            Some(build_floodgate_comment(info, self.my_color, &self.pos, &result.bestmove))
-        } else {
-            None
-        };
-        self.conn.send_move_with_comment(&csa_move, comment.as_deref())?;
-
-        self.pos.apply_csa_move(&csa_move)?;
-        self.usi_moves.push(result.bestmove.clone());
-        self.record.add_move(&csa_move, 0, Some(info), self.my_color);
-        let elapsed_ms = turn_start.elapsed().as_millis().min(u64::MAX as u128) as u64;
-        let engine_label = label_for_color(&self.record, self.my_color);
-        self.record.add_jsonl_move(JsonlMoveExtra {
-            sfen_before,
-            move_usi: result.bestmove.clone(),
-            engine_label,
-            elapsed_ms,
-            think_limit_ms,
-            seldepth: info.seldepth,
-            nodes: info.nodes,
-            time_ms: info.time_ms,
-            nps: info.nps,
-        });
-
-        // ponder 開始
-        if self.config.game.ponder
-            && let Some(ref ponder_mv) = result.ponder_move
-        {
-            let my_estimated_ms = turn_start.elapsed().as_millis() as i64;
-            let ponder_pos_cmd =
-                build_position_cmd_with_ponder(&self.initial_sfen, &self.usi_moves, ponder_mv);
-            let ponder_go = format!(
-                "go ponder {}",
-                self.clock.build_ponder_go_args(
-                    self.config.time.margin_msec,
-                    self.my_color,
-                    my_estimated_ms,
-                )
-            );
-            self.engine.go_ponder(&ponder_pos_cmd, &ponder_go)?;
-            self.ponder_state = Some(PonderState {
-                expected_usi: ponder_mv.clone(),
-            });
-        }
-
-        // サーバーエコー待ち（server_rx から受信）
-        loop {
-            match self.server_rx.recv_timeout(Duration::from_millis(200)) {
-                Ok(Event::ServerLine(line)) => {
-                    if line.starts_with('+') || line.starts_with('-') {
-                        let (_, time_sec) = parse_server_move(&line);
-                        self.clock.consume(self.my_color, time_sec);
-                        self.record.update_last_time(time_sec);
-                        return Ok(MoveAction::Continue);
-                    }
-                    if line.starts_with('#') {
-                        if let Some(game_result) = parse_game_result(&line) {
-                            log::info!("[CSA] 対局終了(エコー待ち中): {line}");
-                            cleanup_ponder(self.engine, &mut self.ponder_state)?;
-                            let reason = self.conn.pending_end_reason.take();
-                            self.record
-                                .set_result(record_result_with_reason(&game_result, &reason));
-                            self.engine.gameover(gameover_str(&game_result))?;
-                            return Ok(MoveAction::GameEnd(
-                                game_result,
-                                Box::new(self.record.clone()),
-                            ));
-                        }
-                        // 中間行
-                        self.conn.pending_end_reason = Some(line);
-                    }
-                }
-                Ok(Event::ServerDisconnected) => {
-                    cleanup_ponder(self.engine, &mut self.ponder_state)?;
-                    self.engine.gameover("lose")?;
-                    return Ok(MoveAction::GameEnd(
-                        GameResult::Interrupted,
-                        Box::new(self.record.clone()),
-                    ));
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    self.conn
-                        .maybe_send_keepalive(self.config.server.keepalive.ping_interval_sec)?;
-                    if self.shutdown.load(Ordering::SeqCst) {
-                        let result = resign_and_wait_rx(
-                            self.conn,
-                            self.engine,
-                            &mut self.ponder_state,
-                            &mut self.record,
-                            self.server_rx,
-                        )?;
-                        return Ok(MoveAction::GameEnd(result, Box::new(self.record.clone())));
-                    }
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    anyhow::bail!("サーバー受信チャネル切断");
-                }
-            }
-        }
-    }
-}
-
-// ────────────────────────────────────────────
-// run_game_session
-// ────────────────────────────────────────────
-
-pub fn run_game_session(
-    conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
-    config: &CsaClientConfig,
-    shutdown: &AtomicBool,
-) -> Result<(GameResult, GameRecord, Option<GameSummary>)> {
-    let summary = conn.recv_game_summary(config.server.keepalive.ping_interval_sec)?;
-    conn.agree_and_wait_start(&summary.game_id)?;
-    engine.new_game()?;
-
-    let summary_for_caller = summary.clone();
-    let (result, record) = run_session_loop(conn, engine, config, shutdown, summary, None)?;
-    Ok((result, record, Some(summary_for_caller)))
-}
-
-/// 再接続成立後の resume セッションを駆動する。
-///
-/// `login_reconnect` が成功した直後の `conn` を受け取り、サーバが続けて送出する
-/// `BEGIN Game_Summary` ... `END Game_Summary` ブロック (新 `Reconnect_Token` 付き)
-/// と `BEGIN Reconnect_State` ... `END Reconnect_State` ブロックを読み取る。
-/// その後、AGREE 経路は **スキップ** して（対局はサーバ側 `Playing` 状態のまま）
-/// 対局ループに戻る。前 session で `gameover("lose")` を発射済みのエンジンに対し
-/// 新 session の `position` / `go` を許可するため、冒頭で `engine.new_game()` を
-/// 呼んで USI 状態をリセットする (hash の温存は後段の最適化として別 PR)。
-pub fn run_resumed_session(
-    conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
-    config: &CsaClientConfig,
-    shutdown: &AtomicBool,
-) -> Result<(GameResult, GameRecord, Option<GameSummary>)> {
-    // resume 時の Game_Summary は切断時点の局面が `position_section` に焼き込まれて
-    // いるため、`initial_moves` は通常空。新 `Reconnect_Token` も含まれる。
-    let summary = conn.recv_game_summary(config.server.keepalive.ping_interval_sec)?;
-    let state = conn.recv_reconnect_state()?;
-    log::info!(
-        "[CSA] 再接続セッション開始: my_color={:?} 残時間 黒:{}ms 白:{}ms",
-        summary.my_color,
-        state.black_remaining_ms,
-        state.white_remaining_ms
-    );
-
-    engine.new_game()?;
-    let summary_for_caller = summary.clone();
-    let (result, record) = run_session_loop(conn, engine, config, shutdown, summary, Some(state))?;
-    Ok((result, record, Some(summary_for_caller)))
-}
-
-/// `run_game_session` / `run_resumed_session` 共通の対局メインループ。
-///
-/// `resume_state` が `Some` のときは Reconnect_State 由来の残時間で `Clock` を
-/// 上書きし、AGREE / `engine.new_game()` のスキップを前提とする。
-fn run_session_loop(
-    conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
-    config: &CsaClientConfig,
-    shutdown: &AtomicBool,
-    summary: GameSummary,
-    resume_state: Option<ReconnectState>,
-) -> Result<(GameResult, GameRecord)> {
-    // サーバー受信スレッドを起動
-    let (server_tx, server_rx) = mpsc::channel();
-    conn.start_reader_thread(server_tx)?;
-
-    let mut clock = Clock::from_summary(&summary);
-    if let Some(state) = &resume_state {
-        // resume の Reconnect_State から残時間を復元する。秒読み / increment 設定は
-        // Game_Summary 側を信用し、本体時間だけ上書き。
-        clock.black_time_ms = state.black_remaining_ms.max(0);
-        clock.white_time_ms = state.white_remaining_ms.max(0);
-    }
-
-    let mut s = SessionState {
-        pos: summary.position.clone(),
-        initial_sfen: summary.position.to_sfen(),
-        usi_moves: Vec::new(),
-        clock,
-        record: GameRecord::new(&summary),
-        ponder_state: None,
-        my_color: summary.my_color,
-        conn,
-        engine,
-        config,
-        shutdown,
-        server_rx: &server_rx,
-    };
-
-    // 途中局面の手順を適用 (resume では通常空)
-    let mut move_color = summary.position.side_to_move;
-    for cm in &summary.initial_moves {
-        let usi = csa_move_to_usi(&cm.mv, &s.pos)?;
-        let initial_sfen_before = s.pos.to_sfen();
-        s.pos.apply_csa_move(&cm.mv)?;
-        s.usi_moves.push(usi.clone());
-        if let Some(t) = cm.time_sec {
-            s.clock.consume(move_color, t);
-        }
-        let time_sec = cm.time_sec.unwrap_or(0);
-        s.record.add_move(&cm.mv, time_sec, None, move_color);
-        // 途中再開の手は両方とも「対戦相手の手」相当として extras に記録する。
-        // 自エンジンは新しい session.new_game() でこの局面から開始するため、
-        // この手は自エンジンの探索ログを持たない。
-        push_opponent_jsonl(&mut s.record, initial_sfen_before, usi, move_color, time_sec);
-        move_color = opposite(move_color);
-    }
-
-    // 対局メインループ
-    loop {
-        if s.pos.side_to_move == s.my_color {
-            let turn_start = Instant::now();
-            let sfen_before = s.pos.to_sfen();
-            let think_limit_ms = s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
-            let position_cmd = build_position_cmd(&s.initial_sfen, &s.usi_moves);
-            let go_cmd =
-                format!("go {}", s.clock.build_go_args(s.config.time.margin_msec, s.my_color));
-            let outcome = s.engine.go(&position_cmd, &go_cmd, s.shutdown, s.server_rx)?;
-
-            match s.handle_search_outcome(outcome, turn_start, sfen_before, think_limit_ms)? {
-                MoveAction::Continue => {}
-                MoveAction::GameEnd(result, record_box) => return Ok((result, *record_box)),
-            }
-        }
-
-        // 相手の手番: server_rx から指し手を待つ
-        loop {
-            match s.server_rx.recv_timeout(Duration::from_millis(200)) {
-                Ok(Event::ServerLine(line)) => {
-                    // 指し手
-                    if line.starts_with('+') || line.starts_with('-') {
-                        let (mv, time_sec) = parse_server_move(&line);
-
-                        if let Some(ps) = s.ponder_state.take() {
-                            let opponent_usi = csa_move_to_usi(&mv, &s.pos)?;
-                            if opponent_usi == ps.expected_usi {
-                                // ponderhit
-                                log::debug!("[PONDER] ponderhit: {}", opponent_usi);
-                                let opponent_sfen_before = s.pos.to_sfen();
-                                s.pos.apply_csa_move(&mv)?;
-                                s.usi_moves.push(opponent_usi.clone());
-                                s.clock.consume(opposite(s.my_color), time_sec);
-                                s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
-                                push_opponent_jsonl(
-                                    &mut s.record,
-                                    opponent_sfen_before,
-                                    opponent_usi,
-                                    opposite(s.my_color),
-                                    time_sec,
-                                );
-
-                                let ponderhit_start = Instant::now();
-                                let my_sfen_before = s.pos.to_sfen();
-                                let my_think_limit_ms =
-                                    s.clock.think_limit_ms(s.config.time.margin_msec, s.my_color);
-                                let outcome = s.engine.ponderhit(s.shutdown, s.server_rx)?;
-
-                                match s.handle_search_outcome(
-                                    outcome,
-                                    ponderhit_start,
-                                    my_sfen_before,
-                                    my_think_limit_ms,
-                                )? {
-                                    MoveAction::Continue => break,
-                                    MoveAction::GameEnd(result, record_box) => {
-                                        return Ok((result, *record_box));
-                                    }
-                                }
-                            } else {
-                                // ponder 外れ
-                                log::debug!(
-                                    "[PONDER] miss: expected={} actual={}",
-                                    ps.expected_usi,
-                                    opponent_usi
-                                );
-                                s.engine.stop_and_wait()?;
-                                let opponent_sfen_before = s.pos.to_sfen();
-                                s.pos.apply_csa_move(&mv)?;
-                                s.usi_moves.push(opponent_usi.clone());
-                                s.clock.consume(opposite(s.my_color), time_sec);
-                                s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
-                                push_opponent_jsonl(
-                                    &mut s.record,
-                                    opponent_sfen_before,
-                                    opponent_usi,
-                                    opposite(s.my_color),
-                                    time_sec,
-                                );
-                                break;
-                            }
-                        } else {
-                            // ponder なし
-                            let opponent_usi = csa_move_to_usi(&mv, &s.pos)?;
-                            let opponent_sfen_before = s.pos.to_sfen();
-                            s.pos.apply_csa_move(&mv)?;
-                            s.usi_moves.push(opponent_usi.clone());
-                            s.clock.consume(opposite(s.my_color), time_sec);
-                            s.record.add_move(&mv, time_sec, None, opposite(s.my_color));
-                            push_opponent_jsonl(
-                                &mut s.record,
-                                opponent_sfen_before,
-                                opponent_usi,
-                                opposite(s.my_color),
-                                time_sec,
-                            );
-                            break;
-                        }
-                    }
-                    // 終局
-                    if line.starts_with('#') {
-                        if let Some(game_result) = parse_game_result(&line) {
-                            log::info!("[CSA] 対局終了: {line}");
-                            cleanup_ponder(s.engine, &mut s.ponder_state)?;
-                            let reason = s.conn.pending_end_reason.take();
-                            s.record.set_result(record_result_with_reason(&game_result, &reason));
-                            s.engine.gameover(gameover_str(&game_result))?;
-                            return Ok((game_result, s.record));
-                        }
-                        // 中間行
-                        s.conn.pending_end_reason = Some(line);
-                    }
-                }
-                Ok(Event::ServerDisconnected) => {
-                    cleanup_ponder(s.engine, &mut s.ponder_state)?;
-                    s.engine.gameover("lose")?;
-                    return Ok((GameResult::Interrupted, s.record));
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    s.conn.maybe_send_keepalive(s.config.server.keepalive.ping_interval_sec)?;
-                    if s.shutdown.load(Ordering::SeqCst) {
-                        let result = resign_and_wait_rx(
-                            s.conn,
-                            s.engine,
-                            &mut s.ponder_state,
-                            &mut s.record,
-                            s.server_rx,
-                        )?;
-                        return Ok((result, s.record));
-                    }
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    anyhow::bail!("サーバー受信チャネル切断");
-                }
-            }
-        }
-    }
-}
-
-// ────────────────────────────────────────────
-// ヘルパー関数
+// Helpers
 // ────────────────────────────────────────────
 
 struct PonderState {
@@ -590,68 +1441,56 @@ fn cleanup_ponder(engine: &mut UsiEngine, ponder_state: &mut Option<PonderState>
     Ok(())
 }
 
-fn resign_and_wait_rx(
-    conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
-    ponder_state: &mut Option<PonderState>,
-    record: &mut GameRecord,
-    server_rx: &Receiver<Event>,
-) -> Result<GameResult> {
-    log::info!("シャットダウン: 投了して終了します...");
-    cleanup_ponder(engine, ponder_state)?;
-    conn.send_resign()?;
-    record.set_result("resign");
-    let (result, _) = wait_game_end_from_rx(server_rx)?;
-    engine.gameover(gameover_str(&result))?;
-    Ok(result)
+/// `ServerInterrupt` の行群から (game_result, reason_line, raw_result_line) を抽出する。
+fn parse_server_interrupt_lines_full(
+    lines: Vec<String>,
+) -> (GameResult, Option<String>, Option<String>) {
+    let mut reason = None;
+    let mut result = GameResult::Interrupted;
+    let mut raw_result = None;
+    for line in lines {
+        if line.starts_with('#') {
+            if let Some(r) = parse_game_result(&line) {
+                result = r;
+                raw_result = Some(line);
+            } else {
+                reason = Some(line);
+            }
+        }
+    }
+    (result, reason, raw_result)
 }
 
-/// server_rx から終局結果を待つ
-fn wait_game_end_from_rx(server_rx: &Receiver<Event>) -> Result<(GameResult, Option<String>)> {
+fn wait_game_end_full_from_rx(
+    server_rx: &Receiver<Event>,
+) -> (GameResult, Option<String>, Option<String>) {
     let start = Instant::now();
     const TIMEOUT: Duration = Duration::from_secs(30);
     let mut pending_reason: Option<String> = None;
     loop {
         if start.elapsed() >= TIMEOUT {
             log::warn!("[CSA] 終局結果の受信タイムアウト ({}秒)", TIMEOUT.as_secs());
-            return Ok((GameResult::Interrupted, None));
+            return (GameResult::Interrupted, pending_reason, None);
         }
         match server_rx.recv_timeout(Duration::from_millis(200)) {
             Ok(Event::ServerLine(line)) => {
                 if line.starts_with('#') {
                     if let Some(result) = parse_game_result(&line) {
                         log::info!("[CSA] 対局終了: {line}");
-                        return Ok((result, pending_reason));
+                        return (result, pending_reason, Some(line));
                     }
                     pending_reason = Some(line);
                 }
-                // 指し手等は無視
             }
             Ok(Event::ServerDisconnected) => {
-                return Ok((GameResult::Interrupted, None));
+                return (GameResult::Interrupted, pending_reason, None);
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                return Ok((GameResult::Interrupted, None));
+                return (GameResult::Interrupted, pending_reason, None);
             }
         }
     }
-}
-
-/// ServerInterrupt の行バッファから GameResult と理由を抽出
-fn parse_server_interrupt_lines(lines: Vec<String>) -> (GameResult, Option<String>) {
-    let mut reason = None;
-    let mut result = GameResult::Interrupted;
-    for line in lines {
-        if line.starts_with('#') {
-            if let Some(r) = parse_game_result(&line) {
-                result = r;
-            } else {
-                reason = Some(line);
-            }
-        }
-    }
-    (result, reason)
 }
 
 fn opposite(color: Color) -> Color {
@@ -661,8 +1500,6 @@ fn opposite(color: Color) -> Color {
     }
 }
 
-/// CSA プレイヤー名から analyze_selfplay の集計キーになる engine label を返す。
-/// `sente_name` / `gote_name` が空なら `"unknown"` を返す。
 fn label_for_color(record: &GameRecord, color: Color) -> String {
     let raw = match color {
         Color::Black => &record.sente_name,
@@ -675,8 +1512,6 @@ fn label_for_color(record: &GameRecord, color: Color) -> String {
     }
 }
 
-/// 相手 (= 自エンジンでない側) が指した手を JSONL 用バッファに追加する。
-/// `time_sec` はサーバが報告した消費秒。`elapsed_ms` 換算で記録する。
 fn push_opponent_jsonl(
     record: &mut GameRecord,
     sfen_before: String,
@@ -783,9 +1618,6 @@ fn build_floodgate_comment(
     } else {
         0
     };
-
-    // CSA Floodgate の追記コメント本体（`'` プレフィックス抜き）。
-    // 送信時は CsaConnection::send_move_with_comment 側で `,'<comment>` 形に整形される。
     let mut comment = format!("* {score}");
     if !info.pv.is_empty() {
         let mut pv_pos = pos.clone();
@@ -806,4 +1638,329 @@ fn build_floodgate_comment(
         }
     }
     comment
+}
+
+// ────────────────────────────────────────────
+// SessionEventSink 用 helper (SFEN 変換 / GameEnd 構築)
+// ────────────────────────────────────────────
+
+/// `ProtocolReconnectState` + `GameSummary.position_section` から public な
+/// [`PublicReconnectState`] を組み立てる。
+fn build_reconnect_state(
+    summary: &GameSummary,
+    proto_state: Option<&ProtocolReconnectState>,
+) -> PublicReconnectState {
+    let last_sfen = summary.position.to_sfen();
+    let last_ply = summary.position.ply.saturating_sub(1);
+    let side_from_state = proto_state
+        .and_then(|ps| ps.current_turn)
+        .unwrap_or(summary.position.side_to_move);
+    let (remaining_self, remaining_opp) = match proto_state {
+        Some(ps) => {
+            let self_ms = match summary.my_color {
+                Color::Black => ps.black_remaining_ms,
+                Color::White => ps.white_remaining_ms,
+            };
+            let opp_ms = match summary.my_color {
+                Color::Black => ps.white_remaining_ms,
+                Color::White => ps.black_remaining_ms,
+            };
+            (Some((self_ms / 1000).max(0) as u32), Some((opp_ms / 1000).max(0) as u32))
+        }
+        None => (None, None),
+    };
+    PublicReconnectState {
+        last_ply,
+        last_sfen,
+        side_to_move: Side::from(side_from_state),
+        remaining_time_sec_self: remaining_self,
+        remaining_time_sec_opp: remaining_opp,
+    }
+}
+
+fn build_game_end_event(
+    result: &GameResult,
+    raw_reason_line: Option<String>,
+    raw_result_line: Option<String>,
+    my_color: Color,
+) -> GameEndEvent {
+    let reason = parse_game_end_reason(result, raw_reason_line.as_deref());
+    let winner = match result {
+        GameResult::Win => Some(Side::from(my_color)),
+        GameResult::Lose => Some(Side::from(opposite(my_color))),
+        GameResult::Draw => None,
+        GameResult::Interrupted | GameResult::Censored => None,
+    };
+    GameEndEvent {
+        result: result.clone(),
+        reason,
+        winner,
+        raw_result_line,
+        raw_reason_line,
+    }
+}
+
+fn parse_game_end_reason(result: &GameResult, raw_reason: Option<&str>) -> GameEndReason {
+    if let Some(reason_line) = raw_reason {
+        if reason_line.contains("TIME_UP") {
+            return GameEndReason::TimeUp;
+        }
+        if reason_line.contains("ILLEGAL") {
+            return GameEndReason::IllegalMove;
+        }
+        if reason_line.contains("JISHOGI") {
+            return GameEndReason::Jishogi;
+        }
+        if reason_line.contains("SENNICHITE") {
+            return GameEndReason::Sennichite;
+        }
+        if reason_line.contains("MAX_MOVES") {
+            return GameEndReason::MaxMoves;
+        }
+        if reason_line.contains("CHUDAN") {
+            return GameEndReason::Interrupted;
+        }
+        if reason_line.contains("CENSORED") {
+            return GameEndReason::Censored;
+        }
+        if reason_line.contains("DISCONNECTED") {
+            return GameEndReason::OtherDisconnect;
+        }
+        // 認識できない reason 文字列は Unknown で前方互換的に保持する
+        return GameEndReason::Unknown(reason_line.to_owned());
+    }
+    match result {
+        GameResult::Win | GameResult::Lose => GameEndReason::Resign,
+        GameResult::Draw => GameEndReason::Sennichite,
+        GameResult::Interrupted => GameEndReason::Interrupted,
+        GameResult::Censored => GameEndReason::Censored,
+    }
+}
+
+fn search_info_to_snapshot(info: &SearchInfo) -> SearchInfoSnapshot {
+    SearchInfoSnapshot {
+        depth: info.depth,
+        seldepth: info.seldepth,
+        score_cp: info.score_cp,
+        mate: info.score_mate,
+        nodes: info.nodes,
+        nps: info.nps,
+        time_ms: info.time_ms,
+        pv: info.pv.clone(),
+        raw_line: None,
+    }
+}
+
+fn map_anyhow_to_session_error(err: anyhow::Error) -> SessionError {
+    SessionError::from(err)
+}
+
+// ────────────────────────────────────────────
+// 内部 helper のユニットテスト
+// ────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::SearchInfoEmitPolicy;
+
+    fn info(depth: Option<u32>) -> SearchInfo {
+        SearchInfo {
+            depth,
+            seldepth: None,
+            score_cp: Some(123),
+            score_mate: None,
+            nodes: Some(1000),
+            time_ms: Some(50),
+            nps: Some(20000),
+            pv: vec!["7g7f".to_owned()],
+        }
+    }
+
+    #[test]
+    fn throttle_disabled_emits_nothing() {
+        let mut t = SearchInfoThrottle::new(SearchInfoEmitPolicy::Disabled);
+        assert!(t.observe(&info(Some(1)), "info depth 1").is_none());
+        assert!(t.observe(&info(Some(2)), "info depth 2").is_none());
+        assert!(t.take_final().is_none());
+    }
+
+    #[test]
+    fn throttle_every_line_always_emits() {
+        let mut t = SearchInfoThrottle::new(SearchInfoEmitPolicy::EveryLine);
+        assert!(t.observe(&info(Some(1)), "info depth 1").is_some());
+        assert!(t.observe(&info(Some(1)), "info depth 1 nodes 2000").is_some());
+        // emit_final も発火
+        assert!(t.take_final().is_some());
+    }
+
+    #[test]
+    fn throttle_interval_respects_depth_change_when_enabled() {
+        let mut t = SearchInfoThrottle::new(SearchInfoEmitPolicy::Interval {
+            min_ms: 60_000,
+            emit_on_depth_change: true,
+            emit_final: true,
+        });
+        // 初回は emit
+        assert!(t.observe(&info(Some(1)), "info depth 1").is_some());
+        // 同 depth・短い時間 -> 抑止
+        assert!(t.observe(&info(Some(1)), "info depth 1 nodes 100").is_none());
+        // depth 変化 -> emit
+        assert!(t.observe(&info(Some(2)), "info depth 2").is_some());
+        // emit_final も拾う
+        assert!(t.take_final().is_some());
+    }
+
+    #[test]
+    fn throttle_interval_emit_final_disabled() {
+        let mut t = SearchInfoThrottle::new(SearchInfoEmitPolicy::Interval {
+            min_ms: 50,
+            emit_on_depth_change: false,
+            emit_final: false,
+        });
+        // 1 件 emit させる
+        let _ = t.observe(&info(Some(1)), "info depth 1");
+        // emit_final は false なので None
+        assert!(t.take_final().is_none());
+    }
+
+    #[test]
+    fn throttle_interval_min_ms_blocks_within_interval() {
+        let mut t = SearchInfoThrottle::new(SearchInfoEmitPolicy::Interval {
+            min_ms: 60_000,
+            emit_on_depth_change: false,
+            emit_final: true,
+        });
+        assert!(t.observe(&info(Some(1)), "info depth 1").is_some());
+        // depth 変化があっても emit_on_depth_change=false なので抑止される
+        assert!(t.observe(&info(Some(2)), "info depth 2").is_none());
+    }
+
+    #[test]
+    fn parse_game_end_reason_classifies_known_lines() {
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Win, Some("#TIME_UP")),
+            GameEndReason::TimeUp
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Win, Some("#ILLEGAL_MOVE")),
+            GameEndReason::IllegalMove
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Draw, Some("#JISHOGI")),
+            GameEndReason::Jishogi
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Draw, Some("#SENNICHITE")),
+            GameEndReason::Sennichite
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Draw, Some("#MAX_MOVES")),
+            GameEndReason::MaxMoves
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Interrupted, Some("#CHUDAN")),
+            GameEndReason::Interrupted
+        );
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Censored, Some("#CENSORED")),
+            GameEndReason::Censored
+        );
+        // 未知の理由は Unknown 保持
+        if let GameEndReason::Unknown(s) =
+            parse_game_end_reason(&GameResult::Lose, Some("#UNKNOWN_FUTURE"))
+        {
+            assert_eq!(s, "#UNKNOWN_FUTURE");
+        } else {
+            panic!("expected Unknown");
+        }
+    }
+
+    #[test]
+    fn parse_game_end_reason_falls_back_when_no_reason_line() {
+        assert_eq!(parse_game_end_reason(&GameResult::Win, None), GameEndReason::Resign);
+        assert_eq!(parse_game_end_reason(&GameResult::Lose, None), GameEndReason::Resign);
+        assert_eq!(parse_game_end_reason(&GameResult::Draw, None), GameEndReason::Sennichite);
+        assert_eq!(
+            parse_game_end_reason(&GameResult::Interrupted, None),
+            GameEndReason::Interrupted
+        );
+        assert_eq!(parse_game_end_reason(&GameResult::Censored, None), GameEndReason::Censored);
+    }
+
+    #[test]
+    fn build_game_end_event_winner_self_when_win() {
+        use rshogi_csa::Color;
+        let evt = build_game_end_event(&GameResult::Win, None, None, Color::Black);
+        assert_eq!(evt.winner, Some(Side::Black));
+        assert_eq!(evt.reason, GameEndReason::Resign);
+    }
+
+    #[test]
+    fn build_game_end_event_winner_opponent_when_lose() {
+        use rshogi_csa::Color;
+        let evt = build_game_end_event(&GameResult::Lose, None, None, Color::Black);
+        assert_eq!(evt.winner, Some(Side::White));
+    }
+
+    #[test]
+    fn build_game_end_event_no_winner_when_draw_or_interrupted() {
+        use rshogi_csa::Color;
+        let draw = build_game_end_event(&GameResult::Draw, None, None, Color::Black);
+        assert_eq!(draw.winner, None);
+        let interrupted = build_game_end_event(&GameResult::Interrupted, None, None, Color::Black);
+        assert_eq!(interrupted.winner, None);
+    }
+
+    #[test]
+    fn build_reconnect_state_uses_summary_position_sfen() {
+        use rshogi_csa::{Color, initial_position};
+        let summary = GameSummary {
+            game_id: "g".to_owned(),
+            my_color: Color::Black,
+            sente_name: "b".to_owned(),
+            gote_name: "w".to_owned(),
+            position: initial_position(),
+            initial_moves: Vec::new(),
+            black_time: crate::protocol::TimeConfig::default(),
+            white_time: crate::protocol::TimeConfig::default(),
+            reconnect_token: None,
+        };
+        let proto_state = ProtocolReconnectState {
+            current_turn: Some(Color::Black),
+            black_remaining_ms: 10_000,
+            white_remaining_ms: 5_000,
+        };
+        let pub_state = build_reconnect_state(&summary, Some(&proto_state));
+        // last_sfen は summary.position.to_sfen() と一致 (履歴 replay は無し)
+        assert_eq!(pub_state.last_sfen, summary.position.to_sfen());
+        assert_eq!(pub_state.side_to_move, Side::Black);
+        assert_eq!(pub_state.remaining_time_sec_self, Some(10));
+        assert_eq!(pub_state.remaining_time_sec_opp, Some(5));
+    }
+
+    #[test]
+    fn build_reconnect_state_swaps_remaining_for_white_player() {
+        use rshogi_csa::{Color, initial_position};
+        let summary = GameSummary {
+            game_id: "g".to_owned(),
+            my_color: Color::White, // 自分は後手
+            sente_name: "b".to_owned(),
+            gote_name: "w".to_owned(),
+            position: initial_position(),
+            initial_moves: Vec::new(),
+            black_time: crate::protocol::TimeConfig::default(),
+            white_time: crate::protocol::TimeConfig::default(),
+            reconnect_token: None,
+        };
+        let proto_state = ProtocolReconnectState {
+            current_turn: Some(Color::White),
+            black_remaining_ms: 10_000,
+            white_remaining_ms: 5_000,
+        };
+        let pub_state = build_reconnect_state(&summary, Some(&proto_state));
+        // self は白 (5_000ms), opp は黒 (10_000ms)
+        assert_eq!(pub_state.remaining_time_sec_self, Some(5));
+        assert_eq!(pub_state.remaining_time_sec_opp, Some(10));
+    }
 }

--- a/crates/rshogi-csa-client/tests/lib_consumer.rs
+++ b/crates/rshogi-csa-client/tests/lib_consumer.rs
@@ -9,9 +9,13 @@
 //! WS 専用シンボル (`CsaTransport::WebSocket` バリアント等) は参照しない。
 
 use rshogi_csa_client::{
-    BestMoveResult, ConnectOpts, CsaClientConfig, CsaConnection, CsaTransport, Event, GameRecord,
-    GameResult, GameSummary, RecordedMove, SearchInfo, SearchOutcome, TransportTarget, UsiEngine,
-    run_game_session, run_resumed_session,
+    BestMoveEvent, BestMoveResult, ConnectOpts, CsaClientConfig, CsaConnection, CsaTransport,
+    DisconnectReason, Event, GameEndEvent, GameEndReason, GameRecord, GameResult, GameSummary,
+    MoveEvent, MovePlayer, NoopSessionEventSink, ReconnectState, RecordedMove, SearchInfo,
+    SearchInfoEmitPolicy, SearchInfoSnapshot, SearchOrigin, SearchOutcome, SessionError,
+    SessionEventSink, SessionOutcome, SessionProgress, Side, SinkError, TransportTarget, UsiEngine,
+    run_game_session, run_game_session_with_events, run_resumed_session,
+    run_resumed_session_with_events,
 };
 
 /// build only: 上の `use` がそのまま resolve できれば pass。型を実体化したり
@@ -35,11 +39,37 @@ fn build_only() {
                          _: GameResult,
                          _: CsaTransport,
                          _: TransportTarget,
-                         _: ConnectOpts| {};
-    // 関数ポインタとしての参照を取得して値として捨てる (call はしない)。
+                         _: ConnectOpts,
+                         _: BestMoveEvent,
+                         _: DisconnectReason,
+                         _: GameEndEvent,
+                         _: GameEndReason,
+                         _: MoveEvent,
+                         _: MovePlayer,
+                         _: NoopSessionEventSink,
+                         _: ReconnectState,
+                         _: SearchInfoEmitPolicy,
+                         _: SearchInfoSnapshot,
+                         _: SearchOrigin,
+                         _: SessionError,
+                         _: SessionOutcome,
+                         _: SessionProgress,
+                         _: Side,
+                         _: SinkError| {};
     let consume_funcs: (fn(_, _, _, _) -> _, fn(_, _, _, _) -> _) =
         (run_game_session, run_resumed_session);
-
-    // どちらも `_var` で未使用警告抑止せず、`let _ = ...` で値を消費する。
+    // 新 API は generic なので関数ポインタ型にキャストせず、`run_game_session_with_events`
+    // / `run_resumed_session_with_events` の名前解決だけ強制する。
+    type WithEventsFn = fn(
+        &CsaClientConfig,
+        &mut CsaConnection,
+        &mut UsiEngine,
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+        &mut NoopSessionEventSink,
+    ) -> Result<SessionOutcome, SessionError>;
+    let _events_funcs: (WithEventsFn, WithEventsFn) =
+        (run_game_session_with_events, run_resumed_session_with_events);
+    // dyn-coercion 確認
+    let _: Option<&mut dyn SessionEventSink> = None;
     let _ = (consume_types, consume_funcs);
 }

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -1,0 +1,720 @@
+//! `run_game_session_with_events` / `run_resumed_session_with_events` の
+//! end-to-end 進捗通知を mock CSA (TCP loopback) + 簡易 USI mock engine (bash 経由)
+//! で確認する integration test。
+//!
+//! - 通常対局: `Connected → GameSummary → GameStarted → BestMoveSelected →
+//!   MoveSent → MoveConfirmed → ... → GameEnded → Disconnected{GameOver}`
+//! - resume: `Connected → Resumed{summary,state} → GameStarted → ...`
+//!   (履歴 replay は emit しないことを確認)
+//! - sink Fatal で `Disconnected{SinkAborted}` + `SessionError::SinkAborted`
+//! - shutdown で `Disconnected{Shutdown}` + `SessionError::Shutdown`
+//!
+//! 対象 OS: Unix (bash 必須)。Windows には現状 mock USI engine 経路がないため
+//! `#[cfg(unix)]` でガードする。
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use rshogi_csa_client::config::CsaClientConfig;
+use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::events::{
+    DisconnectReason, MovePlayer, ReconnectState, SearchInfoEmitPolicy, SessionError,
+    SessionEventSink, SessionProgress, SinkError,
+};
+use rshogi_csa_client::protocol::CsaConnection;
+use rshogi_csa_client::session::{run_game_session_with_events, run_resumed_session_with_events};
+
+// ────────────────────────────────────────────
+// 共通: mock CSA TCP server / mock USI engine 生成
+// ────────────────────────────────────────────
+
+fn spawn_mock_tcp_server<F>(handler: F) -> u16
+where
+    F: FnOnce(&mut BufReader<std::net::TcpStream>, &mut std::net::TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    thread::Builder::new()
+        .name("mock-csa-server".to_string())
+        .spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
+            stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
+            let mut writer = stream.try_clone().expect("clone stream");
+            let mut reader = BufReader::new(stream);
+            handler(&mut reader, &mut writer);
+        })
+        .expect("spawn");
+    port
+}
+
+fn read_line(reader: &mut BufReader<std::net::TcpStream>) -> String {
+    let mut buf = String::new();
+    reader.read_line(&mut buf).expect("read line");
+    buf.trim_end_matches(['\r', '\n']).to_owned()
+}
+
+fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
+    for line in lines {
+        writeln!(writer, "{}", line).expect("write line");
+    }
+    writer.flush().expect("flush");
+}
+
+/// 1 局分の最小フローで bestmove を 1 度だけ返す USI mock engine スクリプトを
+/// 一時ファイルに書き出して path を返す。エンジンは:
+///   - `usi` -> `id name mock\nusiok`
+///   - `isready` -> `info string ready\nreadyok`
+///   - `position ...` + `go ...` -> `info depth 5 score cp 100 nodes 1234 pv 7g7f\nbestmove 7g7f`
+///   - `gameover ...` -> 何もしない
+///   - `quit` -> 終了
+fn mock_usi_engine_script() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = tempfile_root();
+    let seq = SEQ.fetch_add(1, AtomicOrdering::SeqCst);
+    let path = dir.join(format!("mock_usi_engine_{}_{}.sh", std::process::id(), seq));
+    let script = r#"#!/usr/bin/env bash
+# mock USI engine for csa-client integration test
+while IFS= read -r line; do
+    case "$line" in
+        usi)
+            echo "id name mock"
+            echo "usiok"
+            ;;
+        isready)
+            echo "readyok"
+            ;;
+        usinewgame)
+            ;;
+        position*)
+            ;;
+        go*)
+            echo "info depth 5 score cp 100 nodes 1234 nps 5000 time 200 pv 7g7f"
+            echo "bestmove 7g7f"
+            ;;
+        ponderhit)
+            echo "info depth 5 score cp 100 nodes 1234 nps 5000 time 200 pv 7g7f"
+            echo "bestmove 7g7f"
+            ;;
+        stop)
+            echo "bestmove 7g7f"
+            ;;
+        gameover*)
+            ;;
+        quit)
+            exit 0
+            ;;
+    esac
+done
+"#;
+    std::fs::write(&path, script).expect("write mock engine script");
+    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("set perms");
+    path
+}
+
+fn tempfile_root() -> PathBuf {
+    std::env::temp_dir()
+}
+
+/// `CsaClientConfig` を mock 用に組み立てる。
+fn mock_config(engine_path: PathBuf, search_info_emit: SearchInfoEmitPolicy) -> CsaClientConfig {
+    let mut config = CsaClientConfig::default();
+    config.server.id = "alice".to_owned();
+    config.server.password = "pw".to_owned();
+    config.server.floodgate = false;
+    config.server.keepalive.ping_interval_sec = 0;
+    config.engine.path = engine_path;
+    config.game.ponder = false;
+    config.game.search_info_emit = search_info_emit;
+    config
+}
+
+/// 1 局分の `Game_Summary` 行群 (平手・自分先手)。`Reconnect_Token` 拡張あり。
+fn game_summary_lines(game_id: &str) -> Vec<String> {
+    vec![
+        "BEGIN Game_Summary".to_owned(),
+        "Protocol_Version:1.2".to_owned(),
+        format!("Game_ID:{}", game_id),
+        "Name+:alice".to_owned(),
+        "Name-:bob".to_owned(),
+        "Your_Turn:+".to_owned(),
+        "To_Move:+".to_owned(),
+        "Time_Unit:1sec".to_owned(),
+        "Total_Time:600".to_owned(),
+        "Byoyomi:10".to_owned(),
+        "BEGIN Position".to_owned(),
+        "P1-KY-KE-GI-KI-OU-KI-GI-KE-KY".to_owned(),
+        "P2 * -HI *  *  *  *  * -KA *".to_owned(),
+        "P3-FU-FU-FU-FU-FU-FU-FU-FU-FU".to_owned(),
+        "P4 *  *  *  *  *  *  *  *  *".to_owned(),
+        "P5 *  *  *  *  *  *  *  *  *".to_owned(),
+        "P6 *  *  *  *  *  *  *  *  *".to_owned(),
+        "P7+FU+FU+FU+FU+FU+FU+FU+FU+FU".to_owned(),
+        "P8 * +KA *  *  *  *  * +HI *".to_owned(),
+        "P9+KY+KE+GI+KI+OU+KI+GI+KE+KY".to_owned(),
+        "+".to_owned(),
+        "END Position".to_owned(),
+        "Reconnect_Token:tok-xyz".to_owned(),
+        "END Game_Summary".to_owned(),
+    ]
+}
+
+/// 集計用に sink から取り出す Arc 観測 handle 一式。
+type CapturingHandles = (Arc<Mutex<Vec<&'static str>>>, Arc<Mutex<u32>>);
+
+/// Sink 集計用ヘルパー
+struct CapturingSink {
+    events: Arc<Mutex<Vec<&'static str>>>,
+    fatal_after: Option<&'static str>,
+    error_calls: Arc<Mutex<u32>>,
+}
+
+impl CapturingSink {
+    fn new() -> (Self, CapturingHandles) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let error_calls = Arc::new(Mutex::new(0u32));
+        let me = CapturingSink {
+            events: Arc::clone(&events),
+            fatal_after: None,
+            error_calls: Arc::clone(&error_calls),
+        };
+        (me, (events, error_calls))
+    }
+    fn fatal_on(mut self, label: &'static str) -> Self {
+        self.fatal_after = Some(label);
+        self
+    }
+}
+
+impl SessionEventSink for CapturingSink {
+    fn on_event(&mut self, event: SessionProgress) -> Result<(), SinkError> {
+        let label = label_for(&event);
+        self.events.lock().unwrap().push(label);
+        if Some(label) == self.fatal_after {
+            return Err(SinkError::Fatal(Box::new(std::io::Error::other("test fatal"))));
+        }
+        Ok(())
+    }
+
+    fn on_error(&mut self, _error: &SessionError) -> Result<(), SinkError> {
+        *self.error_calls.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+fn label_for(event: &SessionProgress) -> &'static str {
+    match event {
+        SessionProgress::Connected => "Connected",
+        SessionProgress::GameSummary(_) => "GameSummary",
+        SessionProgress::Resumed { .. } => "Resumed",
+        SessionProgress::GameStarted => "GameStarted",
+        SessionProgress::BestMoveSelected(_) => "BestMoveSelected",
+        SessionProgress::MoveSent(_) => "MoveSent",
+        SessionProgress::MoveConfirmed(e) => match e.player {
+            MovePlayer::SelfPlayer => "MoveConfirmedSelf",
+            MovePlayer::Opponent => "MoveConfirmedOpp",
+        },
+        SessionProgress::SearchInfo(_) => "SearchInfo",
+        SessionProgress::GameEnded(_) => "GameEnded",
+        SessionProgress::Disconnected { reason } => match reason {
+            DisconnectReason::GameOver => "Disconnected:GameOver",
+            DisconnectReason::Shutdown => "Disconnected:Shutdown",
+            DisconnectReason::SinkAborted => "Disconnected:SinkAborted",
+            DisconnectReason::TransportError(_) => "Disconnected:Transport",
+            DisconnectReason::Unknown => "Disconnected:Unknown",
+        },
+    }
+}
+
+// ────────────────────────────────────────────
+// 通常対局フローの event 順テスト
+// ────────────────────────────────────────────
+
+#[test]
+fn fresh_session_emits_expected_event_sequence() {
+    // 1 手指して即 #WIN を返す mock CSA サーバ
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        // LOGIN
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        // Game_Summary
+        let lines = game_summary_lines("g-1");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        // AGREE 受信
+        let agree = read_line(reader);
+        assert!(agree.starts_with("AGREE"), "expected AGREE, got: {agree}");
+        write_lines(writer, &["START:g-1"]);
+        // 自分の手 +7776FU を受信
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"), "expected client move +7776FU, got: {mv}");
+        // server echo with time
+        write_lines(writer, &["+7776FU,T2"]);
+        // 終局を即送る (#WIN)
+        write_lines(writer, &["#WIN"]);
+        // LOGOUT を受け流す (best-effort)
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::EveryLine);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    let (sink, (events, _err_calls)) = CapturingSink::new();
+    let mut sink = sink;
+    let outcome = run_game_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+
+    engine.quit();
+
+    let outcome = outcome.expect("session ok");
+    let events = events.lock().unwrap().clone();
+    eprintln!("captured events: {events:?}");
+
+    // 必要な event がこの順番で全部出ていること (SearchInfo は EveryLine 設定で多発し得るので順番チェック時は除外)
+    let filtered: Vec<&str> = events.into_iter().filter(|e| *e != "SearchInfo").collect();
+    let expected_prefix = vec![
+        "Connected",
+        "GameSummary",
+        "GameStarted",
+        "BestMoveSelected",
+        "MoveSent",
+        "MoveConfirmedSelf",
+        "GameEnded",
+        "Disconnected:GameOver",
+    ];
+    assert_eq!(filtered, expected_prefix, "event 順が不一致");
+    assert_eq!(outcome.summary.as_ref().unwrap().game_id, "g-1");
+}
+
+// ────────────────────────────────────────────
+// resume 経路で history replay が出ないことを確認
+// ────────────────────────────────────────────
+
+#[test]
+fn resumed_session_emits_resumed_event_and_no_history_replay() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        // LOGIN (reconnect)
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        // Game_Summary (resume 用)
+        let lines = game_summary_lines("g-resume");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        // Reconnect_State
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:+",
+                "Black_Time_Remaining_Ms:599500",
+                "White_Time_Remaining_Ms:600000",
+                "END Reconnect_State",
+            ],
+        );
+        // AGREE は送られない (resume 経路)。即 自分の手番なので bestmove +7776FU を受け取る。
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"), "expected +7776FU, got: {mv}");
+        write_lines(writer, &["+7776FU,T1"]);
+        // 終局
+        write_lines(writer, &["#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login_reconnect("alice", "pw", "g-resume", "tok-xyz")
+        .expect("login_reconnect");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    let (sink, (events, _err_calls)) = CapturingSink::new();
+    let mut sink = sink;
+    let outcome = run_resumed_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+    engine.quit();
+    let _outcome = outcome.expect("session ok");
+
+    let events = events.lock().unwrap().clone();
+    eprintln!("resume events: {events:?}");
+
+    // GameSummary は emit せず Resumed を 1 度だけ emit する
+    assert!(events.contains(&"Resumed"));
+    assert!(!events.contains(&"GameSummary"));
+    let resumed_count = events.iter().filter(|e| **e == "Resumed").count();
+    assert_eq!(resumed_count, 1);
+
+    // 履歴 replay は無い (initial_moves が空のため、自分の手 1 つ + その echo
+    // の MoveConfirmedSelf 1 つだけが期待される)
+    let confirmed_count = events
+        .iter()
+        .filter(|e| **e == "MoveConfirmedSelf" || **e == "MoveConfirmedOpp")
+        .count();
+    assert_eq!(confirmed_count, 1, "履歴 replay が emit されています: {events:?}");
+}
+
+#[test]
+fn resumed_state_last_sfen_matches_summary_position_section() {
+    use rshogi_csa::parse_csa_full;
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-resume-sfen");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:+",
+                "Black_Time_Remaining_Ms:599500",
+                "White_Time_Remaining_Ms:600000",
+                "END Reconnect_State",
+            ],
+        );
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"));
+        write_lines(writer, &["+7776FU,T1", "#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login_reconnect("alice", "pw", "g-resume-sfen", "tok-xyz")
+        .expect("login_reconnect");
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    // 期待する SFEN は Game_Summary の Position section から導出する。
+    // mock のレイアウトは平手のため `parse_csa_full` 結果は initial_position と等しい。
+    let pos_text = lines_position_section();
+    let (parsed_pos, _, _) = parse_csa_full(&pos_text).expect("parse csa");
+    let expected_sfen = parsed_pos.to_sfen();
+
+    // sink 内で Resumed payload を捕捉
+    let captured_sfen: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_clone = Arc::clone(&captured_sfen);
+    struct CaptureResumedSink {
+        out: Arc<Mutex<Option<String>>>,
+    }
+    impl SessionEventSink for CaptureResumedSink {
+        fn on_event(&mut self, event: SessionProgress) -> Result<(), SinkError> {
+            if let SessionProgress::Resumed { state, .. } = &event {
+                let _: &ReconnectState = state;
+                *self.out.lock().unwrap() = Some(state.last_sfen.clone());
+            }
+            Ok(())
+        }
+    }
+    let mut sink = CaptureResumedSink {
+        out: captured_clone,
+    };
+    let outcome = run_resumed_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+    engine.quit();
+    let _ = outcome.expect("session ok");
+
+    let captured = captured_sfen.lock().unwrap().clone();
+    assert_eq!(
+        captured.as_deref(),
+        Some(expected_sfen.as_str()),
+        "Resumed.state.last_sfen が GameSummary.position_section の SFEN 変換と一致すべき"
+    );
+}
+
+/// Game_Summary の Position section を string で返す (テスト用)。
+fn lines_position_section() -> String {
+    [
+        "P1-KY-KE-GI-KI-OU-KI-GI-KE-KY",
+        "P2 * -HI *  *  *  *  * -KA *",
+        "P3-FU-FU-FU-FU-FU-FU-FU-FU-FU",
+        "P4 *  *  *  *  *  *  *  *  *",
+        "P5 *  *  *  *  *  *  *  *  *",
+        "P6 *  *  *  *  *  *  *  *  *",
+        "P7+FU+FU+FU+FU+FU+FU+FU+FU+FU",
+        "P8 * +KA *  *  *  *  * +HI *",
+        "P9+KY+KE+GI+KI+OU+KI+GI+KE+KY",
+        "+",
+    ]
+    .join("\n")
+}
+
+// ────────────────────────────────────────────
+// Sink Fatal -> SinkAborted で best-effort attempt at clean closure
+// ────────────────────────────────────────────
+
+#[test]
+fn fatal_sink_triggers_clean_closure_and_returns_sink_aborted() {
+    let received_chudan = Arc::new(AtomicBool::new(false));
+    let received_logout = Arc::new(AtomicBool::new(false));
+    let received_chudan_clone = Arc::clone(&received_chudan);
+    let received_logout_clone = Arc::clone(&received_logout);
+
+    let port = spawn_mock_tcp_server(move |reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-fatal");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        // AGREE
+        let _ = read_line(reader);
+        write_lines(writer, &["START:g-fatal"]);
+        // GameStarted で sink Fatal が発生する設定にしているため、CSA 上は AGREE/START
+        // のあと client が CHUDAN + LOGOUT を送ってくるはず。タイムアウト 3 秒。
+        for _ in 0..30 {
+            let mut buf = String::new();
+            match reader.read_line(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let trimmed = buf.trim_end_matches(['\r', '\n']);
+                    if trimmed.contains("CHUDAN") {
+                        received_chudan_clone.store(true, Ordering::SeqCst);
+                    }
+                    if trimmed.contains("LOGOUT") {
+                        received_logout_clone.store(true, Ordering::SeqCst);
+                    }
+                    if received_logout_clone.load(Ordering::SeqCst) {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    let (sink, (events, err_calls)) = CapturingSink::new();
+    let mut sink = sink.fatal_on("GameStarted");
+
+    let outcome = run_game_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+
+    engine.quit();
+
+    // SessionError::SinkAborted が返ること
+    match outcome {
+        Err(SessionError::SinkAborted(_)) => {}
+        other => panic!("expected SessionError::SinkAborted, got {other:?}"),
+    }
+
+    let events = events.lock().unwrap().clone();
+    eprintln!("fatal events: {events:?}");
+    assert!(events.contains(&"Disconnected:SinkAborted"));
+    // on_error が 1 度呼ばれている
+    assert_eq!(*err_calls.lock().unwrap(), 1, "on_error 呼び出し回数");
+
+    // CHUDAN / LOGOUT が wire に出たか確認
+    // (mock サーバスレッドが 3 秒以内に検出するはず)
+    thread::sleep(Duration::from_millis(500));
+    assert!(received_chudan.load(Ordering::SeqCst), "CHUDAN が送信されていません");
+    assert!(received_logout.load(Ordering::SeqCst), "LOGOUT が送信されていません");
+}
+
+// ────────────────────────────────────────────
+// shutdown -> SessionError::Shutdown + Disconnected{Shutdown}
+// ────────────────────────────────────────────
+
+#[test]
+fn external_shutdown_emits_shutdown_disconnected_and_returns_shutdown_error() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-sd");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        let _ = read_line(reader); // AGREE
+        write_lines(writer, &["START:g-sd"]);
+        // 自分の手を待たずに何も送らない。client 側で shutdown が立つと
+        // `%CHUDAN` / `LOGOUT` が来るはず。
+        loop {
+            let mut buf = String::new();
+            match reader.read_line(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let trimmed = buf.trim_end_matches(['\r', '\n']);
+                    if trimmed.contains("LOGOUT") {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    // 別スレッドで 200ms 後に shutdown を立てる
+    let shutdown_signal = Arc::clone(&shutdown);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(300));
+        shutdown_signal.store(true, Ordering::SeqCst);
+    });
+
+    let (sink, (events, _err_calls)) = CapturingSink::new();
+    let mut sink = sink;
+    let outcome = run_game_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+
+    engine.quit();
+
+    match outcome {
+        Err(SessionError::Shutdown) => {}
+        other => panic!("expected SessionError::Shutdown, got {other:?}"),
+    }
+    let events = events.lock().unwrap().clone();
+    assert!(events.contains(&"Disconnected:Shutdown"), "events: {events:?}");
+}
+
+// ────────────────────────────────────────────
+// NonFatal は対局継続
+// ────────────────────────────────────────────
+
+#[test]
+fn nonfatal_sink_does_not_invoke_on_error_and_session_continues() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-nonfatal");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        let _ = read_line(reader); // AGREE
+        write_lines(writer, &["START:g-nonfatal"]);
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"));
+        write_lines(writer, &["+7776FU,T1", "#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    // 全 event を NonFatal で返す sink。結果は対局完了 (Ok(SessionOutcome))
+    // となり、on_error は呼ばれない。
+    let error_calls = Arc::new(Mutex::new(0u32));
+    let error_calls_clone = Arc::clone(&error_calls);
+    struct NonFatalEverywhere {
+        on_error_calls: Arc<Mutex<u32>>,
+    }
+    impl SessionEventSink for NonFatalEverywhere {
+        fn on_event(&mut self, _event: SessionProgress) -> Result<(), SinkError> {
+            Err(SinkError::NonFatal(Box::new(std::io::Error::other("transient warn"))))
+        }
+        fn on_error(&mut self, _err: &SessionError) -> Result<(), SinkError> {
+            *self.on_error_calls.lock().unwrap() += 1;
+            Ok(())
+        }
+    }
+    let mut sink = NonFatalEverywhere {
+        on_error_calls: error_calls_clone,
+    };
+    let outcome = run_game_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+    engine.quit();
+    assert!(outcome.is_ok(), "対局は NonFatal でも完了するはず: {outcome:?}");
+    assert_eq!(*error_calls.lock().unwrap(), 0, "NonFatal 時は on_error が呼ばれないこと");
+}

--- a/crates/rshogi-csa-client/tests/session_events_unit.rs
+++ b/crates/rshogi-csa-client/tests/session_events_unit.rs
@@ -1,0 +1,163 @@
+//! `SessionEventSink` 周辺の event 型・helper 関数のユニットテスト。
+//!
+//! 全フロー (Connected → ... → Disconnected) を mock CSA + mock USI engine で
+//! 駆動するのは別 integration test (`session_events_integration.rs`) で行う。
+//! 本ファイルは公開 API 型と helper の挙動を確定させるためのテスト。
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use rshogi_csa_client::events::{
+    DisconnectReason, GameEndReason, MovePlayer, NoopSessionEventSink, SearchInfoEmitPolicy,
+    SearchInfoSnapshot, SearchOrigin, SessionError, SessionEventSink, SessionProgress, Side,
+    SinkError,
+};
+
+#[test]
+fn search_info_emit_policy_default_returns_default_variant() {
+    let p = SearchInfoEmitPolicy::default();
+    assert!(matches!(p, SearchInfoEmitPolicy::Default));
+}
+
+#[test]
+fn search_info_emit_policy_default_is_documented_to_match_interval_preset() {
+    // doc 上は `Interval { min_ms: 200, emit_on_depth_change: true, emit_final: true }`
+    // 相当と明記している。Default variant 自体は別 enum なので enum 同値性は弱いが、
+    // build-time に意味がずれないよう、Default variant を直接構築できることを確認する。
+    let _ = SearchInfoEmitPolicy::Interval {
+        min_ms: 200,
+        emit_on_depth_change: true,
+        emit_final: true,
+    };
+}
+
+#[test]
+fn side_from_color_round_trips() {
+    use rshogi_csa::Color;
+    assert_eq!(Side::from(Color::Black), Side::Black);
+    assert_eq!(Side::from(Color::White), Side::White);
+}
+
+#[test]
+fn noop_sink_returns_ok_for_all_events() {
+    let mut sink = NoopSessionEventSink;
+    assert!(sink.on_event(SessionProgress::Connected).is_ok());
+    assert!(sink.on_event(SessionProgress::GameStarted).is_ok());
+    assert!(
+        sink.on_event(SessionProgress::SearchInfo(SearchInfoSnapshot::default()))
+            .is_ok()
+    );
+    assert!(
+        sink.on_event(SessionProgress::Disconnected {
+            reason: DisconnectReason::GameOver
+        })
+        .is_ok()
+    );
+    // default on_error returns Ok
+    let err = SessionError::Shutdown;
+    assert!(sink.on_error(&err).is_ok());
+    // default should_continue is true
+    assert!(sink.should_continue());
+}
+
+/// `FnMut(SessionProgress) -> Result<(), SinkError>` が
+/// `SessionEventSink` の blanket impl で sink として使えることを確認する。
+#[test]
+fn closure_is_session_event_sink() {
+    let collected = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+    let collected_clone = Arc::clone(&collected);
+    let mut sink = move |event: SessionProgress| -> Result<(), SinkError> {
+        let mut g = collected_clone.lock().unwrap();
+        g.push(match event {
+            SessionProgress::Connected => "connected",
+            SessionProgress::GameStarted => "started",
+            SessionProgress::Disconnected { .. } => "disconnected",
+            _ => "other",
+        });
+        Ok(())
+    };
+    sink.on_event(SessionProgress::Connected).unwrap();
+    sink.on_event(SessionProgress::GameStarted).unwrap();
+    sink.on_event(SessionProgress::Disconnected {
+        reason: DisconnectReason::GameOver,
+    })
+    .unwrap();
+    let g = collected.lock().unwrap();
+    assert_eq!(g.as_slice(), &["connected", "started", "disconnected"]);
+}
+
+/// `SessionError` は `io::Error` を `Network` に分類する `From<anyhow::Error>` を持つ。
+#[test]
+fn session_error_from_anyhow_with_io_error_is_network() {
+    let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "test connection reset");
+    let any_err: anyhow::Error = io_err.into();
+    let session_err: SessionError = any_err.into();
+    assert!(
+        matches!(session_err, SessionError::Network(_)),
+        "io::Error should map to SessionError::Network, got: {session_err:?}"
+    );
+}
+
+#[test]
+fn session_error_from_anyhow_without_io_error_is_other() {
+    let any_err: anyhow::Error = anyhow::anyhow!("custom protocol error");
+    let session_err: SessionError = any_err.into();
+    assert!(
+        matches!(session_err, SessionError::Other(_)),
+        "non-io anyhow should map to SessionError::Other, got: {session_err:?}"
+    );
+}
+
+/// `SinkError::Fatal` / `NonFatal` を `Display` で確認できる。
+#[test]
+fn sink_error_display_includes_kind() {
+    let inner: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::other("boom"));
+    let fatal = SinkError::Fatal(inner);
+    let s = format!("{fatal}");
+    assert!(s.contains("fatal"), "display should mention fatal: {s}");
+
+    let inner: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::other("warn"));
+    let non_fatal = SinkError::NonFatal(inner);
+    let s = format!("{non_fatal}");
+    assert!(s.contains("non-fatal"), "display should mention non-fatal: {s}");
+}
+
+#[test]
+fn search_origin_variants_are_distinct() {
+    let fresh = SearchOrigin::Fresh;
+    let pondhit = SearchOrigin::Ponderhit;
+    let miss = SearchOrigin::PonderMiss;
+    assert_ne!(fresh, pondhit);
+    assert_ne!(pondhit, miss);
+    assert_ne!(fresh, miss);
+}
+
+#[test]
+fn move_player_variants_are_distinct() {
+    assert_ne!(MovePlayer::SelfPlayer, MovePlayer::Opponent);
+}
+
+#[test]
+fn game_end_reason_unknown_preserves_payload() {
+    let r = GameEndReason::Unknown("#FUTURE_REASON_X".to_owned());
+    if let GameEndReason::Unknown(s) = r {
+        assert_eq!(s, "#FUTURE_REASON_X");
+    } else {
+        panic!("expected Unknown variant");
+    }
+}
+
+#[test]
+fn shutdown_signal_via_arc_atomic_bool_flag_only() {
+    // `Arc<AtomicBool>` を `run_*_with_events` に渡す前段の動作確認。
+    // 実 session driver は別テスト。ここでは値が共有 Arc 経由で読み書きできること
+    // のみを確認する。
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_clone = Arc::clone(&shutdown);
+    std::thread::spawn(move || {
+        shutdown_clone.store(true, Ordering::SeqCst);
+    })
+    .join()
+    .unwrap();
+    assert!(shutdown.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
## Summary
- `run_game_session_with_events` / `run_resumed_session_with_events` を追加し、対局途中の `Connected` / `GameSummary` / `Resumed` / `GameStarted` / `BestMoveSelected` / `MoveSent` / `MoveConfirmed` / `SearchInfo` / `GameEnded` / `Disconnected` を `SessionEventSink` 経由で consumer (Tauri 等) に通知できるようにした
- 戻り値を `(GameResult, GameRecord, Option<GameSummary>)` tuple → `SessionOutcome` struct に変更 (将来 field 追加耐性、既存 CLI は追従済み)
- Sink Fatal / 外部 shutdown 時は **best-effort attempt at clean closure** (`%CHUDAN` → `LOGOUT` → transport close → `on_error` → `Disconnected`)
- thiserror named errors (`SessionError` / `SinkError`) で public boundary の error 型を closed に
- `SearchInfoEmitPolicy` で USI `info` 行 throttle を `CsaClientConfig` 経由で expose (preset `Default` = `Interval { min_ms: 200, emit_on_depth_change: true, emit_final: true }`)
- resume 経路は履歴 replay を一切 emit せず、`ReconnectState.last_sfen` で局面復元 (CSA reconnect protocol が指し手列を再送しないため)
- `SearchOrigin::PonderMiss` の意味を **「ponder miss 後に開始した fresh search」** と確定 (UI が「ponder が外れて生まれた fresh search」を通常 `Fresh` と区別できる)
- 設計 v4 (Issue #572 issuecomment-4350697871) APPROVE 済 + Codex Nit 3 件を doc に反映
- Closes #572

### v4 設計からの deviation (実装上のトレードオフ)
- v4 設計の `(config, transport: CsaTransport, shutdown: Arc<AtomicBool>, sink)` シグネチャに対し、本実装では `(config, &mut conn: CsaConnection, &mut engine: UsiEngine, shutdown: Arc<AtomicBool>, sink)` を採用。理由:
  - 既存 CLI が engine を再利用 (`restart_engine_every_game = false` default) するため engine は外部所有のまま
  - login (および resume の `login_reconnect`) は token / game_id を必要とするため外部で完結させる
  - `transport` は実質「post-login session bundle」として `CsaConnection` で表現する方が直感的
- 既存 `run_game_session` / `run_resumed_session` は `&mut conn / &mut engine / &AtomicBool` シグネチャを維持しつつ `NoopSessionEventSink` で新 API へ委譲する薄いラッパー化

## Test plan
- [x] `cargo build -p rshogi-csa-client` (default / `--no-default-features --features tcp` / `--no-default-features --features websocket`) 全成功
- [x] `cargo test --workspace` 全 green (新規 integration test 6 件 + unit test 17 件含む)
- [x] `cargo clippy --workspace --all-targets --tests` 警告ゼロ
- [x] `cargo fmt --all --check` 成功
- [x] `cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers` 成功 (本 PR 由来の新規警告なし)
- [x] 既存 CLI (`csa_client` バイナリ) が `SessionOutcome` 戻り値で動くこと (build/clippy 確認、e2e は CI に委譲)

🤖 Generated with [Claude Code](https://claude.com/claude-code)