### PR TITLE
[codex] Persist CSA reconnect grace per match

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -288,18 +288,14 @@ impl DurableObject for GameRoom {
             return Ok(());
         }
 
-        // 再接続プロトコルが env で有効化されている (grace_duration > 0 + Floodgate
-        // features opt-in) なら即時 force_abnormal せず、grace registry に対局
-        // 状態のスナップショットを書いて alarm を grace deadline で予約する。
-        // ALLOW_FLOODGATE_FEATURES が立っていない構成で grace_duration が誤って
-        // > 0 になっていた場合は console_log で警告して保守的に旧経路へ落とす。
-        let grace_duration = match resolve_reconnect_grace(&self.env) {
-            Ok(d) => d,
-            Err(e) => {
-                console_log!("[GameRoom] reconnect grace disabled: {e}");
-                Duration::ZERO
-            }
+        // 再接続プロトコルは start_match 時点の設定で対局単位に固定する。
+        // close 時に env を読み直すと、対局中の deploy / 設定変更で
+        // `Reconnect_Token` 配布有無と grace 判定がずれるため、永続化済み
+        // `PersistedConfig` の値だけを参照する。
+        let Some(cfg) = cfg_opt else {
+            return Ok(());
         };
+        let grace_duration = Duration::from_millis(cfg.reconnect_grace_ms.unwrap_or_default());
         if !grace_duration.is_zero() {
             if let Err(e) = self.enter_grace_window(role, grace_duration).await {
                 // grace 経路のセットアップに失敗したら旧経路 (即時 force_abnormal)
@@ -557,6 +553,9 @@ impl GameRoom {
             matched_at_ms: started,
             play_started_at_ms: None,
             initial_sfen,
+            reconnect_grace_ms: Some(grace.as_millis().try_into().map_err(|_| {
+                Error::RustError("reconnect grace duration exceeds u64 milliseconds".into())
+            })?),
             black_reconnect_token: black_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
             white_reconnect_token: white_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
         };

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -49,6 +49,13 @@ pub struct PersistedConfig {
     /// 対局では `Some(sfen)` で、cold start 復元時もこの SFEN から `CoreRoom` を
     /// 組み直す。
     pub(crate) initial_sfen: Option<String>,
+    /// 対局開始時に確定した再接続 grace 時間（ミリ秒）。
+    ///
+    /// `websocket_close` 時に env を読み直すと、対局中の deploy / 設定変更で
+    /// token 配布有無と grace 判定がずれるため、マッチ単位で固定した値を保存する。
+    /// 旧 schema では存在しないため `None` として読み、保守的に grace 無効として扱う。
+    #[serde(default)]
+    pub(crate) reconnect_grace_ms: Option<u64>,
     /// 先手向けに発行した再接続トークン。`Game_Summary` 末尾拡張行で配布した
     /// 値そのまま (32 文字 hex)。`websocket_close` 時に grace registry へ写して
     /// 切断側 LOGIN reconnect 要求の `expected_token` 照合に使う。再接続プロトコル
@@ -236,6 +243,7 @@ mod tests {
             matched_at_ms: PLAY_STARTED_AT_MS - 100,
             play_started_at_ms: None,
             initial_sfen: None,
+            reconnect_grace_ms: Some(0),
             black_reconnect_token: None,
             white_reconnect_token: None,
         }
@@ -659,6 +667,7 @@ mod tests {
         }"#;
         let cfg: PersistedConfig =
             serde_json::from_str(json).expect("旧 schema は default 経由で deserialize できる");
+        assert_eq!(cfg.reconnect_grace_ms, None);
         assert_eq!(cfg.black_reconnect_token, None);
         assert_eq!(cfg.white_reconnect_token, None);
     }
@@ -677,25 +686,29 @@ mod tests {
             "matched_at_ms": 999000,
             "play_started_at_ms": null,
             "initial_sfen": null,
+            "reconnect_grace_ms": null,
             "black_reconnect_token": null,
             "white_reconnect_token": null
         }"#;
         let cfg: PersistedConfig =
             serde_json::from_str(json).expect("null 値は None として deserialize できる");
+        assert_eq!(cfg.reconnect_grace_ms, None);
         assert_eq!(cfg.black_reconnect_token, None);
         assert_eq!(cfg.white_reconnect_token, None);
     }
 
     /// 値あり (`grace > 0` で `start_match` が token を発行した場合の永続化形式) も
-    /// そのまま読み込める。値の round-trip も pin する。
+    /// そのまま読み込める。grace 値と token 値の round-trip を pin する。
     #[test]
     fn persisted_config_round_trips_with_reconnect_token_values() {
         let mut original = baseline_config();
+        original.reconnect_grace_ms = Some(30_000);
         original.black_reconnect_token = Some("a".repeat(32));
         original.white_reconnect_token = Some("b".repeat(32));
         let json = serde_json::to_string(&original).expect("serialize cfg");
         let restored: PersistedConfig =
             serde_json::from_str(&json).expect("deserialize cfg with token values");
+        assert_eq!(restored.reconnect_grace_ms, original.reconnect_grace_ms);
         assert_eq!(restored.black_reconnect_token, original.black_reconnect_token);
         assert_eq!(restored.white_reconnect_token, original.white_reconnect_token);
     }

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -145,6 +145,7 @@ mod tests {
             matched_at_ms: 1_000_000,
             play_started_at_ms: Some(1_000_000),
             initial_sfen: None,
+            reconnect_grace_ms: Some(30_000),
             black_reconnect_token: Some("blk-token".to_owned()),
             white_reconnect_token: Some("wht-token".to_owned()),
         }


### PR DESCRIPTION
## 概要

- `PersistedConfig` に `reconnect_grace_ms` を追加し、対局開始時点の reconnect grace 設定を永続化します。
- `websocket_close` では env を再読込せず、保存済みの grace 値だけを参照するようにしました。
- 旧 schema / null / 値ありの deserialize と round-trip テストを更新しました。

## 背景

Issue #598 のとおり、対局中に `RECONNECT_GRACE_SECONDS` が変更されると、開始時に配布した `Reconnect_Token` と切断時の grace 判定がずれる可能性がありました。対局単位で gate 状態を固定することで、この race を排除します。

## 検証

- `cargo fmt && cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `cargo test -p rshogi-csa-server-workers persisted_config --lib`
- `cargo test -p rshogi-csa-server-workers replay_ --lib`
- `cargo check -p rshogi-csa-server-workers`
- `MINIFLARE_SMOKE_SKIP_BUILD=1 corepack pnpm exec vitest run --config tests/miniflare_smoke/vitest.config.ts reconnect.test.ts`

## 補足

`setOptions()` を使った Miniflare の env 変更 smoke も試しましたが、workerd 再起動により既存 WS close が期待した形で `grace_registry` を作らず、Issue #598 の race を安定して pin できなかったため、PR には含めていません。

Closes #598