### PR TITLE
feat(rshogi-core): Search に PonderhitHandle を追加し ponderhit signal の型安全な API を提供する

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -177,6 +177,49 @@ pub struct SearchResult {
 }
 
 // =============================================================================
+// PonderhitHandle - ponderhit 通知用のハンドル
+// =============================================================================
+
+/// Ponderhit を外部スレッドから signal するための clone 可能な handle。
+///
+/// `Search::ponderhit_handle()` で取得し、driver / コントローラスレッドから
+/// `signal()` を呼ぶことで、探索ループ内部の ponderhit flag を立てる。
+///
+/// `Arc<AtomicBool>` を直接公開するのではなく型で wrap することで、
+/// 外部からの誤った `store(false)` 等の操作を防ぐ。
+///
+/// # Lifetime
+/// 内部に `Arc<AtomicBool>` を保持しているため、生成元の `Search` が
+/// drop された後でも `signal()` 呼び出しは安全 (panic しない) だが、
+/// 観測者がいないため no-op となる。
+///
+/// # `reset_flags` との相互作用
+/// `Search::reset_flags()` 呼び出し後は内部 flag が clear されるため、
+/// 必要に応じて再度 `signal()` を呼ぶ必要がある。
+#[derive(Clone, Debug)]
+pub struct PonderhitHandle {
+    flag: Arc<AtomicBool>,
+}
+
+impl PonderhitHandle {
+    /// Ponderhit を通知する。
+    ///
+    /// 複数回呼んでも安全 (冪等)。Search 側が観測 swap で消費するまで
+    /// flag は立ったままになる。
+    pub fn signal(&self) {
+        // Relaxed: 観測側 (search_with_callback の swap 三箇所) も Relaxed。
+        // flag 自体が唯一の同期点で、ponderhit 前に書いた他メモリの観測を
+        // 探索側に保証する必要は無い。
+        self.flag.store(true, Ordering::Relaxed);
+    }
+}
+
+const _: () = {
+    fn assert_send_sync<T: Send + Sync>() {}
+    let _ = assert_send_sync::<PonderhitHandle>;
+};
+
+// =============================================================================
 // Search - 探索エンジン
 // =============================================================================
 
@@ -779,13 +822,19 @@ impl Search {
     }
 
     /// ponderhitフラグを取得（探索スレッドへの通知に使用）
+    #[deprecated(note = "use ponderhit_handle()")]
     pub fn ponderhit_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.ponderhit_flag)
     }
 
-    /// ponderhitを要求（外部スレッドから）
-    pub fn request_ponderhit(&self) {
-        self.ponderhit_flag.store(true, Ordering::SeqCst);
+    /// Ponderhit を外部スレッドから signal するための handle を取得する。
+    ///
+    /// 返り値の handle は `Clone` 可能で、探索 thread とは独立に保持できる。
+    /// 同一 `Search` から複数回取得した handle はすべて同じ ponderhit flag を共有する。
+    pub fn ponderhit_handle(&self) -> PonderhitHandle {
+        PonderhitHandle {
+            flag: Arc::clone(&self.ponderhit_flag),
+        }
     }
 
     /// 探索を停止
@@ -1876,6 +1925,14 @@ pub(crate) fn search_helper(
 // =============================================================================
 
 #[cfg(test)]
+impl Search {
+    /// テスト専用: ponderhit flag の現在値を読み取る。
+    pub(crate) fn ponderhit_flag_for_test(&self) -> bool {
+        self.ponderhit_flag.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -2272,5 +2329,42 @@ mod tests {
 
         let usi = info.to_usi_string();
         assert!(usi.contains("score mate -4"));
+    }
+
+    #[test]
+    fn ponderhit_handle_signals_search() {
+        let search = Search::new_with_eval_hash(1, 1);
+        let handle = search.ponderhit_handle();
+        handle.signal();
+        assert!(search.ponderhit_flag_for_test());
+    }
+
+    #[test]
+    fn ponderhit_handle_signals_from_other_thread() {
+        let search = Search::new_with_eval_hash(1, 1);
+        let handle = search.ponderhit_handle();
+        std::thread::spawn(move || handle.signal()).join().unwrap();
+        assert!(search.ponderhit_flag_for_test());
+    }
+
+    #[test]
+    fn ponderhit_handle_outlives_search_drop() {
+        let handle = {
+            let search = Search::new_with_eval_hash(1, 1);
+            search.ponderhit_handle()
+        };
+        // Search drop 後でも panic しないことを確認する。
+        // flag の状態は観測できないため、panic 不在のみが検査対象。
+        handle.signal();
+    }
+
+    #[test]
+    fn ponderhit_handle_cleared_by_reset_flags() {
+        let search = Search::new_with_eval_hash(1, 1);
+        let handle = search.ponderhit_handle();
+        handle.signal();
+        assert!(search.ponderhit_flag_for_test());
+        search.reset_flags();
+        assert!(!search.ponderhit_flag_for_test());
     }
 }

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -23,8 +23,8 @@ use rshogi_core::nnue::{
 };
 use rshogi_core::position::Position;
 use rshogi_core::search::{
-    DEFAULT_DRAW_VALUE_BLACK, DEFAULT_DRAW_VALUE_WHITE, LimitsType, Search, SearchInfo,
-    SearchResult, SearchTuneParams,
+    DEFAULT_DRAW_VALUE_BLACK, DEFAULT_DRAW_VALUE_WHITE, LimitsType, PonderhitHandle, Search,
+    SearchInfo, SearchResult, SearchTuneParams,
 };
 use rshogi_core::types::{EnteringKingRule, Move};
 use serde_json::json;
@@ -78,8 +78,8 @@ struct UsiEngine {
     search_thread: Option<thread::JoinHandle<(Search, SearchResult)>>,
     /// 探索停止用のフラグ（探索スレッドと共有）
     stop_flag: Option<Arc<AtomicBool>>,
-    /// ponderhit通知フラグ
-    ponderhit_flag: Option<Arc<AtomicBool>>,
+    /// ponderhit通知ハンドル
+    ponderhit_handle: Option<PonderhitHandle>,
     /// bestmove出力抑制フラグ（cmd_go内部でcmd_stopする際に使用）
     suppress_bestmove: Arc<AtomicBool>,
     /// Stochastic_Ponder オプションのミラー
@@ -136,7 +136,7 @@ impl UsiEngine {
             skill_options: rshogi_core::search::SkillOptions::default(),
             search_thread: None,
             stop_flag: None,
-            ponderhit_flag: None,
+            ponderhit_handle: None,
             suppress_bestmove: Arc::new(AtomicBool::new(false)),
             stochastic_ponder: false,
             last_position_cmd: None,
@@ -1010,9 +1010,8 @@ impl UsiEngine {
         // stop/ponderhitフラグをリセット（スレッド生成前に行い、go()内での競合を防ぐ）
         search.reset_flags();
         let stop_flag = search.stop_flag();
-        let ponderhit_flag = search.ponderhit_flag();
         self.stop_flag = Some(stop_flag.clone());
-        self.ponderhit_flag = Some(ponderhit_flag.clone());
+        self.ponderhit_handle = Some(search.ponderhit_handle());
 
         let suppress_flag = Arc::clone(&self.suppress_bestmove);
         let builder = thread::Builder::new().stack_size(SEARCH_STACK_SIZE);
@@ -1214,8 +1213,8 @@ impl UsiEngine {
             return;
         }
 
-        if let Some(flag) = &self.ponderhit_flag {
-            flag.store(true, Ordering::SeqCst);
+        if let Some(handle) = &self.ponderhit_handle {
+            handle.signal();
         }
     }
 
@@ -1258,7 +1257,7 @@ impl UsiEngine {
             }
         }
         self.stop_flag = None;
-        self.ponderhit_flag = None;
+        self.ponderhit_handle = None;
     }
 
     /// displayコマンド: 現在の局面を表示（デバッグ用）


### PR DESCRIPTION
## Summary

- `Search::ponderhit_handle()` で取得できる新しい `PonderhitHandle` 型を追加し、ponderhit signal を `Arc<AtomicBool>` の直接公開ではなく型 wrap した API で提供する。
- 既存の `Search::ponderhit_flag()` は `#[deprecated(note = "use ponderhit_handle()")]` に変更（後方互換のため残置）。`Search::request_ponderhit()` は `PonderhitHandle::signal()` で代替できるため削除。
- USI バイナリ (`crates/rshogi-usi/src/main.rs`) を `ponderhit_handle` ベースに移行。

## 設計ポイント

- `PonderhitHandle` は `Clone + Send + Sync` を持ち、外部スレッドから `signal()` で ponderhit を通知する。`signal()` は冪等で複数回呼んでも安全。
- 内部 `Arc<AtomicBool>` を保持しているため、生成元 `Search` が drop された後でも `signal()` は panic しない（観測者がいないため no-op）。
- 外部からの誤った `store(false)` 等の操作を型レベルで防止する。
- `signal()` の `Ordering::Relaxed` は探索側 (`search_with_callback` の swap 三箇所) と整合。flag 自体が唯一の同期点。

## Test plan

- [x] 4 ユニットテスト追加 (`engine.rs`):
  - `ponderhit_handle_signals_search`
  - `ponderhit_handle_signals_from_other_thread`
  - `ponderhit_handle_outlives_search_drop`
  - `ponderhit_handle_cleared_by_reset_flags`
- [x] `cargo fmt --all` 通過
- [x] `cargo clippy --workspace --all-targets --tests` 警告ゼロ
- [x] 新規ユニットテスト 4 件 すべて pass
- [x] `cargo test -p rshogi-usi --test usi_flow` 全 5 件 pass (既存の `ponderhit_outputs_bestmove` が回帰なし)
- [x] `cargo test --workspace` 既存 (NNUE 未ロード環境による) failures は本 PR と独立（`main` ブランチでも同様に発生することを確認）

Closes #583

Refs: design APPROVE 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)