### PR TITLE
fix(csa-server-workers): finalize_if_ended で moves テーブル cleanup (#637)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1618,6 +1618,12 @@ impl GameRoom {
             self.try_delete_live_games_index(&cfg_snapshot, started_at_ms).await;
         }
 
+        // moves テーブルを cleanup (https://github.com/SH11235/rshogi/issues/637)。
+        // `KEY_FINISHED` put 後に呼ぶことで、削除失敗時も後続 `ensure_core_loaded`
+        // が finished ガードで早期 return し replay は走らない (二重防御)。
+        // 失敗は best-effort で吸収し、WS close 等の残り処理は必ず進める。
+        self.clear_moves().await;
+
         // CoreRoom を落とす。再度 ensure_core_loaded しても finished ガードで戻る。
         self.core.borrow_mut().take();
 
@@ -2558,6 +2564,25 @@ impl GameRoom {
             sql.exec("SELECT ply, color, line, at_ms FROM moves ORDER BY ply ASC", None)?;
         let rows: Vec<MoveRow> = cursor.to_array()?;
         Ok(rows)
+    }
+
+    /// `moves` テーブルを空にする (https://github.com/SH11235/rshogi/issues/637)。
+    ///
+    /// 終局時に `finalize_if_ended` から呼び出され、同 room_id を再利用するリファクタ
+    /// が将来入った場合でも `replay_core_room` が古い moves を再生して
+    /// `MoveReplayFailed` を起こすのを防ぐ。現状は `KEY_FINISHED` ガードで弾かれる
+    /// 経路だが、二重防御として moves 行を確実に削除しておく。
+    ///
+    /// 失敗は best-effort で `console_log!` のみに落とし、`Result` には漏らさない
+    /// (呼び出し側 `finalize_if_ended` の WS close / live-games-index delete などの
+    /// 終局処理を止めないため)。`KEY_FINISHED` put が成功している前提で呼び出すため、
+    /// 削除失敗で moves が残っても、後続 `ensure_core_loaded` は finished ガードで
+    /// 早期 return し replay は走らない。
+    async fn clear_moves(&self) {
+        let sql = self.state.storage().sql();
+        if let Err(e) = sql.exec("DELETE FROM moves", None) {
+            console_log!("[GameRoom] event=clear_moves_failed err={:?}", e);
+        }
     }
 
     async fn load_slots(&self) -> Result<Vec<Slot>> {


### PR DESCRIPTION
## Summary
- 終局時に DO の SQLite `moves` テーブルを `DELETE FROM moves` で空にする補助関数 `clear_moves` を追加し `finalize_if_ended` から呼び出す。
- 現状 `KEY_FINISHED` ガードで `replay_core_room` は早期 return するため実害は出ていないが、同 room_id 再利用リファクタが将来入った場合に古い moves が再生されて `MoveReplayFailed` を起こす二次的リスクを二重防御として塞ぐ。
- SQL exec 失敗は `console_log!` のみで吸収する best-effort 方針 (WS close / live-games-index delete 等の終局処理を止めない)。

## 設計メモ

### 呼び出し位置
`finalize_if_ended` 内の以下の順序の中で、live-games-index delete 後・`core.take()` 前に挿入:

1. `KEY_FINISHED` put
2. `delete_grace_alarm_state`
3. `schedule_export_retry` (一部失敗時)
4. `try_delete_live_games_index`
5. **`clear_moves`** ← 追加
6. `core.borrow_mut().take()`
7. WS close

### `KEY_FINISHED` put 後の理由
仮に `clear_moves` が失敗して moves が残っても、後続 `ensure_core_loaded` は `load_finished().is_some()` で早期 return するため `replay_core_room` は走らない (二重防御)。

### R2 export との順序
`export_kifu_to_r2` は `clear_moves` より前に走り、`load_moves()` 済 + ExportRetry pending は `ExportPendingState` に CSA 本文を保持しているため、cleanup 後に moves を再読みに行かない。

### Codex local review
APPROVE を獲得済 (削除タイミング・hibernation 復帰時の影響・Issue #638 additive contract との整合・YAGNI すべて問題なし)。

## Test plan
- [x] `cargo fmt && cargo clippy -p rshogi-csa-server-workers --tests --all-targets` — 警告 0
- [x] `cargo test -p rshogi-csa-server-workers` — 全 pass
- [x] `cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown` — OK
- [ ] miniflare smoke 実機通し (CI で実施)

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)