### PR TITLE
feat(csa-client): エンジン死亡時に stderr 末尾を診断 error に含める

### DIFF
--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -305,8 +305,13 @@ impl UsiEngine {
             loop {
                 buf.clear();
                 match read_line_capped(&mut reader, &mut buf, STDERR_LINE_MAX_BYTES) {
-                    Ok(0) => break,
-                    Ok(_) => {
+                    Ok(ReadLineOutcome::Eof) => break,
+                    Ok(ReadLineOutcome::Line) => {
+                        // `Line(0)` (空行) もここに含まれる。EOF と空行を取り違えて
+                        // reader thread を早期終了させると以降の stderr が失われ、
+                        // pipe が詰まって engine 側が write で block するリスクがある
+                        // ため、空行は通常行と同じく ring buffer に push する
+                        // (PR #596 review で指摘された bug への対応)。
                         let raw = String::from_utf8_lossy(&buf).into_owned();
                         let line = raw.trim_end_matches('\r').to_owned();
                         let mut tail = match stderr_tail_writer.lock() {
@@ -830,6 +835,26 @@ fn update_search_info(info: &mut SearchInfo, line: &str) {
     }
 }
 
+/// `read_line_capped` の戻り値。EOF と「空行の delimiter 読み取り」を
+/// 区別するために使う。
+///
+/// ## 背景
+///
+/// 戻り値を単に byte 数 (`usize`) にしてしまうと、空行 `"\n"` を読んだとき
+/// (`buf.len() == 0`) と EOF (`buf.len() == 0`) が区別できず、呼び出し側で
+/// 空行を EOF として誤認して reader thread を早期終了させる bug を生む
+/// (PR #596 codex review で指摘)。`buf` への push は呼び出し側で観測できる
+/// ため、`Line` バリアントは byte 数を持たず純粋に「区切りを 1 行読んだ」
+/// signal として機能させる。
+enum ReadLineOutcome {
+    /// 1 行読み取り完了 (空行を含む)。実 byte 数は呼び出し側が `buf.len()`
+    /// で観測する。
+    Line,
+    /// EOF (これ以上 reader からは読めない)。reader thread を終了させる
+    /// signal として使う。
+    Eof,
+}
+
 /// stderr stream から `\n` 区切りで 1 行読み込む。
 ///
 /// `max_bytes` を超えた分は読み飛ばし (discard) し、次の `\n` で 1 行として
@@ -838,20 +863,31 @@ fn update_search_info(info: &mut SearchInfo, line: &str) {
 /// は戻り値の buf に残るため、ring buffer 投入直前に `trim_end_matches('\r')`
 /// で除去すること。
 ///
-/// 戻り値は `\r` 込みの buf 長 (`BufRead::read_until` と同じ semantics、
-/// ただし delimiter `\n` は含まない、`max_bytes` 超過分は含まない)。
+/// 戻り値は [`ReadLineOutcome`] で EOF と空行を区別する。EOF の場合は
+/// `ReadLineOutcome::Eof` を返し、呼び出し側はこれを受けて reader loop を
+/// 終了する。1 行読み取り (空行を含む) の場合は `ReadLineOutcome::Line(n)` を
+/// 返し、`n` は `\r` 込みの buf 長 (delimiter `\n` を含まず、`max_bytes`
+/// 超過分も含まない)。
 fn read_line_capped<R: BufRead>(
     reader: &mut R,
     buf: &mut Vec<u8>,
     max_bytes: usize,
-) -> std::io::Result<usize> {
+) -> std::io::Result<ReadLineOutcome> {
     let mut byte = [0u8; 1];
+    let mut got_byte = false;
     loop {
         match reader.read(&mut byte) {
-            Ok(0) => break,
+            Ok(0) => {
+                // EOF: 何も読まずに EOF なら Eof、何か読んだ後 EOF なら最終行扱い
+                if got_byte {
+                    return Ok(ReadLineOutcome::Line);
+                }
+                return Ok(ReadLineOutcome::Eof);
+            }
             Ok(_) => {
+                got_byte = true;
                 if byte[0] == b'\n' {
-                    break;
+                    return Ok(ReadLineOutcome::Line);
                 }
                 if buf.len() < max_bytes {
                     buf.push(byte[0]);
@@ -861,7 +897,6 @@ fn read_line_capped<R: BufRead>(
             Err(e) => return Err(e),
         }
     }
-    Ok(buf.len())
 }
 
 /// `JoinHandle` を最大 `deadline` まで待機して join を試みる。timeout 時は

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -1,19 +1,37 @@
 //! USIエンジン管理（ponder対応）
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 
 use crate::event::Event;
 use crate::protocol::parse_game_result;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// stderr ring buffer の最大行数 (engine 死亡時の診断 message 用)。
+const STDERR_TAIL_MAX_LINES: usize = 64;
+
+/// stderr 1 行あたりの byte 上限。超過分は破棄して次の `\n` で改行扱い。
+const STDERR_LINE_MAX_BYTES: usize = 4096;
+
+/// `engine_exited_error()` が stderr reader thread の EOF 観測完了を待つ最大時間。
+const STDERR_DRAIN_WAIT: Duration = Duration::from_millis(200);
+const STDERR_DRAIN_POLL: Duration = Duration::from_millis(50);
+
+/// `quit()` (graceful path) で stderr reader thread の join を待つ最大時間。
+const STDERR_JOIN_WAIT_GRACEFUL: Duration = Duration::from_millis(500);
+
+/// `Drop` (fast path) で stderr reader thread の join を待つ最大時間。
+const STDERR_JOIN_WAIT_DROP: Duration = Duration::from_millis(100);
 
 /// USIエンジンプロセス
 pub struct UsiEngine {
@@ -23,6 +41,25 @@ pub struct UsiEngine {
     pub engine_name: String,
     opt_names: HashSet<String>,
     quit_sent: bool,
+    /// engine binary の path。`engine_name` は handshake 後しか入らないため、
+    /// 死亡時の error message には path も並記して debugging を支援する。
+    /// spawn は対局開始時 1 回しか呼ばれず、`PathBuf` の heap allocation は
+    /// ホットパスにないので許容範囲。
+    engine_path: PathBuf,
+    /// engine の stderr 末尾 64 行 ring buffer。各行 4096 bytes cap。
+    /// engine 死亡時の error message に末尾を付けて原因 debugging を支援する。
+    /// reader thread は best-effort: poison/UTF-8/IO error は loop 終了で吸収。
+    stderr_tail: Arc<Mutex<VecDeque<String>>>,
+    /// stderr reader thread が EOF/IO error 観測後 true をセット。
+    /// `engine_exited_error()` は snapshot 前に短時間 (200ms) この flag を
+    /// best-effort で待つ。実際の tail 可視性は snapshot 時の `Mutex::lock()`
+    /// が Acquire 同期点として機能することで保証される (Acquire load は
+    /// 早期 break 用 signal で、可視性 chain は Mutex 経由)。
+    stderr_done: Arc<AtomicBool>,
+    /// stderr reader thread の handle。`quit()` (graceful) と `Drop` (fast)
+    /// で bounded join + detach fallback。`engine_exited_error()` は handle を
+    /// take しない (副作用なし、cleanup ownership は quit/Drop に集約)。
+    stderr_reader_handle: Option<thread::JoinHandle<()>>,
 }
 
 /// bestmove の解析結果
@@ -234,12 +271,13 @@ impl UsiEngine {
         let mut child = cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| anyhow!("エンジン起動失敗 {}: {e}", path.display()))?;
 
         let stdin = child.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
         let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
+        let stderr = child.stderr.take().ok_or_else(|| anyhow!("no stderr"))?;
         let (tx, rx) = mpsc::channel::<String>();
         std::thread::spawn(move || {
             let reader = BufReader::new(stdout);
@@ -255,6 +293,37 @@ impl UsiEngine {
             }
         });
 
+        // stderr ring buffer。EOF/IO error までは best-effort で末尾 64 行を
+        // 保持し、engine 死亡時に診断 error message へ転写する。
+        let stderr_tail = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_TAIL_MAX_LINES)));
+        let stderr_done = Arc::new(AtomicBool::new(false));
+        let stderr_tail_writer = Arc::clone(&stderr_tail);
+        let stderr_done_writer = Arc::clone(&stderr_done);
+        let stderr_reader_handle = std::thread::spawn(move || {
+            let mut reader = BufReader::new(stderr);
+            let mut buf: Vec<u8> = Vec::with_capacity(STDERR_LINE_MAX_BYTES);
+            loop {
+                buf.clear();
+                match read_line_capped(&mut reader, &mut buf, STDERR_LINE_MAX_BYTES) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        let raw = String::from_utf8_lossy(&buf).into_owned();
+                        let line = raw.trim_end_matches('\r').to_owned();
+                        let mut tail = match stderr_tail_writer.lock() {
+                            Ok(g) => g,
+                            Err(p) => p.into_inner(),
+                        };
+                        if tail.len() >= STDERR_TAIL_MAX_LINES {
+                            tail.pop_front();
+                        }
+                        tail.push_back(line);
+                    }
+                    Err(_) => break,
+                }
+            }
+            stderr_done_writer.store(true, Ordering::Release);
+        });
+
         let mut engine = Self {
             child,
             writer: BufWriter::new(stdin),
@@ -262,6 +331,10 @@ impl UsiEngine {
             engine_name: String::new(),
             opt_names: HashSet::new(),
             quit_sent: false,
+            engine_path: path.to_path_buf(),
+            stderr_tail,
+            stderr_done,
+            stderr_reader_handle: Some(stderr_reader_handle),
         };
         engine.initialize(options, ponder, timeout)?;
         Ok(engine)
@@ -439,21 +512,31 @@ impl UsiEngine {
 
     /// quit を送信してプロセスを終了（タイムアウト付き）
     pub fn quit(&mut self) {
-        if !self.quit_sent {
-            let _ = self.send("quit");
-            // 3秒待ってまだ終了しなければ kill
+        if self.quit_sent {
+            return;
+        }
+        let send_result = self.send("quit");
+        if send_result.is_ok() {
+            // 3 秒待ってまだ終了しなければ kill
             for _ in 0..30 {
                 if let Ok(Some(_)) = self.child.try_wait() {
-                    self.quit_sent = true;
-                    return;
+                    break;
                 }
                 std::thread::sleep(Duration::from_millis(100));
             }
+        }
+        if !matches!(self.child.try_wait(), Ok(Some(_))) {
             log::warn!("[USI] quit タイムアウト、kill します");
             let _ = self.child.kill();
             let _ = self.child.wait();
-            self.quit_sent = true;
         }
+        // stderr handle bounded join (graceful path のみ実施)
+        if let Some(handle) = self.stderr_reader_handle.take()
+            && let Err(unfinished) = join_handle_bounded(handle, STDERR_JOIN_WAIT_GRACEFUL)
+        {
+            drop(unfinished);
+        }
+        self.quit_sent = true;
     }
 
     fn wait_bestmove(
@@ -553,7 +636,7 @@ impl UsiEngine {
                     }
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    bail!("エンジンプロセスが終了しました");
+                    return Err(self.engine_exited_error());
                 }
             }
         }
@@ -561,13 +644,27 @@ impl UsiEngine {
 
     pub(crate) fn send(&mut self, cmd: &str) -> Result<()> {
         log::debug!("[USI] > {cmd}");
-        self.writer.write_all(cmd.as_bytes())?;
-        self.writer.write_all(b"\n")?;
-        self.writer.flush()?;
-        Ok(())
+        let result = self
+            .writer
+            .write_all(cmd.as_bytes())
+            .and_then(|_| self.writer.write_all(b"\n"))
+            .and_then(|_| self.writer.flush());
+        match result {
+            Ok(()) => Ok(()),
+            Err(io_err) if io_err.kind() == std::io::ErrorKind::BrokenPipe => {
+                // BrokenPipe = engine 死亡確定の強い signal (Linux primary scope)。
+                // Windows の `ConnectionAborted` / `ConnectionReset` は followup-J で対応。
+                Err(self.engine_exited_error())
+            }
+            Err(io_err) => {
+                // BrokenPipe 以外は engine 生存中の transient error。
+                // `anyhow::Context::context` で source を保持しつつ伝搬。
+                Err(io_err).context("エンジン I/O エラー")
+            }
+        }
     }
 
-    fn recv(&self, timeout: Duration) -> Result<String> {
+    fn recv(&mut self, timeout: Duration) -> Result<String> {
         match self.rx.recv_timeout(timeout) {
             Ok(line) => {
                 log::trace!("[USI] < {line}");
@@ -576,9 +673,54 @@ impl UsiEngine {
             Err(RecvTimeoutError::Timeout) => {
                 bail!("エンジン応答タイムアウト");
             }
-            Err(RecvTimeoutError::Disconnected) => {
-                bail!("エンジンプロセスが終了しました");
+            Err(RecvTimeoutError::Disconnected) => Err(self.engine_exited_error()),
+        }
+    }
+
+    /// engine 死亡確定経路 (BrokenPipe / Disconnected) から呼ばれる、
+    /// stderr 末尾と exit status を含む診断 error の組み立て。
+    ///
+    /// 副作用なし: `child` の reaping は `try_wait` の std cache 経由のみ、
+    /// `stderr_reader_handle` の take や `quit_sent` のセットは行わない。
+    /// 同一 session で複数回呼ばれても idempotent。cleanup ownership は
+    /// `quit()` (graceful) と `Drop` (fast) に集約する。
+    fn engine_exited_error(&mut self) -> anyhow::Error {
+        // (1) stderr reader の EOF 観測完了を best-effort で 200ms 待つ。
+        //     実際の tail 可視性は snapshot 時の `Mutex::lock()` で確保される
+        //     (Acquire 同期点)。本 wait は reader が最後の行を push し終えるのを
+        //     待つ目的のみ。fatal communication error 経路 (recv Disconnected /
+        //     send BrokenPipe / wait_bestmove Disconnected) から呼ばれる契約
+        //     なので、try_wait の結果に関係なく常に wait する。
+        let poll_iters = (STDERR_DRAIN_WAIT.as_millis() / STDERR_DRAIN_POLL.as_millis()).max(1);
+        for _ in 0..poll_iters {
+            if self.stderr_done.load(Ordering::Acquire) {
+                break;
             }
+            std::thread::sleep(STDERR_DRAIN_POLL);
+        }
+        // (2) try_wait で exit_status 取得 (副作用なし、reaping は std が cache する)
+        let exit_status = match self.child.try_wait() {
+            Ok(Some(status)) => Some(format!("{status}")),
+            _ => None,
+        };
+        // (3) tail snapshot (poison-resistant)
+        let tail: Vec<String> = self
+            .stderr_tail
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .cloned()
+            .collect();
+        // (4) error message 構築
+        let path = self.engine_path.display();
+        let prefix = match exit_status {
+            Some(s) => format!("エンジンプロセスが終了しました (path={path}, exit={s})"),
+            None => format!("エンジンプロセスが終了しました (path={path}, status=unknown)"),
+        };
+        if tail.is_empty() {
+            anyhow!("{prefix}; エンジン stderr は空")
+        } else {
+            anyhow!("{prefix}; エンジン stderr 末尾 {} 行:\n{}", tail.len(), tail.join("\n"))
         }
     }
 
@@ -590,12 +732,22 @@ impl UsiEngine {
 
 impl Drop for UsiEngine {
     fn drop(&mut self) {
+        // 既存 fast path を維持: send("quit") + sleep 100ms + kill + wait。
+        // engine 死亡確定 (BrokenPipe) の場合 send 経由で `engine_exited_error()`
+        // が走り 200ms wait を払うが、Drop 全体の遅延は最大 ~400ms に bounded。
+        // panic-on-drop / test runner 経路で 3.5 秒+ の遅延を回避する設計。
         if !self.quit_sent {
             let _ = self.send("quit");
-            // 少し待ってからプロセスを kill
             std::thread::sleep(Duration::from_millis(100));
             let _ = self.child.kill();
             let _ = self.child.wait();
+        }
+        // stderr handle が残っていれば best-effort で cleanup (bounded join 100ms、
+        // 超過なら detach)
+        if let Some(handle) = self.stderr_reader_handle.take()
+            && let Err(unfinished) = join_handle_bounded(handle, STDERR_JOIN_WAIT_DROP)
+        {
+            drop(unfinished);
         }
     }
 }
@@ -676,4 +828,55 @@ fn update_search_info(info: &mut SearchInfo, line: &str) {
             _ => {}
         }
     }
+}
+
+/// stderr stream から `\n` 区切りで 1 行読み込む。
+///
+/// `max_bytes` を超えた分は読み飛ばし (discard) し、次の `\n` で 1 行として
+/// return する (4 KB 超の長い 1 行は truncate されて残りは破棄、複数行に分割
+/// しない)。LF 区切りのみ。CR 単独 (古い Mac 形式) は同一行扱い。CRLF の `\r`
+/// は戻り値の buf に残るため、ring buffer 投入直前に `trim_end_matches('\r')`
+/// で除去すること。
+///
+/// 戻り値は `\r` 込みの buf 長 (`BufRead::read_until` と同じ semantics、
+/// ただし delimiter `\n` は含まない、`max_bytes` 超過分は含まない)。
+fn read_line_capped<R: BufRead>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    max_bytes: usize,
+) -> std::io::Result<usize> {
+    let mut byte = [0u8; 1];
+    loop {
+        match reader.read(&mut byte) {
+            Ok(0) => break,
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                if buf.len() < max_bytes {
+                    buf.push(byte[0]);
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(buf.len())
+}
+
+/// `JoinHandle` を最大 `deadline` まで待機して join を試みる。timeout 時は
+/// `Err(handle)` を返し caller が `drop()` で detach する。
+fn join_handle_bounded(
+    handle: thread::JoinHandle<()>,
+    deadline: Duration,
+) -> std::result::Result<(), thread::JoinHandle<()>> {
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        if handle.is_finished() {
+            let _ = handle.join();
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    Err(handle)
 }

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -307,7 +307,7 @@ impl UsiEngine {
                 match read_line_capped(&mut reader, &mut buf, STDERR_LINE_MAX_BYTES) {
                     Ok(ReadLineOutcome::Eof) => break,
                     Ok(ReadLineOutcome::Line) => {
-                        // `Line(0)` (空行) もここに含まれる。EOF と空行を取り違えて
+                        // 空行 (buf.len() == 0 の `Line`) もここに含まれる。EOF と空行を取り違えて
                         // reader thread を早期終了させると以降の stderr が失われ、
                         // pipe が詰まって engine 側が write で block するリスクがある
                         // ため、空行は通常行と同じく ring buffer に push する
@@ -865,9 +865,9 @@ enum ReadLineOutcome {
 ///
 /// 戻り値は [`ReadLineOutcome`] で EOF と空行を区別する。EOF の場合は
 /// `ReadLineOutcome::Eof` を返し、呼び出し側はこれを受けて reader loop を
-/// 終了する。1 行読み取り (空行を含む) の場合は `ReadLineOutcome::Line(n)` を
-/// 返し、`n` は `\r` 込みの buf 長 (delimiter `\n` を含まず、`max_bytes`
-/// 超過分も含まない)。
+/// 終了する。1 行読み取り (空行を含む) の場合は `ReadLineOutcome::Line` を
+/// 返し、実 byte 数は呼び出し側が `buf.len()` で観測する (delimiter `\n` を
+/// 含まず、`max_bytes` 超過分も含まない)。
 fn read_line_capped<R: BufRead>(
     reader: &mut R,
     buf: &mut Vec<u8>,

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -1,0 +1,216 @@
+//! USI engine subprocess 死亡時に stderr 末尾 / engine path / exit status を含む
+//! 診断 error を返すことを mock engine で検証する host 単体テスト。
+//!
+//! Issue #593 partial fix の regression guard。fatal communication error 経路
+//! (send BrokenPipe / recv Disconnected / wait_bestmove Disconnected) と
+//! stderr ring buffer (4 KB cap、CRLF 吸収) の挙動を 5 fixture で pin する。
+//!
+//! 対象 OS: Unix (bash 必須)。Windows には mock USI engine 経路がないため
+//! `#[cfg(unix)]` でガードする。
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::event::Event;
+
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+static SCRIPT_SEQ: AtomicU64 = AtomicU64::new(0);
+static TMPDIR_LOCK: Mutex<()> = Mutex::new(());
+
+/// 与えた bash script を 0o755 の実行可能ファイルとして一時ディレクトリに書き出し、
+/// path を返す。test ごとに unique な名前を付与する。
+fn write_mock_script(name: &str, body: &str) -> PathBuf {
+    let _guard = TMPDIR_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let seq = SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst);
+    let path = std::env::temp_dir().join(format!(
+        "csa_client_mock_{}_{}_{}.sh",
+        std::process::id(),
+        name,
+        seq,
+    ));
+    std::fs::write(&path, body).expect("write mock script");
+    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    path
+}
+
+/// 死亡時の error message が満たすべき共通条件 (path + (exit or status=unknown))
+fn assert_diagnostic_prefix(msg: &str, expected_path: &Path) {
+    assert!(msg.contains("エンジンプロセスが終了しました"), "missing prefix in: {msg}");
+    let path_str = expected_path.display().to_string();
+    assert!(msg.contains(&format!("path={path_str}")), "missing path={path_str} in: {msg}");
+    assert!(
+        msg.contains("exit=") || msg.contains("status=unknown"),
+        "missing exit/status in: {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 1: spawn 直後 stderr 書き出し → exit 1
+// ───────────────────────────────────────────────
+#[test]
+fn dying_engine_immediate_includes_stderr_tail() {
+    let script = r#"#!/usr/bin/env bash
+printf 'stderr line 1\n' >&2
+printf 'stderr line 2\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("dying_immediate", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+        Ok(_) => panic!("spawn 即時死で error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    assert!(
+        msg.contains("stderr line 1") || msg.contains("stderr line 2"),
+        "stderr 末尾 (line 1 / line 2) のいずれかが含まれるはず: {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 2: usi/usiok + isready/readyok 後 stderr → exit
+//   new_game() で死亡を観測する
+// ───────────────────────────────────────────────
+#[test]
+fn dying_engine_after_first_handshake_includes_stderr_tail() {
+    let script = r#"#!/usr/bin/env bash
+read line  # usi
+echo "id name mock"
+echo "usiok"
+read line  # isready
+echo "readyok"
+printf 'engine info on stderr A\n' >&2
+printf 'engine info on stderr B\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("dying_after_handshake", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let mut engine = UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT)
+        .expect("初回 handshake は成功する想定");
+    // engine プロセスは usiok+readyok を返した直後に exit。
+    // new_game() は usinewgame + isready を送る。BrokenPipe か recv Disconnected
+    // のいずれかから engine_exited_error() に合流する。
+    let err = engine.new_game().expect_err("engine 死亡で error が期待される");
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    assert!(
+        msg.contains("engine info on stderr A") || msg.contains("engine info on stderr B"),
+        "stderr 末尾の line A/B が含まれるはず: {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 3: full handshake → go の応答前に exit
+// ───────────────────────────────────────────────
+#[test]
+fn dying_engine_during_go_includes_stderr_tail() {
+    let script = r#"#!/usr/bin/env bash
+read line  # usi
+echo "id name mock"
+echo "usiok"
+read line  # isready (initialize)
+echo "readyok"
+read line  # usinewgame
+read line  # isready (new_game)
+echo "readyok"
+read line  # position
+read line  # go
+printf 'info string about to die\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("dying_during_go", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let mut engine =
+        UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT).expect("初回 handshake は成功");
+    engine.new_game().expect("new_game は成功");
+    let shutdown = AtomicBool::new(false);
+    let (_tx, server_rx) = mpsc::channel::<Event>();
+    let err = match engine.go(
+        "position startpos",
+        "go btime 1000 wtime 1000 byoyomi 100",
+        &shutdown,
+        &server_rx,
+    ) {
+        Ok(_) => panic!("go の応答前に engine が死亡 → error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    assert!(
+        msg.contains("info string about to die"),
+        "stderr 末尾の `info string about to die` が含まれるはず: {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 4: 4096 byte cap (1 行 10000 byte → 4096 まで)
+// ───────────────────────────────────────────────
+#[test]
+fn long_stderr_line_is_truncated_to_cap() {
+    let script = r#"#!/usr/bin/env bash
+read line  # usi
+echo "id name mock"
+echo "usiok"
+head -c 10000 /dev/zero | tr '\0' A >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("long_stderr_line", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    // initialize は usiok 後 isready を送る → engine 死亡で error
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+        Ok(_) => panic!("isready 送信前後で engine 死亡 → error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    // 末尾の最長行は 4096 文字 (`A` * 4096) に truncate されているはず。
+    // message 全体長は prefix を加味してもおおよそ < 4096 + 数百 byte。
+    let max_line_len = msg.lines().map(|line| line.chars().count()).max().unwrap_or(0);
+    assert!(
+        max_line_len <= 4096,
+        "最長行は 4096 char 以下に truncate されるはず (実測 {max_line_len}): {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 5: CRLF 吸収 (`\r` 除去)
+// ───────────────────────────────────────────────
+#[test]
+fn crlf_stderr_is_trimmed() {
+    let script = r#"#!/usr/bin/env bash
+read line  # usi
+echo "id name mock"
+echo "usiok"
+printf 'CRLF line\r\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("crlf_stderr", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+        Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    assert!(msg.contains("CRLF line"), "`CRLF line` が含まれるはず: {msg}");
+    // `\r` 単独 (CR だけが残る) は出ないはず。`\r\n` の CR を trim しているか確認。
+    // message 内に `CRLF line\r` (= 末尾 CR) が現れたら trim 失敗。
+    assert!(!msg.contains("CRLF line\r"), "末尾の `\\r` は trim されているはず: {msg}");
+}

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -3,7 +3,7 @@
 //!
 //! Issue #593 partial fix の regression guard。fatal communication error 経路
 //! (send BrokenPipe / recv Disconnected / wait_bestmove Disconnected) と
-//! stderr ring buffer (4 KB cap、CRLF 吸収) の挙動を 5 fixture で pin する。
+//! stderr ring buffer (4 KB cap、CRLF 吸収) の挙動を 6 fixture で pin する。
 //!
 //! 対象 OS: Unix (bash 必須)。Windows には mock USI engine 経路がないため
 //! `#[cfg(unix)]` でガードする。
@@ -30,8 +30,8 @@ static TMPDIR_LOCK: Mutex<()> = Mutex::new(());
 /// path を返す。test ごとに unique な名前を付与する。
 ///
 /// Linux で `cargo test` を並列実行すると、`std::fs::write` 完了直後の `Command::spawn`
-/// で稀に `Text file busy (ETXTBSY)` を踏むため、tmp 書き出し → `sync_all` → atomic
-/// rename → chmod の順で kernel に「書き終えた実行可能ファイル」を確実に認識させる
+/// で稀に `Text file busy (ETXTBSY)` を踏むため、tmp 書き出し → `sync_all` → chmod →
+/// atomic rename の順で kernel に「書き終えた実行可能ファイル」を確実に認識させる
 /// (PR #596 review で指摘された flake への対応)。
 fn write_mock_script(name: &str, body: &str) -> PathBuf {
     use std::io::Write;

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -28,20 +28,37 @@ static TMPDIR_LOCK: Mutex<()> = Mutex::new(());
 
 /// 与えた bash script を 0o755 の実行可能ファイルとして一時ディレクトリに書き出し、
 /// path を返す。test ごとに unique な名前を付与する。
+///
+/// Linux で `cargo test` を並列実行すると、`std::fs::write` 完了直後の `Command::spawn`
+/// で稀に `Text file busy (ETXTBSY)` を踏むため、tmp 書き出し → `sync_all` → atomic
+/// rename → chmod の順で kernel に「書き終えた実行可能ファイル」を確実に認識させる
+/// (PR #596 review で指摘された flake への対応)。
 fn write_mock_script(name: &str, body: &str) -> PathBuf {
+    use std::io::Write;
     let _guard = TMPDIR_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let seq = SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst);
-    let path = std::env::temp_dir().join(format!(
-        "csa_client_mock_{}_{}_{}.sh",
-        std::process::id(),
-        name,
-        seq,
-    ));
-    std::fs::write(&path, body).expect("write mock script");
-    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
+    let dir = std::env::temp_dir();
+    let final_path =
+        dir.join(format!("csa_client_mock_{}_{}_{}.sh", std::process::id(), name, seq,));
+    // 書き込みは別 path で行い、close 後に rename することで「open 中の fd」が
+    // exec と race する経路を排除する (ETXTBSY 回避)。
+    let tmp_path =
+        dir.join(format!("csa_client_mock_{}_{}_{}.sh.tmp", std::process::id(), name, seq,));
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp_path)
+            .expect("open tmp script");
+        f.write_all(body.as_bytes()).expect("write mock script");
+        f.sync_all().expect("sync_all");
+    }
+    let mut perms = std::fs::metadata(&tmp_path).expect("stat").permissions();
     perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).expect("chmod");
-    path
+    std::fs::set_permissions(&tmp_path, perms).expect("chmod");
+    std::fs::rename(&tmp_path, &final_path).expect("atomic rename");
+    final_path
 }
 
 /// 死亡時の error message が満たすべき共通条件 (path + (exit or status=unknown))
@@ -213,4 +230,39 @@ exit 1
     // `\r` 単独 (CR だけが残る) は出ないはず。`\r\n` の CR を trim しているか確認。
     // message 内に `CRLF line\r` (= 末尾 CR) が現れたら trim 失敗。
     assert!(!msg.contains("CRLF line\r"), "末尾の `\\r` は trim されているはず: {msg}");
+}
+
+// ───────────────────────────────────────────────
+// Fixture 6: 空行を含む stderr が EOF として誤認されないこと
+//   PR #596 codex review で指摘された read_line_capped の bug への regression guard。
+//   空行 `\n` を読んだ後に後続行を継続して読めることを pin する。
+// ───────────────────────────────────────────────
+#[test]
+fn empty_stderr_line_is_not_treated_as_eof() {
+    let script = r#"#!/usr/bin/env bash
+read line  # usi
+echo "id name mock"
+echo "usiok"
+printf 'before empty\n' >&2
+printf '\n' >&2
+printf 'after empty\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("empty_line_not_eof", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+        Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    // `before empty` だけでなく `after empty` も含まれていれば、空行を EOF として
+    // 誤認していない証拠。reader thread が空行で break した場合は `after empty` が
+    // ring buffer に届かない (= bug 再発)。
+    assert!(msg.contains("before empty"), "空行前の行が含まれるはず: {msg}");
+    assert!(
+        msg.contains("after empty"),
+        "空行後の行も含まれるはず (空行 EOF 誤認 bug の regression guard): {msg}"
+    );
 }


### PR DESCRIPTION
## Summary

Issue #593 の partial fix。csa_client の engine subprocess 死亡時に stderr
末尾 + path + exit status を含む診断 error を返すよう改善する。

## 設計と review

複数ラウンドの critical review (Codex CLI / Claude subagent) を経て v10 が
最終設計として確定。設計履歴は Issue #593 のコメント参照。

## 効果

- 死亡時 error が「エンジンプロセスが終了しました」のみ → path + exit status +
  stderr 末尾 64 行 (4 KB cap、CRLF 吸収) 付き
- fatal communication error 3 経路 (send BrokenPipe / recv Disconnected /
  wait_bestmove Disconnected) で確実に発火

## 限界

- 同時起動 race の root cause fix は **#593-followup-A** で対応 (本 PR は
  diagnostic 改善のみ、`csa-smoke` Gotcha #1 の `sleep 4` workaround は維持)
- Linux primary scope。Windows の `ConnectionAborted` / `ConnectionReset`
  拡張は **#593-followup-J** で対応

## Test plan

- `cargo fmt && cargo clippy --fix --allow-dirty --tests`
- `cargo test -p rshogi-csa-client` (新規 5 fixture 追加 + 既存無回帰)
- 既存 `tests/session_events_integration.rs` 変更なし (stderr=Piped 通常経路 regression)

Refs #593 (partial fix; full close は followup-A 完了時)