### PR TITLE
feat(spsa): observability layer (iter 0 + startup summary + stderr 統一) (PR2/3)

### DIFF
--- a/crates/tools/docs/spsa_runbook.md
+++ b/crates/tools/docs/spsa_runbook.md
@@ -159,20 +159,83 @@ cargo run --release -p tools --bin spsa -- \
 
 スケジュール設定を変更して再開する場合だけ `--force-schedule` を付与する。
 
-### 4.1 `--init-from` と `--resume` の関係
+### 4.1 `--init-from` / `--resume` / `--force-init` の関係 (v3 以降)
 
-`--init-from <canonical>` は **`--params` のパスが存在しない時だけ canonical を
-コピー**し、存在する時は何もしない (resume と同じ挙動)。両者を併用しても安全:
+> ⚠️ **2026-04 破壊的変更 (PR #576 系)**: 旧版は `--init-from` を渡しても
+> `--params` が既存だと **黙ってスキップ** していたため、誤って rshogi default
+> 値で 75,200 ゲーム規模の SPSA を走らせる事故が発生した。v3 以降は同状況で
+> bail し、ユーザに `--resume` か新設 `--force-init` の明示を要求する。
+> `meta.json` の `format_version: 2` は読まない (新規 run dir で fresh start)。
 
-| `--params` 状態 | `--init-from` | `--resume` | 結果 |
-|---|---|---|---|
-| 不在 | 指定 | (指定有無不問) | canonical をコピーして新規開始 (resume は無視) |
-| 存在 | 指定 | 指定 | 既存ファイルから resume (canonical はコピーしない) |
-| 存在 | 指定 | 未指定 | 既存ファイルを読んで新規 SPSA 反復開始 |
-| 存在 | 未指定 | 指定 | 既存ファイル + meta.json から resume |
+#### 状態遷移マトリクス (16 通り全網羅)
 
-`--init-from` を毎回指定しておけば「初回は canonical から、2 回目以降は前回の続き」
-という運用が 1 コマンドで書ける。
+純粋関数 `decide_init_action(has_init_from, params_exists, resume, force_init)`
+で意思決定。下表で `-` はワイルドカード (該当列の値に関わらず同じ結果)。
+
+| `--params` | `--init-from` | `--resume` | `--force-init` | 結果 |
+|---|---|---|---|---|
+| 不在 | 指定 | - | - | canonical を copy して fresh start |
+| 不在 | 指定 | - | ✓ | **bail** (force-init は既存対象が必要) |
+| 不在 | 指定 | ✓ | - | **bail** (resume は既存 params 必須) |
+| 不在 | 未指定 | - | - | **bail** (入力なし) |
+| 不在 | 未指定 | ✓ | - | **bail** (resume は既存 params 必須) |
+| 存在 | 指定 | - | - | **bail** ★ 旧 silent skip 経路。`--resume` か `--force-init` を明示 |
+| 存在 | 指定 | ✓ | - | resume (整合性 diagnostic 出力) |
+| 存在 | 指定 | - | ✓ | atomic 上書き (meta/CSV 削除 → params replace) |
+| 存在 | 未指定 | - | - | 既存 params で fresh start (旧来の通常動作) |
+| 存在 | 未指定 | ✓ | - | 通常 resume (meta hash 検証) |
+| - | - | ✓ | ✓ | **bail** (resume と force-init は意味が矛盾) |
+| - | 未指定 | - | ✓ | **bail** (force-init は init-from が必要) |
+
+> 注: 表は実装上の同値クラスでまとめており 12 行だが、`(--resume + --force-init = ✓✓)`
+> や `(force-init + --init-from 未指定)` の行はワイルドカードで複数組合せを束ねている
+> ため、4 軸 16 通りすべてが一意に分類される。完全網羅性は単体テスト
+> `decide_covers_all_sixteen_combinations` で担保。
+
+#### 推奨運用パターン
+
+```bash
+RUN_DIR="runs/spsa/$(date -u +%Y%m%d_%H%M%S)_yo_suisho10"
+mkdir -p "${RUN_DIR}"
+
+# 1 回目: --params 不在 → canonical を copy して開始
+spsa --params "${RUN_DIR}/tuned.params" --init-from tune/suisho10.params ...
+
+# 続き (resume): 既存 params + canonical 整合性検証
+spsa --params "${RUN_DIR}/tuned.params" --init-from tune/suisho10.params --resume ...
+
+# 既存 run を破棄して canonical から作り直す:
+spsa --params "${RUN_DIR}/tuned.params" --init-from tune/suisho10.params --force-init ...
+```
+
+#### 関連フラグ
+
+- **`--force-init`**: 既存 `--params` を atomic 上書きして再初期化。`--resume` と排他。
+  - 順序: meta 削除 (失敗で bail) → 関連 CSV 削除 (best-effort warn) → params atomic copy。
+    逆順だと中断時に「新 params + 旧 meta」の不整合 run dir が残る。
+- **`--strict-init-check`**: `--resume` + `--init-from` 時に整合性が
+  median ≥ 0.5σ または max ≥ 5σ を超えたら bail (デフォルトは warn)。CI 等で
+  「想定外の resume」を早期検知したい場合に使う。
+
+#### 起動時 startup summary
+
+v3 以降、SPSA 起動直後に `=== SPSA Startup Summary ===` ブロックが stderr に
+出る (init mode、params/init-from の sha256、active param 数、上位 5 件の値)。
+出力先 stderr なので CSV パイプ運用 (`tee`) を阻害しない。「想定外の値で
+スタートしている」事故を 5 秒で目視検出可能。
+
+> ⚠️ **breaking change (PR #576 続編)**: v3 以降、SPSA の進行ログ・per-game
+> progress (`iter=N seed=X game=Y outcome=...`) ・iter end summary ・early-stop
+> trigger は **すべて stderr に統一** された (旧 stdout)。既存の運用スクリプトが
+> stdout からこれらをパースしていた場合は壊れる。stdout は CSV writer (file 出力)
+> および将来の構造化出力専用。両方を 1 つのログに残したい場合は `2>&1 | tee log.txt`。
+
+#### iter 0 スナップショット
+
+`tuned.params.values.csv` の先頭に **`iteration,foo,bar,...` の next 行として
+`0, <初期値>, ...`** が記録される (fresh / force-init / use-existing-fresh 時のみ。
+resume 時は append のため重複しない)。事故解析時に「最初に何で起動したか」を
+CSV だけで完全に追える。
 
 ## 5. 可視化用CSV変換（任意）
 
@@ -919,10 +982,25 @@ python3 /path/to/rshogi/tune/tune.py apply /tmp/tuned_yo.params source/
 - `--strict-range` を付けるとエラーで止まる。一時的に `--base` の range を広げるか、
   該当 param を `unmapped` に移して翻訳対象から外す
 
-### `init-from: ... already exists, leaving as-is` で意図しない値で開始される
+### `init/resume 設定エラー: --init-from が指定されていますが --params パスは既に存在します`
 
-- `--params <path>` のファイルが残っており resume 扱いされた可能性。新規実行なら
-  `--params` を timestamped 新規パスにする
+- v3 (PR #576) で導入された安全 bail。旧版の silent skip 経路を排除した。
+- 解決策はメッセージにある通り 3 通り:
+  - **続行したい** → `--resume` を追加 (canonical との整合性も diagnostic 出力される)
+  - **既存を破棄して canonical から作り直したい** → `--force-init` を追加
+  - **そもそも指定ミス** → 既存ファイルを `rm` するか、`--params` を新規 timestamped パスにする
+- 推奨は **`--params runs/spsa/<ts>/tuned.params`** のように毎回 timestamped dir を切ること
+
+### `meta format version 不一致 (got v2, expected v3)`
+
+- v3 (PR #576) で meta 形式に hash 群を追加し、後方互換は破棄した
+- v2 meta を持つ run dir は resume 不可。新規 run dir で `--init-from <canonical>` から
+  fresh start する (旧 run の `tuned.params` の値は手動で確認の上 `--init-from` 指定可)
+
+### `param 名集合が meta と不一致です`
+
+- mapping 表に param を追加 / 削除した状態で過去 run を resume しようとした場合に発生
+- 現状 escape hatch なし (PR2 系で検討中)。新規 run dir で fresh start する
 
 ### `info: N param(s) matched --active-only-regex but are unmapped`
 

--- a/crates/tools/docs/spsa_runbook.md
+++ b/crates/tools/docs/spsa_runbook.md
@@ -159,13 +159,14 @@ cargo run --release -p tools --bin spsa -- \
 
 スケジュール設定を変更して再開する場合だけ `--force-schedule` を付与する。
 
-### 4.1 `--init-from` / `--resume` / `--force-init` の関係 (v3 以降)
+### 4.1 `--init-from` / `--resume` / `--force-init` の関係
 
 > ⚠️ **2026-04 破壊的変更 (PR #576 系)**: 旧版は `--init-from` を渡しても
 > `--params` が既存だと **黙ってスキップ** していたため、誤って rshogi default
-> 値で 75,200 ゲーム規模の SPSA を走らせる事故が発生した。v3 以降は同状況で
+> 値で 75,200 ゲーム規模の SPSA を走らせる事故が発生した。本変更以降は同状況で
 > bail し、ユーザに `--resume` か新設 `--force-init` の明示を要求する。
-> `meta.json` の `format_version: 2` は読まない (新規 run dir で fresh start)。
+> `meta.json` のフォーマットも更新したため、旧形式 (`format_version: 2`) を持つ
+> 既存 run dir は resume 不可 (移行手順は §10.7 参照)。
 
 #### 状態遷移マトリクス (16 通り全網羅)
 
@@ -219,12 +220,12 @@ spsa --params "${RUN_DIR}/tuned.params" --init-from tune/suisho10.params --force
 
 #### 起動時 startup summary
 
-v3 以降、SPSA 起動直後に `=== SPSA Startup Summary ===` ブロックが stderr に
+2026-04 以降、SPSA 起動直後に `=== SPSA Startup Summary ===` ブロックが stderr に
 出る (init mode、params/init-from の sha256、active param 数、上位 5 件の値)。
 出力先 stderr なので CSV パイプ運用 (`tee`) を阻害しない。「想定外の値で
 スタートしている」事故を 5 秒で目視検出可能。
 
-> ⚠️ **breaking change (PR #576 続編)**: v3 以降、SPSA の進行ログ・per-game
+> ⚠️ **breaking change (PR #576 続編)**: SPSA の進行ログ・per-game
 > progress (`iter=N seed=X game=Y outcome=...`) ・iter end summary ・early-stop
 > trigger は **すべて stderr に統一** された (旧 stdout)。既存の運用スクリプトが
 > stdout からこれらをパースしていた場合は壊れる。stdout は CSV writer (file 出力)
@@ -954,6 +955,57 @@ python3 /path/to/rshogi/tune/tune.py apply /tmp/tuned_yo.params source/
 `apply` 後、`%%TUNE_DECLARATION%%` 等のマーカーは消え、注入された `TUNE(...)` も実定数に
 置換される。production ビルドして完了。元の状態に戻したい場合は `git checkout source/`。
 
+### 10.7 旧 meta 形式 (`format_version: 2`) の run dir 移行
+
+2026-04 (PR #576 系) 以降は `meta.json` のフォーマットが更新されたため、
+旧形式を持つ既存 run dir をそのまま `--resume` すると下記エラーで停止する:
+
+```
+meta format version 不一致 (got v2, expected v3) in <path>.
+v2 形式は v3 とは互換性がありません。
+新規 run dir で `--init-from <canonical>` から fresh start してください。
+```
+
+**移行できないもの**:
+- `completed_iterations` / `total_games` / 各 seed の累積 SPSA 状態の継承
+  (新フォーマットには起動時の hash 群が必要だが、旧 meta には記録されていない)
+
+**移行できるもの**:
+- 旧 run の `tuned.params` (チューニング途中の値) を **新規 run の `--init-from`
+  ソース** として再利用する
+
+#### 移行手順 (continuation 相当)
+
+```bash
+# 1. 旧 run のディレクトリを退避 (誤って上書きしないよう保存)
+OLD_RUN="runs/spsa/20260401_120000_oldrun"
+NEW_RUN="runs/spsa/$(date -u +%Y%m%d_%H%M%S)_resumed_from_oldrun"
+mkdir -p "${NEW_RUN}"
+
+# 2. 旧 run の最終 params を新 run の --init-from ソースとして使う
+#    (生 params のコピーで OK。meta は捨てる)
+cp "${OLD_RUN}/tuned.params" "${NEW_RUN}/seed_from_oldrun.params"
+
+# 3. 新 run を fresh start として起動 (iter は 0 からカウントし直し)
+cargo run --release -p tools --bin spsa -- \
+  --params "${NEW_RUN}/tuned.params" \
+  --init-from "${NEW_RUN}/seed_from_oldrun.params" \
+  --iterations <残りたい iter 数> \
+  --games-per-iteration 64 ...
+```
+
+#### 注意点
+
+- **iter 数が連続しなくなる**: 新 run の iter 1 は旧 run の続きでなく、
+  「旧 run の最終値を初期値とする新規 SPSA ラン」になる。schedule の `c_k`
+  も最初から (大きい摂動) で始まるため、旧 run 末尾と同じ収束領域に戻るには
+  数十 iter ほど要する場合がある。
+- **stats / values CSV は引き継がない**: 旧 run の CSV は別ファイルとして保管し、
+  集計時に手動で結合する。新 run の CSV は iter 0 から記録される。
+- **完全な「途中から再開」が必要なら**: 旧 run を実行した古いバイナリで継続する
+  しかない (`git checkout` で古いコミットに戻すのは可)。本ツールチェイン上では
+  旧フォーマットのサポートを完全に放棄している。
+
 ## 11. トラブルシューティング
 
 実機での typical な詰まりどころと対処（症状ベース）。
@@ -984,7 +1036,7 @@ python3 /path/to/rshogi/tune/tune.py apply /tmp/tuned_yo.params source/
 
 ### `init/resume 設定エラー: --init-from が指定されていますが --params パスは既に存在します`
 
-- v3 (PR #576) で導入された安全 bail。旧版の silent skip 経路を排除した。
+- 2026-04 (PR #576) で導入された安全 bail。旧版の silent skip 経路を排除した。
 - 解決策はメッセージにある通り 3 通り:
   - **続行したい** → `--resume` を追加 (canonical との整合性も diagnostic 出力される)
   - **既存を破棄して canonical から作り直したい** → `--force-init` を追加
@@ -993,9 +1045,10 @@ python3 /path/to/rshogi/tune/tune.py apply /tmp/tuned_yo.params source/
 
 ### `meta format version 不一致 (got v2, expected v3)`
 
-- v3 (PR #576) で meta 形式に hash 群を追加し、後方互換は破棄した
-- v2 meta を持つ run dir は resume 不可。新規 run dir で `--init-from <canonical>` から
-  fresh start する (旧 run の `tuned.params` の値は手動で確認の上 `--init-from` 指定可)
+- 2026-04 (PR #576) で meta 形式に hash 群を追加し、後方互換は破棄した
+- 旧形式 (`format_version: 2`) の meta を持つ run dir は resume 不可。
+  新規 run dir で `--init-from <canonical>` から fresh start する (旧 run の
+  `tuned.params` を活かしたい場合は §10.7 の移行手順を参照)
 
 ### `param 名集合が meta と不一致です`
 

--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -345,6 +345,20 @@ enum InitMode {
     Resume,
 }
 
+impl std::fmt::Display for InitMode {
+    /// stderr/log 表示用 kebab-case 文字列。`meta.json` の serde 表現と一致させる
+    /// ことで「何が記録されたか」「何が起動したか」を視覚的に紐付けやすくする。
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::FreshInitFrom => "fresh-init-from",
+            Self::FreshExisting => "fresh-existing",
+            Self::ForceInit => "force-init",
+            Self::Resume => "resume",
+        };
+        f.write_str(s)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct IterationStats {
     iteration: u32,
@@ -1787,7 +1801,7 @@ fn run_seed_games_parallel(ctx: SeedRunContext<'_>) -> Result<SeedGameStats> {
             } else {
                 draws += 1;
             }
-            println!(
+            eprintln!(
                 "iter={} seed={}/{}({}) game={}/{} plus_is_black={} outcome={} plus_score={:+.1}",
                 iteration,
                 seed_idx + 1,
@@ -1808,6 +1822,99 @@ fn run_seed_games_parallel(ctx: SeedRunContext<'_>) -> Result<SeedGameStats> {
             draws,
         })
     })
+}
+
+/// `print_startup_summary` の入力をまとめた構造体。位置引数の取り違えを防ぎ、
+/// 将来項目を増やしても呼び出し側の修正が小さくなる。
+struct StartupContext<'a> {
+    snapshot: &'a InitMetaSnapshot,
+    schedule: &'a ScheduleConfig,
+    params: &'a [SpsaParam],
+    active_mask: &'a [bool],
+    active_param_count: usize,
+    start_iteration: u32,
+    end_iteration: u32,
+    seed_values: &'a [u64],
+    params_path: &'a Path,
+    meta_path: &'a Path,
+}
+
+/// scalar (i32 想定の f64) を `is_int` に応じて整形する小ヘルパ。`frac` は
+/// 浮動小数時の有効桁。startup summary 内の value/min/max を統一表記するため。
+fn fmt_param_scalar(p: &SpsaParam, v: f64, frac: usize) -> String {
+    if p.is_int {
+        format!("{}", v.round() as i64)
+    } else {
+        format!("{:.*}", frac, v)
+    }
+}
+
+/// SPSA 起動時に「どんな状態で SPSA を始めるのか」を 1 ブロックで stderr に出力する。
+///
+/// 75,200 ゲーム規模の事故を起こした silent footgun の二度目の予防線として、
+/// 「init mode が想定通り」「active params 上位 5 件が想定値」を起動 5 秒で目視確認
+/// できる形にする。出力先は stderr なので CSV パイプ運用 (`spsa | tee log.csv`) を
+/// 阻害しない。
+fn print_startup_summary(ctx: &StartupContext<'_>) {
+    eprintln!("=== SPSA Startup Summary ===");
+    eprintln!("init mode:      {}", ctx.snapshot.init_mode);
+    eprintln!("params:         {}", ctx.params_path.display());
+    eprintln!("meta:           {}", ctx.meta_path.display());
+    eprintln!("params sha256:  {} (起動時スナップショット)", ctx.snapshot.init_params_sha256);
+    if let (Some(p), Some(h)) =
+        (ctx.snapshot.init_from_path.as_deref(), ctx.snapshot.init_from_sha256.as_deref())
+    {
+        eprintln!("--init-from:    {p} (sha256: {h})");
+    } else {
+        eprintln!("--init-from:    (none)");
+    }
+    eprintln!("engine:         {}", ctx.snapshot.engine_path);
+    if let Some(p) = ctx.snapshot.engine_param_mapping_path.as_deref() {
+        let h = ctx.snapshot.engine_param_mapping_sha256.as_deref().unwrap_or("?");
+        eprintln!("mapping:        {p} (sha256: {h})");
+    }
+    eprintln!(
+        "schedule:       α={} γ={} a_ratio={} mobility={} total_iter={}",
+        ctx.schedule.alpha,
+        ctx.schedule.gamma,
+        ctx.schedule.a_ratio,
+        ctx.schedule.mobility,
+        ctx.schedule.total_iterations
+    );
+    eprintln!(
+        "iteration plan: {} → {} ({} new iter), seeds={:?}",
+        ctx.start_iteration,
+        ctx.end_iteration,
+        ctx.end_iteration.saturating_sub(ctx.start_iteration),
+        ctx.seed_values
+    );
+    eprintln!("active params:  {}/{}", ctx.active_param_count, ctx.params.len());
+
+    // 起動時 active params の上位 5 件を表示。
+    // active_mask を使うことで「active_only_regex / mapping translator で除外された
+    // param が誤って summary に出る」のを防ぐ (not_used フィルタだけだと不十分)。
+    let preview: Vec<&SpsaParam> = ctx
+        .params
+        .iter()
+        .zip(ctx.active_mask.iter())
+        .filter(|(_, a)| **a)
+        .map(|(p, _)| p)
+        .take(5)
+        .collect();
+    if !preview.is_empty() {
+        eprintln!("starting values (first 5 of {} active params):", ctx.active_param_count);
+        for p in preview {
+            eprintln!(
+                "  {:<48} = {:>10} (range [{}, {}], step {})",
+                p.name,
+                fmt_param_scalar(p, p.value, 4),
+                fmt_param_scalar(p, p.min, 2),
+                fmt_param_scalar(p, p.max, 2),
+                p.c_end
+            );
+        }
+    }
+    eprintln!("=== End Summary ===");
 }
 
 fn main() -> Result<()> {
@@ -1872,7 +1979,7 @@ fn main() -> Result<()> {
     if seed_values.is_empty() {
         bail!("at least one seed is required");
     }
-    println!("using base seeds: {:?}", seed_values);
+    eprintln!("using base seeds: {:?}", seed_values);
 
     // --parallel-seeds 指定時、`cli.concurrency` が seed 数で割り切れない、または
     // 1 seed あたりの worker 数が `games_per_iteration` を超える設定だと実効並列度が
@@ -2095,6 +2202,25 @@ fn main() -> Result<()> {
         None
     };
 
+    // iter 0 スナップショット: 起動時の params を記録する (fresh / force-init / use-existing-fresh)。
+    // resume 時は既存 CSV に既に iter 0 行が含まれる前提で append 継続するため、ここではスキップ。
+    // 判定は `effective_action` (NonBailAction) で行うことで、ユーザが手動で
+    // `meta.completed_iterations: 0` を作って --resume したエッジケースで重複書きを防ぐ
+    // (`start_iteration == 0` だけだとそのケースで誤って iter 0 行を append してしまう)。
+    // これがあれば事故解析時 (今回の rshogi default 混入) に「最初に何で起動したか」を CSV だけで追える。
+    let is_fresh_start = matches!(
+        effective_action,
+        NonBailAction::CopyInitFromFresh
+            | NonBailAction::UseExistingFresh
+            | NonBailAction::ForceInitOverwrite,
+    );
+    if is_fresh_start && let Some(writer) = param_values_csv_writer.as_mut() {
+        write_param_values_csv_row(writer, 0, &params)?;
+        // 即 flush: iter 1 完了前にクラッシュしても iter 0 行を CSV に残し、
+        // 「何で起動したか」を後追い解析できるようにする (事故解析用途で必須)。
+        writer.flush()?;
+    }
+
     if cli.startpos_file.is_none() {
         if cli.require_startpos_file {
             bail!("--require-startpos-file was set but --startpos-file was not provided");
@@ -2120,7 +2246,7 @@ fn main() -> Result<()> {
             cli.active_only_regex
         );
     }
-    println!("active params: {active_param_count}/{}", params.len());
+    eprintln!("active params: {active_param_count}/{}", params.len());
 
     // 翻訳器有効時、`active_only_regex` でマッチしたが unmapped で除外されたパラメータを
     // info 出力する。「期待した parameter が摂動されていない」事象に気づきやすくする。
@@ -2136,15 +2262,28 @@ fn main() -> Result<()> {
             .collect();
         if !unmapped_active.is_empty() {
             unmapped_active.sort();
-            println!(
+            eprintln!(
                 "info: {} param(s) matched --active-only-regex but are unmapped (translator skipped):",
                 unmapped_active.len()
             );
             for n in &unmapped_active {
-                println!("  - {n}");
+                eprintln!("  - {n}");
             }
         }
     }
+
+    print_startup_summary(&StartupContext {
+        snapshot: &init_snapshot,
+        schedule: &schedule,
+        params: &params,
+        active_mask: &active_mask,
+        active_param_count,
+        start_iteration,
+        end_iteration,
+        seed_values: &seed_values,
+        params_path: &cli.params,
+        meta_path: &meta_path,
+    });
 
     // 公平な対局条件のため、tournament と同様に NetworkDelay=0 と
     // MinimumThinkingTime をデフォルトで注入する。ユーザーが明示的に
@@ -2446,7 +2585,7 @@ fn main() -> Result<()> {
             init_mode: init_snapshot.init_mode,
         };
         save_meta(&meta_path, &meta)?;
-        println!(
+        eprintln!(
             "iter={} seeds={} raw_result_mean={:+.3} raw_result_var={:.6} \
              avg_abs_update={:.6} max_abs_update={:.6} checkpoint={} meta={}",
             iter + 1,
@@ -2487,7 +2626,7 @@ fn main() -> Result<()> {
             } else {
                 early_stop_consecutive = 0;
             }
-            println!(
+            eprintln!(
                 "iter={} early_stop_hit={} consecutive={}/{} thresholds(avg_abs_update<={:.6}, result_variance<={:.6})",
                 iter + 1,
                 early_stop_hit,
@@ -2497,7 +2636,7 @@ fn main() -> Result<()> {
                 config.result_variance_threshold
             );
             if early_stop_consecutive >= config.patience {
-                println!(
+                eprintln!(
                     "early stop triggered at iter={} (consecutive={})",
                     iter + 1,
                     early_stop_consecutive
@@ -2885,6 +3024,20 @@ mod tests {
         assert!(result.is_err(), "should bail when meta removal fails");
         // params は触られていない (atomic copy が走らない)
         assert_eq!(std::fs::read(&target_params).unwrap(), b"old content\n");
+    }
+
+    #[test]
+    fn init_mode_display_matches_serde_kebab_case() {
+        // Display と serde 表現を一致させる契約 (startup summary の表記と
+        // meta.json の値が同じ文字列で見えることを担保)
+        assert_eq!(format!("{}", InitMode::FreshInitFrom), "fresh-init-from");
+        assert_eq!(format!("{}", InitMode::FreshExisting), "fresh-existing");
+        assert_eq!(format!("{}", InitMode::ForceInit), "force-init");
+        assert_eq!(format!("{}", InitMode::Resume), "resume");
+
+        // serde で round-trip して同じ文字列で出ることも確認
+        let json = serde_json::to_string(&InitMode::FreshInitFrom).unwrap();
+        assert_eq!(json, "\"fresh-init-from\"");
     }
 
     #[test]

--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -198,11 +198,11 @@ struct Cli {
     /// 正本 `.params` の上書き保護用。`--params` のパスが存在しない場合に
     /// `<init-from>` の内容をコピーしてから SPSA を開始する。
     ///
-    /// **挙動 (v3 以降):** 既に `--params` が存在する場合、`--resume` か
-    /// `--force-init` のどちらかを明示しないと bail する。これは旧版の
-    /// 「既存ファイルを黙って初期値として使う」挙動が rshogi default 値の
-    /// 混入による事故を引き起こしたための安全対策。
-    /// 詳細は `crates/tools/docs/spsa_runbook.md` §10.6 参照。
+    /// **挙動 (2026-04 / PR #576 以降):** 既に `--params` が存在する場合、
+    /// `--resume` か `--force-init` のどちらかを明示しないと bail する。
+    /// これは旧版の「既存ファイルを黙って初期値として使う」挙動が rshogi
+    /// default 値の混入による事故を引き起こしたための安全対策。
+    /// 詳細は `crates/tools/docs/spsa_runbook.md` §4.1 参照。
     #[arg(long)]
     init_from: Option<PathBuf>,
 

--- a/tune/README.md
+++ b/tune/README.md
@@ -90,6 +90,26 @@ cargo run --release -p tools --bin check_param_mapping -- \
   --yo-binary /path/to/YaneuraOu-tune-patched
 ```
 
+## 注意: 中間 `.params` ファイルを SPSA `--params` に直接渡さない
+
+`yo_to_rshogi_params` / `rshogi_to_yo_params` の出力ファイル (例:
+`from_rshogi.params`, `from_yo.params`) は **ラウンドトリップ確認や apply 前の
+焼き戻し用** であり、SPSA の `--params` に直接渡すとそのファイルが反復ごとに
+上書きされる。
+
+過去 (2026-04) に、`rshogi_to_yo_params` の出力 (rshogi default 値が YO 名で
+書かれたファイル) を SPSA に投入して 75,200 ゲーム規模のチューニングが台無し
+になる事故が発生した。
+
+**正しい運用**:
+- 正本ファイル (`tune/suisho10.params` 等) は `--init-from` に指定する
+- 反復用ファイルは `--params runs/spsa/<ts>/tuned.params` のように毎回
+  timestamped dir に置く
+- 起動時に出る `=== SPSA Startup Summary ===` で **init mode と上位 5 件の値**
+  が想定通りかを目視確認する
+
+詳細は `crates/tools/docs/spsa_runbook.md` §4.1 参照。
+
 ## 関連ドキュメント
 
 - `crates/tools/docs/spsa_runbook.md` — SPSA 実行 runbook (本ディレクトリの全コマンド例 + トラブルシューティング)


### PR DESCRIPTION
## Summary

PR1 (#576) の safety core を観測面から補完する 2 つ目の PR。silent footgun の二重防御 (止める + 気付ける) を完成させる。

**重要: ベースブランチは \`worktree-spsa-init-safety-core\` (PR1)** です。PR1 マージ後にこの PR の base を main に切り替えるか、stack PR としてレビューしてください。

## 主要変更

### iter 0 スナップショット
\`effective_action\` (\`NonBailAction\`) で fresh / use-existing-fresh / force-init 時のみ values.csv に iter 0 行を書く。手動で \`meta.completed_iterations:0\` + \`--resume\` のエッジで重複書きしないよう、\`start_iteration == 0\` ではなく明示的に判定。即 flush で iter 1 完了前 crash でも CSV に開始値が残る。

### Startup summary
起動直後に \`=== SPSA Startup Summary ===\` ブロックを stderr に出力 (init mode、params/init-from の sha256、active 数、上位 5 件の値)。「想定外の値で start している」を 5 秒で目視検出可能。\`active_mask\` で active のみに絞り込み、\`fmt_param_scalar\` ヘルパで is_int 分岐を統一。

\`\`\`
=== SPSA Startup Summary ===
init mode:      fresh-init-from
params:         runs/spsa/.../tuned.params
meta:           runs/spsa/.../tuned.params.meta.json
params sha256:  bb326... (起動時スナップショット)
--init-from:    tune/suisho10.params (sha256: bb326...)
engine:         /path/to/YaneuraOu-tune-patched
schedule:       α=0.602 γ=0.101 a_ratio=0.1 mobility=1 total_iter=200
iteration plan: 0 → 200 (200 new iter), seeds=[1,2,3,4]
active params:  102/102
starting values (first 5 of 102 active params):
  correction_value_1                              =       8164 (range [0, 17734], step 886.7)
  ...
=== End Summary ===
\`\`\`

### \`InitMode::Display\`
kebab-case 文字列を返す Display (\`fresh-init-from\` 等)。serde 表現と一致するよう \`init_mode_display_matches_serde_kebab_case\` テストで担保。

### stdout/stderr 統一
\`println!\` → \`eprintln!\` 全面置換。stdout は CSV writer (file 出力) と将来の構造化出力専用に。既存スクリプトが stdout からログをパースしていた場合は壊れる。runbook §4.1 で breaking change を明示。

### ドキュメント
- \`crates/tools/docs/spsa_runbook.md\` §4.1 全面書き換え: 旧 4 行マトリクスを v3 の 12 行 (4 軸 16 通りワイルドカード集約) + 脚注で完全網羅性説明、\`--force-init\` / \`--strict-init-check\` 説明、推奨運用パターン、トラブルシューティング 3 件追加
- \`tune/README.md\` に「中間 \`.params\` を \`--params\` に直接渡さない」注意書き追加 (今回の事故経緯記録)
- \`MEMORY.md\` (auto-memory) に feedback エントリ追加

## レビュー履歴

ローカル code-reviewer 2 ラウンド:
- round 1: Major 3 件 (iter 0 ガード条件 / StartupContext / active_mask) + Minor 6 件
- round 2: 全 Major + Minor m1-m5 + n2 対応確認、**Approve**

## Test plan

- [x] cargo build -p tools --bin spsa
- [x] cargo clippy -p tools --bin spsa --tests (warning 0)
- [x] cargo test -p tools --bin spsa (31 tests, 全 pass)
- [x] cargo fmt
- [x] smoke test: startup summary 出力 + values.csv に iter 0 行記録 + init mode kebab-case 表示

## 後続 PR 予定

- **PR3**: \`rshogi_to_yo_params\` の rshogi default 検知 + \`--allow-rshogi-defaults\` opt-in (事故の上流防御)

🤖 Generated with [Claude Code](https://claude.com/claude-code)