### PR TITLE
fix(csa-server-workers): Reconnect_Token を constant-time 比較 (#640)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "rshogi-csa-server",
  "serde",
  "serde_json",
+ "subtle",
  "tokio",
  "toml",
  "worker",

--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -25,6 +25,9 @@ serde_json.workspace = true
 # chrono はホスト／wasm32 で挙動を揃えるため `clock` 既定を切り、
 # serde 以外の機能は取り込まない。
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
+# Reconnect_Token のタイミング攻撃耐性比較に使う。`default-features = false`
+# で std を切っておくと wasm32-unknown-unknown でも問題なく動く (no_std 経路)。
+subtle = { version = "2", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm32-unknown-unknown 以外では参照しない。worker-build / wrangler dev から

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -111,14 +111,29 @@ impl PendingReconnect {
         if now_ms > self.deadline_ms {
             return ReconnectMatchOutcome::Expired;
         }
-        if self.disconnected_handle != handle
-            || self.disconnected_color != color_to_str(color)
-            || self.expected_token != token
-        {
+        // handle / color は CSA LOGIN 行から自明に観測可能なため short-circuit
+        // 比較で問題ない。token は攻撃者が当てにいく対象 (128bit hex) のため、
+        // 比較は短絡なしの constant-time にする。
+        if self.disconnected_handle != handle || self.disconnected_color != color_to_str(color) {
+            return ReconnectMatchOutcome::Rejected;
+        }
+        if !ct_str_eq(self.expected_token.as_bytes(), token.as_bytes()) {
             return ReconnectMatchOutcome::Rejected;
         }
         ReconnectMatchOutcome::Accepted
     }
+}
+
+/// 同長の byte 列を constant-time で比較する。長さの不一致は `len()` 自身が
+/// 公開情報なので即 false にしてよい (timing leak しない)。同長時は `subtle`
+/// の `ConstantTimeEq` で 1 byte ごと xor を畳み込み、`Choice` の bool 化まで
+/// 定数時間で完了する。
+fn ct_str_eq(a: &[u8], b: &[u8]) -> bool {
+    use subtle::ConstantTimeEq;
+    if a.len() != b.len() {
+        return false;
+    }
+    a.ct_eq(b).into()
 }
 
 /// 再接続成立時にクライアントへ送出する状態再送メッセージを組み立てる。


### PR DESCRIPTION
Closes #640

## 概要

`reconnect.rs::match_request` の token 比較が `==` short-circuit で書かれており、タイミング攻撃で token byte を 1 byte ずつ確定させる経路が理論上残っていた。`subtle` crate (default-features=false で no_std → wasm32 互換) を追加し、token 比較を `subtle::ConstantTimeEq` 経由の `ct_str_eq` ヘルパで定数時間化する。

handle / color は CSA LOGIN 行から自明に観測可能な公開情報なので short-circuit のまま維持し、token のみ早期リターンを避ける構成にした。

## redaction layer は本 PR では不要

`grep -rn 'token' crates/rshogi-csa-server-workers/src/ | grep console_log!` でヒット 0 件のため、log redaction layer の追加は本 PR では不要と判断。Game_Summary に Reconnect_Token は含まれるが client への配送のみで、Workers Logs / Cloudflare tail には流れない。仕様変更で token を log に出すような変更が入った場合は本 PR commit message を参照して redaction を併せて入れること。

## レビュー履歴

- 設計レビュー: 親エージェントが直接実施 (sub-agent stall 後の引き取り)
- コードレビュー: Codex local review 1 round → **APPROVE** (指摘なし)
  - constant-time 化の正当性、subtle crate の wasm32 互換、handle/color short-circuit の判断、test カバレッジ、redaction スコープの保留 — 全て適切と判定

## 検証

- `cargo fmt && cargo clippy --tests` 警告 0
- `cargo test -p rshogi-csa-server-workers --tests` 全 pass (271 tests)
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)