### PR TITLE
feat(csa-server-workers): admin 認可 foundation (admin_auth + ADMIN_API_TOKEN) (#560)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/admin_auth.rs
+++ b/crates/rshogi-csa-server-workers/src/admin_auth.rs
@@ -1,0 +1,165 @@
+//! `ADMIN_API_TOKEN` ベースの admin 認可 helper (Floodgate audit
+//! [#560](https://github.com/SH11235/rshogi/issues/560) で導入)。
+//!
+//! Worker 側で admin 権限を要求する経路 (将来の HTTP admin endpoint /
+//! [#621](https://github.com/SH11235/rshogi/issues/621) の WS 内 `%%ADMIN <token>`
+//! 等) が共通で踏む token 検証ロジックを 1 か所に集約する。token は Cloudflare
+//! secret (`wrangler secret put ADMIN_API_TOKEN`) として配置し、Worker は
+//! `env.var(ConfigKeys::ADMIN_API_TOKEN)` で読み出す (Cloudflare 仕様で
+//! var / secret は同 namespace)。
+//!
+//! # 設計の論点
+//!
+//! - **HMAC は採用しない**: replay 対策や canonical string 設計を伴うと運用
+//!   レビューコストが膨らむ一方で、Cloudflare 側で TLS / IP 制限 / Cloudflare
+//!   Access (Zero Trust) を併用すれば static token + constant-time 比較で十分。
+//! - **constant-time 比較**: token は攻撃者が当てにいく対象なので、長さ一致時の
+//!   byte 比較は短絡せず [`subtle::ConstantTimeEq`] で xor を畳み込む。長さ自体
+//!   は公開情報として扱う (秘密の長さを `len()` で leak しない契約に依存しない)。
+//! - **fail-closed 既定**: secret 未設定 (Cloudflare secret 未登録 / local dev で
+//!   placeholder 空文字) は [`AdminAuthError::TokenNotConfigured`] を返し、
+//!   呼び出し側は 404 / 拒否で fail-closed する。攻撃者に「admin 機能は
+//!   存在するが token 未設定」を知らせない方針。
+//!
+//! # ホスト target テスト方針
+//!
+//! [`verify_token_str`] は `worker::Env` 依存を持たない pure helper として実装し、
+//! ホスト target でも `cargo test` から到達できる。Worker runtime に閉じる
+//! [`verify_admin_token_str`] は wasm32 でのみコンパイルし、env 取得経路の
+//! 配線確認は `wrangler dev` / staging deploy 経由で行う。
+
+use subtle::ConstantTimeEq;
+
+#[cfg(target_arch = "wasm32")]
+use worker::Env;
+
+#[cfg(target_arch = "wasm32")]
+use crate::config::ConfigKeys;
+
+/// admin 認可が失敗する原因を網羅する error enum。
+///
+/// 各 variant は呼び出し側の surface (HTTP endpoint / WS admin command 等) で
+/// 適切な拒否応答に翻訳される想定。本 crate 内では Worker `Response` への変換
+/// helper を提供しない (HTTP admin endpoint が登場した時点で呼び出し側に書く)。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdminAuthError {
+    /// `ADMIN_API_TOKEN` secret が未設定 (Cloudflare secret 未登録、または
+    /// local dev で placeholder が空文字)。fail-closed 経路で扱う。
+    TokenNotConfigured,
+    /// 提供された credential が空 (Authorization header 欠落 / `%%ADMIN` の
+    /// token 部が空)。
+    MissingCredential,
+    /// token 比較が一致しなかった (長さ不一致 / 内容不一致)。
+    TokenMismatch,
+}
+
+/// 提供 token と secret token を constant-time 比較する pure helper。
+///
+/// 判定順:
+/// 1. `secret` が空 → [`AdminAuthError::TokenNotConfigured`] (秘密未設定)。
+/// 2. `provided` が空 → [`AdminAuthError::MissingCredential`] (credential 欠落)。
+/// 3. 長さ不一致 → [`AdminAuthError::TokenMismatch`] (長さは公開情報扱い)。
+/// 4. 同長 → [`subtle::ConstantTimeEq`] で 1 byte ごと xor を畳み込み、
+///    `Choice` の bool 化まで定数時間で完了する。
+///
+/// 両者空のケースは「秘密未設定」を優先 error として返す (404 fail-closed を
+/// 意図する呼び出し側で credential 欠落と区別したい場合に備える)。
+pub fn verify_token_str(provided: &str, secret: &str) -> Result<(), AdminAuthError> {
+    if secret.is_empty() {
+        return Err(AdminAuthError::TokenNotConfigured);
+    }
+    if provided.is_empty() {
+        return Err(AdminAuthError::MissingCredential);
+    }
+    let p = provided.as_bytes();
+    let s = secret.as_bytes();
+    if p.len() != s.len() {
+        return Err(AdminAuthError::TokenMismatch);
+    }
+    let eq: bool = p.ct_eq(s).into();
+    if eq {
+        Ok(())
+    } else {
+        Err(AdminAuthError::TokenMismatch)
+    }
+}
+
+/// Worker 環境変数から `ADMIN_API_TOKEN` を読み出し、提供 token と
+/// constant-time 比較する。WS 内 admin command (`%%ADMIN <token>` 等) を
+/// 想定した Worker hook。
+///
+/// secret 未登録時は [`AdminAuthError::TokenNotConfigured`]、`provided` が空文字
+/// 時は [`AdminAuthError::MissingCredential`] を返す。詳細は
+/// [`verify_token_str`] の判定順を参照。
+#[cfg(target_arch = "wasm32")]
+pub fn verify_admin_token_str(provided: &str, env: &Env) -> Result<(), AdminAuthError> {
+    let secret = env
+        .var(ConfigKeys::ADMIN_API_TOKEN)
+        .ok()
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    verify_token_str(provided, &secret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_when_provided_equals_secret() {
+        assert!(verify_token_str("rshogi-ops-abcd1234", "rshogi-ops-abcd1234").is_ok());
+    }
+
+    #[test]
+    fn rejects_one_byte_diff_as_mismatch() {
+        assert_eq!(
+            verify_token_str("rshogi-ops-abcd1234", "rshogi-ops-abcd1235"),
+            Err(AdminAuthError::TokenMismatch),
+        );
+    }
+
+    #[test]
+    fn rejects_length_diff_as_mismatch() {
+        // 短い provided / 長い provided どちらも TokenMismatch にする (長さ leak は
+        // 仕様で許容)。
+        assert_eq!(
+            verify_token_str("short", "rshogi-ops-abcd1234"),
+            Err(AdminAuthError::TokenMismatch),
+        );
+        assert_eq!(
+            verify_token_str("rshogi-ops-abcd1234-extra", "rshogi-ops-abcd1234"),
+            Err(AdminAuthError::TokenMismatch),
+        );
+    }
+
+    #[test]
+    fn empty_secret_yields_token_not_configured() {
+        assert_eq!(
+            verify_token_str("rshogi-ops-abcd1234", ""),
+            Err(AdminAuthError::TokenNotConfigured),
+        );
+    }
+
+    #[test]
+    fn empty_provided_yields_missing_credential_when_secret_set() {
+        assert_eq!(
+            verify_token_str("", "rshogi-ops-abcd1234"),
+            Err(AdminAuthError::MissingCredential),
+        );
+    }
+
+    #[test]
+    fn both_empty_prefers_token_not_configured() {
+        // 両者空時は「秘密未設定」を優先。404 fail-closed 経路で「endpoint 自体
+        // を隠す」運用を素直に実現できるようにする。
+        assert_eq!(verify_token_str("", ""), Err(AdminAuthError::TokenNotConfigured));
+    }
+
+    #[test]
+    fn whitespace_provided_is_compared_verbatim() {
+        // trim はしない。secret 側に空白を含む値を許す運用余地を残す
+        // (上位レイヤで trim したい場合は呼び出し側で行う契約)。
+        assert!(verify_token_str("  spaced  ", "  spaced  ").is_ok());
+        assert_eq!(verify_token_str("spaced", "  spaced  "), Err(AdminAuthError::TokenMismatch),);
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/admin_auth.rs
+++ b/crates/rshogi-csa-server-workers/src/admin_auth.rs
@@ -16,10 +16,16 @@
 //! - **constant-time 比較**: token は攻撃者が当てにいく対象なので、長さ一致時の
 //!   byte 比較は短絡せず [`subtle::ConstantTimeEq`] で xor を畳み込む。長さ自体
 //!   は公開情報として扱う (秘密の長さを `len()` で leak しない契約に依存しない)。
-//! - **fail-closed 既定**: secret 未設定 (Cloudflare secret 未登録 / local dev で
-//!   placeholder 空文字) は [`AdminAuthError::TokenNotConfigured`] を返し、
-//!   呼び出し側は 404 / 拒否で fail-closed する。攻撃者に「admin 機能は
-//!   存在するが token 未設定」を知らせない方針。
+//! - **fail-closed 既定**: secret 未設定 (Cloudflare secret 未配置、または
+//!   local dev で意図的に `ADMIN_API_TOKEN` を空文字へ書き換え) は
+//!   [`AdminAuthError::TokenNotConfigured`] を返し、呼び出し側は 404 / 拒否で
+//!   fail-closed する。攻撃者に「admin 機能は存在するが token 未設定」を
+//!   知らせない方針。`wrangler.toml.example` の placeholder
+//!   (`local-dev-admin-token-placeholder`) は他の `LOCAL_DEV_ONLY_VARS_KEYS`
+//!   (例: `ADMIN_HANDLE = "admin"`) と同じく **local dev で friction なく
+//!   admin 経路を通電させる** ための既知 dev token であり、production / staging
+//!   へは絶対に持ち込まない (`tests/wrangler_environment_toml_consistency.rs`
+//!   が混入を gate)。
 //!
 //! # ホスト target テスト方針
 //!

--- a/crates/rshogi-csa-server-workers/src/admin_auth.rs
+++ b/crates/rshogi-csa-server-workers/src/admin_auth.rs
@@ -34,6 +34,8 @@
 //! [`verify_admin_token_str`] は wasm32 でのみコンパイルし、env 取得経路の
 //! 配線確認は `wrangler dev` / staging deploy 経由で行う。
 
+use std::fmt;
+
 use subtle::ConstantTimeEq;
 
 #[cfg(target_arch = "wasm32")]
@@ -58,6 +60,21 @@ pub enum AdminAuthError {
     /// token 比較が一致しなかった (長さ不一致 / 内容不一致)。
     TokenMismatch,
 }
+
+impl fmt::Display for AdminAuthError {
+    /// 運用ログ向けの簡潔表記。token 値や提供長など秘密に依存する情報は
+    /// 含めない (logging 経路で leak しない契約)。
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::TokenNotConfigured => "admin token not configured",
+            Self::MissingCredential => "admin credential missing",
+            Self::TokenMismatch => "admin token mismatch",
+        };
+        f.write_str(msg)
+    }
+}
+
+impl std::error::Error for AdminAuthError {}
 
 /// 提供 token と secret token を constant-time 比較する pure helper。
 ///
@@ -99,11 +116,14 @@ pub fn verify_token_str(provided: &str, secret: &str) -> Result<(), AdminAuthErr
 /// [`verify_token_str`] の判定順を参照。
 #[cfg(target_arch = "wasm32")]
 pub fn verify_admin_token_str(provided: &str, env: &Env) -> Result<(), AdminAuthError> {
-    let secret = env
-        .var(ConfigKeys::ADMIN_API_TOKEN)
-        .ok()
-        .map(|v| v.to_string())
-        .unwrap_or_default();
+    // `Err(_)` は「キー未設定」と Worker ランタイム側内部エラーを両方含むが、
+    // どちらも fail-closed の `TokenNotConfigured` 経路に集約してよい (admin
+    // 機能の存在 leak を防ぐ)。後続で worker::console_error! や tracing を
+    // 挟みたい場合は `Err(e)` arm で hook できるよう match 形式で固定する。
+    let secret = match env.var(ConfigKeys::ADMIN_API_TOKEN) {
+        Ok(v) => v.to_string(),
+        Err(_) => String::new(),
+    };
     verify_token_str(provided, &secret)
 }
 
@@ -167,5 +187,14 @@ mod tests {
         // (上位レイヤで trim したい場合は呼び出し側で行う契約)。
         assert!(verify_token_str("  spaced  ", "  spaced  ").is_ok());
         assert_eq!(verify_token_str("spaced", "  spaced  "), Err(AdminAuthError::TokenMismatch),);
+    }
+
+    #[test]
+    fn display_omits_token_or_credential_values() {
+        // 運用ログで Display を経由して error を文字列化したときに、token 値や
+        // credential 長さなど秘密に依存する情報が含まれないことを固定する。
+        assert_eq!(format!("{}", AdminAuthError::TokenNotConfigured), "admin token not configured",);
+        assert_eq!(format!("{}", AdminAuthError::MissingCredential), "admin credential missing");
+        assert_eq!(format!("{}", AdminAuthError::TokenMismatch), "admin token mismatch");
     }
 }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -90,6 +90,21 @@ impl ConfigKeys {
     /// `env.var(ConfigKeys::ADMIN_HANDLE)` で var/secret どちらも読む（Cloudflare
     /// 仕様で同じ namespace に展開される）。
     pub const ADMIN_HANDLE: &'static str = "ADMIN_HANDLE";
+    /// 管理 API トークン (Floodgate audit https://github.com/SH11235/rshogi/issues/560
+    /// 由来)。HTTP admin endpoint や WS 内 admin command (後続の
+    /// https://github.com/SH11235/rshogi/issues/621 で消費) の認可基盤として
+    /// [`crate::admin_auth`] から参照される 1 本の static API token。HMAC は
+    /// overkill 判定 (replay/canonical string 設計コスト > 利得)、Cloudflare
+    /// Access (Zero Trust) は運用層で別管理する。
+    ///
+    /// **production / staging**: Cloudflare secret として
+    /// `wrangler secret put ADMIN_API_TOKEN` で配置する (rotation 手順は
+    /// `docs/csa-server/admin_auth.md` 参照)。secret 経由なので OSS repo にも
+    /// CI ログにも値は残らない。
+    /// **local dev**: `wrangler.toml.example` の `[vars]` に placeholder を残し、
+    /// `wrangler dev` を friction なく動かせるようにする。Worker code は
+    /// `env.var(ConfigKeys::ADMIN_API_TOKEN)` で var/secret どちらも読む。
+    pub const ADMIN_API_TOKEN: &'static str = "ADMIN_API_TOKEN";
     /// 切断時の再接続猶予秒数。`0` または未設定なら再接続プロトコルを無効化し、
     /// WebSocket close を即時 `#ABNORMAL` に流す（保守的既定）。`> 0` を指定する
     /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
@@ -188,7 +203,8 @@ impl ConfigKeys {
     /// `wrangler.toml.example` には `SHARED_PUBLIC_VARS_KEYS ∪ LOCAL_DEV_ONLY_VARS_KEYS`
     /// 全件を `[vars]` として記載することで、新規メンバーが `cp wrangler.toml.example
     /// wrangler.toml && wrangler dev` で即動作確認できる friction レス運用を維持する。
-    pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] = &[Self::ADMIN_HANDLE];
+    pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] =
+        &[Self::ADMIN_HANDLE, Self::ADMIN_API_TOKEN];
 
     /// **deploy 時に CI から runtime 注入される** `[vars]` キーの網羅列挙
     /// ([`Self::DEPLOYED_SHA`] 等)。`SHARED_PUBLIC_VARS_KEYS` / `LOCAL_DEV_ONLY_VARS_KEYS`

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -22,6 +22,7 @@ compile_error!(
      the wasm32 runtime cannot use tokio multi-threaded primitives."
 );
 
+pub mod admin_auth;
 pub mod attachment;
 // `client_kind` は `X-Client` ヘッダ値を運用ログ向けに正規化する純粋ロジック。
 // `viewer_api` (wasm32 専用) から呼ばれるが、本体は I/O 非依存なのでホスト

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -179,3 +179,11 @@ CHALLENGE_TTL_SEC = "3600"
 #   設定: `vp exec wrangler secret put ADMIN_HANDLE --config wrangler.production.toml`
 #   確認: `vp exec wrangler secret list --config wrangler.production.toml`
 #   詳細は `docs/csa-server/deployment.md` §2.5 参照。
+#
+# - ADMIN_API_TOKEN: HTTP admin endpoint や WS 内 admin command (`%%ADMIN <token>`
+#   等、後続 https://github.com/SH11235/rshogi/issues/621 で消費) の認可基盤として
+#   `crate::admin_auth` から参照される 1 本の static API token (Floodgate audit
+#   https://github.com/SH11235/rshogi/issues/560 由来)。
+#   設定: `vp exec wrangler secret put ADMIN_API_TOKEN --config wrangler.production.toml`
+#   確認: `vp exec wrangler secret list --config wrangler.production.toml`
+#   rotation / token 生成手順は `docs/csa-server/admin_auth.md` 参照。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -180,3 +180,11 @@ CHALLENGE_TTL_SEC = "600"
 #   設定: `vp exec wrangler secret put ADMIN_HANDLE --config wrangler.staging.toml`
 #   確認: `vp exec wrangler secret list --config wrangler.staging.toml`
 #   詳細は `docs/csa-server/deployment.md` 参照。
+#
+# - ADMIN_API_TOKEN: HTTP admin endpoint や WS 内 admin command の認可基盤として
+#   `crate::admin_auth` から参照される 1 本の static API token (Floodgate audit
+#   https://github.com/SH11235/rshogi/issues/560 由来)。production と異なる値で
+#   分離する運用は ADMIN_HANDLE と同じ。
+#   設定: `vp exec wrangler secret put ADMIN_API_TOKEN --config wrangler.staging.toml`
+#   確認: `vp exec wrangler secret list --config wrangler.staging.toml`
+#   rotation / token 生成手順は `docs/csa-server/admin_auth.md` 参照。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -119,6 +119,12 @@ BYOYOMI_MIN = "1"
 CLOCK_PRESETS = "[]"
 # `%%SETBUOY` / `%%DELETEBUOY` を許可する運営ハンドル（LOGIN の handle 部分）。
 ADMIN_HANDLE = "admin"
+# admin 認可基盤 (HTTP admin endpoint / WS 内 admin command で共用される
+# static API token、https://github.com/SH11235/rshogi/issues/560)。
+# production / staging では `wrangler secret put ADMIN_API_TOKEN` で配置するため
+# 本テンプレートには placeholder のみを置く。local dev で admin 経路を通電させる
+# 場合のみ実値を埋める運用 (rotation 手順は `docs/csa-server/admin_auth.md` 参照)。
+ADMIN_API_TOKEN = "local-dev-admin-token-placeholder"
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "0"

--- a/docs/csa-server/README.md
+++ b/docs/csa-server/README.md
@@ -11,6 +11,7 @@
 ## 設計 / 運用 (Workers)
 
 - [`deployment.md`](deployment.md) — Cloudflare Workers の staging / production 構築・運用 runbook。
+- [`admin_auth.md`](admin_auth.md) — admin 認可 (`ADMIN_API_TOKEN`) の生成・登録・rotation 手順 ([#560](https://github.com/SH11235/rshogi/issues/560))。
 - [`viewer_access_control.md`](viewer_access_control.md) — viewer / spectate API の access control (Origin allowlist / kill-switch) 運用。
 - [`lobby_design.md`](lobby_design.md) — LobbyDO + マッチングの詳細設計 (`/ws/lobby`、`MATCHED` 通知、queue 戦略)。
 - [`lobby_e2e_runbook.md`](lobby_e2e_runbook.md) — Lobby マッチング対局を実機 staging で回す E2E 運用手順。

--- a/docs/csa-server/admin_auth.md
+++ b/docs/csa-server/admin_auth.md
@@ -47,6 +47,10 @@ head -c 32 /dev/urandom | xxd -p -c 64
 
 ## 3. 登録 (初回 / rotation 共通)
 
+`vp` は本リポの開発者環境で `pnpm exec` 相当を担う wrapper (詳細は
+[`docs/csa-server/deployment.md`](deployment.md) §1 参照、`vp exec wrangler X`
+と `pnpm exec wrangler X` は等価)。`vp` が無い環境では `pnpm exec` で読み替えてよい。
+
 `vp exec wrangler login` を済ませた後で、対象環境の toml を指定して
 `wrangler secret put` を実行する。
 
@@ -69,13 +73,16 @@ Worker code は `env.var(ConfigKeys::ADMIN_API_TOKEN)` で参照する (var / se
 旧 token grace 期間は持たない設計のため、以下の順序で実施する:
 
 1. 新 token を §2 の手順で生成。
-2. `wrangler secret put ADMIN_API_TOKEN --config wrangler.<env>.toml` で上書き
-   (旧 token は即時無効化される)。
+2. `wrangler secret put ADMIN_API_TOKEN --config wrangler.<env>.toml` を実行。
+   **実行が成功した瞬間に Cloudflare 側で旧 token は即時無効化される (猶予期間
+   なし)**。Worker は本 secret を `env.var()` で都度参照するため、追加の deploy
+   は不要 (次の HTTP/WS リクエストから新 token のみが有効)。
 3. 利用側 (運用 client / CI / cron 等) の保管値を新 token に差し替える。
+   **手順 2 と 3 の間は admin 経路がすべて `PERMISSION_DENIED` を返す**ため、
+   ラグを最小化する。
 4. 1 局 / 1 endpoint 通電して動作確認 (例: HTTP admin endpoint の 200、または
-   WS 内 admin command が `OK` を返す)。
+   WS 内 admin command が `##[ADMIN] OK` を返す)。
 
-旧 token grace を持たないため **手順 2 と 3 のラグを最小化** する。
 複数オペレータが旧 token を保持している運用なら、rotation 直前に共有チャネル
 (Slack 等) でアナウンスし、即時切替できる体制を整える。
 

--- a/docs/csa-server/admin_auth.md
+++ b/docs/csa-server/admin_auth.md
@@ -25,13 +25,16 @@ Floodgate audit ([#560](https://github.com/SH11235/rshogi/issues/560)) で導入
 ## 2. token 生成
 
 256bit (32 byte) 以上の URL-safe random を推奨。OSS repo に値が混入しない経路
-で生成する。例 (どれを使ってもよい):
+で生成する。例 (どれを使ってもよい、いずれも 32 byte = 256bit のエントロピー):
 
 ```bash
-# openssl
-openssl rand -base64 33 | tr -d '/+=' | head -c 43
+# openssl (64 文字の hex、長さが固定で読みやすい)
+openssl rand -hex 32
 
-# Python
+# openssl (URL-safe base64、'+' '/' を '-' '_' に置換、padding を除去)
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+
+# Python (URL-safe base64、約 43 文字)
 python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
 
 # /dev/urandom + xxd

--- a/docs/csa-server/admin_auth.md
+++ b/docs/csa-server/admin_auth.md
@@ -1,0 +1,113 @@
+# admin 認可 (`ADMIN_API_TOKEN`) 運用ガイド
+
+Floodgate audit ([#560](https://github.com/SH11235/rshogi/issues/560)) で導入
+した admin 認可基盤の運用手順。HTTP admin endpoint と WS 内 admin command
+(後続 [#621](https://github.com/SH11235/rshogi/issues/621) で消費) の両方が
+共通の `ADMIN_API_TOKEN` secret を踏む。
+
+本ドキュメントは「token をどう作って Cloudflare に登録し、どう rotate するか」
+の運用部分に閉じる。コード側の検証ロジック仕様は
+[`crate::admin_auth`](../../crates/rshogi-csa-server-workers/src/admin_auth.rs)
+の docstring を参照。
+
+## 1. 設計サマリ
+
+| 項目 | 採用案 | 理由 |
+|---|---|---|
+| 認可方式 | static API token | replay 対策や canonical string 設計が必要な HMAC は overkill |
+| 配置 | Cloudflare secret (`wrangler secret put ADMIN_API_TOKEN`) | OSS repo / CI ログ / `wrangler.<env>.toml` に値が残らない |
+| 比較 | [`subtle::ConstantTimeEq`] による constant-time | timing leak で token の brute force 加速を防ぐ |
+| Cloudflare Access | 別管理 (運用層) | コード変更なしで IP / SSO 制限を上乗せできる |
+| 旧 token grace | 持たない (1 token のみ valid) | rotation の窓を最短化、bookkeeping を排除 |
+
+[`subtle::ConstantTimeEq`]: https://docs.rs/subtle/latest/subtle/trait.ConstantTimeEq.html
+
+## 2. token 生成
+
+256bit (32 byte) 以上の URL-safe random を推奨。OSS repo に値が混入しない経路
+で生成する。例 (どれを使ってもよい):
+
+```bash
+# openssl
+openssl rand -base64 33 | tr -d '/+=' | head -c 43
+
+# Python
+python3 -c 'import secrets; print(secrets.token_urlsafe(32))'
+
+# /dev/urandom + xxd
+head -c 32 /dev/urandom | xxd -p -c 64
+```
+
+短い token (16 文字未満等) や辞書語ベースの token は brute force の標的に
+なるため避ける。staging と production は **必ず別の値** にして、staging で
+漏れた token が production に通用しない分離を保つ。
+
+## 3. 登録 (初回 / rotation 共通)
+
+`vp exec wrangler login` を済ませた後で、対象環境の toml を指定して
+`wrangler secret put` を実行する。
+
+```bash
+cd crates/rshogi-csa-server-workers
+
+# staging
+vp exec wrangler secret put ADMIN_API_TOKEN --config wrangler.staging.toml
+
+# production (staging とは別値)
+vp exec wrangler secret put ADMIN_API_TOKEN --config wrangler.production.toml
+```
+
+プロンプトに値を入力 (echo されない)。Cloudflare 側で encrypted at rest され、
+Worker code は `env.var(ConfigKeys::ADMIN_API_TOKEN)` で参照する (var / secret
+は同 namespace に展開される Cloudflare 仕様)。
+
+## 4. rotation 手順
+
+旧 token grace 期間は持たない設計のため、以下の順序で実施する:
+
+1. 新 token を §2 の手順で生成。
+2. `wrangler secret put ADMIN_API_TOKEN --config wrangler.<env>.toml` で上書き
+   (旧 token は即時無効化される)。
+3. 利用側 (運用 client / CI / cron 等) の保管値を新 token に差し替える。
+4. 1 局 / 1 endpoint 通電して動作確認 (例: HTTP admin endpoint の 200、または
+   WS 内 admin command が `OK` を返す)。
+
+旧 token grace を持たないため **手順 2 と 3 のラグを最小化** する。
+複数オペレータが旧 token を保持している運用なら、rotation 直前に共有チャネル
+(Slack 等) でアナウンスし、即時切替できる体制を整える。
+
+## 5. 削除 / 無効化
+
+```bash
+vp exec wrangler secret delete ADMIN_API_TOKEN --config wrangler.<env>.toml
+```
+
+削除後は admin 認可が必要な経路がすべて
+[`AdminAuthError::TokenNotConfigured`](../../crates/rshogi-csa-server-workers/src/admin_auth.rs)
+で fail-closed する (404 / 拒否で隠蔽)。即時 kill-switch として有効。
+
+## 6. 確認
+
+```bash
+# 登録済 secret 一覧 (値は表示されない)
+vp exec wrangler secret list --config wrangler.<env>.toml
+```
+
+`ADMIN_API_TOKEN` が一覧に含まれていない環境では admin 経路は通電しない。
+
+## 7. 整合性 gate
+
+整合性 test (`tests/wrangler_environment_toml_consistency.rs`) が、
+`wrangler.production.toml` / `wrangler.staging.toml` の `[vars]` に
+`ADMIN_API_TOKEN` が混入していたら CI で fail させる契約。本値は必ず secret 経由
+で配置し、env toml の `[vars]` テーブルには書かない。
+
+`wrangler.toml.example` (local dev template) には placeholder として
+`[vars]` に書くのが正しい運用 (`tests/wrangler_template_consistency.rs` で
+gate 済み)。
+
+## 8. 関連
+
+- 認可ロジック仕様: [`crates/rshogi-csa-server-workers/src/admin_auth.rs`](../../crates/rshogi-csa-server-workers/src/admin_auth.rs)
+- Cloudflare secret 全般: [`docs/csa-server/deployment.md`](deployment.md) §2.5
+- 後続 issue: [#621](https://github.com/SH11235/rshogi/issues/621) (LOGIN/admin 認証強化、本 helper を WS 経路で消費)

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -286,6 +286,7 @@ Required reviewers の **作成時設定** 自体は §2.4.1 / §2.4.2 の通り
 | Secret | 用途 |
 |---|---|
 | `ADMIN_HANDLE` | `%%SETBUOY` / `%%DELETEBUOY` を許可する運営ハンドル名。OSS repo に handle 名が出ない経路で defense-in-depth を保つ |
+| `ADMIN_API_TOKEN` | HTTP admin endpoint や WS 内 admin command の認可基盤として `crate::admin_auth` から参照する static API token (Floodgate audit [#560](https://github.com/SH11235/rshogi/issues/560))。生成 / rotation 手順は [`docs/csa-server/admin_auth.md`](admin_auth.md) を参照。 |
 
 設定手順（`vp exec wrangler login` を済ませた後で）:
 
@@ -320,8 +321,12 @@ vp exec wrangler secret put ADMIN_HANDLE --config wrangler.production.toml
 | 一覧 | `vp exec wrangler secret list --config wrangler.<env>.toml` |
 
 整合性 test (`tests/wrangler_environment_toml_consistency.rs`) が
-`wrangler.<env>.toml` の `[vars]` に `ADMIN_HANDLE` が混入していたら CI で
-fail させる契約。
+`wrangler.<env>.toml` の `[vars]` に `ADMIN_HANDLE` / `ADMIN_API_TOKEN` 等
+[`ConfigKeys::LOCAL_DEV_ONLY_VARS_KEYS`](../../crates/rshogi-csa-server-workers/src/config.rs)
+の値が混入していたら CI で fail させる契約。
+
+`ADMIN_API_TOKEN` の token 生成方針 / rotation / 削除手順は
+[`docs/csa-server/admin_auth.md`](admin_auth.md) に集約してある。
 
 ### 2.6 (オプション) Health URL を Environment variable に設定
 


### PR DESCRIPTION
## Summary

Floodgate audit (2026-05-08) 起票の #560 を **scope 縮小して** 実装。HTTP admin endpoint 本体や WS 内 admin command (`%%ADMIN <token>`) は本 PR 外、authorization の foundation のみを提供する (Codex consultation 2026-05-09 で確定)。

- `crates/rshogi-csa-server-workers/src/admin_auth.rs` (新規): `verify_token_str` (pure, constant-time) + `verify_admin_token_str` (wasm32, env wrapper) + `AdminAuthError` enum
- `ConfigKeys::ADMIN_API_TOKEN` を `LOCAL_DEV_ONLY_VARS_KEYS` に追加。既存の wrangler 整合性 test (template / production / staging) が自動で gate
- `wrangler.toml.example` placeholder + production / staging toml の secret comment block 追記
- `docs/csa-server/admin_auth.md` (新規 runbook): token 生成 / 登録 / rotation / 削除 / 整合性 gate を集約
- `docs/csa-server/deployment.md` §2.5: secret 表に `ADMIN_API_TOKEN` 追記、admin_auth.md へリンク

## 設計判断 (Codex consultation 2026-05-09)

| 項目 | 採用案 | 理由 |
|---|---|---|
| 認可方式 | static API token | replay 対策 / canonical string 設計が必要な HMAC は overkill |
| 配置 | Cloudflare secret | OSS repo / CI ログ / `wrangler.<env>.toml` に値を残さない |
| 比較 | `subtle::ConstantTimeEq` | timing leak 対策 (既存 `reconnect.rs` の `ct_str_eq` と同パターン) |
| 旧 token grace | 持たない (1 token のみ valid) | rotation 窓を最短化、bookkeeping 排除 |
| Cloudflare Access | 別管理 (運用層) | コード変更なしで IP / SSO 制限を上乗せできる |

## 後続消費者 (本 PR 外)

- **#621** (P0 LOGIN/admin 認証強化): WS 内 `%%ADMIN <token>` で `verify_admin_token_str` を消費。`is_admin_handle` を session-scoped admin flag に置換
- **将来**: HTTP admin endpoint (`/api/v1/admin/*`) — 必要になった時点で `verify_admin_request(req, env)` 等の HTTP wrapper を追加する想定 (YAGNI で foundation には含めない)

## Codex review

`bd905c14` に対して APPROVE_WITH_NITS、major 0 件。指摘 2 件 (`openssl rand` 生成例の改善 + module doc の placeholder 表現整合) は `e2f9a260` で修正済み。

## Test plan

- [x] `cargo fmt -p rshogi-csa-server-workers` クリーン
- [x] `cargo clippy -p rshogi-csa-server-workers --tests --all-targets` 警告 0 (新規分)
- [x] `cargo test -p rshogi-csa-server-workers` 全 pass (既存 + 新 admin_auth 7 tests)
- [x] `cargo build --target wasm32-unknown-unknown --lib --release` green
- [ ] CI green
- [ ] (後続 #621 で消費) Worker `%%ADMIN <token>` 通電確認

## 関連

- Closes #560 (scope 縮小完了)
- Refs #621 (consumer)
- Floodgate audit 全体: 2026-05-08 起票分 #621-#643

🤖 Generated with [Claude Code](https://claude.com/claude-code)