### PR TITLE
feat(csa-server-workers): WS frame / spectator queue サイズ上限 (#627)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -11,7 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// WS 受信 1 メッセージあたりの最大バイト数 (Issue #627)。
+/// WS 受信 1 メッセージあたりの最大バイト数 (https://github.com/SH11235/rshogi/issues/627)。
 ///
 /// CSA LOGIN / CHAT / move 行 / lobby command (`LOGIN_LOBBY` /
 /// `CHALLENGE_LOBBY` / `LOGOUT_LOBBY` 等) はいずれも数百バイト未満で収まる
@@ -25,14 +25,14 @@ use serde::{Deserialize, Serialize};
 /// で改行を削る **前** の元バイト数に対して行う。
 pub const MAX_WS_LINE_BYTES: usize = 4096;
 
-/// Spectator pending_queue に積める行数上限 (Issue #627)。
+/// Spectator pending_queue に積める行数上限 (https://github.com/SH11235/rshogi/issues/627)。
 ///
 /// snapshot 送信中に到着した broadcast 行を per-WS キューに積む経路で、
 /// チャット flood 等で無制限に成長する DoS 経路を遮断する。1 局 ≤ 512 手 +
 /// CHAT / START / 終局通知の余裕として 1024 を採る。
 pub const MAX_SPECTATOR_QUEUE_ITEMS: usize = 1024;
 
-/// Spectator pending_queue の累計バイト数上限 (Issue #627)。
+/// Spectator pending_queue の累計バイト数上限 (https://github.com/SH11235/rshogi/issues/627)。
 ///
 /// 行数上限とは独立に、長文 CHAT が積み上がるケースに備えて bytes 上限も
 /// 課す。`pending_queue` の各行 (`String`) の `len()` の総和で判定する。
@@ -331,7 +331,7 @@ mod tests {
         assert_ne!(player, spec);
     }
 
-    /// Issue #627: 受信メッセージサイズ上限の値が CSA プロトコル正常系に対し
+    /// https://github.com/SH11235/rshogi/issues/627: 受信メッセージサイズ上限の値が CSA プロトコル正常系に対し
     /// 十分余裕を持っていること、かつ Cloudflare WS の最大 32 MiB より
     /// 大幅に小さいことの sanity check。値変更時にビルド時 regression を検出する。
     /// `const { assert!(..) }` を使うことで run-time コストゼロで固定する。
@@ -346,7 +346,7 @@ mod tests {
         };
     }
 
-    /// Issue #627: spectator pending_queue 上限値が 1 局の通常運用に対し
+    /// https://github.com/SH11235/rshogi/issues/627: spectator pending_queue 上限値が 1 局の通常運用に対し
     /// 十分余裕を持っていることの sanity check (ビルド時固定)。
     #[test]
     fn spectator_queue_limits_are_sane() {

--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -11,6 +11,33 @@
 
 use serde::{Deserialize, Serialize};
 
+/// WS 受信 1 メッセージあたりの最大バイト数 (Issue #627)。
+///
+/// CSA LOGIN / CHAT / move 行 / lobby command (`LOGIN_LOBBY` /
+/// `CHALLENGE_LOBBY` / `LOGOUT_LOBBY` 等) はいずれも数百バイト未満で収まる
+/// 設計だが、Cloudflare WebSocket は最大 32 MiB のメッセージを許容するため、
+/// アプリ層で明示的な上限を入れないと巨大ペイロードが parser / allocation に
+/// 流れて CPU と memory を浪費する。
+///
+/// 4096 バイトはプロトコル正常系に対し 1 桁以上の余裕がある安全側の値。
+/// 受信側ハンドラで `raw.len() > MAX_WS_LINE_BYTES` を満たした WS は
+/// `1009 Message Too Big` で即時 close する契約。判定は `trim_end_matches`
+/// で改行を削る **前** の元バイト数に対して行う。
+pub const MAX_WS_LINE_BYTES: usize = 4096;
+
+/// Spectator pending_queue に積める行数上限 (Issue #627)。
+///
+/// snapshot 送信中に到着した broadcast 行を per-WS キューに積む経路で、
+/// チャット flood 等で無制限に成長する DoS 経路を遮断する。1 局 ≤ 512 手 +
+/// CHAT / START / 終局通知の余裕として 1024 を採る。
+pub const MAX_SPECTATOR_QUEUE_ITEMS: usize = 1024;
+
+/// Spectator pending_queue の累計バイト数上限 (Issue #627)。
+///
+/// 行数上限とは独立に、長文 CHAT が積み上がるケースに備えて bytes 上限も
+/// 課す。`pending_queue` の各行 (`String`) の `len()` の総和で判定する。
+pub const MAX_SPECTATOR_QUEUE_BYTES: usize = 64 * 1024;
+
 /// 先手・後手の別。`rshogi_csa_server::types::Color` が `serde::Serialize` を
 /// 実装していないため、attachment 用には独自のタグ付き列挙を使う。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -302,5 +329,35 @@ mod tests {
         let player = WsAttachment::player(Role::Black, "alice", "room-1");
         let spec = WsAttachment::spectator("room-1");
         assert_ne!(player, spec);
+    }
+
+    /// Issue #627: 受信メッセージサイズ上限の値が CSA プロトコル正常系に対し
+    /// 十分余裕を持っていること、かつ Cloudflare WS の最大 32 MiB より
+    /// 大幅に小さいことの sanity check。値変更時にビルド時 regression を検出する。
+    /// `const { assert!(..) }` を使うことで run-time コストゼロで固定する。
+    #[test]
+    fn ws_message_size_limit_is_sane() {
+        const _: () = {
+            // 通常の CSA 行 (LOGIN / move / CHAT 等) は数百バイト未満で収まる。
+            // 1024 バイトを下回ると正常系を弾く恐れがあるため最低限の floor を設ける。
+            assert!(MAX_WS_LINE_BYTES >= 1024);
+            // 1 MiB を超えると DoS 防御として機能しないため天井も設ける。
+            assert!(MAX_WS_LINE_BYTES <= 1024 * 1024);
+        };
+    }
+
+    /// Issue #627: spectator pending_queue 上限値が 1 局の通常運用に対し
+    /// 十分余裕を持っていることの sanity check (ビルド時固定)。
+    #[test]
+    fn spectator_queue_limits_are_sane() {
+        const _: () = {
+            // 1 局の指し手は最大 512 ply 程度。CHAT / START / 終局通知の余裕を
+            // 含めても 512 を下回ると正常系を弾く恐れがある。
+            assert!(MAX_SPECTATOR_QUEUE_ITEMS >= 512);
+            // 1 行 ≤ MAX_WS_LINE_BYTES * (件数上限) の理論上限よりは小さくて良いが、
+            // bytes 上限が件数上限 * 32 byte を下回ると、通常対局でも先に bytes 側で
+            // 詰まる。
+            assert!(MAX_SPECTATOR_QUEUE_BYTES >= MAX_SPECTATOR_QUEUE_ITEMS * 32);
+        };
     }
 }

--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -1,6 +1,6 @@
 //! viewer 配信用 R2 prefix の補完 / orphan 掃除を担う cron ジョブ群。
 //!
-//! Issue #551 設計 v3 に従い、以下 2 つの best-effort ジョブを実装する:
+//! https://github.com/SH11235/rshogi/issues/551 設計 v3 に従い、以下 2 つの best-effort ジョブを実装する:
 //!
 //! - [`run_games_index_backfill`]: `kifu-by-id/<id>.meta.json` を 1 ページ
 //!   (1000 件) 単位で list し、各 meta 本文から `games-index/<inv>-<id>.json`

--- a/crates/rshogi-csa-server-workers/src/client_kind.rs
+++ b/crates/rshogi-csa-server-workers/src/client_kind.rs
@@ -1,6 +1,6 @@
 //! `X-Client` ヘッダ値を運用ログ向けに正規化する純粋ロジック。
 //!
-//! Issue #564 設計 v4 §3 に対応。viewer 配信 API のレスポンスログに
+//! https://github.com/SH11235/rshogi/issues/564 設計 v4 §3 に対応。viewer 配信 API のレスポンスログに
 //! `client_kind=<kind>` として埋め込むため、任意文字列が logfmt を破壊しない
 //! よう kebab-case ASCII (`[a-z0-9-]`) のみを許可するホワイトリスト方式で
 //! 正規化する。

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -45,7 +45,7 @@ impl ConfigKeys {
     pub const LOBBY_QUEUE_SIZE_LIMIT: &'static str = "LOBBY_QUEUE_SIZE_LIMIT";
     /// 私的対局 (`CHALLENGE_LOBBY`) で発行された token の TTL (秒)。期限超過した
     /// 未消費 token は LobbyDO の Alarm ハンドラで `purge_expired` され、保留中の
-    /// WS 接続がいれば切断される。未設定時は 3600 秒 (1 時間)。Issue #582 の
+    /// WS 接続がいれば切断される。未設定時は 3600 秒 (1 時間)。https://github.com/SH11235/rshogi/issues/582 の
     /// Workers 経路で参照する。
     pub const CHALLENGE_TTL_SEC: &'static str = "CHALLENGE_TTL_SEC";
     /// R2 バケットバインディング名（CSA V2 棋譜保存）。
@@ -97,7 +97,7 @@ impl ConfigKeys {
     pub const RECONNECT_GRACE_SECONDS: &'static str = "RECONNECT_GRACE_SECONDS";
     /// LOGIN OK 後の AGREE 待ち TTL (秒)。`start_match` で Game_Summary を送信した
     /// 直後に予約し、両者 AGREE 受領 (`HandleOutcome::GameStarted`) で cancel する。
-    /// 発火時は対局が成立する前に部屋を解放する (Issue #600)。
+    /// 発火時は対局が成立する前に部屋を解放する (https://github.com/SH11235/rshogi/issues/600)。
     /// `0` または未設定は安全側既定 [`DEFAULT_AGREE_TIMEOUT_SEC`] にフォールバック
     /// する (TTL 0 = 無効化は memory / room 枠の長期占有リスクを再現するため許容しない)。
     pub const AGREE_TIMEOUT_SECONDS: &'static str = "AGREE_TIMEOUT_SECONDS";
@@ -119,7 +119,7 @@ impl ConfigKeys {
     /// 注入される。ここでの `<sha>` は `github.sha` ではなく
     /// `.github/workflows/deploy-workers.yml` の `push.paths` にマッチする main 上の
     /// **最新 commit sha** (`git log -1 --format=%H -- <paths>`)。docs-only commit が
-    /// main HEAD にあっても本値は変わらないため、Issue #639 の drift detection
+    /// main HEAD にあっても本値は変わらないため、https://github.com/SH11235/rshogi/issues/639 の drift detection
     /// workflow で「deploy 対象コードの commit ↔ Cloudflare 上の current version」を
     /// 突合する基準として使える。
     ///
@@ -218,7 +218,7 @@ pub(crate) const DEFAULT_CHALLENGE_TTL_SEC: u64 = 3600;
 
 /// `AGREE_TIMEOUT_SECONDS` 既定値 (60 秒)。TCP frontend は 5 分既定だが、Workers
 /// DO は 1 部屋 = 1 instance で memory / room 枠を専有するため、より短めの既定で
-/// stuck DO を素早く解放する設計を採る (Issue #600)。
+/// stuck DO を素早く解放する設計を採る (https://github.com/SH11235/rshogi/issues/600)。
 pub(crate) const DEFAULT_AGREE_TIMEOUT_SEC: u64 = 60;
 
 /// `CHALLENGE_TTL_SEC` 文字列を `Duration` へ解決する。`None` / 空文字 /

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -260,7 +260,10 @@ impl DurableObject for GameRoom {
             WebSocketIncomingMessage::String(s) => s,
             WebSocketIncomingMessage::Binary(_) => return Ok(()),
         };
-        // Issue #627: parser / allocation に流す前に元バイト数で上限判定する。
+        // Issue #627: アプリ層の parser / 追加 allocation (`to_owned` 等) に
+        // 流す前に、受信した `String` の元バイト数で上限判定する。ランタイム側
+        // の `String` 取り込みは既に済んでいるが、parser / trim 後の解釈処理や
+        // attachment 経路 (spectator queue 等) への流入は弾ける。
         // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず raw の
         // 元の長さを使う。超過時は `1009 Message Too Big` で即 close し、
         // 構造化 console_log を残す (rate limit は #622 / 別 issue scope)。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -176,7 +176,7 @@ pub struct GameRoom {
     core: RefCell<Option<CoreRoom>>,
     config: RefCell<Option<PersistedConfig>>,
     /// この isolate 寿命中に `live-games-index/<inv>-<id>.json` の put が成功
-    /// 済みかどうか (Issue #549)。hibernation で isolate が破棄されると
+    /// 済みかどうか (https://github.com/SH11235/rshogi/issues/549)。hibernation で isolate が破棄されると
     /// `false` に戻るため、cold start 後の最初の `ensure_core_loaded` で 1 回
     /// だけ retry が走る。`mark_play_started` 経路で put 成功した直後にも
     /// `true` を立て、同 isolate 内の後続 `ensure_core_loaded` で冗長 put が
@@ -256,7 +256,7 @@ impl DurableObject for GameRoom {
     }
 
     async fn websocket_message(&self, ws: WebSocket, msg: WebSocketIncomingMessage) -> Result<()> {
-        // Issue #627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
+        // https://github.com/SH11235/rshogi/issues/627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
         // CSA protocol は text-only なので Binary は最終的に discard するが、サイズ
         // 上限を効かせるためには discard する前に len() を見る必要がある (Cloudflare
         // ランタイムは frame 受信時点で 32 MiB まで取り込めてしまうため、binary 経路を
@@ -497,7 +497,7 @@ impl GameRoom {
         white_handle: &str,
         game_name: &str,
     ) -> Result<bool> {
-        // Issue #626: `start_match` の呼び出し前に存在する重複起動防止ガード
+        // https://github.com/SH11235/rshogi/issues/626: `start_match` の呼び出し前に存在する重複起動防止ガード
         // (`handle_login` 側は `evaluate_match` の `MatchResult::Match` 判定、
         // `try_start_pending_match` 側は `handle_game_line` 入口の
         // `active_game_id().is_none()` 判定) が、cold start race (`KEY_CONFIG`
@@ -577,7 +577,7 @@ impl GameRoom {
         // 両クライアントには Game_Summary も `##[ERROR]` 通知も届かず部屋が永久に
         // 詰まる。`CLOCK_PRESETS` の不正設定 (`parse_clock_presets` Err) や、env
         // 設定の不整合で `game_name` 未登録に落ちるケースも、buoy reservation 失敗
-        // と同じ pending match abort 経路に揃えて部屋を解放する (Issue #641 で
+        // と同じ pending match abort 経路に揃えて部屋を解放する (https://github.com/SH11235/rshogi/issues/641 で
         // Lobby 側の OnceCell キャッシュ廃止後は両 DO ともに env を毎回読み直す
         // ため deploy race による乖離は解消されたが、`CLOCK_PRESETS` 不正設定時の
         // fail-fast 経路は残す)。
@@ -730,7 +730,7 @@ impl GameRoom {
         self.send_to_role(Role::Black, &summary_black).await?;
         self.send_to_role(Role::White, &summary_white).await?;
 
-        // AGREE 待ち TTL を予約する (Issue #600)。LOGIN OK 後に AGREE が届かない
+        // AGREE 待ち TTL を予約する (https://github.com/SH11235/rshogi/issues/600)。LOGIN OK 後に AGREE が届かない
         // まま片方が刺さると、`/api/v1/games/live` に出ない (mark_play_started が
         // 走らないので live-games-index に put しない) のに DO 側では memory /
         // room 枠を専有し続ける edge case を解消する。
@@ -802,7 +802,7 @@ impl GameRoom {
         // Playing 開始を確定できた瞬間だけ cfg を更新（冪等）。
         if let HandleOutcome::GameStarted = result.outcome {
             self.mark_play_started(now).await?;
-            // AGREE 待ち TTL タグを片付ける (Issue #600)。alarm 本体は直後の
+            // AGREE 待ち TTL タグを片付ける (https://github.com/SH11235/rshogi/issues/600)。alarm 本体は直後の
             // `reschedule_turn_alarm` が turn budget で上書きするため、タグだけ
             // 消せば後続 alarm 発火は既定 (TimeUp) として処理される。
             self.clear_agree_timeout_tag().await;
@@ -1415,9 +1415,9 @@ impl GameRoom {
         self.delete_grace_alarm_state().await?;
 
         // KEY_FINISHED が確定した後に live-games-index entry を best-effort で
-        // 削除する (Issue #549 §4)。「終局 entry も live entry も無い」矛盾
+        // 削除する (https://github.com/SH11235/rshogi/issues/549 §4)。「終局 entry も live entry も無い」矛盾
         // 状態を最小化するため、`KEY_FINISHED` put より後に delete を置く。
-        // delete 失敗時は orphan として残るが、cron sweep (Issue #551) が
+        // delete 失敗時は orphan として残るが、cron sweep (https://github.com/SH11235/rshogi/issues/551) が
         // 後追い掃除する契約。`play_started_at_ms` が None のまま終局した
         // (= AGREE 前 abnormal 等) ケースは live entry を put していないので
         // delete も skip する。
@@ -1520,7 +1520,7 @@ impl GameRoom {
         // すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。`?` は意図的
         // に使わない。
         //
-        // 書き込み順序 (Issue #551 設計 v3 §1):
+        // 書き込み順序 (https://github.com/SH11235/rshogi/issues/551 設計 v3 §1):
         //   1. csa 本文 / by-id (上で完了)
         //   2. `kifu-by-id/<id>.meta.json` — backfill / orphan sweep の真の判定
         //      キー (primary)。csa 成功直後に書く。
@@ -1703,7 +1703,7 @@ impl GameRoom {
                 continue;
             };
             if snapshot_in_progress {
-                // Issue #627: queue を push する前に上限を判定する。
+                // https://github.com/SH11235/rshogi/issues/627: queue を push する前に上限を判定する。
                 // - 行数 > `MAX_SPECTATOR_QUEUE_ITEMS`
                 // - bytes (各 line の `len()` 総和 + 今回追加分) > `MAX_SPECTATOR_QUEUE_BYTES`
                 // のいずれか満たす場合は、attachment を上書きせずに観戦者を切断する。
@@ -1826,7 +1826,7 @@ impl GameRoom {
         }
 
         // live-games-index put が抜けたまま hibernation で isolate が落ちた
-        // ケースを救済する (Issue #549 §5)。
+        // ケースを救済する (https://github.com/SH11235/rshogi/issues/549 §5)。
         self.retry_live_games_index_if_needed().await?;
         Ok(())
     }
@@ -1963,13 +1963,15 @@ impl GameRoom {
     ///
     /// 終局確定 (`KEY_FINISHED` put 成功) 直後に呼び、live 一覧から進行中
     /// 表示を消す。R2 delete は idempotent なので、transient error には最大
-    /// [`LIVE_INDEX_DELETE_MAX_ATTEMPTS`] 回まで retry し ([Issue #629])、各
-    /// attempt 間に [`LIVE_INDEX_DELETE_BACKOFF_MS`] の wall-clock 待機を挟む。
+    /// [`LIVE_INDEX_DELETE_MAX_ATTEMPTS`] 回まで retry し
+    /// (https://github.com/SH11235/rshogi/issues/629)、各 attempt 間に
+    /// [`LIVE_INDEX_DELETE_BACKOFF_MS`] の wall-clock 待機を挟む。
     ///
     /// 全試行が失敗した場合は `live_games_index_delete_giveup` イベントを記録
-    /// して諦める。残った orphan は Issue #551 の sweep ジョブ
-    /// (`run_live_orphan_sweep`) が 15 分以内に掃除する契約 (Issue #629 で 1
-    /// 時間 → 15 分に短縮)。
+    /// して諦める。残った orphan は
+    /// https://github.com/SH11235/rshogi/issues/551 の sweep ジョブ
+    /// (`run_live_orphan_sweep`) が 15 分以内に掃除する契約
+    /// (https://github.com/SH11235/rshogi/issues/629 で 1 時間 → 15 分に短縮)。
     ///
     /// key 生成失敗 / bucket binding 解決失敗は retry 不能なので 1 回で諦める
     /// (`live_games_index_delete_skip` を出して return)。
@@ -2401,7 +2403,7 @@ impl GameRoom {
         Ok(())
     }
 
-    /// AGREE 待ち TTL タグだけを片付ける best-effort helper (Issue #600)。
+    /// AGREE 待ち TTL タグだけを片付ける best-effort helper (https://github.com/SH11235/rshogi/issues/600)。
     /// `HandleOutcome::GameStarted` 観測時に呼ぶ。`KEY_GRACE_REGISTRY` は
     /// AGREE 経路では存在しない (grace 経路は対局成立後にしか入らない) ため
     /// 触らない。
@@ -2409,7 +2411,7 @@ impl GameRoom {
         let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
     }
 
-    /// alarm が `AgreeTimeout` 種別で発火した経路 (Issue #600)。
+    /// alarm が `AgreeTimeout` 種別で発火した経路 (https://github.com/SH11235/rshogi/issues/600)。
     ///
     /// - 既に終局済 / 対局成立済の場合は no-op (race ガード)。
     /// - そうでなければ両 player WS に `##[ERROR] agree_timeout` を送って close
@@ -2502,7 +2504,7 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
 ///   到達するのは Lobby を経由しない単体テスト経路、もしくはプリセット書き換え直後の
 ///   race など限定的なケース。
 ///
-/// **キャッシュなし設計** (Issue #641): Lobby DO もキャッシュを廃止して毎 LOGIN
+/// **キャッシュなし設計** (https://github.com/SH11235/rshogi/issues/641): Lobby DO もキャッシュを廃止して毎 LOGIN
 /// 時に env を読み直す方針に揃えたため、本関数は両 DO 共通の挙動になっている。
 /// Cloudflare DO は hibernation から起床しても `OnceCell` キャッシュが更新されず、
 /// deploy で `CLOCK_PRESETS` を変更しても旧 instance が古い値を保持する race が
@@ -2537,7 +2539,7 @@ fn resolve_clock_spec_for_game(env: &Env, game_name: &str) -> Result<ClockSpec> 
 /// 実体ロジックは [`resolve_reconnect_grace_from_strings`] (host 単体テスト可能な
 /// pure helper) に委譲し、本関数は `worker::Env` 依存を切り出す薄い shim に閉じる。
 /// `AGREE_TIMEOUT_SECONDS` env を読み、AGREE 待ち TTL を `Duration` で返す
-/// (Issue #600)。値の解釈は [`parse_agree_timeout_duration`] に従う:
+/// (https://github.com/SH11235/rshogi/issues/600)。値の解釈は [`parse_agree_timeout_duration`] に従う:
 /// `None` / 空文字 / `0` / 非数値は [`crate::config::DEFAULT_AGREE_TIMEOUT_SEC`]
 /// にフォールバックする (env 不正で stuck DO が無限残存する事態を避ける)。
 fn resolve_agree_timeout(env: &Env) -> Duration {

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -256,26 +256,29 @@ impl DurableObject for GameRoom {
     }
 
     async fn websocket_message(&self, ws: WebSocket, msg: WebSocketIncomingMessage) -> Result<()> {
-        let raw = match msg {
-            WebSocketIncomingMessage::String(s) => s,
-            WebSocketIncomingMessage::Binary(_) => return Ok(()),
+        // Issue #627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
+        // CSA protocol は text-only なので Binary は最終的に discard するが、サイズ
+        // 上限を効かせるためには discard する前に len() を見る必要がある (Cloudflare
+        // ランタイムは frame 受信時点で 32 MiB まで取り込めてしまうため、binary 経路を
+        // 素通しにすると DoS 緩和が片肺になる)。`trim_end_matches` で改行を削った後だと
+        // 判定対象が縮むため必ず元の長さで判定。超過時は `1009 Message Too Big` で即 close。
+        let raw_len = match &msg {
+            WebSocketIncomingMessage::String(s) => s.len(),
+            WebSocketIncomingMessage::Binary(b) => b.len(),
         };
-        // Issue #627: アプリ層の parser / 追加 allocation (`to_owned` 等) に
-        // 流す前に、受信した `String` の元バイト数で上限判定する。ランタイム側
-        // の `String` 取り込みは既に済んでいるが、parser / trim 後の解釈処理や
-        // attachment 経路 (spectator queue 等) への流入は弾ける。
-        // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず raw の
-        // 元の長さを使う。超過時は `1009 Message Too Big` で即 close し、
-        // 構造化 console_log を残す (rate limit は #622 / 別 issue scope)。
-        if raw.len() > MAX_WS_LINE_BYTES {
+        if raw_len > MAX_WS_LINE_BYTES {
             console_log!(
                 "[GameRoom] event=ws_message_too_big bytes={} limit={}",
-                raw.len(),
+                raw_len,
                 MAX_WS_LINE_BYTES,
             );
             let _ = ws.close(Some(1009), Some("message too big".to_owned()));
             return Ok(());
         }
+        let raw = match msg {
+            WebSocketIncomingMessage::String(s) => s,
+            WebSocketIncomingMessage::Binary(_) => return Ok(()),
+        };
         let line = raw.trim_end_matches(['\r', '\n']).to_owned();
 
         let attachment: WsAttachment = ws

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -62,7 +62,10 @@ use rshogi_csa_server::types::{
 };
 use rshogi_csa_server::{FloodgateHistoryEntry, FloodgateHistoryStorage, HistoryColor};
 
-use crate::attachment::{Role, WsAttachment, parse_login_handle};
+use crate::attachment::{
+    MAX_SPECTATOR_QUEUE_BYTES, MAX_SPECTATOR_QUEUE_ITEMS, MAX_WS_LINE_BYTES, Role, WsAttachment,
+    parse_login_handle,
+};
 use crate::config::{
     ConfigKeys, parse_agree_timeout_duration, parse_clock_presets, parse_clock_spec,
     resolve_reconnect_grace_from_strings,
@@ -257,6 +260,19 @@ impl DurableObject for GameRoom {
             WebSocketIncomingMessage::String(s) => s,
             WebSocketIncomingMessage::Binary(_) => return Ok(()),
         };
+        // Issue #627: parser / allocation に流す前に元バイト数で上限判定する。
+        // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず raw の
+        // 元の長さを使う。超過時は `1009 Message Too Big` で即 close し、
+        // 構造化 console_log を残す (rate limit は #622 / 別 issue scope)。
+        if raw.len() > MAX_WS_LINE_BYTES {
+            console_log!(
+                "[GameRoom] event=ws_message_too_big bytes={} limit={}",
+                raw.len(),
+                MAX_WS_LINE_BYTES,
+            );
+            let _ = ws.close(Some(1009), Some("message too big".to_owned()));
+            return Ok(());
+        }
         let line = raw.trim_end_matches(['\r', '\n']).to_owned();
 
         let attachment: WsAttachment = ws
@@ -1681,6 +1697,29 @@ impl GameRoom {
                 continue;
             };
             if snapshot_in_progress {
+                // Issue #627: queue を push する前に上限を判定する。
+                // - 行数 > `MAX_SPECTATOR_QUEUE_ITEMS`
+                // - bytes (各 line の `len()` 総和 + 今回追加分) > `MAX_SPECTATOR_QUEUE_BYTES`
+                // のいずれか満たす場合は、attachment を上書きせずに観戦者を切断する。
+                // serialize_attachment をスキップすることで、close 後の hibernation
+                // 復帰時にも肥大化した queue が残らないことを保証する (Codex review)。
+                let next_items = pending_queue.len().saturating_add(1);
+                let current_bytes: usize = pending_queue.iter().map(|(s, _)| s.len()).sum();
+                let next_bytes = current_bytes.saturating_add(line.len());
+                if next_items > MAX_SPECTATOR_QUEUE_ITEMS || next_bytes > MAX_SPECTATOR_QUEUE_BYTES
+                {
+                    console_log!(
+                        "[GameRoom] event=spectator_queue_overflow room_id={} items={} bytes={} \
+                         limit_items={} limit_bytes={}",
+                        room_id,
+                        next_items,
+                        next_bytes,
+                        MAX_SPECTATOR_QUEUE_ITEMS,
+                        MAX_SPECTATOR_QUEUE_BYTES,
+                    );
+                    let _ = ws.close(Some(1009), Some("spectator queue overflow".to_owned()));
+                    continue;
+                }
                 // snapshot 送信中は queue に積むだけ。flush 経路で重複手は弾く。
                 pending_queue.push((line.to_owned(), ply));
                 let updated = WsAttachment::Spectator {

--- a/crates/rshogi-csa-server-workers/src/games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_index.rs
@@ -68,7 +68,7 @@ pub fn games_index_key(ended_at_ms: u64, game_id: &str) -> Result<String, Storag
 
 /// games-index に書き込む 1 entry の wire format。
 ///
-/// API contract A (Issue #542 issuecomment-4338125621) に準拠し、`result_kind` /
+/// API contract A (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338125621) に準拠し、`result_kind` /
 /// `end_reason` を **2 フィールドに分離** する。client 側 (ramu-shogi viewer)
 /// は両者を合わせて UI 表示用の構造化結果に変換する。
 ///

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -112,7 +112,7 @@ pub const SWEEP_ONLY_CRON: &str = "15,30,45 * * * *";
 /// Workers ランタイムの scheduled イベント (cron trigger)。
 ///
 /// `wrangler.toml` の `[triggers] crons` で 2 つの cron を登録している
-/// (Issue #551 / Issue #629):
+/// (https://github.com/SH11235/rshogi/issues/551 / https://github.com/SH11235/rshogi/issues/629):
 ///
 /// - [`BACKFILL_CRON`] (`0 * * * *`): `run_games_index_backfill` →
 ///   `run_live_orphan_sweep` を順次実行する (= 既存挙動)。

--- a/crates/rshogi-csa-server-workers/src/live_games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/live_games_index.rs
@@ -15,8 +15,8 @@
 //! - 対局開始 → R2 put までの数百 ms ～ 数秒は live に出てこない
 //! - 終局 → R2 delete までは live に残る (viewer の click 時に既に終局済 cfg)
 //! - DO crash で put 済だが delete されない orphan が残るリスクあり
-//!   (orphan sweep は Issue #551 で扱う backfill ジョブに統合する)
-//! - Issue #636: viewer API (`/api/v1/games/live`) は `caches.default` で
+//!   (orphan sweep は https://github.com/SH11235/rshogi/issues/551 で扱う backfill ジョブに統合する)
+//! - https://github.com/SH11235/rshogi/issues/636: viewer API (`/api/v1/games/live`) は `caches.default` で
 //!   60 秒 TTL の per-URL cache を被せる。R2 put / delete の反映に追加で
 //!   **最大 60 秒** の cache stale が乗る。具体的には:
 //!     - 対局開始 → live list に現れるまで: 上記 R2 put 反映 + 60 秒

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -16,10 +16,10 @@
 //!
 //! 認証は self-claim (`<password>` 値検証なし)、本家 Floodgate と同じ扱い。
 //!
-//! # 私的対局 (Issue #582) — 本 PR スコープ
+//! # 私的対局 (https://github.com/SH11235/rshogi/issues/582) — 本 PR スコープ
 //!
 //! 本 PR では以下のみ実装する。両者揃った後の対局起動経路 (consume → GameRoom
-//! DO 起動 + clock_spec / initial_sfen バトンパス) は Issue #582 follow-up
+//! DO 起動 + clock_spec / initial_sfen バトンパス) は https://github.com/SH11235/rshogi/issues/582 follow-up
 //! integration の後半スコープに分割する。
 //!
 //! - `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` 受理
@@ -164,7 +164,7 @@ impl DurableObject for Lobby {
     }
 
     async fn websocket_message(&self, ws: WebSocket, msg: WebSocketIncomingMessage) -> Result<()> {
-        // Issue #627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
+        // https://github.com/SH11235/rshogi/issues/627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
         // Lobby protocol は text-only なので Binary は最終的に discard するが、Binary
         // 経路を素通しにすると Cloudflare ランタイム側で 32 MiB の frame を受け取って
         // しまい DoS 緩和が片肺になる。discard 前に len() を見て、超過なら 1009 close。
@@ -257,7 +257,7 @@ impl Lobby {
 
     /// `CLOCK_PRESETS` 環境変数をパースして得たマップを返す。
     ///
-    /// **キャッシュなし設計** (Issue #641): 以前は `OnceCell` で DO 起動時に 1 度
+    /// **キャッシュなし設計** (https://github.com/SH11235/rshogi/issues/641): 以前は `OnceCell` で DO 起動時に 1 度
     /// だけパースしていたが、Cloudflare DO は hibernation から起床しても OnceCell
     /// が更新されないため、deploy で `CLOCK_PRESETS` を変更しても旧 instance が
     /// 古い値を保持し続け、新 preset が `unknown_clock_preset` で reject される
@@ -622,7 +622,7 @@ impl Lobby {
 
     /// 私的対局 LOGIN_LOBBY (`<handle>+private-<token>+free`) の処理。
     ///
-    /// 検証順序 (Issue #582 仕様):
+    /// 検証順序 (https://github.com/SH11235/rshogi/issues/582 仕様):
     /// 1. パース失敗 (`+free` 以外 / hex 不正 / 引数不足) → `LOGIN_LOBBY:incorrect`
     ///    + 適切な reason
     /// 2. token 期限切れ / 未登録 → `LOGIN_LOBBY:incorrect challenge_expired`

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -164,25 +164,28 @@ impl DurableObject for Lobby {
     }
 
     async fn websocket_message(&self, ws: WebSocket, msg: WebSocketIncomingMessage) -> Result<()> {
-        let raw = match msg {
-            WebSocketIncomingMessage::String(s) => s,
-            WebSocketIncomingMessage::Binary(_) => return Ok(()),
+        // Issue #627: 受信フレームの byte 数を **String/Binary 共通で** 上限判定する。
+        // Lobby protocol は text-only なので Binary は最終的に discard するが、Binary
+        // 経路を素通しにすると Cloudflare ランタイム側で 32 MiB の frame を受け取って
+        // しまい DoS 緩和が片肺になる。discard 前に len() を見て、超過なら 1009 close。
+        // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず元の長さで判定。
+        let raw_len = match &msg {
+            WebSocketIncomingMessage::String(s) => s.len(),
+            WebSocketIncomingMessage::Binary(b) => b.len(),
         };
-        // Issue #627: アプリ層の parser / 追加 allocation (`to_owned` 等) に
-        // 流す前に、受信した `String` の元バイト数で上限判定する。ランタイム側
-        // の `String` 取り込みは既に済んでいるが、parser / trim 後の解釈処理は
-        // 弾ける。`trim_end_matches` で改行を削った後だと判定対象が縮むため、
-        // 必ず raw の元の長さを使う。超過時は `1009 Message Too Big` で即 close
-        // し、構造化 console_log を残す。
-        if raw.len() > MAX_WS_LINE_BYTES {
+        if raw_len > MAX_WS_LINE_BYTES {
             console_log!(
                 "[Lobby] event=ws_message_too_big bytes={} limit={}",
-                raw.len(),
+                raw_len,
                 MAX_WS_LINE_BYTES,
             );
             let _ = ws.close(Some(1009), Some("message too big".to_owned()));
             return Ok(());
         }
+        let raw = match msg {
+            WebSocketIncomingMessage::String(s) => s,
+            WebSocketIncomingMessage::Binary(_) => return Ok(()),
+        };
         let line = raw.trim_end_matches(['\r', '\n']).to_owned();
 
         let attachment: LobbyAttachment = ws

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -54,6 +54,8 @@ use rshogi_csa_server::matching::challenge::{
 };
 use rshogi_csa_server::types::{Color, PlayerName, ReconnectToken};
 
+use crate::attachment::MAX_WS_LINE_BYTES;
+
 /// LobbyDO 内 in-memory queue 上限の既定値 (`LOBBY_QUEUE_SIZE_LIMIT` 未設定時)。
 const DEFAULT_LOBBY_QUEUE_SIZE_LIMIT: usize = 100;
 
@@ -166,6 +168,19 @@ impl DurableObject for Lobby {
             WebSocketIncomingMessage::String(s) => s,
             WebSocketIncomingMessage::Binary(_) => return Ok(()),
         };
+        // Issue #627: parser / allocation に流す前に元バイト数で上限判定する。
+        // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず raw の
+        // 元の長さを使う。超過時は `1009 Message Too Big` で即 close し、
+        // 構造化 console_log を残す。
+        if raw.len() > MAX_WS_LINE_BYTES {
+            console_log!(
+                "[Lobby] event=ws_message_too_big bytes={} limit={}",
+                raw.len(),
+                MAX_WS_LINE_BYTES,
+            );
+            let _ = ws.close(Some(1009), Some("message too big".to_owned()));
+            return Ok(());
+        }
         let line = raw.trim_end_matches(['\r', '\n']).to_owned();
 
         let attachment: LobbyAttachment = ws

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -168,10 +168,12 @@ impl DurableObject for Lobby {
             WebSocketIncomingMessage::String(s) => s,
             WebSocketIncomingMessage::Binary(_) => return Ok(()),
         };
-        // Issue #627: parser / allocation に流す前に元バイト数で上限判定する。
-        // `trim_end_matches` で改行を削った後だと判定対象が縮むため、必ず raw の
-        // 元の長さを使う。超過時は `1009 Message Too Big` で即 close し、
-        // 構造化 console_log を残す。
+        // Issue #627: アプリ層の parser / 追加 allocation (`to_owned` 等) に
+        // 流す前に、受信した `String` の元バイト数で上限判定する。ランタイム側
+        // の `String` 取り込みは既に済んでいるが、parser / trim 後の解釈処理は
+        // 弾ける。`trim_end_matches` で改行を削った後だと判定対象が縮むため、
+        // 必ず raw の元の長さを使う。超過時は `1009 Message Too Big` で即 close
+        // し、構造化 console_log を残す。
         if raw.len() > MAX_WS_LINE_BYTES {
             console_log!(
                 "[Lobby] event=ws_message_too_big bytes={} limit={}",

--- a/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
@@ -9,7 +9,7 @@
 //! - in-memory queue ([`LobbyQueue`]) と直接マッチング (`DirectMatchStrategy` 再利用)。
 //! - 出力 line のシリアライズ (`LOGIN_LOBBY:<handle> OK` / `MATCHED <room_id> <color>` 等)。
 //! - 私的対局 (`CHALLENGE_LOBBY` / `LOGIN_LOBBY <handle>+private-<token>+free`)
-//!   の入口パース。Issue #582 の Workers 側受け入れ基準のうち本 PR スコープ
+//!   の入口パース。https://github.com/SH11235/rshogi/issues/582 の Workers 側受け入れ基準のうち本 PR スコープ
 //!   (token 発行 + LOGIN 認識 + 永続化 + Alarm purge) で参照される。両者揃った
 //!   後の対局起動経路は次 PR に分割するため、本モジュールは対局室 (GameRoom DO)
 //!   起動側の知識を持たない。
@@ -244,7 +244,7 @@ pub fn build_login_incorrect_line(reason: &str) -> String {
 }
 
 /// `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` の
-/// パース結果。Issue #582 Workers 経路で `%%CHALLENGE` の代わりとなる
+/// パース結果。https://github.com/SH11235/rshogi/issues/582 Workers 経路で `%%CHALLENGE` の代わりとなる
 /// メッセージで、`Lobby` DO の `websocket_message` 入口から駆動する。
 ///
 /// password / 認証は持たない (Workers 経路は self-claim、`<inviter>` を

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -648,7 +648,7 @@ mod tests {
 
     /// 旧 schema (本フィールド導入前の cold start snapshot) に
     /// `black_reconnect_token` / `white_reconnect_token` フィールドが存在しなくても、
-    /// `#[serde(default)]` で `None` として deserialize できる。Issue #591 hotfix で
+    /// `#[serde(default)]` で `None` として deserialize できる。https://github.com/SH11235/rshogi/issues/591 hotfix で
     /// `start_match` が常に `Some` を書く挙動から `None` も書く挙動に変わったため、
     /// 旧 snapshot との互換性を回帰防止する。
     #[test]

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -184,7 +184,7 @@ pub enum PendingAlarmKind {
     /// `HandleOutcome::GameStarted` で cancel される。発火時は対局成立前
     /// (= `play_started_at_ms` 未確定 / `KEY_FINISHED` 未設定 / live-games-index
     /// 未 put) のため、`force_abnormal` ではなく `abort_pending_match_with_error`
-    /// + `KEY_FINISHED` セット相当の経路で部屋を解放する (Issue #600)。
+    /// + `KEY_FINISHED` セット相当の経路で部屋を解放する (https://github.com/SH11235/rshogi/issues/600)。
     AgreeTimeout,
 }
 
@@ -194,7 +194,7 @@ pub enum PendingAlarmKind {
 /// `PersistedConfig` への保存もスキップする。
 ///
 /// production の保守的既定 (`RECONNECT_GRACE_SECONDS=0`) では本関数は常に
-/// `(None, None)` を返し、Issue #591 の `LOGIN:incorrect reconnect_rejected`
+/// `(None, None)` を返し、https://github.com/SH11235/rshogi/issues/591 の `LOGIN:incorrect reconnect_rejected`
 /// 経路に client が到達しなくなる (`csa_client::run_one_game` の reconnect
 /// skip 判定で `summary.reconnect_token == None` のため reconnect 試行自体を
 /// skip する)。
@@ -223,7 +223,7 @@ pub(crate) fn classify_alarm_after_enter_grace(
     }
 }
 
-/// `start_match` 入口の防御ガード判定結果 (Issue #626)。
+/// `start_match` 入口の防御ガード判定結果 (https://github.com/SH11235/rshogi/issues/626)。
 ///
 /// `start_match` は副作用 (`KEY_CONFIG` put / buoy reservation / `set_alarm`) の
 /// 前にこの関数の判定で early return する。本 enum を介して入口判定を純粋関数
@@ -251,7 +251,7 @@ pub enum StartMatchGuard {
     AlarmPending(PendingAlarmKind),
 }
 
-/// `start_match` 入口の三段ガードを純粋関数として表現する (Issue #626)。
+/// `start_match` 入口の三段ガードを純粋関数として表現する (https://github.com/SH11235/rshogi/issues/626)。
 ///
 /// 引数は永続化キー (`KEY_FINISHED` / `KEY_CONFIG` / `KEY_PENDING_ALARM_KIND`)
 /// の存在 / 値を直接取り、内部参照型に依存しない (`PersistedConfig` /
@@ -470,7 +470,7 @@ mod tests {
         assert!(should_set_grace);
     }
 
-    /// `start_match` 入口の三段ガード仕様を pin する (Issue #626)。
+    /// `start_match` 入口の三段ガード仕様を pin する (https://github.com/SH11235/rshogi/issues/626)。
     ///
     /// `proceeds_when_no_state`: 何も永続化されていない初回 LOGIN マッチ成立直後の
     /// 経路で副作用なしの続行を許可する。
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(classify_start_match_guard(false, true, None), StartMatchGuard::AlreadyMatched);
     }
 
-    /// Issue #626 の主要シナリオ。`enter_grace_window` で `GraceExpired` alarm が
+    /// https://github.com/SH11235/rshogi/issues/626 の主要シナリオ。`enter_grace_window` で `GraceExpired` alarm が
     /// 予約済の状態で `start_match` を踏むと、`AgreeTimeout` で上書きしてしまう
     /// ため reject する。
     #[test]

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -4,7 +4,7 @@
 //! - `GET /ws/:room_id` → Origin 検査後、`room_id` を `id_from_name` で
 //!   決定論的に解決した Durable Object へ Upgrade 要求を転送する。
 //! - `GET /` と `GET /health` → サーバ識別と deploy 元 commit sha を JSON で返す
-//!   簡易ヘルスチェック。Issue #639 の rollback drift detection が `deployed_sha`
+//!   簡易ヘルスチェック。https://github.com/SH11235/rshogi/issues/639 の rollback drift detection が `deployed_sha`
 //!   を main HEAD と突合する基準にするため、JSON schema の安定性を保つこと。
 //! - 他は 404。
 
@@ -172,7 +172,7 @@ async fn forward_ws_to_room(
 ///
 /// `deployed_sha` は CI deploy 時に `wrangler deploy --var DEPLOYED_SHA:<sha>` で
 /// 注入された commit sha (= `.github/workflows/deploy-workers.yml` の `push.paths`
-/// にマッチする main 上の最新 commit)。Issue #639 の drift detection workflow が
+/// にマッチする main 上の最新 commit)。https://github.com/SH11235/rshogi/issues/639 の drift detection workflow が
 /// 本フィールドを `git log -1 --format=%H -- <paths>` の結果と突合して、Cloudflare
 /// 側に残った rollback 後の旧 version を検出する。
 ///

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -1,6 +1,6 @@
 //! viewer 配信 HTTP API (`/api/v1/games`) のルーティングと R2 アクセス。
 //!
-//! v3 設計 (Issue #542 issuecomment-4338088406) に準拠する 3 エンドポイント:
+//! v3 設計 (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338088406) に準拠する 3 エンドポイント:
 //!
 //! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧 (終局済)
 //!   `KIFU_BUCKET.list({prefix: "games-index/", cursor, limit})` を 1 回呼び、
@@ -10,7 +10,7 @@
 //! - `GET /api/v1/games/live?cursor=<opaque>&limit=<N>` 一覧 (進行中)
 //!   `KIFU_BUCKET.list({prefix: "live-games-index/", cursor, limit})` を 1 回呼び、
 //!   各オブジェクト本文 (= [`crate::live_games_index::LiveGamesIndexEntry`] の JSON)
-//!   を `live_games[]` に詰めて返す (Issue #549)。終局済 list と同じ pagination
+//!   を `live_games[]` に詰めて返す (https://github.com/SH11235/rshogi/issues/549)。終局済 list と同じ pagination
 //!   semantics、`/api/v1/games/<id>` のような単局エンドポイントは進行中対局には
 //!   設けない (= viewer 側は live entry を **発見手段** として扱い、行クリック時に
 //!   WS spectate 接続で実状態を確認する)。
@@ -27,10 +27,10 @@
 //!
 //! `try_handle` 配下に新しい `/api/v1/*` エンドポイントを追加する場合は、
 //! `check_origin` / `with_cors` の通過と `WS_ALLOWED_ORIGINS` allowlist 体系
-//! (Issue #550 で強化予定) に確実に乗ることを必ずレビューする。allowlist 未設定
+//! (https://github.com/SH11235/rshogi/issues/550 で強化予定) に確実に乗ることを必ずレビューする。allowlist 未設定
 //! 環境での挙動 (= Origin ヘッダなしで通る) も含めて回帰させない。
 //!
-//! # Cloudflare Cache API による R2 Class B ops 削減 (Issue #636)
+//! # Cloudflare Cache API による R2 Class B ops 削減 (https://github.com/SH11235/rshogi/issues/636)
 //!
 //! 1 リクエストで `bucket.list` (1 RTT) + 各 entry `bucket.get` (最大 N=100 RTT)
 //! を消費する N+1 パターンを Cloudflare の `caches.default` で短期キャッシュする。
@@ -85,7 +85,7 @@ const MIN_LIMIT: u32 = 1;
 /// 引き継ぐ (404 までの fallthrough)。
 ///
 /// `OPTIONS` は CORS preflight として viewer API 配下のパスでのみ受理する
-/// (Issue #564 設計 v4 §3)。`X-Client` を custom request header として送る
+/// (https://github.com/SH11235/rshogi/issues/564 設計 v4 §3)。`X-Client` を custom request header として送る
 /// クライアント (ramu-shogi web / desktop) のために `Access-Control-Allow-Headers`
 /// を返す必要がある。`ALLOW_VIEWER_API` 無効時は GET と同様 404 へフォールスルー
 /// し、preflight の段階で kill-switch を効かせる。
@@ -126,7 +126,7 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
             // 余分な階層 (`/api/v1/games/x/y`) や末尾 `/` は 404 で扱う。
             // viewer API 配下のエラー応答は一律 `Cache-Control: no-store` を
             // 付け、edge cache が誤って 404 を保持しないように倒す
-            // (Issue #636 review v1)。with_cors も通して ACAO + Vary を
+            // (https://github.com/SH11235/rshogi/issues/636 review v1)。with_cors も通して ACAO + Vary を
             // 揃える。
             let resp = no_store_error("Not Found", 404)?;
             return Ok(Some(with_cors(resp, req, env)?));
@@ -214,7 +214,7 @@ struct LiveListResponse {
 struct GameResponse<'a> {
     game_id: &'a str,
     csa: String,
-    /// `kifu-by-id/<id>.meta.json` から取得した正準メタ (Issue #551 設計 v3 §12)。
+    /// `kifu-by-id/<id>.meta.json` から取得した正準メタ (https://github.com/SH11235/rshogi/issues/551 設計 v3 §12)。
     /// meta 不在時は 404 を返す前提なので、ここは常に `Some` 相当だが JSON 上は
     /// serde 既定で field として出る。
     meta: serde_json::Value,
@@ -222,7 +222,7 @@ struct GameResponse<'a> {
 
 /// cache TTL を path 種別から決める純粋ロジック。
 ///
-/// Issue #636 で導入した `caches.default` per-URL cache の TTL 値固定化。
+/// https://github.com/SH11235/rshogi/issues/636 で導入した `caches.default` per-URL cache の TTL 値固定化。
 /// 値は `viewer_api` モジュール doc に書いた契約と一致させ、テストで固定する。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CacheableKind {
@@ -246,7 +246,7 @@ impl CacheableKind {
 
 /// 終局済一覧ハンドラ。`games-index/` を 1 ページ list する。
 ///
-/// Issue #636 の cache 経路:
+/// https://github.com/SH11235/rshogi/issues/636 の cache 経路:
 /// 1. allowlist チェック → 403 origin block の場合は no-store で即返却
 /// 2. cache.get (key = request URL) → hit なら ACAO 被せて返す
 /// 3. miss なら collect_index_page で R2 list + N×get → origin-neutral Response
@@ -471,7 +471,7 @@ async fn collect_index_page(
 /// 単局ハンドラ。`<game_id>` (URL-decoded path 残部) を受け取り、kifu-by-id を
 /// 直接 get する。
 ///
-/// 終局済棋譜は immutable のため Cache TTL を 600 秒で固定する (Issue #636)。
+/// 終局済棋譜は immutable のため Cache TTL を 600 秒で固定する (https://github.com/SH11235/rshogi/issues/636)。
 async fn handle_get(req: &Request, env: &Env, game_id: &str) -> Result<Response> {
     if let Some(blocked) = check_origin(req, env)? {
         return Ok(blocked);
@@ -576,7 +576,7 @@ async fn build_single_game(
 
 /// `kifu-by-id/<id>.meta.json` を直接 get して `game_id` の meta を返す。
 ///
-/// Issue #551 設計 v3 §12 で meta primary 化したことにより、`games-index/`
+/// https://github.com/SH11235/rshogi/issues/551 設計 v3 §12 で meta primary 化したことにより、`games-index/`
 /// を prefix list で走査する旧経路 (O(N)) は廃止し O(1) get に統一した。
 /// meta が存在しない場合は `Ok(None)` を返し、呼び出し側で 404 を返す。
 async fn find_meta_for(
@@ -634,12 +634,12 @@ fn check_origin(req: &Request, env: &Env) -> Result<Option<Response>> {
 /// Origin はリストに含まれている (もしくは Origin ヘッダなし)。
 ///
 /// `Vary` は `Origin, Access-Control-Request-Headers` を一括して設定する
-/// (Issue #564 設計 v4 §3 review v1 (e))。preflight (OPTIONS) と GET の
+/// (https://github.com/SH11235/rshogi/issues/564 設計 v4 §3 review v1 (e))。preflight (OPTIONS) と GET の
 /// 双方に適用することで、CDN / ブラウザキャッシュが Origin あるいは
 /// preflight で送られた `Access-Control-Request-Headers` を取り違えて
 /// レスポンスを共有する事故を防ぐ。
 ///
-/// Issue #636: cache から取り出した origin-neutral な Response も最終的に本関数で
+/// https://github.com/SH11235/rshogi/issues/636: cache から取り出した origin-neutral な Response も最終的に本関数で
 /// ACAO + Vary を被せる。cache に保存する側では ACAO を含めない (origin-neutral
 /// 化) ことで Origin ごとに cache が分散しないようにしている。
 fn with_cors(mut resp: Response, req: &Request, env: &Env) -> Result<Response> {
@@ -723,7 +723,7 @@ async fn cache_put_origin_neutral(
 
 /// 失敗ログを logfmt で出す統一窓口。viewer API の経路別 event 名と、
 /// 呼出側クライアントを特定する `client_kind` を持たせる
-/// (Issue #564 設計 v4 §3)。`client_kind` は [`normalize_client_kind`] により
+/// (https://github.com/SH11235/rshogi/issues/564 設計 v4 §3)。`client_kind` は [`normalize_client_kind`] により
 /// `[a-z0-9-]{1,64}` に正規化済みの ASCII 文字列、または `unknown` / `invalid`。
 fn console_log_failed(event: &str, client_kind: &str, detail: &str) {
     worker::console_log!("[viewer_api] event={event} client_kind={client_kind} detail={detail}");

--- a/crates/rshogi-csa-server-workers/src/x1_paths.rs
+++ b/crates/rshogi-csa-server-workers/src/x1_paths.rs
@@ -36,7 +36,7 @@ pub fn kifu_by_id_object_key(game_id: &str) -> String {
 /// game_id から逆引きする棋譜メタ (`<id>.meta.json`) キー。
 ///
 /// `kifu_by_id_object_key` と同じ `encode_component(game_id)` を通すことで、
-/// CSA 本体キーと完全に同じエンコーディング規約に揃える (Issue #551 v3 §12)。
+/// CSA 本体キーと完全に同じエンコーディング規約に揃える (https://github.com/SH11235/rshogi/issues/551 v3 §12)。
 /// reader (viewer_api) と writer (game_room / backfill) で生成キーが乖離しない
 /// ように、本ヘルパを必ず経由して `<game_id>.meta.json` を構築する。
 pub fn kifu_by_id_meta_key(game_id: &str) -> String {

--- a/crates/rshogi-csa-server-workers/tests/do_schema_additive_contract.rs
+++ b/crates/rshogi-csa-server-workers/tests/do_schema_additive_contract.rs
@@ -9,7 +9,7 @@
 //! 限定する必要がある。
 //!
 //! 具体的には `CREATE TABLE IF NOT EXISTS <name> ( ... )` のみを許可する
-//! (Issue #638 / `docs/csa-server/deployment.md` §3.4.1)。SQLite の
+//! (https://github.com/SH11235/rshogi/issues/638 / `docs/csa-server/deployment.md` §3.4.1)。SQLite の
 //! `ALTER TABLE ... ADD COLUMN` は同名 column が既に存在すると
 //! `duplicate column name` で fail するため、再 exec で no-op にならない。
 //! column 追加が必要になった場合は `SCHEMA_SQL` に直接入れず、

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -30,13 +30,13 @@ struct EnvironmentBindings {
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
     compatibility_date: Option<String>,
-    /// `[vars] CLOCK_PRESETS` の値そのまま (JSON 配列文字列、空配列含む)。Issue #610 で
+    /// `[vars] CLOCK_PRESETS` の値そのまま (JSON 配列文字列、空配列含む)。https://github.com/SH11235/rshogi/issues/610 で
     /// 両環境の preset 名集合が揃っていることを assert するために保持する。
     raw_clock_presets: Option<String>,
     /// `[[migrations]]` 配列を生のまま保持する。`new_sqlite_classes` 等を
     /// 各 test が独自に検査するため、`Vec<toml::Value>` のまま持つ。
     migrations: Vec<toml::Value>,
-    /// `[triggers] crons = [...]` の値 (Issue #551)。空配列は未宣言。
+    /// `[triggers] crons = [...]` の値 (https://github.com/SH11235/rshogi/issues/551)。空配列は未宣言。
     crons: Vec<String>,
 }
 
@@ -176,7 +176,7 @@ fn assert_no_local_dev_only_keys(env: &EnvironmentBindings) {
     );
 }
 
-/// `ConfigKeys::RUNTIME_INJECTED_VARS_KEYS` (Issue #639 で追加した `DEPLOYED_SHA`
+/// `ConfigKeys::RUNTIME_INJECTED_VARS_KEYS` (https://github.com/SH11235/rshogi/issues/639 で追加した `DEPLOYED_SHA`
 /// 等、CI deploy 時に `wrangler deploy --var KEY:VALUE` で注入される値) が
 /// env toml の `[vars]` テーブルに **書かれていない** ことを検証する。
 ///
@@ -202,7 +202,7 @@ fn assert_no_runtime_injected_keys(env: &EnvironmentBindings) {
     );
 }
 
-/// Issue #551 で追加した `[triggers] crons` が各 deploy 環境に宣言されていることを
+/// https://github.com/SH11235/rshogi/issues/551 で追加した `[triggers] crons` が各 deploy 環境に宣言されていることを
 /// 固定する。`[event(scheduled)]` ハンドラは production / staging 両方で稼働させる
 /// 契約 (片方だけ宣言だと backfill / orphan sweep が動かず orphan が滞留する)。
 ///
@@ -249,7 +249,7 @@ fn assert_crons_match(lhs: &EnvironmentBindings, rhs: &EnvironmentBindings) {
 
 /// 両環境の `[vars] CLOCK_PRESETS` が同じ preset 名集合を宣言していることを assert する。
 /// staging / production で同じ `game_name` で接続したクライアントが同じ clock 設定で
-/// 動くことを保証するため、preset 名は両環境で揃える契約 (Issue #610)。
+/// 動くことを保証するため、preset 名は両環境で揃える契約 (https://github.com/SH11235/rshogi/issues/610)。
 ///
 /// 値（total_time_*, byoyomi_*）まで一致させると将来環境ごとに調整したいケースを
 /// 縛るため、ここでは「名前集合」の一致だけを pin する。
@@ -300,7 +300,7 @@ fn assert_clock_preset_names_match(lhs: &EnvironmentBindings, rhs: &EnvironmentB
     );
     assert!(
         !lhs_names.is_empty(),
-        "{file} ({label}): CLOCK_PRESETS must declare at least one preset (Issue #610)",
+        "{file} ({label}): CLOCK_PRESETS must declare at least one preset (https://github.com/SH11235/rshogi/issues/610)",
         file = lhs.file_name,
         label = lhs.label,
     );

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -29,7 +29,7 @@ struct TemplateBindings {
     r2_bindings: Vec<String>,
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
-    /// `[triggers] crons = [...]` の値を保持する (Issue #551)。空配列は未宣言。
+    /// `[triggers] crons = [...]` の値を保持する (https://github.com/SH11235/rshogi/issues/551)。空配列は未宣言。
     crons: Vec<String>,
 }
 
@@ -161,7 +161,7 @@ fn wrangler_template_vars_keys_match_config_keys() {
     assert_bidirectional("vars_keys", &expected, &TEMPLATE.vars_keys);
 }
 
-/// Issue #551 で追加した `[triggers] crons` が template に宣言されていることを
+/// https://github.com/SH11235/rshogi/issues/551 で追加した `[triggers] crons` が template に宣言されていることを
 /// 固定する。`[event(scheduled)]` ハンドラと cron trigger は同 PR で導入したので、
 /// 片方だけが残ったまま運用者が `cp wrangler.toml.example wrangler.toml` した場合
 /// に handler が永久 dormant にならないよう、template 側で必須化する。
@@ -186,14 +186,14 @@ fn wrangler_template_declares_backfill_cron_trigger() {
     );
 }
 
-/// `ConfigKeys::RUNTIME_INJECTED_VARS_KEYS` (Issue #639 で追加した `DEPLOYED_SHA`
+/// `ConfigKeys::RUNTIME_INJECTED_VARS_KEYS` (https://github.com/SH11235/rshogi/issues/639 で追加した `DEPLOYED_SHA`
 /// 等、CI deploy 時に `wrangler deploy --var KEY:VALUE` で注入される値) が
 /// `wrangler.toml.example` の `[vars]` テーブルに **書かれていない** ことを検証する。
 ///
 /// template の `[vars]` には `SHARED_PUBLIC_VARS_KEYS ∪ LOCAL_DEV_ONLY_VARS_KEYS`
 /// 全件を記載する規約だが、本配列の値は CI runtime 注入経路でのみ供給される設計
 /// なので template には書かない (書くと local dev で `/health` の `deployed_sha`
-/// が固定 placeholder を返し、Issue #639 の drift detection が想定する semantics
+/// が固定 placeholder を返し、https://github.com/SH11235/rshogi/issues/639 の drift detection が想定する semantics
 /// と齟齬になる)。
 #[test]
 fn wrangler_template_vars_must_not_contain_runtime_injected_keys() {


### PR DESCRIPTION
## Summary
- Cloudflare WS は最大 32 MiB のメッセージを許容するため、`websocket_message` 入口で `MAX_WS_LINE_BYTES = 4096` を超える受信は `1009 Message Too Big` で即 close (GameRoom DO / Lobby DO 双方)
- Spectator pending_queue に件数 (`MAX_SPECTATOR_QUEUE_ITEMS = 1024`) と累計バイト (`MAX_SPECTATOR_QUEUE_BYTES = 64 KiB`) の上限を追加し、超過時は `serialize_attachment` をスキップしつつ `1009` で close することで肥大化 queue が hibernation 復帰時に残らないことを担保
- 上限値の sanity を `const { assert!(..) }` でビルド時固定 (run-time コストゼロ)

## 設計判断
- 受信バイト数判定は `trim_end_matches` で改行を削る **前** の `raw.len()` で行う (Codex 設計レビュー指摘)
- queue overflow 時は attachment 上書きを行わない (Codex 設計レビュー指摘)
- close code はいずれも `1009 Message Too Big` を採用。queue overflow は意味的には `1008 Policy Violation` も候補だが、DoS 防御として「処理可能サイズを超えた」という運用観点で `1009` で揃える
- per-second rate limit は #622 の範疇のため本 PR では扱わない (issue 本文の方針通り)
- TCP server 側 (`rshogi-csa-server-tcp`) のサイズ上限は本 issue の主眼 (Workers DO への DoS 防御) と分離されるため別 issue 対応とする

## Codex review 経過
- 設計レビュー: APPROVE (task-mowumxc9-d1l7ww)
- 実装レビュー: APPROVE (task-mowvlj2a-yanezu)。コメント精度の補足のみ反映済み。

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --tests -p rshogi-csa-server-workers --no-deps` 警告ゼロ
- [x] `cargo test -p rshogi-csa-server-workers` 全 pass (249 lib + 16 + 5 integration tests)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown` 通過
- [ ] Miniflare integration test (本 PR では追加せず。rate limit / e2e fuzz は #622 で検討)

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)