### PR TITLE
feat(csa-server-workers): AGREE 待ち TTL を配線して stuck DO を排除 (#600)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -95,6 +95,12 @@ impl ConfigKeys {
     /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
     /// を要求する Floodgate features の opt-in 経路に乗る。
     pub const RECONNECT_GRACE_SECONDS: &'static str = "RECONNECT_GRACE_SECONDS";
+    /// LOGIN OK 後の AGREE 待ち TTL (秒)。`start_match` で Game_Summary を送信した
+    /// 直後に予約し、両者 AGREE 受領 (`HandleOutcome::GameStarted`) で cancel する。
+    /// 発火時は対局が成立する前に部屋を解放する (Issue #600)。
+    /// `0` または未設定は安全側既定 [`DEFAULT_AGREE_TIMEOUT_SEC`] にフォールバック
+    /// する (TTL 0 = 無効化は memory / room 枠の長期占有リスクを再現するため許容しない)。
+    pub const AGREE_TIMEOUT_SECONDS: &'static str = "AGREE_TIMEOUT_SECONDS";
     /// Floodgate 機能群を opt-in 有効化するブール変数。`true` / `1` / `yes` / `on`
     /// で有効。`reconnect_protocol` 等の Floodgate 系を要求する構成で必須。
     pub const ALLOW_FLOODGATE_FEATURES: &'static str = "ALLOW_FLOODGATE_FEATURES";
@@ -150,6 +156,7 @@ impl ConfigKeys {
         Self::BYOYOMI_MIN,
         Self::CLOCK_PRESETS,
         Self::RECONNECT_GRACE_SECONDS,
+        Self::AGREE_TIMEOUT_SECONDS,
         Self::ALLOW_FLOODGATE_FEATURES,
         Self::ALLOW_VIEWER_API,
         Self::LOBBY_QUEUE_SIZE_LIMIT,
@@ -170,6 +177,11 @@ impl ConfigKeys {
 /// `None` / 空文字 / パース失敗時のフォールバックとして参照する。
 pub(crate) const DEFAULT_CHALLENGE_TTL_SEC: u64 = 3600;
 
+/// `AGREE_TIMEOUT_SECONDS` 既定値 (60 秒)。TCP frontend は 5 分既定だが、Workers
+/// DO は 1 部屋 = 1 instance で memory / room 枠を専有するため、より短めの既定で
+/// stuck DO を素早く解放する設計を採る (Issue #600)。
+pub(crate) const DEFAULT_AGREE_TIMEOUT_SEC: u64 = 60;
+
 /// `CHALLENGE_TTL_SEC` 文字列を `Duration` へ解決する。`None` / 空文字 /
 /// 非数値 / `u64` 範囲外は [`DEFAULT_CHALLENGE_TTL_SEC`] にフォールバック
 /// する (challenge TTL 不正で全 `CHALLENGE_LOBBY` 発行が止まる事態を避ける
@@ -183,6 +195,22 @@ pub fn parse_challenge_ttl_duration(raw: Option<&str>) -> std::time::Duration {
     match trimmed.parse::<u64>() {
         Ok(secs) => std::time::Duration::from_secs(secs),
         Err(_) => std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC),
+    }
+}
+
+/// `AGREE_TIMEOUT_SECONDS` 文字列を `Duration` へ解決する。
+///
+/// `None` / 空文字 / `0` / 非数値 / `u64` 範囲外は [`DEFAULT_AGREE_TIMEOUT_SEC`]
+/// にフォールバックする (env 不正で stuck DO が無限残存する事態を避ける安全側挙動)。
+/// `> 0` の正値はそのまま秒として `Duration` にする。
+pub fn parse_agree_timeout_duration(raw: Option<&str>) -> std::time::Duration {
+    let trimmed = raw.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return std::time::Duration::from_secs(DEFAULT_AGREE_TIMEOUT_SEC);
+    }
+    match trimmed.parse::<u64>() {
+        Ok(0) | Err(_) => std::time::Duration::from_secs(DEFAULT_AGREE_TIMEOUT_SEC),
+        Ok(secs) => std::time::Duration::from_secs(secs),
     }
 }
 
@@ -491,6 +519,33 @@ mod tests {
     fn parse_clock_spec_rejects_unknown_kind() {
         let err = parse_clock_spec(Some("weird"), None, None, None, None, None, None).unwrap_err();
         assert!(err.contains("countdown|countdown_msec|fischer|stopwatch"));
+    }
+
+    #[test]
+    fn parse_agree_timeout_duration_defaults_when_unset_or_blank_or_zero() {
+        let default = std::time::Duration::from_secs(DEFAULT_AGREE_TIMEOUT_SEC);
+        assert_eq!(parse_agree_timeout_duration(None), default);
+        assert_eq!(parse_agree_timeout_duration(Some("")), default);
+        assert_eq!(parse_agree_timeout_duration(Some(" \t ")), default);
+        // `0` は「無効化」を意図した運用ミスと解釈し、stuck DO の長期占有を避ける
+        // ため安全側既定にフォールバックする (TTL 0 = 無効化は許容しない)。
+        assert_eq!(parse_agree_timeout_duration(Some("0")), default);
+    }
+
+    #[test]
+    fn parse_agree_timeout_duration_accepts_positive_seconds() {
+        assert_eq!(parse_agree_timeout_duration(Some("30")), std::time::Duration::from_secs(30),);
+        assert_eq!(
+            parse_agree_timeout_duration(Some(" 120\n")),
+            std::time::Duration::from_secs(120),
+        );
+    }
+
+    #[test]
+    fn parse_agree_timeout_duration_falls_back_on_non_numeric() {
+        let default = std::time::Duration::from_secs(DEFAULT_AGREE_TIMEOUT_SEC);
+        assert_eq!(parse_agree_timeout_duration(Some("forever")), default);
+        assert_eq!(parse_agree_timeout_duration(Some("-5")), default);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -64,7 +64,8 @@ use rshogi_csa_server::{FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryC
 
 use crate::attachment::{Role, WsAttachment, parse_login_handle};
 use crate::config::{
-    ConfigKeys, parse_clock_presets, parse_clock_spec, resolve_reconnect_grace_from_strings,
+    ConfigKeys, parse_agree_timeout_duration, parse_clock_presets, parse_clock_spec,
+    resolve_reconnect_grace_from_strings,
 };
 use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
 use crate::floodgate_history::R2FloodgateHistoryStorage;
@@ -337,12 +338,16 @@ impl DurableObject for GameRoom {
             return Response::ok("already finished");
         }
 
-        // alarm 種別タグを読み、`GraceExpired` 経路だけ grace registry の処理に
-        // 委譲する。既定値 (タグ未設定) は時間切れ駆動とみなす。
+        // alarm 種別タグを読み、`GraceExpired` / `AgreeTimeout` 経路を分岐する。
+        // 既定値 (タグ未設定 / `TimeUp`) は時間切れ駆動とみなす。
         let kind = self.load_pending_alarm_kind().await?;
         if matches!(kind, Some(PendingAlarmKind::GraceExpired)) {
             self.handle_grace_expired_alarm().await?;
             return Response::ok("grace_expired handled");
+        }
+        if matches!(kind, Some(PendingAlarmKind::AgreeTimeout)) {
+            self.handle_agree_timeout_alarm().await?;
+            return Response::ok("agree_timeout handled");
         }
 
         self.ensure_core_loaded().await?;
@@ -627,6 +632,26 @@ impl GameRoom {
         self.send_to_role(Role::Black, &summary_black).await?;
         self.send_to_role(Role::White, &summary_white).await?;
 
+        // AGREE 待ち TTL を予約する (Issue #600)。LOGIN OK 後に AGREE が届かない
+        // まま片方が刺さると、`/api/v1/games/live` に出ない (mark_play_started が
+        // 走らないので live-games-index に put しない) のに DO 側では memory /
+        // room 枠を専有し続ける edge case を解消する。
+        //
+        // - 両者 AGREE で `HandleOutcome::GameStarted` が観測されたら
+        //   `clear_agree_timeout_tag` で kind タグだけ削除する。alarm 本体は
+        //   直後の `reschedule_turn_alarm` が turn budget で上書きするため、
+        //   別途 cancel する必要はない (タグが無いので alarm は TimeUp として処理される)。
+        // - alarm が `AgreeTimeout` のまま発火したら `handle_agree_timeout_alarm` で
+        //   部屋を解放する (`abort_pending_match_with_error` 相当 + `KEY_FINISHED`
+        //   セット)。AGREE 前なので live-games-index は put 前 (cleanup 不要)、
+        //   `play_started_at_ms` も None のまま (R2 棋譜エクスポート skip)。
+        let agree_timeout = resolve_agree_timeout(&self.env);
+        self.state
+            .storage()
+            .put(KEY_PENDING_ALARM_KIND, &PendingAlarmKind::AgreeTimeout)
+            .await?;
+        self.state.storage().set_alarm(agree_timeout).await?;
+
         Ok(true)
     }
 
@@ -679,6 +704,10 @@ impl GameRoom {
         // Playing 開始を確定できた瞬間だけ cfg を更新（冪等）。
         if let HandleOutcome::GameStarted = result.outcome {
             self.mark_play_started(now).await?;
+            // AGREE 待ち TTL タグを片付ける (Issue #600)。alarm 本体は直後の
+            // `reschedule_turn_alarm` が turn budget で上書きするため、タグだけ
+            // 消せば後続 alarm 発火は既定 (TimeUp) として処理される。
+            self.clear_agree_timeout_tag().await;
         }
 
         // 着手を永続化。MoveAccepted の場合のみ moves テーブルに append する。
@@ -2226,6 +2255,62 @@ impl GameRoom {
             .await;
         Ok(())
     }
+
+    /// AGREE 待ち TTL タグだけを片付ける best-effort helper (Issue #600)。
+    /// `HandleOutcome::GameStarted` 観測時に呼ぶ。`KEY_GRACE_REGISTRY` は
+    /// AGREE 経路では存在しない (grace 経路は対局成立後にしか入らない) ため
+    /// 触らない。
+    async fn clear_agree_timeout_tag(&self) {
+        let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+    }
+
+    /// alarm が `AgreeTimeout` 種別で発火した経路 (Issue #600)。
+    ///
+    /// - 既に終局済 / 対局成立済の場合は no-op (race ガード)。
+    /// - そうでなければ両 player WS に `##[ERROR] agree_timeout` を送って close
+    ///   し、slot を解放、`KEY_FINISHED` で再 LOGIN を弾く。`play_started_at_ms`
+    ///   が None のまま到達するため live-games-index は put 前で cleanup 不要、
+    ///   R2 棋譜エクスポートも skip する (`finalize_if_ended` を呼ばない)。
+    /// - `core` が in-memory に残っていれば落とす (= 後続の `ensure_core_loaded`
+    ///   は `KEY_FINISHED` ガードで早期 return する)。
+    async fn handle_agree_timeout_alarm(&self) -> Result<()> {
+        // 終局済 (既に何らかの経路で確定) ならタグだけ片付けて終了。
+        if self.load_finished().await?.is_some() {
+            let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+            return Ok(());
+        }
+        // race: alarm 直前で AGREE が成立していて `mark_play_started` 済なら
+        // 何もしない。タグも `clear_agree_timeout_tag` 経路で消える (race で
+        // 残っているなら念のため明示削除)。
+        let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
+        if let Some(cfg) = cfg_opt.as_ref() {
+            if cfg.play_started_at_ms.is_some() {
+                let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+                return Ok(());
+            }
+        }
+
+        console_log!("[GameRoom] agree timeout fired; releasing pending match");
+        // `abort_pending_match_with_error` と同じ pending 解放ロジックを再利用
+        // して、両 player に `##[ERROR] agree_timeout` を返した上で slot を空に
+        // 戻す。
+        self.abort_pending_match_with_error("##[ERROR] agree_timeout").await?;
+        // 後続の LOGIN を弾くため `KEY_FINISHED` を立てる。`result_code` は
+        // 終局集計には乗らない (R2 棋譜・games-index も put しない) が、
+        // `load_finished` ガードを駆動する目的で観測可能な値を埋めておく。
+        let finished = FinishedState {
+            result_code: "agree_timeout".to_owned(),
+            ended_at_ms: self.now_ms(),
+        };
+        self.state.storage().put(KEY_FINISHED, &finished).await?;
+        // alarm 種別タグを片付ける (alarm は既に発火済なので `delete_alarm` は
+        // 不要だが、防御的に明示削除しても副作用はない)。
+        let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+        // 万一 `core` が残っていれば落とす (`ensure_core_loaded` は finished
+        // ガードで以後何もロードしない)。
+        self.core.borrow_mut().take();
+        Ok(())
+    }
 }
 
 /// 末尾改行を付けて 1 行送出する。CSA 行は改行終端が契約なので、
@@ -2304,6 +2389,15 @@ fn resolve_clock_spec_for_game(env: &Env, game_name: &str) -> Result<ClockSpec> 
 ///
 /// 実体ロジックは [`resolve_reconnect_grace_from_strings`] (host 単体テスト可能な
 /// pure helper) に委譲し、本関数は `worker::Env` 依存を切り出す薄い shim に閉じる。
+/// `AGREE_TIMEOUT_SECONDS` env を読み、AGREE 待ち TTL を `Duration` で返す
+/// (Issue #600)。値の解釈は [`parse_agree_timeout_duration`] に従う:
+/// `None` / 空文字 / `0` / 非数値は [`crate::config::DEFAULT_AGREE_TIMEOUT_SEC`]
+/// にフォールバックする (env 不正で stuck DO が無限残存する事態を避ける)。
+fn resolve_agree_timeout(env: &Env) -> Duration {
+    let raw = env.var(ConfigKeys::AGREE_TIMEOUT_SECONDS).ok().map(|v| v.to_string());
+    parse_agree_timeout_duration(raw.as_deref())
+}
+
 fn resolve_reconnect_grace(env: &Env) -> std::result::Result<Duration, String> {
     let grace_raw = env.var(ConfigKeys::RECONNECT_GRACE_SECONDS).ok().map(|v| v.to_string());
     let allow_raw = env.var(ConfigKeys::ALLOW_FLOODGATE_FEATURES).ok().map(|v| v.to_string());

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -165,6 +165,12 @@ pub enum PendingAlarmKind {
     /// grace 期間満了。grace registry を読み取り、切断側を `force_abnormal` で
     /// 敗北として確定させる経路を駆動する。
     GraceExpired,
+    /// AGREE 待ち TTL 満了。`start_match` 直後に予約し、両者 AGREE による
+    /// `HandleOutcome::GameStarted` で cancel される。発火時は対局成立前
+    /// (= `play_started_at_ms` 未確定 / `KEY_FINISHED` 未設定 / live-games-index
+    /// 未 put) のため、`force_abnormal` ではなく `abort_pending_match_with_error`
+    /// + `KEY_FINISHED` セット相当の経路で部屋を解放する (Issue #600)。
+    AgreeTimeout,
 }
 
 /// 再接続 grace が有効化されている (`grace > 0`) のときのみ対局者ごとの

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/agree_timeout.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/agree_timeout.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CsaClient, createMiniflare, makeTempPersistRoot } from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+/// Issue #600: LOGIN OK 後に AGREE 完了前に片方が刺さると、対局が live API
+/// にも出ず DO 上に無限残存する edge case の回帰テスト。
+///
+/// `start_match` で Game_Summary 送出直後に AGREE 待ち TTL (`AGREE_TIMEOUT_SECONDS`)
+/// で `set_alarm` が予約され、両者 AGREE 受領 (`HandleOutcome::GameStarted`) で
+/// `clear_agree_timeout_tag` が `KEY_PENDING_ALARM_KIND` を消すことで cancel
+/// される。発火時は `handle_agree_timeout_alarm` が `##[ERROR] agree_timeout`
+/// を両 player に送って WS を close し、`KEY_FINISHED` をセットして以後の
+/// LOGIN を弾く。
+describe("miniflare smoke: AGREE 待ち TTL (Issue #600)", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      // 1 秒で発火させて test を高速化する。production では 60 秒既定。
+      agreeTimeoutSeconds: 1,
+      // 時計切れ alarm が先に張られないよう、十分長い手番制限を確保する
+      // (AGREE 待ち TTL が turn alarm より先に処理されることを pin)。
+      totalTimeSec: 600,
+      byoyomiSec: 10,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("両 LOGIN OK 後 AGREE せず放置すると agree_timeout で部屋が解放される", async () => {
+    const roomId = "agree-timeout-room-1";
+    const gameName = "byoyomi-600-10";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black = await CsaClient.connect(mf, roomId);
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    // 双方が Game_Summary を受信するところまで進める。AGREE は意図的に送らない。
+    await black.drainGameSummary();
+    await white.drainGameSummary();
+
+    // alarm 発火 (AGREE_TIMEOUT_SECONDS=1 + ALARM_SAFETY_MS=200ms 程度) を
+    // 待って `##[ERROR] agree_timeout` を観測する。timeout は wall-clock 依存
+    // のため余裕を持たせる。
+    const blackErr = await black.recvLine(10_000);
+    expect(blackErr).toBe("##[ERROR] agree_timeout");
+    const whiteErr = await white.recvLine(10_000);
+    expect(whiteErr).toBe("##[ERROR] agree_timeout");
+
+    // server-initiated close を待つ (close ack)。
+    await black.close();
+    await white.close();
+  });
+
+  it("両 AGREE が間に合えば agree_timeout は cancel され通常対局を続行できる", async () => {
+    const roomId = "agree-timeout-room-2";
+    const gameName = "byoyomi-600-10";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black = await CsaClient.connect(mf, roomId);
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    await black.drainGameSummary();
+    await white.drainGameSummary();
+
+    // 1 秒の TTL より十分早く AGREE を返す。
+    black.send("AGREE");
+    white.send("AGREE");
+    // START を双方が受信できれば、agree alarm は cancel されている。
+    await black.recvUntil((l) => l.startsWith("START:"), 5_000);
+    await white.recvUntil((l) => l.startsWith("START:"), 5_000);
+
+    // 後続で TTL 経過時間 (1 秒 + 余裕) を待っても `##[ERROR] agree_timeout`
+    // が届かないことを pin する。turn alarm は 600 秒先なので発火しない。
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    // 着手を 1 手通せば対局が正常進行している証拠になる。
+    black.send("+7776FU");
+    await black.recvUntil((l) => l.startsWith("+7776FU"), 5_000);
+    await white.recvUntil((l) => l.startsWith("+7776FU"), 5_000);
+
+    await black.close();
+    await white.close();
+  });
+});

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -67,6 +67,11 @@ export interface HarnessOptions {
   /// 切って必ず指定する契約。`makeTempPersistRoot()` のヘルパで作るのが基本経路。
   persistRoot: string;
   reconnectGraceSeconds?: number;
+  /// AGREE 待ち TTL (秒)。`start_match` 直後に予約され、両者 AGREE で cancel
+  /// される (Issue #600)。テストで stuck 経路を再現する際は短めの値 (例: 1) を
+  /// 渡し、`alarm()` 発火で部屋解放されることを assert する。未指定時は server
+  /// 側既定 ([`config::DEFAULT_AGREE_TIMEOUT_SEC`] = 60) にフォールバック。
+  agreeTimeoutSeconds?: number;
   allowFloodgateFeatures?: boolean;
   totalTimeSec?: number;
   byoyomiSec?: number;
@@ -109,6 +114,10 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       // 出て reconnect 経路が有効化される。Issue #591 hotfix 後は server 側 token
       // 配布も grace に応じた gate を通る。
       RECONNECT_GRACE_SECONDS: String(opts.reconnectGraceSeconds ?? 0),
+      // 未指定時は空文字を渡して server 側 fallback (= 60 秒既定) を使う。
+      // 数値を指定したテストでは start_match 直後に AGREE 待ち alarm が予約される。
+      AGREE_TIMEOUT_SECONDS:
+        opts.agreeTimeoutSeconds === undefined ? "" : String(opts.agreeTimeoutSeconds),
       ALLOW_FLOODGATE_FEATURES: opts.allowFloodgateFeatures ? "true" : "false",
       WS_ALLOWED_ORIGINS: opts.wsAllowedOrigins ?? "https://example.com",
       LOBBY_QUEUE_SIZE_LIMIT: String(opts.lobbyQueueSizeLimit ?? 100),

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -134,6 +134,11 @@ CLOCK_PRESETS = '''[
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "30"
+# LOGIN OK 後の AGREE 待ち TTL (秒)。`start_match` で Game_Summary を送信した
+# 直後に予約し、両者 AGREE で cancel する。発火時は対局成立前に部屋を解放
+# (Issue #600)。`0` / 未設定 / 非数値は 60 秒既定にフォールバック (TTL 0 =
+# 無効化は memory / room 枠の長期占有リスクを再現するため許容しない)。
+AGREE_TIMEOUT_SECONDS = "60"
 # Floodgate 系運用機能（再接続プロトコル等）を opt-in 有効化する。`true` / `1` /
 # `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
 ALLOW_FLOODGATE_FEATURES = "true"

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -140,6 +140,11 @@ CLOCK_PRESETS = '''[
 # 吸収を兼ねる経験的下限。production 昇格時は実運用 client の再接続所要時間を
 # 計測してから再評価する。
 RECONNECT_GRACE_SECONDS = "30"
+# LOGIN OK 後の AGREE 待ち TTL (秒)。両者 AGREE 前に片方が刺さった対局を DO 上
+# から自動解放する (Issue #600)。staging では E2E をテンポよく回すため短めの
+# 30 秒で運用し、production 昇格時に 60 秒へ揃える運用とする。`0` / 未設定 /
+# 非数値は 60 秒既定にフォールバック。
+AGREE_TIMEOUT_SECONDS = "30"
 ALLOW_FLOODGATE_FEATURES = "true"
 # viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in 有効化する。
 # staging は実機通電 (web client / spectator E2E) を回す前提で `"1"` を既定とする。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -110,6 +110,11 @@ ADMIN_HANDLE = "admin"
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "0"
+# LOGIN OK 後の AGREE 待ち TTL (秒)。両者 AGREE 前に片方が刺さった対局を DO
+# 上から自動解放する (Issue #600)。`0` / 未設定 / 非数値は 60 秒既定にフォール
+# バック (TTL 0 = 無効化は memory / room 枠の長期占有リスクを再現するため許容
+# しない)。本ファイルでは local dev で長めに観察できるよう 60 秒を既定に置く。
+AGREE_TIMEOUT_SECONDS = "60"
 # Floodgate 系運用機能（再接続プロトコル等）を opt-in で有効化する。`true` / `1` /
 # `yes` / `on` で有効。空または `false` のとき該当機能要求は起動 fail-fast。
 ALLOW_FLOODGATE_FEATURES = "false"


### PR DESCRIPTION
## 概要

Workers DO で **AGREE 待ち TTL が未配線** だった edge case (#600) を解消する。LOGIN OK 後に AGREE 完了前に片方が刺さると、対局が `/api/v1/games/live` にも出ず DO 上に無限残存し memory / room 枠を長期占有していた。TCP frontend (`wait_both_agree::agree_timeout`) と等価な経路を Workers 側に追加する。

## 変更点

- `PendingAlarmKind::AgreeTimeout` variant を追加 (`crates/rshogi-csa-server-workers/src/reconnect.rs`)
- `start_match` で Game_Summary 送信直後に AGREE 待ち TTL を予約 (`set_alarm` + `KEY_PENDING_ALARM_KIND = AgreeTimeout`)
- `HandleOutcome::GameStarted` 観測時に `clear_agree_timeout_tag` でタグだけ削除。alarm 本体は直後の `reschedule_turn_alarm` が turn budget で上書きするため別途 cancel は不要 (タグが無いので alarm は既定 = TimeUp として処理される)
- `alarm()` で `AgreeTimeout` 種別を分岐、`handle_agree_timeout_alarm` が `abort_pending_match_with_error` 相当 + `KEY_FINISHED` セットで部屋を解放
- `AGREE_TIMEOUT_SECONDS` env を新規追加 (production=60s / staging=30s / template=60s)。`SHARED_PUBLIC_VARS_KEYS` にも登録して wrangler consistency test を駆動
- `parse_agree_timeout_duration` を pure helper として実装。`0` / 未設定 / 非数値は `DEFAULT_AGREE_TIMEOUT_SEC` (60s) にフォールバック

## 設計判断

- **alarm 多重化**: `state.alarm()` は DO 1 instance につき同時 1 つしかセットできないため、既存 `PendingAlarmKind` (TimeUp / GraceExpired) のタグ分岐パターンに乗せた。AGREE 待ち中は turn alarm 未予約 (`mark_play_started` 未呼出のため) で、grace alarm も対局成立後にしか入らないので衝突しない
- **alarm cancel 経路**: 両者 AGREE 受領で `reschedule_turn_alarm(GameStarted)` が turn budget で `set_alarm` を上書きするため、本実装は **タグのみ削除** で十分。明示的な `delete_alarm` は冗長
- **発火時 cleanup**: AGREE 前のため `play_started_at_ms = None` → live-games-index は未 put / R2 棋譜エクスポート skip / grace registry も無い。`abort_pending_match_with_error` (両 player に `##[ERROR] agree_timeout` + WS close + slot 解放) + `KEY_FINISHED` で十分
- **TTL=0 を許容しない**: `RECONNECT_GRACE_SECONDS=0` は再接続プロトコル無効化として許容するが、`AGREE_TIMEOUT_SECONDS=0` は本 issue が解こうとしている stuck DO リスクを再現するため、安全側既定 (60s) にフォールバックする方針に倒した

## 設計レビュー履歴

Plan agent (Agent tool) は本セッション環境で利用不可だったため、設計レビューは Codex review に集約した (詳細は次節)。

## コードレビュー履歴

- **Codex local review (task subcommand) 1 ラウンド**: COMMENT (許容) で通過。blocker 無し
- **指摘事項 (follow-up)**: spectator WS の close 処理 (nice-to-have)。本 PR では対局者 WS の close + slot 解放 + `KEY_FINISHED` で stuck DO の解消は完結しており、観戦者 WS は最終的に DO の hibernation / R2 棋譜エクスポート未実行で破棄される。明示 close を入れるなら別 PR で扱う

## 検証

- `cargo fmt && cargo clippy --fix --allow-dirty --tests`: 警告 0
- `cargo test --workspace --tests`: 全 pass
- `cargo test -p rshogi-csa-server-workers --tests`: 全 pass (config / wrangler consistency / 既存 240+ ユニットテスト含む)
- `pnpm test:smoke` (miniflare): 24 tests / 10 files all pass
  - 新規 `agree_timeout.test.ts` 2 件: AGREE せず放置 → `##[ERROR] agree_timeout` で部屋解放 / 両 AGREE が間に合えば cancel されて通常対局を続行できる

Closes #600