### PR TITLE
[codex] Enable CSA reconnect grace in production

### DIFF
--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -29,6 +29,7 @@ struct EnvironmentBindings {
     r2_bindings: Vec<String>,
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
+    compatibility_date: Option<String>,
     /// `[[migrations]]` 配列を生のまま保持する。`new_sqlite_classes` 等を
     /// 各 test が独自に検査するため、`Vec<toml::Value>` のまま持つ。
     migrations: Vec<toml::Value>,
@@ -77,6 +78,9 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
         .map(|t| t.keys().cloned().collect())
         .unwrap_or_default();
 
+    let compatibility_date =
+        doc.get("compatibility_date").and_then(|v| v.as_str()).map(str::to_owned);
+
     let migrations = doc.get("migrations").and_then(|v| v.as_array()).cloned().unwrap_or_default();
 
     let crons = doc
@@ -92,6 +96,7 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
         r2_bindings,
         do_bindings,
         vars_keys,
+        compatibility_date,
         migrations,
         crons,
     }
@@ -172,6 +177,21 @@ fn assert_declares_backfill_cron_trigger(env: &EnvironmentBindings) {
         file = env.file_name,
         label = env.label,
         crons = env.crons,
+    );
+}
+
+fn assert_compatibility_dates_match(lhs: &EnvironmentBindings, rhs: &EnvironmentBindings) {
+    assert_eq!(
+        lhs.compatibility_date,
+        rhs.compatibility_date,
+        "{lhs_file} ({lhs_label}) and {rhs_file} ({rhs_label}) must use the same \
+         compatibility_date; got lhs={lhs_date:?}, rhs={rhs_date:?}",
+        lhs_file = lhs.file_name,
+        lhs_label = lhs.label,
+        rhs_file = rhs.file_name,
+        rhs_label = rhs.label,
+        lhs_date = lhs.compatibility_date,
+        rhs_date = rhs.compatibility_date,
     );
 }
 
@@ -260,4 +280,9 @@ fn wrangler_staging_declares_sqlite_migration_for_game_room() {
 #[test]
 fn wrangler_staging_declares_backfill_cron_trigger() {
     assert_declares_backfill_cron_trigger(&STAGING);
+}
+
+#[test]
+fn wrangler_environment_compatibility_dates_match() {
+    assert_compatibility_dates_match(&PRODUCTION, &STAGING);
 }

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -123,12 +123,12 @@ BYOYOMI_MIN = "1"
 # 命名規則: `byoyomi-<total_sec>-<byoyomi_sec>` / `fischer-<total_sec>-<increment_sec>F`
 CLOCK_PRESETS = "[]"
 
-# 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
+# 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
-RECONNECT_GRACE_SECONDS = "0"
+RECONNECT_GRACE_SECONDS = "30"
 # Floodgate 系運用機能（再接続プロトコル等）を opt-in 有効化する。`true` / `1` /
 # `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
-ALLOW_FLOODGATE_FEATURES = "false"
+ALLOW_FLOODGATE_FEATURES = "true"
 # viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in 有効化する。
 # `true` / `1` / `yes` / `on` で有効、`false` / `0` / `no` / `off` または
 # 未設定で無効化（該当 endpoint は 404）。本値は production rollout の kill-switch


### PR DESCRIPTION
## Summary
- production wrangler config で `RECONNECT_GRACE_SECONDS=30` と `ALLOW_FLOODGATE_FEATURES=true` を有効化
- production/staging の `compatibility_date` がずれた場合に検知する TOML 一貫性テストを追加

## Stack
- Stacked on #608
- Refs #599

## Verification
- `cargo fmt && cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `cargo test -p rshogi-csa-server-workers --test wrangler_environment_toml_consistency`
- `cargo check -p rshogi-csa-server-workers`

## 追加動作確認 (2026-05-03 JST)
- staging `/health` 応答 OK: `https://rshogi-csa-server-workers-staging.sh11235.workers.dev/health`
- Miniflare reconnect smoke OK: `reconnect.test.ts` / `reconnect_alarm.test.ts` の 2 files, 3 tests passed
- `rshogi-csa-client` 2 本で staging 実機 1 局完走 OK
  - `101 Switching Protocols` → `LOGIN OK` → `Game_Summary` → `Reconnect_Token` → `START` → 指し手交換 → `#TIME_UP/#WIN/#LOSE` → ローカル棋譜保存まで確認
  - 実行時は `target/release/rshogi-usi` に `LS_PROGRESS_COEFF=/mnt/nvme1/development/bullet-shogi/data/progress/nodchip_progress_e1_f1_cuda.bin` を指定
- staging raw CSA-over-WebSocket reconnect OK
  - 黒切断後、同一 `game_id + Reconnect_Token` で `LOGIN OK`
  - `BEGIN Reconnect_State` と `Current_Turn:-` を受信
  - 再接続後に `-3334FU` を継続受信し、最後に `%TORYO` → `#RESIGN,#LOSE` まで確認

## Merge 前確認事項
- production bucket cold-start 後の `PUT /api/v1/games/{id}` 互換確認
- ramu-shogi viewer での CSA 表示互換確認
- staging で production 相当 clock 設定の reconnect smoke
- production deploy 後の reconnect smoke