### PR TITLE
fix(csa-server-workers): orphan sweep deadline 早期 + retry assert (#654)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -277,6 +277,16 @@ mod imp {
 
         let mut cursor: Option<String> = None;
         'outer: loop {
+            // 各 page 取得前に deadline をチェックする
+            // (https://github.com/SH11235/rshogi/issues/654)。各 object 処理後の
+            // deadline チェックは loop 内にあるが、次反復先頭の `builder.execute`
+            // 前に確認しておかないと 30s cron 制限の境界で 1 page 余分に R2 list
+            // を発行してしまうケースが残る。1 page 取得 (R2 list) は約 50-200ms
+            // 必要なので、deadline ギリギリで再 list するより安全側で break する。
+            if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                stats.deadline_reached = true;
+                break 'outer;
+            }
             let mut builder = bucket.list().prefix(LIVE_KEY_PREFIX).limit(PAGE_SIZE);
             if let Some(c) = cursor.as_ref() {
                 builder = builder.cursor(c);

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -119,7 +119,18 @@ const LIVE_INDEX_DELETE_MAX_ATTEMPTS: u32 = 3;
 /// 配列長 = `LIVE_INDEX_DELETE_MAX_ATTEMPTS - 1`。最終 attempt の後は backoff
 /// せず giveup ログに抜けるため、最後の値は使われない。`100, 200` で合計 wall
 /// 300ms 以内に収める (Workers cron の 30s 制限を圧迫しない)。
+///
+/// 配列長の不変条件は下記 `const _: () = assert!(...)` で **コンパイル時** に gate
+/// する (https://github.com/SH11235/rshogi/issues/654)。将来 `MAX_ATTEMPTS` を
+/// 変更する際にこの配列も同時に更新しないとビルドが失敗するため、runtime
+/// out-of-bounds を防ぐ。
 const LIVE_INDEX_DELETE_BACKOFF_MS: [u64; 2] = [100, 200];
+
+const _: () = assert!(
+    LIVE_INDEX_DELETE_BACKOFF_MS.len() as u32 == LIVE_INDEX_DELETE_MAX_ATTEMPTS - 1,
+    "LIVE_INDEX_DELETE_BACKOFF_MS の長さは LIVE_INDEX_DELETE_MAX_ATTEMPTS - 1 と一致させてください \
+     (最終 attempt の後は backoff せず giveup するため、配列要素は MAX_ATTEMPTS - 1 個)"
+);
 
 /// Durable Object 初期化 SQL。
 ///


### PR DESCRIPTION
Closes #654

## 概要
PR #650 review 残 2 件 (claude[bot] non-blocker):
1. P2: pagination loop 入口で deadline 確認を追加 (30s cron 制限の境界で 1 page 余分に R2 list 発行する race を排除)
2. `LIVE_INDEX_DELETE_BACKOFF_MS` / `LIVE_INDEX_DELETE_MAX_ATTEMPTS` の整合を `const _: () = assert!()` でコンパイル時に gate

## 検証
- fmt + clippy 警告 0 / test 278+ 全 pass / wasm32 build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)