### PR TITLE
[codex] Fix CSA grace alarm intent

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -288,18 +288,14 @@ impl DurableObject for GameRoom {
             return Ok(());
         }
 
-        // 再接続プロトコルが env で有効化されている (grace_duration > 0 + Floodgate
-        // features opt-in) なら即時 force_abnormal せず、grace registry に対局
-        // 状態のスナップショットを書いて alarm を grace deadline で予約する。
-        // ALLOW_FLOODGATE_FEATURES が立っていない構成で grace_duration が誤って
-        // > 0 になっていた場合は console_log で警告して保守的に旧経路へ落とす。
-        let grace_duration = match resolve_reconnect_grace(&self.env) {
-            Ok(d) => d,
-            Err(e) => {
-                console_log!("[GameRoom] reconnect grace disabled: {e}");
-                Duration::ZERO
-            }
+        // 再接続プロトコルは start_match 時点の設定で対局単位に固定する。
+        // close 時に env を読み直すと、対局中の deploy / 設定変更で
+        // `Reconnect_Token` 配布有無と grace 判定がずれるため、永続化済み
+        // `PersistedConfig` の値だけを参照する。
+        let Some(cfg) = cfg_opt else {
+            return Ok(());
         };
+        let grace_duration = Duration::from_millis(cfg.reconnect_grace_ms.unwrap_or_default());
         if !grace_duration.is_zero() {
             if let Err(e) = self.enter_grace_window(role, grace_duration).await {
                 // grace 経路のセットアップに失敗したら旧経路 (即時 force_abnormal)
@@ -557,6 +553,9 @@ impl GameRoom {
             matched_at_ms: started,
             play_started_at_ms: None,
             initial_sfen,
+            reconnect_grace_ms: Some(grace.as_millis().try_into().map_err(|_| {
+                Error::RustError("reconnect grace duration exceeds u64 milliseconds".into())
+            })?),
             black_reconnect_token: black_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
             white_reconnect_token: white_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
         };

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -124,10 +124,19 @@ const KEY_SLOTS: &str = "slots";
 const KEY_CONFIG: &str = "config";
 const KEY_FINISHED: &str = "finished";
 /// 切断 → 再接続待ちエントリの DO storage key (1 対局 = 0..=1 件)。
+///
+/// ⚠ `enter_grace_window` 内のローカル struct `GraceAlarmWrite` の
+/// `#[serde(rename = "grace_registry")]` と一致させること。`put_multiple` は
+/// struct のフィールド名 (rename 後) を storage key として使うため、ずれると
+/// `load_grace_registry` 側が `None` を返す silent failure になる。
 const KEY_GRACE_REGISTRY: &str = "grace_registry";
 /// 次に発火する `state.alarm()` の種別タグ。`None` は alarm 未予約 / 既存 alarm
 /// が時間切れ駆動 (TimeUp) であることを示す。grace 経路に入ったときだけ
 /// `GraceExpired` を書き込む。
+///
+/// ⚠ `enter_grace_window` 内のローカル struct `GraceAlarmWrite` の
+/// `#[serde(rename = "pending_alarm_kind")]` と一致させること（理由は
+/// `KEY_GRACE_REGISTRY` と同じ）。
 const KEY_PENDING_ALARM_KIND: &str = "pending_alarm_kind";
 
 /// R2 上の buoy 保存フォーマット。
@@ -1907,8 +1916,10 @@ impl GameRoom {
         // この値と「再接続時刻 + 残時間 budget」のうち早い方を採用することで、
         // 悪意あるクライアントが切断 → grace 直前再接続を繰り返して相手手番の
         // wall-clock 上の deadline を不当に延長する経路を防ぐ。
-        let original_turn_alarm_epoch_ms =
-            self.state.storage().get_alarm().await.ok().flatten().map(|e| e as u64);
+        // 同じ値を後段の `classify_alarm_after_enter_grace` でも使うため、
+        // `get_alarm` は 1 回だけ呼んで使い回す。
+        let existing_alarm = self.state.storage().get_alarm().await.ok().flatten();
+        let original_turn_alarm_epoch_ms = existing_alarm.map(|e| e as u64);
         let pending = {
             let borrow = self.core.borrow();
             let core = borrow.as_ref().ok_or_else(|| {
@@ -1927,9 +1938,8 @@ impl GameRoom {
         // 未予約なら `None`。
         let now_ms = self.now_ms();
         let grace_deadline_ms = pending.deadline_ms;
-        let existing = self.state.storage().get_alarm().await.ok().flatten();
         let (alarm_kind, should_set_grace) =
-            classify_alarm_after_enter_grace(existing, grace_deadline_ms);
+            classify_alarm_after_enter_grace(existing_alarm, grace_deadline_ms);
 
         #[derive(Serialize)]
         struct GraceAlarmWrite<'a> {

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -78,7 +78,8 @@ use crate::persistence::{
 };
 use crate::reconnect::{
     PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot,
-    build_resume_message, color_from_str, color_to_str, issue_tokens_if_enabled,
+    build_resume_message, classify_alarm_after_enter_grace, color_from_str, color_to_str,
+    issue_tokens_if_enabled,
 };
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
 use crate::spectator_control::{
@@ -1275,6 +1276,7 @@ impl GameRoom {
             ended_at_ms,
         };
         self.state.storage().put(KEY_FINISHED, &finished).await?;
+        self.delete_grace_alarm_state().await?;
 
         // KEY_FINISHED が確定した後に live-games-index entry を best-effort で
         // 削除する (Issue #549 §4)。「終局 entry も live entry も無い」矛盾
@@ -1920,28 +1922,30 @@ impl GameRoom {
                 original_turn_alarm_epoch_ms,
             )?
         };
-        // `KEY_GRACE_REGISTRY` と `KEY_PENDING_ALARM_KIND` を 2 回の `put` で
-        // 書き分ける。Cloudflare DO は同一 instance に対する fetch / alarm /
-        // websocket_* を単一スレッドで逐次処理するため、1 件目 put 後の `await`
-        // 中に他ハンドラが割り込んで不整合を観測する race は起きない。
-        // worker 0.8.1 では `Storage::transaction` と `put_multiple` ともに既に
-        // 提供されているが、本 Issue #591 hotfix scope では既存の 2 段 put のまま
-        // 据え置く。followup-B で atomic 化を検討する。
-        self.state.storage().put(KEY_GRACE_REGISTRY, &pending).await?;
-        self.state
-            .storage()
-            .put(KEY_PENDING_ALARM_KIND, &PendingAlarmKind::GraceExpired)
-            .await?;
         // 既存の turn alarm より grace deadline が早ければ上書き、遅ければ既存
         // alarm (時間切れ) を残す。`get_alarm` は次回発火時刻 (epoch ms) を返し、
         // 未予約なら `None`。
         let now_ms = self.now_ms();
         let grace_deadline_ms = pending.deadline_ms;
         let existing = self.state.storage().get_alarm().await.ok().flatten();
-        let should_set_grace = match existing {
-            Some(epoch_ms) if (epoch_ms as u64) <= grace_deadline_ms => false,
-            _ => true,
-        };
+        let (alarm_kind, should_set_grace) =
+            classify_alarm_after_enter_grace(existing, grace_deadline_ms);
+
+        #[derive(Serialize)]
+        struct GraceAlarmWrite<'a> {
+            #[serde(rename = "grace_registry")]
+            grace_registry: &'a PendingReconnect,
+            #[serde(rename = "pending_alarm_kind")]
+            pending_alarm_kind: PendingAlarmKind,
+        }
+
+        self.state
+            .storage()
+            .put_multiple(GraceAlarmWrite {
+                grace_registry: &pending,
+                pending_alarm_kind: alarm_kind,
+            })
+            .await?;
         if should_set_grace {
             let delay = grace_deadline_ms.saturating_sub(now_ms).saturating_add(ALARM_SAFETY_MS);
             self.state.storage().set_alarm(Duration::from_millis(delay)).await?;
@@ -2034,7 +2038,7 @@ impl GameRoom {
         let Some(pending) = pending else {
             // 再接続が成立して registry が片付けられた直後の race 等。alarm kind
             // も並行で TimeUp に戻されているはずだが、念のため tag を片付けておく。
-            self.delete_pending_alarm_kind().await?;
+            self.delete_grace_alarm_state().await?;
             return Ok(());
         };
         self.ensure_core_loaded().await?;
@@ -2042,8 +2046,7 @@ impl GameRoom {
             Ok(c) => Role::from_core(c),
             Err(e) => {
                 console_log!("[GameRoom] grace alarm: invalid color in registry: {e}");
-                self.delete_grace_registry().await?;
-                self.delete_pending_alarm_kind().await?;
+                self.delete_grace_alarm_state().await?;
                 return Ok(());
             }
         };
@@ -2053,8 +2056,7 @@ impl GameRoom {
             self.dispatch_broadcasts(&result.broadcasts).await?;
             self.finalize_if_ended(&result).await?;
         }
-        self.delete_grace_registry().await?;
-        self.delete_pending_alarm_kind().await?;
+        self.delete_grace_alarm_state().await?;
         Ok(())
     }
 
@@ -2146,11 +2148,7 @@ impl GameRoom {
         ws.serialize_attachment(&att)
             .map_err(|e| Error::RustError(format!("attach player on reconnect: {e}")))?;
 
-        self.delete_grace_registry().await?;
-        // alarm tag を片付ける。直後に turn alarm を再セットして上書きするため、
-        // 順序は kind tag 削除 → set_alarm の順で書き直す（kind tag 未設定は
-        // 既定で `TimeUp` 扱い）。
-        self.delete_pending_alarm_kind().await?;
+        self.delete_grace_alarm_state().await?;
         // 再接続クライアントが指し手を送らず放置しても確実に turn deadline が
         // 発火するよう、即時 alarm を貼り直す。決定方針:
         // - 候補 A: 切断時に取り置いた元 turn alarm の発火時刻 (`pending.original
@@ -2206,17 +2204,16 @@ impl GameRoom {
         Ok(cfg_opt.map(|c| c.game_name).unwrap_or_default())
     }
 
-    async fn delete_grace_registry(&self) -> Result<()> {
-        let _ = self.state.storage().delete(KEY_GRACE_REGISTRY).await;
-        Ok(())
-    }
-
     async fn load_pending_alarm_kind(&self) -> Result<Option<PendingAlarmKind>> {
         Ok(self.state.storage().get(KEY_PENDING_ALARM_KIND).await.ok().flatten())
     }
 
-    async fn delete_pending_alarm_kind(&self) -> Result<()> {
-        let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+    async fn delete_grace_alarm_state(&self) -> Result<()> {
+        let _ = self
+            .state
+            .storage()
+            .delete_multiple(vec![KEY_GRACE_REGISTRY, KEY_PENDING_ALARM_KIND])
+            .await;
         Ok(())
     }
 }

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -49,6 +49,13 @@ pub struct PersistedConfig {
     /// 対局では `Some(sfen)` で、cold start 復元時もこの SFEN から `CoreRoom` を
     /// 組み直す。
     pub(crate) initial_sfen: Option<String>,
+    /// 対局開始時に確定した再接続 grace 時間（ミリ秒）。
+    ///
+    /// `websocket_close` 時に env を読み直すと、対局中の deploy / 設定変更で
+    /// token 配布有無と grace 判定がずれるため、マッチ単位で固定した値を保存する。
+    /// 旧 schema では存在しないため `None` として読み、保守的に grace 無効として扱う。
+    #[serde(default)]
+    pub(crate) reconnect_grace_ms: Option<u64>,
     /// 先手向けに発行した再接続トークン。`Game_Summary` 末尾拡張行で配布した
     /// 値そのまま (32 文字 hex)。`websocket_close` 時に grace registry へ写して
     /// 切断側 LOGIN reconnect 要求の `expected_token` 照合に使う。再接続プロトコル
@@ -236,6 +243,7 @@ mod tests {
             matched_at_ms: PLAY_STARTED_AT_MS - 100,
             play_started_at_ms: None,
             initial_sfen: None,
+            reconnect_grace_ms: Some(0),
             black_reconnect_token: None,
             white_reconnect_token: None,
         }
@@ -659,6 +667,7 @@ mod tests {
         }"#;
         let cfg: PersistedConfig =
             serde_json::from_str(json).expect("旧 schema は default 経由で deserialize できる");
+        assert_eq!(cfg.reconnect_grace_ms, None);
         assert_eq!(cfg.black_reconnect_token, None);
         assert_eq!(cfg.white_reconnect_token, None);
     }
@@ -677,25 +686,29 @@ mod tests {
             "matched_at_ms": 999000,
             "play_started_at_ms": null,
             "initial_sfen": null,
+            "reconnect_grace_ms": null,
             "black_reconnect_token": null,
             "white_reconnect_token": null
         }"#;
         let cfg: PersistedConfig =
             serde_json::from_str(json).expect("null 値は None として deserialize できる");
+        assert_eq!(cfg.reconnect_grace_ms, None);
         assert_eq!(cfg.black_reconnect_token, None);
         assert_eq!(cfg.white_reconnect_token, None);
     }
 
     /// 値あり (`grace > 0` で `start_match` が token を発行した場合の永続化形式) も
-    /// そのまま読み込める。値の round-trip も pin する。
+    /// そのまま読み込める。grace 値と token 値の round-trip を pin する。
     #[test]
     fn persisted_config_round_trips_with_reconnect_token_values() {
         let mut original = baseline_config();
+        original.reconnect_grace_ms = Some(30_000);
         original.black_reconnect_token = Some("a".repeat(32));
         original.white_reconnect_token = Some("b".repeat(32));
         let json = serde_json::to_string(&original).expect("serialize cfg");
         let restored: PersistedConfig =
             serde_json::from_str(&json).expect("deserialize cfg with token values");
+        assert_eq!(restored.reconnect_grace_ms, original.reconnect_grace_ms);
         assert_eq!(restored.black_reconnect_token, original.black_reconnect_token);
         assert_eq!(restored.white_reconnect_token, original.white_reconnect_token);
     }

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -187,6 +187,21 @@ pub(crate) fn issue_tokens_if_enabled(
     }
 }
 
+/// grace 登録時に次回 alarm が表す意味と、alarm 本体を grace deadline に
+/// 上書きするかを決める。
+///
+/// 既存 turn alarm が grace deadline 以前に発火するなら、alarm 本体はそのまま
+/// `TimeUp` として扱う。そうでなければ tag/body ともに `GraceExpired` に揃える。
+pub(crate) fn classify_alarm_after_enter_grace(
+    existing_alarm_epoch_ms: Option<i64>,
+    grace_deadline_ms: u64,
+) -> (PendingAlarmKind, bool) {
+    match existing_alarm_epoch_ms.and_then(|epoch_ms| u64::try_from(epoch_ms).ok()) {
+        Some(epoch_ms) if epoch_ms <= grace_deadline_ms => (PendingAlarmKind::TimeUp, false),
+        _ => (PendingAlarmKind::GraceExpired, true),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -357,5 +372,26 @@ mod tests {
         let black = black.expect("grace>0 で black token は Some");
         let white = white.expect("grace>0 で white token は Some");
         assert_ne!(black.as_str(), white.as_str(), "黒/白 token は互いに異なるべき (盗用防止)");
+    }
+
+    #[test]
+    fn classify_alarm_after_enter_grace_keeps_earlier_turn_alarm_as_time_up() {
+        let (kind, should_set_grace) = classify_alarm_after_enter_grace(Some(1_000), 2_000);
+        assert_eq!(kind, PendingAlarmKind::TimeUp);
+        assert!(!should_set_grace);
+    }
+
+    #[test]
+    fn classify_alarm_after_enter_grace_uses_grace_when_deadline_is_earlier() {
+        let (kind, should_set_grace) = classify_alarm_after_enter_grace(Some(3_000), 2_000);
+        assert_eq!(kind, PendingAlarmKind::GraceExpired);
+        assert!(should_set_grace);
+    }
+
+    #[test]
+    fn classify_alarm_after_enter_grace_uses_grace_when_no_alarm_exists() {
+        let (kind, should_set_grace) = classify_alarm_after_enter_grace(None, 2_000);
+        assert_eq!(kind, PendingAlarmKind::GraceExpired);
+        assert!(should_set_grace);
     }
 }

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -145,6 +145,7 @@ mod tests {
             matched_at_ms: 1_000_000,
             play_started_at_ms: Some(1_000_000),
             initial_sfen: None,
+            reconnect_grace_ms: Some(30_000),
             black_reconnect_token: Some("blk-token".to_owned()),
             white_reconnect_token: Some("wht-token".to_owned()),
         }

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect_alarm.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect_alarm.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: 再接続 grace と turn alarm の優先順位", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      reconnectGraceSeconds: 30,
+      allowFloodgateFeatures: true,
+      totalTimeSec: 1,
+      byoyomiSec: 0,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("off-turn 切断時に既存 turn alarm が早い場合は TimeUp として処理する", async () => {
+    const roomId = "reconnect-alarm-room-1";
+    const gameName = "fg-1-0";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black = await CsaClient.connect(mf, roomId);
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    await black.drainGameSummary();
+    await white.drainGameSummary();
+    black.send("AGREE");
+    white.send("AGREE");
+    await black.recvLine();
+    await white.recvLine();
+
+    black.send("+7776FU");
+    await black.recvUntil((l) => l.startsWith("+7776FU"));
+    await white.recvUntil((l) => l.startsWith("+7776FU"));
+
+    await black.close();
+
+    const whiteEnd = await white.recvUntil((l) => l === "#LOSE", 10_000);
+    expect(whiteEnd.includes("#TIME_UP"), `white stream: ${JSON.stringify(whiteEnd)}`).toBe(true);
+    expect(whiteEnd.includes("#ABNORMAL"), `white stream: ${JSON.stringify(whiteEnd)}`).toBe(false);
+
+    await white.close();
+  });
+});


### PR DESCRIPTION
## 概要

- `enter_grace_window` で既存 turn alarm が grace deadline より早い場合、`pending_alarm_kind` を `TimeUp` として保存するよう修正しました。
- `grace_registry` / `pending_alarm_kind` の保存を `put_multiple` に寄せ、削除も `delete_multiple` でまとめました。
- 終局時の grace/alarm cleanup を `finalize_if_ended` に集約しました。
- off-turn 切断時に turn alarm が優先される Miniflare smoke を追加しました。

## 背景

Issue #597 の defect 1 にある通り、従来は turn alarm を残すケースでも tag だけ `GraceExpired` になり、次回 alarm が本来の time-up ではなく grace-expired として処理される可能性がありました。

## 検証

- `cargo fmt && cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `cargo test -p rshogi-csa-server-workers classify_alarm_after_enter_grace --lib`
- `corepack pnpm exec tsc --noEmit -p tests/miniflare_smoke/tsconfig.json`
- `corepack pnpm exec vitest run --config tests/miniflare_smoke/vitest.config.ts reconnect.test.ts`
- `MINIFLARE_SMOKE_SKIP_BUILD=1 corepack pnpm exec vitest run --config tests/miniflare_smoke/vitest.config.ts reconnect_alarm.test.ts`
- `MINIFLARE_SMOKE_SKIP_BUILD=1 corepack pnpm exec vitest run --config tests/miniflare_smoke/vitest.config.ts reconnect.test.ts reconnect_alarm.test.ts`

Refs #597

Stacked on #607.