### PR TITLE
Add glob input deletion mode for PSV partitioning

### DIFF
--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -185,15 +185,14 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 通常モードは Phase 1 完了時点で「入力ぶんの一時ファイル + 元入力」が同時に存在するため、入力と同等以上の空きが必要になる。`--partition-only` はこの制約を緩めるためのモードで、Phase 1 (振り分け) だけを実行し、入力ファイルを 1 つずつ処理→削除して進められる。
 
 ```bash
-# 1 ファイルずつ振り分け、終わったら元を削除する
-for f in /data/psv/*.bin; do
-  cargo run --release -p tools --bin psv_dedup_partition -- \
-    --partition-only \
-    --input "$f" \
-    --temp-dir /fast/ssd/psv_tmp \
-    --partitions 1024
-  rm "$f"
-done
+# glob は shell ではなくツール側で展開するため、クォートして渡す。
+# 各入力ファイルは、読み切りと partition 書き込みの flush が成功した後に削除される。
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --partition-only \
+  --input "/data/psv/*.bin" \
+  --temp-dir /fast/ssd/psv_tmp \
+  --partitions 1024 \
+  --delete-input-on-success
 
 # 全件の振り分けが終わったら最後に Phase 2 だけ実行
 cargo run --release -p tools --bin psv_dedup_partition -- \
@@ -205,6 +204,10 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 挙動と制約:
 
 - 既存の `partition_NNNNN.bin` には append モードで追記される
+- `--input` にはファイル、ディレクトリ、glob を指定できる。複数指定はカンマ区切り
+- glob はツール側で展開する。Unix shell で先に展開されないよう `"/data/psv/*.bin"` のようにクォートする
+- `--delete-input-on-success` は `--partition-only` 専用。各入力ファイルを完全に読み切り、partition 書き込みの flush に成功した場合だけ元ファイルを削除する
+- `--delete-input-on-success` と `--max-positions` は併用不可
 - 2 回目以降の `--partitions` が初回と異なるとエラー (ハッシュ空間不整合を防止)
 - `--reference` は **初回のみ** 指定可能。`ref/` に reference データが書き込まれた状態で再指定するとエラー
   - 過去の中途失敗で `ref/` に空 partition ファイルだけが残っている場合は失敗の残骸とみなしてリトライを許容する (空ファイルへの append は新規作成と等価)
@@ -217,7 +220,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 | オプション | 説明 | デフォルト |
 |---|---|---|
 | `--reference` | 参照ファイル（カンマ区切り）。HashSet に登録するが出力しない | — |
-| `--input` | 入力ファイル（カンマ区切り）。`--input-dir` と排他 | — |
+| `--input` | 入力ファイル、ディレクトリ、glob（カンマ区切り）。`--input-dir` と排他 | — |
 | `--input-dir` | 入力ディレクトリ。`--pattern` と組み合わせ | — |
 | `--pattern` | `--input-dir` 使用時の glob パターン | `*.bin` |
 | `--output` | 出力ファイルパス | — |
@@ -227,6 +230,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 | `--max-positions` | 処理する入力レコードの最大件数（0 = 全件、試走用）。参照は常に全件 | `0` |
 | `--dedup-only` | Phase 1 をスキップして既存一時ファイルから再開（ref/ は自動検出） | off |
 | `--partition-only` | Phase 2 をスキップして Phase 1 (振り分け) のみ実行（既存 partition には append） | off |
+| `--delete-input-on-success` | `--partition-only` で各入力ファイルの処理成功後に元ファイルを削除する | off |
 | `--keep-temp` | 完了後も一時ファイル・ディレクトリを削除しない（`--partition-only` では暗黙で有効） | off |
 | `--force` | メモリ/ディスク不足でも警告のみで続行する | off |
 

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -551,38 +551,49 @@ fn partition_files_into(
             }
             eprintln!("Warning: {} size {size} is not a multiple of {PSV_SIZE}", input.display());
         }
-        let mut reader = BufReader::with_capacity(8 << 20, file);
+        let mut input_bytes_read = 0u64;
+        let completed_input = {
+            let mut reader = BufReader::with_capacity(8 << 20, file);
+            loop {
+                if max_positions > 0 && total_records >= max_positions {
+                    break false;
+                }
 
-        let completed_input = loop {
-            if max_positions > 0 && total_records >= max_positions {
-                break false;
-            }
+                if !read_psv_record(&mut reader, &mut buf, input)? {
+                    break true;
+                }
+                input_bytes_read += PSV_SIZE as u64;
 
-            match reader.read_exact(&mut buf) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break true,
-                Err(e) => return Err(e),
-            }
+                let sfen: &[u8; SFEN_SIZE] = buf[..SFEN_SIZE].try_into().unwrap();
+                let h = hash_packed_sfen(sfen);
+                let partition = (h as usize) % num_partitions;
+                writers[partition].write_all(&buf)?;
 
-            let sfen: &[u8; SFEN_SIZE] = buf[..SFEN_SIZE].try_into().unwrap();
-            let h = hash_packed_sfen(sfen);
-            let partition = (h as usize) % num_partitions;
-            writers[partition].write_all(&buf)?;
-
-            total_records += 1;
-            if total_records.is_multiple_of(100_000_000) {
-                let elapsed = start.elapsed().as_secs_f64();
-                let speed = total_records as f64 / elapsed / 1e6;
-                eprintln!(
-                    "    {:.0}M partitioned, {:.1}s ({:.1}M rec/s)",
-                    total_records as f64 / 1e6,
-                    elapsed,
-                    speed,
-                );
+                total_records += 1;
+                if total_records.is_multiple_of(100_000_000) {
+                    let elapsed = start.elapsed().as_secs_f64();
+                    let speed = total_records as f64 / elapsed / 1e6;
+                    eprintln!(
+                        "    {:.0}M partitioned, {:.1}s ({:.1}M rec/s)",
+                        total_records as f64 / 1e6,
+                        elapsed,
+                        speed,
+                    );
+                }
             }
         };
 
         if delete_inputs_on_success && completed_input {
+            if input_bytes_read != size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "{} was read as {input_bytes_read} bytes but metadata reported {size}; \
+                         入力が処理中に変更された可能性があるため削除しません",
+                        input.display(),
+                    ),
+                ));
+            }
             flush_partition_writers(&mut writers)?;
             std::fs::remove_file(input)?;
             eprintln!("    deleted input: {}", input.display());
@@ -605,6 +616,31 @@ fn partition_files_into(
     eprintln!("  [{label}] done: {total_records} records, {elapsed:.1}s");
 
     Ok(total_records)
+}
+
+fn read_psv_record(
+    reader: &mut impl Read,
+    buf: &mut [u8; PSV_SIZE],
+    input: &Path,
+) -> io::Result<bool> {
+    let mut filled = 0usize;
+    while filled < PSV_SIZE {
+        let n = reader.read(&mut buf[filled..])?;
+        if n == 0 {
+            if filled == 0 {
+                return Ok(false);
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "{} ended in the middle of a PSV record ({filled}/{PSV_SIZE} bytes)",
+                    input.display(),
+                ),
+            ));
+        }
+        filled += n;
+    }
+    Ok(true)
 }
 
 fn flush_partition_writers(writers: &mut [BufWriter<File>]) -> io::Result<()> {
@@ -1295,6 +1331,7 @@ fn run_partition_only(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
     use tempfile::TempDir;
 
     #[test]
@@ -1347,6 +1384,23 @@ mod tests {
         // 1 バイトでもデータがあれば「取り込み済み」とみなして true
         std::fs::write(dir.path().join(partition_filename(0)), b"x").unwrap();
         assert!(has_any_partition_file(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn read_psv_record_distinguishes_clean_eof_from_short_record() {
+        let mut buf = [0u8; PSV_SIZE];
+        let input = Path::new("input.bin");
+
+        let mut empty = Cursor::new(Vec::<u8>::new());
+        assert!(!read_psv_record(&mut empty, &mut buf, input).unwrap());
+
+        let mut full = Cursor::new(vec![7u8; PSV_SIZE]);
+        assert!(read_psv_record(&mut full, &mut buf, input).unwrap());
+        assert_eq!(buf, [7u8; PSV_SIZE]);
+
+        let mut short = Cursor::new(vec![1u8; PSV_SIZE - 1]);
+        let err = read_psv_record(&mut short, &mut buf, input).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     /// `--partition-only` を 2 回繰り返した結果が、1 回の通常 Phase1 と同等になる。

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -37,15 +37,13 @@
 ///     --temp-dir /path/to/tmp \
 ///     --dedup-only
 ///
-///   # Phase 1 (パーティション振り分け) だけを行い、入力ファイルを 1 つずつ
-///   # 削除しながら処理することで、入力サイズの 2 倍の空きを必要としない。
-///   # `--temp-dir` の partition ファイルには append モードで追記される。
-///   for f in /data/*.bin; do
-///     cargo run --release --bin psv_dedup_partition -- \
-///       --partition-only --input "$f" \
-///       --temp-dir /path/to/tmp --partitions 1024
-///     rm "$f"
-///   done
+///   # Phase 1 (パーティション振り分け) だけを行い、入力ファイルを読み切るたびに
+///   # ツール側で削除することで、入力サイズの 2 倍の空きを必要としない。
+///   # glob は shell ではなくツール側で展開するため、クォートして渡す。
+///   cargo run --release --bin psv_dedup_partition -- \
+///     --partition-only --input "/data/*.bin" \
+///     --temp-dir /path/to/tmp --partitions 1024 \
+///     --delete-input-on-success
 ///   cargo run --release --bin psv_dedup_partition -- \
 ///     --dedup-only --output /path/to/deduped.bin --temp-dir /path/to/tmp
 use std::{
@@ -75,7 +73,8 @@ struct Args {
     #[arg(long)]
     reference: Option<String>,
 
-    /// 入力 PSV ファイル（カンマ区切り）。--input-dir と排他
+    /// 入力 PSV ファイル、ディレクトリ、glob（カンマ区切りで複数可）。--input-dir と排他。
+    /// glob は shell で展開させず、"/data/*.bin" のようにクォートして渡す。
     #[arg(long)]
     input: Option<String>,
 
@@ -122,6 +121,12 @@ struct Args {
     /// `--keep-temp` は暗黙で有効になり、`--output` は不要。`--dedup-only` と排他。
     #[arg(long)]
     partition_only: bool,
+
+    /// `--partition-only` で各入力ファイルを読み切り、partition 書き込みの flush に
+    /// 成功した後、その入力ファイルを削除する。数 TB 級のデータで入力と同サイズの
+    /// 追加空きを確保できない場合に使う。`--max-positions` とは併用不可。
+    #[arg(long)]
+    delete_input_on_success: bool,
 
     /// 完了後も一時ディレクトリを削除しない
     #[arg(long)]
@@ -505,6 +510,7 @@ fn partition_files_into(
     partition_buffer_bytes: usize,
     max_positions: u64,
     append: bool,
+    delete_inputs_on_success: bool,
 ) -> io::Result<u64> {
     std::fs::create_dir_all(subdir)?;
 
@@ -533,18 +539,28 @@ fn partition_files_into(
         let meta = file.metadata()?;
         let size = meta.len();
         if !size.is_multiple_of(PSV_SIZE as u64) {
+            if delete_inputs_on_success {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "{} size {size} is not a multiple of {PSV_SIZE}; \
+                         削除を伴う処理では入力破損の可能性があるファイルは削除しません",
+                        input.display(),
+                    ),
+                ));
+            }
             eprintln!("Warning: {} size {size} is not a multiple of {PSV_SIZE}", input.display());
         }
         let mut reader = BufReader::with_capacity(8 << 20, file);
 
-        loop {
+        let completed_input = loop {
             if max_positions > 0 && total_records >= max_positions {
-                break 'outer;
+                break false;
             }
 
             match reader.read_exact(&mut buf) {
                 Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break true,
                 Err(e) => return Err(e),
             }
 
@@ -564,6 +580,15 @@ fn partition_files_into(
                     speed,
                 );
             }
+        };
+
+        if delete_inputs_on_success && completed_input {
+            flush_partition_writers(&mut writers)?;
+            std::fs::remove_file(input)?;
+            eprintln!("    deleted input: {}", input.display());
+        }
+        if !completed_input {
+            break 'outer;
         }
     }
 
@@ -580,6 +605,13 @@ fn partition_files_into(
     eprintln!("  [{label}] done: {total_records} records, {elapsed:.1}s");
 
     Ok(total_records)
+}
+
+fn flush_partition_writers(writers: &mut [BufWriter<File>]) -> io::Result<()> {
+    for writer in writers {
+        writer.flush()?;
+    }
+    Ok(())
 }
 
 /// パーティションファイルを読み、各レコードのコールバックを呼ぶ。
@@ -830,6 +862,18 @@ fn main() -> io::Result<()> {
             "--dedup-only モードでは --input / --input-dir は使えません（既存の一時ファイルから再開するため）",
         ));
     }
+    if args.delete_input_on_success && !args.partition_only {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--delete-input-on-success は --partition-only モードでのみ使えます",
+        ));
+    }
+    if args.delete_input_on_success && args.max_positions > 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--delete-input-on-success と --max-positions は併用できません（入力を途中までしか読まないため）",
+        ));
+    }
 
     let partition_buffer_bytes = args.partition_buffer_kb * 1024;
     let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
@@ -992,6 +1036,7 @@ fn main() -> io::Result<()> {
                 partition_buffer_bytes,
                 0, // reference は常に全件
                 false,
+                false,
             )?
         };
 
@@ -1002,6 +1047,7 @@ fn main() -> io::Result<()> {
             partitions,
             partition_buffer_bytes,
             args.max_positions,
+            false,
             false,
         )?;
 
@@ -1203,6 +1249,7 @@ fn run_partition_only(
             partition_buffer_bytes,
             0,
             true,
+            false,
         )?
     };
 
@@ -1214,6 +1261,7 @@ fn run_partition_only(
         partition_buffer_bytes,
         args.max_positions,
         true,
+        args.delete_input_on_success,
     )?;
 
     let total_input_bytes = sum_existing_partition_bytes(input_subdir)?;
@@ -1341,6 +1389,7 @@ mod tests {
             64 * 1024,
             0,
             false,
+            false,
         )
         .unwrap();
 
@@ -1355,6 +1404,7 @@ mod tests {
             64 * 1024,
             0,
             true,
+            false,
         )
         .unwrap();
         partition_files_into(
@@ -1365,6 +1415,7 @@ mod tests {
             64 * 1024,
             0,
             true,
+            false,
         )
         .unwrap();
 
@@ -1374,5 +1425,68 @@ mod tests {
             let multi = std::fs::read(multi_subdir.join(partition_filename(i))).unwrap();
             assert_eq!(single, multi, "partition {i} mismatch between single-pass and append");
         }
+    }
+
+    #[test]
+    fn partition_files_deletes_inputs_only_after_successful_flush() {
+        let make_psv = |seed: u8| -> [u8; PSV_SIZE] {
+            let mut buf = [0u8; PSV_SIZE];
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = seed.wrapping_add(i as u8);
+            }
+            buf
+        };
+
+        let workdir = TempDir::new().unwrap();
+        let file_a = workdir.path().join("a.bin");
+        let file_b = workdir.path().join("b.bin");
+        {
+            let mut f = File::create(&file_a).unwrap();
+            f.write_all(&make_psv(1)).unwrap();
+            let mut f = File::create(&file_b).unwrap();
+            f.write_all(&make_psv(2)).unwrap();
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let input_subdir = temp_dir.path().join(INPUT_SUBDIR);
+        let records = partition_files_into(
+            "input",
+            &[file_a.clone(), file_b.clone()],
+            &input_subdir,
+            4,
+            64 * 1024,
+            0,
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(records, 2);
+        assert!(!file_a.exists());
+        assert!(!file_b.exists());
+        assert_eq!(sum_existing_partition_bytes(&input_subdir).unwrap(), 2 * PSV_SIZE as u64);
+    }
+
+    #[test]
+    fn partition_files_keeps_invalid_input_when_delete_requested() {
+        let workdir = TempDir::new().unwrap();
+        let input = workdir.path().join("broken.bin");
+        std::fs::write(&input, [1u8; PSV_SIZE - 1]).unwrap();
+
+        let temp_dir = TempDir::new().unwrap();
+        let err = partition_files_into(
+            "input",
+            std::slice::from_ref(&input),
+            &temp_dir.path().join(INPUT_SUBDIR),
+            4,
+            64 * 1024,
+            0,
+            true,
+            true,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(input.exists());
     }
 }

--- a/crates/tools/src/common/dedup.rs
+++ b/crates/tools/src/common/dedup.rs
@@ -31,7 +31,8 @@ pub fn game_ply_from_record(record: &[u8; PSV_SIZE]) -> u16 {
     u16::from_le_bytes([record[36], record[37]])
 }
 
-/// `--input` (カンマ区切り) または `--input-dir` + `--pattern` からファイル一覧を収集する。
+/// `--input` (カンマ区切りのファイル / ディレクトリ / glob) または
+/// `--input-dir` + `--pattern` からファイル一覧を収集する。
 pub fn collect_input_paths(
     input: Option<&str>,
     input_dir: Option<&PathBuf>,
@@ -46,41 +47,85 @@ pub fn collect_input_paths(
             io::ErrorKind::InvalidInput,
             "--data/--input または --input-dir のいずれかを指定してください",
         )),
-        (Some(data), None) => {
-            let paths: Vec<PathBuf> = data.split(',').map(|s| PathBuf::from(s.trim())).collect();
-            for p in &paths {
-                if !p.exists() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::NotFound,
-                        format!("入力ファイルが存在しません: {}", p.display()),
-                    ));
-                }
-            }
-            Ok(paths)
-        }
-        (None, Some(dir)) => {
-            if !dir.is_dir() {
-                return Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    format!("入力ディレクトリが存在しません: {}", dir.display()),
-                ));
-            }
-            let pat = glob::Pattern::new(pattern).map_err(|e| {
-                io::Error::new(io::ErrorKind::InvalidInput, format!("無効な glob パターン: {e}"))
-            })?;
-            let mut paths: Vec<PathBuf> = walkdir::WalkDir::new(dir)
-                .into_iter()
-                .filter_map(|e| e.ok())
-                .filter(|e| e.file_type().is_file())
-                .filter(|e| {
-                    e.path().file_name().and_then(|n| n.to_str()).is_some_and(|n| pat.matches(n))
-                })
-                .map(|e| e.into_path())
-                .collect();
-            paths.sort();
-            Ok(paths)
+        (Some(data), None) => collect_input_specs(data, pattern),
+        (None, Some(dir)) => collect_input_dir(dir, pattern),
+    }
+}
+
+fn collect_input_specs(input: &str, pattern: &str) -> io::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for spec in input.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        let path = PathBuf::from(spec);
+        if path.is_file() {
+            paths.push(path);
+        } else if path.is_dir() {
+            paths.extend(collect_input_dir(&path, pattern)?);
+        } else if has_glob_metachar(spec) {
+            paths.extend(collect_input_glob(spec)?);
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("入力ファイルまたはディレクトリが存在しません: {}", path.display()),
+            ));
         }
     }
+
+    if paths.is_empty() && !input.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("入力に一致するファイルが見つかりません: {input}"),
+        ));
+    }
+
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn collect_input_dir(dir: &Path, pattern: &str) -> io::Result<Vec<PathBuf>> {
+    if !dir.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("入力ディレクトリが存在しません: {}", dir.display()),
+        ));
+    }
+    let pat = glob::Pattern::new(pattern).map_err(|e| {
+        io::Error::new(io::ErrorKind::InvalidInput, format!("無効な glob パターン: {e}"))
+    })?;
+    let mut paths: Vec<PathBuf> = walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().file_name().and_then(|n| n.to_str()).is_some_and(|n| pat.matches(n)))
+        .map(|e| e.into_path())
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_input_glob(pattern: &str) -> io::Result<Vec<PathBuf>> {
+    let entries = glob::glob(pattern).map_err(|e| {
+        io::Error::new(io::ErrorKind::InvalidInput, format!("無効な glob パターン: {e}"))
+    })?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let path = entry.map_err(|e| io::Error::other(format!("glob 展開に失敗しました: {e}")))?;
+        if path.is_file() {
+            paths.push(path);
+        }
+    }
+    if paths.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("glob に一致する入力ファイルが見つかりません: {pattern}"),
+        ));
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn has_glob_metachar(spec: &str) -> bool {
+    spec.contains('*') || spec.contains('?') || spec.contains('[')
 }
 
 /// まだ存在しないかもしれないパスを正規化する。
@@ -346,6 +391,37 @@ mod tests {
         fs::write(&input, [0u8; PSV_SIZE]).unwrap();
 
         check_output_not_in_inputs(&dir.path().join("new/out.psv"), &[input]).unwrap();
+    }
+
+    #[test]
+    fn collect_input_paths_accepts_glob_in_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.bin");
+        let b = dir.path().join("b.bin");
+        let ignored = dir.path().join("c.txt");
+        fs::write(&a, [0u8; PSV_SIZE]).unwrap();
+        fs::write(&b, [1u8; PSV_SIZE]).unwrap();
+        fs::write(ignored, []).unwrap();
+
+        let pattern = format!("{}/*.bin", dir.path().display());
+        let paths = collect_input_paths(Some(&pattern), None, "*.bin").unwrap();
+
+        assert_eq!(paths, vec![a, b]);
+    }
+
+    #[test]
+    fn collect_input_paths_accepts_directory_in_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.bin");
+        let b = dir.path().join("nested/b.bin");
+        fs::create_dir_all(b.parent().unwrap()).unwrap();
+        fs::write(&a, [0u8; PSV_SIZE]).unwrap();
+        fs::write(&b, [1u8; PSV_SIZE]).unwrap();
+
+        let input = dir.path().to_string_lossy();
+        let paths = collect_input_paths(Some(&input), None, "*.bin").unwrap();
+
+        assert_eq!(paths, vec![a, b]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Allow `--input` to resolve files, directories, and quoted glob patterns inside the tool.
- Add `--delete-input-on-success` for `psv_dedup_partition --partition-only` so processed input files are deleted only after successful read and partition writer flush.
- Replace the documented shell loop with a tool-owned glob/deletion workflow.

## Why
The previous large-data workflow delegated file iteration and deletion to a user shell loop. That is OS-dependent and makes destructive behavior depend on shell error handling. The tool should own the file-by-file success boundary for multi-TB partitioning workflows.

## Safety
- `--delete-input-on-success` is limited to `--partition-only`.
- It is rejected with `--max-positions` because partial reads must not delete inputs.
- Inputs whose size is not a multiple of the PSV record size are rejected before deletion.
- Each input is removed only after it is fully read and partition writers are flushed.

## Verification
- `cargo fmt`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`