### PR TITLE
feat(csa-server-workers): private challenge feature flag (#635)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -118,6 +118,22 @@ impl ConfigKeys {
     /// 設定不正値は安全側に倒し（無効化）、`worker::console_log!` で警告ログを
     /// 出す。
     pub const ALLOW_VIEWER_API: &'static str = "ALLOW_VIEWER_API";
+    /// 私的対局 (`CHALLENGE_LOBBY` および `LOGIN_LOBBY <handle>+private-<token>+free`)
+    /// 経路を opt-in 有効化するブール変数 (https://github.com/SH11235/rshogi/issues/635)。
+    /// `true` / `1` / `yes` / `on` で有効、`false` / `0` / `no` / `off` または
+    /// 未設定で無効化。
+    ///
+    /// 無効時 (= production の既定) は LobbyDO の `dispatch_pending_line` 入口で
+    /// 早期 reject し、`CHALLENGE_LOBBY:incorrect unsupported` /
+    /// `LOGIN_LOBBY:incorrect unsupported` を返す (private LOGIN_LOBBY は加えて
+    /// 1003 close)。両者揃った後の対局起動経路 (consume → GameRoom DO 起動 +
+    /// clock_spec / initial_sfen バトンパス) が未実装のため、production client が
+    /// 誤って使うと pending state でハマるのを防ぐ feature gate。
+    ///
+    /// staging では起動経路実装の動作確認時のみ `"true"` に切り替える。
+    /// 設定不正値 (`true` / `false` / 数字 / yes/no/on/off 以外) は `ALLOW_VIEWER_API`
+    /// と同じく安全側 (= 無効化) に倒し、`worker::console_log!` で警告ログを出す。
+    pub const PRIVATE_CHALLENGE_ENABLED: &'static str = "PRIVATE_CHALLENGE_ENABLED";
 
     /// deploy 対象コードの provenance commit sha (`DEPLOY_TRIGGER_SHA`)。
     ///
@@ -185,6 +201,7 @@ impl ConfigKeys {
         Self::ALLOW_VIEWER_API,
         Self::LOBBY_QUEUE_SIZE_LIMIT,
         Self::CHALLENGE_TTL_SEC,
+        Self::PRIVATE_CHALLENGE_ENABLED,
     ];
 
     /// **local dev のみ** の `wrangler.toml.example` `[vars]` テーブルに追加で
@@ -444,6 +461,30 @@ pub fn is_viewer_api_enabled(env: &worker::Env) -> bool {
         Ok(v) => v,
         Err(e) => {
             worker::console_log!("[viewer_api] event=invalid_allow_viewer_api err={e}");
+            false
+        }
+    }
+}
+
+/// 私的対局経路 (`CHALLENGE_LOBBY` / `LOGIN_LOBBY <handle>+private-<token>+free`)
+/// が有効化されているかを `[vars]` `PRIVATE_CHALLENGE_ENABLED` から判定する
+/// (https://github.com/SH11235/rshogi/issues/635)。
+///
+/// 値の解釈は [`rshogi_csa_server::config::parse_truthy_bool_env`] に委ねる。
+/// 設定不正値（`true` / `false` / 数字 / yes/no/on/off 以外）は安全側に倒し
+/// （= private challenge 無効化）、`worker::console_log!` で警告ログを出す。
+///
+/// 無効時は LobbyDO の `dispatch_pending_line` 入口で早期 reject し、
+/// `CHALLENGE_LOBBY:incorrect unsupported` / `LOGIN_LOBBY:incorrect unsupported`
+/// を返す。両者揃った後の対局起動経路 (consume → GameRoom DO 起動) が未実装の
+/// ため、production client が誤って使うと pending state でハマるのを防ぐ。
+#[cfg(target_arch = "wasm32")]
+pub fn is_private_challenge_enabled(env: &worker::Env) -> bool {
+    let raw = env.var(ConfigKeys::PRIVATE_CHALLENGE_ENABLED).ok().map(|v| v.to_string());
+    match rshogi_csa_server::config::parse_truthy_bool_env(raw.as_deref()) {
+        Ok(v) => v,
+        Err(e) => {
+            worker::console_log!("[lobby] event=invalid_private_challenge_enabled err={e}");
             false
         }
     }

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -40,7 +40,9 @@ use worker::{
     WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
 };
 
-use crate::config::{ConfigKeys, parse_challenge_ttl_duration, parse_clock_presets};
+use crate::config::{
+    ConfigKeys, is_private_challenge_enabled, parse_challenge_ttl_duration, parse_clock_presets,
+};
 use crate::lobby_protocol::{
     ChallengeLobbyError, LobbyQueue, LoginLobbyError, LoginLobbyPrivateError,
     LoginLobbyPrivateRequest, MatchedEntries, QueueEntry, build_challenge_incorrect_line,
@@ -351,8 +353,23 @@ impl Lobby {
     /// と「私的対局経路 (`<handle>+private-<token>+free`)」を peek 分岐する。
     /// `is_private_login_handle` で `true` を返した場合は私的経路に分岐し、
     /// CHALLENGE_LOBBY 行は専用パス (`handle_challenge_lobby`) に分岐させる。
+    ///
+    /// **私的対局 feature gate (https://github.com/SH11235/rshogi/issues/635)**:
+    /// `PRIVATE_CHALLENGE_ENABLED` が無効 (production の既定) のとき、私的対局
+    /// 2 経路 (`CHALLENGE_LOBBY ` / `LOGIN_LOBBY <handle>+private-...+free`) は
+    /// `parse_*` / registry load 等の副作用に入る前に `:incorrect unsupported`
+    /// を返して終了する。両者揃った後の対局起動経路 (consume → GameRoom DO 起動)
+    /// が未実装の状態で client が誤って使うと pending state でハマるため、production
+    /// 到達不能化を最入口で行う。
     async fn dispatch_pending_line(&self, ws: &WebSocket, line: &str) -> Result<()> {
         if line.starts_with("CHALLENGE_LOBBY ") {
+            // CHALLENGE_LOBBY は新規 token 発行要求であって login 状態への遷移を
+            // 伴わないため、disabled でも close せず `:incorrect unsupported` の
+            // 1 行返却にとどめる (既存 parser エラー `bad_format` 等と同じ流儀)。
+            if !is_private_challenge_enabled(&self.env) {
+                send_line(ws, &build_challenge_incorrect_line("unsupported"))?;
+                return Ok(());
+            }
             // 中身は `parse_challenge_lobby` 側で再度 strip + 構造化するので、ここでは
             // prefix の有無のみを判定して dispatch する。
             return self.handle_challenge_lobby(ws, line).await;
@@ -362,6 +379,15 @@ impl Lobby {
             if let Some(id) = rest.split_whitespace().next()
                 && is_private_login_handle(id)
             {
+                // private LOGIN_LOBBY は既存の private parser エラーが
+                // `send_private_login_error` で 1003 close している経路と
+                // 揃え、disabled でも `1003` close で「この login 形式は
+                // この server では受けない」扱いにする。
+                if !is_private_challenge_enabled(&self.env) {
+                    send_line(ws, &build_login_incorrect_line("unsupported"))?;
+                    let _ = ws.close(Some(1003), Some("private_challenge_disabled"));
+                    return Ok(());
+                }
                 return self.handle_login_lobby_private(ws, line).await;
             }
         }

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -168,6 +168,17 @@ LOBBY_QUEUE_SIZE_LIMIT = "100"
 # 未消費 token は Lobby DO の Alarm ハンドラで自動削除する。1 時間 = 3600
 # は対戦相手が招待後にゆっくり PC を起動する想定の保守的既定。
 CHALLENGE_TTL_SEC = "3600"
+# 私的対局 (CHALLENGE_LOBBY / LOGIN_LOBBY+private-<token>+free) 経路の opt-in
+# 有効化フラグ (https://github.com/SH11235/rshogi/issues/635)。production では
+# 「両者揃った後の対局起動経路 (consume → GameRoom DO 起動 + clock_spec /
+# initial_sfen バトンパス)」が未実装で、production client が誤って使うと
+# pending state でハマるため fail-closed で `"false"` を既定とする。
+# (同じ `[vars]` 内の他の opt-in フラグ `ALLOW_VIEWER_API` は本番運用済機能
+# なので `"1"` だが、本フラグは未完成機能の production 到達不能化が目的で
+# あるため fail-closed の `"false"` を採用している。)
+# staging では起動経路実装の動作確認時のみ `"true"` に切り替え、production
+# 昇格時は本値を `"true"` に変えて redeploy する。
+PRIVATE_CHALLENGE_ENABLED = "false"
 
 # --- secret として設定する値 ---
 # 本番運用に必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -168,6 +168,12 @@ LOBBY_QUEUE_SIZE_LIMIT = "100"
 # 確認をテンポよく回すため短めの 600 秒 (10 分) で運用する。production 昇格
 # 時は 3600 秒に揃える。
 CHALLENGE_TTL_SEC = "600"
+# 私的対局 (CHALLENGE_LOBBY / LOGIN_LOBBY+private-<token>+free) 経路の opt-in
+# 有効化フラグ (https://github.com/SH11235/rshogi/issues/635)。両者揃った後の
+# 対局起動経路 (consume → GameRoom DO 起動) が未実装の現状、staging では起動
+# 経路実装の動作確認 (E2E 通電) を回す前提で `"true"` を既定とする。production
+# は fail-closed で `"false"` 既定 (production toml 側参照)。
+PRIVATE_CHALLENGE_ENABLED = "true"
 
 # --- secret として設定する値 ---
 # staging で必要だが OSS repo には書かない値は `wrangler secret put` 経由で設定する。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -147,3 +147,13 @@ LOBBY_QUEUE_SIZE_LIMIT = "100"
 # 未消費 token は Lobby DO の Alarm ハンドラで自動削除し、保留中の WS 接続
 # があれば切断信号を送る。Issue #582 の Workers 経路で参照する。
 CHALLENGE_TTL_SEC = "3600"
+# 私的対局 (CHALLENGE_LOBBY / LOGIN_LOBBY+private-<token>+free) 経路の opt-in
+# 有効化フラグ (Issue #635)。両者揃った後の対局起動経路 (consume → GameRoom
+# DO 起動 + clock_spec / initial_sfen バトンパス) が未実装のため、production
+# 既定と揃えて fail-closed の `"false"` を採用する。
+# 無効時は LobbyDO の dispatch_pending_line 入口で
+# `CHALLENGE_LOBBY:incorrect unsupported` /
+# `LOGIN_LOBBY:incorrect unsupported` を返して private 経路を到達不能化する
+# (private LOGIN_LOBBY は加えて 1003 close)。
+# local dev で機能を試す場合のみ明示的に `"true"` に変更する。
+PRIVATE_CHALLENGE_ENABLED = "false"


### PR DESCRIPTION
## Summary

未完成の私的対局経路 (CHALLENGE_LOBBY / LOGIN_LOBBY+private-`<token>`+free) を production で feature flag gate する (Closes #635)。両者揃った後の対局起動経路 (consume → GameRoom DO 起動 + clock_spec / initial_sfen バトンパス) が未実装のため、production client が誤って使うと pending state でハマる事故を fail-closed で防ぐ。

- `PRIVATE_CHALLENGE_ENABLED` env (production default `"false"` / staging `"true"`) を導入し、`LobbyDO::dispatch_pending_line` 入口で private 2 分岐前に早期 reject
- 既存 `is_viewer_api_enabled` と同じパターンで wasm32-only ヘルパ `is_private_challenge_enabled(env)` を追加 (`parse_truthy_bool_env` 経由、設定不正値は安全側 `false`)
- `SHARED_PUBLIC_VARS_KEYS` に追加することで wrangler 整合性テスト (production / staging / example.toml) で過不足を双方向検証

## 設計判断 (Codex review APPROVE 済)

| 観点 | 採用 |
| --- | --- |
| gate 配置 | `dispatch_pending_line` の private 2 分岐**直前** (`parse_*` / registry load / TTL purge / clock preset 解決などの副作用前) |
| reason 文字列 | CHALLENGE_LOBBY / LOGIN_LOBBY 両方とも `unsupported` で統一 |
| close 挙動 | CHALLENGE_LOBBY: close なし (新規発行要求は login 状態遷移を伴わないため、既存 parser エラー `bad_format` 等と同じ流儀) / private LOGIN_LOBBY: 1003 close (既存 `send_private_login_error` の流儀と揃える、close reason `"private_challenge_disabled"`) |
| `wrangler.toml.example` 既定 | `"false"` (production と揃え、機能を試すときは local dev 側で明示的に `"true"`) |
| host-side unit test | YAGNI (truthy 解釈は `parse_truthy_bool_env` 側でカバー済、起動経路実装時に miniflare smoke で固定する方針) |

## 変更ファイル

- `crates/rshogi-csa-server-workers/src/config.rs` — `ConfigKeys::PRIVATE_CHALLENGE_ENABLED` 追加 + `SHARED_PUBLIC_VARS_KEYS` 登録 + `is_private_challenge_enabled` 実装
- `crates/rshogi-csa-server-workers/src/lobby.rs` — `dispatch_pending_line` に flag check 2 箇所
- `crates/rshogi-csa-server-workers/wrangler.production.toml` — `PRIVATE_CHALLENGE_ENABLED = "false"`
- `crates/rshogi-csa-server-workers/wrangler.staging.toml` — `PRIVATE_CHALLENGE_ENABLED = "true"`
- `crates/rshogi-csa-server-workers/wrangler.toml.example` — `PRIVATE_CHALLENGE_ENABLED = "false"`

## Test plan

- [x] `cargo fmt -p rshogi-csa-server-workers`: clean
- [x] `cargo clippy -p rshogi-csa-server-workers --tests`: warnings 0
- [x] `cargo test -p rshogi-csa-server-workers`: 35 件 / 全 pass (wrangler 整合性テスト 22 件含む)
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`: success
- [ ] (optional) staging deploy 後に miniflare smoke / 実機で flag false → CHALLENGE_LOBBY:incorrect unsupported を返すことを確認

## ロールアウト

- production: 自動 deploy で `"false"` 固定 (現状の到達不能化と等価、退行なし)
- staging: 自動 deploy で `"true"` (既存の私的対局通電テストを継続可能)
- 起動経路実装 (#582 follow-up) で「両者揃った後の GameRoom 起動」を実装した PR にて、production を `"true"` に切り替える

🤖 Generated with [Claude Code](https://claude.com/claude-code)