### PR TITLE
fix(csa-server-workers): CLOCK_PRESETS の OnceCell stale race を廃止 (#641)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -479,10 +479,12 @@ impl GameRoom {
         let game_id = format!("{room_id}-{started}");
         // 双方の LOGIN は既に OK を返しているため、ここで `?` で Err を伝播させると
         // 両クライアントには Game_Summary も `##[ERROR]` 通知も届かず部屋が永久に
-        // 詰まる。`CLOCK_PRESETS` の不正設定 (`parse_clock_presets` Err) や、deploy
-        // race で Lobby OnceCell キャッシュと GameRoom env が乖離して `game_name`
-        // 未登録に落ちるケースも、buoy reservation 失敗と同じ pending match abort
-        // 経路に揃えて部屋を解放する。
+        // 詰まる。`CLOCK_PRESETS` の不正設定 (`parse_clock_presets` Err) や、env
+        // 設定の不整合で `game_name` 未登録に落ちるケースも、buoy reservation 失敗
+        // と同じ pending match abort 経路に揃えて部屋を解放する (Issue #641 で
+        // Lobby 側の OnceCell キャッシュ廃止後は両 DO ともに env を毎回読み直す
+        // ため deploy race による乖離は解消されたが、`CLOCK_PRESETS` 不正設定時の
+        // fail-fast 経路は残す)。
         let clock_spec = match resolve_clock_spec_for_game(&self.env, game_name) {
             Ok(spec) => spec,
             Err(e) => {
@@ -2357,11 +2359,13 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
 ///   到達するのは Lobby を経由しない単体テスト経路、もしくはプリセット書き換え直後の
 ///   race など限定的なケース。
 ///
-/// **キャッシュなし設計**: Lobby DO は LOGIN ごとに `clock_presets()` を呼ぶため
-/// `OnceCell` キャッシュを持たせるが、GameRoom DO は 1 対局 = 1 インスタンスで
-/// `start_match` のたった 1 回でしか評価しないため、env 再パースのコストが無視できる。
-/// 各 DO のライフサイクルに合わせ計算を最小化することで設計の対称性より局所最適を
-/// 優先している。
+/// **キャッシュなし設計** (Issue #641): Lobby DO もキャッシュを廃止して毎 LOGIN
+/// 時に env を読み直す方針に揃えたため、本関数は両 DO 共通の挙動になっている。
+/// Cloudflare DO は hibernation から起床しても `OnceCell` キャッシュが更新されず、
+/// deploy で `CLOCK_PRESETS` を変更しても旧 instance が古い値を保持する race が
+/// 発生していたため、両 DO とも env を毎回読み直す方針に統一した。GameRoom DO は
+/// 1 対局 = 1 インスタンスで `start_match` のたった 1 回しか評価しないため
+/// もともと re-parse コストは問題にならない。
 fn resolve_clock_spec_for_game(env: &Env, game_name: &str) -> Result<ClockSpec> {
     use crate::config::{PresetResolution, resolve_clock_spec_from_presets_map};
     let raw = env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -30,7 +30,7 @@
 //!   DO storage 永続化 (cold start 復元 + `purge_expired` 後再保存)
 //! - DO Alarm による TTL purge と保留中 WS への切断信号送出
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -137,10 +137,6 @@ pub struct Lobby {
     state: State,
     env: Env,
     queue: RefCell<LobbyQueue>,
-    /// `CLOCK_PRESETS` 環境変数を 1 度だけパースして保持するキャッシュ。
-    /// 起動中に env vars は不変のため、初回 LOGIN_LOBBY のたびに JSON パースを
-    /// 走らせる無駄を避ける。空 HashMap = preset 未宣言 = strict mode 無効。
-    clock_presets: OnceCell<HashMap<String, ClockSpec>>,
 }
 
 impl DurableObject for Lobby {
@@ -149,7 +145,6 @@ impl DurableObject for Lobby {
             state,
             env,
             queue: RefCell::new(LobbyQueue::new()),
-            clock_presets: OnceCell::new(),
         }
     }
 
@@ -240,22 +235,31 @@ impl Lobby {
             .unwrap_or(DEFAULT_LOBBY_QUEUE_SIZE_LIMIT)
     }
 
-    /// `CLOCK_PRESETS` 環境変数をパースして得たマップを返す（OnceCell キャッシュ）。
+    /// `CLOCK_PRESETS` 環境変数をパースして得たマップを返す。
+    ///
+    /// **キャッシュなし設計** (Issue #641): 以前は `OnceCell` で DO 起動時に 1 度
+    /// だけパースしていたが、Cloudflare DO は hibernation から起床しても OnceCell
+    /// が更新されないため、deploy で `CLOCK_PRESETS` を変更しても旧 instance が
+    /// 古い値を保持し続け、新 preset が `unknown_clock_preset` で reject される
+    /// race が発生していた。`game_room.rs::resolve_clock_spec_for_game` は LOGIN
+    /// ごとに env を読み直していたため、Lobby と GameRoom で挙動が乖離する状態
+    /// だった。本関数も毎 LOGIN_LOBBY / CHALLENGE_LOBBY 受信ごとに env を読み直
+    /// すことで両 DO の挙動を対称化する。overhead は `CLOCK_PRESETS` の 1 KB 程度
+    /// JSON を 1 回パースするだけで、LOGIN は人手駆動の頻度のため許容範囲。
+    ///
     /// パース失敗時は空 HashMap として扱い、`console_log!` で警告を残して strict
     /// mode を無効化する（preset 設定不正で全 LOGIN がブロックされる事態を避ける
     /// 安全側挙動。`CLOCK_PRESETS` 値そのものは `parse_clock_presets` の起動時
-    /// テストでカバーする）。
-    fn clock_presets(&self) -> &HashMap<String, ClockSpec> {
-        self.clock_presets.get_or_init(|| {
-            let raw = self.env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
-            match parse_clock_presets(raw.as_deref()) {
-                Ok(map) => map,
-                Err(e) => {
-                    console_log!("[Lobby] event=invalid_clock_presets err={e}");
-                    HashMap::new()
-                }
+    /// テストでカバーする）。空 HashMap = preset 未宣言 = strict mode 無効。
+    fn clock_presets(&self) -> HashMap<String, ClockSpec> {
+        let raw = self.env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
+        match parse_clock_presets(raw.as_deref()) {
+            Ok(map) => map,
+            Err(e) => {
+                console_log!("[Lobby] event=invalid_clock_presets err={e}");
+                HashMap::new()
             }
-        })
+        }
     }
 
     /// `CHALLENGE_TTL_SEC` env を `Duration` に解決する (未設定時は 3600 秒の


### PR DESCRIPTION
## 概要

Lobby DO の `clock_presets` フィールドが `OnceCell<HashMap<String, ClockSpec>>` で DO 起動時に 1 度だけパースしてキャッシュしていたが、Cloudflare DO は hibernation から起床しても OnceCell が更新されないため、deploy で `CLOCK_PRESETS` env を変更しても旧 DO instance が古い値を保持し続け、新 preset が `unknown_clock_preset` で reject される race が存在した。

`game_room.rs::resolve_clock_spec_for_game` は LOGIN ごとに env を読み直すため、deploy 直後に Lobby (古い preset) と GameRoom (新 preset) で挙動が乖離する non-trivial race だった。

OnceCell を廃止して両 DO の挙動を対称化する。

## 設計

検討した選択肢:
- (a) **OnceCell を削除し毎 LOGIN 時に env 再読み込み** ← 採用
- (b) deploy 時に LobbyDO を明示 alarm trigger で reset → 運用負荷高、却下

(a) を採用した理由:
- `CLOCK_PRESETS` は 1 KB 程度の JSON で `serde_json` パースは数 us 程度
- LOGIN_LOBBY / CHALLENGE_LOBBY はクライアント認証直後の人手駆動頻度であり、preset map の事前計算が問題になるホットパスではない
- GameRoom DO は元々 `parse_clock_presets` を毎回呼ぶ実装で、両 DO の対称化は保守性の観点でメリットが大きい
- parse error 時の挙動 (`console_log!` 警告 + 空 map fallback で preset 未宣言と等価扱い、strict mode 無効化) は従来同様維持

## 変更点

- `lobby.rs`: `OnceCell<HashMap<String, ClockSpec>>` フィールドと `std::cell::OnceCell` import を削除。`clock_presets()` を毎呼び出しで `env.var(CLOCK_PRESETS)` → `parse_clock_presets` を呼ぶ実装に変更し、戻り値を `&HashMap` から `HashMap` (所有値) に変更。呼び出し側 (`handle_login_lobby`, `handle_challenge_lobby`) は一時 binding で扱っているため所有値で問題なく動作。
- `game_room.rs`: 「Lobby は OnceCell, GameRoom は毎回」の対称性論述コメントを Issue #641 経緯付きで両 DO 共通挙動の説明に更新。`start_match` の race 言及コメントも実態 (deploy race 解消) に合わせて整理。

## Test plan

- [x] `cargo fmt --check`: パス
- [x] `cargo clippy -p rshogi-csa-server-workers --tests`: 警告ゼロ
- [x] `cargo test -p rshogi-csa-server-workers`: 258 tests pass
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`: ビルド成功
- [x] Codex local review (`codex review --uncommitted`): 既存挙動を破壊する不具合なしと判定

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)