### PR TITLE
feat(spsa): startup summary に launch action を追加 (origin mode と分離)

### DIFF
--- a/crates/tools/src/bin/spsa.rs
+++ b/crates/tools/src/bin/spsa.rs
@@ -1006,6 +1006,22 @@ impl NonBailAction {
             Self::Resume { .. } => InitMode::Resume,
         }
     }
+
+    /// 「今この起動で何をしたか」を表す kebab-case ラベル (startup summary 用)。
+    ///
+    /// run の **出自** (= 初回起動モード) を表す `InitMode` (`meta.init_mode`) とは
+    /// 別軸で、毎回の起動アクションを示す。fresh 系初回起動なら `InitMode` と
+    /// 同値、resume 起動なら `"resume"` と `InitMode::FreshInitFrom` 等の組み合わせ
+    /// になる。これにより summary 上で「今 resume なのか fresh なのか」と
+    /// 「この run は最初に何で生まれたか」を独立に確認できる。
+    fn launch_label(&self) -> &'static str {
+        match self {
+            Self::CopyInitFromFresh => "fresh-init-from",
+            Self::UseExistingFresh => "fresh-existing",
+            Self::ForceInitOverwrite => "force-init",
+            Self::Resume { .. } => "resume",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2127,6 +2143,9 @@ fn run_seed_games_parallel(ctx: SeedRunContext<'_>) -> Result<SeedGameStats> {
 /// 将来項目を増やしても呼び出し側の修正が小さくなる。
 struct StartupContext<'a> {
     snapshot: &'a InitMetaSnapshot,
+    /// 今回の起動アクション (resume / fresh-init-from / fresh-existing / force-init)。
+    /// `snapshot.init_mode` (run 全体の出自) とは別軸で表示するため別途渡す。
+    launch_action: &'a NonBailAction,
     schedule: &'a ScheduleConfig,
     params: &'a [SpsaParam],
     active_mask: &'a [bool],
@@ -2156,7 +2175,11 @@ fn fmt_param_scalar(p: &SpsaParam, v: f64, frac: usize) -> String {
 /// (`spsa | tee log.csv`) を阻害しない。
 fn print_startup_summary(ctx: &StartupContext<'_>) {
     eprintln!("=== SPSA Startup Summary ===");
-    eprintln!("init mode:      {}", ctx.snapshot.init_mode);
+    // launch action: 「今この起動で何をしたか」 (= NonBailAction)。
+    // origin mode: 「この run は最初に何で生まれたか」 (= meta.init_mode)。
+    // fresh 系初回起動なら両者は一致、resume では割れる (resume / fresh-init-from 等)。
+    eprintln!("launch action:  {}", ctx.launch_action.launch_label());
+    eprintln!("origin mode:    {}", ctx.snapshot.init_mode);
     eprintln!("params:         {}", ctx.params_path.display());
     eprintln!("meta:           {}", ctx.meta_path.display());
     eprintln!("params sha256:  {} (起動時スナップショット)", ctx.snapshot.init_params_sha256);
@@ -2602,6 +2625,7 @@ fn main() -> Result<()> {
 
     print_startup_summary(&StartupContext {
         snapshot: &init_snapshot,
+        launch_action: &effective_action,
         schedule: &schedule,
         params: &params,
         active_mask: &active_mask,
@@ -3507,6 +3531,28 @@ mod tests {
         assert!(result.is_err(), "should bail when meta removal fails");
         // params は触られていない (atomic copy が走らない)
         assert_eq!(std::fs::read(&target_params).unwrap(), b"old content\n");
+    }
+
+    #[test]
+    fn non_bail_action_launch_label_covers_all_variants() {
+        // launch_label と init_mode の対応関係:
+        //   - fresh 系 (CopyInitFromFresh / UseExistingFresh / ForceInitOverwrite) は
+        //     launch_label と init_mode の文字列が同値 (run の出自 = 今回の起動)
+        //   - Resume では launch_label="resume" / init_mode は元 run の出自を保持
+        assert_eq!(NonBailAction::CopyInitFromFresh.launch_label(), "fresh-init-from");
+        assert_eq!(NonBailAction::UseExistingFresh.launch_label(), "fresh-existing");
+        assert_eq!(NonBailAction::ForceInitOverwrite.launch_label(), "force-init");
+        assert_eq!(NonBailAction::Resume { verify_init: false }.launch_label(), "resume");
+        assert_eq!(NonBailAction::Resume { verify_init: true }.launch_label(), "resume");
+
+        // fresh 系では launch_label と init_mode (kebab-case Display) が一致する
+        for action in [
+            NonBailAction::CopyInitFromFresh,
+            NonBailAction::UseExistingFresh,
+            NonBailAction::ForceInitOverwrite,
+        ] {
+            assert_eq!(action.launch_label(), format!("{}", action.init_mode()));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

実機 smoke テスト (rshogi-usi / YaneuraOu の 5 iter run + resume) で観察された
UX 課題への対応。resume 起動時の startup summary を「今この起動で何をしたか
(launch action)」と「run の出自 (origin mode)」の 2 軸に分離する。

## 課題

旧 summary は resume 起動でも `init mode: fresh-init-from` のように **元 run
の init_mode** を表示していた。\`init_snapshot\` を meta から復元する audit
trail 重視の意図的な実装ではあるが、画面上で「resume 起動」と「fresh-init-from
表記」が同居し混乱しやすい。

## 設計

別エージェントの design review で以下の理由から **案 (c)** (常に 2 行表示)
を採用:

1. **意味論が直交**: audit (run の出自) vs operational (今の起動)
2. **条件分岐ゼロは保守上の美徳**: 固定レイアウトで grep/diff 容易
3. **冗長性は実害が小さい**: fresh 初回で両者が同値でも「初回だから一致」と即解読可能
4. **時間軸を明示するラベル**: `origin` / `launch action`

### 新表示

fresh 起動 (両者一致):
\`\`\`
launch action:  fresh-init-from
origin mode:    fresh-init-from
\`\`\`

resume 起動 (割れて識別可能):
\`\`\`
launch action:  resume
origin mode:    fresh-init-from
\`\`\`

## 実装

- \`NonBailAction::launch_label() -> &'static str\` 新設 (kebab-case 4 種)
- \`StartupContext\` に \`launch_action: &NonBailAction\` 追加
- \`print_startup_summary\` の \`init mode:\` 行を 2 行に分割 (ラベル幅 16ch で他 field と整合)
- 単体テスト \`non_bail_action_launch_label_covers_all_variants\` 追加
  (4 variants + Resume の verify_init 両方 + fresh 系の \`launch_label == init_mode.to_string()\` 不変)

## レビュー履歴

- design 相談: 別 Claude エージェントが (a)/(b)/(c)/(d) 4 案から (c) を推奨
- code review (別 Claude エージェント): 5 観点 + 副作用すべて OK、Approve

## Test plan

- [x] cargo fmt -p tools
- [x] cargo clippy -p tools --tests (warning 0)
- [x] cargo test -p tools (44 unit + 4 integration = 48 全 pass)
- [x] 実機 smoke (rshogi-usi): fresh 起動 + resume で表示が期待通りに割れる

## 後方互換

- \`meta.json\` フォーマット変更なし (表示専用変更)
- integration test (\`spsa_run_dir_integration.rs\`) は \`meta.json\` の
  \`init_mode\` field のみ assert、stderr 文字列に非依存
- 外部 grep ベース監視がある場合: \`init mode:\` → \`launch action:\` /
  \`origin mode:\` のいずれかに置換すれば追従可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)