### PR TITLE
chore(csa-client): CLI flag idiom + SpawnOptions struct + test assert (#619, #656)

### DIFF
--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -33,6 +33,25 @@ const STDERR_JOIN_WAIT_GRACEFUL: Duration = Duration::from_millis(500);
 /// `Drop` (fast path) で stderr reader thread の join を待つ最大時間。
 const STDERR_JOIN_WAIT_DROP: Duration = Duration::from_millis(100);
 
+/// [`UsiEngine::spawn`] の起動オプション。
+///
+/// `bool` 引数 (ponder / stderr_passthrough) の意味取り違えを防ぐため、起動時に
+/// 個別意味を持つ flag は本 struct に集約する。`Default` impl は意図的に提供しない:
+/// 全 call site が値を明示することで「どの flag が ON か」を呼び出し位置で読めるようにする
+/// (TOML/CLI から渡された値をそのまま透過するのが既存運用)。
+pub struct SpawnOptions {
+    /// USI engine に ponder (相手手番中思考) を許可するか。CSA `--ponder` / TOML
+    /// `game.ponder` から伝搬される。
+    pub ponder: bool,
+    /// USI handshake (`usi` → `usiok` → `isready` → `readyok`) を待つ最大時間。
+    /// CSA TOML `engine.startup_timeout_sec` から伝搬される。
+    pub startup_timeout: Duration,
+    /// engine stderr を csa_client log に多重化するか。true のとき stderr reader
+    /// thread は ring buffer に push するのに加えて各行を `log::info!("[engine stderr] ...")`
+    /// に転送する。debug / 初期セットアップ用で、通常稼働時は false。
+    pub stderr_passthrough: bool,
+}
+
 /// USIエンジンプロセス
 pub struct UsiEngine {
     child: Child,
@@ -113,17 +132,21 @@ pub type InfoCallback<'a> = dyn FnMut(&SearchInfo, &str) + 'a;
 /// 利用例:
 ///
 /// ```ignore
-/// use rshogi_csa_client::{run_game_session_with_events, UsiEngine, UsiEngineDriver};
+/// use rshogi_csa_client::{
+///     run_game_session_with_events, SpawnOptions, UsiEngine, UsiEngineDriver,
+/// };
 ///
 /// // 1. 具象 `UsiEngine` をそのまま渡す
-/// let mut engine = UsiEngine::spawn(&path, &options, ponder, timeout, false)?;
+/// let opts = SpawnOptions { ponder, startup_timeout: timeout, stderr_passthrough: false };
+/// let mut engine = UsiEngine::spawn(&path, &options, opts)?;
 /// run_game_session_with_events(&config, &mut conn, &mut engine, shutdown, &mut sink)?;
 ///
 /// // 2. dyn dispatch で複数 engine 実装を切り替える
+/// let opts = SpawnOptions { ponder, startup_timeout: timeout, stderr_passthrough: false };
 /// let mut engine: Box<dyn UsiEngineDriver> = if use_builtin {
 ///     Box::new(BuiltinEngine::new(...))
 /// } else {
-///     Box::new(UsiEngine::spawn(&path, &options, ponder, timeout, false)?)
+///     Box::new(UsiEngine::spawn(&path, &options, opts)?)
 /// };
 /// run_game_session_with_events(&config, &mut conn, &mut *engine, shutdown, &mut sink)?;
 /// ```
@@ -250,17 +273,19 @@ pub struct SearchInfo {
 impl UsiEngine {
     /// USIエンジンを起動し、初期化する。
     ///
-    /// `stderr_passthrough` が true のとき、stderr reader thread は ring buffer
-    /// に push するのに加えて各行を `log::info!("[engine stderr] {line}")` で
-    /// csa_client log に多重化する。debug / 初期セットアップ時に engine 出力を
-    /// 即時確認するための機能で、通常稼働時は false を渡す。
+    /// `opts` は [`SpawnOptions`] を参照: ponder 可否 / handshake timeout /
+    /// stderr passthrough を集約する。bool 2 個 (ponder と stderr_passthrough) を
+    /// 位置引数で並べると call site で意味が逆転して気付きにくいため struct で渡す。
     pub fn spawn(
         path: &Path,
         options: &HashMap<String, toml::Value>,
-        ponder: bool,
-        timeout: Duration,
-        stderr_passthrough: bool,
+        opts: SpawnOptions,
     ) -> Result<Self> {
+        let SpawnOptions {
+            ponder,
+            startup_timeout: timeout,
+            stderr_passthrough,
+        } = opts;
         let mut cmd = Command::new(path);
         // 子プロセスを独立したプロセスグループで起動
         #[cfg(unix)]

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -82,7 +82,9 @@ pub mod transport;
 // `use rshogi_csa_client::{CsaClientConfig, UsiEngine, ...}` で参照できる。
 // 型名は実装側に合わせており、別名は付与しない。
 pub use config::CsaClientConfig;
-pub use engine::{BestMoveResult, SearchInfo, SearchOutcome, UsiEngine, UsiEngineDriver};
+pub use engine::{
+    BestMoveResult, SearchInfo, SearchOutcome, SpawnOptions, UsiEngine, UsiEngineDriver,
+};
 pub use event::Event;
 pub use events::{
     BestMoveEvent, DisconnectReason, GameEndEvent, GameEndReason, MoveEvent, MovePlayer,

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -19,10 +19,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
-use clap::{Parser, ValueEnum};
+use clap::{ArgAction, Parser, ValueEnum};
 
 use rshogi_csa_client::config::CsaClientConfig;
-use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::events::SessionOutcome;
 use rshogi_csa_client::jsonl::write_game_jsonl;
 use rshogi_csa_client::protocol::{CsaConnection, GameResult};
@@ -173,8 +173,39 @@ struct Cli {
     /// engine stderr を csa_client log に多重化する (`log::info!("[engine stderr] ...")`).
     /// debug / 初期セットアップ用。default は false (既存の ring buffer 末尾捕捉のみ)。
     /// TOML の `engine.stderr_passthrough` でも指定可。
-    #[arg(long, default_missing_value = "true", num_args = 0..=1)]
-    engine_stderr_passthrough: Option<bool>,
+    ///
+    /// `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` のペアで指定する。
+    /// 両方指定された場合は clap の `overrides_with` により最後に指定された方が勝つ。
+    /// 旧形式 `--engine-stderr-passthrough=false` は廃止 (`--no-engine-stderr-passthrough` を使用)。
+    #[arg(
+        long = "engine-stderr-passthrough",
+        action = ArgAction::SetTrue,
+        overrides_with = "no_engine_stderr_passthrough_flag"
+    )]
+    engine_stderr_passthrough_flag: bool,
+
+    /// `--engine-stderr-passthrough` を打ち消す。TOML 値を CLI から明示的に false 上書きする
+    /// 用途で使用する。両方指定された場合は最後に指定された方が勝つ。
+    #[arg(
+        long = "no-engine-stderr-passthrough",
+        action = ArgAction::SetTrue,
+        overrides_with = "engine_stderr_passthrough_flag"
+    )]
+    no_engine_stderr_passthrough_flag: bool,
+}
+
+/// CLI で `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` のいずれかが
+/// 明示指定された場合のみ `Some(bool)` を返す。未指定時は `None` を返し、TOML/環境変数の
+/// 値をそのまま温存する。`overrides_with` のため両方指定後に最後に勝った方の flag のみ
+/// true になる前提。
+fn cli_engine_stderr_passthrough(cli: &Cli) -> Option<bool> {
+    match (cli.engine_stderr_passthrough_flag, cli.no_engine_stderr_passthrough_flag) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        // (false, false): 未指定 / (true, true): clap の overrides_with の挙動上ありえないが
+        // 念のため None で TOML 値を温存する。
+        _ => None,
+    }
 }
 
 fn main() -> Result<()> {
@@ -333,9 +364,11 @@ fn spawn_engine(config: &CsaClientConfig) -> Result<UsiEngine> {
     UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(config.engine.startup_timeout_sec),
-        config.engine.stderr_passthrough,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(config.engine.startup_timeout_sec),
+            stderr_passthrough: config.engine.stderr_passthrough,
+        },
     )
 }
 
@@ -737,7 +770,7 @@ fn apply_cli_overrides(config: &mut CsaClientConfig, cli: &Cli) {
     if let Some(ref dir) = cli.jsonl_out {
         config.record.jsonl_out = Some(dir.clone());
     }
-    if let Some(passthrough) = cli.engine_stderr_passthrough {
+    if let Some(passthrough) = cli_engine_stderr_passthrough(cli) {
         config.engine.stderr_passthrough = passthrough;
     }
     if let Some(ref opts) = cli.options {
@@ -854,7 +887,8 @@ mod tests {
             record_dir: None,
             jsonl_out: None,
             options: None,
-            engine_stderr_passthrough: None,
+            engine_stderr_passthrough_flag: false,
+            no_engine_stderr_passthrough_flag: false,
         }
     }
 
@@ -1084,5 +1118,60 @@ mod tests {
     fn should_attempt_reconnect_returns_none_when_result_is_not_interrupted() {
         let outcome = session_outcome_with(GameResult::Win, Some("a".repeat(32)));
         assert!(should_attempt_reconnect(&outcome, false).is_none());
+    }
+
+    // ───────────────────────────────────────────────
+    // `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` の clap
+    // パース挙動を pin する。`overrides_with` ペアで「未指定 = None」「肯定 / 否定 =
+    // Some(bool)」「両指定 = 最後勝ち」を表現するため、helper の判定が clap の
+    // 振る舞いと整合することを確認する。
+    // ───────────────────────────────────────────────
+
+    /// 引数解析用の minimal arg 列を組み立てる。Cli は `argv[0]` (= 実行ファイル名) と
+    /// その後に flag を取るため、binary 名 placeholder + 任意の追加引数で組み立てる。
+    fn parse_cli(extra: &[&str]) -> Cli {
+        let mut argv: Vec<&str> = vec!["rshogi-csa-client"];
+        argv.extend_from_slice(extra);
+        Cli::try_parse_from(argv).expect("clap parse")
+    }
+
+    #[test]
+    fn cli_engine_stderr_passthrough_unset_returns_none() {
+        let cli = parse_cli(&[]);
+        assert_eq!(cli_engine_stderr_passthrough(&cli), None);
+    }
+
+    #[test]
+    fn cli_engine_stderr_passthrough_flag_only_returns_some_true() {
+        let cli = parse_cli(&["--engine-stderr-passthrough"]);
+        assert_eq!(cli_engine_stderr_passthrough(&cli), Some(true));
+    }
+
+    #[test]
+    fn cli_engine_stderr_passthrough_no_flag_only_returns_some_false() {
+        let cli = parse_cli(&["--no-engine-stderr-passthrough"]);
+        assert_eq!(cli_engine_stderr_passthrough(&cli), Some(false));
+    }
+
+    /// `--engine-stderr-passthrough --no-engine-stderr-passthrough` の順で指定された場合は
+    /// `overrides_with` により後勝ちで `Some(false)` になる。
+    #[test]
+    fn cli_engine_stderr_passthrough_flag_then_no_flag_returns_some_false() {
+        let cli = parse_cli(&[
+            "--engine-stderr-passthrough",
+            "--no-engine-stderr-passthrough",
+        ]);
+        assert_eq!(cli_engine_stderr_passthrough(&cli), Some(false));
+    }
+
+    /// `--no-engine-stderr-passthrough --engine-stderr-passthrough` の順で指定された場合は
+    /// `overrides_with` により後勝ちで `Some(true)` になる。
+    #[test]
+    fn cli_engine_stderr_passthrough_no_flag_then_flag_returns_some_true() {
+        let cli = parse_cli(&[
+            "--no-engine-stderr-passthrough",
+            "--engine-stderr-passthrough",
+        ]);
+        assert_eq!(cli_engine_stderr_passthrough(&cli), Some(true));
     }
 }

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -18,10 +18,20 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
-use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::event::Event;
 
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// 既存テストの 5 引数 spawn 呼び出しを集約するためのヘルパ。`stderr_passthrough` 以外は
+/// fixture でほぼ固定値のため、testless な call site を増やさず簡潔に書けるようにする。
+fn spawn_opts(stderr_passthrough: bool) -> SpawnOptions {
+    SpawnOptions {
+        ponder: false,
+        startup_timeout: SPAWN_TIMEOUT,
+        stderr_passthrough,
+    }
+}
 
 static SCRIPT_SEQ: AtomicU64 = AtomicU64::new(0);
 static TMPDIR_LOCK: Mutex<()> = Mutex::new(());
@@ -85,7 +95,7 @@ exit 1
 "#;
     let path = write_mock_script("dying_immediate", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
+    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -116,8 +126,8 @@ exit 1
 "#;
     let path = write_mock_script("dying_after_handshake", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let mut engine = UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false)
-        .expect("初回 handshake は成功する想定");
+    let mut engine =
+        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
     // engine プロセスは usiok+readyok を返した直後に exit。
     // new_game() は usinewgame + isready を送る。BrokenPipe か recv Disconnected
     // のいずれかから engine_exited_error() に合流する。
@@ -153,7 +163,7 @@ exit 1
     let path = write_mock_script("dying_during_go", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let mut engine =
-        UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false).expect("初回 handshake は成功");
+        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功");
     engine.new_game().expect("new_game は成功");
     let shutdown = AtomicBool::new(false);
     let (_tx, server_rx) = mpsc::channel::<Event>();
@@ -190,7 +200,7 @@ exit 1
     let path = write_mock_script("long_stderr_line", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // initialize は usiok 後 isready を送る → engine 死亡で error
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
+    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 送信前後で engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -220,7 +230,7 @@ exit 1
 "#;
     let path = write_mock_script("crlf_stderr", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
+    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -251,7 +261,7 @@ exit 1
 "#;
     let path = write_mock_script("empty_line_not_eof", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, false) {
+    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -283,15 +293,19 @@ exit 1
 "#;
     let path = write_mock_script("passthrough_smoke", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    // 第 5 引数 stderr_passthrough = true。
-    let err = match UsiEngine::spawn(&path, &opts, false, SPAWN_TIMEOUT, true) {
+    // SpawnOptions { stderr_passthrough: true } で起動。
+    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(true)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
     let msg = format!("{err:#}");
     assert_diagnostic_prefix(&msg, &path);
+    // STDERR_TAIL_MAX_LINES = 64 なので 2 行の `passthrough line A` / `passthrough line B`
+    // は cap 落ちしない前提で両方とも diagnostic msg に含まれていることを厳格 assert する。
+    // ring buffer cap が 1 行に縮まる将来変更があれば本 assertion は再検討が必要 (mock の
+    // 出力行数 / cap のいずれかを揃える)。
     assert!(
-        msg.contains("passthrough line A") || msg.contains("passthrough line B"),
-        "passthrough=true でも ring buffer に末尾が積まれているはず: {msg}"
+        msg.contains("passthrough line A") && msg.contains("passthrough line B"),
+        "passthrough=true でも ring buffer に末尾 (line A / line B 両方) が積まれているはず: {msg}"
     );
 }

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -24,7 +24,7 @@ use std::thread;
 use std::time::Duration;
 
 use rshogi_csa_client::config::CsaClientConfig;
-use rshogi_csa_client::engine::UsiEngine;
+use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::events::{
     DisconnectReason, MovePlayer, ReconnectState, SearchInfoEmitPolicy, SessionError,
     SessionEventSink, SessionProgress, SinkError,
@@ -279,9 +279,11 @@ fn fresh_session_emits_expected_event_sequence() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -362,9 +364,11 @@ fn resumed_session_emits_resumed_event_and_no_history_replay() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -432,9 +436,11 @@ fn resumed_state_last_sfen_matches_summary_position_section() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -549,9 +555,11 @@ fn fatal_sink_triggers_clean_closure_and_returns_sink_aborted() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -627,9 +635,11 @@ fn external_shutdown_emits_shutdown_disconnected_and_returns_shutdown_error() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -698,9 +708,11 @@ fn external_shutdown_observed_through_legacy_run_game_session() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 
@@ -751,9 +763,11 @@ fn nonfatal_sink_does_not_invoke_on_error_and_session_continues() {
     let mut engine = UsiEngine::spawn(
         &config.engine.path,
         &config.engine.options,
-        config.game.ponder,
-        Duration::from_secs(5),
-        false,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
     )
     .expect("spawn engine");
 


### PR DESCRIPTION
## Summary

PR #615 review 残 3 件を統合実装し、`#619` と `#656` をまとめて close する。

- **#619 #1: CLI flag を `--flag` / `--no-flag` ペアに変更**
  `--engine-stderr-passthrough` の `default_missing_value = \"true\"` + `num_args = 0..=1` を、`clap::ArgAction::SetTrue` + `overrides_with` ペアに置き換え clap 4.x 標準 idiom に揃える。`cli_engine_stderr_passthrough()` helper で 4 状態 ((false,false) / (true,false) / (false,true) / (true,true)) を `Option<bool>` に正規化し、TOML override 互換 (未指定 = TOML 値温存) を維持。

- **#656: `UsiEngine::spawn()` を `SpawnOptions` struct に切り出し**
  bool 2 引数 (`ponder` + `stderr_passthrough`) を `SpawnOptions { ponder, startup_timeout, stderr_passthrough }` に集約し、引数取り違え (silent な意味逆転) を防ぐ。`Default` impl は意図的に提供せず、全 call site (main + tests 14 箇所) で値を明示する。

- **#619 #3 + #656: `stderr_passthrough_preserves_ring_buffer` の `||` を `&&` に**
  「line A と line B のいずれか」を「両方とも」に厳格化。`STDERR_TAIL_MAX_LINES = 64` cap 落ち時の保守コメントを残す。

## Breaking changes

- 旧形式 `--engine-stderr-passthrough=false` は廃止 (代替: `--no-engine-stderr-passthrough`)。
- `UsiEngine::spawn()` の public signature 変更 (in-tree consumer は同 PR で全更新済み)。

## Codex review

- 設計レビュー: COMMENT (overrides_with id typo / CLI parse 単体テスト追加要望) → 反映済み
- コードレビュー: APPROVE (`ignore` doc の import 補足のみ軽微指摘 → 対応済み)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p rshogi-csa-client --tests --all-targets` 警告 0
- [x] `cargo test -p rshogi-csa-client` 全 pass (CLI parse 5 件含む)
  - `engine_stderr_diagnostic` は稀に `Text file busy (ETXTBSY)` flake (本変更前から発生する mock script race)。`--test-threads=1` で安定。
- [x] `cargo check -p tools` (別 `UsiEngine` 型のため signature 変更による破壊なし)

Closes #619
Closes #656

Generated with [Claude Code](https://claude.com/claude-code)