### PR TITLE
feat(rshogi_to_yo_params): rshogi default 値の混入検知 (PR3/3)

### DIFF
--- a/crates/tools/src/bin/rshogi_to_yo_params.rs
+++ b/crates/tools/src/bin/rshogi_to_yo_params.rs
@@ -6,12 +6,21 @@
 //! - YO 側の min/max/step/alpha は `--base` で指定した YO `.params`（例: tune/suisho10.params）
 //!   の値を保持する。`--base` 省略時は rshogi 値を中心に簡易 range を生成する。
 //! - rshogi 独自パラメータ（`unmapped.rshogi`）は YO 出力には含まれない（warn 出力）。
+//!
+//! ## rshogi default 検知 (PR3)
+//!
+//! 入力 rshogi `.params` の値列が `SearchTuneParams::option_specs()` の default と
+//! 95% 以上一致した場合、警告を出す。これは「`generate_spsa_params` の出力をそのまま
+//! 渡してしまった」事故 (2026-04 に 75,200 ゲーム規模の SPSA を台無しにした) の
+//! 再発防止。意図的に default 値から開始したい場合は `--allow-rshogi-defaults` で
+//! 警告を抑制、CI で完全防止したい場合は `--strict-rshogi-defaults` で error 化。
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
+use rshogi_core::search::SearchTuneParams;
 use tools::spsa_param_mapping::{
     MappingTable, ParamRow, load_params, rshogi_to_yo_value, write_params,
 };
@@ -38,6 +47,69 @@ struct Cli {
     /// 範囲外値を検出した時に warning に留めず error にする
     #[arg(long)]
     strict_range: bool,
+
+    /// 入力 rshogi `.params` の値列が rshogi 内部 default と高一致した場合の警告を抑制する。
+    ///
+    /// 意図的に default 値から SPSA を始めたい場合 (新規探索ベースライン作り等) に指定。
+    /// 指定しない場合、95% 以上の一致率で警告 (続行はする)、`--strict-rshogi-defaults`
+    /// 指定時は error で停止。
+    #[arg(long, default_value_t = false)]
+    allow_rshogi_defaults: bool,
+
+    /// rshogi default 値の混入検知を error 化する (CI 用)。
+    ///
+    /// `--allow-rshogi-defaults` と同時指定すると `--allow` が優先され警告自体が出ない。
+    #[arg(long, default_value_t = false)]
+    strict_rshogi_defaults: bool,
+}
+
+/// rshogi default 一致が閾値超過と判定する一致率 (95%)。
+///
+/// `generate_spsa_params` の出力をそのまま入力にすると 100% 一致するので
+/// 確実に発火。本物の SPSA tuned params は数十パーセント単位で値が動くため
+/// 通常は 95% 未満に収まる。意図的に default 開始したい少数派は
+/// `--allow-rshogi-defaults` で警告抑制可能。
+const DEFAULT_MATCH_WARN_RATE: f64 = 0.95;
+
+/// rshogi default 一致検知の結果。
+#[derive(Debug, Clone)]
+struct DefaultMatchReport {
+    /// rshogi default を持つパラメータの総数 (option_specs と入力の交差)
+    checked: usize,
+    /// 上記のうち入力値が default と完全一致したもの
+    matched: usize,
+}
+
+impl DefaultMatchReport {
+    fn match_rate(&self) -> f64 {
+        if self.checked == 0 {
+            0.0
+        } else {
+            self.matched as f64 / self.checked as f64
+        }
+    }
+}
+
+/// 入力 rshogi `.params` の値列が `SearchTuneParams::option_specs()` の default と
+/// どの程度一致しているかを集計する。
+///
+/// 一致率の閾値判定 (95%) は呼び出し側で行う。ここではカウントだけ返す。
+fn detect_rshogi_default_match(rshogi_rows: &[ParamRow]) -> DefaultMatchReport {
+    let defaults: HashMap<&str, i32> = SearchTuneParams::option_specs()
+        .iter()
+        .map(|s| (s.usi_name, s.default))
+        .collect();
+    let mut checked = 0usize;
+    let mut matched = 0usize;
+    for r in rshogi_rows {
+        if let Some(&def) = defaults.get(r.name.as_str()) {
+            checked += 1;
+            if r.value == def {
+                matched += 1;
+            }
+        }
+    }
+    DefaultMatchReport { checked, matched }
 }
 
 /// `--base` がない場合に YO 行を簡易生成する
@@ -66,8 +138,46 @@ fn synthesize_yo_row(yo_name: &str, value: i32) -> ParamRow {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    if cli.allow_rshogi_defaults && cli.strict_rshogi_defaults {
+        bail!(
+            "--allow-rshogi-defaults と --strict-rshogi-defaults は同時指定できません \
+             (前者は警告抑制、後者は warn → error 昇格で意味が矛盾します)"
+        );
+    }
     let table = MappingTable::load(&cli.mapping)?;
     let rshogi_rows = load_params(&cli.rshogi_params)?;
+
+    // rshogi default 一致検知: --allow-rshogi-defaults 指定時はスキップ。
+    // 95% 以上一致なら警告 (or strict 時は error)。意図的な default 開始ユーザの
+    // ノイズを最小化しつつ、事故 (generate_spsa_params 出力混入) は捕捉する。
+    if !cli.allow_rshogi_defaults {
+        let report = detect_rshogi_default_match(&rshogi_rows);
+        // checked == 0 のとき (= 入力に rshogi 名が 1 件も含まれない) は素通し:
+        // YO 名混在ファイル等を「rshogi default 混入事故」と誤検知しないため。
+        // 真の事故 (generate_spsa_params 出力混入) は 100% 一致なので必ず捕捉できる。
+        if report.checked > 0 && report.match_rate() >= DEFAULT_MATCH_WARN_RATE {
+            let msg = format!(
+                "入力 rshogi params の値列が rshogi 内部 default と {}/{} ({:.1}%) 一致しています。\n\
+                 \n  これは以下のどちらかを示唆します:\n\
+                 \n  (a) 意図的に rshogi default 値から SPSA を始めたい (e.g. 新規探索)\n      \
+                 → 警告抑制には --allow-rshogi-defaults を追加してください\n\
+                 \n  (b) `generate_spsa_params` の出力を間違って入力にしてしまった (事故)\n      \
+                 → 入力ファイル ({}) を再確認し、suisho10 等の canonical を渡してください\n\
+                 \n  この変換を SPSA --params に投入すると suisho10 由来でない rshogi default 値で\n  \
+                 SPSA が走り出す可能性があります (2026-04 に 75,200 ゲーム規模の事故事例あり)。",
+                report.matched,
+                report.checked,
+                report.match_rate() * 100.0,
+                cli.rshogi_params.display()
+            );
+            if cli.strict_rshogi_defaults {
+                bail!("--strict-rshogi-defaults: {msg}");
+            } else {
+                eprintln!("warn: {msg}");
+            }
+        }
+    }
+
     let rshogi_by_name: HashMap<&str, &ParamRow> =
         rshogi_rows.iter().map(|r| (r.name.as_str(), r)).collect();
 
@@ -165,4 +275,99 @@ fn main() -> Result<()> {
     eprintln!("wrote {}", cli.output.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_row(name: &str, value: i32) -> ParamRow {
+        ParamRow {
+            name: name.to_string(),
+            kind: "int".to_string(),
+            value,
+            min: 0,
+            max: 1000,
+            step: 50.0,
+            alpha: 0.002,
+            not_used: false,
+        }
+    }
+
+    #[test]
+    fn detect_returns_zero_for_unknown_names() {
+        // mapping にも option_specs にもない名前は checked にカウントされない
+        let rows = vec![
+            make_row("totally_unknown_param", 42),
+            make_row("another_made_up", 99),
+        ];
+        let report = detect_rshogi_default_match(&rows);
+        assert_eq!(report.checked, 0);
+        assert_eq!(report.matched, 0);
+        // match_rate は 0/0 で 0.0 を返す (NaN にならない)
+        assert!((report.match_rate() - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn detect_counts_only_known_specs() {
+        // SearchTuneParams::option_specs() にある最初のパラメータの default を取り、
+        // 一致 / 不一致を構築して checked/matched を確認する
+        let specs = SearchTuneParams::option_specs();
+        assert!(!specs.is_empty(), "option_specs must be non-empty");
+        let first = &specs[0];
+        let rows = vec![
+            make_row(first.usi_name, first.default), // 一致
+            make_row("totally_unknown_param", 42),   // unknown (count されない)
+        ];
+        let report = detect_rshogi_default_match(&rows);
+        assert_eq!(report.checked, 1);
+        assert_eq!(report.matched, 1);
+        assert!((report.match_rate() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn detect_partial_match_below_threshold() {
+        // option_specs の先頭 4 件で 1 つだけ一致 → 25% < 95% 閾値
+        let specs = SearchTuneParams::option_specs();
+        assert!(specs.len() >= 4, "need >=4 specs for this test");
+        let rows = vec![
+            make_row(specs[0].usi_name, specs[0].default), // 一致
+            make_row(specs[1].usi_name, specs[1].default + 12345), // 不一致 (default + 12345 で衝突しない値に)
+            make_row(specs[2].usi_name, specs[2].default + 12345),
+            make_row(specs[3].usi_name, specs[3].default + 12345),
+        ];
+        let report = detect_rshogi_default_match(&rows);
+        assert_eq!(report.checked, 4);
+        assert_eq!(report.matched, 1);
+        assert!(report.match_rate() < DEFAULT_MATCH_WARN_RATE);
+    }
+
+    #[test]
+    fn detect_match_rate_at_threshold_triggers() {
+        // 20 件中 19 件一致 = 95.0% (DEFAULT_MATCH_WARN_RATE ちょうど)
+        // `>= 0.95` の境界条件で発火することを担保
+        let specs = SearchTuneParams::option_specs();
+        assert!(specs.len() >= 20, "need >=20 specs for boundary test");
+        let mut rows: Vec<ParamRow> =
+            specs.iter().take(20).map(|s| make_row(s.usi_name, s.default)).collect();
+        // 1 件だけ default からズラす (default + 12345 で衝突回避)
+        rows[0].value = specs[0].default + 12345;
+        let report = detect_rshogi_default_match(&rows);
+        assert_eq!(report.checked, 20);
+        assert_eq!(report.matched, 19);
+        let rate = report.match_rate();
+        assert!((rate - 0.95).abs() < 1e-9, "match_rate should be exactly 0.95, got {rate}");
+        assert!(rate >= DEFAULT_MATCH_WARN_RATE);
+    }
+
+    #[test]
+    fn detect_full_default_match_triggers_threshold() {
+        // option_specs の全件を default 値で構築 → 100% 一致 → 閾値超過
+        let specs = SearchTuneParams::option_specs();
+        let rows: Vec<ParamRow> = specs.iter().map(|s| make_row(s.usi_name, s.default)).collect();
+        let report = detect_rshogi_default_match(&rows);
+        assert_eq!(report.checked, specs.len());
+        assert_eq!(report.matched, specs.len());
+        assert!(report.match_rate() >= DEFAULT_MATCH_WARN_RATE);
+    }
 }

--- a/crates/tools/src/bin/rshogi_to_yo_params.rs
+++ b/crates/tools/src/bin/rshogi_to_yo_params.rs
@@ -58,7 +58,7 @@ struct Cli {
 
     /// rshogi default 値の混入検知を error 化する (CI 用)。
     ///
-    /// `--allow-rshogi-defaults` と同時指定すると `--allow` が優先され警告自体が出ない。
+    /// `--allow-rshogi-defaults` と同時指定するとエラーになります (両フラグは意味が矛盾します)。
     #[arg(long, default_value_t = false)]
     strict_rshogi_defaults: bool,
 }
@@ -94,17 +94,25 @@ impl DefaultMatchReport {
 /// どの程度一致しているかを集計する。
 ///
 /// 一致率の閾値判定 (95%) は呼び出し側で行う。ここではカウントだけ返す。
+///
+/// **重複名の扱い**: 入力に同名 row が複数ある場合、後段の変換ロジック
+/// (`rshogi_by_name: HashMap<&str, &ParamRow>`) は last-write-wins で 1 entry に
+/// 集約する。検知側もそれと一致させるため、HashMap で重複排除してから集計する。
+/// (旧実装は全行カウントで、重複入力時に検知と実動作が乖離するバグがあった)
 fn detect_rshogi_default_match(rshogi_rows: &[ParamRow]) -> DefaultMatchReport {
     let defaults: HashMap<&str, i32> = SearchTuneParams::option_specs()
         .iter()
         .map(|s| (s.usi_name, s.default))
         .collect();
+    // 後段の変換と同じ per-name view を作る (last-write-wins)
+    let by_name: HashMap<&str, &ParamRow> =
+        rshogi_rows.iter().map(|r| (r.name.as_str(), r)).collect();
     let mut checked = 0usize;
     let mut matched = 0usize;
-    for r in rshogi_rows {
-        if let Some(&def) = defaults.get(r.name.as_str()) {
+    for (name, row) in &by_name {
+        if let Some(&def) = defaults.get(name) {
             checked += 1;
-            if r.value == def {
+            if row.value == def {
                 matched += 1;
             }
         }
@@ -332,7 +340,7 @@ mod tests {
         assert!(specs.len() >= 4, "need >=4 specs for this test");
         let rows = vec![
             make_row(specs[0].usi_name, specs[0].default), // 一致
-            make_row(specs[1].usi_name, specs[1].default + 12345), // 不一致 (default + 12345 で衝突しない値に)
+            make_row(specs[1].usi_name, specs[1].default + 12345), // 不一致 (default と確実に異なる値 (+12345 offset))
             make_row(specs[2].usi_name, specs[2].default + 12345),
             make_row(specs[3].usi_name, specs[3].default + 12345),
         ];
@@ -370,4 +378,33 @@ mod tests {
         assert_eq!(report.matched, specs.len());
         assert!(report.match_rate() >= DEFAULT_MATCH_WARN_RATE);
     }
+
+    #[test]
+    fn detect_handles_duplicate_names_with_last_write_wins() {
+        // 同名 row が複数あるとき、後段の rshogi_to_yo_params 変換は HashMap
+        // (last-write-wins) で 1 entry に集約する。検知側も同じ per-name view で
+        // 数え上げないと、--strict-rshogi-defaults で false positive を起こす。
+        let specs = SearchTuneParams::option_specs();
+        assert!(!specs.is_empty(), "option_specs must be non-empty");
+        let first = &specs[0];
+        // 同名で 3 つの row。Vec 順は default → default → default+12345 (last は不一致)
+        let rows = vec![
+            make_row(first.usi_name, first.default),
+            make_row(first.usi_name, first.default),
+            make_row(first.usi_name, first.default + 12345),
+        ];
+        let report = detect_rshogi_default_match(&rows);
+        // by_name 集約後は 1 entry のみ。HashMap の last-write-wins で値は不一致になる
+        // 可能性があるが、HashMap iteration 順は不定なのでどの value が採用されるかは
+        // 実装依存。検知件数 (checked) が 3 ではなく 1 であることだけ保証する。
+        assert_eq!(
+            report.checked, 1,
+            "duplicates should be deduplicated to match conversion logic"
+        );
+    }
+
+    // 注: --allow-rshogi-defaults と --strict-rshogi-defaults の同時指定 bail は
+    // main() レベルでしか検証できない (clap parse 自体は成功するが main 内で弾く)。
+    // unit test では検証困難なため、PR description / runbook の smoke test 4
+    // シナリオで担保している。
 }

--- a/crates/tools/src/bin/rshogi_to_yo_params.rs
+++ b/crates/tools/src/bin/rshogi_to_yo_params.rs
@@ -7,13 +7,13 @@
 //!   の値を保持する。`--base` 省略時は rshogi 値を中心に簡易 range を生成する。
 //! - rshogi 独自パラメータ（`unmapped.rshogi`）は YO 出力には含まれない（warn 出力）。
 //!
-//! ## rshogi default 検知 (PR3)
+//! ## rshogi default 値の検知
 //!
 //! 入力 rshogi `.params` の値列が `SearchTuneParams::option_specs()` の default と
-//! 95% 以上一致した場合、警告を出す。これは「`generate_spsa_params` の出力をそのまま
-//! 渡してしまった」事故 (2026-04 に 75,200 ゲーム規模の SPSA を台無しにした) の
-//! 再発防止。意図的に default 値から開始したい場合は `--allow-rshogi-defaults` で
-//! 警告を抑制、CI で完全防止したい場合は `--strict-rshogi-defaults` で error 化。
+//! 95% 以上一致した場合、警告を出す。`generate_spsa_params` の出力を canonical の
+//! 代わりに誤投入するのを防ぐためのチェック。意図的に default 値から開始したい
+//! 場合は `--allow-rshogi-defaults` で警告抑制、CI で混入を完全に防ぐ場合は
+//! `--strict-rshogi-defaults` で error 化。
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -156,23 +156,17 @@ fn main() -> Result<()> {
     let rshogi_rows = load_params(&cli.rshogi_params)?;
 
     // rshogi default 一致検知: --allow-rshogi-defaults 指定時はスキップ。
-    // 95% 以上一致なら警告 (or strict 時は error)。意図的な default 開始ユーザの
-    // ノイズを最小化しつつ、事故 (generate_spsa_params 出力混入) は捕捉する。
+    // 95% 以上一致なら警告 (strict 指定時は error)。
     if !cli.allow_rshogi_defaults {
         let report = detect_rshogi_default_match(&rshogi_rows);
-        // checked == 0 のとき (= 入力に rshogi 名が 1 件も含まれない) は素通し:
-        // YO 名混在ファイル等を「rshogi default 混入事故」と誤検知しないため。
-        // 真の事故 (generate_spsa_params 出力混入) は 100% 一致なので必ず捕捉できる。
+        // checked == 0 (= 入力に rshogi 名が 1 件も含まれない) は素通し。
+        // YO 名混在ファイル等を「default 値混入」と誤検知しないため。
         if report.checked > 0 && report.match_rate() >= DEFAULT_MATCH_WARN_RATE {
             let msg = format!(
-                "入力 rshogi params の値列が rshogi 内部 default と {}/{} ({:.1}%) 一致しています。\n\
-                 \n  これは以下のどちらかを示唆します:\n\
-                 \n  (a) 意図的に rshogi default 値から SPSA を始めたい (e.g. 新規探索)\n      \
-                 → 警告抑制には --allow-rshogi-defaults を追加してください\n\
-                 \n  (b) `generate_spsa_params` の出力を間違って入力にしてしまった (事故)\n      \
-                 → 入力ファイル ({}) を再確認し、suisho10 等の canonical を渡してください\n\
-                 \n  この変換を SPSA --params に投入すると suisho10 由来でない rshogi default 値で\n  \
-                 SPSA が走り出す可能性があります (2026-04 に 75,200 ゲーム規模の事故事例あり)。",
+                "入力 rshogi params の値列が rshogi 内部 default と {}/{} ({:.1}%) 一致しています ({}).\n\
+                 \n  意図的に default 値から始める場合: --allow-rshogi-defaults を追加してください\n\
+                 \n  そうでない場合: 入力ファイルを再確認し、suisho10 等の canonical を渡してください\n      \
+                 (`generate_spsa_params` の出力をそのまま入力にしている可能性があります)",
                 report.matched,
                 report.checked,
                 report.match_rate() * 100.0,

--- a/tune/README.md
+++ b/tune/README.md
@@ -80,6 +80,32 @@ cargo run --release -p tools --bin rshogi_to_yo_params -- \
   --output /tmp/tuned_yo.params
 ```
 
+#### `rshogi_to_yo_params` の rshogi default 検知 (PR3 系)
+
+入力 rshogi `.params` の値列が `SearchTuneParams::option_specs()` の default と
+**95% 以上一致** した場合、警告を出す:
+
+```
+warn: 入力 rshogi params の値列が rshogi 内部 default と 163/163 (100.0%) 一致しています。
+
+  これは以下のどちらかを示唆します:
+  (a) 意図的に rshogi default 値から SPSA を始めたい (e.g. 新規探索)
+      → 警告抑制には --allow-rshogi-defaults を追加してください
+  (b) `generate_spsa_params` の出力を間違って入力にしてしまった (事故)
+      → 入力ファイルを再確認し、suisho10 等の canonical を渡してください
+```
+
+**フラグの使い分け**:
+- 未指定 (default): 95% 一致で warn 出力 + 続行
+- `--allow-rshogi-defaults`: 警告を完全抑制 (default 値から始めることを意図的に表明)
+- `--strict-rshogi-defaults`: warn を error に昇格 (CI で事故完全防止)
+
+**動機**: 2026-04 に `generate_spsa_params` の出力を間違って `rshogi_to_yo_params`
+の入力にしてしまい、生成された .params (rshogi default 値が YO 名で書かれた状態)
+を SPSA に投入。`--init-from suisho10.params` も併用したが silent skip で無視され、
+**rshogi default 値から SPSA 200 iter / 75,200 ゲームが走り棋力低下**した事故が
+発生。本検知は「上流で値の出所を確認させる」一次防衛。
+
 ### マッピング表の整合性検証
 
 ```bash

--- a/tune/README.md
+++ b/tune/README.md
@@ -80,31 +80,23 @@ cargo run --release -p tools --bin rshogi_to_yo_params -- \
   --output /tmp/tuned_yo.params
 ```
 
-#### `rshogi_to_yo_params` の rshogi default 検知 (PR3 系)
+#### rshogi default 値の検知
 
 入力 rshogi `.params` の値列が `SearchTuneParams::option_specs()` の default と
-**95% 以上一致** した場合、警告を出す:
+95% 以上一致した場合、`rshogi_to_yo_params` は警告を出す。これは
+`generate_spsa_params` の出力 (= rshogi 内部 default 値) を canonical の代わりに
+誤投入するのを防ぐためのチェック。
 
-```
-warn: 入力 rshogi params の値列が rshogi 内部 default と 163/163 (100.0%) 一致しています。
+挙動とフラグ:
 
-  これは以下のどちらかを示唆します:
-  (a) 意図的に rshogi default 値から SPSA を始めたい (e.g. 新規探索)
-      → 警告抑制には --allow-rshogi-defaults を追加してください
-  (b) `generate_spsa_params` の出力を間違って入力にしてしまった (事故)
-      → 入力ファイルを再確認し、suisho10 等の canonical を渡してください
-```
+| 状況 | デフォルト | `--allow-rshogi-defaults` | `--strict-rshogi-defaults` |
+|---|---|---|---|
+| default と <95% 一致 | 通常変換 | 通常変換 | 通常変換 |
+| default と ≥95% 一致 | warn 出力 + 続行 | 警告抑制して続行 | error で停止 |
 
-**フラグの使い分け**:
-- 未指定 (default): 95% 一致で warn 出力 + 続行
-- `--allow-rshogi-defaults`: 警告を完全抑制 (default 値から始めることを意図的に表明)
-- `--strict-rshogi-defaults`: warn を error に昇格 (CI で事故完全防止)
-
-**動機**: 2026-04 に `generate_spsa_params` の出力を間違って `rshogi_to_yo_params`
-の入力にしてしまい、生成された .params (rshogi default 値が YO 名で書かれた状態)
-を SPSA に投入。`--init-from suisho10.params` も併用したが silent skip で無視され、
-**rshogi default 値から SPSA 200 iter / 75,200 ゲームが走り棋力低下**した事故が
-発生。本検知は「上流で値の出所を確認させる」一次防衛。
+意図的に default 値から始めたい場合は `--allow-rshogi-defaults` を、CI で混入を
+完全に防ぎたい場合は `--strict-rshogi-defaults` を指定する。両者の同時指定は
+意味が矛盾するため bail。
 
 ### マッピング表の整合性検証
 


### PR DESCRIPTION
## Summary

別ユーザーがリモートで実行した SPSA (200 iter / 75,200 ゲーム) 事故 (rshogi 内部 default 値からチューニングが走り棋力低下) の **上流防御** PR。3 PR シリーズの 3 つ目で、**main 独立** (PR1/PR2 とは別系統で merge 可能)。

## 事故経路

1. \`generate_spsa_params --output X\` (rshogi default 値の rshogi 名 .params) を \`rshogi_to_yo_params --rshogi-params X --base suisho10.params\` に投入 → 「YO 名 + rshogi default 値」のファイルが作られた
2. SPSA \`--params X\` で投入。\`--init-from suisho10.params\` 併用したが silent skip で suisho10 が無視された

PR1 (#576) / PR2 (#577) で #2 の silent skip は止めた。本 PR3 は **#1 の中間ファイル生成時に値の出所を問う UX** を入れる。

## 変更点

### 検知ロジック
- \`detect_rshogi_default_match\` 純粋関数: \`SearchTuneParams::option_specs()\` の default 値と入力 rshogi_rows を照合し \`(checked, matched)\` を集計
- 閾値 95% (\`DEFAULT_MATCH_WARN_RATE\`) を超えると警告発火
- \`checked == 0\` (rshogi 名を 1 件も含まない入力) は素通し → YO 名混在ファイル誤検知防止

### 段階的 UX (Codex の設計提案を実装)
- 未指定: warn 出力 + 続行。意図と事故の二択を明示し対応コマンドを提示
- \`--allow-rshogi-defaults\`: 警告完全抑制 (default 値開始の意図表明)
- \`--strict-rshogi-defaults\`: warn → error 昇格 (CI 用)
- 同時指定は bail

### 警告メッセージ例

\`\`\`
warn: 入力 rshogi params の値列が rshogi 内部 default と 163/163 (100.0%) 一致しています。

  これは以下のどちらかを示唆します:

  (a) 意図的に rshogi default 値から SPSA を始めたい (e.g. 新規探索)
      → 警告抑制には --allow-rshogi-defaults を追加してください

  (b) `generate_spsa_params` の出力を間違って入力にしてしまった (事故)
      → 入力ファイルを再確認し、suisho10 等の canonical を渡してください

  この変換を SPSA --params に投入すると suisho10 由来でない rshogi default 値で
  SPSA が走り出す可能性があります (2026-04 に 75,200 ゲーム規模の事故事例あり)。
\`\`\`

## レビュー履歴

ローカル code-reviewer 2 ラウンド:
- round 1: Critical/Major なし、Minor 3 件 + Nitpick 3 件
- round 2: Minor M1 (素通しコメント) / M2 (95% 境界テスト) / N1 (const 配置) 対応確認、**Approve**

## Test plan

- [x] cargo build -p tools --bin rshogi_to_yo_params
- [x] cargo clippy -p tools --bin rshogi_to_yo_params --tests (warning 0)
- [x] cargo test -p tools --bin rshogi_to_yo_params (5 tests, 全 pass)
- [x] cargo fmt
- [x] smoke test 4 シナリオ (rshogi default 入力 → warn / --strict → error / --allow → 抑制 / 同時指定 → bail)

## PR シリーズの位置づけ

3 PR 連動で「事故再発防止」の三層防衛が完成:
- **PR3 (本)**: 上流警告 (中間ファイル生成時に値の出所を確認)
- **PR1 (#576)**: 下流 bail (silent skip を禁止し明示的 flag を要求)
- **PR2 (#577)**: 観測 (startup summary + iter 0 で fresh start 時の値を可視化)

PR3 は main 独立なので、PR1/PR2 のレビュー・マージとは並行で進められます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)