### PR TITLE
feat(csa-client): stderr diagnostic 拡張 (passthrough / Windows ErrorKind) (#603)

### DIFF
--- a/crates/rshogi-csa-client/src/config.rs
+++ b/crates/rshogi-csa-client/src/config.rs
@@ -81,6 +81,11 @@ pub struct EngineConfig {
     /// USIオプション (key → value)
     #[serde(default)]
     pub options: HashMap<String, toml::Value>,
+    /// engine の stderr 出力を csa_client log に多重化する (`log::info!`)。
+    /// debug / 初期セットアップで engine 出力を即時確認したいときに有効化する。
+    /// default は false (既存の ring buffer 末尾捕捉のみ)。
+    #[serde(default)]
+    pub stderr_passthrough: bool,
 }
 
 impl Default for EngineConfig {
@@ -89,6 +94,7 @@ impl Default for EngineConfig {
             path: PathBuf::new(),
             startup_timeout_sec: 30,
             options: HashMap::new(),
+            stderr_passthrough: false,
         }
     }
 }

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -116,14 +116,14 @@ pub type InfoCallback<'a> = dyn FnMut(&SearchInfo, &str) + 'a;
 /// use rshogi_csa_client::{run_game_session_with_events, UsiEngine, UsiEngineDriver};
 ///
 /// // 1. 具象 `UsiEngine` をそのまま渡す
-/// let mut engine = UsiEngine::spawn(&path, &options, ponder, timeout)?;
+/// let mut engine = UsiEngine::spawn(&path, &options, ponder, timeout, false)?;
 /// run_game_session_with_events(&config, &mut conn, &mut engine, shutdown, &mut sink)?;
 ///
 /// // 2. dyn dispatch で複数 engine 実装を切り替える
 /// let mut engine: Box<dyn UsiEngineDriver> = if use_builtin {
 ///     Box::new(BuiltinEngine::new(...))
 /// } else {
-///     Box::new(UsiEngine::spawn(&path, &options, ponder, timeout)?)
+///     Box::new(UsiEngine::spawn(&path, &options, ponder, timeout, false)?)
 /// };
 /// run_game_session_with_events(&config, &mut conn, &mut *engine, shutdown, &mut sink)?;
 /// ```
@@ -248,12 +248,18 @@ pub struct SearchInfo {
 }
 
 impl UsiEngine {
-    /// USIエンジンを起動し、初期化する
+    /// USIエンジンを起動し、初期化する。
+    ///
+    /// `stderr_passthrough` が true のとき、stderr reader thread は ring buffer
+    /// に push するのに加えて各行を `log::info!("[engine stderr] {line}")` で
+    /// csa_client log に多重化する。debug / 初期セットアップ時に engine 出力を
+    /// 即時確認するための機能で、通常稼働時は false を渡す。
     pub fn spawn(
         path: &Path,
         options: &HashMap<String, toml::Value>,
         ponder: bool,
         timeout: Duration,
+        stderr_passthrough: bool,
     ) -> Result<Self> {
         let mut cmd = Command::new(path);
         // 子プロセスを独立したプロセスグループで起動
@@ -314,6 +320,13 @@ impl UsiEngine {
                         // (PR #596 review で指摘された bug への対応)。
                         let raw = String::from_utf8_lossy(&buf).into_owned();
                         let line = raw.trim_end_matches('\r').to_owned();
+                        // passthrough 時は ring push と並行して log::info! で
+                        // csa_client log に多重化する。lock 取得前に行うのは
+                        // log macro 側の latency を mutex critical section に
+                        // 持ち込まないため (best-effort 経路、順序保証不要)。
+                        if stderr_passthrough {
+                            log::info!("[engine stderr] {line}");
+                        }
                         let mut tail = match stderr_tail_writer.lock() {
                             Ok(g) => g,
                             Err(p) => p.into_inner(),
@@ -656,13 +669,25 @@ impl UsiEngine {
             .and_then(|_| self.writer.flush());
         match result {
             Ok(()) => Ok(()),
-            Err(io_err) if io_err.kind() == std::io::ErrorKind::BrokenPipe => {
+            Err(io_err)
+                if matches!(
+                    io_err.kind(),
+                    std::io::ErrorKind::BrokenPipe
+                        | std::io::ErrorKind::ConnectionAborted
+                        | std::io::ErrorKind::ConnectionReset
+                ) =>
+            {
                 // BrokenPipe = engine 死亡確定の強い signal (Linux primary scope)。
-                // Windows の `ConnectionAborted` / `ConnectionReset` は followup-J で対応。
+                // Windows の subprocess stdin 死亡は `ConnectionAborted` /
+                // `ConnectionReset` で報告されるため、`matches!` arm に追加して
+                // Windows でも engine 死亡確定経路として扱う。Linux で
+                // `ConnectionAborted/Reset` が stdin pipe に来ることはない
+                // (発生したら同じく fatal 扱いで safe) ので、`cfg(target_os)`
+                // gate は不要。
                 Err(self.engine_exited_error())
             }
             Err(io_err) => {
-                // BrokenPipe 以外は engine 生存中の transient error。
+                // 上記 fatal kind 以外は engine 生存中の transient error。
                 // `anyhow::Context::context` で source を保持しつつ伝搬。
                 Err(io_err).context("エンジン I/O エラー")
             }

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -169,6 +169,12 @@ struct Cli {
     /// USIエンジンオプション (K=V,K=V,...)
     #[arg(long)]
     options: Option<String>,
+
+    /// engine stderr を csa_client log に多重化する (`log::info!("[engine stderr] ...")`).
+    /// debug / 初期セットアップ用。default は false (既存の ring buffer 末尾捕捉のみ)。
+    /// TOML の `engine.stderr_passthrough` でも指定可。
+    #[arg(long, default_missing_value = "true", num_args = 0..=1)]
+    engine_stderr_passthrough: Option<bool>,
 }
 
 fn main() -> Result<()> {
@@ -329,6 +335,7 @@ fn spawn_engine(config: &CsaClientConfig) -> Result<UsiEngine> {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(config.engine.startup_timeout_sec),
+        config.engine.stderr_passthrough,
     )
 }
 
@@ -730,6 +737,9 @@ fn apply_cli_overrides(config: &mut CsaClientConfig, cli: &Cli) {
     if let Some(ref dir) = cli.jsonl_out {
         config.record.jsonl_out = Some(dir.clone());
     }
+    if let Some(passthrough) = cli.engine_stderr_passthrough {
+        config.engine.stderr_passthrough = passthrough;
+    }
     if let Some(ref opts) = cli.options {
         for kv in opts.split(',') {
             if let Some((k, v)) = kv.split_once('=') {
@@ -844,6 +854,7 @@ mod tests {
             record_dir: None,
             jsonl_out: None,
             options: None,
+            engine_stderr_passthrough: None,
         }
     }
 

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -85,7 +85,7 @@ exit 1
 "#;
     let path = write_mock_script("dying_immediate", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -116,7 +116,7 @@ exit 1
 "#;
     let path = write_mock_script("dying_after_handshake", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let mut engine = UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT)
+    let mut engine = UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false)
         .expect("初回 handshake は成功する想定");
     // engine プロセスは usiok+readyok を返した直後に exit。
     // new_game() は usinewgame + isready を送る。BrokenPipe か recv Disconnected
@@ -153,7 +153,7 @@ exit 1
     let path = write_mock_script("dying_during_go", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let mut engine =
-        UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT).expect("初回 handshake は成功");
+        UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false).expect("初回 handshake は成功");
     engine.new_game().expect("new_game は成功");
     let shutdown = AtomicBool::new(false);
     let (_tx, server_rx) = mpsc::channel::<Event>();
@@ -190,7 +190,7 @@ exit 1
     let path = write_mock_script("long_stderr_line", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // initialize は usiok 後 isready を送る → engine 死亡で error
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
         Ok(_) => panic!("isready 送信前後で engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -220,7 +220,7 @@ exit 1
 "#;
     let path = write_mock_script("crlf_stderr", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -251,7 +251,7 @@ exit 1
 "#;
     let path = write_mock_script("empty_line_not_eof", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT) {
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -264,5 +264,34 @@ exit 1
     assert!(
         msg.contains("after empty"),
         "空行後の行も含まれるはず (空行 EOF 誤認 bug の regression guard): {msg}"
+    );
+}
+
+// ───────────────────────────────────────────────
+// Fixture 7: --engine-stderr-passthrough=true でも既存の ring buffer 末尾捕捉が
+//   壊れないことの smoke test。log 多重化 (`log::info!`) 自体の capture は
+//   global logger 依存で flake しやすいため本 test では検証せず、push 経路
+//   との並行動作 (ring buffer 同等動作) を pin する。
+// ───────────────────────────────────────────────
+#[test]
+fn stderr_passthrough_preserves_ring_buffer() {
+    let script = r#"#!/usr/bin/env bash
+printf 'passthrough line A\n' >&2
+printf 'passthrough line B\n' >&2
+exec 2>&-
+exit 1
+"#;
+    let path = write_mock_script("passthrough_smoke", script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    // 第 5 引数 stderr_passthrough = true。
+    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, true) {
+        Ok(_) => panic!("spawn 即時死で error が期待される"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert_diagnostic_prefix(&msg, &path);
+    assert!(
+        msg.contains("passthrough line A") || msg.contains("passthrough line B"),
+        "passthrough=true でも ring buffer に末尾が積まれているはず: {msg}"
     );
 }

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -281,6 +281,7 @@ fn fresh_session_emits_expected_event_sequence() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -363,6 +364,7 @@ fn resumed_session_emits_resumed_event_and_no_history_replay() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -432,6 +434,7 @@ fn resumed_state_last_sfen_matches_summary_position_section() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -548,6 +551,7 @@ fn fatal_sink_triggers_clean_closure_and_returns_sink_aborted() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -625,6 +629,7 @@ fn external_shutdown_emits_shutdown_disconnected_and_returns_shutdown_error() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -695,6 +700,7 @@ fn external_shutdown_observed_through_legacy_run_game_session() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 
@@ -747,6 +753,7 @@ fn nonfatal_sink_does_not_invoke_on_error_and_session_continues() {
         &config.engine.options,
         config.game.ponder,
         Duration::from_secs(5),
+        false,
     )
     .expect("spawn engine");
 


### PR DESCRIPTION
## Summary

Issue #603 の nice-to-have 拡張を 2 件実装。拡張 2 (killpg) は `unsafe` 持ち込み + テスト scope 肥大化を避けるため**本 PR では分離**し、別 issue として残す (Issue #603 自体は残拡張の追跡 issue として open のままにする想定)。

- **拡張 1: `--engine-stderr-passthrough` flag** — engine stderr を `log::info!("[engine stderr] {line}")` で csa_client log に多重化。debug / 初期セットアップで engine 出力を即時確認するための feature。default false で既存 ring buffer 末尾捕捉 (engine 死亡時診断) は変更なし。CLI flag と TOML key (`engine.stderr_passthrough`) の両方に配線。
- **拡張 3: Windows ErrorKind 拡張** — `send()` の fatal 判定を `BrokenPipe` 単独 → `matches!(.., BrokenPipe | ConnectionAborted | ConnectionReset)` に拡張。Windows subprocess stdin 死亡時の `ConnectionAborted` / `ConnectionReset` 経路をカバー。Linux で stdin pipe 経由でこれらが来ることはなく、来ても fatal 扱いで safe なため `cfg(target_os)` gate は不要。
- **拡張 2 (killpg) は別 issue に分離** — `pre_exec(setpgid)` 経由で立てた pgid に `libc::killpg(pgid, SIGKILL)` を投げる経路は `unsafe` block を要し、CLAUDE.md の unsafe ポリシー上「process spawn 制約」と同等の正当化が必要。加えて孫プロセス reap 検証用の test fixture も別途設計が要るため、本 PR scope から外して個別 issue で扱う。

## 変更点

| File | 変更 |
|---|---|
| `crates/rshogi-csa-client/src/config.rs` | `EngineConfig.stderr_passthrough: bool` (default false) |
| `crates/rshogi-csa-client/src/engine.rs` | `UsiEngine::spawn()` に第 5 引数 `stderr_passthrough` 追加。reader thread 内で flag が true なら ring push (Mutex lock) の **前** に `log::info!` (critical section に log macro latency を持ち込まない、順序保証は best-effort)。`send()` の fatal 判定を `matches!` arm で 3 ErrorKind に拡張 |
| `crates/rshogi-csa-client/src/main.rs` | `--engine-stderr-passthrough` flag、`apply_cli_overrides` で TOML を上書き |
| `crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs` | 既存 6 fixture を第 5 引数 `false` で更新。Fixture 7 (passthrough=true smoke) を追加 (passthrough 有効時に ring buffer 末尾捕捉が壊れないことを pin。log 多重化自体の capture は global logger 依存で本 PR 未検証) |
| `crates/rshogi-csa-client/tests/session_events_integration.rs` | spawn 7 callsite に `false` を追加 |

## 設計レビュー

- Codex local review: **APPROVE**。指摘なし。
  - `init_logger` が最初の `spawn_engine` より前に呼ばれていて log multiplex は logger init 後に走る点を確認
  - default false で既存挙動互換、Mutex lock 前 log macro 配置の妥当性、`matches!` 拡張の安全側性、smoke test に留めた判断、YAGNI 遵守すべて確認

## チェック済み

- [x] `cargo fmt && cargo clippy --tests` 警告ゼロ
- [x] `cargo test` (workspace 全体) 全 pass
- [x] `cargo test -p rshogi-csa-client --test engine_stderr_diagnostic` 7/7 pass

## Test plan

- [ ] CI green (`cargo test` / `cargo clippy` matrix)
- [ ] 手動 smoke (任意): `csa_client --engine-stderr-passthrough` で起動した engine の stderr が `[engine stderr] ...` プレフィクス付きで csa_client log に流れること
- [ ] 拡張 2 (killpg) は別 issue で続編 PR を作成する

Refs #603 #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)