### PR TITLE
feat(csa-client): UsiEngineDriver trait で外部 USI 以外の engine 実装を受け入れ可能にする

### DIFF
--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -34,15 +34,164 @@ pub struct BestMoveResult {
 
 /// 探索の終了理由
 pub enum SearchOutcome {
-    /// エンジンが bestmove を返した
+    /// エンジンが bestmove を返した。第 2 引数は終了時点の累積 [`SearchInfo`]
+    /// (final score, final pv, final depth 等)。
     BestMove(BestMoveResult, SearchInfo),
-    /// サーバーから終局通知が来たため探索を中断した
+
+    /// 探索中に server から終局通知 (or disconnect) を受信して中断した。
+    /// 内包する `Vec<String>` は中断契機となった server からの行を含む:
+    ///
+    /// - `#WIN` / `#LOSE` / `#DRAW` / `#CENSORED` / `#CHUDAN` / `#TIME_UP` などの結果行
+    /// - `#ILLEGAL_MOVE` / `#JISHOGI` / `#SENNICHITE` / `#MAX_MOVES` などの理由行
+    /// - server 切断時は `#DISCONNECTED` という synthetic line
+    ///
+    /// session 側は本 Vec の内容から `GameEndEvent.reason` ([`crate::events::GameEndReason`])
+    /// を解釈する。実装は中断時の server 受信行を漏れなくこの Vec に含めること。
     ServerInterrupt(Vec<String>),
 }
 
-/// USI `info` 行を観測する都度呼び出される callback。`(累積 SearchInfo, 生の info 行)`
-/// を受け取り、`SessionEventSink` への `SearchInfo` snapshot 発火に使われる。
+/// USI `info` 行を観測する都度呼び出される callback。
+///
+/// 引数:
+/// - `&SearchInfo`: 観測時点の累積 search info (depth/score/pv 等は最後に観測した値で更新済)
+/// - `&str`: USI engine から受信した raw info 行 (例: `"info depth 12 score cp 87 pv 7g7f 8c8d ..."`)
+///
+/// 呼び出される順序:
+/// - bestmove を受信する**前**に、各 info 行ごとに 1 度だけ呼ばれる
+/// - 探索中断 (stop / server interrupt) の場合、それまでに受信した info 行ぶんは呼ばれている
+///
+/// session 側は本 callback を `SearchInfoEmitPolicy` で throttle した上で
+/// `SessionEventSink::on_event(SessionProgress::SearchInfo(...))` に変換する。
 pub type InfoCallback<'a> = dyn FnMut(&SearchInfo, &str) + 'a;
+
+/// CSA 対局ループから呼び出される USI engine の最小 contract。
+///
+/// 既存 [`UsiEngine`] (外部 USI プロセス driver) が reference impl。consumer は本 trait を
+/// 実装することで in-process engine / mock engine 等を
+/// [`run_game_session_with_events`](crate::run_game_session_with_events) に渡せる。
+///
+/// 同期前提。`Send + Sync` bound は付けない (consumer が必要なら自身の型で課す)。
+/// `Result` は [`anyhow::Result`] を採用する (現行 `UsiEngine` API と整合)。
+///
+/// 利用例:
+///
+/// ```ignore
+/// use rshogi_csa_client::{run_game_session_with_events, UsiEngine, UsiEngineDriver};
+///
+/// // 1. 具象 `UsiEngine` をそのまま渡す
+/// let mut engine = UsiEngine::spawn(&path, &options, ponder, timeout)?;
+/// run_game_session_with_events(&config, &mut conn, &mut engine, shutdown, &mut sink)?;
+///
+/// // 2. dyn dispatch で複数 engine 実装を切り替える
+/// let mut engine: Box<dyn UsiEngineDriver> = if use_builtin {
+///     Box::new(BuiltinEngine::new(...))
+/// } else {
+///     Box::new(UsiEngine::spawn(&path, &options, ponder, timeout)?)
+/// };
+/// run_game_session_with_events(&config, &mut conn, &mut *engine, shutdown, &mut sink)?;
+/// ```
+pub trait UsiEngineDriver {
+    /// USI `usinewgame` 相当を実装する。対局開始前に 1 度呼ばれる。
+    fn new_game(&mut self) -> Result<()>;
+
+    /// `position` + `go` を送信し、bestmove または server interrupt まで block する。
+    ///
+    /// 実装の責任:
+    /// 1. `position_cmd` (例: `"position sfen ... moves ..."`) を engine に送信
+    /// 2. `go_cmd` (例: `"go btime 60000 wtime 60000 byoyomi 5000"`) を engine に送信
+    /// 3. info 行を受信するたびに `info_callback` を呼び、累積 [`SearchInfo`] と raw info 行を渡す
+    /// 4. 探索中、`shutdown.load(Ordering::SeqCst)` が true になった場合は `stop` を engine
+    ///    に送り、bestmove を待ってから `Ok(SearchOutcome::BestMove(...))` で返す (resign 扱いも可)
+    /// 5. 探索中、`server_rx` から [`Event::ServerLine`] を受信し、`#GAME_OVER` などの終局
+    ///    行を検出した場合は engine に `stop` を送り、bestmove を drain してから
+    ///    `Ok(SearchOutcome::ServerInterrupt(server_lines))` を返す
+    /// 6. [`Event::ServerDisconnected`] を受信した場合も同様に終局として扱う
+    ///
+    /// 実装は探索中、`shutdown` を `try_recv` / timeout poll 等で blocking しない形で観測
+    /// すること (例: 200ms 以下の poll interval、または engine 応答ストリームと multiplex)。
+    /// blocking read のみで `shutdown` / `server_rx` を放置すると session 全体が固まる。
+    ///
+    /// `server_rx` から [`Event::ServerLine`] / [`Event::ServerDisconnected`] を受信したら
+    /// 探索を中断 (`stop` 送信 + bestmove drain) し、
+    /// [`SearchOutcome::ServerInterrupt`] で返す。`server_lines` には中断契機の行を
+    /// 漏れなく含めること。
+    fn go_with_info(
+        &mut self,
+        position_cmd: &str,
+        go_cmd: &str,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome>;
+
+    /// `position` + `go ponder` を送信し、bestmove を**待たない**で即座に return する。
+    /// 後続で [`UsiEngineDriver::ponderhit_with_info`] または
+    /// [`UsiEngineDriver::stop_and_wait`] が呼ばれる。
+    fn go_ponder(&mut self, position_cmd: &str, go_cmd: &str) -> Result<()>;
+
+    /// USI `ponderhit` を送信し、bestmove または server interrupt まで block する。
+    /// `shutdown` / `server_rx` / `info_callback` の semantics は
+    /// [`UsiEngineDriver::go_with_info`] と同じ。
+    fn ponderhit_with_info(
+        &mut self,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome>;
+
+    /// USI `stop` を送信し、bestmove の drain (= 棋譜には載せない) を行う。
+    ///
+    /// session は ponder 中の cleanup 用にこの method を呼ぶ。実装は ponder 中で
+    /// なくとも安全に呼び出されることを保証すること (副作用は USI `stop` 送信のみ
+    /// に留める)。
+    fn stop_and_wait(&mut self) -> Result<()>;
+
+    /// USI `gameover <result>` を送信する。
+    ///
+    /// `result` は `"win"` / `"lose"` / `"draw"` のいずれか (USI 仕様準拠)。
+    /// session 側は [`crate::protocol::GameResult::Interrupted`] /
+    /// [`crate::protocol::GameResult::Censored`] を `"draw"` に丸める (既存
+    /// `gameover_str` 関数の挙動)。
+    fn gameover(&mut self, result: &str) -> Result<()>;
+}
+
+impl UsiEngineDriver for UsiEngine {
+    fn new_game(&mut self) -> Result<()> {
+        UsiEngine::new_game(self)
+    }
+
+    fn go_with_info(
+        &mut self,
+        position_cmd: &str,
+        go_cmd: &str,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome> {
+        UsiEngine::go_with_info(self, position_cmd, go_cmd, shutdown, server_rx, info_callback)
+    }
+
+    fn go_ponder(&mut self, position_cmd: &str, go_cmd: &str) -> Result<()> {
+        UsiEngine::go_ponder(self, position_cmd, go_cmd)
+    }
+
+    fn ponderhit_with_info(
+        &mut self,
+        shutdown: &AtomicBool,
+        server_rx: &Receiver<Event>,
+        info_callback: &mut InfoCallback<'_>,
+    ) -> Result<SearchOutcome> {
+        UsiEngine::ponderhit_with_info(self, shutdown, server_rx, info_callback)
+    }
+
+    fn stop_and_wait(&mut self) -> Result<()> {
+        UsiEngine::stop_and_wait(self)
+    }
+
+    fn gameover(&mut self, result: &str) -> Result<()> {
+        UsiEngine::gameover(self, result)
+    }
+}
 
 /// info 行から抽出した探索情報
 ///

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -58,6 +58,15 @@
 //!   [`ReconnectState::last_sfen`] から盤面を再構築する責任を持つ。
 //! - [`SearchInfoSnapshot`] は累積 snapshot で、observed したぶんだけ field を
 //!   上書きする (差分ではなく常に「現時点までの最新値の集合」)。
+//!
+//! # UsiEngineDriver trait (engine 抽象)
+//!
+//! [`run_game_session_with_events`] / [`run_resumed_session_with_events`] は engine 引数を
+//! [`UsiEngineDriver`] trait の generic で受ける。`UsiEngine` (外部 USI プロセス driver) が
+//! reference impl で、consumer は同 trait を自前型 (in-process engine / mock 等) に
+//! 実装することで session API に渡せる。`&mut UsiEngine` をそのまま渡しても、
+//! `&mut dyn UsiEngineDriver` 経由の dyn dispatch でも同一 entry を利用できる。
+//! trait の contract と method 一覧は [`UsiEngineDriver`] の doc を参照。
 
 pub mod config;
 pub mod engine;
@@ -73,7 +82,7 @@ pub mod transport;
 // `use rshogi_csa_client::{CsaClientConfig, UsiEngine, ...}` で参照できる。
 // 型名は実装側に合わせており、別名は付与しない。
 pub use config::CsaClientConfig;
-pub use engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
+pub use engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine, UsiEngineDriver};
 pub use event::Event;
 pub use events::{
     BestMoveEvent, DisconnectReason, GameEndEvent, GameEndReason, MoveEvent, MovePlayer,

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -26,7 +26,7 @@ use anyhow::Result;
 use rshogi_csa::{Color, Position, csa_move_to_usi, usi_move_to_csa};
 
 use crate::config::CsaClientConfig;
-use crate::engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine};
+use crate::engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine, UsiEngineDriver};
 use crate::event::Event;
 use crate::events::{
     BestMoveEvent, DisconnectReason, GameEndEvent, GameEndReason, MoveEvent, MovePlayer,
@@ -52,14 +52,15 @@ use crate::record::{GameRecord, JsonlMoveExtra};
 /// `drop(conn)` か追加 close 処理を呼び出し側が決められる。
 ///
 /// resume 経路は [`run_resumed_session_with_events`] を使うこと。
-pub fn run_game_session_with_events<S>(
+pub fn run_game_session_with_events<E, S>(
     config: &CsaClientConfig,
     conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
+    engine: &mut E,
     shutdown: Arc<AtomicBool>,
     sink: &mut S,
 ) -> Result<SessionOutcome, SessionError>
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Fresh)
@@ -71,14 +72,15 @@ where
 /// 本関数は履歴 replay を `MoveConfirmed` として emit しない (resume 時の局面は
 /// `Resumed.state.last_sfen` から再構築する)。詳細は [`crate::events`] の
 /// crate-level doc を参照。
-pub fn run_resumed_session_with_events<S>(
+pub fn run_resumed_session_with_events<E, S>(
     config: &CsaClientConfig,
     conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
+    engine: &mut E,
     shutdown: Arc<AtomicBool>,
     sink: &mut S,
 ) -> Result<SessionOutcome, SessionError>
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Resumed)
@@ -118,15 +120,16 @@ enum SessionMode {
     Resumed,
 }
 
-fn drive_session<S>(
+fn drive_session<E, S>(
     config: &CsaClientConfig,
     conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
+    engine: &mut E,
     shutdown: &AtomicBool,
     sink: &mut S,
     mode: SessionMode,
 ) -> Result<SessionOutcome, SessionError>
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     // Step 1: Connected
@@ -272,10 +275,11 @@ enum LoopOutcome {
 // ────────────────────────────────────────────
 
 /// メインループの可変状態。ライフタイム `'a` は 1 局分の借用。
-/// `S` は generic な sink。`?Sized` を許して `dyn SessionEventSink` も渡せるようにする。
-struct SessionState<'a, S: ?Sized + 'a> {
+/// `E` は engine driver、`S` は sink。いずれも `?Sized` を許して
+/// `&mut dyn UsiEngineDriver` / `&mut dyn SessionEventSink` も渡せるようにする。
+struct SessionState<'a, E: ?Sized + 'a, S: ?Sized + 'a> {
     conn: &'a mut CsaConnection,
-    engine: &'a mut UsiEngine,
+    engine: &'a mut E,
     config: &'a CsaClientConfig,
     shutdown: &'a AtomicBool,
     server_rx: &'a Receiver<Event>,
@@ -305,9 +309,9 @@ enum MoveAction {
 // メインループ
 // ────────────────────────────────────────────
 
-fn run_session_loop<S>(
+fn run_session_loop<E, S>(
     conn: &mut CsaConnection,
-    engine: &mut UsiEngine,
+    engine: &mut E,
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
     summary: GameSummary,
@@ -315,6 +319,7 @@ fn run_session_loop<S>(
     sink: &mut S,
 ) -> LoopOutcome
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     let (server_tx, server_rx) = mpsc::channel();
@@ -563,8 +568,8 @@ where
 }
 
 /// 自分の bestmove 後、SearchOrigin を意識してハンドリングする。
-fn handle_search_outcome_with_origin<S>(
-    s: &mut SessionState<'_, S>,
+fn handle_search_outcome_with_origin<E, S>(
+    s: &mut SessionState<'_, E, S>,
     outcome: SearchOutcome,
     turn_start: Instant,
     sfen_before: String,
@@ -572,6 +577,7 @@ fn handle_search_outcome_with_origin<S>(
     origin: SearchOrigin,
 ) -> MoveAction
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     match outcome {
@@ -599,8 +605,8 @@ where
     }
 }
 
-fn send_bestmove_and_wait_echo<S>(
-    s: &mut SessionState<'_, S>,
+fn send_bestmove_and_wait_echo<E, S>(
+    s: &mut SessionState<'_, E, S>,
     result: &BestMoveResult,
     info: &SearchInfo,
     turn_start: Instant,
@@ -609,6 +615,7 @@ fn send_bestmove_and_wait_echo<S>(
     origin: SearchOrigin,
 ) -> MoveAction
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     if result.bestmove == "resign" {
@@ -818,8 +825,9 @@ where
 }
 
 /// 相手手番で受信した指し手 1 行 (`+...` / `-...`) を処理する。
-fn handle_opponent_move_line<S>(s: &mut SessionState<'_, S>, line: &str) -> MoveAction
+fn handle_opponent_move_line<E, S>(s: &mut SessionState<'_, E, S>, line: &str) -> MoveAction
 where
+    E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
     let (mv, time_sec) = parse_server_move(line);
@@ -1434,7 +1442,10 @@ struct PonderState {
     expected_usi: String,
 }
 
-fn cleanup_ponder(engine: &mut UsiEngine, ponder_state: &mut Option<PonderState>) -> Result<()> {
+fn cleanup_ponder<E: UsiEngineDriver + ?Sized>(
+    engine: &mut E,
+    ponder_state: &mut Option<PonderState>,
+) -> Result<()> {
     if ponder_state.take().is_some() {
         engine.stop_and_wait()?;
     }

--- a/crates/rshogi-csa-client/tests/lib_consumer.rs
+++ b/crates/rshogi-csa-client/tests/lib_consumer.rs
@@ -14,7 +14,7 @@ use rshogi_csa_client::{
     MoveEvent, MovePlayer, NoopSessionEventSink, ReconnectState, RecordedMove, SearchInfo,
     SearchInfoEmitPolicy, SearchInfoSnapshot, SearchOrigin, SearchOutcome, SessionError,
     SessionEventSink, SessionOutcome, SessionProgress, Side, SinkError, TransportTarget, UsiEngine,
-    run_game_session, run_game_session_with_events, run_resumed_session,
+    UsiEngineDriver, run_game_session, run_game_session_with_events, run_resumed_session,
     run_resumed_session_with_events,
 };
 
@@ -58,8 +58,10 @@ fn build_only() {
                          _: SinkError| {};
     let consume_funcs: (fn(_, _, _, _) -> _, fn(_, _, _, _) -> _) =
         (run_game_session, run_resumed_session);
-    // 新 API は generic なので関数ポインタ型にキャストせず、`run_game_session_with_events`
-    // / `run_resumed_session_with_events` の名前解決だけ強制する。
+    // 新 API は engine / sink の両方に対して generic なので、関数ポインタ型として
+    // `&mut UsiEngine` 受けと `&mut dyn UsiEngineDriver` 受けの両形を確認する。
+    // どちらも `run_game_session_with_events` / `run_resumed_session_with_events` の
+    // monomorphize 経路を通り、consumer が自前の dyn dispatch を構築できることを保証する。
     type WithEventsFn = fn(
         &CsaClientConfig,
         &mut CsaConnection,
@@ -67,9 +69,46 @@ fn build_only() {
         std::sync::Arc<std::sync::atomic::AtomicBool>,
         &mut NoopSessionEventSink,
     ) -> Result<SessionOutcome, SessionError>;
-    let _events_funcs: (WithEventsFn, WithEventsFn) =
+    let events_funcs: (WithEventsFn, WithEventsFn) =
         (run_game_session_with_events, run_resumed_session_with_events);
-    // dyn-coercion 確認
-    let _: Option<&mut dyn SessionEventSink> = None;
-    let _ = (consume_types, consume_funcs);
+
+    // `&mut dyn UsiEngineDriver` を `run_game_session_with_events` /
+    // `run_resumed_session_with_events` に渡せることを build-only で確認する。
+    // 関数ポインタへキャストすると `for<'a> &'a mut dyn Trait + 'a` と
+    // 個別の lifetime ジェネリクス引数が衝突するため、call site の型推論で固定する。
+    fn consume_dyn_engine_with_events(
+        cfg: &CsaClientConfig,
+        conn: &mut CsaConnection,
+        engine: &mut dyn UsiEngineDriver,
+        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        sink: &mut dyn SessionEventSink,
+    ) {
+        if false {
+            let _ = run_game_session_with_events(cfg, conn, engine, shutdown.clone(), sink);
+            let _ = run_resumed_session_with_events(cfg, conn, engine, shutdown, sink);
+        }
+    }
+
+    // `UsiEngine` が `UsiEngineDriver` を実装していることを type-level で固定する。
+    // generic 関数 `takes::<UsiEngine>` が monomorphize できれば trait bound check が
+    // 通っている証跡になる。値は使わず `assert_usi_engine_implements_driver` 関数として
+    // 名前解決自体を `consume_funcs` 経由で参照させる。
+    fn takes_engine<E: UsiEngineDriver + ?Sized>(_: &mut E) {}
+    let assert_usi_engine_implements_driver: fn(&mut UsiEngine) = takes_engine::<UsiEngine>;
+
+    // dyn-coercion 確認 (None でも `&mut dyn Trait` の型推論を強制)
+    let dyn_sink_slot: Option<&mut dyn SessionEventSink> = None;
+    let dyn_engine_slot: Option<&mut dyn UsiEngineDriver> = None;
+
+    // 値そのものは使わず、`let _ = (...);` で discard することで未使用警告を抑える
+    // (`_var` prefix の警告抑止ではなく、tuple 全体を pattern として _ に束縛する idiom)。
+    let _ = (
+        consume_types,
+        consume_funcs,
+        events_funcs,
+        consume_dyn_engine_with_events,
+        assert_usi_engine_implements_driver,
+        dyn_sink_slot,
+        dyn_engine_slot,
+    );
 }

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -30,7 +30,9 @@ use rshogi_csa_client::events::{
     SessionEventSink, SessionProgress, SinkError,
 };
 use rshogi_csa_client::protocol::CsaConnection;
-use rshogi_csa_client::session::{run_game_session_with_events, run_resumed_session_with_events};
+use rshogi_csa_client::session::{
+    run_game_session, run_game_session_with_events, run_resumed_session_with_events,
+};
 
 // ────────────────────────────────────────────
 // 共通: mock CSA TCP server / mock USI engine 生成
@@ -651,6 +653,66 @@ fn external_shutdown_emits_shutdown_disconnected_and_returns_shutdown_error() {
     }
     let events = events.lock().unwrap().clone();
     assert!(events.contains(&"Disconnected:Shutdown"), "events: {events:?}");
+}
+
+/// 既存 `run_game_session(&AtomicBool)` 経路でも、外部から立てた shutdown が
+/// `drive_session` 内のループで観測されて `SessionError::Shutdown` で抜けることを
+/// 確認する regression test。`Arc<AtomicBool>` 化に伴う snapshot 問題を起こさない
+/// ための再発防止 guard。
+#[test]
+fn external_shutdown_observed_through_legacy_run_game_session() {
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-legacy-sd");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        let _ = read_line(reader); // AGREE
+        write_lines(writer, &["START:g-legacy-sd"]);
+        loop {
+            let mut buf = String::new();
+            match reader.read_line(&mut buf) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    let trimmed = buf.trim_end_matches(['\r', '\n']);
+                    if trimmed.contains("LOGOUT") {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        config.game.ponder,
+        Duration::from_secs(5),
+    )
+    .expect("spawn engine");
+
+    let shutdown_signal = Arc::clone(&shutdown);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(300));
+        shutdown_signal.store(true, Ordering::SeqCst);
+    });
+
+    // 既存 API: `&AtomicBool` (Arc 介さず参照を直接渡す)
+    let outcome = run_game_session(&mut conn, &mut engine, &config, shutdown.as_ref());
+
+    engine.quit();
+
+    match outcome {
+        Err(SessionError::Shutdown) => {}
+        other => panic!("expected SessionError::Shutdown via legacy API, got {other:?}"),
+    }
 }
 
 // ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- UsiEngineDriver trait (6 method: new_game / go_with_info / go_ponder / ponderhit_with_info / stop_and_wait / gameover) を追加
- 既存 UsiEngine は trait の reference impl として保持、各 method を既存実装に forward する shim
- run_game_session_with_events / run_resumed_session_with_events を generic `<E, S>` に変更
- 内部 drive_session / SessionState / run_session_loop / cleanup_ponder / handle_search_outcome_with_origin / send_bestmove_and_wait_echo / handle_opponent_move_line にも engine generic を伝播
- shutdown は drive_session 内部で `&AtomicBool` 統一、`*_with_events` から `Arc<AtomicBool>::as_ref()` で渡す (snapshot 化なし)
- 既存 run_game_session / run_resumed_session の API シグネチャは互換維持
- crate root に UsiEngineDriver を pub use、SearchOutcome::ServerInterrupt / InfoCallback / 各 trait method に contract doc を明記
- Closes #574

## Test plan
- [x] cargo build (default / --no-default-features --features tcp / --no-default-features --features websocket) 全成功
- [x] cargo test --workspace 全 green
- [x] cargo clippy --workspace --all-targets --tests -- -D warnings 警告ゼロ
- [x] wasm32 check (rshogi-csa-server-workers) 成功
- [x] tests/lib_consumer.rs で &mut dyn UsiEngineDriver build-only smoke 通過
- [x] shutdown observability test (Arc<AtomicBool> 経由 / &AtomicBool 経由 両方) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)