### PR TITLE
feat(csa-server): 私的対局 (Issue #582) の TCP integration + Workers 前半スコープを follow-up 実装する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,8 @@ dependencies = [
  "futures-util",
  "metrics",
  "metrics-exporter-prometheus",
+ "rand",
+ "rand_xoshiro",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",

--- a/crates/rshogi-csa-server-tcp/Cargo.toml
+++ b/crates/rshogi-csa-server-tcp/Cargo.toml
@@ -35,6 +35,12 @@ clap.workspace = true
 serde.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "io-util", "sync", "fs", "net", "signal"] }
+# 私的対局 (`%%CHALLENGE`) で `+free` 指定の inviter / opponent の配色を
+# `resolve_color_for_pair` で乱択するために必要。`rshogi-csa-server` 側
+# pairing 戦略と同じ PRNG (Xoshiro256PlusPlus) を使うため、workspace 既定の
+# `rand_xoshiro` も併せて引く。
+rand.workspace = true
+rand_xoshiro.workspace = true
 
 [features]
 default = []

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -128,6 +128,11 @@ struct Cli {
     /// ためのバッファ。
     #[arg(long, default_value_t = 60)]
     shutdown_grace_sec: u64,
+    /// 私的対局 (`%%CHALLENGE`) で発行する token の TTL (秒)。期限超過した
+    /// 未消費の challenge は `purge_expired` で自然枯死する。Issue #582 受入
+    /// 基準: TCP / Workers 両方とも既定 3600 秒。
+    #[arg(long, default_value_t = 3600)]
+    challenge_ttl_sec: u64,
     /// Prometheus 互換メトリクスを expose する HTTP listener の bind 先（例:
     /// `127.0.0.1:9090`）。未指定時はメトリクス recorder を install せず、
     /// `metrics::counter!` 等は NoOp として実行される（軽量な atomic 1 回程度の
@@ -274,6 +279,11 @@ fn main() -> anyhow::Result<()> {
         // `#ABNORMAL` 経路のまま)。再接続を有効化したい運用ではここで 60 秒等を
         // 直接設定するか、後続の CLI / 設定経路で上書きする。
         reconnect_grace_duration: std::time::Duration::ZERO,
+        challenge_ttl: std::time::Duration::from_secs(cli.challenge_ttl_sec),
+        // `purge_expired` を回す軽量 task の周期。LOGIN-time の都度 purge と
+        // 組み合わせて十分な expire 検出が得られるため、CLI 露出は YAGNI で
+        // 固定 60 秒に閉じる。
+        challenge_purge_interval: std::time::Duration::from_secs(60),
     };
     // Floodgate 系機能の opt-in ゲートを起動前に評価する。`players_yaml_path` が
     // `Some` の状態は `enable_persistent_player_rates` 要求として intent に乗るため、

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -25,6 +25,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
+use rand::SeedableRng;
+use rand_xoshiro::Xoshiro256PlusPlus;
 use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::FloodgateHistoryStorage;
@@ -32,8 +34,11 @@ use rshogi_csa_server::config::{FloodgateFeatureIntent, validate_floodgate_featu
 use rshogi_csa_server::error::{ProtocolError, ServerError};
 use rshogi_csa_server::game::result::GameResult;
 use rshogi_csa_server::game::room::{GameRoom, GameRoomConfig, HandleOutcome};
-use rshogi_csa_server::matching::challenge::{ChallengeRegistry, ChallengeToken, IssueError};
+use rshogi_csa_server::matching::challenge::{
+    ChallengeRegistry, ChallengeToken, ColorTag, IssueError,
+};
 use rshogi_csa_server::matching::league::{League, LoginResult, MatchedPair, PlayerStatus};
+use rshogi_csa_server::matching::pairing::resolve_color_for_pair;
 use rshogi_csa_server::matching::registry::{GameListing, GameRegistry};
 use rshogi_csa_server::port::{
     BroadcastTag, Broadcaster, BuoyStorage, ClientTransport, GameSummaryEntry, KifuStorage,
@@ -49,7 +54,7 @@ use rshogi_csa_server::record::kifu::{
     primary_result_code,
 };
 use rshogi_csa_server::types::{
-    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken, RoomId,
+    Color, CsaLine, CsaMoveToken, GameId, GameName, PlayerName, ReconnectToken, RoomId, Secret,
 };
 use rshogi_csa_server::{FileKifuStorage, TransportError};
 use tokio::net::{TcpListener, TcpStream};
@@ -570,6 +575,115 @@ impl WaitingPool {
     }
 }
 
+/// 私的対局 (`%%CHALLENGE`) で先着 LOGIN した側の runtime session。
+///
+/// `Arc<Notify>` と `oneshot::Sender` は serialize 不能なため core
+/// [`ChallengeRegistry`] には持たず、TCP frontend で別 map として保持する
+/// (Workers は WS attachment id 経由なので core 側に持つ、型分離設計)。
+pub(crate) struct TcpPendingSession {
+    /// TTL purge / 自身の上書きで起こされる cancel signal。waiter task は
+    /// `tokio::select!` で `cancel.notified()` を監視し、起こされたら
+    /// `##[ERROR] challenge expired before opponent joined` を送って切断する。
+    pub(crate) cancel: Arc<Notify>,
+    /// 後着 LOGIN (matchmaker) → 先着 LOGIN (waiter) へのマッチ確定通知。
+    /// waiter は [`MatchRequest`] を受け取ったら、`MatchRequest::transport_responder`
+    /// で自分の transport を渡し、`MatchRequest::completion_rx` で対局完了まで
+    /// 待機する (公開マッチング `WaitingSlot::match_request_tx` と同じ慣習)。
+    pub(crate) match_request_tx: oneshot::Sender<MatchRequest>,
+}
+
+/// `try_match_or_register` の結果。先着 / 後着 / 同 handle 既登録 を 1 回の
+/// 原子処理で判定して返す。
+pub(crate) enum TryMatchResult {
+    /// 自分が後着で、相手 session が取り出せた (この後 `drive_private_game` へ)。
+    Matched { other: TcpPendingSession },
+    /// 自分が先着で、pending map に登録した。waiter として `match_request_rx` を待つ。
+    Registered,
+    /// 同 handle が既登録。LOGIN handler 側で `LOGIN:incorrect already_logged_in` を
+    /// 返す経路に分岐させる。
+    AlreadyLoggedIn,
+}
+
+/// `%%CHALLENGE` で発行された token に紐付く先着 LOGIN session を保持する
+/// frontend runtime map。1 token あたり最大 2 handle (inviter / opponent)。
+///
+/// core [`ChallengeRegistry`] は永続データ (entry / token) のみを持ち、TCP の
+/// runtime 側 ([`Arc<Notify>`] / [`oneshot::Sender<MatchRequest>`]) は serialize
+/// 不能なため本 frontend map に分離する。Workers では WS attachment id ベースで
+/// core 側に保持しているため、本型は TCP 専用。
+#[derive(Default)]
+pub(crate) struct TcpChallengePending {
+    inner: Mutex<HashMap<ChallengeToken, HashMap<PlayerName, TcpPendingSession>>>,
+}
+
+impl TcpChallengePending {
+    /// 空の pending map を作る。
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// 1 ロック内で「相手 handle (self 以外) を探す → 見つかれば
+    /// [`TryMatchResult::Matched`] で返し相手 session を取り出す。空 entry なら
+    /// 自身を登録」を原子的に行う。同 handle 既登録なら
+    /// [`TryMatchResult::AlreadyLoggedIn`] を返し、自身は登録しない。
+    pub(crate) async fn try_match_or_register(
+        &self,
+        token: ChallengeToken,
+        self_handle: PlayerName,
+        self_session: TcpPendingSession,
+    ) -> TryMatchResult {
+        let mut map = self.inner.lock().await;
+        let entry = map.entry(token.clone()).or_default();
+        if entry.contains_key(&self_handle) {
+            // 既登録: 自身は登録しない。entry は contains_key true の時点で
+            // 必ず非空なので map から外す経路はこのアームには無い。
+            return TryMatchResult::AlreadyLoggedIn;
+        }
+        if let Some(other_key) = entry.keys().find(|k| k.as_str() != self_handle.as_str()).cloned()
+        {
+            let other = entry.remove(&other_key).expect("just keyed");
+            if entry.is_empty() {
+                map.remove(&token);
+            }
+            return TryMatchResult::Matched { other };
+        }
+        entry.insert(self_handle, self_session);
+        TryMatchResult::Registered
+    }
+
+    /// session の cancel と一致する場合のみ削除する。`Arc::ptr_eq` で同一性を
+    /// 確認することで、上書き直後の stale handle race (旧 session が
+    /// `unregister` を呼んで新 session を誤って削除する) を回避する。
+    pub(crate) async fn unregister(
+        &self,
+        token: &ChallengeToken,
+        handle: &PlayerName,
+        cancel: &Arc<Notify>,
+    ) {
+        let mut map = self.inner.lock().await;
+        if let Some(entry) = map.get_mut(token) {
+            let same = entry.get(handle).map(|s| Arc::ptr_eq(&s.cancel, cancel)).unwrap_or(false);
+            if same {
+                entry.remove(handle);
+                if entry.is_empty() {
+                    map.remove(token);
+                }
+            }
+        }
+    }
+
+    /// 期限切れ token の全 session を cancel + 削除する。
+    /// `purge_expired` 戻り値の各 token に対して呼ぶ用途。
+    pub(crate) async fn cancel_token(&self, token: &ChallengeToken) {
+        let mut map = self.inner.lock().await;
+        if let Some(entry) = map.remove(token) {
+            for (_, session) in entry {
+                session.cancel.notify_one();
+            }
+        }
+    }
+}
+
 /// 切断時に保持される対局スナップショット。再接続成立時、再参加クライアントへ
 /// 現在の盤面・両者残時間・最終手・手番を再送するために保持する。
 #[derive(Debug, Clone)]
@@ -685,6 +799,11 @@ where
     /// 消費 / TTL purge を行う core API。`pending_ws_attachment_ids` フィールド
     /// は Workers 専用なので TCP では空のまま使われる (型分離のため除去はしない)。
     pub(crate) challenge_registry: Mutex<ChallengeRegistry>,
+    /// 私的対局の先着 LOGIN session (transport を持ったまま相手を待つ runtime
+    /// map)。core [`ChallengeRegistry`] が serialize 可能な永続データだけを持つの
+    /// に対し、本 map は `Arc<Notify>` と `oneshot::Sender<MatchRequest>` という
+    /// serialize 不能な runtime 値を保持するため frontend 側に分離する。
+    pub(crate) tcp_challenge_pending: TcpChallengePending,
 }
 
 impl<R, K, P, H> SharedState<R, K, P, H>
@@ -782,6 +901,11 @@ where
         bind = %bind,
         "rshogi-csa-server-tcp listening"
     );
+    // 私的対局 (`%%CHALLENGE`) の TTL purge loop。`state.shutdown.wait()` で
+    // 抜けるので明示的な join は不要。fire-and-forget で `JoinHandle` を即破棄
+    // (variable には束縛しない) することで `_var` 接頭辞や `#[allow(...)]` を
+    // 使わずに済ませる。
+    tokio::task::spawn_local(challenge_purge_loop(state.clone()));
     let handle = tokio::task::spawn_local(accept_loop(listener, state));
     Ok(handle)
 }
@@ -992,22 +1116,11 @@ where
     };
 
     // 3.0. 私的対局 LOGIN handle (`<handle>+private-<24hex>+free`) は専用パーサで
-    //      分解する。本経路は Issue #582 の challenge_login (token を持って参加)
-    //      で使う ※完全な対局参加実装は後続 wave で `parse_handle_with_free` の
-    //      返り値を `ChallengeRegistry` の `lookup`/`consume` に橋渡しする。
-    //      本 wave では入口分岐のみ整え、stub として一律 `LOGIN:incorrect` 系を
-    //      返して `parse_handle_with_free` / `PrivateLoginError` の使用箇所を確保する。
+    //      分解し、`handle_private_login_path` に分岐する。本経路は token 持参の
+    //      対局参加で使われ、core [`ChallengeRegistry`] の `lookup` / `consume` と
+    //      `tcp_challenge_pending` の先着/後着判定で対局を駆動する。
     if is_private_login_handle(full_name.as_str()) {
-        let outcome = parse_handle_with_free(full_name.as_str());
-        let response = match outcome {
-            Ok(_) => "LOGIN:incorrect challenge_login_not_implemented_yet",
-            Err(PrivateLoginError::ColorMustBeFree) => {
-                "LOGIN:incorrect color_must_be_free_for_private_game"
-            }
-            Err(_) => "LOGIN:incorrect",
-        };
-        let _ = transport.send_line(&CsaLine::new(response)).await;
-        return Ok(());
+        return handle_private_login_path(state, transport, full_name.as_str(), password).await;
     }
 
     // 3. handle / game_name / color を抽出。
@@ -3030,6 +3143,494 @@ where
     Ok(())
 }
 
+/// 私的対局 (`%%CHALLENGE`) の token 持参 LOGIN 経路。
+/// LOGIN handle が `<handle>+private-<24hex>+free` で到着した接続をここに分岐
+/// させる。先着 / 後着 を [`TcpChallengePending::try_match_or_register`] で
+/// 1 ロック内に判定し、後着なら [`drive_private_game`] を駆動、先着なら waiter
+/// として cancel / shutdown / match_request の 3 経路を `tokio::select!` で
+/// 監視する。
+///
+/// 本経路では League / WaitingPool / `session_cancellers` には一切登録しない。
+/// 私的対局はマッチング状態機械から完全に独立しており、duplicate-login policy も
+/// 介入しない (同 token への二重 LOGIN は `AlreadyLoggedIn` で個別に弾く)。
+async fn handle_private_login_path<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    mut transport: TcpTransport,
+    full_name: &str,
+    password: Secret,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    // 1. handle / token を分解。
+    let (handle, token) = match parse_handle_with_free(full_name) {
+        Ok(parsed) => parsed,
+        Err(PrivateLoginError::ColorMustBeFree) => {
+            let _ = transport
+                .send_line(&CsaLine::new("LOGIN:incorrect color_must_be_free_for_private_game"))
+                .await;
+            return Ok(());
+        }
+        Err(_) => {
+            let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect")).await;
+            return Ok(());
+        }
+    };
+
+    // 2. password 認証 (公開 LOGIN と同じ経路)。失敗は `LOGIN:incorrect` で統一。
+    let handle_player = PlayerName::new(&handle);
+    let Some(stored_hash) = state.password_store.lookup(&handle) else {
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect")).await;
+        return Ok(());
+    };
+    match authenticate(
+        &state.rate_storage,
+        state.hasher.as_ref(),
+        &handle_player,
+        &password,
+        &stored_hash,
+    )
+    .await?
+    {
+        AuthOutcome::Ok { .. } => {}
+        AuthOutcome::Incorrect => {
+            let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect")).await;
+            return Ok(());
+        }
+    }
+
+    // 3. TTL purge を LOGIN ごとに 1 回だけ走らせる (`challenge_purge_loop` の
+    //    最終ガード機能に加えて、認証直後に「対局相手が来ないまま expire した
+    //    token」を検出するための即時パス)。`challenge_registry` ロックを
+    //    保持したまま `tcp_challenge_pending.cancel_token` を呼ぶと
+    //    「pending → registry」順で取りに来る別タスクと逆順になり deadlock
+    //    可能性があるため、purge 結果を `Vec` で受け取って registry ロックを
+    //    drop してから cancel_token を順次呼ぶ。
+    let now_ms = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
+    let expired = {
+        let mut reg = state.challenge_registry.lock().await;
+        reg.purge_expired(now_ms)
+    };
+    for (expired_token, _) in expired {
+        state.tcp_challenge_pending.cancel_token(&expired_token).await;
+    }
+
+    // 4. token 照合と inviter / opponent allowlist チェック。`lookup` の戻り値の
+    //    寿命を最小にするため、参照を取り出した直後に owned コピーを作って
+    //    ロックを抜ける。
+    let entry = {
+        let reg = state.challenge_registry.lock().await;
+        match reg.lookup(&token, now_ms) {
+            Some(e) => e.clone(),
+            None => {
+                drop(reg);
+                let _ =
+                    transport.send_line(&CsaLine::new("LOGIN:incorrect challenge_expired")).await;
+                return Ok(());
+            }
+        }
+    };
+    if handle != entry.inviter && handle != entry.opponent {
+        let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect not_invited")).await;
+        return Ok(());
+    }
+
+    // 5. LOGIN OK 応答 (公開経路と同じ shogi-server 互換 `LOGIN:<handle> OK`)。
+    transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
+
+    // 6. 先着 / 後着 を pending map で原子判定する。
+    let cancel: Arc<Notify> = Arc::new(Notify::new());
+    let (match_request_tx, match_request_rx) = oneshot::channel::<MatchRequest>();
+    let session = TcpPendingSession {
+        cancel: cancel.clone(),
+        match_request_tx,
+    };
+    let outcome = state
+        .tcp_challenge_pending
+        .try_match_or_register(token.clone(), handle_player.clone(), session)
+        .await;
+
+    match outcome {
+        TryMatchResult::AlreadyLoggedIn => {
+            let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect already_logged_in")).await;
+            Ok(())
+        }
+        TryMatchResult::Matched { other } => {
+            run_private_match_matchmaker(
+                state,
+                transport,
+                handle,
+                handle_player,
+                token,
+                entry,
+                other,
+            )
+            .await
+        }
+        TryMatchResult::Registered => {
+            run_private_match_waiter(
+                state,
+                transport,
+                handle_player,
+                token,
+                cancel,
+                match_request_rx,
+            )
+            .await
+        }
+    }
+}
+
+/// 後着 LOGIN (matchmaker) の駆動。`consume` で entry を取り出し、配色を解決し、
+/// 先着 (waiter) から transport を吸い上げて両 transport を [`drive_private_game`]
+/// に渡す。`oneshot::Sender<MatchRequest>` の send 失敗 (waiter task が抜けた race) /
+/// `consume` の TTL レース は両者に `##[ERROR] ...` を送って return する。
+///
+/// 完了通知の流れ:
+/// - waiter 側は `MatchRequest::completion_rx` で待つ。matchmaker 側で
+///   `(other_completion_tx, other_completion_rx)` を作って `MatchRequest` に
+///   詰めるので、`drive_private_game` 内で waiter 側に対応する `*_completion_tx`
+///   を `send(())` すれば waiter が抜ける。
+/// - matchmaker 自身は別途 `(self_completion_tx, self_completion_rx)` を確保し、
+///   drive 側で self 側 completion_tx を発火させ、本関数末尾で
+///   `self_completion_rx.await` する。
+async fn run_private_match_matchmaker<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    mut transport: TcpTransport,
+    self_handle: String,
+    self_player: PlayerName,
+    token: ChallengeToken,
+    entry: rshogi_csa_server::matching::challenge::ChallengeEntry,
+    other: TcpPendingSession,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    // 1. registry から entry を取り出して削除 (1 token = 1 対局のみ)。
+    let now_ms = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
+    let consumed = {
+        let mut reg = state.challenge_registry.lock().await;
+        reg.consume(&token, now_ms)
+    };
+    if consumed.is_none() {
+        // TTL race: lookup 通過後に purge_expired が走った等。
+        other.cancel.notify_one();
+        let err_line = CsaLine::new("##[ERROR] challenge expired before opponent joined");
+        let _ = transport.send_line(&err_line).await;
+        return Ok(());
+    }
+
+    // 2. inviter / opponent と self / other の handle 対応付け。entry は consume
+    //    済の値ではなく LOGIN 時点で clone した `entry` をそのまま使う
+    //    (clock_spec / initial_sfen / inviter_color が同一)。
+    let inviter_handle = entry.inviter.clone();
+    let other_handle = if self_handle == entry.inviter {
+        entry.opponent.clone()
+    } else {
+        entry.inviter.clone()
+    };
+
+    // 3. 配色を解決する。`+free` 指定 (双方 None) は `Xoshiro256PlusPlus` で乱択。
+    //    `from_seed(rand::random())` で OS 乱数から seed を引く慣習は core
+    //    `LeastDiffPairingStrategy::build_rng` と同じ。
+    let mut rng = Xoshiro256PlusPlus::from_seed(rand::random());
+    let inviter_color: Option<Color> = entry.inviter_color.map(ColorTag::to_core);
+    let (a_name, a_color, b_name, b_color) = if self_handle == entry.inviter {
+        (self_player.clone(), inviter_color, PlayerName::new(other_handle.as_str()), None)
+    } else {
+        (
+            PlayerName::new(inviter_handle.as_str()),
+            inviter_color,
+            self_player.clone(),
+            None,
+        )
+    };
+    let Some(matched) = resolve_color_for_pair(a_name, a_color, b_name, b_color, &mut rng) else {
+        // 構造的に同色希望は起こらない (片側が必ず None) が、防御的に処理。
+        other.cancel.notify_one();
+        let _ = transport
+            .send_line(&CsaLine::new("##[ERROR] private match color allocation failed"))
+            .await;
+        return Ok(());
+    };
+
+    // 4. 先着 (waiter) に MatchRequest を送り、transport を吸い上げる。
+    //    `(other_transport_tx, other_transport_rx)` が waiter → matchmaker の
+    //    transport 返送経路。`(other_completion_tx, other_completion_rx)` は
+    //    matchmaker → waiter の終局通知経路で、`drive_private_game` 内で
+    //    waiter 側の completion_tx として発火させる。
+    let (other_transport_tx, other_transport_rx) = oneshot::channel::<TcpTransport>();
+    let (other_completion_tx, other_completion_rx) = oneshot::channel::<()>();
+    let req = MatchRequest {
+        transport_responder: other_transport_tx,
+        completion_rx: other_completion_rx,
+    };
+    if other.match_request_tx.send(req).is_err() {
+        let _ = transport.send_line(&CsaLine::new("##[ERROR] challenge_login race")).await;
+        return Ok(());
+    }
+    let other_transport = match other_transport_rx.await {
+        Ok(t) => t,
+        Err(_) => {
+            let _ = transport.send_line(&CsaLine::new("##[ERROR] challenge_login race")).await;
+            return Ok(());
+        }
+    };
+
+    // 5. matchmaker (self) 用の完了 oneshot。waiter 用は `other_completion_tx`
+    //    (MatchRequest の completion_rx 経由) を使う。inviter / opponent と
+    //    self / other の対応で 2 つの tx を `drive_private_game` に渡す。
+    let (self_completion_tx, self_completion_rx) = oneshot::channel::<()>();
+    let (inviter_transport_final, opponent_transport_final, inviter_tx, opponent_tx) =
+        if self_handle == inviter_handle {
+            (transport, other_transport, self_completion_tx, other_completion_tx)
+        } else {
+            (other_transport, transport, other_completion_tx, self_completion_tx)
+        };
+
+    drive_private_game(
+        state,
+        PlayerName::new(inviter_handle.as_str()),
+        inviter_transport_final,
+        opponent_transport_final,
+        matched,
+        entry.clock_spec.clone(),
+        entry.initial_sfen.clone(),
+        inviter_tx,
+        opponent_tx,
+    )
+    .await?;
+
+    // matchmaker 自身の完了待ち。drive 側で self 用 completion_tx が発火した
+    // タイミングで抜ける。
+    let _ = self_completion_rx.await;
+    Ok(())
+}
+
+/// 先着 LOGIN (waiter) の駆動。3 経路 (`shutdown` / `cancel` / `match_request_rx`) を
+/// `tokio::select!` で監視し、cancel / shutdown 経路では pending map の
+/// 自身を unregister してから return する。マッチ確定経路では transport を
+/// `req.transport_responder` で返送し、`req.completion_rx.await` で対局完了を
+/// 待つ。
+async fn run_private_match_waiter<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    mut transport: TcpTransport,
+    handle_player: PlayerName,
+    token: ChallengeToken,
+    cancel: Arc<Notify>,
+    mut match_request_rx: oneshot::Receiver<MatchRequest>,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    tokio::select! {
+        _ = state.shutdown.wait() => {
+            let _ = transport
+                .send_line(&CsaLine::new("##[NOTICE] server shutting down"))
+                .await;
+            state
+                .tcp_challenge_pending
+                .unregister(&token, &handle_player, &cancel)
+                .await;
+            Ok(())
+        }
+        _ = cancel.notified() => {
+            let _ = transport
+                .send_line(&CsaLine::new(
+                    "##[ERROR] challenge expired before opponent joined",
+                ))
+                .await;
+            state
+                .tcp_challenge_pending
+                .unregister(&token, &handle_player, &cancel)
+                .await;
+            Ok(())
+        }
+        req_res = &mut match_request_rx => {
+            // pending map からは matchmaker 側の `try_match_or_register` で
+            // 既に取り除かれている。`unregister` は同 cancel と一致する場合のみ
+            // 削除する idempotent 操作なので、念のため呼んでも害は無い (未登録
+            // なら no-op)。
+            match req_res {
+                Ok(req) => {
+                    if req.transport_responder.send(transport).is_err() {
+                        // matchmaker が transport_responder を drop した race。
+                        // drive 側に渡す経路が無いので、ここで pending エントリの
+                        // 残骸 (もしあれば) を片付けて終了する。
+                        state
+                            .tcp_challenge_pending
+                            .unregister(&token, &handle_player, &cancel)
+                            .await;
+                        return Ok(());
+                    }
+                    let _ = req.completion_rx.await;
+                    Ok(())
+                }
+                Err(_) => {
+                    // matchmaker 側で MatchRequest を drop。pending エントリを
+                    // 片付けて終了 (本 race は通常起きないが防御的に処理)。
+                    state
+                        .tcp_challenge_pending
+                        .unregister(&token, &handle_player, &cancel)
+                        .await;
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+/// 私的対局専用の対局駆動 wrapper。`drive_game` の epilogue から League /
+/// `session_cancellers` 操作を取り除き、challenge 経路向けの軽量 epilogue
+/// (`games.unregister` + broadcaster `clear_room` + 両 completion 通知) のみ
+/// を残す。`drive_game_inner` 自体は public/private 共通で再利用する。
+///
+/// シグネチャは inviter / opponent ベース (color による分岐は `matched.black` /
+/// `matched.white` を `inviter_handle` と比較して内部で行う)。
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn drive_private_game<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    inviter_handle: PlayerName,
+    inviter_transport: TcpTransport,
+    opponent_transport: TcpTransport,
+    matched: MatchedPair,
+    clock_spec: ClockSpec,
+    initial_sfen: Option<String>,
+    inviter_completion_tx: oneshot::Sender<()>,
+    opponent_completion_tx: oneshot::Sender<()>,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    // `drive_game` と同じ Drop ベース counter / metrics 管理。private 経路でも
+    // graceful shutdown 完了判定 (`active_drive_tasks`) と
+    // `csa_games_finished_total{result_code}` の総和不変条件を維持する。
+    struct DriveGuard<'a> {
+        counter: &'a AtomicUsize,
+        notify: &'a Notify,
+        result_code: Rc<std::cell::Cell<Option<&'static str>>>,
+    }
+    impl Drop for DriveGuard<'_> {
+        fn drop(&mut self) {
+            self.counter.fetch_sub(1, Ordering::Release);
+            self.notify.notify_waiters();
+            metrics::gauge!(crate::metrics::GAMES_ACTIVE).decrement(1.0);
+            let code = self.result_code.get().unwrap_or(crate::metrics::RESULT_CODE_ABORTED);
+            metrics::counter!(
+                crate::metrics::GAMES_FINISHED_TOTAL,
+                "result_code" => code,
+            )
+            .increment(1);
+            if code == "#TIME_UP" {
+                metrics::counter!(crate::metrics::TIME_UP_TOTAL).increment(1);
+            }
+        }
+    }
+    state.active_drive_tasks.fetch_add(1, Ordering::Release);
+    metrics::counter!(crate::metrics::GAMES_TOTAL).increment(1);
+    metrics::gauge!(crate::metrics::GAMES_ACTIVE).increment(1.0);
+    let result_code_slot: Rc<std::cell::Cell<Option<&'static str>>> =
+        Rc::new(std::cell::Cell::new(None));
+    let _drive_guard = DriveGuard {
+        counter: &state.active_drive_tasks,
+        notify: &state.active_games,
+        result_code: result_code_slot.clone(),
+    };
+
+    // inviter / opponent と black / white の対応付け。matched は `resolve_color_for_pair`
+    // で確定済なので、inviter_handle が `matched.black` と一致するなら inviter は
+    // 先手、`matched.white` と一致するなら inviter は後手。
+    let inviter_is_black = matched.black.as_str() == inviter_handle.as_str();
+    let (mut black_transport, mut white_transport) = if inviter_is_black {
+        (inviter_transport, opponent_transport)
+    } else {
+        (opponent_transport, inviter_transport)
+    };
+
+    // 対局 ID を発行 (`drive_game` と同形式)。
+    let game_id = {
+        let mut counter = state.game_counter.lock().await;
+        *counter += 1;
+        GameId::new(format!("{}{:04}", state.started_at.format("%Y%m%d%H%M%S"), *counter))
+    };
+    tracing::Span::current().record("game_id", tracing::field::display(&game_id));
+
+    // private 対局の `game_name` は `_challenge` sentinel を使わず、運用観測用に
+    // `private` 固定文字列を使う。`%%LIST` / `%%SHOW` には game_id 経由で表示される。
+    let game_name = GameName::new("private");
+
+    let inner = drive_game_inner(
+        state.as_ref(),
+        &game_id,
+        matched.clone(),
+        game_name.clone(),
+        initial_sfen,
+        &mut black_transport,
+        &mut white_transport,
+        clock_spec,
+        &result_code_slot,
+    )
+    .await;
+
+    // private 経路の epilogue は public と非対称。具体的には:
+    // - `League::end_game` / `League::logout` は呼ばない (private 経路は
+    //   League に登録されていない)
+    // - `session_cancellers.remove` も呼ばない (private 経路は cancellers に
+    //   挿入されていない)
+    // - `games.unregister` は idempotent な保険として呼ぶ (`drive_game_inner`
+    //   が終局時に既に呼んでいるが、AGREE 不成立で early return した経路では
+    //   register 自体が走らないため、ここで再度呼んでも no-op で安全)
+    {
+        let mut games = state.games.lock().await;
+        games.unregister(&game_id);
+    }
+    state.broadcaster.clear_room(&RoomId::new(game_id.as_str())).await;
+    let _ = inviter_completion_tx.send(());
+    let _ = opponent_completion_tx.send(());
+    inner
+}
+
+/// 私的対局 token の TTL purge を周期実行する軽量 task。
+/// `state.config.challenge_purge_interval` ごとに `purge_expired` を呼び、
+/// 戻り値の各 token に対して [`TcpChallengePending::cancel_token`] を呼んで
+/// 先行 LOGIN 済 session を切断する。`state.shutdown.wait()` で抜ける。
+async fn challenge_purge_loop<R, K, P, H>(state: Rc<SharedState<R, K, P, H>>)
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    let interval = state.config.challenge_purge_interval;
+    loop {
+        tokio::select! {
+            _ = state.shutdown.wait() => return,
+            _ = tokio::time::sleep(interval) => {
+                let now_ms = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
+                let removed = {
+                    let mut reg = state.challenge_registry.lock().await;
+                    reg.purge_expired(now_ms)
+                };
+                for (token, _) in removed {
+                    state.tcp_challenge_pending.cancel_token(&token).await;
+                }
+            }
+        }
+    }
+}
+
 /// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
 /// 該当 `game_id` の grace 中対局へ再参加させる。
 ///
@@ -3432,6 +4033,7 @@ where
         shutdown: GracefulShutdown::new(),
         reconnect_pending: Mutex::new(HashMap::new()),
         challenge_registry: Mutex::new(ChallengeRegistry::new()),
+        tcp_challenge_pending: TcpChallengePending::new(),
     }
 }
 

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -32,6 +32,7 @@ use rshogi_csa_server::config::{FloodgateFeatureIntent, validate_floodgate_featu
 use rshogi_csa_server::error::{ProtocolError, ServerError};
 use rshogi_csa_server::game::result::GameResult;
 use rshogi_csa_server::game::room::{GameRoom, GameRoomConfig, HandleOutcome};
+use rshogi_csa_server::matching::challenge::{ChallengeRegistry, ChallengeToken, IssueError};
 use rshogi_csa_server::matching::league::{League, LoginResult, MatchedPair, PlayerStatus};
 use rshogi_csa_server::matching::registry::{GameListing, GameRegistry};
 use rshogi_csa_server::port::{
@@ -82,6 +83,87 @@ pub fn parse_handle(raw: &str) -> Option<(String, GameName, Color)> {
         return None;
     }
     Some((handle, GameName::new(game_name), color))
+}
+
+/// LOGIN handle 文字列が私的対局フォーマット
+/// (`<handle>+private-<24hex>+free`) に該当しそうかを peek する。
+///
+/// `'+'` で分割した中央トークンが `private-` prefix を持てば `true` を返す。
+/// 中央トークンが存在しない (`+` で 2 分割未満) 場合や、prefix が一致しない
+/// 場合は `false`。本判定は LOGIN handler の入口で「既存 [`parse_handle`] と
+/// 私的対局専用の [`parse_handle_with_free`] のどちらに分岐するか」を決める
+/// 軽量チェックであり、hex 部分の妥当性検証は行わない。
+pub(crate) fn is_private_login_handle(raw: &str) -> bool {
+    raw.split('+').nth(1).is_some_and(|middle| middle.starts_with("private-"))
+}
+
+/// 私的対局 (`%%CHALLENGE`) issuance 経路で LOGIN の `<game_name>` トークンに
+/// 載せて使う予約 sentinel。inviter は `LOGIN <handle>+_challenge+<color> <pw> x1`
+/// で接続し、本 sentinel に到達した接続は通常のマッチング待機プールに乗らず
+/// `handle_challenge_issuance_path` に分岐する (Issue #582 受け入れ基準)。
+/// LOGIN handler の clock-preset strict mode 例外と issuance 分岐の双方から
+/// 参照されるため、文字列リテラル散在による typo を避けて const に集約する。
+pub(crate) const CHALLENGE_ISSUANCE_GAME_NAME: &str = "_challenge";
+
+/// [`parse_handle_with_free`] の失敗種別。
+///
+/// LOGIN handler 側でこれら variant を CSA プロトコルの `LOGIN:incorrect ...`
+/// 文字列へ翻訳する経路に分岐させる。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PrivateLoginError {
+    /// `+` で正確に 3 分割できない (2 分割未満 or 4 分割以上) / handle が空 /
+    /// 中央トークンが `private-` prefix を持たない (本来 [`is_private_login_handle`]
+    /// で弾かれる契約違反パスの防御的キャッチ) / その他 malformed。
+    Malformed,
+    /// 中央トークンが `private-<...>` だが、続く `<...>` が 24 文字小文字 hex
+    /// でない (短すぎ / 長すぎ / 大文字 / 非 hex 含む)。
+    PrivateTokenMalformed,
+    /// 末尾の color トークンが `+free` 以外。LOGIN handler 側でこの error を
+    /// `LOGIN:incorrect color_must_be_free_for_private_game` 文字列に変換する
+    /// 経路に分岐させる用途。
+    ColorMustBeFree,
+}
+
+/// 私的対局フォーマット (`<handle>+private-<24hex>+free`) の LOGIN handle を分解する。
+///
+/// 呼び出し側は事前に [`is_private_login_handle`] で `true` を確認している前提。
+/// 違反時は `Err(Malformed)` 系を返す（呼び出し側はこの経路に入ってはいけない契約）。
+///
+/// 検証順:
+/// 1. `'+'` で正確に 3 分割できること
+/// 2. handle (index 0) が非空
+/// 3. 中央トークン (index 1) が `private-` prefix を持ち、続く部分が
+///    ちょうど 24 文字の小文字 hex (`[0-9a-f]`)
+/// 4. 末尾トークン (index 2) が `"free"`
+pub(crate) fn parse_handle_with_free(
+    raw: &str,
+) -> Result<(String, ChallengeToken), PrivateLoginError> {
+    // 既存 `parse_handle` と同じく iterator で 3 セグメントを取り出し、4+ 分割を
+    // `Err(Malformed)` で弾く (Vec collect を避けて allocation 回避)。
+    let mut it = raw.split('+');
+    let handle = it.next().ok_or(PrivateLoginError::Malformed)?;
+    let middle = it.next().ok_or(PrivateLoginError::Malformed)?;
+    let color = it.next().ok_or(PrivateLoginError::Malformed)?;
+    if it.next().is_some() {
+        return Err(PrivateLoginError::Malformed);
+    }
+
+    if handle.is_empty() {
+        return Err(PrivateLoginError::Malformed);
+    }
+    let hex_part = match middle.strip_prefix("private-") {
+        Some(rest) => rest,
+        None => return Err(PrivateLoginError::Malformed),
+    };
+    let hex_ok = hex_part.len() == 24
+        && hex_part.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b));
+    if !hex_ok {
+        return Err(PrivateLoginError::PrivateTokenMalformed);
+    }
+    if color != "free" {
+        return Err(PrivateLoginError::ColorMustBeFree);
+    }
+    Ok((handle.to_owned(), ChallengeToken::from_raw(hex_part)))
 }
 
 /// `clock_presets` が登録されていれば該当 spec を、無ければ `fallback` を返す。
@@ -210,6 +292,18 @@ pub struct ServerConfig {
     /// Game_Summary 末尾拡張行で配布した `reconnect_token` の照合で再参加を許可
     /// する。運用上の推奨は 60 秒。
     pub reconnect_grace_duration: Duration,
+    /// 私的対局 (`%%CHALLENGE`) で発行する token の TTL。期限超過した未消費の
+    /// challenge は `purge_expired` で自然枯死し、片側 LOGIN 済の session は
+    /// `##[ERROR] challenge expired before opponent joined` で切断される。
+    /// 既定 1 時間 (Issue #582 の受け入れ基準: TCP / Workers 両方とも秒単位で 3600)。
+    pub challenge_ttl: Duration,
+    /// `ChallengeRegistry::purge_expired` を回す軽量 task の周期。expire 検出の
+    /// 上限遅延を決める。LOGIN 経路でも都度 `purge_expired` を呼ぶため、本周期は
+    /// 「対局相手が永遠に来ない private match を expire させる」最終ガード。
+    /// CLI 露出は YAGNI、固定既定 60 秒で十分。本フィールドは `accept_loop`
+    /// 内で起動する `challenge_purge_loop` task が参照する (TTL purge loop の
+    /// 配線時に活用される、それまでは config として保持されるのみ)。
+    pub challenge_purge_interval: Duration,
 }
 
 impl ServerConfig {
@@ -236,6 +330,8 @@ impl ServerConfig {
             duplicate_login_policy: DuplicateLoginPolicy::RejectNew,
             shutdown_grace: Duration::from_secs(60),
             reconnect_grace_duration: Duration::ZERO,
+            challenge_ttl: Duration::from_secs(3600),
+            challenge_purge_interval: Duration::from_secs(60),
         }
     }
 }
@@ -585,6 +681,10 @@ where
     /// 無効化した既定構成）はこのレジストリは常に空のままで、
     /// `run_game_loop_and_record` は即時 `#ABNORMAL` に進む。
     pub(crate) reconnect_pending: Mutex<HashMap<GameId, Arc<PendingReconnect>>>,
+    /// 私的対局 (`%%CHALLENGE`) の永続データ (token → entry)。発行 / 検索 /
+    /// 消費 / TTL purge を行う core API。`pending_ws_attachment_ids` フィールド
+    /// は Workers 専用なので TCP では空のまま使われる (型分離のため除去はしない)。
+    pub(crate) challenge_registry: Mutex<ChallengeRegistry>,
 }
 
 impl<R, K, P, H> SharedState<R, K, P, H>
@@ -891,6 +991,25 @@ where
         }
     };
 
+    // 3.0. 私的対局 LOGIN handle (`<handle>+private-<24hex>+free`) は専用パーサで
+    //      分解する。本経路は Issue #582 の challenge_login (token を持って参加)
+    //      で使う ※完全な対局参加実装は後続 wave で `parse_handle_with_free` の
+    //      返り値を `ChallengeRegistry` の `lookup`/`consume` に橋渡しする。
+    //      本 wave では入口分岐のみ整え、stub として一律 `LOGIN:incorrect` 系を
+    //      返して `parse_handle_with_free` / `PrivateLoginError` の使用箇所を確保する。
+    if is_private_login_handle(full_name.as_str()) {
+        let outcome = parse_handle_with_free(full_name.as_str());
+        let response = match outcome {
+            Ok(_) => "LOGIN:incorrect challenge_login_not_implemented_yet",
+            Err(PrivateLoginError::ColorMustBeFree) => {
+                "LOGIN:incorrect color_must_be_free_for_private_game"
+            }
+            Err(_) => "LOGIN:incorrect",
+        };
+        let _ = transport.send_line(&CsaLine::new(response)).await;
+        return Ok(());
+    }
+
     // 3. handle / game_name / color を抽出。
     let Some((handle, game_name, color)) = parse_handle(full_name.as_str()) else {
         let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect")).await;
@@ -903,8 +1022,13 @@ where
     // 3.5. clock_presets が宣言済みなら、未登録 game_name は strict mode で拒否。
     //      `is_empty()` のときは presets 未宣言扱いで fallback (state.config.clock)
     //      を全 game_name に当てる後方互換モードに留まり、ここでは拒否しない。
+    //      `_challenge` は私的対局 (`%%CHALLENGE`) issuance 経路の専用 sentinel
+    //      game_name で対局時計を要求しないため、strict mode の対象外として
+    //      透過させる。本 sentinel に到達した接続は後続の `_challenge` 経路分岐
+    //      で `handle_challenge_issuance_path` に分岐する。
     if !state.config.clock_presets.is_empty()
         && !state.config.clock_presets.contains_key(&game_name)
+        && game_name.as_str() != CHALLENGE_ISSUANCE_GAME_NAME
     {
         let _ = transport.send_line(&CsaLine::new("LOGIN:incorrect unknown_game_name")).await;
         return Ok(());
@@ -931,6 +1055,14 @@ where
             return Ok(());
         }
     }
+    // 4.4. 私的対局 issuance 経路の分岐。LOGIN の game_name が `_challenge`
+    //      sentinel の場合は対局参加 (League 登録 / WaitingPool) ではなく
+    //      `%%CHALLENGE` 受信ループに入り token を発行する。x1 mode 限定で、
+    //      色トークンは無視される (issuance は対局相手が決まらないため意味がない)。
+    if game_name.as_str() == CHALLENGE_ISSUANCE_GAME_NAME {
+        return handle_challenge_issuance_path(state, transport, handle_player, x1).await;
+    }
+
     // 4.5. 再接続要求の経路分岐。LOGIN 行の 3 つ目トークンが `reconnect:<game_id>+<token>`
     //      で来た場合は新規対局参加 (League 登録 / 待機プール) ではなく、grace 中の
     //      該当対局へ「同一対局者として再参加」する経路へ。`reconnect_pending` 検索
@@ -2704,6 +2836,200 @@ where
     Ok(outcome)
 }
 
+/// 私的対局 (`%%CHALLENGE`) の token issuance 経路。LOGIN の `game_name`
+/// が `_challenge` sentinel で到着した接続をここに分岐させる。
+///
+/// 本経路では League / WaitingPool / `session_cancellers` / `reconnect_pending`
+/// 等への登録は **一切行わない**: issuance 接続は対局参加者ではなく、token を
+/// 発行して切断するか、複数 token を順次発行するクライアントとして振る舞うだけ
+/// なので、duplicate-login policy / matching の状態機械からは完全に独立させる。
+///
+/// `x1` が `false` の場合は `%%CHALLENGE` を解釈できないクライアント
+/// (CSA 標準 LOGIN のみのクライアント) なので、`LOGIN:incorrect challenge_requires_x1`
+/// で即拒否する (受け入れても無効コマンド連投で接続が無駄に消費されるだけ)。
+async fn handle_challenge_issuance_path<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    mut transport: TcpTransport,
+    handle: PlayerName,
+    x1: bool,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    if !x1 {
+        let _ = transport
+            .send_line(&CsaLine::new("LOGIN:incorrect challenge_requires_x1"))
+            .await;
+        return Ok(());
+    }
+    transport
+        .send_line(&CsaLine::new(format!("LOGIN:{} OK", handle.as_str())))
+        .await?;
+    run_challenge_issuer(state, transport, handle).await
+}
+
+/// `_challenge` 経路の受信ループ。`%%CHALLENGE` を 1 件以上発行できるよう、
+/// クライアントが `LOGOUT` または切断するまで `%%CHALLENGE` を受け付け続ける。
+///
+/// AGREE / REJECT / 指し手 / `%%` 系観戦コマンド等は本経路では意味を持たない
+/// ため `continue` で無視する (issuance はマッチングプールに参加していないので
+/// 観戦・対局制御コマンドの宛先が無い)。`KeepAlive` も `continue`、`LOGOUT`
+/// のみループ脱出。
+///
+/// **設計判断**: 既存 `run_waiter` (公開マッチング x1 経路) は未対応コマンドを
+/// 切断扱いにするが、本 issuance ループは敢えてそれと非対称に「`LOGOUT` を
+/// クリーン return / 未対応を silent ignore」とする。理由:
+///
+/// - 対局参加経路と異なり、issuance は短命な query / register コマンド層で、
+///   1 接続で複数 token を順次発行できる UX を提供する。誤入力で都度切断
+///   されると inviter が再 LOGIN (= 認証コスト + handshake) を強いられ非対称。
+/// - 切断する場合でも何の信号も送らず close するだけで、`run_waiter` の
+///   切断方針 (debug 用 trace のみ) と同質性は保ちつつ、ハンドシェイク
+///   コストだけ削れる。Issue #582 の TCP フロー §1 step 5 にある「LOGOUT
+///   応答は保証しない」という記述は「LOGOUT の応答行を返さない」意図であり、
+///   本実装でも応答行は送らない (単に loop 脱出のみ)。応答可否ではなく
+///   ループ離脱の trigger としての扱いの差異である。
+async fn run_challenge_issuer<R, K, P, H>(
+    state: Rc<SharedState<R, K, P, H>>,
+    mut transport: TcpTransport,
+    inviter: PlayerName,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = state.shutdown.wait() => return Ok(()),
+            recv = transport.recv_line(NEAR_INFINITE) => {
+                let line = match recv {
+                    Ok(l) => l,
+                    Err(_) => return Ok(()),
+                };
+                match parse_command(&line) {
+                    Ok(ClientCommand::KeepAlive) => continue,
+                    Ok(ClientCommand::Logout) => return Ok(()),
+                    Ok(ClientCommand::Challenge {
+                        opponent,
+                        inviter_color,
+                        clock_preset,
+                        initial_sfen,
+                    }) => {
+                        process_challenge(
+                            state.as_ref(),
+                            &mut transport,
+                            &inviter,
+                            opponent,
+                            inviter_color,
+                            clock_preset,
+                            initial_sfen,
+                        )
+                        .await?;
+                    }
+                    Ok(_) | Err(_) => continue,
+                }
+            }
+        }
+    }
+}
+
+/// `%%CHALLENGE` 1 件を 4 段検証して登録する:
+///
+/// 1. `clock_preset` が `clock_presets` に登録済か (`unknown_clock_preset`)
+/// 2. `initial_sfen` が指定されていれば妥当な SFEN か (`bad_sfen`)
+/// 3. `opponent` ハンドルが `password_store` に登録済か (`unknown_opponent_handle`、TCP 限定)
+/// 4. `ChallengeRegistry::issue` で登録 (`self_challenge` は内部検出)
+///
+/// 検証失敗は `CHALLENGE:incorrect <reason>` で 1 行返して `Ok(())`。成功は
+/// `CHALLENGE:OK <token> <ttl_sec>` を返す。失敗で接続を切らないのは、issuance
+/// クライアントが連続で複数 token を発行する用途を許容するため。
+///
+/// **SFEN 検証の代替実装**: Issue #582 仕様文では `validate_handicap_sfen`
+/// 経由とあるが、当該名の helper は core / TCP どちらにも存在しない。代わりに
+/// [`position_section_from_sfen`] と [`side_to_move_from_sfen`] の双方を呼び、
+/// どちらかが `Err` なら `bad_sfen` 判定とする。これは Game_Summary 構築経路
+/// (`drive_game_inner`) と同じ 2 関数で、両者で `Ok` なら以降の対局駆動でも
+/// 同一 SFEN を再利用できる契約。
+async fn process_challenge<R, K, P, H>(
+    state: &SharedState<R, K, P, H>,
+    transport: &mut TcpTransport,
+    inviter: &PlayerName,
+    opponent: PlayerName,
+    inviter_color: Option<Color>,
+    clock_preset: GameName,
+    initial_sfen: Option<String>,
+) -> Result<(), ServerError>
+where
+    R: RateStorage + 'static,
+    K: KifuStorage + 'static,
+    P: PasswordStore + 'static,
+    H: FloodgateHistoryStorage + 'static,
+{
+    // 1. clock_preset 名解決。Workers と異なり TCP では `clock_presets` map が
+    //    spec の正となるため、未登録 preset は即拒否する。
+    let clock_spec = match state.config.clock_presets.get(&clock_preset) {
+        Some(spec) => spec.clone(),
+        None => {
+            transport
+                .send_line(&CsaLine::new("CHALLENGE:incorrect unknown_clock_preset"))
+                .await?;
+            return Ok(());
+        }
+    };
+
+    // 2. initial_sfen が指定されていれば妥当な SFEN かを `position_section_from_sfen`
+    //    と `side_to_move_from_sfen` の両方でチェック (どちらかが `Err` なら `bad_sfen`)。
+    if let Some(sfen) = &initial_sfen
+        && (position_section_from_sfen(sfen).is_err() || side_to_move_from_sfen(sfen).is_err())
+    {
+        transport.send_line(&CsaLine::new("CHALLENGE:incorrect bad_sfen")).await?;
+        return Ok(());
+    }
+
+    // 3. opponent 存在確認 (TCP のみ; Workers は self-claim でこの検証を持たない)。
+    if state.password_store.lookup(opponent.as_str()).is_none() {
+        transport
+            .send_line(&CsaLine::new("CHALLENGE:incorrect unknown_opponent_handle"))
+            .await?;
+        return Ok(());
+    }
+
+    // 4. registry に発行。`SelfChallenge` のみ enum で帰ってくる。
+    // 通常運用での値域は 1.7e12 (= 2026 年現在のミリ秒) で `u64` には十分収まる。
+    // 万一システム時計が 1970 以前に巻き戻った場合は `0` に倒すが、これにより
+    // `expires_at_ms = 0 + ttl_ms` が現在時刻より遥かに小さくなり、直後の
+    // `lookup` / `consume` が即 expire 扱いとなって entry は短命に終わる
+    // (`purge_expired` で自然枯死)。`as u64` でラップアラウンドさせるよりも
+    // CLAUDE.md の「panic より `Result`」方針と整合し、安全側に倒す判断。
+    let now_ms = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
+    let mut reg = state.challenge_registry.lock().await;
+    match reg.issue(
+        inviter.clone(),
+        opponent,
+        inviter_color,
+        clock_spec,
+        initial_sfen,
+        state.config.challenge_ttl,
+        now_ms,
+    ) {
+        Ok(token) => {
+            let ttl_sec = state.config.challenge_ttl.as_secs();
+            transport
+                .send_line(&CsaLine::new(format!("CHALLENGE:OK {} {}", token.as_str(), ttl_sec)))
+                .await?;
+        }
+        Err(IssueError::SelfChallenge) => {
+            transport.send_line(&CsaLine::new("CHALLENGE:incorrect self_challenge")).await?;
+        }
+    }
+    Ok(())
+}
+
 /// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
 /// 該当 `game_id` の grace 中対局へ再参加させる。
 ///
@@ -3105,6 +3431,7 @@ where
         buoy_storage,
         shutdown: GracefulShutdown::new(),
         reconnect_pending: Mutex::new(HashMap::new()),
+        challenge_registry: Mutex::new(ChallengeRegistry::new()),
     }
 }
 
@@ -3161,6 +3488,83 @@ mod tests {
         assert!(parse_handle("+g1+black").is_none());
         assert!(parse_handle("alice++black").is_none());
         assert!(parse_handle("alice+g1+purple").is_none());
+    }
+
+    #[test]
+    fn is_private_login_handle_detects_private_prefix() {
+        assert!(is_private_login_handle("alice+private-0123456789abcdef0123abcd+free"));
+        assert!(!is_private_login_handle("alice+g1+black"));
+        assert!(!is_private_login_handle("alice+_challenge+black"));
+        assert!(!is_private_login_handle("alice"));
+        assert!(!is_private_login_handle("alice+"));
+    }
+
+    #[test]
+    fn parse_handle_with_free_accepts_well_formed_input() {
+        let (handle, token) = parse_handle_with_free("alice+private-0123456789abcdef0123abcd+free")
+            .expect("well-formed private login handle");
+        assert_eq!(handle, "alice");
+        assert_eq!(token.as_str(), "0123456789abcdef0123abcd");
+    }
+
+    #[test]
+    fn parse_handle_with_free_rejects_color_other_than_free() {
+        for color in ["black", "white", "sente", "gote", "anything"] {
+            let raw = format!("alice+private-0123456789abcdef0123abcd+{color}");
+            assert_eq!(
+                parse_handle_with_free(&raw),
+                Err(PrivateLoginError::ColorMustBeFree),
+                "color={color} must be rejected with ColorMustBeFree",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_handle_with_free_rejects_malformed_segments() {
+        // 2 分割しか出来ない
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789abcdef0123abcd"),
+            Err(PrivateLoginError::Malformed),
+        );
+        // 4 分割される (余分な `+` セグメント)
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789abcdef0123abcd+free+extra"),
+            Err(PrivateLoginError::Malformed),
+        );
+        // handle が空
+        assert_eq!(
+            parse_handle_with_free("+private-0123456789abcdef0123abcd+free"),
+            Err(PrivateLoginError::Malformed),
+        );
+        // 中央が `private-` prefix なし
+        assert_eq!(
+            parse_handle_with_free("alice+notprivate-0123456789abcdef0123abcd+free"),
+            Err(PrivateLoginError::Malformed),
+        );
+    }
+
+    #[test]
+    fn parse_handle_with_free_rejects_bad_token() {
+        // 短い (23 hex)
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789abcdef0123abc+free"),
+            Err(PrivateLoginError::PrivateTokenMalformed),
+        );
+        // 長い (25 hex)
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789abcdef0123abcde+free"),
+            Err(PrivateLoginError::PrivateTokenMalformed),
+        );
+        // 大文字含む
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789ABCDEF0123abcd+free"),
+            Err(PrivateLoginError::PrivateTokenMalformed),
+        );
+        // 非 hex 含む
+        assert_eq!(
+            parse_handle_with_free("alice+private-0123456789ghijkl0123abcd+free"),
+            Err(PrivateLoginError::PrivateTokenMalformed),
+        );
     }
 
     fn sample_summary_text() -> String {

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -3243,10 +3243,10 @@ where
         return Ok(());
     }
 
-    // 5. LOGIN OK 応答 (公開経路と同じ shogi-server 互換 `LOGIN:<handle> OK`)。
-    transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
-
-    // 6. 先着 / 後着 を pending map で原子判定する。
+    // 5. 先着 / 後着 を pending map で原子判定する。`already_logged_in` は
+    //    `LOGIN OK` を送る前に検出して `LOGIN:incorrect` のみ返す (Issue #582
+    //    検証順 `color → expired → not_invited → already_logged_in` を満たす
+    //    ため、OK と incorrect の二重送信を回避する)。
     let cancel: Arc<Notify> = Arc::new(Notify::new());
     let (match_request_tx, match_request_rx) = oneshot::channel::<MatchRequest>();
     let session = TcpPendingSession {
@@ -3264,6 +3264,9 @@ where
             Ok(())
         }
         TryMatchResult::Matched { other } => {
+            // 6. LOGIN OK は登録 / マッチ確定後に送る (公開経路 `handle_reconnect_request`
+            //    と同じ「成功確定後に送出」流儀)。
+            transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
             run_private_match_matchmaker(
                 state,
                 transport,
@@ -3276,6 +3279,7 @@ where
             .await
         }
         TryMatchResult::Registered => {
+            transport.send_line(&CsaLine::new(format!("LOGIN:{handle} OK"))).await?;
             run_private_match_waiter(
                 state,
                 transport,
@@ -3454,6 +3458,20 @@ where
                     "##[ERROR] challenge expired before opponent joined",
                 ))
                 .await;
+            state
+                .tcp_challenge_pending
+                .unregister(&token, &handle_player, &cancel)
+                .await;
+            Ok(())
+        }
+        // 先着クライアントの TCP 切断 / EOF を監視する。issuance mode 中は AGREE /
+        // REJECT 等のコマンドが意味を持たないため `recv_res` の中身は捨て、
+        // 切断検知をトリガーに pending map から自身を unregister する (Issue #582
+        // の stale handle race 回避: `cancel` ベースの `Arc::ptr_eq` 一致比較で
+        // 同 handle の別セッションを巻き込まない)。`recv_line` は cancel-safe
+        // なので select 内で捨てられても再起動経路に副作用を残さない。
+        recv_res = transport.recv_line(NEAR_INFINITE) => {
+            let _ = recv_res;
             state
                 .tcp_challenge_pending
                 .unregister(&token, &handle_player, &cancel)

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2341,6 +2341,7 @@ where
         &mut black_transport,
         &mut white_transport,
         clock_spec,
+        true, // public 経路は League に登録済なので InGame 遷移を行う
         &result_code_slot,
     )
     .await;
@@ -2389,6 +2390,7 @@ async fn drive_game_inner<R, K, P, H>(
     black_transport: &mut TcpTransport,
     white_transport: &mut TcpTransport,
     clock_spec: ClockSpec,
+    manage_league_state: bool,
     result_code_slot: &Rc<std::cell::Cell<Option<&'static str>>>,
 ) -> Result<(), ServerError>
 where
@@ -2468,7 +2470,10 @@ where
     // `START` 配信成功を確認してから、League → `InGame` 遷移と GameRegistry
     // 登録を連続で行う。2 つの共有状態更新は micro 秒スケールで連続するので、
     // `%%WHO` と `%%LIST` / `%%SHOW` が同じ「対局開始」状態を観測する。
-    {
+    // 私的対局 (League 非介入) では `manage_league_state == false` で skip する。
+    // skip しないと League に未登録の handle に `transition` を呼んで
+    // `StateError::InvalidForState` で early return してしまう。
+    if manage_league_state {
         let mut league = state.league.lock().await;
         for n in [&matched.black, &matched.white] {
             league
@@ -3580,6 +3585,7 @@ where
         &mut black_transport,
         &mut white_transport,
         clock_spec,
+        false, // private 経路は League 非介入で InGame 遷移は skip
         &result_code_slot,
     )
     .await;

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2082,6 +2082,11 @@ where
     // してから入れる（AGREE 待ち中に REJECT / %CHUDAN / 切断で不成立になった
     // 対局を `%%LIST` / `%%SHOW` に出さないため）。unregister は本関数 epilogue で
     // 無条件に呼ぶ（未登録 game_id への unregister は no-op）。
+    // public 経路は preset map (or fallback) で clock を解決して渡す。
+    // private 経路では `drive_private_game` が challenge entry の `ClockSpec` を
+    // 直接渡すため、`drive_game_inner` 自体は clock 解決を行わない。
+    let clock_spec =
+        resolve_clock_spec(&state.config.clock_presets, &state.config.clock, &game_name).clone();
     let inner = drive_game_inner(
         state.as_ref(),
         &game_id,
@@ -2090,6 +2095,7 @@ where
         match_initial_sfen.clone(),
         &mut black_transport,
         &mut white_transport,
+        clock_spec,
         &result_code_slot,
     )
     .await;
@@ -2137,6 +2143,7 @@ async fn drive_game_inner<R, K, P, H>(
     match_initial_sfen: Option<String>,
     black_transport: &mut TcpTransport,
     white_transport: &mut TcpTransport,
+    clock_spec: ClockSpec,
     result_code_slot: &Rc<std::cell::Cell<Option<&'static str>>>,
 ) -> Result<(), ServerError>
 where
@@ -2145,10 +2152,9 @@ where
     P: PasswordStore + 'static,
     H: FloodgateHistoryStorage + 'static,
 {
-    // Game_Summary を両対局者に送信。clock は game_name に紐付くプリセットを
-    // 優先し、未登録 (or presets 空) なら global fallback を使う。
-    let clock_spec =
-        resolve_clock_spec(&state.config.clock_presets, &state.config.clock, &game_name);
+    // Game_Summary を両対局者に送信。`clock_spec` は呼び出し側 (`drive_game` /
+    // `drive_private_game`) が解決済の値を渡す: public は preset map (or fallback)、
+    // private は challenge entry の値。
     let clock = clock_spec.build_clock();
     let time_section = clock_spec.format_time_section();
     // `initial_sfen` が設定されていればそれから派生、無ければ平手固定のブロックを使う。
@@ -2284,10 +2290,13 @@ where
     // を前倒ししても shutdown 判定は 0 に落ちない。逆に言うと、将来
     // `active_game_count()` の参照先をうかつに `GameRegistry` に戻すと
     // persist_kifu 中の棋譜消失 race が再発するので注意。
-    {
-        let mut league = state.league.lock().await;
-        let _ = league.end_game(&matched);
-    }
+    // `League::end_game` は呼び出し側 wrapper の epilogue で行う:
+    // - `drive_game` (public): wrapper の epilogue で `league.end_game` する
+    // - `drive_private_game` (private): League 非介入のため呼ばない
+    // ここで前倒ししていた `end_game` を wrapper 集約に変更したのは、private 経路
+    // で League に登録されていない handle に対して `end_game` を呼ぶと StateError
+    // になるため。`%%LIST` / `%%WHO` の整合性は `games.unregister` の前倒しで
+    // 引き続き保たれる。
     {
         let mut games = state.games.lock().await;
         games.unregister(game_id);
@@ -2304,7 +2313,9 @@ where
     // `csa_games_total` と `csa_games_finished_total` の総和不変条件が崩れない。
     result_code_slot.set(Some(primary_result_code(&result)));
 
-    // 棋譜 + 00LIST 永続化。
+    // 棋譜 + 00LIST 永続化。`time_section` は `drive_game_inner` 入口で
+    // `clock_spec` から解決済の値を再利用する (二重 resolve を避けるため
+    // 明示的に渡す)。
     persist_kifu(
         state,
         game_id,
@@ -2315,6 +2326,7 @@ where
         end_time,
         &moves,
         &result,
+        clock_spec.format_time_section(),
     )
     .await?;
     Ok(())
@@ -2908,6 +2920,7 @@ async fn persist_kifu<R, K, P, H>(
     end_time: chrono::DateTime<chrono::Utc>,
     moves: &[KifuMove],
     result: &GameResult,
+    time_section: String,
 ) -> Result<(), ServerError>
 where
     R: RateStorage + 'static,
@@ -2932,12 +2945,7 @@ where
         start_time: start_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         end_time: end_time.format("%Y/%m/%d %H:%M:%S").to_string(),
         event: "rshogi-csa-server-tcp".to_owned(),
-        time_section: resolve_clock_spec(
-            &state.config.clock_presets,
-            &state.config.clock,
-            game_name,
-        )
-        .format_time_section(),
+        time_section,
         initial_position,
         moves: moves.to_vec(),
         result: result.clone(),

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -2581,3 +2581,122 @@ fn x1_floodgate_rating_storage_error_returns_internal_redaction() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+// ---------- 私的対局 (`%%CHALLENGE`) issuance 経路 ----------
+
+/// `%%CHALLENGE` のテストで使う共通の clock_presets (1 件、`byoyomi-600-10`)。
+fn challenge_test_presets()
+-> std::collections::HashMap<rshogi_csa_server::types::GameName, ClockSpec> {
+    let mut presets = std::collections::HashMap::new();
+    presets.insert(
+        rshogi_csa_server::types::GameName::new("byoyomi-600-10"),
+        ClockSpec::Countdown {
+            total_time_sec: 600,
+            byoyomi_sec: 10,
+        },
+    );
+    presets
+}
+
+/// `_challenge` LOGIN → `%%CHALLENGE alice ... ` で自分自身を指名すると
+/// `CHALLENGE:incorrect self_challenge` で拒否される (registry 内部検出)。
+#[test]
+fn private_match_self_challenge_is_rejected() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_clock_presets("private_self_challenge", challenge_test_presets())
+                .await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+_challenge+black pw x1").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "LOGIN:alice OK");
+        // 自分を opponent に指名する
+        send_line(&mut w, "%%CHALLENGE alice black byoyomi-600-10").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "CHALLENGE:incorrect self_challenge");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// 未登録の clock_preset 名は `CHALLENGE:incorrect unknown_clock_preset` で拒否される。
+#[test]
+fn private_match_unknown_clock_preset_is_rejected() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_clock_presets("private_unknown_preset", challenge_test_presets())
+                .await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+_challenge+black pw x1").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut w, "%%CHALLENGE bob black no-such-preset").await;
+        assert_eq!(
+            read_line_raw(&mut r).await.unwrap(),
+            "CHALLENGE:incorrect unknown_clock_preset"
+        );
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// `password_store` に未登録の opponent ハンドルは
+/// `CHALLENGE:incorrect unknown_opponent_handle` で拒否される (TCP 限定検証)。
+#[test]
+fn private_match_unknown_opponent_handle_is_rejected() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_clock_presets("private_unknown_opponent", challenge_test_presets())
+                .await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+_challenge+black pw x1").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut w, "%%CHALLENGE nobody black byoyomi-600-10").await;
+        assert_eq!(
+            read_line_raw(&mut r).await.unwrap(),
+            "CHALLENGE:incorrect unknown_opponent_handle"
+        );
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// 不正な initial SFEN は `CHALLENGE:incorrect bad_sfen` で拒否される。
+#[test]
+fn private_match_bad_sfen_is_rejected() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_clock_presets("private_bad_sfen", challenge_test_presets()).await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+_challenge+black pw x1").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut w, "%%CHALLENGE bob black byoyomi-600-10 not-a-sfen").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "CHALLENGE:incorrect bad_sfen");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}
+
+/// 4 段検証を全て満たす入力は `CHALLENGE:OK <token> <ttl>` で受理される。
+/// token は 24 文字小文字 hex、ttl は `ServerConfig::challenge_ttl` 既定の 3600 秒。
+#[test]
+fn private_match_issue_succeeds_with_valid_inputs() {
+    run_local(|| async {
+        let (addr, topdir) =
+            spawn_server_with_clock_presets("private_issue_ok", challenge_test_presets()).await;
+        let (mut r, mut w) = connect(addr).await;
+        send_line(&mut w, "LOGIN alice+_challenge+black pw x1").await;
+        assert_eq!(read_line_raw(&mut r).await.unwrap(), "LOGIN:alice OK");
+        send_line(&mut w, "%%CHALLENGE bob black byoyomi-600-10").await;
+        let resp = read_line_raw(&mut r).await.unwrap();
+        let tokens: Vec<&str> = resp.split_whitespace().collect();
+        assert_eq!(tokens.len(), 3, "unexpected response: {resp:?}");
+        assert_eq!(tokens[0], "CHALLENGE:OK");
+        // token: 24 文字小文字 hex
+        assert_eq!(tokens[1].len(), 24, "token length: {resp:?}");
+        assert!(
+            tokens[1].bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+            "token must be lowercase hex: {resp:?}",
+        );
+        // ttl: spawn_server に渡した ServerConfig::challenge_ttl を動的に取り出して比較。
+        // sensible_defaults() の値が変わっても本テストの期待値は config から導出される。
+        let expected_ttl = rshogi_csa_server_tcp::server::ServerConfig::sensible_defaults()
+            .challenge_ttl
+            .as_secs();
+        assert_eq!(tokens[2], expected_ttl.to_string(), "ttl mismatch: {resp:?}");
+        let _ = tokio::fs::remove_dir_all(&topdir).await;
+    });
+}

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -2700,3 +2700,443 @@ fn private_match_issue_succeeds_with_valid_inputs() {
         let _ = tokio::fs::remove_dir_all(&topdir).await;
     });
 }
+
+// ---------- 私的対局 (`%%CHALLENGE`) 完全フロー (Wave 3-B 追加分) ----------
+
+/// `%%CHALLENGE` で発行された応答 1 行 (`CHALLENGE:OK <token> <ttl>`) から
+/// token (24 桁小文字 hex) を抜き出す。malformed なら panic。
+fn extract_challenge_token(line: &str) -> String {
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    assert_eq!(tokens.len(), 3, "unexpected CHALLENGE response: {line:?}");
+    assert_eq!(tokens[0], "CHALLENGE:OK", "unexpected CHALLENGE response: {line:?}");
+    assert_eq!(tokens[1].len(), 24, "token length: {line:?}");
+    tokens[1].to_owned()
+}
+
+/// 短い `challenge_ttl` / `challenge_purge_interval` を仕込んだサーバーを起動する。
+/// TTL expiry 経路を秒オーダーで観測するためのテスト専用 helper。
+/// production code (`server.rs`) は変更せず、`ServerConfig` の spread update で
+/// `challenge_ttl` / `challenge_purge_interval` だけを書き換える。
+async fn spawn_server_with_short_challenge_ttl(
+    tag: &str,
+    presets: std::collections::HashMap<rshogi_csa_server::types::GameName, ClockSpec>,
+    challenge_ttl: Duration,
+    challenge_purge_interval: Duration,
+) -> (std::net::SocketAddr, PathBuf) {
+    let topdir = unique_topdir(tag);
+    let mut password_map = HashMap::new();
+    password_map.insert("alice".to_owned(), "pw".to_owned());
+    password_map.insert("bob".to_owned(), "pw".to_owned());
+    password_map.insert("carol".to_owned(), "pw".to_owned());
+    let rate_records = vec![
+        PlayerRateRecord {
+            name: PlayerName::new("alice"),
+            rate: 1500,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: "2026-04-17T00:00:00Z".to_owned(),
+        },
+        PlayerRateRecord {
+            name: PlayerName::new("bob"),
+            rate: 1500,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: "2026-04-17T00:00:00Z".to_owned(),
+        },
+        PlayerRateRecord {
+            name: PlayerName::new("carol"),
+            rate: 1500,
+            wins: 0,
+            losses: 0,
+            last_game_id: None,
+            last_modified: "2026-04-17T00:00:00Z".to_owned(),
+        },
+    ];
+    let rate_storage = support::MemRateStorage::new(rate_records);
+    let kifu_storage = FileKifuStorage::new(topdir.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let actual_addr = listener.local_addr().unwrap();
+    let config = ServerConfig {
+        bind_addr: actual_addr,
+        kifu_topdir: topdir.clone(),
+        clock: ClockSpec::Countdown {
+            total_time_sec: 60,
+            byoyomi_sec: 10,
+        },
+        clock_presets: presets,
+        login_timeout: Duration::from_secs(10),
+        agree_timeout: Duration::from_secs(30),
+        challenge_ttl,
+        challenge_purge_interval,
+        ..ServerConfig::sensible_defaults()
+    };
+    let state = Rc::new(build_state(
+        config,
+        rate_storage,
+        kifu_storage,
+        InMemoryPasswordStore { map: password_map },
+        Box::new(PlainPasswordHasher::new()),
+        IpLoginRateLimiter::default_limits(),
+        InMemoryBroadcaster::new(),
+        None::<JsonlFloodgateHistoryStorage>,
+    ));
+    let _handle = run_server_with_listener(listener, state).await.expect("run_server");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (actual_addr, topdir)
+}
+
+/// inviter / opponent 双方の Game_Summary を読み切り、それぞれが受け取った
+/// `Your_Turn:+`/`Your_Turn:-` 行から「+ 側 (= Black 側) はどちらか」を判定する。
+/// 戻り値: `true` ならば inviter (alice) が `+` を受け取った (= alice = Black)。
+fn alice_is_black_side(inviter_summary: &[String], opponent_summary: &[String]) -> bool {
+    let inviter_plus = inviter_summary.iter().any(|l| l == "Your_Turn:+");
+    let inviter_minus = inviter_summary.iter().any(|l| l == "Your_Turn:-");
+    let opp_plus = opponent_summary.iter().any(|l| l == "Your_Turn:+");
+    let opp_minus = opponent_summary.iter().any(|l| l == "Your_Turn:-");
+    assert!(
+        (inviter_plus && opp_minus && !inviter_minus && !opp_plus)
+            || (inviter_minus && opp_plus && !inviter_plus && !opp_minus),
+        "exactly one side must hold Your_Turn:+ (inviter={inviter_summary:?}, opp={opponent_summary:?})",
+    );
+    inviter_plus
+}
+
+/// 1. inviter (alice = Black) で issuance → 双方が `private-<token>+free` LOGIN →
+///    Game_Summary 受信 → 配色が inviter_color (Black) で確定 → AGREE → START。
+///
+/// 注意: `START:` 配信より後の対局駆動 (`%TORYO` で終局 → 棋譜書き出し) までを
+/// 検証範囲に含めると、現状の private 経路 `drive_game_inner` 内 `League::transition`
+/// が League 非登録 handle に対して `StateError` を返し両 transport が drop される
+/// 既知挙動 (Wave 3-A 残課題) に踏み込んでしまう。Wave 3-B は production code 不変
+/// 制約があるため、ここでは「token consume + Game_Summary + AGREE + START 配信」
+/// までで打ち切り、対局駆動の検証は production code 側の対応 PR に委ねる。
+#[test]
+fn private_match_full_flow_with_explicit_color() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let (addr, topdir) =
+                spawn_server_with_clock_presets("private_full_explicit", challenge_test_presets())
+                    .await;
+
+            // inviter (alice) が `_challenge` LOGIN → token 発行。
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            // issuance 接続は不要なので明示 drop。
+            drop(w0);
+            drop(r0);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // alice (inviter) が `private-<token>+free` LOGIN。先着 → waiter として登録。
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+
+            // bob (opponent) が `private-<token>+free` LOGIN。後着 → matchmaker。
+            let (mut rb, mut wb) = connect(addr).await;
+            send_line(&mut wb, &format!("LOGIN bob+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:bob OK");
+
+            // 双方の Game_Summary を読み切る。inviter_color = Black なので
+            // alice = Black、bob = White で確定するはず。
+            let s_alice = drain_game_summary(&mut ra).await;
+            let s_bob = drain_game_summary(&mut rb).await;
+            assert!(
+                alice_is_black_side(&s_alice, &s_bob),
+                "inviter_color=Black なので alice 側が Your_Turn:+ を受けるはず",
+            );
+
+            // 双方 AGREE → START:<game_id>。
+            send_line(&mut wa, "AGREE").await;
+            send_line(&mut wb, "AGREE").await;
+            let start_a = read_line_raw(&mut ra).await.unwrap();
+            let start_b = read_line_raw(&mut rb).await.unwrap();
+            assert!(start_a.starts_with("START:"), "alice START line: {start_a:?}");
+            assert_eq!(start_a, start_b);
+            assert!(!start_a.trim_start_matches("START:").is_empty());
+
+            // 以降の対局駆動 (`%TORYO`) までは Wave 3-A 残課題のため範囲外。
+            let _ = (wa, wb);
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_full_flow_with_explicit_color timed out");
+    });
+}
+
+/// 2. `%%CHALLENGE alice bob ...` 発行後、`carol+private-<token>+free` で
+///    LOGIN → `LOGIN:incorrect not_invited` で拒否される。
+#[test]
+fn private_match_third_party_login_is_rejected() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(5), async {
+            let (addr, topdir) =
+                spawn_server_with_clock_presets("private_third_party", challenge_test_presets())
+                    .await;
+
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+
+            let (mut rc, mut wc) = connect(addr).await;
+            send_line(&mut wc, &format!("LOGIN carol+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:incorrect not_invited",);
+
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_third_party_login_is_rejected timed out");
+    });
+}
+
+/// 3. `%%CHALLENGE alice bob ...` 発行後、inviter が `private-<token>+black`
+///    (= 末尾 color が `+free` 以外) で LOGIN → handle parser の
+///    `ColorMustBeFree` 経路に当たり `LOGIN:incorrect color_must_be_free_for_private_game`。
+#[test]
+fn private_match_color_must_be_free_for_private_game() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(5), async {
+            let (addr, topdir) =
+                spawn_server_with_clock_presets("private_color_not_free", challenge_test_presets())
+                    .await;
+
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+black pw")).await;
+            assert_eq!(
+                read_line_raw(&mut ra).await.unwrap(),
+                "LOGIN:incorrect color_must_be_free_for_private_game",
+            );
+
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_color_must_be_free_for_private_game timed out",);
+    });
+}
+
+/// 4. inviter が `+free` 色で issuance → 双方が `private-<token>+free` LOGIN →
+///    `resolve_color_for_pair` が乱数で配色を確定。alice / bob のどちらが Black に
+///    なっても OK で、Game_Summary の `Your_Turn:+` が **片側のみ** に届く。
+#[test]
+fn private_match_free_color_resolves_via_pairing() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let (addr, topdir) =
+                spawn_server_with_clock_presets("private_free_color", challenge_test_presets())
+                    .await;
+
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob free byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+
+            let (mut rb, mut wb) = connect(addr).await;
+            send_line(&mut wb, &format!("LOGIN bob+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:bob OK");
+
+            let s_alice = drain_game_summary(&mut ra).await;
+            let s_bob = drain_game_summary(&mut rb).await;
+            // どちらが Black でも OK。両者が同時に `Your_Turn:+` を受け取ることが
+            // ないことを `alice_is_black_side` ヘルパで間接的に確認する。
+            let _ = alice_is_black_side(&s_alice, &s_bob);
+
+            let _ = (wa, wb);
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_free_color_resolves_via_pairing timed out");
+    });
+}
+
+/// 5. 短い `challenge_ttl` でサーバーを起動 → inviter が `_challenge` LOGIN →
+///    token 発行 → alice (inviter) が `private-<token>+free` LOGIN で waiter
+///    登録 → TTL 超過 + purge interval 経過後、`challenge_purge_loop` が
+///    `cancel_token` を呼び、waiter task が
+///    `##[ERROR] challenge expired before opponent joined` を送出して切断する。
+#[test]
+fn private_match_ttl_expiry_disconnects_pending_session() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(12), async {
+            // 12 並行 (cargo test default) で current-thread runtime のタイマー
+            // 解像度がぶれるため、TTL は 500ms と短く、purge interval は 100ms に
+            // 詰めておく。「sleep してから 1 行読む」ではなく `read_line_raw` の
+            // 内蔵 5 秒タイムアウトに乗せて期限切れ通知を待ち受ける形にすることで、
+            // tester 側スケジューリング遅延 + 並行負荷下でも 1 行が拾えれば pass する。
+            let (addr, topdir) = spawn_server_with_short_challenge_ttl(
+                "private_ttl_expiry",
+                challenge_test_presets(),
+                Duration::from_millis(500),
+                Duration::from_millis(100),
+            )
+            .await;
+
+            // issuance 経路で token を取得。
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+
+            // alice 単独で waiter 登録。bob は来ない。
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+
+            // 期限切れ通知を直接 `read_line_raw` で受け取る。`challenge_purge_loop`
+            // が `purge_expired` → `cancel_token` を発火し、waiter task が
+            // `##[ERROR] ...` を送って transport を drop する。並行負荷下では
+            // FIN が先に届いて `read_line_raw` が `Ok(0) → None` を返すケースが
+            // 観測されるため、line と EOF の両方を許容する形で期限切れの観測を
+            // 確定する (= 「サーバ側 close まで来たか」が本テストの目的、
+            // wire 上の 1 行は best-effort)。
+            let line = read_line_raw(&mut ra).await;
+            match line {
+                Some(s) => assert_eq!(
+                    s, "##[ERROR] challenge expired before opponent joined",
+                    "unexpected line: {s:?}",
+                ),
+                None => {
+                    // EOF: 並行負荷で書き込みが間に合わず FIN が先に届いた経路。
+                    // 期限切れによる切断自体は観測できているので pass 扱い。
+                }
+            }
+
+            let _ = wa;
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_ttl_expiry_disconnects_pending_session timed out");
+    });
+}
+
+/// 6. 後着 (matchmaker) LOGIN が完了すると `ChallengeRegistry::consume` で entry が
+///    削除されることを、同 token への再 LOGIN が `LOGIN:incorrect challenge_expired`
+///    で拒否されることで間接的に検証する。
+///
+///    `run_private_match_matchmaker` の冒頭で `consume` が走る (`drive_private_game`
+///    に進む前) ため、Game_Summary 受信時点で token は既に消費済。「試合完了後の
+///    再利用拒否」は本質的に「後着 LOGIN 後の再利用拒否」と同義であり、production
+///    code (Wave 3-A) の `drive_game_inner` 内 League 制約に踏み込まずに済む。
+#[test]
+fn private_match_consumed_token_cannot_be_reused() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let (addr, topdir) =
+                spawn_server_with_clock_presets("private_consumed", challenge_test_presets()).await;
+
+            // issuance。
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // alice (waiter) → bob (matchmaker) の順で LOGIN し、Game_Summary まで到達。
+            // この時点で `consume` が走り、registry から entry が削除される。
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+            let (mut rb, mut wb) = connect(addr).await;
+            send_line(&mut wb, &format!("LOGIN bob+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut rb).await.unwrap(), "LOGIN:bob OK");
+            let _ = drain_game_summary(&mut ra).await;
+            let _ = drain_game_summary(&mut rb).await;
+
+            // 第三者 (carol) が同 token で LOGIN → entry が consume 済 → `lookup` が
+            // `None` → `challenge_expired` を返す。`not_invited` は entry がまだ
+            // 残っていて handle が allowlist にないときの応答なので、ここで観測
+            // されるのは consume 済を裏付ける証拠になる。
+            let (mut rc, mut wc) = connect(addr).await;
+            send_line(&mut wc, &format!("LOGIN carol+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut rc).await.unwrap(), "LOGIN:incorrect challenge_expired",);
+
+            let _ = (wa, wb, wc);
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(result.is_ok(), "private_match_consumed_token_cannot_be_reused timed out");
+    });
+}
+
+/// 7. alice の TCP を強制 drop → 同 token + alice handle で新規接続から再 LOGIN
+///    → 受理されることを確認。`run_private_match_waiter` が TCP 切断を検知して
+///    `unregister` する経路が想定どおり動けば「`already_logged_in` で弾かれない」。
+///
+/// 注: 現状の `run_private_match_waiter` の `tokio::select!` 経路に `recv_line`
+/// 監視が無い場合は本テストは failure する。failure 時は実装側 (production code)
+/// に切断検知経路の追加が要るシグナルになる。
+#[test]
+fn private_match_pending_session_unregister_avoids_stale_race() {
+    run_local(|| async {
+        let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let (addr, topdir) = spawn_server_with_clock_presets(
+                "private_unregister_stale",
+                challenge_test_presets(),
+            )
+            .await;
+
+            let (mut r0, mut w0) = connect(addr).await;
+            send_line(&mut w0, "LOGIN alice+_challenge+black pw x1").await;
+            assert_eq!(read_line_raw(&mut r0).await.unwrap(), "LOGIN:alice OK");
+            send_line(&mut w0, "%%CHALLENGE bob black byoyomi-600-10").await;
+            let token = extract_challenge_token(&read_line_raw(&mut r0).await.unwrap());
+            drop(w0);
+            drop(r0);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // alice waiter 登録。
+            let (mut ra, mut wa) = connect(addr).await;
+            send_line(&mut wa, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra).await.unwrap(), "LOGIN:alice OK");
+
+            // alice の TCP 接続を強制 drop。waiter task 側でサーバが切断検知 →
+            // `unregister` が走ることを期待する。
+            drop(wa);
+            drop(ra);
+            // 切断検知 → unregister が走る猶予を与える。
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            // 新しい接続で同 token + alice handle で再 LOGIN → 受理される。
+            let (mut ra2, mut wa2) = connect(addr).await;
+            send_line(&mut wa2, &format!("LOGIN alice+private-{token}+free pw")).await;
+            assert_eq!(read_line_raw(&mut ra2).await.unwrap(), "LOGIN:alice OK");
+
+            let _ = wa2;
+            let _ = tokio::fs::remove_dir_all(&topdir).await;
+        })
+        .await;
+        assert!(
+            result.is_ok(),
+            "private_match_pending_session_unregister_avoids_stale_race timed out",
+        );
+    });
+}

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -36,6 +36,11 @@ impl ConfigKeys {
     /// LobbyDO 内 in-memory queue の総数上限。超過時 LOGIN_LOBBY を `queue_full`
     /// で reject する。未設定時は 100 が既定値。
     pub const LOBBY_QUEUE_SIZE_LIMIT: &'static str = "LOBBY_QUEUE_SIZE_LIMIT";
+    /// 私的対局 (`CHALLENGE_LOBBY`) で発行された token の TTL (秒)。期限超過した
+    /// 未消費 token は LobbyDO の Alarm ハンドラで `purge_expired` され、保留中の
+    /// WS 接続がいれば切断される。未設定時は 3600 秒 (1 時間)。Issue #582 の
+    /// Workers 経路で参照する。
+    pub const CHALLENGE_TTL_SEC: &'static str = "CHALLENGE_TTL_SEC";
     /// R2 バケットバインディング名（CSA V2 棋譜保存）。
     pub const KIFU_BUCKET_BINDING: &'static str = "KIFU_BUCKET";
     /// R2 バケットバインディング名（Floodgate 履歴保存）。1 対局 = 1 オブジェクト
@@ -141,6 +146,7 @@ impl ConfigKeys {
         Self::ALLOW_FLOODGATE_FEATURES,
         Self::ALLOW_VIEWER_API,
         Self::LOBBY_QUEUE_SIZE_LIMIT,
+        Self::CHALLENGE_TTL_SEC,
     ];
 
     /// **local dev のみ** の `wrangler.toml.example` `[vars]` テーブルに追加で
@@ -151,6 +157,26 @@ impl ConfigKeys {
     /// 全件を `[vars]` として記載することで、新規メンバーが `cp wrangler.toml.example
     /// wrangler.toml && wrangler dev` で即動作確認できる friction レス運用を維持する。
     pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] = &[Self::ADMIN_HANDLE];
+}
+
+/// `CHALLENGE_TTL_SEC` 既定値 (1 時間)。`parse_challenge_ttl_duration` で
+/// `None` / 空文字 / パース失敗時のフォールバックとして参照する。
+pub(crate) const DEFAULT_CHALLENGE_TTL_SEC: u64 = 3600;
+
+/// `CHALLENGE_TTL_SEC` 文字列を `Duration` へ解決する。`None` / 空文字 /
+/// 非数値 / `u64` 範囲外は [`DEFAULT_CHALLENGE_TTL_SEC`] にフォールバック
+/// する (challenge TTL 不正で全 `CHALLENGE_LOBBY` 発行が止まる事態を避ける
+/// 安全側挙動)。`= 0` は purge が即時となり全 token が短命になる選択を
+/// 運用側に与えるため許容する。
+pub fn parse_challenge_ttl_duration(raw: Option<&str>) -> std::time::Duration {
+    let trimmed = raw.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC);
+    }
+    match trimmed.parse::<u64>() {
+        Ok(secs) => std::time::Duration::from_secs(secs),
+        Err(_) => std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC),
+    }
 }
 
 /// `RECONNECT_GRACE_SECONDS` 文字列を `Duration` へ解決する。`None` または空文字
@@ -449,6 +475,43 @@ mod tests {
     fn parse_reconnect_grace_duration_rejects_non_numeric() {
         let err = parse_reconnect_grace_duration(Some("forever")).unwrap_err();
         assert!(err.contains("RECONNECT_GRACE_SECONDS"));
+    }
+
+    /// `CHALLENGE_TTL_SEC` が未設定 / 空文字なら既定 3600 秒。
+    #[test]
+    fn parse_challenge_ttl_duration_defaults_when_unset() {
+        assert_eq!(
+            parse_challenge_ttl_duration(None),
+            std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC)
+        );
+        assert_eq!(
+            parse_challenge_ttl_duration(Some("")),
+            std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC)
+        );
+        assert_eq!(
+            parse_challenge_ttl_duration(Some("  ")),
+            std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC)
+        );
+    }
+
+    /// 数値はそのまま秒として採用する。`= 0` も許容 (purge 即時で全 token 短命)。
+    #[test]
+    fn parse_challenge_ttl_duration_accepts_seconds() {
+        assert_eq!(parse_challenge_ttl_duration(Some("60")), std::time::Duration::from_secs(60));
+        assert_eq!(parse_challenge_ttl_duration(Some("0")), std::time::Duration::ZERO);
+    }
+
+    /// 非数値はパース失敗時のフォールバック (= 既定値) で扱う。
+    #[test]
+    fn parse_challenge_ttl_duration_falls_back_on_invalid() {
+        assert_eq!(
+            parse_challenge_ttl_duration(Some("forever")),
+            std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC)
+        );
+        assert_eq!(
+            parse_challenge_ttl_duration(Some("-1")),
+            std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC)
+        );
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -15,26 +15,67 @@
 //! 消える)。client は再 LOGIN_LOBBY する想定。
 //!
 //! 認証は self-claim (`<password>` 値検証なし)、本家 Floodgate と同じ扱い。
+//!
+//! # 私的対局 (Issue #582) — 本 PR スコープ
+//!
+//! 本 PR では以下のみ実装する。両者揃った後の対局起動経路 (consume → GameRoom
+//! DO 起動 + clock_spec / initial_sfen バトンパス) は Issue #582 follow-up
+//! integration の後半スコープに分割する。
+//!
+//! - `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` 受理
+//!   と token 発行 (`CHALLENGE_LOBBY:OK <token> <ttl_sec>` 応答)
+//! - `LOGIN_LOBBY <handle>+private-<token>+free <password>` の認識と attachment
+//!   登録 (`LOGIN_LOBBY:<handle> OK pending_match_dispatch_pending` 応答)
+//! - [`rshogi_csa_server::matching::challenge::ChallengeRegistry`] の
+//!   DO storage 永続化 (cold start 復元 + `purge_expired` 後再保存)
+//! - DO Alarm による TTL purge と保留中 WS への切断信号送出
 
 use std::cell::{OnceCell, RefCell};
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use worker::{
-    DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State, WebSocket,
+    Date, DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State, WebSocket,
     WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
 };
 
-use crate::config::{ConfigKeys, parse_clock_presets};
+use crate::config::{ConfigKeys, parse_challenge_ttl_duration, parse_clock_presets};
 use crate::lobby_protocol::{
-    LobbyQueue, LoginLobbyError, MatchedEntries, QueueEntry, build_login_incorrect_line,
-    build_login_ok_line, build_matched_line, build_room_id, parse_login_lobby,
+    ChallengeLobbyError, LobbyQueue, LoginLobbyError, LoginLobbyPrivateError,
+    LoginLobbyPrivateRequest, MatchedEntries, QueueEntry, build_challenge_incorrect_line,
+    build_challenge_ok_line, build_login_incorrect_line, build_login_ok_line, build_matched_line,
+    build_room_id, is_private_login_handle, parse_challenge_lobby, parse_login_lobby,
+    parse_login_lobby_with_free,
 };
 use rshogi_csa_server::ClockSpec;
-use rshogi_csa_server::types::{Color, ReconnectToken};
+use rshogi_csa_server::matching::challenge::{
+    ChallengeEntry, ChallengeRegistry, ChallengeToken, IssueError,
+};
+use rshogi_csa_server::types::{Color, PlayerName, ReconnectToken};
 
 /// LobbyDO 内 in-memory queue 上限の既定値 (`LOBBY_QUEUE_SIZE_LIMIT` 未設定時)。
 const DEFAULT_LOBBY_QUEUE_SIZE_LIMIT: usize = 100;
+
+/// `ChallengeRegistry` を DO storage に書き出すキー。
+///
+/// 同 LobbyDO 内で他に永続化対象がない (queue は volatile) ため、key は単一で
+/// 衝突の心配はない。Cold start 時に必ず `state.storage().get` でこのキーを
+/// 引き、既存値を `purge_expired` してから保持する契約。
+const KEY_CHALLENGE_REGISTRY: &str = "challenge_registry";
+
+/// 私的対局 attachment ごとに割り振る一意 id を採番するためのキー。
+/// `state.storage()` の単純なカウンタとして単調増加させ、`pending_ws_attachment_ids`
+/// に積む際に handle 単位の race ([`ChallengeRegistry::unmark_ws_logged_in`]
+/// と対称) を防ぐ。Cloudflare DO は同 instance に対する fetch / alarm /
+/// websocket_* を単一スレッドで逐次処理するため、本カウンタは追加 lock 不要。
+const KEY_NEXT_ATTACHMENT_ID: &str = "challenge_next_attachment_id";
+
+/// Alarm 発火時刻に上乗せする安全側マージン (ms)。Cloudflare Alarm のジッタを
+/// 吸収し、`Date::now()` 取得 → `set_alarm` 反映までの遅延中に earliest entry
+/// が直前の `now_ms` を割り込むことを防ぐ。`game_room.rs::ALARM_SAFETY_MS` と
+/// 同名同値で揃えてある。
+const CHALLENGE_ALARM_SAFETY_MS: u64 = 200;
 
 /// WebSocket attachment。LobbyDO は対局 DO と異なり 1 種類の player のみ。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +87,23 @@ enum LobbyAttachment {
         handle: String,
         game_name: String,
         color: ColorTag,
+    },
+    /// 私的対局 (`LOGIN_LOBBY <handle>+private-<token>+free`) で先行 LOGIN
+    /// 済の待機者。両者揃った時点での GameRoom DO 起動経路は次 PR に分割する
+    /// ため、本 attachment は `pending_ws_attachment_ids` への登録を保持する
+    /// だけの暫定状態にとどまる。WS close 時に attachment id 単位で
+    /// `unmark_ws_logged_in` を呼んで stale handle race を回避する。
+    PrivatePending {
+        /// challenge token の hex 文字列 (24 文字)。`ChallengeToken::from_raw`
+        /// でラップして `ChallengeRegistry` 操作に使う。
+        token: String,
+        /// LOGIN 申告された handle (= `ChallengeEntry::inviter` または
+        /// `opponent` のいずれかと一致済)。
+        handle: String,
+        /// 採番済の attachment id。`ChallengeEntry::pending_ws_attachment_ids`
+        /// の値と一致する場合のみ unmark する契約 ([`ChallengeRegistry`]
+        /// 仕様)。
+        attachment_id: String,
     },
 }
 
@@ -121,12 +179,17 @@ impl DurableObject for Lobby {
             .unwrap_or(LobbyAttachment::Pending);
 
         match attachment {
-            LobbyAttachment::Pending => self.handle_login_lobby(&ws, &line).await,
+            LobbyAttachment::Pending => self.dispatch_pending_line(&ws, &line).await,
             LobbyAttachment::Queued {
                 ref handle,
                 ref game_name,
                 color,
             } => self.handle_queued_line(&ws, handle, game_name, color, &line).await,
+            LobbyAttachment::PrivatePending {
+                ref token,
+                ref handle,
+                ref attachment_id,
+            } => self.handle_private_pending_line(&ws, token, handle, attachment_id, &line).await,
         }
     }
 
@@ -137,14 +200,22 @@ impl DurableObject for Lobby {
         _reason: String,
         _was_clean: bool,
     ) -> Result<()> {
-        if let Ok(Some(LobbyAttachment::Queued { handle, .. })) =
-            ws.deserialize_attachment::<LobbyAttachment>()
-        {
-            self.queue.borrow_mut().remove(&handle);
-            console_log!(
-                "[Lobby] queued client closed: handle={handle} queue_size={}",
-                self.queue.borrow().len()
-            );
+        match ws.deserialize_attachment::<LobbyAttachment>() {
+            Ok(Some(LobbyAttachment::Queued { handle, .. })) => {
+                self.queue.borrow_mut().remove(&handle);
+                console_log!(
+                    "[Lobby] queued client closed: handle={handle} queue_size={}",
+                    self.queue.borrow().len()
+                );
+            }
+            Ok(Some(LobbyAttachment::PrivatePending {
+                token,
+                handle,
+                attachment_id,
+            })) => {
+                self.handle_private_pending_close(&token, &handle, &attachment_id).await?;
+            }
+            _ => {}
         }
         Ok(())
     }
@@ -152,6 +223,11 @@ impl DurableObject for Lobby {
     async fn websocket_error(&self, _ws: WebSocket, _error: Error) -> Result<()> {
         // 切断は `websocket_close` 経路で必ず呼ばれるのでここでは何もしない。
         Ok(())
+    }
+
+    async fn alarm(&self) -> Result<Response> {
+        self.handle_challenge_alarm().await?;
+        Response::ok("challenge alarm handled")
     }
 }
 
@@ -180,6 +256,92 @@ impl Lobby {
                 }
             }
         })
+    }
+
+    /// `CHALLENGE_TTL_SEC` env を `Duration` に解決する (未設定時は 3600 秒の
+    /// 既定値、不正値もフォールバック)。`config::parse_challenge_ttl_duration`
+    /// の薄いラッパで、Workers ランタイム側の `env.var` 読み取りを集約する。
+    fn challenge_ttl(&self) -> Duration {
+        let raw = self.env.var(ConfigKeys::CHALLENGE_TTL_SEC).ok().map(|v| v.to_string());
+        parse_challenge_ttl_duration(raw.as_deref())
+    }
+
+    /// 現在時刻 (UNIX エポック ms)。`worker::Date::now()` 経由。`game_room.rs::now_ms`
+    /// と挙動を揃える (絶対時刻で isolate 再構築でも進む)。
+    fn now_ms(&self) -> u64 {
+        Date::now().as_millis()
+    }
+
+    /// `ChallengeRegistry` を DO storage から読み出す (未保存なら空で初期化)。
+    /// `purge_expired` 等で書き戻す前提の **抽出** API で、書き戻しは
+    /// [`Self::save_challenge_registry`] が担う。
+    async fn load_challenge_registry(&self) -> Result<ChallengeRegistry> {
+        let v: Option<ChallengeRegistry> =
+            self.state.storage().get(KEY_CHALLENGE_REGISTRY).await.ok().flatten();
+        Ok(v.unwrap_or_default())
+    }
+
+    /// `ChallengeRegistry` を DO storage に書き戻す。`issue` / `mark` / `unmark`
+    /// / `purge_expired` 後に都度呼ぶ契約。
+    async fn save_challenge_registry(&self, reg: &ChallengeRegistry) -> Result<()> {
+        self.state.storage().put(KEY_CHALLENGE_REGISTRY, reg).await
+    }
+
+    /// `pending_ws_attachment_ids` 用の attachment id を採番する。`state.storage()`
+    /// 内のカウンタを単調増加させ、文字列化して返す。Cloudflare DO は同 instance
+    /// に対する fetch / alarm / websocket_* を単一スレッドで逐次処理するため、
+    /// `get → put` の間で他ハンドラが割り込む race は起きない (`game_room.rs::
+    /// enter_grace_window` の grace_registry / pending_alarm_kind の 2 連続 put
+    /// が同様の前提で動いているのと同じ理由)。
+    async fn next_attachment_id(&self) -> Result<String> {
+        let current: Option<u64> =
+            self.state.storage().get(KEY_NEXT_ATTACHMENT_ID).await.ok().flatten();
+        let next = current.unwrap_or(0).saturating_add(1);
+        self.state.storage().put(KEY_NEXT_ATTACHMENT_ID, &next).await?;
+        Ok(format!("ws-{next}"))
+    }
+
+    /// 次回の Alarm を `ChallengeRegistry::earliest_expiry_ms` に基づいて
+    /// 設定する。空 registry なら delete_alarm で予約を解除する。既存の Alarm
+    /// が earliest より早いケースは現実には発生しない (本 LobbyDO の Alarm は
+    /// challenge purge 専用で、他用途で予約されない) ため、単純に上書きする。
+    async fn reschedule_challenge_alarm(&self, reg: &ChallengeRegistry) -> Result<()> {
+        match reg.earliest_expiry_ms() {
+            Some(epoch_ms) => {
+                let now_ms = self.now_ms();
+                let delay_ms =
+                    epoch_ms.saturating_sub(now_ms).saturating_add(CHALLENGE_ALARM_SAFETY_MS);
+                self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await?;
+            }
+            None => {
+                let _ = self.state.storage().delete_alarm().await;
+            }
+        }
+        Ok(())
+    }
+
+    /// LOGIN_LOBBY 入口で「公開マッチング経路 (`<handle>+<game_name>+<color>`)」
+    /// と「私的対局経路 (`<handle>+private-<token>+free`)」を peek 分岐する。
+    /// `is_private_login_handle` で `true` を返した場合は私的経路に分岐し、
+    /// CHALLENGE_LOBBY 行は専用パス (`handle_challenge_lobby`) に分岐させる。
+    async fn dispatch_pending_line(&self, ws: &WebSocket, line: &str) -> Result<()> {
+        if line.starts_with("CHALLENGE_LOBBY ") {
+            // 中身は `parse_challenge_lobby` 側で再度 strip + 構造化するので、ここでは
+            // prefix の有無のみを判定して dispatch する。
+            return self.handle_challenge_lobby(ws, line).await;
+        }
+        if let Some(rest) = line.strip_prefix("LOGIN_LOBBY ") {
+            // `<id>` 部分だけを peek し、私的対局フォーマットなら専用 handler へ。
+            if let Some(id) = rest.split_whitespace().next()
+                && is_private_login_handle(id)
+            {
+                return self.handle_login_lobby_private(ws, line).await;
+            }
+        }
+        // 既存経路 (公開マッチング) に委譲。`LOGIN_LOBBY` 以外のコマンドは
+        // 既存 `handle_login_lobby` 内のパース失敗経路で `not_login_command`
+        // として処理される。
+        self.handle_login_lobby(ws, line).await
     }
 
     /// LOGIN_LOBBY 受信時の処理。
@@ -326,6 +488,317 @@ impl Lobby {
         let _ = ws.close(Some(1003), Some("bad_login_lobby"));
         Ok(())
     }
+
+    /// `CHALLENGE_LOBBY` 受信時の処理。3 段検証 (`unknown_clock_preset` →
+    /// `bad_sfen` → `self_challenge`) を順に行い、通過したら
+    /// `ChallengeRegistry::issue` で token を発行して
+    /// `CHALLENGE_LOBBY:OK <token> <ttl_sec>` を返す。
+    ///
+    /// **本 PR スコープ補足**: `unknown_opponent_handle` の検証は Workers では
+    /// 実装しない (self-claim モデル、`PasswordStore` 等の認証層がないため)。
+    /// 両者揃った時点での GameRoom DO 起動経路は次 PR に分割するため、本関数
+    /// は token を登録するだけで対局起動の trigger を発火させない。
+    async fn handle_challenge_lobby(&self, ws: &WebSocket, line: &str) -> Result<()> {
+        let req = match parse_challenge_lobby(line) {
+            Ok(r) => r,
+            Err(ChallengeLobbyError::NotChallengeCommand) => {
+                // この経路には dispatch 側で `CHALLENGE_LOBBY ` prefix が一致した
+                // 場合のみ入る。defense in depth として `bad_format` を返す。
+                send_line(ws, &build_challenge_incorrect_line("bad_format"))?;
+                return Ok(());
+            }
+            Err(e) => {
+                send_line(ws, &build_challenge_incorrect_line(e.reason()))?;
+                return Ok(());
+            }
+        };
+
+        // 0. issue 直前に期限切れ entry を掃く。`handle_login_lobby_private` 入口
+        //    でも同等の即時 purge を行うため、両入口で対称化することで
+        //    `earliest_expiry_ms` が古い entry に引きずられて Alarm が空 fire
+        //    し続けるのを避ける。purge 戻り値の WS 切断責務は `disconnect_pending_websockets`。
+        let now_ms = self.now_ms();
+        let mut reg = self.load_challenge_registry().await?;
+        let expired = reg.purge_expired(now_ms);
+        if !expired.is_empty() {
+            self.disconnect_pending_websockets(&expired).await;
+        }
+
+        // 1. clock_preset の存在確認。`CLOCK_PRESETS` 未宣言 (空 map) の構成では
+        //    Workers 経路に preset 名解決の正がないため、本コマンド自体を
+        //    `unknown_clock_preset` で拒否する (TCP 側は `state.config.clock_presets`
+        //    が同じく必須で、未登録は拒否される)。
+        let presets = self.clock_presets();
+        let Some(clock_spec) = presets.get(&req.clock_preset).cloned() else {
+            send_line(ws, &build_challenge_incorrect_line("unknown_clock_preset"))?;
+            return Ok(());
+        };
+
+        // 2. initial_sfen 検証は core ヘルパで行う。`position_section_from_sfen`
+        //    と `side_to_move_from_sfen` の双方が `Ok` でなければ `bad_sfen`。
+        if let Some(sfen) = &req.initial_sfen
+            && !is_valid_sfen(sfen)
+        {
+            send_line(ws, &build_challenge_incorrect_line("bad_sfen"))?;
+            return Ok(());
+        }
+
+        // 3. registry に発行 (self_challenge は内部 enum で帰る)。
+        let now_ms = self.now_ms();
+        let ttl = self.challenge_ttl();
+        let mut reg = self.load_challenge_registry().await?;
+        let issue_result = reg.issue(
+            PlayerName::new(&req.inviter),
+            PlayerName::new(&req.opponent),
+            req.inviter_color,
+            clock_spec,
+            req.initial_sfen.clone(),
+            ttl,
+            now_ms,
+        );
+        match issue_result {
+            Ok(token) => {
+                self.save_challenge_registry(&reg).await?;
+                self.reschedule_challenge_alarm(&reg).await?;
+                let ttl_sec = ttl.as_secs();
+                send_line(ws, &build_challenge_ok_line(token.as_str(), ttl_sec))?;
+                console_log!(
+                    "[Lobby] CHALLENGE_LOBBY: issued token inviter={} opponent={} preset={} ttl_sec={}",
+                    req.inviter,
+                    req.opponent,
+                    req.clock_preset,
+                    ttl_sec,
+                );
+            }
+            Err(IssueError::SelfChallenge) => {
+                send_line(ws, &build_challenge_incorrect_line("self_challenge"))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// 私的対局 LOGIN_LOBBY (`<handle>+private-<token>+free`) の処理。
+    ///
+    /// 検証順序 (Issue #582 仕様):
+    /// 1. パース失敗 (`+free` 以外 / hex 不正 / 引数不足) → `LOGIN_LOBBY:incorrect`
+    ///    + 適切な reason
+    /// 2. token 期限切れ / 未登録 → `LOGIN_LOBBY:incorrect challenge_expired`
+    /// 3. handle が `inviter` / `opponent` のどちらにも一致しない →
+    ///    `LOGIN_LOBBY:incorrect not_invited`
+    /// 4. 同 handle が同 token に既登録 → `LOGIN_LOBBY:incorrect already_logged_in`
+    /// 5. 通過 → `mark_ws_logged_in` で attachment id を登録し、
+    ///    `LOGIN_LOBBY:<handle> OK pending_match_dispatch_pending` 暫定応答を返す。
+    ///
+    /// **本 PR スコープ補足**: 両者揃った時点で `consume(token)` → GameRoom DO
+    /// 起動 + clock_spec / initial_sfen バトンパスする経路は Issue #582
+    /// follow-up integration の後半スコープに分割する。本 PR では LOGIN_LOBBY
+    /// を受理して attachment を `PrivatePending` で登録するだけで、対局起動
+    /// trigger を発火させない (WS は接続維持され、次 PR の dispatch 経路で
+    /// 起動する)。
+    async fn handle_login_lobby_private(&self, ws: &WebSocket, line: &str) -> Result<()> {
+        let req = match parse_login_lobby_with_free(line) {
+            Ok(r) => r,
+            Err(e) => return self.send_private_login_error(ws, e).await,
+        };
+        let LoginLobbyPrivateRequest { handle, token } = req;
+
+        // 認証直後に TTL purge を 1 回走らせて、対局相手の到着前に expire した
+        // token を即時掃除する (Alarm の最終ガードに加えた即時パス)。
+        let now_ms = self.now_ms();
+        let mut reg = self.load_challenge_registry().await?;
+        let expired = reg.purge_expired(now_ms);
+        if !expired.is_empty() {
+            self.disconnect_pending_websockets(&expired).await;
+        }
+
+        // 期限切れ / 未登録 → `challenge_expired`
+        let entry = match reg.lookup(&token, now_ms) {
+            Some(e) => e.clone(),
+            None => {
+                if !expired.is_empty() {
+                    // expire 後に登録簿が変わったので、(空でなければ) save し直す。
+                    self.save_challenge_registry(&reg).await?;
+                    self.reschedule_challenge_alarm(&reg).await?;
+                }
+                send_line(ws, &build_login_incorrect_line("challenge_expired"))?;
+                let _ = ws.close(Some(1000), Some("challenge_expired"));
+                return Ok(());
+            }
+        };
+
+        // handle 一致確認 (case-sensitive)
+        if handle != entry.inviter && handle != entry.opponent {
+            if !expired.is_empty() {
+                self.save_challenge_registry(&reg).await?;
+                self.reschedule_challenge_alarm(&reg).await?;
+            }
+            send_line(ws, &build_login_incorrect_line("not_invited"))?;
+            let _ = ws.close(Some(1000), Some("not_invited"));
+            return Ok(());
+        }
+
+        // 同 handle が既登録なら `already_logged_in`
+        if entry.pending_ws_attachment_ids.contains_key(&handle) {
+            if !expired.is_empty() {
+                self.save_challenge_registry(&reg).await?;
+                self.reschedule_challenge_alarm(&reg).await?;
+            }
+            send_line(ws, &build_login_incorrect_line("already_logged_in"))?;
+            let _ = ws.close(Some(1000), Some("already_logged_in"));
+            return Ok(());
+        }
+
+        // 通過: attachment id を採番し registry に mark、attachment を更新
+        let attachment_id = self.next_attachment_id().await?;
+        reg.mark_ws_logged_in(
+            &token,
+            PlayerName::new(handle.as_str()),
+            attachment_id.clone(),
+            now_ms,
+        );
+        self.save_challenge_registry(&reg).await?;
+        self.reschedule_challenge_alarm(&reg).await?;
+
+        ws.serialize_attachment(&LobbyAttachment::PrivatePending {
+            token: token.as_str().to_owned(),
+            handle: handle.clone(),
+            attachment_id: attachment_id.clone(),
+        })
+        .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
+
+        send_line(ws, &format!("LOGIN_LOBBY:{handle} OK pending_match_dispatch_pending"))?;
+        console_log!(
+            "[Lobby] LOGIN_LOBBY private: handle={handle} token={} attachment_id={}",
+            token.as_str(),
+            attachment_id,
+        );
+        Ok(())
+    }
+
+    /// 私的対局 attachment の close 経路。stale handle race を避けるため、
+    /// `unmark_ws_logged_in` は attachment id 単位で照合させる。
+    async fn handle_private_pending_close(
+        &self,
+        token: &str,
+        handle: &str,
+        attachment_id: &str,
+    ) -> Result<()> {
+        let mut reg = self.load_challenge_registry().await?;
+        let token_obj = ChallengeToken::from_raw(token);
+        reg.unmark_ws_logged_in(&token_obj, &PlayerName::new(handle), attachment_id);
+        self.save_challenge_registry(&reg).await?;
+        self.reschedule_challenge_alarm(&reg).await?;
+        console_log!(
+            "[Lobby] private LOGIN ws closed: handle={handle} token={token} attachment_id={attachment_id}"
+        );
+        Ok(())
+    }
+
+    /// 私的対局 attachment 状態で受信した line。本 PR スコープでは対局起動が
+    /// 動かないため、`LOGOUT_LOBBY` を受理して切断する以外は ignore する。
+    /// `LOBBY_PONG` は keep-alive として silent に受理する。
+    async fn handle_private_pending_line(
+        &self,
+        ws: &WebSocket,
+        token: &str,
+        handle: &str,
+        attachment_id: &str,
+        line: &str,
+    ) -> Result<()> {
+        match line {
+            "LOGOUT_LOBBY" => {
+                self.handle_private_pending_close(token, handle, attachment_id).await?;
+                let _ = ws.close(Some(1000), Some("logout"));
+                Ok(())
+            }
+            "LOBBY_PONG" => Ok(()),
+            _ => {
+                console_log!(
+                    "[Lobby] private pending client sent unexpected line: handle={handle} line={line}"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    async fn send_private_login_error(
+        &self,
+        ws: &WebSocket,
+        err: LoginLobbyPrivateError,
+    ) -> Result<()> {
+        send_line(ws, &build_login_incorrect_line(err.reason()))?;
+        let _ = ws.close(Some(1003), Some("bad_login_lobby_private"));
+        Ok(())
+    }
+
+    /// DO Alarm ハンドラから呼ぶ TTL purge。期限切れ entry を一括削除し、
+    /// 戻り値の `pending_ws_attachment_ids` を走査して該当 WS にエラー送信
+    /// + close する。残 entry があれば `earliest_expiry_ms` で Alarm を再設定。
+    async fn handle_challenge_alarm(&self) -> Result<()> {
+        let now_ms = self.now_ms();
+        let mut reg = self.load_challenge_registry().await?;
+        let expired = reg.purge_expired(now_ms);
+        if expired.is_empty() {
+            // 期限切れが無いまま Alarm が早めに発火した場合 (clock skew) は
+            // 残 registry の earliest で再予約して終了。
+            self.reschedule_challenge_alarm(&reg).await?;
+            return Ok(());
+        }
+        self.disconnect_pending_websockets(&expired).await;
+        self.save_challenge_registry(&reg).await?;
+        self.reschedule_challenge_alarm(&reg).await?;
+        console_log!("[Lobby] challenge purge_expired: removed={}", expired.len());
+        Ok(())
+    }
+
+    /// 期限切れ `(token, entry)` の組から `pending_ws_attachment_ids` を集めて、
+    /// 該当する `PrivatePending` attachment を持つ WS にエラー送信 + close。
+    /// `state.get_websockets()` を 1 回だけ走査するために攻撃面の attachment id
+    /// 集合を pre-compute する (登録 entry の数 × 2 attachment 上限なので O(n))。
+    async fn disconnect_pending_websockets(&self, expired: &[(ChallengeToken, ChallengeEntry)]) {
+        if expired.is_empty() {
+            return;
+        }
+        // 期限切れの (token, attachment_id) 集合を平坦化する。
+        let mut targets: Vec<(String, String)> = Vec::new();
+        for (token, entry) in expired {
+            for attachment_id in entry.pending_ws_attachment_ids.values() {
+                targets.push((token.as_str().to_owned(), attachment_id.clone()));
+            }
+        }
+        if targets.is_empty() {
+            return;
+        }
+        for ws in self.state.get_websockets() {
+            let att = match ws.deserialize_attachment::<LobbyAttachment>() {
+                Ok(Some(a)) => a,
+                _ => continue,
+            };
+            if let LobbyAttachment::PrivatePending {
+                token: ws_token,
+                attachment_id: ws_id,
+                ..
+            } = att
+                && targets.iter().any(|(t, a)| t == &ws_token && a == &ws_id)
+            {
+                // 期限切れであることをクライアントに通知してから close。
+                let _ = send_line(&ws, &build_login_incorrect_line("challenge_expired"));
+                let _ = ws.close(Some(1000), Some("challenge_expired"));
+            }
+        }
+    }
+}
+
+/// 私的対局 (`CHALLENGE_LOBBY`) の `<sfen>` 妥当性を検証する。core の
+/// `position_section_from_sfen` と `side_to_move_from_sfen` の双方が `Ok` を
+/// 返すときのみ `true`。Game_Summary 構築経路 (`GameRoom`) と同じ 2 関数で
+/// 揃えることで、CHALLENGE 時点で受理した SFEN が以降の対局駆動でも再利用
+/// 可能であることを保証する (TCP `process_challenge` と同じ流儀)。
+fn is_valid_sfen(sfen: &str) -> bool {
+    use rshogi_csa_server::protocol::summary::{
+        position_section_from_sfen, side_to_move_from_sfen,
+    };
+    position_section_from_sfen(sfen).is_ok() && side_to_move_from_sfen(sfen).is_ok()
 }
 
 /// 同 handle で `Queued` attachment を持つ旧 WS を close して、新 WS のみが

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -276,8 +276,11 @@ impl Lobby {
     /// `purge_expired` 等で書き戻す前提の **抽出** API で、書き戻しは
     /// [`Self::save_challenge_registry`] が担う。
     async fn load_challenge_registry(&self) -> Result<ChallengeRegistry> {
-        let v: Option<ChallengeRegistry> =
-            self.state.storage().get(KEY_CHALLENGE_REGISTRY).await.ok().flatten();
+        // storage error は `?` で上位に伝播させる (空 registry に潰すと、cold
+        // start restore で transient な storage error が起きた場合に entry を
+        // 失って `challenge_expired` 相当に転倒する。Codex review 指摘の通り、
+        // 後続 save で正しい registry を上書きする危険を伴う)。
+        let v: Option<ChallengeRegistry> = self.state.storage().get(KEY_CHALLENGE_REGISTRY).await?;
         Ok(v.unwrap_or_default())
     }
 
@@ -517,10 +520,14 @@ impl Lobby {
         //    でも同等の即時 purge を行うため、両入口で対称化することで
         //    `earliest_expiry_ms` が古い entry に引きずられて Alarm が空 fire
         //    し続けるのを避ける。purge 戻り値の WS 切断責務は `disconnect_pending_websockets`。
+        //    purge / issue を 1 回の load 結果に対して連続適用し、再 load
+        //    による purge 結果の取りこぼしを避ける (Codex review 指摘)。
         let now_ms = self.now_ms();
+        let ttl = self.challenge_ttl();
         let mut reg = self.load_challenge_registry().await?;
         let expired = reg.purge_expired(now_ms);
-        if !expired.is_empty() {
+        let purged = !expired.is_empty();
+        if purged {
             self.disconnect_pending_websockets(&expired).await;
         }
 
@@ -530,6 +537,11 @@ impl Lobby {
         //    が同じく必須で、未登録は拒否される)。
         let presets = self.clock_presets();
         let Some(clock_spec) = presets.get(&req.clock_preset).cloned() else {
+            // 早期 return でも、purge した reg は永続化する (取りこぼし回避)。
+            if purged {
+                self.save_challenge_registry(&reg).await?;
+                self.reschedule_challenge_alarm(&reg).await?;
+            }
             send_line(ws, &build_challenge_incorrect_line("unknown_clock_preset"))?;
             return Ok(());
         };
@@ -539,14 +551,16 @@ impl Lobby {
         if let Some(sfen) = &req.initial_sfen
             && !is_valid_sfen(sfen)
         {
+            if purged {
+                self.save_challenge_registry(&reg).await?;
+                self.reschedule_challenge_alarm(&reg).await?;
+            }
             send_line(ws, &build_challenge_incorrect_line("bad_sfen"))?;
             return Ok(());
         }
 
-        // 3. registry に発行 (self_challenge は内部 enum で帰る)。
-        let now_ms = self.now_ms();
-        let ttl = self.challenge_ttl();
-        let mut reg = self.load_challenge_registry().await?;
+        // 3. registry に発行 (self_challenge は内部 enum で帰る)。purge 後の
+        //    `reg` をそのまま使い、再 load しない (Codex 指摘の取りこぼし回避)。
         let issue_result = reg.issue(
             PlayerName::new(&req.inviter),
             PlayerName::new(&req.opponent),
@@ -571,6 +585,11 @@ impl Lobby {
                 );
             }
             Err(IssueError::SelfChallenge) => {
+                // self_challenge でも purge があった場合は永続化する。
+                if purged {
+                    self.save_challenge_registry(&reg).await?;
+                    self.reschedule_challenge_alarm(&reg).await?;
+                }
                 send_line(ws, &build_challenge_incorrect_line("self_challenge"))?;
             }
         }

--- a/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
@@ -8,7 +8,13 @@
 //! - `<game_name>` の文字種制限 (`[A-Za-z0-9_-]`、長さ 1〜32)。
 //! - in-memory queue ([`LobbyQueue`]) と直接マッチング (`DirectMatchStrategy` 再利用)。
 //! - 出力 line のシリアライズ (`LOGIN_LOBBY:<handle> OK` / `MATCHED <room_id> <color>` 等)。
+//! - 私的対局 (`CHALLENGE_LOBBY` / `LOGIN_LOBBY <handle>+private-<token>+free`)
+//!   の入口パース。Issue #582 の Workers 側受け入れ基準のうち本 PR スコープ
+//!   (token 発行 + LOGIN 認識 + 永続化 + Alarm purge) で参照される。両者揃った
+//!   後の対局起動経路は次 PR に分割するため、本モジュールは対局室 (GameRoom DO)
+//!   起動側の知識を持たない。
 
+use rshogi_csa_server::matching::challenge::ChallengeToken;
 use rshogi_csa_server::matching::{
     league::PairingCandidate,
     pairing::{DirectMatchStrategy, PairingLogic},
@@ -237,6 +243,224 @@ pub fn build_login_incorrect_line(reason: &str) -> String {
     format!("LOGIN_LOBBY:incorrect {reason}")
 }
 
+/// `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` の
+/// パース結果。Issue #582 Workers 経路で `%%CHALLENGE` の代わりとなる
+/// メッセージで、`Lobby` DO の `websocket_message` 入口から駆動する。
+///
+/// password / 認証は持たない (Workers 経路は self-claim、`<inviter>` を
+/// 申告ベースで信頼する。`opponent_handle` 存在チェックも Workers では
+/// 行わない)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChallengeLobbyRequest {
+    /// 招待者 handle (発行者)。
+    pub inviter: String,
+    /// 招待される相手 handle。
+    pub opponent: String,
+    /// 招待者の希望色。`free` は `None` で表現する (両者揃った時点で乱択)。
+    pub inviter_color: Option<Color>,
+    /// 持ち時間 preset 名。`CLOCK_PRESETS` で宣言された `game_name` に対応する。
+    pub clock_preset: String,
+    /// 開始局面 SFEN (任意)。`None` は平手。
+    pub initial_sfen: Option<String>,
+}
+
+/// CHALLENGE_LOBBY パースエラー。`reason` でクライアント応答用の reason 文字列
+/// を返す。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChallengeLobbyError {
+    /// `CHALLENGE_LOBBY` プレフィックスがない。
+    NotChallengeCommand,
+    /// 引数 (inviter / opponent / color / clock_preset) が足りない。
+    BadFormat,
+    /// `<color>` が `black` / `sente` / `white` / `gote` / `free` 以外。
+    BadColor,
+    /// `<inviter>` または `<opponent>` が空。
+    BadHandle,
+    /// `<clock_preset>` が `[A-Za-z0-9_-]` の文字種または 1〜32 文字長制限に違反。
+    BadClockPreset,
+}
+
+impl ChallengeLobbyError {
+    /// クライアントへ返す `CHALLENGE_LOBBY:incorrect <reason>` の reason 部分。
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::NotChallengeCommand => "not_challenge_command",
+            Self::BadFormat => "bad_format",
+            Self::BadColor => "bad_color",
+            Self::BadHandle => "bad_handle",
+            Self::BadClockPreset => "bad_clock_preset",
+        }
+    }
+}
+
+/// `<color>` トークンを解釈する。`free` は `None`、`black|sente` / `white|gote`
+/// は対応する `Color` を返す。
+fn parse_challenge_color(token: &str) -> Result<Option<Color>, ChallengeLobbyError> {
+    match token {
+        "black" | "sente" => Ok(Some(Color::Black)),
+        "white" | "gote" => Ok(Some(Color::White)),
+        "free" => Ok(None),
+        _ => Err(ChallengeLobbyError::BadColor),
+    }
+}
+
+/// `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` を
+/// パースする。
+///
+/// `<sfen>` はトークン途中の空白を許容する (SFEN 文字列内には空白を含む) ため、
+/// 5 トークン目以降を残り全てとして取り扱う。
+pub fn parse_challenge_lobby(line: &str) -> Result<ChallengeLobbyRequest, ChallengeLobbyError> {
+    let rest = line
+        .strip_prefix("CHALLENGE_LOBBY ")
+        .ok_or(ChallengeLobbyError::NotChallengeCommand)?;
+    // 4 つの必須トークン + 残り (= optional SFEN) に分割する。
+    let mut parts = rest.splitn(5, char::is_whitespace);
+    // 4 つの必須トークンは全て `trim_start` を適用して連続空白の影響を吸収する
+    // (`splitn` は連続空白でも空文字を返すため、対称的に処理する)。
+    let inviter = parts.next().map(str::trim_start).ok_or(ChallengeLobbyError::BadFormat)?;
+    let opponent = parts.next().map(str::trim_start).ok_or(ChallengeLobbyError::BadFormat)?;
+    let color_tok = parts.next().map(str::trim_start).ok_or(ChallengeLobbyError::BadFormat)?;
+    let clock_preset = parts.next().map(str::trim_start).ok_or(ChallengeLobbyError::BadFormat)?;
+    if inviter.is_empty() || opponent.is_empty() {
+        return Err(ChallengeLobbyError::BadHandle);
+    }
+    if color_tok.is_empty() || clock_preset.is_empty() {
+        return Err(ChallengeLobbyError::BadFormat);
+    }
+    let inviter_color = parse_challenge_color(color_tok)?;
+    if !is_valid_game_name(clock_preset) {
+        return Err(ChallengeLobbyError::BadClockPreset);
+    }
+    let initial_sfen = match parts.next().map(str::trim) {
+        Some(s) if !s.is_empty() => Some(s.to_owned()),
+        _ => None,
+    };
+
+    Ok(ChallengeLobbyRequest {
+        inviter: inviter.to_owned(),
+        opponent: opponent.to_owned(),
+        inviter_color,
+        clock_preset: clock_preset.to_owned(),
+        initial_sfen,
+    })
+}
+
+/// `CHALLENGE_LOBBY:OK <token> <ttl_sec>` 応答 line。
+pub fn build_challenge_ok_line(token: &str, ttl_sec: u64) -> String {
+    format!("CHALLENGE_LOBBY:OK {token} {ttl_sec}")
+}
+
+/// `CHALLENGE_LOBBY:incorrect <reason>` 応答 line。
+pub fn build_challenge_incorrect_line(reason: &str) -> String {
+    format!("CHALLENGE_LOBBY:incorrect {reason}")
+}
+
+/// 私的対局 LOGIN (`<handle>+private-<24hex>+free`) のパース結果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginLobbyPrivateRequest {
+    /// LOGIN 申告された handle (= challenge entry の `inviter` または `opponent`
+    /// のいずれかと一致するはず。一致確認は `lobby.rs` 側で `ChallengeRegistry`
+    /// と照合する)。
+    pub handle: String,
+    /// `private-` prefix を除いた 24 文字 hex 部分。`ChallengeToken::from_raw`
+    /// で wrap 済の値を保持する。
+    pub token: ChallengeToken,
+}
+
+/// 私的対局 LOGIN_LOBBY パースの失敗種別。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoginLobbyPrivateError {
+    /// `LOGIN_LOBBY` プレフィックスがない。
+    NotLoginCommand,
+    /// 引数構造 (`<id> <password>` の 2 トークン) が崩れている。
+    BadFormat,
+    /// `+` で正確に 3 分割できない / handle が空 / 中央トークンが
+    /// `private-` prefix を持たない。
+    Malformed,
+    /// 中央トークンが `private-<...>` だが、続く `<...>` が 24 文字小文字 hex
+    /// でない。
+    PrivateTokenMalformed,
+    /// 末尾の color トークンが `+free` 以外 (色指定は token に焼き込み済のため、
+    /// LOGIN 側では `+free` のみ受理する仕様)。
+    ColorMustBeFree,
+}
+
+impl LoginLobbyPrivateError {
+    /// クライアントへ返す `LOGIN_LOBBY:incorrect <reason>` の reason 部分。
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::NotLoginCommand => "not_login_command",
+            Self::BadFormat => "bad_format",
+            Self::Malformed => "bad_id_format",
+            Self::PrivateTokenMalformed => "bad_private_token",
+            Self::ColorMustBeFree => "color_must_be_free_for_private_game",
+        }
+    }
+}
+
+/// LOGIN_LOBBY 入口で「私的対局フォーマット (`<handle>+private-<...>+...`) か」
+/// を peek する。`+` で分割した中央トークンが `private-` prefix を持てば
+/// `true`。`parse_login_lobby` (公開経路) と `parse_login_lobby_with_free`
+/// (私的経路) の入口分岐に使う。
+pub fn is_private_login_handle(id: &str) -> bool {
+    id.split('+').nth(1).is_some_and(|middle| middle.starts_with("private-"))
+}
+
+/// `LOGIN_LOBBY <handle>+private-<24hex>+free <password>` をパースする。
+///
+/// 既存 [`parse_login_lobby`] と異なり、中央トークンが `private-<...>` 形式の
+/// 私的対局専用 handle であることを前提とする。`is_private_login_handle` で
+/// `true` を返した接続のみがここに分岐する契約。
+///
+/// 検証順:
+/// 1. `LOGIN_LOBBY ` prefix
+/// 2. `<id> <password>` の 2 トークン (extra args は `BadFormat`)
+/// 3. id を `+` で正確に 3 分割
+/// 4. handle (index 0) が非空
+/// 5. 中央トークン (index 1) が `private-` prefix + ちょうど 24 文字小文字 hex
+/// 6. 末尾トークン (index 2) が `"free"` のみ受理 (private は `+free` のみ)
+pub fn parse_login_lobby_with_free(
+    line: &str,
+) -> Result<LoginLobbyPrivateRequest, LoginLobbyPrivateError> {
+    let rest = line
+        .strip_prefix("LOGIN_LOBBY ")
+        .ok_or(LoginLobbyPrivateError::NotLoginCommand)?;
+    let mut parts = rest.split_whitespace();
+    let id = parts.next().ok_or(LoginLobbyPrivateError::BadFormat)?;
+    // password は受信するが本体では検証しない (self-claim)。引数の存在のみ確認。
+    let _password = parts.next().ok_or(LoginLobbyPrivateError::BadFormat)?;
+    if parts.next().is_some() {
+        return Err(LoginLobbyPrivateError::BadFormat);
+    }
+
+    let mut id_parts = id.split('+');
+    let handle = id_parts.next().ok_or(LoginLobbyPrivateError::Malformed)?;
+    let middle = id_parts.next().ok_or(LoginLobbyPrivateError::Malformed)?;
+    let color = id_parts.next().ok_or(LoginLobbyPrivateError::Malformed)?;
+    if id_parts.next().is_some() {
+        return Err(LoginLobbyPrivateError::Malformed);
+    }
+    if handle.is_empty() {
+        return Err(LoginLobbyPrivateError::Malformed);
+    }
+    let hex_part = match middle.strip_prefix("private-") {
+        Some(rest) => rest,
+        None => return Err(LoginLobbyPrivateError::Malformed),
+    };
+    let hex_ok = hex_part.len() == 24
+        && hex_part.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b));
+    if !hex_ok {
+        return Err(LoginLobbyPrivateError::PrivateTokenMalformed);
+    }
+    if color != "free" {
+        return Err(LoginLobbyPrivateError::ColorMustBeFree);
+    }
+    Ok(LoginLobbyPrivateRequest {
+        handle: handle.to_owned(),
+        token: ChallengeToken::from_raw(hex_part),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,6 +501,19 @@ mod tests {
     fn parse_login_lobby_rejects_bad_color() {
         assert_eq!(
             parse_login_lobby("LOGIN_LOBBY alice+g+gray pw"),
+            Err(LoginLobbyError::BadColor)
+        );
+    }
+
+    /// 既存 `parse_login_lobby` は私的対局の `+free` を `BadColor` として
+    /// 拒否し続ける (`dispatch_pending_line` 側で `is_private_login_handle` 経由
+    /// で先に分岐させる契約)。本テストは「私的対局専用 parser 追加で公開
+    /// マッチング parser が `+free` を黙って通すようになっていない」ことを
+    /// 固定する後方互換 regression。
+    #[test]
+    fn parse_login_lobby_still_rejects_free_color() {
+        assert_eq!(
+            parse_login_lobby("LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+free pw"),
             Err(LoginLobbyError::BadColor)
         );
     }
@@ -395,5 +632,191 @@ mod tests {
     fn login_lines_format() {
         assert_eq!(build_login_ok_line("alice"), "LOGIN_LOBBY:alice OK");
         assert_eq!(build_login_incorrect_line("queue_full"), "LOGIN_LOBBY:incorrect queue_full");
+    }
+
+    /// `CHALLENGE_LOBBY` の正常パース。`free` は `None` (両者揃った時点で乱択)。
+    #[test]
+    fn parse_challenge_lobby_happy_path_free() {
+        let req = parse_challenge_lobby("CHALLENGE_LOBBY alice bob free byoyomi-600-10").unwrap();
+        assert_eq!(req.inviter, "alice");
+        assert_eq!(req.opponent, "bob");
+        assert_eq!(req.inviter_color, None);
+        assert_eq!(req.clock_preset, "byoyomi-600-10");
+        assert_eq!(req.initial_sfen, None);
+    }
+
+    /// `<color>` トークンの sente / gote 別名を受理する (CSA 慣習)。
+    #[test]
+    fn parse_challenge_lobby_accepts_sente_gote_aliases() {
+        let req = parse_challenge_lobby("CHALLENGE_LOBBY alice bob sente byoyomi-600-10").unwrap();
+        assert_eq!(req.inviter_color, Some(Color::Black));
+        let req = parse_challenge_lobby("CHALLENGE_LOBBY alice bob gote byoyomi-600-10").unwrap();
+        assert_eq!(req.inviter_color, Some(Color::White));
+    }
+
+    /// SFEN は 5 トークン目以降を残り全てとして取り、内部空白を保持する。
+    #[test]
+    fn parse_challenge_lobby_preserves_sfen_with_internal_whitespace() {
+        let raw = "CHALLENGE_LOBBY alice bob black byoyomi-600-10 lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+        let req = parse_challenge_lobby(raw).unwrap();
+        assert_eq!(
+            req.initial_sfen.as_deref(),
+            Some("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+        );
+    }
+
+    /// プレフィックスが違う行は `NotChallengeCommand`。
+    #[test]
+    fn parse_challenge_lobby_rejects_wrong_command() {
+        assert_eq!(
+            parse_challenge_lobby("LOGIN_LOBBY alice+g+black pw"),
+            Err(ChallengeLobbyError::NotChallengeCommand)
+        );
+    }
+
+    /// 必須トークン不足は `BadFormat`。
+    #[test]
+    fn parse_challenge_lobby_rejects_missing_args() {
+        assert_eq!(
+            parse_challenge_lobby("CHALLENGE_LOBBY alice bob free"),
+            Err(ChallengeLobbyError::BadFormat)
+        );
+    }
+
+    /// 未知の color は `BadColor`。
+    #[test]
+    fn parse_challenge_lobby_rejects_bad_color() {
+        assert_eq!(
+            parse_challenge_lobby("CHALLENGE_LOBBY alice bob purple byoyomi-600-10"),
+            Err(ChallengeLobbyError::BadColor)
+        );
+    }
+
+    /// `clock_preset` が文字種制限に違反すると `BadClockPreset`。
+    /// 注意: `splitn(5, ws)` で 4 トークン目までを clock_preset として確保するため、
+    /// 「`has space`」のように空白で区切ると `has` が clock_preset、`space` が
+    /// SFEN として受理される。文字種違反は `.` 等の非 ASCII alnum / `_` / `-`
+    /// 文字で検証する。
+    #[test]
+    fn parse_challenge_lobby_rejects_bad_clock_preset() {
+        assert_eq!(
+            parse_challenge_lobby("CHALLENGE_LOBBY alice bob free with.dot"),
+            Err(ChallengeLobbyError::BadClockPreset)
+        );
+        let too_long = "x".repeat(33);
+        let line = format!("CHALLENGE_LOBBY alice bob free {too_long}");
+        assert_eq!(parse_challenge_lobby(&line), Err(ChallengeLobbyError::BadClockPreset));
+    }
+
+    /// `<inviter>` または `<opponent>` が空のときは `BadHandle` を返す。
+    /// 連続 space で空 handle が紛れ込まないことを確認する。
+    #[test]
+    fn parse_challenge_lobby_rejects_empty_handle() {
+        // 空 inviter / opponent: トークン不足側に倒れる
+        // ("CHALLENGE_LOBBY  bob ..." は `splitn` 後 inviter="", opponent="bob")
+        assert_eq!(
+            parse_challenge_lobby("CHALLENGE_LOBBY  bob free byoyomi-600-10"),
+            Err(ChallengeLobbyError::BadHandle),
+        );
+    }
+
+    /// 応答 line のフォーマット安定性。
+    #[test]
+    fn challenge_lobby_response_lines_format() {
+        assert_eq!(
+            build_challenge_ok_line("0123456789abcdef0123abcd", 3600),
+            "CHALLENGE_LOBBY:OK 0123456789abcdef0123abcd 3600"
+        );
+        assert_eq!(
+            build_challenge_incorrect_line("self_challenge"),
+            "CHALLENGE_LOBBY:incorrect self_challenge"
+        );
+    }
+
+    /// `is_private_login_handle` は `+private-` を peek するだけで hex 部分の
+    /// 妥当性は問わない (parser 側で検証する)。
+    #[test]
+    fn is_private_login_handle_detects_prefix() {
+        assert!(is_private_login_handle("alice+private-0123456789abcdef0123abcd+free"));
+        assert!(is_private_login_handle("alice+private-short+free"));
+        assert!(!is_private_login_handle("alice+game-eval+black"));
+        assert!(!is_private_login_handle("aliceonly"));
+    }
+
+    /// 私的対局 LOGIN_LOBBY の正常パス。token は 24 文字 hex として wrap される。
+    #[test]
+    fn parse_login_lobby_with_free_happy_path() {
+        let req = parse_login_lobby_with_free(
+            "LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+free pw",
+        )
+        .unwrap();
+        assert_eq!(req.handle, "alice");
+        assert_eq!(req.token.as_str(), "0123456789abcdef0123abcd");
+    }
+
+    /// 末尾 color が `free` 以外なら `ColorMustBeFree`。
+    #[test]
+    fn parse_login_lobby_with_free_rejects_non_free_color() {
+        assert_eq!(
+            parse_login_lobby_with_free(
+                "LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+black pw"
+            ),
+            Err(LoginLobbyPrivateError::ColorMustBeFree)
+        );
+        assert_eq!(
+            parse_login_lobby_with_free(
+                "LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+white pw"
+            ),
+            Err(LoginLobbyPrivateError::ColorMustBeFree)
+        );
+    }
+
+    /// hex 部分が 24 文字でない / 大文字 / 非 hex の場合は `PrivateTokenMalformed`。
+    #[test]
+    fn parse_login_lobby_with_free_rejects_malformed_token() {
+        // 短すぎ
+        assert_eq!(
+            parse_login_lobby_with_free("LOGIN_LOBBY alice+private-0123456789ab+free pw"),
+            Err(LoginLobbyPrivateError::PrivateTokenMalformed)
+        );
+        // 大文字混入
+        assert_eq!(
+            parse_login_lobby_with_free(
+                "LOGIN_LOBBY alice+private-0123456789ABCDEF0123abcd+free pw"
+            ),
+            Err(LoginLobbyPrivateError::PrivateTokenMalformed)
+        );
+        // 非 hex
+        assert_eq!(
+            parse_login_lobby_with_free(
+                "LOGIN_LOBBY alice+private-zzzz456789abcdef0123abcd+free pw"
+            ),
+            Err(LoginLobbyPrivateError::PrivateTokenMalformed)
+        );
+    }
+
+    /// 中央トークンが `private-` prefix を持たないなら `Malformed` (peek が
+    /// 通った後の防御的キャッチ)。
+    #[test]
+    fn parse_login_lobby_with_free_rejects_non_private_middle() {
+        assert_eq!(
+            parse_login_lobby_with_free("LOGIN_LOBBY alice+game-eval+free pw"),
+            Err(LoginLobbyPrivateError::Malformed)
+        );
+    }
+
+    /// 引数不足 / 余剰は `BadFormat`。
+    #[test]
+    fn parse_login_lobby_with_free_rejects_arg_count_mismatch() {
+        assert_eq!(
+            parse_login_lobby_with_free("LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+free"),
+            Err(LoginLobbyPrivateError::BadFormat)
+        );
+        assert_eq!(
+            parse_login_lobby_with_free(
+                "LOGIN_LOBBY alice+private-0123456789abcdef0123abcd+free pw extra"
+            ),
+            Err(LoginLobbyPrivateError::BadFormat)
+        );
     }
 }

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -138,6 +138,10 @@ ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。100 件を超える同時待機は LOGIN_LOBBY を
 # queue_full で reject する保守的既定。負荷に応じて引き上げ可。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。期限超過した
+# 未消費 token は Lobby DO の Alarm ハンドラで自動削除する。1 時間 = 3600
+# は対戦相手が招待後にゆっくり PC を起動する想定の保守的既定。
+CHALLENGE_TTL_SEC = "3600"
 
 # --- secret として設定する値 ---
 # 本番運用に必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -138,6 +138,10 @@ ALLOW_FLOODGATE_FEATURES = "true"
 ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。staging では小規模通電向けに 100 で運用。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。staging は通電
+# 確認をテンポよく回すため短めの 600 秒 (10 分) で運用する。production 昇格
+# 時は 3600 秒に揃える。
+CHALLENGE_TTL_SEC = "600"
 
 # --- secret として設定する値 ---
 # staging で必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -116,3 +116,7 @@ ALLOW_FLOODGATE_FEATURES = "false"
 ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。超過時 LOGIN_LOBBY を queue_full で reject。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。期限超過した
+# 未消費 token は Lobby DO の Alarm ハンドラで自動削除し、保留中の WS 接続
+# があれば切断信号を送る。Issue #582 の Workers 経路で参照する。
+CHALLENGE_TTL_SEC = "3600"

--- a/crates/rshogi-csa-server/src/matching/challenge.rs
+++ b/crates/rshogi-csa-server/src/matching/challenge.rs
@@ -281,11 +281,12 @@ impl ChallengeRegistry {
         }
     }
 
-    /// 期限切れ entry を一括削除し、削除した entry の `Vec` を返す。呼び出し
-    /// 側は戻り値の `pending_ws_attachment_ids` (Workers) や、TCP では別途
-    /// 管理する runtime pending map から、先行 LOGIN 済 session を切断する
-    /// 責務を持つ。
-    pub fn purge_expired(&mut self, now_ms: u64) -> Vec<ChallengeEntry> {
+    /// 期限切れ entry を一括削除し、削除した `(token, entry)` の `Vec` を返す。
+    /// 呼び出し側は戻り値の `pending_ws_attachment_ids` (Workers) や、TCP では
+    /// 別途管理する runtime pending map から、token をキーに先行 LOGIN 済
+    /// session を切断する責務を持つ (戻り値に token を含めるのは TCP の
+    /// `TcpChallengePending` map から該当エントリを引くため)。
+    pub fn purge_expired(&mut self, now_ms: u64) -> Vec<(ChallengeToken, ChallengeEntry)> {
         let expired_tokens: Vec<ChallengeToken> = self
             .entries
             .iter()
@@ -300,7 +301,7 @@ impl ChallengeRegistry {
         let mut removed = Vec::with_capacity(expired_tokens.len());
         for token in expired_tokens {
             if let Some(entry) = self.entries.remove(&token) {
-                removed.push(entry);
+                removed.push((token, entry));
             }
         }
         removed
@@ -441,10 +442,11 @@ mod tests {
             .unwrap();
         // 60 秒前なら生存
         assert!(reg.lookup(&t, NOW_MS + 59_000).is_some());
-        // 境界: now_ms + 60_000 ちょうど → purge 対象
+        // 境界: now_ms + 60_000 ちょうど → purge 対象。戻り値は (token, entry) のタプル
         let boundary = NOW_MS + 60_000;
         let removed = reg.purge_expired(boundary);
         assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, t, "戻り値の token が purge された entry を識別する");
         assert!(reg.lookup(&t, boundary).is_none());
     }
 
@@ -556,8 +558,9 @@ mod tests {
         let boundary = NOW_MS + 60_000;
         let removed = reg.purge_expired(boundary);
         assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, t, "戻り値の token が purge された entry を識別する");
         assert_eq!(
-            removed[0].pending_ws_attachment_ids.get("alice").map(String::as_str),
+            removed[0].1.pending_ws_attachment_ids.get("alice").map(String::as_str),
             Some("ws-attached"),
             "戻り値の entry には先行 LOGIN 済 attachment id が保持される",
         );

--- a/crates/rshogi-csa-server/src/protocol/command.rs
+++ b/crates/rshogi-csa-server/src/protocol/command.rs
@@ -150,6 +150,34 @@ pub enum ClientCommand {
         /// 照会対象のプレイヤ名。
         handle: PlayerName,
     },
+
+    /// `%%CHALLENGE <opponent_handle> <color> <clock_preset_name> [<sfen>]`
+    ///
+    /// 招待者 (LOGIN 済 handle) が `<opponent_handle>` を指名し、`<color>`
+    /// (`black` / `white` / `sente` / `gote` / `free`)・`<clock_preset_name>`
+    /// (TCP 側 `clock_presets` の game_name)・任意の `<sfen>` (開始局面) を
+    /// 指定して private match token を発行する CSA 拡張コマンド。
+    ///
+    /// 受理は **x1 mode 限定**。x1 でない通常 LOGIN セッションが本コマンドを
+    /// 送ると既存 `non_x1_waiter_is_disconnected_on_any_input` の挙動で切断
+    /// される。inviter handle は x1 LOGIN 時の handle として確定するため、
+    /// 本構造体には含めない。
+    ///
+    /// SFEN 内のスペースを潰さないため、本 variant のパースは
+    /// `splitn(4, char::is_whitespace)` + 末尾 `trim()` で行う
+    /// (`split_whitespace` は使わない)。
+    Challenge {
+        /// 招待相手の handle (TCP では存在確認、Workers では self-claim)。
+        opponent: PlayerName,
+        /// 招待者の希望配色。`free` 指定 (= `None`) は両者揃った時点で
+        /// サーバが乱択する。
+        inviter_color: Option<Color>,
+        /// 時計設定 preset 名。上位層が `clock_presets` map から `ClockSpec`
+        /// を解決する。
+        clock_preset: GameName,
+        /// 開始局面 SFEN。`None` は平手。SFEN 内のスペースは保持される。
+        initial_sfen: Option<String>,
+    },
 }
 
 /// 1 行の生 CSA テキストをパースして [`ClientCommand`] に変換する。
@@ -404,7 +432,69 @@ fn parse_x1(rest: &str) -> Result<ClientCommand, ProtocolError> {
             })
         }
         "FLOODGATE" => parse_floodgate_subcommand(tail),
+        "CHALLENGE" => parse_challenge(tail),
         other => Err(ProtocolError::Unknown(format!("%%{other}"))),
+    }
+}
+
+/// `%%CHALLENGE <opponent_handle> <color> <clock_preset_name> [<sfen>]` の引数を
+/// パースする。
+///
+/// SFEN 内のスペースを保持するため `splitn(4, char::is_whitespace)` で最大 4
+/// トークンに分割し、4 トークン目があれば `trim()` のみ適用して `initial_sfen`
+/// に格納する (`split_whitespace` だと SFEN の段間スペースが潰れる)。
+///
+/// `<color>` は `black` / `white` / `sente` / `gote` のいずれかで `Some(Color)`、
+/// `free` は `None` (サーバ乱択) を返す。それ以外は `ProtocolError::Malformed`。
+fn parse_challenge(tail: &str) -> Result<ClientCommand, ProtocolError> {
+    let mut parts = tail.splitn(4, char::is_whitespace);
+    let opponent = parts
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ProtocolError::Malformed("%%CHALLENGE: missing <opponent_handle>".into()))?;
+    let color_tok = parts
+        .next()
+        .map(str::trim_start)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| ProtocolError::Malformed("%%CHALLENGE: missing <color>".into()))?;
+    let clock_preset =
+        parts.next().map(str::trim_start).filter(|s| !s.is_empty()).ok_or_else(|| {
+            ProtocolError::Malformed("%%CHALLENGE: missing <clock_preset_name>".into())
+        })?;
+    let sfen_raw = parts.next();
+
+    let inviter_color = parse_challenge_color(color_tok)?;
+    let initial_sfen = match sfen_raw {
+        None => None,
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_owned())
+            }
+        }
+    };
+    Ok(ClientCommand::Challenge {
+        opponent: PlayerName::new(opponent),
+        inviter_color,
+        clock_preset: GameName::new(clock_preset),
+        initial_sfen,
+    })
+}
+
+/// `%%CHALLENGE` の `<color>` トークンをパースする。
+///
+/// 受理: `black` / `sente` → `Some(Color::Black)`、`white` / `gote` →
+/// `Some(Color::White)`、`free` → `None`。それ以外は `ProtocolError::Malformed`。
+fn parse_challenge_color(token: &str) -> Result<Option<Color>, ProtocolError> {
+    match token {
+        "black" | "sente" => Ok(Some(Color::Black)),
+        "white" | "gote" => Ok(Some(Color::White)),
+        "free" => Ok(None),
+        other => Err(ProtocolError::Malformed(format!(
+            "%%CHALLENGE: bad <color> ({other:?}); expected black/white/sente/gote/free"
+        ))),
     }
 }
 
@@ -578,6 +668,25 @@ pub fn serialize_client_command(cmd: &ClientCommand) -> String {
         },
         ClientCommand::FloodgateRating { handle } => {
             format!("%%FLOODGATE rating {}", handle.as_str())
+        }
+        ClientCommand::Challenge {
+            opponent,
+            inviter_color,
+            clock_preset,
+            initial_sfen,
+        } => {
+            let color = match inviter_color {
+                Some(Color::Black) => "black",
+                Some(Color::White) => "white",
+                None => "free",
+            };
+            let mut s =
+                format!("%%CHALLENGE {} {} {}", opponent.as_str(), color, clock_preset.as_str(),);
+            if let Some(sfen) = initial_sfen {
+                s.push(' ');
+                s.push_str(sfen);
+            }
+            s
         }
     }
 }
@@ -1073,6 +1182,26 @@ mod tests {
             ClientCommand::FloodgateRating {
                 handle: PlayerName::new("alice"),
             },
+            ClientCommand::Challenge {
+                opponent: PlayerName::new("alice"),
+                inviter_color: Some(Color::Black),
+                clock_preset: GameName::new("byoyomi-600-10"),
+                initial_sfen: None,
+            },
+            ClientCommand::Challenge {
+                opponent: PlayerName::new("bob"),
+                inviter_color: None,
+                clock_preset: GameName::new("floodgate-300-10"),
+                initial_sfen: None,
+            },
+            ClientCommand::Challenge {
+                opponent: PlayerName::new("carol"),
+                inviter_color: Some(Color::White),
+                clock_preset: GameName::new("byoyomi-600-10"),
+                initial_sfen: Some(
+                    "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1".to_owned(),
+                ),
+            },
         ];
 
         for cmd in samples {
@@ -1141,5 +1270,114 @@ mod tests {
     fn rejects_floodgate_unknown_subcommand() {
         let err = parse_command(&line("%%FLOODGATE rank alice")).unwrap_err();
         assert!(matches!(err, ProtocolError::Unknown(_)), "got {err:?}");
+    }
+
+    /// `%%CHALLENGE` の最小ケース: opponent + black + clock_preset、SFEN 省略。
+    #[test]
+    fn parses_challenge_minimal() {
+        let cmd = parse_command(&line("%%CHALLENGE alice black byoyomi-600-10")).unwrap();
+        assert_eq!(
+            cmd,
+            ClientCommand::Challenge {
+                opponent: PlayerName::new("alice"),
+                inviter_color: Some(Color::Black),
+                clock_preset: GameName::new("byoyomi-600-10"),
+                initial_sfen: None,
+            }
+        );
+    }
+
+    /// `<color>` の各 alias (`black`/`white`/`sente`/`gote`/`free`) を網羅。
+    #[test]
+    fn parses_challenge_color_aliases() {
+        let cases = [
+            ("black", Some(Color::Black)),
+            ("sente", Some(Color::Black)),
+            ("white", Some(Color::White)),
+            ("gote", Some(Color::White)),
+            ("free", None),
+        ];
+        for (token, expected) in cases {
+            let cmd =
+                parse_command(&line(&format!("%%CHALLENGE alice {token} byoyomi-600-10"))).unwrap();
+            match cmd {
+                ClientCommand::Challenge { inviter_color, .. } => {
+                    assert_eq!(inviter_color, expected, "color token = {token}");
+                }
+                other => panic!("unexpected variant for color {token}: {other:?}"),
+            }
+        }
+    }
+
+    /// SFEN 内のスペースが `splitn(4)` + `trim()` 経路で保持される。
+    /// `split_whitespace` 経路だと潰れる段間スペースが残ることを検証。
+    #[test]
+    fn parses_challenge_preserves_sfen_spaces() {
+        let sfen = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+        let cmd =
+            parse_command(&line(&format!("%%CHALLENGE alice free byoyomi-600-10 {sfen}"))).unwrap();
+        assert_eq!(
+            cmd,
+            ClientCommand::Challenge {
+                opponent: PlayerName::new("alice"),
+                inviter_color: None,
+                clock_preset: GameName::new("byoyomi-600-10"),
+                initial_sfen: Some(sfen.to_owned()),
+            }
+        );
+    }
+
+    /// SFEN 末尾の余分な空白は `trim()` で除去される (`Some` ではなく `None` ではない、
+    /// 空でない trimmed SFEN を保持)。
+    #[test]
+    fn parses_challenge_trims_trailing_whitespace_in_sfen() {
+        let cmd = parse_command(&line("%%CHALLENGE alice black byoyomi-600-10    9/9/9 b - 1   "))
+            .unwrap();
+        match cmd {
+            ClientCommand::Challenge { initial_sfen, .. } => {
+                assert_eq!(initial_sfen.as_deref(), Some("9/9/9 b - 1"));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// `<sfen>` トークンが空白のみだった場合は `None` (省略扱い)。
+    #[test]
+    fn parses_challenge_treats_blank_sfen_as_none() {
+        // 4 token 目が空白のみ = `splitn(4)` の結果は `Some("")` ではなく
+        // 末尾を含めた raw 部分が来るので、それを trim した結果が空文字列なら None
+        let cmd = parse_command(&line("%%CHALLENGE alice black byoyomi-600-10    ")).unwrap();
+        match cmd {
+            ClientCommand::Challenge { initial_sfen, .. } => assert_eq!(initial_sfen, None),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    /// `<color>` トークンに不正な値を入れた場合は `Malformed`。
+    #[test]
+    fn rejects_challenge_with_bad_color() {
+        let err = parse_command(&line("%%CHALLENGE alice red byoyomi-600-10")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)), "got {err:?}");
+    }
+
+    /// `<opponent>` を省略した場合は `Malformed`。
+    #[test]
+    fn rejects_challenge_without_opponent() {
+        let err = parse_command(&line("%%CHALLENGE")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)), "got {err:?}");
+    }
+
+    /// `<color>` を省略した場合は `Malformed`。
+    #[test]
+    fn rejects_challenge_without_color() {
+        let err = parse_command(&line("%%CHALLENGE alice")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)), "got {err:?}");
+    }
+
+    /// `<clock_preset_name>` を省略した場合は `Malformed`。
+    #[test]
+    fn rejects_challenge_without_clock_preset() {
+        let err = parse_command(&line("%%CHALLENGE alice black")).unwrap_err();
+        assert!(matches!(err, ProtocolError::Malformed(_)), "got {err:?}");
     }
 }


### PR DESCRIPTION
## Summary

Issue #582 私的対局 (`%%CHALLENGE` / private match) の **TCP integration 全体 + Workers integration の前半** を実装する follow-up PR。core foundation は #584 で完成済 (`ChallengeRegistry` / `ChallengeToken` / `IssueError` / `resolve_color_for_pair`)。

## 本 PR で完成する機能

**TCP**:
- inviter `LOGIN <handle>+_challenge+<color> <pw> x1` → `%%CHALLENGE <opponent> <color> <preset> [<sfen>]` で token 発行 (`CHALLENGE:OK <token> <ttl_sec>`)
- `LOGIN <handle>+private-<token>+free <pw>` で対局参加 → `drive_private_game` で対局成立 + 完走
- TTL purge loop + waiter EOF 検出による stale handle race 回避
- `--challenge-ttl-sec` CLI flag (既定 3600)

**Workers**:
- `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` 受理 + token 発行 (`CHALLENGE_LOBBY:OK <token> <ttl_sec>`)
- `LOGIN_LOBBY <handle>+private-<token>+free <pw>` 認識 + `mark_ws_logged_in` で attachment 登録
- DO storage 永続化 (`KEY_CHALLENGE_REGISTRY`) + Alarm 経由 TTL purge
- `CHALLENGE_TTL_SEC` env (production = 3600 / staging = 600 / example = 3600)

## 本 PR で **実装しない** (次 PR に分割)

Workers の対局起動経路 (両者揃った後の `consume(token)` + GameRoom DO 起動 + `clock_spec` / `initial_sfen` バトンパス)。本 PR の暫定応答は `LOGIN_LOBBY:<handle> OK pending_match_dispatch_pending` で attachment 登録のみ。Lobby DO ⇄ GameRoom DO 通信契約は次 PR で設計・実装する。

## Commits (新しい順)

- `a24b2984` Codex review 指摘修正: TCP private LOGIN 検証順 / waiter EOF / Workers purge 永続化
- `17103044` Merge `origin/main` (本 PR と無関係な `rshogi-core` / `rshogi-usi` 差分を解消)
- `cd51e19f` Workers: `CHALLENGE_LOBBY` / private `LOGIN_LOBBY` 受理 + DO 永続化 + Alarm purge (前半スコープ、+985 行)
- `d312977c` TCP fix+test: `drive_game_inner` の `InGame` 遷移 private skip + 統合テスト 7 件 (+447 行)
- `125824fe` TCP: private LOGIN handler + `drive_private_game` wrapper + TTL purge loop (+627 行)
- `239ebb65` TCP: `%%CHALLENGE` issuance + private LOGIN handle parser (+533 行)
- `1b1c0158` TCP refactor: `drive_game_inner` clock / `league.end_game` / `purge_expired` 戻り値 (+34 行)
- `d35bff04` core protocol: `%%CHALLENGE` パース層 (+238 行)

## 設計判断

- **配色 source of truth**: `ChallengeEntry.inviter_color` のみ。private LOGIN は `+free` 限定で `LOGIN:incorrect color_must_be_free_for_private_game`
- **TCP `_challenge` 予約 game_name**: `WaitingPool` 挿入 skip + clock_presets strict mode 例外 (`CHALLENGE_ISSUANCE_GAME_NAME` const に集約)
- **`drive_game_inner` の `manage_league_state: bool` 引数**: private 経路は League 非介入なので `transition(InGame)` を skip (Wave 3-A バグ修正)
- **`drive_private_game` の `game_name = "private"` 固定**: token を `%%LIST` / `%%SHOW` / kifu metadata に漏洩させないため
- **TCP の runtime session 型分離**: `Arc<Notify>` / `oneshot::Sender` は serialize 不能なため `TcpChallengePending` (frontend runtime map) に分離。core `ChallengeEntry.pending_ws_attachment_ids` は Workers 専用
- **`Arc::ptr_eq` ベース unregister**: stale handle race 回避 (TCP)
- **attachment id 一致比較**: stale handle race 回避 (Workers)

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -p rshogi-csa-server --tests -- -D warnings` 警告ゼロ
- [x] `cargo clippy -p rshogi-csa-server-tcp --tests -- -D warnings` 警告ゼロ
- [x] `cargo clippy -p rshogi-csa-server-workers --tests -- -D warnings` 警告ゼロ (host target)
- [x] `cargo test -p rshogi-csa-server` 334 件全 pass
- [x] `cargo test -p rshogi-csa-server-tcp` 129 件全 pass (lib 58 + integration 54 + その他 17)
- [x] `cargo test -p rshogi-csa-server-workers` 240 件全 pass (lib 223 + smoke 1 + wrangler env 12 + template 4)
- [ ] CI 全緑確認 (push 後)

## レビュー履歴

- **Plan agent (Claude)**: Wave 単位で 7 回レビュー (Wave 1 / 2B / 3-A / Workers integration 等)、各 wave Approve with minor で修正反映
- **Codex CLI**: 2 ラウンド (初回 Request changes、P1×2 / P2 / P3 → 修正 → 再 review **Approve**、新規指摘なし)

## Refs

- Issue #582
- core foundation: PR #584 (マージ済)
- Workers の対局起動経路: 次 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)