### PR TITLE
fix(csa-server-workers): start_match で AgreeTimeout が GraceExpired を上書きする race を防止 (#626)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -78,9 +78,9 @@ use crate::persistence::{
     FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
 };
 use crate::reconnect::{
-    PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot,
-    build_resume_message, classify_alarm_after_enter_grace, color_from_str, color_to_str,
-    issue_tokens_if_enabled,
+    PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot, StartMatchGuard,
+    build_resume_message, classify_alarm_after_enter_grace, classify_start_match_guard,
+    color_from_str, color_to_str, issue_tokens_if_enabled,
 };
 use crate::session_state::{LoginReply, MatchResult, Slot, evaluate_match};
 use crate::spectator_control::{
@@ -465,6 +465,70 @@ impl GameRoom {
         white_handle: &str,
         game_name: &str,
     ) -> Result<bool> {
+        // Issue #626: `start_match` の呼び出し前に存在する重複起動防止ガード
+        // (`handle_login` 側は `evaluate_match` の `MatchResult::Match` 判定、
+        // `try_start_pending_match` 側は `handle_game_line` 入口の
+        // `active_game_id().is_none()` 判定) が、cold start race (`KEY_CONFIG`
+        // read transient err 等) で誤通過した場合、末尾の
+        // `set_alarm(agree_timeout)` で `enter_grace_window` 経由の `GraceExpired`
+        // alarm を上書きし、合意済み対局を `agree_timeout` で abort する race が
+        // 理論上残る。副作用 (buoy reservation / `KEY_CONFIG` put / `set_alarm`)
+        // の前に三段ガード (FINISHED / KEY_CONFIG / KEY_PENDING_ALARM_KIND) を
+        // 逐次 early return で配置し、いずれか set 済なら
+        // `abort_pending_match_with_error` で pending slot を片付けて
+        // `Ok(false)` を返す。判定ロジックは `reconnect::classify_start_match_guard`
+        // で純粋関数化し unit test で固定する。
+        //
+        // 各 read を逐次にしているのは、`finished` を読み終えた直後に後続 read が
+        // err になっても、判定済みの強い状態 (FINISHED) を優先して abort cleanup
+        // まで到達できるようにするため (Codex review round 3 の指摘)。
+        // `KEY_FINISHED` チェック: 通常は `handle_login` / `handle_game_line`
+        // 入口の `load_finished` ガードで弾かれる経路。defensive な fallback と
+        // して残し、Player attachment の WS は `abort_pending_match_with_error`
+        // で server-initiated close する (`handle_login` で `LOGIN OK` 送出 +
+        // attachment が Player に差し替わっているため、無言で `Ok(false)` だと
+        // WS が宙ぶらりんになる)。
+        let finished_present = self.load_finished().await?.is_some();
+        if let StartMatchGuard::AlreadyFinished =
+            classify_start_match_guard(finished_present, false, None)
+        {
+            console_log!("[GameRoom] start_match aborted: already finished");
+            self.abort_pending_match_with_error("##[ERROR] room already finished").await?;
+            return Ok(false);
+        }
+        // `KEY_CONFIG` チェック: race 想定では既存対局の Player WS は (a) 切断済
+        // (= attachment は Player のままだが close 済の状態を
+        // `abort_pending_match_with_error` が無視する) か (b) grace 中 (= 同様に
+        // 既に close 済) のいずれか。万一既存対局の生 WS が同 DO に残っている
+        // 場合は close されるが、KEY_CONFIG present + 新規 LOGIN 経路自体が
+        // cold start race 想定で、巻き込みは race 経路の defensive 副作用として
+        // 許容する (Codex round 2)。
+        let cfg_present = self.state.storage().get::<PersistedConfig>(KEY_CONFIG).await?.is_some();
+        if let StartMatchGuard::AlreadyMatched =
+            classify_start_match_guard(false, cfg_present, None)
+        {
+            console_log!("[GameRoom] start_match aborted: KEY_CONFIG already present");
+            self.abort_pending_match_with_error("##[ERROR] match already in progress")
+                .await?;
+            return Ok(false);
+        }
+        // `KEY_PENDING_ALARM_KIND` チェック: `GraceExpired` / `TimeUp` /
+        // `AgreeTimeout` のどれが残っていても reject する。`AgreeTimeout` の前回
+        // start_match 残留を続行扱いにすると、古い alarm 本体が新 match を巻き
+        // 込む可能性があるため (Codex round 2 → round 3 の合意点)。
+        let existing_kind: Option<PendingAlarmKind> =
+            self.state.storage().get(KEY_PENDING_ALARM_KIND).await?;
+        if let StartMatchGuard::AlarmPending(kind) =
+            classify_start_match_guard(false, false, existing_kind)
+        {
+            console_log!(
+                "[GameRoom] start_match aborted: pending_alarm_kind={kind:?} already present"
+            );
+            self.abort_pending_match_with_error("##[ERROR] match already has pending alarm")
+                .await?;
+            return Ok(false);
+        }
+
         // `room_id` は fetch 時に永続化している（DO インスタンス = room_id なので
         // 他 DO と衝突しない。game_id は `<room_id>-<epoch_ms>` 形式で、
         // 別 DO が同一ミリ秒にマッチしても R2 キー `YYYY/MM/DD/<game_id>.csa` が

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -208,6 +208,60 @@ pub(crate) fn classify_alarm_after_enter_grace(
     }
 }
 
+/// `start_match` 入口の防御ガード判定結果 (Issue #626)。
+///
+/// `start_match` は副作用 (`KEY_CONFIG` put / buoy reservation / `set_alarm`) の
+/// 前にこの関数の判定で early return する。本 enum を介して入口判定を純粋関数
+/// として固定することで、cold start race (`KEY_CONFIG` read transient err 等) で
+/// `active_game_id` ガードが誤通過した場合に `AgreeTimeout` の `set_alarm` で
+/// 既存 `GraceExpired` alarm を上書きしないことを unit test で固定する。
+///
+/// `game_room::start_match` 側の実処理は逐次 early return で書かれているが、
+/// 判定の優先度・条件はこの関数とまったく同一であり、仕様の一意な参照点として
+/// 本関数を扱う (Codex review round 3 の方針)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartMatchGuard {
+    /// 副作用なしで `start_match` 本体を続行してよい。
+    Proceed,
+    /// `KEY_FINISHED` 既存 → 既に終局済みの DO で start_match を踏んだ。
+    AlreadyFinished,
+    /// `KEY_CONFIG` 既存 → 既に対局成立済 (`active_game_id` ガードを race で
+    /// すり抜けた cold start 復元経路想定)。
+    AlreadyMatched,
+    /// `KEY_PENDING_ALARM_KIND` 既存 → 別種別の alarm (典型的には
+    /// `GraceExpired`) が予約済。`AgreeTimeout` で上書きすると合意済み対局を
+    /// `agree_timeout` で abort してしまう経路。`AgreeTimeout` 残留も含めて
+    /// reject する (前回 start_match の古い alarm 本体が新 match を巻き込む
+    /// race を防ぐため)。
+    AlarmPending(PendingAlarmKind),
+}
+
+/// `start_match` 入口の三段ガードを純粋関数として表現する (Issue #626)。
+///
+/// 引数は永続化キー (`KEY_FINISHED` / `KEY_CONFIG` / `KEY_PENDING_ALARM_KIND`)
+/// の存在 / 値を直接取り、内部参照型に依存しない (`PersistedConfig` /
+/// `FinishedState` の中身は判定に使わないため bool で十分)。
+///
+/// 判定優先度は `finished_present` > `cfg_present` > `alarm_kind` の順で、より
+/// 強い既存状態を優先する。実処理 (`start_match`) 側は read を逐次 early return
+/// で行うが、判定ロジック自体はここで固定し unit test でカバレッジを担保する。
+pub(crate) fn classify_start_match_guard(
+    finished_present: bool,
+    cfg_present: bool,
+    alarm_kind: Option<PendingAlarmKind>,
+) -> StartMatchGuard {
+    if finished_present {
+        return StartMatchGuard::AlreadyFinished;
+    }
+    if cfg_present {
+        return StartMatchGuard::AlreadyMatched;
+    }
+    if let Some(kind) = alarm_kind {
+        return StartMatchGuard::AlarmPending(kind);
+    }
+    StartMatchGuard::Proceed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -399,5 +453,79 @@ mod tests {
         let (kind, should_set_grace) = classify_alarm_after_enter_grace(None, 2_000);
         assert_eq!(kind, PendingAlarmKind::GraceExpired);
         assert!(should_set_grace);
+    }
+
+    /// `start_match` 入口の三段ガード仕様を pin する (Issue #626)。
+    ///
+    /// `proceeds_when_no_state`: 何も永続化されていない初回 LOGIN マッチ成立直後の
+    /// 経路で副作用なしの続行を許可する。
+    #[test]
+    fn classify_start_match_guard_proceeds_when_no_state() {
+        assert_eq!(classify_start_match_guard(false, false, None), StartMatchGuard::Proceed);
+    }
+
+    /// `KEY_FINISHED` 既存。defensive な fallback 経路 (通常は `handle_login` /
+    /// `handle_game_line` 入口の `load_finished` ガードで弾かれる)。
+    #[test]
+    fn classify_start_match_guard_rejects_when_finished() {
+        assert_eq!(classify_start_match_guard(true, false, None), StartMatchGuard::AlreadyFinished);
+    }
+
+    /// `KEY_CONFIG` 既存。`active_game_id` ガードを cold start race ですり抜けた
+    /// 経路を想定し、`AgreeTimeout` で `set_alarm` を上書きしないように reject する。
+    #[test]
+    fn classify_start_match_guard_rejects_when_config_present() {
+        assert_eq!(classify_start_match_guard(false, true, None), StartMatchGuard::AlreadyMatched);
+    }
+
+    /// Issue #626 の主要シナリオ。`enter_grace_window` で `GraceExpired` alarm が
+    /// 予約済の状態で `start_match` を踏むと、`AgreeTimeout` で上書きしてしまう
+    /// ため reject する。
+    #[test]
+    fn classify_start_match_guard_rejects_when_grace_expired_pending() {
+        assert_eq!(
+            classify_start_match_guard(false, false, Some(PendingAlarmKind::GraceExpired)),
+            StartMatchGuard::AlarmPending(PendingAlarmKind::GraceExpired)
+        );
+    }
+
+    /// `TimeUp` 残留 (理論上の race) も reject する。`KEY_CONFIG` が無い限り
+    /// `TimeUp` がここに残ること自体は通常起きないが、防御的に弾く。
+    #[test]
+    fn classify_start_match_guard_rejects_when_time_up_pending() {
+        assert_eq!(
+            classify_start_match_guard(false, false, Some(PendingAlarmKind::TimeUp)),
+            StartMatchGuard::AlarmPending(PendingAlarmKind::TimeUp)
+        );
+    }
+
+    /// 前回 `start_match` の `AgreeTimeout` 残留も reject する。続行扱いにすると
+    /// 古い alarm 本体が新 match を巻き込む race を防ぐため (Codex review round 2
+    /// → round 3 の合意点)。
+    #[test]
+    fn classify_start_match_guard_rejects_when_agree_timeout_pending() {
+        assert_eq!(
+            classify_start_match_guard(false, false, Some(PendingAlarmKind::AgreeTimeout)),
+            StartMatchGuard::AlarmPending(PendingAlarmKind::AgreeTimeout)
+        );
+    }
+
+    /// 判定優先度の固定: `finished_present=true` なら cfg / alarm に関わらず
+    /// `AlreadyFinished`。
+    #[test]
+    fn classify_start_match_guard_finished_takes_precedence() {
+        assert_eq!(
+            classify_start_match_guard(true, true, Some(PendingAlarmKind::GraceExpired)),
+            StartMatchGuard::AlreadyFinished
+        );
+    }
+
+    /// 判定優先度の固定: cfg があれば alarm_kind に関わらず `AlreadyMatched`。
+    #[test]
+    fn classify_start_match_guard_config_takes_precedence_over_alarm_kind() {
+        assert_eq!(
+            classify_start_match_guard(false, true, Some(PendingAlarmKind::GraceExpired)),
+            StartMatchGuard::AlreadyMatched
+        );
     }
 }


### PR DESCRIPTION
## 概要

cold start race (`KEY_CONFIG` read transient err) で `active_game_id` ガードが誤通過した場合、`start_match` 末尾の `set_alarm(agree_timeout)` で `enter_grace_window` が予約した `GraceExpired` alarm を `AgreeTimeout` で上書きし、合意済み対局を `agree_timeout` で abort する race が理論上残る。`start_match` 入口に三段ガード (FINISHED / KEY_CONFIG / KEY_PENDING_ALARM_KIND) を副作用前に配置して race を塞ぐ。

Closes #626

## 実装

### `crates/rshogi-csa-server-workers/src/game_room.rs` (`start_match`)

副作用 (buoy reservation / `KEY_CONFIG` put / `Game_Summary` 送出 / `set_alarm`) の **前** に逐次 early return:

\`\`\`rust
let finished_present = self.load_finished().await?.is_some();
if let StartMatchGuard::AlreadyFinished = classify_start_match_guard(finished_present, false, None) {
    self.abort_pending_match_with_error(\"##[ERROR] room already finished\").await?;
    return Ok(false);
}
let cfg_present = self.state.storage().get::<PersistedConfig>(KEY_CONFIG).await?.is_some();
if let StartMatchGuard::AlreadyMatched = classify_start_match_guard(false, cfg_present, None) {
    self.abort_pending_match_with_error(\"##[ERROR] match already in progress\").await?;
    return Ok(false);
}
let existing_kind: Option<PendingAlarmKind> = self.state.storage().get(KEY_PENDING_ALARM_KIND).await?;
if let StartMatchGuard::AlarmPending(kind) = classify_start_match_guard(false, false, existing_kind) {
    self.abort_pending_match_with_error(\"##[ERROR] match already has pending alarm\").await?;
    return Ok(false);
}
\`\`\`

各 read を逐次にしているのは、`finished` を読み終えた直後に後続 read が err になっても、判定済みの強い状態 (FINISHED) を優先して abort cleanup まで到達できるようにするため。

### `crates/rshogi-csa-server-workers/src/reconnect.rs` (新規純粋関数)

\`\`\`rust
pub enum StartMatchGuard {
    Proceed,
    AlreadyFinished,
    AlreadyMatched,
    AlarmPending(PendingAlarmKind),
}

pub(crate) fn classify_start_match_guard(
    finished_present: bool,
    cfg_present: bool,
    alarm_kind: Option<PendingAlarmKind>,
) -> StartMatchGuard { /* ... */ }
\`\`\`

判定優先度は `finished_present` > `cfg_present` > `alarm_kind` の順。bool 引数化しているのは、判定に必要なのは presence のみで `PersistedConfig` / `FinishedState` の中身を使わないため (`reconnect.rs` から `persistence.rs` への依存を増やさない)。

## ガード条件の根拠

- **`KEY_FINISHED` 既存**: defensive な fallback。通常は `handle_login` (385) / `handle_game_line` (666) 入口の `load_finished` ガードで弾かれる。
- **`KEY_CONFIG` 既存**: cold start race で `active_game_id` ガードをすり抜けた経路。`abort_pending_match_with_error` で pending slot 片付け。race 想定では既存対局の Player WS は (a) 切断済 か (b) grace 中 のいずれかで、巻き込みは race 経路の defensive 副作用として許容。
- **`KEY_PENDING_ALARM_KIND` 既存**: `GraceExpired` / `TimeUp` / `AgreeTimeout` のどれが残っていても reject する。`AgreeTimeout` 残留を続行扱いにすると古い alarm 本体が新 match を巻き込む可能性があるため一律 reject。strict (`?` 伝搬) で読み、storage error 握り潰し (`load_pending_alarm_kind` の `.ok().flatten()`) は使わない。

## テスト

`reconnect::tests` に unit test 8 件を追加してガード判定を pin:

- `classify_start_match_guard_proceeds_when_no_state`
- `..._rejects_when_finished`
- `..._rejects_when_config_present`
- `..._rejects_when_grace_expired_pending` (Issue #626 主要シナリオ)
- `..._rejects_when_time_up_pending`
- `..._rejects_when_agree_timeout_pending`
- `..._finished_takes_precedence`
- `..._config_takes_precedence_over_alarm_kind`

miniflare smoke は public API だけで race 再現が困難 (private method の `enter_grace_window` を直接トリガーできない) なため、新規 fixture は追加せず既存 `agree_timeout.test.ts` の「両 AGREE で agree_timeout cancel」「未 AGREE で agree_timeout 発火」で本変更が挙動を破壊しないことを担保する (Codex review 合意)。

## Codex local review 履歴

| Round | 種別 | 結論 | 反映 |
|---|---|---|---|
| 1 | 設計 | REQUEST CHANGES | ガード位置を副作用前に集約 / `Ok(false)` 経路で `abort_pending_match_with_error` 呼出 / `load_pending_alarm_kind` ではなく strict read |
| 2 | 設計 | COMMENT | `AgreeTimeout` 残留も reject (`KEY_CONFIG` なし + AgreeTimeout 続行で古い alarm が新 match 巻き込む懸念) / unit test 名で AgreeTimeout reject 仕様を明示 |
| 3 | 設計 | APPROVE | 各 read を逐次 early return で書く方針確認 |
| 4 | 実装 | APPROVE | コメント細部 (handle_login の active_game_id ガード言及) のみ調整 |

## 検証

- \`cargo fmt && cargo clippy --tests\` warning 0
- \`cargo test -p rshogi-csa-server-workers --tests\` 全 266 tests pass (新規 8 + 既存 258)
- \`cargo test --tests\` workspace 全 pass、regression なし
- \`cargo check --target wasm32-unknown-unknown -p rshogi-csa-server-workers\` OK

## Test plan

- [ ] CI で \`cargo test -p rshogi-csa-server-workers --tests\` が pass する
- [ ] CI で workspace 全体の \`cargo clippy --tests\` warning 0 が維持される
- [ ] CI で wasm32 ターゲットビルドが pass する
- [ ] 既存 \`agree_timeout.test.ts\` (miniflare smoke) で「両 AGREE で agree_timeout cancel」「未 AGREE で agree_timeout 発火」の挙動が回帰していない

## 関連 commit

- 53658bd fix(csa-server-workers): start_match で AgreeTimeout が GraceExpired を上書きする race を防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)