### PR TITLE
fix(csa-server-workers): live-games-index orphan の cron 頻度 + retry + pagination (#629)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -4,14 +4,19 @@
 //!
 //! - [`run_games_index_backfill`]: `kifu-by-id/<id>.meta.json` を 1 ページ
 //!   (1000 件) 単位で list し、各 meta 本文から `games-index/<inv>-<id>.json`
-//!   key を再生成して上書き put する (派生 index 補完)。
-//! - [`run_live_orphan_sweep`]: `live-games-index/` を 1 ページ単位で list し、
-//!   対応する `kifu-by-id/<id>.meta.json` (= 終局済 primary 判定キー、設計 v3
-//!   §3) が存在する live entry を delete する (orphan 掃除)。
+//!   key を再生成して上書き put する (派生 index 補完)。1 cron = 1 page のみ。
+//! - [`run_live_orphan_sweep`]: `live-games-index/` を pagination loop で list
+//!   し、対応する `kifu-by-id/<id>.meta.json` (= 終局済 primary 判定キー、設計
+//!   v3 §3) が存在する live entry を delete する (orphan 掃除)。Issue #629 で
+//!   1 page → 複数 page (`SWEEP_DEADLINE_MS` 内) に拡張した。
 //!
-//! いずれも 1 page (1000 件) のみ処理し、cursor の持ち越しは行わない (= 次回
-//! cron で続行する eventual semantics)。本実装範囲では admin invoke endpoint
-//! や 1 万件超の bulk 並列化は Non-goals (設計 v3 §10)。
+//! `run_games_index_backfill` は 1 page (1000 件) のみ処理し、cursor の持ち越し
+//! は行わない (= 次回 cron で続行する eventual semantics)。
+//! `run_live_orphan_sweep` は cron 30s 制限の安全側 (`SWEEP_DEADLINE_MS`) 内で
+//! 複数 page を処理し、超過分は次回 cron に持ち越す (cursor は再開しない =
+//! 先頭から再走査するが、live key は新しい対局順なので大きな問題にならない)。
+//! 本実装範囲では admin invoke endpoint や 1 万件超の bulk 並列化は Non-goals
+//! (設計 v3 §10)。
 //!
 //! 進捗ログは logfmt 構造化 (`event=…_progress listed=… elapsed_ms=…`) で
 //! `console_log!` に流す。Cloudflare Workers の Logs / tail で grep 可能。
@@ -41,6 +46,19 @@ pub(crate) const META_SUFFIX: &str = ".meta.json";
 /// 経由で複数ページ一気に処理する案 (設計 v2 §5 (a)) を別 issue で検討する。
 pub(crate) const PAGE_SIZE: u32 = 1000;
 
+/// `run_live_orphan_sweep` の 1 cron 内 pagination 上限 (Issue #629)。
+///
+/// Cloudflare Workers の cron 起動は wall-clock 30s 制限を持つため、安全側
+/// マージン (5s) を引いた 25s で打ち切り、未処理 page は次回 cron に持ち越す。
+/// 各 object 処理は `head` + 条件付き `delete` (Class B) で平均 5-10ms 想定の
+/// ため、1 page (1000 件) で約 5-10s。25s なら 2-3 page を安全に処理できる。
+pub(crate) const SWEEP_DEADLINE_MS: u64 = 25_000;
+
+/// `run_live_orphan_sweep` の安全側 page 上限 (Issue #629)。`SWEEP_DEADLINE_MS`
+/// を超えなくても、cursor が永遠に truncated を返し続ける異常時に無限 loop を
+/// 避けるための break 条件。100 page = 100,000 件で十分な余白。
+pub(crate) const SWEEP_MAX_PAGES: u32 = 100;
+
 /// `run_games_index_backfill` の進捗統計。テスト容易性のため値型で返す。
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct BackfillStats {
@@ -59,6 +77,12 @@ pub struct SweepStats {
     pub listed: u64,
     /// `kifu-by-id/<id>.meta.json` が存在する (= 終局済) ため delete した件数。
     pub deleted: u64,
+    /// 走査した R2 list page 数 (Issue #629)。pagination loop 化に伴って導入。
+    /// 1 cron で複数 page を処理した状況をログから確認するための運用 metric。
+    pub pages: u32,
+    /// `SWEEP_DEADLINE_MS` 経過で打ち切った場合に `true`。`true` の cron が
+    /// 連続したら page size または cron 頻度の見直しが必要 (Issue #629)。
+    pub deadline_reached: bool,
 }
 
 /// `kifu-by-id/<id>.meta.json` の本文を deserialize する最小 view。
@@ -85,7 +109,7 @@ pub(crate) struct LiveEntryGameId {
 mod imp {
     use super::{
         BackfillStats, KIFU_BY_ID_PREFIX, LiveEntryGameId, META_SUFFIX, MetaForIndexKey, PAGE_SIZE,
-        SweepStats,
+        SWEEP_DEADLINE_MS, SWEEP_MAX_PAGES, SweepStats,
     };
     use worker::{Date, Env, Result, console_log};
 
@@ -227,6 +251,17 @@ mod imp {
     /// cron で finalize 経路の副作用で meta が put された後に消える、または
     /// 手動オペレーションで対処)。
     ///
+    /// Issue #629 で pagination loop 化した。R2 list の `truncated` が `true`
+    /// の間は cursor を辿って次 page を処理し、以下のいずれかの条件で打ち切る:
+    ///
+    /// 1. `truncated() == false` (全件処理完了)
+    /// 2. 経過時間 ≥ `SWEEP_DEADLINE_MS` (cron 30s 制限を圧迫しないための安全
+    ///    側打ち切り。object loop 内でも判定して 1 page 完走を待たない)
+    /// 3. `pages >= SWEEP_MAX_PAGES` (異常時の無限 loop ガード)
+    ///
+    /// 打ち切った残りは次回 cron で先頭から再走査する (cursor は永続化しない =
+    /// live key prefix の昇順 lexicographic に依存した再走査)。
+    ///
     /// 各失敗は logfmt で記録し `Err` を伝播しない。
     pub async fn run_live_orphan_sweep(env: &Env) -> Result<SweepStats> {
         let started_at_ms = Date::now().as_millis();
@@ -240,63 +275,121 @@ mod imp {
             }
         };
 
-        let page = match bucket.list().prefix(LIVE_KEY_PREFIX).limit(PAGE_SIZE).execute().await {
-            Ok(p) => p,
-            Err(e) => {
-                console_log!("[backfill] event=live_orphan_sweep_list_failed err={:?}", e);
-                return Ok(stats);
+        let mut cursor: Option<String> = None;
+        'outer: loop {
+            let mut builder = bucket.list().prefix(LIVE_KEY_PREFIX).limit(PAGE_SIZE);
+            if let Some(c) = cursor.as_ref() {
+                builder = builder.cursor(c);
             }
-        };
-
-        for obj in page.objects() {
-            let live_key = obj.key();
-            stats.listed = stats.listed.saturating_add(1);
-
-            // live entry 本文から game_id を取り出す。key 文字列パースより本文
-            // の `game_id` field を信頼するほうが、key 形式の将来変更に対して
-            // 頑健。
-            let game_id = match read_live_entry_game_id(&bucket, &live_key).await {
-                Some(id) => id,
-                None => continue,
-            };
-
-            // primary meta が存在 = 終局済 → live は orphan として delete 対象。
-            let meta_key = kifu_by_id_meta_key(&game_id);
-            let head_result = match bucket.head(&meta_key).await {
-                Ok(o) => o,
+            let page = match builder.execute().await {
+                Ok(p) => p,
                 Err(e) => {
                     console_log!(
-                        "[backfill] event=live_orphan_sweep_head_failed game_id={} meta_key={} err={:?}",
-                        game_id,
-                        meta_key,
+                        "[backfill] event=live_orphan_sweep_list_failed pages={} err={:?}",
+                        stats.pages,
                         e,
                     );
-                    continue;
+                    break;
                 }
             };
-            if head_result.is_none() {
-                // meta が無い = まだ進行中 (or 終局時 meta put 失敗)。前者は
-                // 正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的な保守)。
-                continue;
+            stats.pages = stats.pages.saturating_add(1);
+
+            for obj in page.objects() {
+                let live_key = obj.key();
+                stats.listed = stats.listed.saturating_add(1);
+
+                // live entry 本文から game_id を取り出す。key 文字列パースより
+                // 本文の `game_id` field を信頼するほうが、key 形式の将来変更
+                // に対して頑健。
+                let game_id = match read_live_entry_game_id(&bucket, &live_key).await {
+                    Some(id) => id,
+                    None => {
+                        if Date::now().as_millis().saturating_sub(started_at_ms)
+                            >= SWEEP_DEADLINE_MS
+                        {
+                            stats.deadline_reached = true;
+                            break 'outer;
+                        }
+                        continue;
+                    }
+                };
+
+                // primary meta が存在 = 終局済 → live は orphan として delete 対象。
+                let meta_key = kifu_by_id_meta_key(&game_id);
+                let head_result = match bucket.head(&meta_key).await {
+                    Ok(o) => o,
+                    Err(e) => {
+                        console_log!(
+                            "[backfill] event=live_orphan_sweep_head_failed game_id={} meta_key={} err={:?}",
+                            game_id,
+                            meta_key,
+                            e,
+                        );
+                        if Date::now().as_millis().saturating_sub(started_at_ms)
+                            >= SWEEP_DEADLINE_MS
+                        {
+                            stats.deadline_reached = true;
+                            break 'outer;
+                        }
+                        continue;
+                    }
+                };
+                if head_result.is_none() {
+                    // meta が無い = まだ進行中 (or 終局時 meta put 失敗)。前者は
+                    // 正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的な保守)。
+                    if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                        stats.deadline_reached = true;
+                        break 'outer;
+                    }
+                    continue;
+                }
+
+                if let Err(e) = bucket.delete(&live_key).await {
+                    console_log!(
+                        "[backfill] event=live_orphan_sweep_delete_failed game_id={} live_key={} err={:?}",
+                        game_id,
+                        live_key,
+                        e,
+                    );
+                    if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                        stats.deadline_reached = true;
+                        break 'outer;
+                    }
+                    continue;
+                }
+                stats.deleted = stats.deleted.saturating_add(1);
+
+                if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                    stats.deadline_reached = true;
+                    break 'outer;
+                }
             }
 
-            if let Err(e) = bucket.delete(&live_key).await {
-                console_log!(
-                    "[backfill] event=live_orphan_sweep_delete_failed game_id={} live_key={} err={:?}",
-                    game_id,
-                    live_key,
-                    e,
-                );
-                continue;
+            if !page.truncated() {
+                break;
             }
-            stats.deleted = stats.deleted.saturating_add(1);
+            if stats.pages >= SWEEP_MAX_PAGES {
+                console_log!(
+                    "[backfill] event=live_orphan_sweep_max_pages_reached pages={}",
+                    stats.pages,
+                );
+                break;
+            }
+            cursor = page.cursor();
+            if cursor.is_none() {
+                // truncated == true なのに cursor が None の場合は安全側に break
+                // (R2 仕様上は通常起こらない)。
+                break;
+            }
         }
 
         let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
         console_log!(
-            "[backfill] event=live_orphan_sweep_progress listed={} deleted={} elapsed_ms={}",
+            "[backfill] event=live_orphan_sweep_progress listed={} deleted={} pages={} deadline_reached={} elapsed_ms={}",
             stats.listed,
             stats.deleted,
+            stats.pages,
+            stats.deadline_reached,
             elapsed_ms,
         );
         Ok(stats)
@@ -420,9 +513,31 @@ mod tests {
             stats,
             SweepStats {
                 listed: 0,
-                deleted: 0
+                deleted: 0,
+                pages: 0,
+                deadline_reached: false,
             }
         );
+    }
+
+    #[test]
+    fn sweep_deadline_is_safely_below_workers_30s_limit() {
+        // Cloudflare Workers cron の wall-clock 制限は 30s。`SWEEP_DEADLINE_MS`
+        // は安全側マージン (≥ 5s) を確保していないと、deadline 検知後の
+        // pagination break + 後続ログ出力中に 30s 制限を踏む恐れがある。
+        const _: () = assert!(
+            SWEEP_DEADLINE_MS + 5_000 <= 30_000,
+            "SWEEP_DEADLINE_MS must leave at least a 5s margin under the 30s cron limit",
+        );
+    }
+
+    #[test]
+    fn sweep_max_pages_caps_runaway_pagination() {
+        // `SWEEP_DEADLINE_MS` を超えなくても、cursor が壊れて truncated を
+        // 返し続けるような異常時に無限 loop を避けるための gate。1 page =
+        // 1000 件で 100 page = 100,000 件は live-games-index の現実的な
+        // 上限を大きく超えている。
+        const _: () = assert!(SWEEP_MAX_PAGES >= 1, "SWEEP_MAX_PAGES must allow at least 1 page");
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -34,8 +34,8 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use worker::{
-    Date, DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State, WebSocket,
-    WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
+    Date, Delay, DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State,
+    WebSocket, WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
 };
 
 use rshogi_core::types::EnteringKingRule;
@@ -105,6 +105,16 @@ const MAX_SPECTATORS_PER_ROOM: usize = 50;
 /// Alarm 発火時刻に上乗せする安全側マージン（ミリ秒）。Cloudflare Alarm API
 /// のジッタと `Date::now()` ↔ `handle_line` の now_ms 伝搬遅延を吸収する。
 const ALARM_SAFETY_MS: u64 = 200;
+
+/// `try_delete_live_games_index` の delete 試行上限 (Issue #629)。R2 delete は
+/// idempotent なので transient error は積極的に retry する。
+const LIVE_INDEX_DELETE_MAX_ATTEMPTS: u32 = 3;
+
+/// `try_delete_live_games_index` の attempt 間 backoff (ミリ秒、Issue #629)。
+/// 配列長 = `LIVE_INDEX_DELETE_MAX_ATTEMPTS - 1`。最終 attempt の後は backoff
+/// せず giveup ログに抜けるため、最後の値は使われない。`100, 200` で合計 wall
+/// 300ms 以内に収める (Workers cron の 30s 制限を圧迫しない)。
+const LIVE_INDEX_DELETE_BACKOFF_MS: [u64; 2] = [100, 200];
 
 /// Durable Object 初期化 SQL。
 ///
@@ -1907,9 +1917,17 @@ impl GameRoom {
     /// `live-games-index/<inv>-<id>.json` を best-effort で delete する。
     ///
     /// 終局確定 (`KEY_FINISHED` put 成功) 直後に呼び、live 一覧から進行中
-    /// 表示を消す。失敗 (R2 一時障害 / key 生成失敗) は `console_log!` で
-    /// 吸収して `Result` を返さない。残った orphan は Issue #551 の sweep
-    /// ジョブで掃除する契約。
+    /// 表示を消す。R2 delete は idempotent なので、transient error には最大
+    /// [`LIVE_INDEX_DELETE_MAX_ATTEMPTS`] 回まで retry し ([Issue #629])、各
+    /// attempt 間に [`LIVE_INDEX_DELETE_BACKOFF_MS`] の wall-clock 待機を挟む。
+    ///
+    /// 全試行が失敗した場合は `live_games_index_delete_giveup` イベントを記録
+    /// して諦める。残った orphan は Issue #551 の sweep ジョブ
+    /// (`run_live_orphan_sweep`) が 15 分以内に掃除する契約 (Issue #629 で 1
+    /// 時間 → 15 分に短縮)。
+    ///
+    /// key 生成失敗 / bucket binding 解決失敗は retry 不能なので 1 回で諦める
+    /// (`live_games_index_delete_skip` を出して return)。
     async fn try_delete_live_games_index(&self, cfg: &PersistedConfig, started_at_ms: u64) {
         let key = match live_games_index_key(started_at_ms, &cfg.game_id) {
             Ok(k) => k,
@@ -1935,14 +1953,30 @@ impl GameRoom {
             }
         };
 
-        if let Err(e) = bucket.delete(&key).await {
-            console_log!(
-                "[GameRoom] event=live_games_index_delete_failed game_id={} key={} err={:?}",
-                cfg.game_id,
-                key,
-                e,
-            );
+        for attempt in 0..LIVE_INDEX_DELETE_MAX_ATTEMPTS {
+            match bucket.delete(&key).await {
+                Ok(_) => return,
+                Err(e) => {
+                    console_log!(
+                        "[GameRoom] event=live_games_index_delete_failed attempt={} game_id={} key={} err={:?}",
+                        attempt + 1,
+                        cfg.game_id,
+                        key,
+                        e,
+                    );
+                    // 最終 attempt の後は backoff せず giveup ログへ抜ける。
+                    if let Some(&backoff_ms) = LIVE_INDEX_DELETE_BACKOFF_MS.get(attempt as usize) {
+                        Delay::from(std::time::Duration::from_millis(backoff_ms)).await;
+                    }
+                }
+            }
         }
+        console_log!(
+            "[GameRoom] event=live_games_index_delete_giveup game_id={} key={} attempts={}",
+            cfg.game_id,
+            key,
+            LIVE_INDEX_DELETE_MAX_ATTEMPTS,
+        );
     }
 
     /// `moves` テーブルを ply 昇順で読み出す。

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -93,11 +93,34 @@ pub async fn fetch(
     router::handle_fetch(req, env).await
 }
 
+/// Backfill + sweep を両方走らせる cron 文字列 (毎時 0 分)。
+///
+/// `wrangler.{production,staging,toml.example}.toml` の `[triggers] crons` 配列
+/// 第 1 要素と一致させる。`scheduled` ハンドラは `event.cron()` の文字列マッチで
+/// backfill 実行可否を分岐するため、wrangler 側の表記を変える場合は本定数も
+/// 同期更新する (`tests/wrangler_environment_toml_consistency.rs` /
+/// `wrangler_template_consistency.rs` で gate)。
+pub const BACKFILL_CRON: &str = "0 * * * *";
+
+/// Sweep のみ走らせる cron 文字列 (15 / 30 / 45 分)。
+///
+/// Issue #629 で導入した orphan sweep 高頻度化用。`try_delete_live_games_index`
+/// が R2 transient で失敗した場合の復旧遅延を 1 時間 → 15 分に短縮する目的で、
+/// 本 cron では backfill (Class A put 増) を走らせず sweep のみ実行する。
+pub const SWEEP_ONLY_CRON: &str = "15,30,45 * * * *";
+
 /// Workers ランタイムの scheduled イベント (cron trigger)。
 ///
-/// `wrangler.toml` の `[triggers] crons = ["0 */1 * * *"]` (毎時 0 分) で起動し、
-/// 順次 `run_games_index_backfill` → `run_live_orphan_sweep` を呼ぶ
-/// (Issue #551 設計 v3 §11)。
+/// `wrangler.toml` の `[triggers] crons` で 2 つの cron を登録している
+/// (Issue #551 / Issue #629):
+///
+/// - [`BACKFILL_CRON`] (`0 * * * *`): `run_games_index_backfill` →
+///   `run_live_orphan_sweep` を順次実行する (= 既存挙動)。
+/// - [`SWEEP_ONLY_CRON`] (`15,30,45 * * * *`): `run_live_orphan_sweep` のみ。
+///   delete best-effort 失敗時の復旧遅延を 15 分以内に詰めるための高頻度経路。
+///
+/// `event.cron()` 文字列で分岐し、未知の cron 文字列に対しては安全側に倒して
+/// 既存挙動 (backfill + sweep) と等価動作する (= 設定変更時の暫定挙動を保証)。
 ///
 /// 各ジョブは内部的に best-effort で失敗を握り潰し `Result::Ok` で返すため、
 /// scheduled handler 側ではさらに伝播禁止 (cron の継続可用性を最優先する) で
@@ -111,12 +134,18 @@ pub async fn scheduled(
     _ctx: worker::ScheduleContext,
 ) {
     let cron = event.cron();
-    if let Err(e) = backfill::run_games_index_backfill(&env).await {
-        worker::console_log!(
-            "[scheduled] event=games_index_backfill_failed cron={} err={:?}",
-            cron,
-            e,
-        );
+    // SWEEP_ONLY_CRON では backfill を skip。それ以外は既存挙動 (backfill +
+    // sweep) を保つ。未知 cron 文字列は安全側 = 全部走らせる。
+    let run_backfill = cron != SWEEP_ONLY_CRON;
+
+    if run_backfill {
+        if let Err(e) = backfill::run_games_index_backfill(&env).await {
+            worker::console_log!(
+                "[scheduled] event=games_index_backfill_failed cron={} err={:?}",
+                cron,
+                e,
+            );
+        }
     }
     if let Err(e) = backfill::run_live_orphan_sweep(&env).await {
         worker::console_log!(
@@ -124,5 +153,27 @@ pub async fn scheduled(
             cron,
             e,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cron_constants_are_distinct() {
+        // 同一文字列に揃えると `event.cron()` 分岐が崩れる (sweep-only cron で
+        // backfill が走る、または backfill cron で sweep がスキップされる)。
+        assert_ne!(BACKFILL_CRON, SWEEP_ONLY_CRON);
+    }
+
+    #[test]
+    fn cron_constants_have_5_fields() {
+        // Cloudflare Workers cron expression は 5 field (minute hour dom month dow)。
+        // 6 field (秒つき) や 7 field (年つき) は受け付けないため、定数側で固定。
+        for cron in [BACKFILL_CRON, SWEEP_ONLY_CRON] {
+            let fields: Vec<&str> = cron.split_whitespace().collect();
+            assert_eq!(fields.len(), 5, "cron expression must have 5 fields, got {cron:?}");
+        }
     }
 }

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -205,14 +205,45 @@ fn assert_no_runtime_injected_keys(env: &EnvironmentBindings) {
 /// Issue #551 で追加した `[triggers] crons` が各 deploy 環境に宣言されていることを
 /// 固定する。`[event(scheduled)]` ハンドラは production / staging 両方で稼働させる
 /// 契約 (片方だけ宣言だと backfill / orphan sweep が動かず orphan が滞留する)。
+///
+/// Issue #629 で cron を 1 → 2 に増やした (sweep のみ 15 分間隔)。両 cron が
+/// 必ず宣言されていること、かつ `lib.rs::BACKFILL_CRON` /
+/// `lib.rs::SWEEP_ONLY_CRON` 定数と文字列が一致していることを assert する
+/// (定数を変更したのに wrangler 側を更新し忘れる事故を防ぐ)。
 fn assert_declares_backfill_cron_trigger(env: &EnvironmentBindings) {
     assert!(
-        !env.crons.is_empty(),
-        "{file} ({label}) must declare [triggers] crons = [...] for the backfill scheduled handler; \
-         got: {crons:?}",
+        env.crons.contains(&rshogi_csa_server_workers::BACKFILL_CRON.to_owned()),
+        "{file} ({label}) [triggers] crons must contain BACKFILL_CRON ({backfill:?}); got: {crons:?}",
         file = env.file_name,
         label = env.label,
+        backfill = rshogi_csa_server_workers::BACKFILL_CRON,
         crons = env.crons,
+    );
+    assert!(
+        env.crons.contains(&rshogi_csa_server_workers::SWEEP_ONLY_CRON.to_owned()),
+        "{file} ({label}) [triggers] crons must contain SWEEP_ONLY_CRON ({sweep:?}) for orphan sweep \
+         high-frequency path (Issue #629); got: {crons:?}",
+        file = env.file_name,
+        label = env.label,
+        sweep = rshogi_csa_server_workers::SWEEP_ONLY_CRON,
+        crons = env.crons,
+    );
+}
+
+/// 両環境の `[triggers] crons` が同じ集合 (順序含む) を宣言していることを assert
+/// する。production / staging で挙動を揃える契約 (Issue #629)。
+fn assert_crons_match(lhs: &EnvironmentBindings, rhs: &EnvironmentBindings) {
+    assert_eq!(
+        lhs.crons,
+        rhs.crons,
+        "{lhs_file} ({lhs_label}) and {rhs_file} ({rhs_label}) must declare the same \
+         [triggers] crons array; lhs={lhs_crons:?} rhs={rhs_crons:?}",
+        lhs_file = lhs.file_name,
+        lhs_label = lhs.label,
+        rhs_file = rhs.file_name,
+        rhs_label = rhs.label,
+        lhs_crons = lhs.crons,
+        rhs_crons = rhs.crons,
     );
 }
 
@@ -395,4 +426,9 @@ fn wrangler_environment_compatibility_dates_match() {
 #[test]
 fn wrangler_environment_clock_preset_names_match() {
     assert_clock_preset_names_match(&PRODUCTION, &STAGING);
+}
+
+#[test]
+fn wrangler_environment_crons_match() {
+    assert_crons_match(&PRODUCTION, &STAGING);
 }

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -165,11 +165,24 @@ fn wrangler_template_vars_keys_match_config_keys() {
 /// 固定する。`[event(scheduled)]` ハンドラと cron trigger は同 PR で導入したので、
 /// 片方だけが残ったまま運用者が `cp wrangler.toml.example wrangler.toml` した場合
 /// に handler が永久 dormant にならないよう、template 側で必須化する。
+///
+/// Issue #629 で sweep のみ高頻度 (15 分間隔) cron を追加したため、両 cron が
+/// 必ず宣言されていること、かつ `lib.rs::BACKFILL_CRON` /
+/// `lib.rs::SWEEP_ONLY_CRON` 定数と文字列が一致していることを assert する。
 #[test]
 fn wrangler_template_declares_backfill_cron_trigger() {
     assert!(
-        !TEMPLATE.crons.is_empty(),
-        "wrangler.toml.example must declare [triggers] crons = [...] for the backfill scheduled handler",
+        TEMPLATE.crons.contains(&rshogi_csa_server_workers::BACKFILL_CRON.to_owned()),
+        "wrangler.toml.example [triggers] crons must contain BACKFILL_CRON ({backfill:?}); got: {crons:?}",
+        backfill = rshogi_csa_server_workers::BACKFILL_CRON,
+        crons = TEMPLATE.crons,
+    );
+    assert!(
+        TEMPLATE.crons.contains(&rshogi_csa_server_workers::SWEEP_ONLY_CRON.to_owned()),
+        "wrangler.toml.example [triggers] crons must contain SWEEP_ONLY_CRON ({sweep:?}) for orphan sweep \
+         high-frequency path (Issue #629); got: {crons:?}",
+        sweep = rshogi_csa_server_workers::SWEEP_ONLY_CRON,
+        crons = TEMPLATE.crons,
     );
 }
 

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -74,12 +74,24 @@ binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-prod"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
-# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
-# のみ処理する eventual semantics。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
+# (Issue #629 で 1 → 2 に分離)。
+#
+# - `0 * * * *` (毎時 0 分):
+#   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+#   `live-games-index/` の orphan を掃除する (Issue #551)。backfill は 1 run =
+#   1 page (1000 件) のみ。
+# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
+#   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
+#   sweep のみ高頻度化する (Issue #629)。sweep は 1 cron 内で pagination
+#   loop し、cron 30s 制限内で複数 page を処理する。
+#
+# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
+# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
+# 定数も同期更新すること (wrangler test が違反を検知する)。
 [triggers]
-crons = ["0 */1 * * *"]
+crons = ["0 * * * *", "15,30,45 * * * *"]
 
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、本番 client URL に応じて運用者が更新する。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -71,12 +71,24 @@ binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-staging"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
-# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
-# のみ処理する eventual semantics。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
+# (Issue #629 で 1 → 2 に分離)。
+#
+# - `0 * * * *` (毎時 0 分):
+#   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+#   `live-games-index/` の orphan を掃除する (Issue #551)。backfill は 1 run =
+#   1 page (1000 件) のみ。
+# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
+#   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
+#   sweep のみ高頻度化する (Issue #629)。sweep は 1 cron 内で pagination
+#   loop し、cron 30s 制限内で複数 page を処理する。
+#
+# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
+# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
+# 定数も同期更新すること (wrangler test が違反を検知する)。
 [triggers]
-crons = ["0 */1 * * *"]
+crons = ["0 * * * *", "15,30,45 * * * *"]
 
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、staging client の Origin に応じて運用者が更新する。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -64,12 +64,24 @@ bucket_name = "local-floodgate-history-dev"
 preview_bucket_name = "local-floodgate-history-dev"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を毎時 0 分に起動し、
-# `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-# `live-games-index/` の orphan を掃除する (Issue #551)。1 run = 1 page (1000 件)
-# のみ処理する eventual semantics。bulk 1 万件超は admin invoke 経路を別途検討。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
+# (Issue #629 で 1 → 2 に分離)。
+#
+# - `0 * * * *` (毎時 0 分):
+#   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
+#   `live-games-index/` の orphan を掃除する (Issue #551)。backfill は 1 run =
+#   1 page (1000 件) のみ。bulk 1 万件超は admin invoke 経路を別途検討。
+# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
+#   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
+#   sweep のみ高頻度化する (Issue #629)。sweep は 1 cron 内で pagination
+#   loop し、cron 30s 制限内で複数 page を処理する。
+#
+# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
+# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
+# 定数も同期更新すること (wrangler test が違反を検知する)。
 [triggers]
-crons = ["0 */1 * * *"]
+crons = ["0 * * * *", "15,30,45 * * * *"]
 
 # --- 変数 ---
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。ブラウザ経由


### PR DESCRIPTION
## Summary

`try_delete_live_games_index` が R2 transient error で失敗したときの orphan
復旧遅延を **最大 1 時間 → 15 分** に短縮する。Issue #629 の P1 対処。

- **Cron 分離**: `BACKFILL_CRON` (`0 * * * *`) と `SWEEP_ONLY_CRON`
  (`15,30,45 * * * *`) に分離。15 分間隔 cron では backfill (Class A put
  1000 件/run) を skip し、orphan sweep のみを走らせる。
- **Delete retry**: `try_delete_live_games_index` に最大 3 回 retry +
  100ms / 200ms backoff を追加。R2 delete は idempotent。最終失敗時は
  `live_games_index_delete_giveup` event を記録。
- **Sweep pagination**: `run_live_orphan_sweep` を 1 page → cursor 駆動の
  pagination loop に拡張。`SWEEP_DEADLINE_MS = 25_000` / `SWEEP_MAX_PAGES =
  100` で 30s cron 制限の安全側まで複数 page を処理し、超過分は次回 cron
  に持ち越す。object loop 内でも deadline をチェックして 1 page 完走を
  待たない。`SweepStats` に `pages` / `deadline_reached` を追加。

## 設計レビュー (Codex local)

設計案は v1 → v2 で REQUEST_CHANGES → APPROVE。主な指摘:

1. **R2 ops cost**: 単純に cron 4 倍化すると backfill の Class A put も
   4 倍になる → cron を 2 つに分け、sweep のみ高頻度化。backfill 増加なし。
2. **30s 制限**: page 間だけの deadline チェックでは 1 page 内 1000 件で
   既に 30s 超過しうる → object loop 内でも `Date::now()` 比較で break。
3. **giveup ログ二段化**: attempt 単位の `failed` と最終 `giveup` を別
   event 名にすると運用監視で「永続失敗」だけ集計できる。

`worker::Delay::from(Duration)` は worker 0.8.1 の `setTimeout` ラッパで
CPU 時間を消費しない (= wall-clock のみ)。最大 wall 300ms 以内。

## 影響範囲

- `crates/rshogi-csa-server-workers/src/lib.rs`: cron 定数 + scheduled
  handler 分岐
- `crates/rshogi-csa-server-workers/src/game_room.rs`: retry loop +
  giveup イベント
- `crates/rshogi-csa-server-workers/src/backfill.rs`: pagination loop +
  SweepStats 拡張
- wrangler.{production,staging,toml.example}.toml: crons 配列を 2 要素化
- wrangler test 2 ファイル: 両 cron 文字列の必須化 + 両環境間一致 assert

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --tests -p rshogi-csa-server-workers` (warning 0)
- [x] `cargo test -p rshogi-csa-server-workers` (251 + 1 + 13 + 17 + 5 pass)
- [x] `cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown --release` 成功
- [x] Codex local review (branch scope) で問題指摘なし
- [ ] CI green
- [ ] Staging deploy で `live_orphan_sweep_progress` ログに `pages` /
      `deadline_reached` が出ることを目視確認 (推奨)
- [ ] Staging で対局終局 → 15 分以内に `/api/v1/games/live` から消える
      ことを E2E で確認 (推奨、retry 経路は通常運用では発火しないので
      sweep 側の高頻度動作を見るだけでよい)

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)