### PR TITLE
feat(csa-server-workers): R2 export 失敗時の retry/outbox + meta repair (#623)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/export_retry.rs
+++ b/crates/rshogi-csa-server-workers/src/export_retry.rs
@@ -1,0 +1,78 @@
+//! 終局時 R2 export PUT 失敗時の retry policy (Issue #623)。
+//!
+//! 終局時に CSA 本文 / by-id / meta / games-index の 4 オブジェクトを R2 に
+//! 書き出すが、Cloudflare の transient 失敗で 1 つでも PUT に失敗すると以前は
+//! 棋譜が恒久欠損していた。本モジュールは:
+//!
+//! - DO storage に [`ExportPendingState`](crate::persistence::ExportPendingState)
+//!   を残して再 PUT に必要な body / key を保持する
+//! - [`PendingAlarmKind::ExportRetry`](crate::reconnect::PendingAlarmKind::ExportRetry)
+//!   タグで `state.alarm()` 経路を分岐する (`KEY_FINISHED` ガードよりも前で受ける)
+//! - 本モジュール内の純粋ロジック ([`next_retry_delay_ms`] / [`is_exhausted`])
+//!   で次回 alarm 遅延と打ち切り判定を一元化する
+//!
+//! 純粋ロジックのみ置く方針なので I/O (DO storage / R2 binding) は呼び出し側
+//! ([`crate::game_room`]) が担う。
+
+/// retry の遅延列 (秒)。要素長 = retry の最大回数。
+///
+/// `attempt = 0` (初回 finalize 直後の最初の retry alarm) は
+/// `RETRY_DELAYS_SEC[0] = 30` 秒後。`attempt = 4` まで使い切ると 5 回目の
+/// `next_retry_delay_ms` 呼び出しで `None` を返し、呼び出し側は
+/// `KEY_PENDING_ALARM_KIND` を消して alarm を停止する (= pending entry のみ
+/// 残置して観測性を保つ運用へ移行する)。
+///
+/// 30 / 60 / 120 / 300 / 600 秒の指数寄り。R2 の数分単位の transient 障害を
+/// 拾いやすく、かつ Workers 側の wall-clock を浪費しすぎない範囲。
+pub const RETRY_DELAYS_SEC: [u64; 5] = [30, 60, 120, 300, 600];
+
+/// 次回 retry alarm までの遅延 (ミリ秒) を返す。
+///
+/// `attempt` は **これから実行する** retry の試行番号 (0 始まり)。`None` を
+/// 返すケースは呼び出し側で打ち切り (= alarm 停止 + pending 残置) する契約。
+pub fn next_retry_delay_ms(attempt: u32) -> Option<u64> {
+    RETRY_DELAYS_SEC.get(attempt as usize).map(|sec| sec.saturating_mul(1000))
+}
+
+/// 全 retry を消費しきっているか (= 次回 alarm を張れない)。
+///
+/// `next_retry_delay_ms(attempt).is_none()` と同値だが、呼び出し側で
+/// 「打ち切り判定」セマンティクスを明示するために別名で公開する。
+pub fn is_exhausted(attempt: u32) -> bool {
+    next_retry_delay_ms(attempt).is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delays_have_expected_sequence() {
+        // Codex 設計レビュー (v2 COMMENT) で承認された 30/60/120/300/600 秒列。
+        // 値を変更すると wall-clock 上の retry 挙動が変わるため、契約として固定する。
+        assert_eq!(RETRY_DELAYS_SEC, [30, 60, 120, 300, 600]);
+    }
+
+    #[test]
+    fn next_retry_delay_ms_returns_some_for_in_range_attempts() {
+        assert_eq!(next_retry_delay_ms(0), Some(30_000));
+        assert_eq!(next_retry_delay_ms(1), Some(60_000));
+        assert_eq!(next_retry_delay_ms(2), Some(120_000));
+        assert_eq!(next_retry_delay_ms(3), Some(300_000));
+        assert_eq!(next_retry_delay_ms(4), Some(600_000));
+    }
+
+    #[test]
+    fn next_retry_delay_ms_returns_none_when_exhausted() {
+        assert_eq!(next_retry_delay_ms(5), None);
+        assert_eq!(next_retry_delay_ms(u32::MAX), None);
+    }
+
+    #[test]
+    fn is_exhausted_matches_next_retry_delay_ms_none() {
+        assert!(!is_exhausted(0));
+        assert!(!is_exhausted(4));
+        assert!(is_exhausted(5));
+        assert!(is_exhausted(u32::MAX));
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -68,6 +68,7 @@ use crate::config::{
     resolve_reconnect_grace_from_strings,
 };
 use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
+use crate::export_retry::{is_exhausted, next_retry_delay_ms};
 use crate::floodgate_history::R2FloodgateHistoryStorage;
 use crate::games_index::{
     ClockSpec as IndexClockSpec, GamesIndexEntry, classify_result, games_index_key,
@@ -75,7 +76,8 @@ use crate::games_index::{
 };
 use crate::live_games_index::{LiveGamesIndexEntry, live_games_index_key};
 use crate::persistence::{
-    FinishedState, MoveRow, PersistedConfig, ReplaySummary, replay_core_room,
+    ExportBodyKind, ExportPendingState, FailedExportObject, FinishedState, MoveRow,
+    PersistedConfig, ReplaySummary, replay_core_room,
 };
 use crate::reconnect::{
     PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot, StartMatchGuard,
@@ -139,6 +141,67 @@ const KEY_GRACE_REGISTRY: &str = "grace_registry";
 /// `#[serde(rename = "pending_alarm_kind")]` と一致させること（理由は
 /// `KEY_GRACE_REGISTRY` と同じ）。
 const KEY_PENDING_ALARM_KIND: &str = "pending_alarm_kind";
+/// 終局時に R2 export PUT が一部または全部失敗したときに、再 PUT に必要な
+/// CSA 本文 / meta JSON / 失敗 key 一覧を保持する DO storage key (Issue #623)。
+/// `KEY_PENDING_ALARM_KIND = ExportRetry` とペアでセットされ、`alarm()` 経路で
+/// `handle_export_retry_alarm` が読み取る。retry 全消費後は alarm のみ停止し
+/// 本 key は残置する (運用観測用)。
+const KEY_EXPORT_PENDING: &str = "export_pending";
+
+/// 終局時 R2 export 試行の結果分類 (Issue #623)。
+///
+/// `export_kifu_to_r2` は本 enum を返し、呼び出し側 (`finalize_if_ended`) が
+/// `Complete` / `Pending` / `Skipped` に応じて pending 永続化 + retry alarm
+/// 予約 / 何もしない を分岐する。
+#[derive(Debug)]
+enum ExportAttempt {
+    /// すべての PUT が成功した (`exported_at_ms = Some` を埋められる)。
+    Complete,
+    /// 1 つ以上 PUT 失敗で retry 必要。本 variant が持つ
+    /// [`ExportPendingState`] を `KEY_EXPORT_PENDING` に永続化する。
+    Pending(Box<ExportPendingState>),
+    /// retry しても解決しない致命的失敗 (bucket binding 不在 / load_moves 失敗 /
+    /// SFEN 不正 / serialize 失敗等)。`exported_at_ms = None` のままで観測上は
+    /// 欠損として残るが、それ以外の処理は通常通り進める。
+    Skipped,
+}
+
+impl ExportAttempt {
+    /// `failed_keys` の長さで `Complete` / `Pending` を選ぶ helper。
+    fn from_failed_keys(
+        game_id: String,
+        ended_at_ms: u64,
+        csa_text: String,
+        meta_body: Vec<u8>,
+        failed_keys: Vec<FailedExportObject>,
+    ) -> Self {
+        if failed_keys.is_empty() {
+            ExportAttempt::Complete
+        } else {
+            ExportAttempt::Pending(Box::new(ExportPendingState {
+                game_id,
+                ended_at_ms,
+                csa_text,
+                meta_body,
+                failed_keys,
+                attempt: 0,
+            }))
+        }
+    }
+
+    /// 全 PUT 成功か (`exported_at_ms` を埋めて良いか)。
+    fn is_complete(&self) -> bool {
+        matches!(self, ExportAttempt::Complete)
+    }
+
+    /// pending 永続化対象を取り出す。`Complete` / `Skipped` は `None`。
+    fn into_pending(self) -> Option<ExportPendingState> {
+        match self {
+            ExportAttempt::Pending(state) => Some(*state),
+            _ => None,
+        }
+    }
+}
 
 /// R2 上の buoy 保存フォーマット。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -333,14 +396,24 @@ impl DurableObject for GameRoom {
     }
 
     async fn alarm(&self) -> Result<Response> {
+        // alarm 種別タグを読み、各経路を分岐する。
+        // 既定値 (タグ未設定 / `TimeUp`) は時間切れ駆動とみなす。
+        //
+        // ⚠ Issue #623: `ExportRetry` は `KEY_FINISHED` 確定**後**に発火する
+        // 特殊な alarm なので、`load_finished` ガードよりも**前**に分岐する必要
+        // がある。それ以外 (`GraceExpired` / `AgreeTimeout` / `TimeUp`) は終局前
+        // 経路なので従来どおり `load_finished` ガードを先に通す。
+        let kind = self.load_pending_alarm_kind().await?;
+        if matches!(kind, Some(PendingAlarmKind::ExportRetry)) {
+            self.handle_export_retry_alarm().await?;
+            return Response::ok("export_retry handled");
+        }
+
         // 既に終局済みの DO でアラームが届いたら何もしない（念のためのガード）。
         if self.load_finished().await?.is_some() {
             return Response::ok("already finished");
         }
 
-        // alarm 種別タグを読み、`GraceExpired` / `AgreeTimeout` 経路を分岐する。
-        // 既定値 (タグ未設定 / `TimeUp`) は時間切れ駆動とみなす。
-        let kind = self.load_pending_alarm_kind().await?;
         if matches!(kind, Some(PendingAlarmKind::GraceExpired)) {
             self.handle_grace_expired_alarm().await?;
             return Response::ok("grace_expired handled");
@@ -1353,6 +1426,16 @@ impl GameRoom {
     }
 
     /// 終局したなら R2 に棋譜を書き出し、finished フラグを立てて両 ws を close する。
+    ///
+    /// R2 export PUT が一部または全部失敗した場合 (Issue #623):
+    /// 1. CSA 本文 / meta JSON / 失敗 key 一覧を [`ExportPendingState`] として
+    ///    `KEY_EXPORT_PENDING` に保存する
+    /// 2. `KEY_PENDING_ALARM_KIND = ExportRetry` をセット
+    /// 3. `RETRY_DELAYS_SEC[0]` 後に `state.alarm()` を予約 (`handle_export_retry_alarm`
+    ///    が再 PUT する)
+    ///
+    /// 終局確定 (`KEY_FINISHED` put) と WS close は **必ず** 実行される。export
+    /// 関連の失敗で finalize 自体を中断してはならない (P0: 対局結果欠損防止)。
     async fn finalize_if_ended(&self, result: &HandleResult) -> Result<()> {
         let HandleOutcome::GameEnded(ref game_result) = result.outcome else {
             return Ok(());
@@ -1361,11 +1444,10 @@ impl GameRoom {
         let code = primary_result_code(game_result).to_owned();
         let ended_at_ms = self.now_ms();
 
-        // 棋譜エクスポートは best-effort：R2 バインディングが設定されていない開発
-        // 環境や一時的な put 失敗で終局処理自体を止めないよう、ログだけ残して続行する。
-        if let Err(e) = self.export_kifu_to_r2(game_result, ended_at_ms).await {
-            console_log!("[GameRoom] kifu export failed: {e:?}");
-        }
+        // R2 export を試行し、失敗 PUT 一覧を集約する。bucket binding 不在 /
+        // serialize 失敗等の「retry しても解決しない致命的失敗」は内部で console_log
+        // し `ExportAttempt::Skipped` で返す (pending 化しない)。
+        let attempt = self.export_kifu_to_r2(game_result, ended_at_ms).await;
 
         // Floodgate 履歴の R2 永続化も同じ best-effort 方針。`ALLOW_FLOODGATE_FEATURES`
         // が立っていなければ何もしない。TCP 側 (`server.rs`) は append 失敗時に
@@ -1375,12 +1457,32 @@ impl GameRoom {
         // `console_log!` のみで吸収するため呼び出し側は `Result` を待たない。
         self.try_persist_floodgate_history(game_result, &code, ended_at_ms).await;
 
+        // export 全成功なら `exported_at_ms` を埋め、retry 経路は不要。
+        // 一部失敗なら `exported_at_ms = None` で書き、後述の pending 経路で
+        // 再 PUT を予約する。「retry できない skip 失敗」も `exported_at_ms = None`
+        // にしておくと観測上は欠損として残る (運用上の手動補修対象)。
+        let exported_at_ms = if attempt.is_complete() {
+            Some(ended_at_ms)
+        } else {
+            None
+        };
         let finished = FinishedState {
             result_code: code,
             ended_at_ms,
+            exported_at_ms,
         };
         self.state.storage().put(KEY_FINISHED, &finished).await?;
+        // grace / agree-timeout / time-up 系の alarm/registry を片付けてから
+        // ExportRetry alarm を張る。順序を逆にすると `delete_grace_alarm_state`
+        // が ExportRetry タグを巻き込んで消す race がある。
         self.delete_grace_alarm_state().await?;
+
+        // export 一部失敗なら pending 永続化 + retry alarm を貼る。pending put /
+        // alarm 書き込みは best-effort で失敗ログのみ残し、`finalize_if_ended` の
+        // 残り処理 (live-games-index 削除 / WS close) を必ず進める (Issue #623 主契約)。
+        if let Some(pending) = attempt.into_pending() {
+            self.schedule_export_retry(pending).await;
+        }
 
         // KEY_FINISHED が確定した後に live-games-index entry を best-effort で
         // 削除する (Issue #549 §4)。「終局 entry も live entry も無い」矛盾
@@ -1408,24 +1510,291 @@ impl GameRoom {
         Ok(())
     }
 
+    /// 終局時 export PUT 失敗の retry を予約する (Issue #623)。
+    ///
+    /// `KEY_EXPORT_PENDING` (本文 + 失敗 key 一覧) と `KEY_PENDING_ALARM_KIND =
+    /// ExportRetry` を put し、`RETRY_DELAYS_SEC[0]` 後に `state.alarm()` を貼る。
+    /// 各 storage 操作の失敗は logfmt で記録した上で吸収する (`finalize_if_ended`
+    /// の残り処理を止めないため)。pending payload が永続化できなければ retry
+    /// 経路は走らないが、その場合でも `exported_at_ms = None` のまま `KEY_FINISHED`
+    /// は確定しているので運用上 export 欠損として観測できる。
+    async fn schedule_export_retry(&self, pending: ExportPendingState) {
+        if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
+            console_log!(
+                "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
+                pending.game_id,
+                e,
+            );
+            return;
+        }
+        if let Err(e) = self
+            .state
+            .storage()
+            .put(KEY_PENDING_ALARM_KIND, &PendingAlarmKind::ExportRetry)
+            .await
+        {
+            console_log!(
+                "[GameRoom] event=export_retry_kind_put_failed game_id={} err={:?}",
+                pending.game_id,
+                e,
+            );
+            return;
+        }
+        let Some(delay_ms) = next_retry_delay_ms(pending.attempt) else {
+            // 最初の予約で `attempt = 0` のため到達しない契約。防御的に log のみ。
+            console_log!(
+                "[GameRoom] event=export_retry_initial_exhausted game_id={} attempt={}",
+                pending.game_id,
+                pending.attempt,
+            );
+            return;
+        };
+        if let Err(e) = self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await {
+            console_log!(
+                "[GameRoom] event=export_retry_alarm_set_failed game_id={} delay_ms={} err={:?}",
+                pending.game_id,
+                delay_ms,
+                e,
+            );
+        } else {
+            console_log!(
+                "[GameRoom] event=export_retry_scheduled game_id={} attempt={} delay_ms={} failed_count={}",
+                pending.game_id,
+                pending.attempt,
+                delay_ms,
+                pending.failed_keys.len(),
+            );
+        }
+    }
+
+    /// `PendingAlarmKind::ExportRetry` で alarm が発火したときの再 PUT 経路 (Issue #623)。
+    ///
+    /// `KEY_EXPORT_PENDING` から保存済の本文 + 失敗 key 一覧を読み、各 key に
+    /// 対して再 PUT を試みる。全成功で `exported_at_ms` を埋めて pending を消し、
+    /// 一部失敗なら `attempt` を進めて次の遅延 (`RETRY_DELAYS_SEC[attempt]`) で
+    /// alarm を再予約する。retry 全消費後は `KEY_PENDING_ALARM_KIND` と alarm を
+    /// 消し、pending entry のみ残置する (運用観測用)。
+    async fn handle_export_retry_alarm(&self) -> Result<()> {
+        let pending: Option<ExportPendingState> =
+            self.state.storage().get(KEY_EXPORT_PENDING).await.ok().flatten();
+        let Some(mut pending) = pending else {
+            // pending が無い (race / 旧 deploy 状態の cleanup) は alarm タグだけ
+            // 片付けて終了する。`KEY_FINISHED` 経路は既に確定済の前提。
+            console_log!("[GameRoom] event=export_retry_no_pending");
+            let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+            let _ = self.state.storage().delete_alarm().await;
+            return Ok(());
+        };
+
+        let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=export_retry_bucket_missing game_id={} attempt={} err={:?}",
+                    pending.game_id,
+                    pending.attempt,
+                    e,
+                );
+                // bucket binding 不在 = config 不正。retry を進めても解決しない
+                // ので alarm を停止し pending は残置 (deploy 修正で再開する想定
+                // だが、本 PR の scope ではここまで)。
+                let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+                let _ = self.state.storage().delete_alarm().await;
+                return Ok(());
+            }
+        };
+
+        // 失敗 key を順に再 PUT。成功した key は `still_failed` に積まない。
+        let mut still_failed: Vec<FailedExportObject> =
+            Vec::with_capacity(pending.failed_keys.len());
+        for failed in pending.failed_keys.drain(..) {
+            let body: Vec<u8> = match failed.body_kind {
+                ExportBodyKind::Csa => pending.csa_text.as_bytes().to_vec(),
+                ExportBodyKind::Meta => pending.meta_body.clone(),
+            };
+            match bucket.put(&failed.key, body).execute().await {
+                Ok(_) => {
+                    console_log!(
+                        "[GameRoom] event=export_retry_put_ok game_id={} key={} attempt={}",
+                        pending.game_id,
+                        failed.key,
+                        pending.attempt,
+                    );
+                }
+                Err(e) => {
+                    console_log!(
+                        "[GameRoom] event=export_retry_put_failed game_id={} key={} attempt={} err={:?}",
+                        pending.game_id,
+                        failed.key,
+                        pending.attempt,
+                        e,
+                    );
+                    still_failed.push(failed);
+                }
+            }
+        }
+
+        if still_failed.is_empty() {
+            // 全成功: pending を消し、`exported_at_ms` を埋め、alarm/タグを片付ける。
+            self.complete_export_retry(&pending).await;
+            return Ok(());
+        }
+
+        // 一部失敗: attempt を進めて次回 alarm を予約する (上限超なら停止)。
+        let next_attempt = pending.attempt.saturating_add(1);
+        pending.failed_keys = still_failed;
+        pending.attempt = next_attempt;
+
+        if is_exhausted(next_attempt) {
+            console_log!(
+                "[GameRoom] event=export_retry_exhausted game_id={} attempt={} remaining={}",
+                pending.game_id,
+                next_attempt,
+                pending.failed_keys.len(),
+            );
+            // pending を最新 attempt で書き直して観測性を保ち、alarm/タグだけ
+            // 停止する。
+            if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
+                console_log!(
+                    "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
+                    pending.game_id,
+                    e,
+                );
+            }
+            let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+            let _ = self.state.storage().delete_alarm().await;
+            return Ok(());
+        }
+
+        if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
+            console_log!(
+                "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
+                pending.game_id,
+                e,
+            );
+            return Ok(());
+        }
+        let Some(delay_ms) = next_retry_delay_ms(next_attempt) else {
+            // is_exhausted で先に return しているので到達しない。
+            return Ok(());
+        };
+        if let Err(e) = self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await {
+            console_log!(
+                "[GameRoom] event=export_retry_alarm_set_failed game_id={} delay_ms={} err={:?}",
+                pending.game_id,
+                delay_ms,
+                e,
+            );
+        } else {
+            console_log!(
+                "[GameRoom] event=export_retry_rescheduled game_id={} attempt={} delay_ms={} failed_count={}",
+                pending.game_id,
+                next_attempt,
+                delay_ms,
+                pending.failed_keys.len(),
+            );
+        }
+        Ok(())
+    }
+
+    /// retry 全成功後の cleanup。pending を消し、`exported_at_ms` を埋め、alarm
+    /// 関連タグを停止する。各失敗は logfmt で吸収する (alarm 経路を Err で抜けて
+    /// retry 自体を破壊しないため)。
+    async fn complete_export_retry(&self, pending: &ExportPendingState) {
+        if let Err(e) = self.state.storage().delete(KEY_EXPORT_PENDING).await {
+            console_log!(
+                "[GameRoom] event=export_pending_delete_failed game_id={} err={:?}",
+                pending.game_id,
+                e,
+            );
+        }
+        let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
+        let _ = self.state.storage().delete_alarm().await;
+
+        // `KEY_FINISHED` の `exported_at_ms` を埋め直す。失敗してもログのみ
+        // (運用観測上、`exported_at_ms = None` のまま retry 完了になるが、
+        // pending 削除済なので二重 export はない)。
+        let now_ms = self.now_ms();
+        match self.state.storage().get::<FinishedState>(KEY_FINISHED).await {
+            Ok(Some(mut finished)) => {
+                finished.exported_at_ms = Some(now_ms);
+                if let Err(e) = self.state.storage().put(KEY_FINISHED, &finished).await {
+                    console_log!(
+                        "[GameRoom] event=export_retry_finished_update_failed game_id={} err={:?}",
+                        pending.game_id,
+                        e,
+                    );
+                } else {
+                    console_log!(
+                        "[GameRoom] event=export_retry_completed game_id={} attempt={}",
+                        pending.game_id,
+                        pending.attempt,
+                    );
+                }
+            }
+            Ok(None) => {
+                console_log!(
+                    "[GameRoom] event=export_retry_finished_missing game_id={}",
+                    pending.game_id,
+                );
+            }
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=export_retry_finished_load_failed game_id={} err={:?}",
+                    pending.game_id,
+                    e,
+                );
+            }
+        }
+    }
+
     /// R2 バケットに CSA V2 形式の棋譜を書き出す。
     ///
     /// キー体系: `YYYY/MM/DD/<game_id>.csa`。TCP 版 `FileKifuStorage` と同一
     /// 構造なので、外部のレート集計や HTML レンダリングなどの後段処理は R2 を
     /// mount するだけで TCP 版と同じパスで読める。
+    ///
+    /// 戻り値 [`ExportAttempt`] (Issue #623):
+    /// - `Complete`: 4 オブジェクト (csa 本文 / by-id / meta / games-index) すべて
+    ///   PUT 成功 (= retry 不要)。
+    /// - `Pending(state)`: 1 つ以上 PUT 失敗で retry 用の本文 + 失敗 key 一覧を
+    ///   保持。`finalize_if_ended` は本値を `KEY_EXPORT_PENDING` に永続化する。
+    /// - `Skipped`: bucket binding 不在 / `load_moves` 失敗 / SFEN 不正 / serialize
+    ///   失敗等の「retry しても解決しない致命的失敗」。本関数内で `console_log!`
+    ///   で吸収済みなので呼び出し側は何もしない (`exported_at_ms = None` だけ残る)。
+    ///
+    /// 本関数は `Result` ではなく `ExportAttempt` を返す。R2 PUT 失敗を上位に
+    /// 伝播させると `finalize_if_ended` が中断し WS close / `KEY_FINISHED` put が
+    /// 抜ける退行になるため、すべての失敗を構造化して返す契約 (Codex 設計
+    /// レビュー v2 反映)。
     async fn export_kifu_to_r2(
         &self,
         game_result: &rshogi_csa_server::game::result::GameResult,
         ended_at_ms: u64,
-    ) -> Result<()> {
+    ) -> ExportAttempt {
         use rshogi_csa_server::record::kifu::{KifuMove, KifuRecord};
 
         let cfg = match self.config.borrow().as_ref() {
             Some(c) => c.clone(),
-            None => return Ok(()),
+            None => {
+                // PersistedConfig 未確定 = AGREE 前の致命的経路で finalize に
+                // 入った race。CSA 本文を組み立てる材料がないので skip する。
+                console_log!("[GameRoom] event=export_skip reason=config_missing");
+                return ExportAttempt::Skipped;
+            }
         };
 
-        let moves_rows = self.load_moves().await?;
+        let moves_rows = match self.load_moves().await {
+            Ok(rows) => rows,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=export_skip game_id={} reason=load_moves:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return ExportAttempt::Skipped;
+            }
+        };
         // MoveRow は raw CSA 行（例: `+7776FU,T3`）を保持しているので、トークン部のみを
         // 抽出して `KifuMove` に変換する。消費時間は at_ms 差分から秒に丸める。
         let mut kifu_moves: Vec<KifuMove> = Vec::with_capacity(moves_rows.len());
@@ -1453,6 +1822,21 @@ impl GameRoom {
         let start_str = format_csa_datetime(cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms));
         let end_str = format_csa_datetime(ended_at_ms);
 
+        let initial_position = match cfg.initial_sfen.as_deref() {
+            Some(sfen) => match position_section_from_sfen(sfen) {
+                Ok(p) => p,
+                Err(reason) => {
+                    console_log!(
+                        "[GameRoom] event=export_skip game_id={} reason=invalid_sfen:{}",
+                        cfg.game_id,
+                        reason,
+                    );
+                    return ExportAttempt::Skipped;
+                }
+            },
+            None => standard_initial_position_block(),
+        };
+
         let record = KifuRecord {
             game_id: GameId::new(cfg.game_id.clone()),
             black: PlayerName::new(cfg.black_handle.clone()),
@@ -1463,42 +1847,65 @@ impl GameRoom {
             time_section,
             // Game_Summary の position_section と同じ SFEN 由来のブロックを使う。
             // 三点一致契約 (CoreRoom / Summary / 棋譜 initial_position) の R2 側。
-            initial_position: match cfg.initial_sfen.as_deref() {
-                Some(sfen) => position_section_from_sfen(sfen).map_err(Error::RustError)?,
-                None => standard_initial_position_block(),
-            },
+            initial_position,
             moves: kifu_moves,
             result: game_result.clone(),
         };
         let text = record.build_v2();
 
         let date_path = format_date_path(cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms));
-        let key = format!("{date_path}/{}.csa", cfg.game_id);
+        let date_key = format!("{date_path}/{}.csa", cfg.game_id);
         let by_id_key = kifu_by_id_object_key(&cfg.game_id);
 
-        let bucket = self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING)?;
-        bucket.put(&key, text.as_bytes().to_vec()).execute().await?;
-        bucket.put(&by_id_key, text.as_bytes().to_vec()).execute().await?;
-        console_log!("[GameRoom] kifu exported to R2 key='{key}'");
+        let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(b) => b,
+            Err(e) => {
+                console_log!(
+                    "[GameRoom] event=export_skip game_id={} reason=bucket_binding:{:?}",
+                    cfg.game_id,
+                    e,
+                );
+                return ExportAttempt::Skipped;
+            }
+        };
+
+        // 4 つの PUT を集約する。各 PUT は独立して試行し、失敗した key だけを
+        // `failed_keys` に積む。CSA 本文 PUT が失敗しても meta / index PUT は試す
+        // (Issue #623: best-effort 全 put → retry で残りを順送り)。
+        let mut failed_keys: Vec<FailedExportObject> = Vec::with_capacity(4);
+        let csa_bytes = text.as_bytes().to_vec();
+        for (key, label) in [
+            (date_key.as_str(), "date_key"),
+            (by_id_key.as_str(), "by_id_key"),
+        ] {
+            if let Err(e) = bucket.put(key, csa_bytes.clone()).execute().await {
+                console_log!(
+                    "[GameRoom] event=export_put_failed game_id={} {}={} err={:?}",
+                    cfg.game_id,
+                    label,
+                    key,
+                    e,
+                );
+                failed_keys.push(FailedExportObject {
+                    key: key.to_owned(),
+                    body_kind: ExportBodyKind::Csa,
+                });
+            }
+        }
 
         // viewer 配信 API 用の正準メタ (`kifu-by-id/<id>.meta.json`) と派生
-        // インデックス (`games-index/<inv>-<id>.json`) を続けて put する。
-        // CSA 本文 + by-id put は既に成功しているため、以降の put のいかなる
-        // 失敗も `finalize_if_ended` を Err にしてはならない (best-effort)。
-        // すべての失敗を `if let Err` で吸収して Ok(()) で抜ける。`?` は意図的
-        // に使わない。
+        // インデックス (`games-index/<inv>-<id>.json`)。
         //
         // 書き込み順序 (Issue #551 設計 v3 §1):
         //   1. csa 本文 / by-id (上で完了)
         //   2. `kifu-by-id/<id>.meta.json` — backfill / orphan sweep の真の判定
-        //      キー (primary)。csa 成功直後に書く。
+        //      キー (primary)。
         //   3. `games-index/<inv>-<id>.json` — meta から派生する一覧索引
         //      (secondary)。failure 時は backfill cron が meta を起点に再生成する。
         //
         // `source` 判定は `live-games-index/` の対局開始時 entry と完全に揃える
         // ため、`games_index::resolve_index_source` 共通 helper に集約済 (Issue
-        // #549 設計 v3 §3)。`floodgate-history/` への put 成否ではなく「Floodgate
-        // 環境設定下で起きた終局」を表す semantics は同 helper の契約に従う。
+        // #549 設計 v3 §3)。
         let source = resolve_index_source(&self.env);
 
         let (result_kind, end_reason) = classify_result(game_result);
@@ -1529,13 +1936,20 @@ impl GameRoom {
                     cfg.game_id,
                     e,
                 );
-                return Ok(());
+                // CSA 本文 PUT は試行済 (failed_keys に積まれているかも) なので、
+                // CSA 部分だけ pending 化する。meta/index は serialize できない以上
+                // retry でも解決しないので失敗 key として積まない (= 観測上は
+                // exported_at_ms=None のまま残る)。
+                return ExportAttempt::from_failed_keys(
+                    cfg.game_id.clone(),
+                    ended_at_ms,
+                    text,
+                    Vec::new(),
+                    failed_keys,
+                );
             }
         };
 
-        // (2) `kifu-by-id/<id>.meta.json` — primary。failure は backfill 経路で
-        // 復元できないので observable に log は残すが、後段の games-index put は
-        // 引き続き試行する (現行 best-effort 一連 put 方針を維持。設計 v2 §1)。
         let meta_key = kifu_by_id_meta_key(&cfg.game_id);
         if let Err(e) = bucket.put(&meta_key, body.clone()).execute().await {
             console_log!(
@@ -1544,9 +1958,12 @@ impl GameRoom {
                 meta_key,
                 e,
             );
+            failed_keys.push(FailedExportObject {
+                key: meta_key.clone(),
+                body_kind: ExportBodyKind::Meta,
+            });
         }
 
-        // (3) `games-index/<inv>-<id>.json` — secondary。
         let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
             Ok(k) => k,
             Err(e) => {
@@ -1555,19 +1972,38 @@ impl GameRoom {
                     cfg.game_id,
                     e,
                 );
-                return Ok(());
+                // games-index key 生成失敗は retry 不可。pending には CSA / meta
+                // のみ残す。
+                return ExportAttempt::from_failed_keys(
+                    cfg.game_id.clone(),
+                    ended_at_ms,
+                    text,
+                    body,
+                    failed_keys,
+                );
             }
         };
-        if let Err(e) = bucket.put(&index_key, body).execute().await {
+        if let Err(e) = bucket.put(&index_key, body.clone()).execute().await {
             console_log!(
                 "[GameRoom] event=games_index_put_failed game_id={} inv_key={} err={:?}",
                 cfg.game_id,
                 index_key,
                 e,
             );
+            failed_keys.push(FailedExportObject {
+                key: index_key.clone(),
+                body_kind: ExportBodyKind::Meta,
+            });
         }
 
-        Ok(())
+        if failed_keys.is_empty() {
+            console_log!(
+                "[GameRoom] event=export_complete game_id={} key={}",
+                cfg.game_id,
+                date_key,
+            );
+        }
+        ExportAttempt::from_failed_keys(cfg.game_id.clone(), ended_at_ms, text, body, failed_keys)
     }
 
     /// Floodgate 履歴 1 件を `FLOODGATE_HISTORY_BUCKET` に永続化する。`ALLOW_FLOODGATE_FEATURES`
@@ -2367,6 +2803,11 @@ impl GameRoom {
         let finished = FinishedState {
             result_code: "agree_timeout".to_owned(),
             ended_at_ms: self.now_ms(),
+            // R2 棋譜 export を行わない経路なので `exported_at_ms` を立てる
+            // 必要はない。`Some(now_ms)` にすると「export 完了」と誤って観測
+            // されるため、`None` のまま (= retry 待ちでもなく export 不要の
+            // 終了ステータス) を意味する値にしておく。
+            exported_at_ms: None,
         };
         self.state.storage().put(KEY_FINISHED, &finished).await?;
         // alarm 種別タグを片付ける (alarm は既に発火済なので `delete_alarm` は

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -155,20 +155,24 @@ const KEY_EXPORT_PENDING: &str = "export_pending";
 /// 予約 / 何もしない を分岐する。
 #[derive(Debug)]
 enum ExportAttempt {
-    /// すべての PUT が成功した (`exported_at_ms = Some` を埋められる)。
+    /// 4 オブジェクト (csa 本文 / by-id / meta / games-index) すべて PUT 成功
+    /// (`exported_at_ms = Some` を埋められる)。
     Complete,
     /// 1 つ以上 PUT 失敗で retry 必要。本 variant が持つ
     /// [`ExportPendingState`] を `KEY_EXPORT_PENDING` に永続化する。
     Pending(Box<ExportPendingState>),
     /// retry しても解決しない致命的失敗 (bucket binding 不在 / load_moves 失敗 /
-    /// SFEN 不正 / serialize 失敗等)。`exported_at_ms = None` のままで観測上は
-    /// 欠損として残るが、それ以外の処理は通常通り進める。
+    /// SFEN 不正 / serialize 失敗 / games_index_key 生成失敗等)。
+    /// `exported_at_ms = None` のままで観測上は欠損として残るが、それ以外の処理
+    /// は通常通り進める。retry できるはずの CSA PUT 失敗が混在している場合は
+    /// `Pending` に倒し、CSA 部分だけ retry する (Codex code review #2 反映)。
     Skipped,
 }
 
 impl ExportAttempt {
-    /// `failed_keys` の長さで `Complete` / `Pending` を選ぶ helper。
-    fn from_failed_keys(
+    /// 4 オブジェクト全てが PUT 試行済の経路から呼ぶコンストラクタ。
+    /// `failed_keys` が空 = 全成功 → `Complete`、非空 → `Pending`。
+    fn from_full_attempt(
         game_id: String,
         ended_at_ms: u64,
         csa_text: String,
@@ -177,6 +181,36 @@ impl ExportAttempt {
     ) -> Self {
         if failed_keys.is_empty() {
             ExportAttempt::Complete
+        } else {
+            ExportAttempt::Pending(Box::new(ExportPendingState {
+                game_id,
+                ended_at_ms,
+                csa_text,
+                meta_body,
+                failed_keys,
+                attempt: 0,
+            }))
+        }
+    }
+
+    /// 4 オブジェクト中いずれかを **PUT 試行できなかった** 経路から呼ぶ
+    /// コンストラクタ (Codex code review #2 反映)。serialize 失敗 /
+    /// games_index_key 生成失敗で meta or index PUT が抜けたケースなど。
+    ///
+    /// retry 可能な CSA PUT 失敗が `failed_keys` にあれば `Pending` に倒し、
+    /// CSA 部分だけ再試行する (`exported_at_ms` は引き続き `None`)。
+    /// `failed_keys` が空 (= 4 中 N 個 PUT 成功 / 残りは retry 不能で skip) なら
+    /// `Skipped` を返し、`Complete` を**絶対に返さない** (= `exported_at_ms` を
+    /// 埋めない)。
+    fn from_partial_attempt(
+        game_id: String,
+        ended_at_ms: u64,
+        csa_text: String,
+        meta_body: Vec<u8>,
+        failed_keys: Vec<FailedExportObject>,
+    ) -> Self {
+        if failed_keys.is_empty() {
+            ExportAttempt::Skipped
         } else {
             ExportAttempt::Pending(Box::new(ExportPendingState {
                 game_id,
@@ -1936,11 +1970,11 @@ impl GameRoom {
                     cfg.game_id,
                     e,
                 );
-                // CSA 本文 PUT は試行済 (failed_keys に積まれているかも) なので、
-                // CSA 部分だけ pending 化する。meta/index は serialize できない以上
-                // retry でも解決しないので失敗 key として積まない (= 観測上は
-                // exported_at_ms=None のまま残る)。
-                return ExportAttempt::from_failed_keys(
+                // CSA 本文 PUT は試行済 (failed_keys に積まれているかも) だが、
+                // meta/index は serialize 失敗で本経路で PUT 試行できていない。
+                // 4 PUT 全成功にはなり得ないので `from_partial_attempt` で
+                // `Complete` を絶対返さない経路に倒す (Codex code review #2)。
+                return ExportAttempt::from_partial_attempt(
                     cfg.game_id.clone(),
                     ended_at_ms,
                     text,
@@ -1973,8 +2007,9 @@ impl GameRoom {
                     e,
                 );
                 // games-index key 生成失敗は retry 不可。pending には CSA / meta
-                // のみ残す。
-                return ExportAttempt::from_failed_keys(
+                // のみ残す。index PUT が抜けるため `from_partial_attempt` で
+                // `Complete` 経路を塞ぐ (Codex code review #2)。
+                return ExportAttempt::from_partial_attempt(
                     cfg.game_id.clone(),
                     ended_at_ms,
                     text,
@@ -2003,7 +2038,9 @@ impl GameRoom {
                 date_key,
             );
         }
-        ExportAttempt::from_failed_keys(cfg.game_id.clone(), ended_at_ms, text, body, failed_keys)
+        // 4 オブジェクトすべての PUT を試行できた経路。`failed_keys` の中身で
+        // `Complete` / `Pending` を選ぶ。
+        ExportAttempt::from_full_attempt(cfg.game_id.clone(), ended_at_ms, text, body, failed_keys)
     }
 
     /// Floodgate 履歴 1 件を `FLOODGATE_HISTORY_BUCKET` に永続化する。`ALLOW_FLOODGATE_FEATURES`
@@ -2595,9 +2632,19 @@ impl GameRoom {
             self.core.borrow_mut().as_mut().map(|core| core.force_abnormal(role.to_core()));
         if let Some(result) = result_opt {
             self.dispatch_broadcasts(&result.broadcasts).await?;
+            // `finalize_if_ended` は内部で `delete_grace_alarm_state` を呼んだ後に
+            // ExportRetry alarm を貼り直す可能性がある (Issue #623)。ここで重ねて
+            // `delete_grace_alarm_state` を呼ぶと `KEY_PENDING_ALARM_KIND=ExportRetry`
+            // を巻き込んで削除してしまい、retry alarm が発火しても kind が `None`
+            // で `KEY_FINISHED` ガードに弾かれる。`finalize_if_ended` の責務に任せ
+            // 再 cleanup しない。
             self.finalize_if_ended(&result).await?;
+        } else {
+            // force_abnormal が呼べなかった (CoreRoom 不在 = cold start 後 replay
+            // 失敗等) ケースでは finalize_if_ended が走らないので、grace registry /
+            // alarm tag は本経路で明示的に片付ける必要がある。
+            self.delete_grace_alarm_state().await?;
         }
-        self.delete_grace_alarm_state().await?;
         Ok(())
     }
 

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -36,6 +36,10 @@ pub mod client_kind;
 pub(crate) mod backfill;
 pub mod config;
 pub mod datetime;
+// `export_retry` は finalize_if_ended / handle_export_retry_alarm から消費される
+// 純粋ロジック (RETRY_DELAYS_SEC 等)。ホスト target でも cargo test から到達できる
+// ように `pub mod` で公開する。
+pub mod export_retry;
 pub mod floodgate_history;
 pub mod games_index;
 pub mod live_games_index;

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -70,12 +70,72 @@ pub struct PersistedConfig {
 }
 
 /// 終局フラグ。一度 `Some` になったらその DO は同じ対局を二度開始しない。
+///
+/// `exported_at_ms` は R2 棋譜エクスポートが全 PUT 完了した時刻 (UNIX epoch ms)。
+/// `None` のあいだは終局はしているが R2 への書き出しが未完了で、Issue #623 の
+/// `KEY_EXPORT_PENDING` + `PendingAlarmKind::ExportRetry` 経路で再試行されている
+/// ことを示す。`#[serde(default)]` で旧 schema (本フィールド導入前の cold start
+/// snapshot) との互換を保つ。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinishedState {
     /// CSA 終局コード（`#RESIGN` / `#TIME_UP` / `#ILLEGAL_MOVE` 等）。
     pub(crate) result_code: String,
     /// 終局確定時刻（UNIX エポック ミリ秒）。
     pub(crate) ended_at_ms: u64,
+    /// R2 棋譜エクスポート完了時刻。`None` は export 未完了 (retry 待ち) を示す。
+    #[serde(default)]
+    pub(crate) exported_at_ms: Option<u64>,
+}
+
+/// 終局時の R2 export PUT のうち失敗した key を表すエントリ (Issue #623)。
+///
+/// `body_kind` で再 PUT 時に乗せる本文 (`csa` = CSA 本文 / `meta` = JSON meta) を
+/// 区別する。`key` 文字列の prefix 推測ではなく明示分類にするのは、key 形式の
+/// 将来変更に対する堅牢性のため (例: `kifu-by-id/` と `games-index/` で同 JSON
+/// body だが path が違う、`YYYY/MM/DD/` と `kifu-by-id/` で同 CSA 本文だが path
+/// が違う、といった対応関係を struct で固定する)。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailedExportObject {
+    /// R2 オブジェクトキー (例: `2026/05/08/g1.csa` / `kifu-by-id/g1.meta.json`)。
+    pub(crate) key: String,
+    /// 再 PUT 時に本文として乗せる種別。
+    pub(crate) body_kind: ExportBodyKind,
+}
+
+/// `FailedExportObject` の本文種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportBodyKind {
+    /// CSA V2 形式の棋譜本文 (`YYYY/MM/DD/<id>.csa` / `kifu-by-id/<id>.csa`)。
+    Csa,
+    /// `GamesIndexEntry` を serialize した JSON (`kifu-by-id/<id>.meta.json` /
+    /// `games-index/<inv>-<id>.json`)。
+    Meta,
+}
+
+/// 終局時に R2 export の一部または全部が失敗したときに DO storage へ残す
+/// retry payload (Issue #623)。
+///
+/// CSA 本文 / meta JSON は finalize 時点で計算済のものをそのまま保存する
+/// (cold start 後でも `load_moves` を呼び直さず再 PUT できる)。`failed_keys`
+/// は初回 finalize 時点で実際に PUT 失敗した key のみが残り、retry alarm が
+/// 順番に再 PUT する。`attempt` は再試行回数で、`RETRY_DELAYS_SEC` の上限を
+/// 超えたら exhausted として alarm を停止する (= pending entry は残置し
+/// 観測性を保つ)。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportPendingState {
+    /// 対局 ID。観測ログ / cold start 後の retry 経路の primary key。
+    pub(crate) game_id: String,
+    /// 終局確定時刻。`exported_at_ms` を埋める際に再利用する。
+    pub(crate) ended_at_ms: u64,
+    /// 再 PUT 用の CSA V2 棋譜本文 (`Csa` 種別の `failed_keys` に流す)。
+    pub(crate) csa_text: String,
+    /// 再 PUT 用の meta JSON 本文 (`Meta` 種別の `failed_keys` に流す)。
+    pub(crate) meta_body: Vec<u8>,
+    /// 残っている再 PUT 対象 key 一覧 (初回 finalize で失敗したもの)。
+    pub(crate) failed_keys: Vec<FailedExportObject>,
+    /// これまでの retry 回数 (0 = 初回 finalize 後の最初の alarm が attempt=0)。
+    pub(crate) attempt: u32,
 }
 
 /// `moves` SQL テーブル 1 行分。replay / alarm で使う。
@@ -623,11 +683,59 @@ mod tests {
         let original = FinishedState {
             result_code: "#RESIGN".to_owned(),
             ended_at_ms: PLAY_STARTED_AT_MS + 9_000,
+            exported_at_ms: Some(PLAY_STARTED_AT_MS + 9_500),
         };
         let json = serde_json::to_string(&original).unwrap();
         let restored: FinishedState = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.result_code, original.result_code);
         assert_eq!(restored.ended_at_ms, original.ended_at_ms);
+        assert_eq!(restored.exported_at_ms, original.exported_at_ms);
+    }
+
+    /// 旧 schema (本 `exported_at_ms` フィールド導入前) で書かれた DO storage
+    /// 値が `#[serde(default)]` 経由で `None` として deserialize できることを
+    /// 固定する (Issue #623)。本契約が壊れると cold start 後の DO で
+    /// `load_finished` が失敗し、終局済 DO が新規 LOGIN を受け付ける退行になる。
+    #[test]
+    fn finished_state_deserializes_when_exported_at_ms_absent() {
+        let json = r##"{
+            "result_code": "#RESIGN",
+            "ended_at_ms": 1234567890
+        }"##;
+        let restored: FinishedState = serde_json::from_str(json).unwrap();
+        assert_eq!(restored.result_code, "#RESIGN");
+        assert_eq!(restored.ended_at_ms, 1_234_567_890);
+        assert_eq!(restored.exported_at_ms, None);
+    }
+
+    /// `ExportPendingState` の round-trip 固定 (Issue #623)。`failed_keys` の
+    /// `body_kind` が `csa` / `meta` の lower snake で wire される (rename_all)
+    /// ことも本テストで実装契約として固定する。
+    #[test]
+    fn export_pending_state_round_trips_through_serde_json() {
+        let original = ExportPendingState {
+            game_id: "lobby-1".to_owned(),
+            ended_at_ms: PLAY_STARTED_AT_MS + 10_000,
+            csa_text: "V2.2\nN+alice\nN-bob\n".to_owned(),
+            meta_body: br#"{"game_id":"lobby-1"}"#.to_vec(),
+            failed_keys: vec![
+                FailedExportObject {
+                    key: "2026/05/08/lobby-1.csa".to_owned(),
+                    body_kind: ExportBodyKind::Csa,
+                },
+                FailedExportObject {
+                    key: "kifu-by-id/lobby-1.meta.json".to_owned(),
+                    body_kind: ExportBodyKind::Meta,
+                },
+            ],
+            attempt: 1,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        // wire 形式で `body_kind` が snake_case の lower 表現になっていること
+        assert!(json.contains(r#""body_kind":"csa""#), "json={json}");
+        assert!(json.contains(r#""body_kind":"meta""#), "json={json}");
+        let restored: ExportPendingState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, original);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -186,6 +186,12 @@ pub enum PendingAlarmKind {
     /// 未 put) のため、`force_abnormal` ではなく `abort_pending_match_with_error`
     /// + `KEY_FINISHED` セット相当の経路で部屋を解放する (Issue #600)。
     AgreeTimeout,
+    /// R2 棋譜 export PUT 失敗の retry (Issue #623)。`KEY_FINISHED` 確定後の
+    /// alarm 経路。終局時に PUT 失敗したオブジェクトキーを `KEY_EXPORT_PENDING`
+    /// に保存しておき、本タグで `handle_export_retry_alarm` を駆動して再 PUT する。
+    /// 終局後発火の特殊性から `alarm()` 入口で `KEY_FINISHED` ガード**より前**に
+    /// 分岐させる必要がある (他種別と異なり「終局済 DO」での発火が正常経路)。
+    ExportRetry,
 }
 
 /// 再接続 grace が有効化されている (`grace > 0`) のときのみ対局者ごとの
@@ -410,6 +416,11 @@ mod tests {
         let restored: PendingAlarmKind =
             serde_json::from_str(&s).expect("deserialize GraceExpired");
         assert_eq!(restored, PendingAlarmKind::GraceExpired);
+        // Issue #623: ExportRetry も同形式で wire 互換であること。
+        let s =
+            serde_json::to_string(&PendingAlarmKind::ExportRetry).expect("serialize ExportRetry");
+        let restored: PendingAlarmKind = serde_json::from_str(&s).expect("deserialize ExportRetry");
+        assert_eq!(restored, PendingAlarmKind::ExportRetry);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -267,6 +267,7 @@ mod tests {
         let finished = FinishedState {
             result_code: "#RESIGN".to_owned(),
             ended_at_ms: 1_010_000,
+            exported_at_ms: Some(1_010_500),
         };
         let lines = build_spectator_snapshot(SpectatorSnapshotInput {
             config: &cfg,
@@ -303,6 +304,7 @@ mod tests {
         let finished = FinishedState {
             result_code: "#TIME_UP".to_owned(),
             ended_at_ms: 1_010_000,
+            exported_at_ms: None,
         };
         let lines = build_spectator_snapshot(SpectatorSnapshotInput {
             config: &cfg,


### PR DESCRIPTION
## Summary

終局時の R2 export PUT (CSA 本文 / by-id / meta / games-index) が一時障害で失敗しても、対局結果が恒久欠損しないよう DO storage 上の outbox + alarm retry 経路を追加する (Issue #623, P0)。

- `FinishedState` に `exported_at_ms: Option<u64>` を追加し、終局確定と export 完了を観測上で分離
- `ExportPendingState` (CSA 本文 + meta JSON + 失敗 key 一覧) を `KEY_EXPORT_PENDING` に保存し、cold start 後でも `load_moves` を呼び直さず再 PUT できる
- `PendingAlarmKind::ExportRetry` を追加。`alarm()` 入口で **`KEY_FINISHED` ガードよりも前**に分岐させ、終局済 DO でも retry が発火する
- 指数 backoff (30/60/120/300/600s) で 5 回まで再試行、消費後は alarm 停止し pending を残置 (運用観測用)
- `finalize_if_ended` は export 失敗で **絶対に Err を返さない**。終局確定 + WS close は必ず実行される (P0 主契約)

## 設計レビュー履歴 (Codex local)

- v1 (`task-mowumui9-saocld`): **REQUEST_CHANGES**
  - `KEY_FINISHED` 後の alarm dispatch が `KEY_FINISHED` ガードに弾かれる
  - pending payload に再 PUT 可能な full body を保存すべき
  - 指数 backoff 推奨
- v2 (`task-mowvozcv-rqz0pu`): **COMMENT** (= near-approve)
  - `body_kind` を明示分岐 (Csa/Meta) すべき
  - storage put は `?` で finalize_if_ended を落とさないこと
  - 上記すべて反映済

## コードレビュー履歴 (Codex local)

- v1 (`task-mowwa0px-2dosna`): **REQUEST_CHANGES**
  1. `handle_grace_expired_alarm` の重複 `delete_grace_alarm_state()` が `finalize_if_ended` の設定した `KEY_PENDING_ALARM_KIND=ExportRetry` を巻き込み削除する bug
  2. serialize / `games_index_key` 失敗時に `failed_keys` 空 → `Complete` を返してしまう bug (`exported_at_ms` を誤って埋める)
- v2 (`task-mowwg5yt-urf6jz`): **APPROVE**
  - 両 bug の修正を確認済

## 検証結果

- `cargo test -p rshogi-csa-server-workers --tests`: 288 件すべて pass
- `cargo clippy --tests -p rshogi-csa-server-workers`: warning 0
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`: 通過
- `cargo fmt --check`: pass

## 主要 commit hash

- `d3ab145f` — feat: 主実装
- `d59ebdf4` — fix: Codex code review v1 指摘 (grace_expired race + Complete 誤判定)

## Out of scope (P1 followup, 別 issue)

- cron による R2 全文 sweep / `export-pending/` outbox marker
- `kifu-by-id/<id>.csa` から meta を再構築する admin repair job
- `KEY_EXPORT_PENDING` 残置を観測する admin endpoint

## Test plan

- [x] unit: `ExportPendingState` serde round-trip / `body_kind` snake_case wire 固定
- [x] unit: `FinishedState.exported_at_ms` 旧 schema 互換 (`#[serde(default)]`)
- [x] unit: `RETRY_DELAYS_SEC` 列固定 + `next_retry_delay_ms` / `is_exhausted` の境界
- [x] unit: `PendingAlarmKind::ExportRetry` の serde round-trip
- [x] wasm32 build 通過
- [ ] staging 上で実機動作確認 (PR merge 後 deploy で `wrangler tail` 確認)

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)