### PR TITLE
feat(csa-server-workers): Lobby queue TTL + heartbeat purge (#631)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -43,6 +43,13 @@ impl ConfigKeys {
     /// LobbyDO 内 in-memory queue の総数上限。超過時 LOGIN_LOBBY を `queue_full`
     /// で reject する。未設定時は 100 が既定値。
     pub const LOBBY_QUEUE_SIZE_LIMIT: &'static str = "LOBBY_QUEUE_SIZE_LIMIT";
+    /// 公開マッチング queue (`LobbyQueue`) の entry TTL (秒)。`LOBBY_PONG`
+    /// 受信から本値を超えると LobbyDO の Alarm purge で stale 判定され、
+    /// `LOGIN_LOBBY:incorrect queue_expired` 送信 + WS close される
+    /// (https://github.com/SH11235/rshogi/issues/631)。
+    /// network 分断や WS close 遅延で残った stale entry を一定時間で掃除し、
+    /// 後続ユーザの誤マッチを防ぐ目的。未設定時は 300 秒 (5 分) が既定値。
+    pub const LOBBY_QUEUE_ENTRY_TTL_SEC: &'static str = "LOBBY_QUEUE_ENTRY_TTL_SEC";
     /// 私的対局 (`CHALLENGE_LOBBY`) で発行された token の TTL (秒)。期限超過した
     /// 未消費 token は LobbyDO の Alarm ハンドラで `purge_expired` され、保留中の
     /// WS 接続がいれば切断される。未設定時は 3600 秒 (1 時間)。https://github.com/SH11235/rshogi/issues/582 の
@@ -200,6 +207,7 @@ impl ConfigKeys {
         Self::ALLOW_FLOODGATE_FEATURES,
         Self::ALLOW_VIEWER_API,
         Self::LOBBY_QUEUE_SIZE_LIMIT,
+        Self::LOBBY_QUEUE_ENTRY_TTL_SEC,
         Self::CHALLENGE_TTL_SEC,
         Self::PRIVATE_CHALLENGE_ENABLED,
     ];
@@ -239,6 +247,10 @@ impl ConfigKeys {
 /// `None` / 空文字 / パース失敗時のフォールバックとして参照する。
 pub(crate) const DEFAULT_CHALLENGE_TTL_SEC: u64 = 3600;
 
+/// `LOBBY_QUEUE_ENTRY_TTL_SEC` 既定値 (5 分)。stale public queue entry の
+/// 上限滞在時間として保守的な値を採る。
+pub(crate) const DEFAULT_LOBBY_QUEUE_ENTRY_TTL_SEC: u64 = 300;
+
 /// `AGREE_TIMEOUT_SECONDS` 既定値 (60 秒)。TCP frontend は 5 分既定だが、Workers
 /// DO は 1 部屋 = 1 instance で memory / room 枠を専有するため、より短めの既定で
 /// stuck DO を素早く解放する設計を採る (https://github.com/SH11235/rshogi/issues/600)。
@@ -257,6 +269,22 @@ pub fn parse_challenge_ttl_duration(raw: Option<&str>) -> std::time::Duration {
     match trimmed.parse::<u64>() {
         Ok(secs) => std::time::Duration::from_secs(secs),
         Err(_) => std::time::Duration::from_secs(DEFAULT_CHALLENGE_TTL_SEC),
+    }
+}
+
+/// `LOBBY_QUEUE_ENTRY_TTL_SEC` 文字列を `Duration` へ解決する。
+///
+/// `None` / 空文字 / `0` / 非数値 / `u64` 範囲外は [`DEFAULT_LOBBY_QUEUE_ENTRY_TTL_SEC`]
+/// にフォールバックする (env 不正で TTL 0 = 即時 purge となり全 queue 待機が
+/// 切断される事故を避ける安全側挙動。`AGREE_TIMEOUT_SECONDS` と同じ流儀)。
+pub fn parse_lobby_queue_entry_ttl_duration(raw: Option<&str>) -> std::time::Duration {
+    let trimmed = raw.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        return std::time::Duration::from_secs(DEFAULT_LOBBY_QUEUE_ENTRY_TTL_SEC);
+    }
+    match trimmed.parse::<u64>() {
+        Ok(0) | Err(_) => std::time::Duration::from_secs(DEFAULT_LOBBY_QUEUE_ENTRY_TTL_SEC),
+        Ok(secs) => std::time::Duration::from_secs(secs),
     }
 }
 
@@ -718,6 +746,33 @@ mod tests {
     fn parse_challenge_ttl_duration_accepts_seconds() {
         assert_eq!(parse_challenge_ttl_duration(Some("60")), std::time::Duration::from_secs(60));
         assert_eq!(parse_challenge_ttl_duration(Some("0")), std::time::Duration::ZERO);
+    }
+
+    /// `LOBBY_QUEUE_ENTRY_TTL_SEC` 未設定 / 空文字 / `0` / 非数値は安全側既定 (300 秒)。
+    #[test]
+    fn parse_lobby_queue_entry_ttl_duration_defaults_when_unset_or_zero_or_invalid() {
+        let default = std::time::Duration::from_secs(DEFAULT_LOBBY_QUEUE_ENTRY_TTL_SEC);
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(None), default);
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(Some("")), default);
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(Some("  ")), default);
+        // `0` は「無効化」を意図した運用ミスと解釈し、queue 全切断を避けるため
+        // 安全側既定にフォールバックする (TTL 0 = 即時 purge は許容しない)。
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(Some("0")), default);
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(Some("forever")), default);
+        assert_eq!(parse_lobby_queue_entry_ttl_duration(Some("-1")), default);
+    }
+
+    /// 数値はそのまま秒として採用する。
+    #[test]
+    fn parse_lobby_queue_entry_ttl_duration_accepts_seconds() {
+        assert_eq!(
+            parse_lobby_queue_entry_ttl_duration(Some("60")),
+            std::time::Duration::from_secs(60)
+        );
+        assert_eq!(
+            parse_lobby_queue_entry_ttl_duration(Some(" 600\n")),
+            std::time::Duration::from_secs(600)
+        );
     }
 
     /// 非数値はパース失敗時のフォールバック (= 既定値) で扱う。

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -42,6 +42,7 @@ use worker::{
 
 use crate::config::{
     ConfigKeys, is_private_challenge_enabled, parse_challenge_ttl_duration, parse_clock_presets,
+    parse_lobby_queue_entry_ttl_duration,
 };
 use crate::lobby_protocol::{
     ChallengeLobbyError, LobbyQueue, LoginLobbyError, LoginLobbyPrivateError,
@@ -87,10 +88,15 @@ enum LobbyAttachment {
     /// LOGIN_LOBBY 到着前の匿名接続。`websocket_message` で初手は LOGIN_LOBBY を期待する。
     Pending,
     /// queue 登録済みの待機者。
+    /// `attachment_id` は LobbyDO 採番の WS 一意 id (`PrivatePending` と同じ値域)。
+    /// queue entry の `(handle, attachment_id)` と照合することで、同 handle で
+    /// 旧 WS の close が遅延しても新 entry が誤って削除されない race-safe な
+    /// 識別キーとして使う (https://github.com/SH11235/rshogi/issues/631)。
     Queued {
         handle: String,
         game_name: String,
         color: ColorTag,
+        attachment_id: String,
     },
     /// 私的対局 (`LOGIN_LOBBY <handle>+private-<token>+free`) で先行 LOGIN
     /// 済の待機者。両者揃った時点での GameRoom DO 起動経路は次 PR に分割する
@@ -201,7 +207,11 @@ impl DurableObject for Lobby {
                 ref handle,
                 ref game_name,
                 color,
-            } => self.handle_queued_line(&ws, handle, game_name, color, &line).await,
+                ref attachment_id,
+            } => {
+                self.handle_queued_line(&ws, handle, game_name, color, attachment_id, &line)
+                    .await
+            }
             LobbyAttachment::PrivatePending {
                 ref token,
                 ref handle,
@@ -218,12 +228,18 @@ impl DurableObject for Lobby {
         _was_clean: bool,
     ) -> Result<()> {
         match ws.deserialize_attachment::<LobbyAttachment>() {
-            Ok(Some(LobbyAttachment::Queued { handle, .. })) => {
-                self.queue.borrow_mut().remove(&handle);
+            Ok(Some(LobbyAttachment::Queued {
+                handle,
+                attachment_id,
+                ..
+            })) => {
+                self.queue.borrow_mut().remove(&handle, &attachment_id);
                 console_log!(
-                    "[Lobby] queued client closed: handle={handle} queue_size={}",
+                    "[Lobby] queued client closed: handle={handle} attachment_id={attachment_id} queue_size={}",
                     self.queue.borrow().len()
                 );
+                // queue 状態が変わった (entry 削除) ので alarm の earliest を更新する。
+                self.reschedule_alarm().await?;
             }
             Ok(Some(LobbyAttachment::PrivatePending {
                 token,
@@ -243,8 +259,17 @@ impl DurableObject for Lobby {
     }
 
     async fn alarm(&self) -> Result<Response> {
-        self.handle_challenge_alarm().await?;
-        Response::ok("challenge alarm handled")
+        // 単一の Alarm 経路で 2 種類の TTL purge を順に処理する:
+        // 1. challenge_registry の期限切れ token を purge (`purge_expired`)
+        // 2. public queue の stale entry を purge (https://github.com/SH11235/rshogi/issues/631)
+        // 両 purge は独立で副作用が交錯しないため、順序は固定で良い (どちらが
+        // 先でも結果は同じ)。両 purge 後に earliest を再計算して alarm を
+        // **1 回だけ** 再予約する (`reschedule_alarm`) ことで、各 purge が個別に
+        // alarm を上書きする race を避ける。
+        self.handle_challenge_purge(self.now_ms()).await?;
+        self.handle_queue_purge(self.now_ms()).await?;
+        self.reschedule_alarm().await?;
+        Response::ok("lobby alarm handled")
     }
 }
 
@@ -292,6 +317,14 @@ impl Lobby {
         parse_challenge_ttl_duration(raw.as_deref())
     }
 
+    /// `LOBBY_QUEUE_ENTRY_TTL_SEC` env を `Duration` に解決する (未設定 / `0` /
+    /// 不正値は 300 秒既定にフォールバック)。
+    /// `config::parse_lobby_queue_entry_ttl_duration` の薄いラッパ。
+    fn queue_entry_ttl(&self) -> Duration {
+        let raw = self.env.var(ConfigKeys::LOBBY_QUEUE_ENTRY_TTL_SEC).ok().map(|v| v.to_string());
+        parse_lobby_queue_entry_ttl_duration(raw.as_deref())
+    }
+
     /// 現在時刻 (UNIX エポック ms)。`worker::Date::now()` 経由。`game_room.rs::now_ms`
     /// と挙動を揃える (絶対時刻で isolate 再構築でも進む)。
     fn now_ms(&self) -> u64 {
@@ -330,12 +363,33 @@ impl Lobby {
         Ok(format!("ws-{next}"))
     }
 
-    /// 次回の Alarm を `ChallengeRegistry::earliest_expiry_ms` に基づいて
-    /// 設定する。空 registry なら delete_alarm で予約を解除する。既存の Alarm
-    /// が earliest より早いケースは現実には発生しない (本 LobbyDO の Alarm は
-    /// challenge purge 専用で、他用途で予約されない) ため、単純に上書きする。
-    async fn reschedule_challenge_alarm(&self, reg: &ChallengeRegistry) -> Result<()> {
-        match reg.earliest_expiry_ms() {
+    /// 次回の Alarm を「challenge_registry の earliest_expiry_ms」と「public
+    /// queue の earliest_last_pong_at_ms + ttl_ms」の **両方を併合した earliest**
+    /// に基づいて設定する。両者空なら `delete_alarm` で予約を解除する。
+    ///
+    /// 本 LobbyDO の Alarm は challenge purge と queue purge の 2 用途を共有する
+    /// ため、各 purge / mark / unmark / enqueue / remove / pong update の **全て**
+    /// から本関数を呼ぶ契約。各経路が個別に `set_alarm` / `delete_alarm` を呼ぶと
+    /// race して earliest が壊れるので、必ず本関数経由で 1 本化する。
+    async fn reschedule_alarm(&self) -> Result<()> {
+        let reg = self.load_challenge_registry().await?;
+        self.reschedule_alarm_with(&reg).await
+    }
+
+    /// `reschedule_alarm` の inner 版。直前で `load_challenge_registry` 済の caller
+    /// (`handle_challenge_lobby` 等) が再 load を避けるために使う。
+    async fn reschedule_alarm_with(&self, reg: &ChallengeRegistry) -> Result<()> {
+        let challenge_earliest = reg.earliest_expiry_ms();
+        let ttl_ms = u64::try_from(self.queue_entry_ttl().as_millis()).unwrap_or(u64::MAX);
+        let queue_earliest =
+            self.queue.borrow().earliest_last_pong_at_ms().map(|t| t.saturating_add(ttl_ms));
+        let earliest = match (challenge_earliest, queue_earliest) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        match earliest {
             Some(epoch_ms) => {
                 let now_ms = self.now_ms();
                 let delay_ms =
@@ -412,10 +466,17 @@ impl Lobby {
             return self.send_login_error(ws, LoginLobbyError::UnknownGameName).await;
         }
 
+        // attachment id を採番し、queue entry / WS attachment / heartbeat 時刻を
+        // 同じ id で揃える。private 経路 (`pending_ws_attachment_ids`) と同じ
+        // 採番器を共有し、id 値域を一本化する (storage key も共通)。
+        let attachment_id = self.next_attachment_id().await?;
+        let now_ms = self.now_ms();
         let entry = QueueEntry {
             handle: req.handle.clone(),
             game_name: req.game_name.clone(),
             color: req.color,
+            attachment_id: attachment_id.clone(),
+            last_pong_at_ms: now_ms,
         };
         let limit = self.queue_size_limit();
         if !self.queue.borrow_mut().enqueue(entry, limit) {
@@ -427,22 +488,24 @@ impl Lobby {
         // 抜いてあるが、attachment が `Queued` のまま残ると `dispatch_match` の
         // `state.get_websockets()` 走査で旧 WS にも MATCHED が誤送される。close を
         // 先に行うことで websocket_close 経路に乗せ、attachment を消す。
-        evict_old_websockets_with_handle(&self.state, &ws, &req.handle);
+        evict_old_websockets_with_handle(&self.state, ws, &req.handle);
 
         // attachment を Queued に差し替えて待機状態に遷移。
         ws.serialize_attachment(&LobbyAttachment::Queued {
             handle: req.handle.clone(),
             game_name: req.game_name.clone(),
             color: ColorTag::from_core(req.color),
+            attachment_id: attachment_id.clone(),
         })
         .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
 
         send_line(ws, &build_login_ok_line(&req.handle))?;
         console_log!(
-            "[Lobby] LOGIN_LOBBY: handle={} game_name={} color={:?} queue_size={}",
+            "[Lobby] LOGIN_LOBBY: handle={} game_name={} color={:?} attachment_id={} queue_size={}",
             req.handle,
             req.game_name,
             req.color,
+            attachment_id,
             self.queue.borrow().len()
         );
 
@@ -450,6 +513,9 @@ impl Lobby {
         if let Some(matched) = self.queue.borrow_mut().try_pair() {
             self.dispatch_match(matched).await?;
         }
+        // queue 状態が変わった (enqueue / dispatch) ので earliest_last_pong_at_ms
+        // も変わる。alarm を min(challenge.earliest, queue.earliest+ttl) で更新。
+        self.reschedule_alarm().await?;
         Ok(())
     }
 
@@ -460,17 +526,24 @@ impl Lobby {
         handle: &str,
         _game_name: &str,
         _color: ColorTag,
+        attachment_id: &str,
         line: &str,
     ) -> Result<()> {
         match line {
             "LOGOUT_LOBBY" => {
-                self.queue.borrow_mut().remove(handle);
-                console_log!("[Lobby] LOGOUT_LOBBY: handle={handle}");
+                self.queue.borrow_mut().remove(handle, attachment_id);
+                console_log!("[Lobby] LOGOUT_LOBBY: handle={handle} attachment_id={attachment_id}");
                 let _ = ws.close(Some(1000), Some("logout"));
+                // queue が縮んだので alarm を再評価。
+                self.reschedule_alarm().await?;
                 Ok(())
             }
             "LOBBY_PONG" => {
-                // keep-alive 応答。現状は受信のみ (PING 送出は未実装)。
+                // keep-alive 応答。`(handle, attachment_id)` 一致時のみ
+                // `last_pong_at_ms` を更新し、stale 判定を延長する
+                // (https://github.com/SH11235/rshogi/issues/631)。
+                let now_ms = self.now_ms();
+                self.queue.borrow_mut().touch_pong(handle, attachment_id, now_ms);
                 Ok(())
             }
             _ => {
@@ -490,12 +563,26 @@ impl Lobby {
                 Ok(Some(a)) => a,
                 _ => continue,
             };
-            let LobbyAttachment::Queued { handle, color, .. } = att else {
+            let LobbyAttachment::Queued {
+                handle,
+                color,
+                attachment_id,
+                ..
+            } = att
+            else {
                 continue;
             };
-            let target_color = if handle == matched.black.handle {
+            // 同 handle で旧 WS が close 遅延しているケースでも誤って `MATCHED` を
+            // 送らないよう、`attachment_id` までを含めて完全一致で照合する
+            // (https://github.com/SH11235/rshogi/issues/631)。`try_pair` で
+            // queue から取り出した entry の `attachment_id` を真値とし、本 WS が
+            // 同 (handle, attachment_id) でなければ skip する。
+            let target_color = if handle == matched.black.handle
+                && attachment_id == matched.black.attachment_id
+            {
                 Color::Black
-            } else if handle == matched.white.handle {
+            } else if handle == matched.white.handle && attachment_id == matched.white.attachment_id
+            {
                 Color::White
             } else {
                 continue;
@@ -590,7 +677,7 @@ impl Lobby {
             // 早期 return でも、purge した reg は永続化する (取りこぼし回避)。
             if purged {
                 self.save_challenge_registry(&reg).await?;
-                self.reschedule_challenge_alarm(&reg).await?;
+                self.reschedule_alarm_with(&reg).await?;
             }
             send_line(ws, &build_challenge_incorrect_line("unknown_clock_preset"))?;
             return Ok(());
@@ -603,7 +690,7 @@ impl Lobby {
         {
             if purged {
                 self.save_challenge_registry(&reg).await?;
-                self.reschedule_challenge_alarm(&reg).await?;
+                self.reschedule_alarm_with(&reg).await?;
             }
             send_line(ws, &build_challenge_incorrect_line("bad_sfen"))?;
             return Ok(());
@@ -623,7 +710,7 @@ impl Lobby {
         match issue_result {
             Ok(token) => {
                 self.save_challenge_registry(&reg).await?;
-                self.reschedule_challenge_alarm(&reg).await?;
+                self.reschedule_alarm_with(&reg).await?;
                 let ttl_sec = ttl.as_secs();
                 send_line(ws, &build_challenge_ok_line(token.as_str(), ttl_sec))?;
                 console_log!(
@@ -638,7 +725,7 @@ impl Lobby {
                 // self_challenge でも purge があった場合は永続化する。
                 if purged {
                     self.save_challenge_registry(&reg).await?;
-                    self.reschedule_challenge_alarm(&reg).await?;
+                    self.reschedule_alarm_with(&reg).await?;
                 }
                 send_line(ws, &build_challenge_incorrect_line("self_challenge"))?;
             }
@@ -687,7 +774,7 @@ impl Lobby {
                 if !expired.is_empty() {
                     // expire 後に登録簿が変わったので、(空でなければ) save し直す。
                     self.save_challenge_registry(&reg).await?;
-                    self.reschedule_challenge_alarm(&reg).await?;
+                    self.reschedule_alarm_with(&reg).await?;
                 }
                 send_line(ws, &build_login_incorrect_line("challenge_expired"))?;
                 let _ = ws.close(Some(1000), Some("challenge_expired"));
@@ -699,7 +786,7 @@ impl Lobby {
         if handle != entry.inviter && handle != entry.opponent {
             if !expired.is_empty() {
                 self.save_challenge_registry(&reg).await?;
-                self.reschedule_challenge_alarm(&reg).await?;
+                self.reschedule_alarm_with(&reg).await?;
             }
             send_line(ws, &build_login_incorrect_line("not_invited"))?;
             let _ = ws.close(Some(1000), Some("not_invited"));
@@ -710,7 +797,7 @@ impl Lobby {
         if entry.pending_ws_attachment_ids.contains_key(&handle) {
             if !expired.is_empty() {
                 self.save_challenge_registry(&reg).await?;
-                self.reschedule_challenge_alarm(&reg).await?;
+                self.reschedule_alarm_with(&reg).await?;
             }
             send_line(ws, &build_login_incorrect_line("already_logged_in"))?;
             let _ = ws.close(Some(1000), Some("already_logged_in"));
@@ -726,7 +813,7 @@ impl Lobby {
             now_ms,
         );
         self.save_challenge_registry(&reg).await?;
-        self.reschedule_challenge_alarm(&reg).await?;
+        self.reschedule_alarm_with(&reg).await?;
 
         ws.serialize_attachment(&LobbyAttachment::PrivatePending {
             token: token.as_str().to_owned(),
@@ -756,7 +843,7 @@ impl Lobby {
         let token_obj = ChallengeToken::from_raw(token);
         reg.unmark_ws_logged_in(&token_obj, &PlayerName::new(handle), attachment_id);
         self.save_challenge_registry(&reg).await?;
-        self.reschedule_challenge_alarm(&reg).await?;
+        self.reschedule_alarm_with(&reg).await?;
         console_log!(
             "[Lobby] private LOGIN ws closed: handle={handle} token={token} attachment_id={attachment_id}"
         );
@@ -800,23 +887,56 @@ impl Lobby {
         Ok(())
     }
 
-    /// DO Alarm ハンドラから呼ぶ TTL purge。期限切れ entry を一括削除し、
-    /// 戻り値の `pending_ws_attachment_ids` を走査して該当 WS にエラー送信
-    /// + close する。残 entry があれば `earliest_expiry_ms` で Alarm を再設定。
-    async fn handle_challenge_alarm(&self) -> Result<()> {
-        let now_ms = self.now_ms();
+    /// Alarm 経路から呼ぶ challenge_registry の TTL purge。期限切れ entry を
+    /// 一括削除し、戻り値の `pending_ws_attachment_ids` を走査して該当 WS に
+    /// エラー送信 + close する。本関数自体は **alarm を再予約しない**:
+    /// alarm 再予約は呼び出し側 (`alarm()`) が queue purge とまとめて 1 回だけ
+    /// 行う契約 (https://github.com/SH11235/rshogi/issues/631)。
+    async fn handle_challenge_purge(&self, now_ms: u64) -> Result<()> {
         let mut reg = self.load_challenge_registry().await?;
         let expired = reg.purge_expired(now_ms);
         if expired.is_empty() {
-            // 期限切れが無いまま Alarm が早めに発火した場合 (clock skew) は
-            // 残 registry の earliest で再予約して終了。
-            self.reschedule_challenge_alarm(&reg).await?;
             return Ok(());
         }
         self.disconnect_pending_websockets(&expired).await;
         self.save_challenge_registry(&reg).await?;
-        self.reschedule_challenge_alarm(&reg).await?;
         console_log!("[Lobby] challenge purge_expired: removed={}", expired.len());
+        Ok(())
+    }
+
+    /// Alarm 経路から呼ぶ public queue の TTL purge。
+    /// `now - last_pong_at_ms >= LOBBY_QUEUE_ENTRY_TTL_SEC` の entry を抜き、
+    /// 該当 WS に `LOGIN_LOBBY:incorrect queue_expired` を送って close する。
+    /// 本関数も alarm を再予約しない (`alarm()` が最後にまとめて呼ぶ)。
+    async fn handle_queue_purge(&self, now_ms: u64) -> Result<()> {
+        let ttl_ms = u64::try_from(self.queue_entry_ttl().as_millis()).unwrap_or(u64::MAX);
+        let removed = self.queue.borrow_mut().purge_stale(now_ms, ttl_ms);
+        if removed.is_empty() {
+            return Ok(());
+        }
+        // 期限切れ `(handle, attachment_id)` 集合を pre-compute して 1 回の
+        // `state.get_websockets()` 走査に詰める (queue 上限 100 で O(n))。
+        let targets: Vec<(String, String)> =
+            removed.iter().map(|e| (e.handle.clone(), e.attachment_id.clone())).collect();
+        for ws in self.state.get_websockets() {
+            let att = match ws.deserialize_attachment::<LobbyAttachment>() {
+                Ok(Some(a)) => a,
+                _ => continue,
+            };
+            let LobbyAttachment::Queued {
+                handle: ws_handle,
+                attachment_id: ws_id,
+                ..
+            } = att
+            else {
+                continue;
+            };
+            if targets.iter().any(|(h, a)| h == &ws_handle && a == &ws_id) {
+                let _ = send_line(&ws, &build_login_incorrect_line("queue_expired"));
+                let _ = ws.close(Some(1000), Some("queue_expired"));
+            }
+        }
+        console_log!("[Lobby] queue purge_stale: removed={}", removed.len());
         Ok(())
     }
 

--- a/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
@@ -109,13 +109,28 @@ pub fn parse_login_lobby(line: &str) -> Result<LoginLobbyRequest, LoginLobbyErro
     })
 }
 
-/// 1 件のキューエントリ。WS 識別子は呼び出し側で別途保持する (DO ランタイム側で
-/// `WebSocket` 値に紐付ける)。
+/// 1 件のキューエントリ。WS 識別子 (`attachment_id`) は LobbyDO が採番した一意 id
+/// を保持し、同 handle で旧 WS が close 遅延した場合の race を回避する
+/// (https://github.com/SH11235/rshogi/issues/631)。
+///
+/// `last_pong_at_ms` は purge 判定用の epoch ms。`LOBBY_PONG` 受信ごとに更新し、
+/// `now - last_pong_at_ms >= ttl` で stale 判定する。LOGIN_LOBBY 受信直後は
+/// 「pong を 1 度受け取った」相当の状態として `last_pong_at_ms = now` で初期化
+/// する。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueEntry {
     pub handle: String,
     pub game_name: String,
     pub color: Color,
+    /// LobbyDO 内で採番した一意な WS 識別子。private 経路の `pending_ws_attachment_ids`
+    /// と同じ値域を共有する (`ws-<u64>`)。`remove` / purge / pong 更新で
+    /// `(handle, attachment_id)` をキーとして照合し、旧 WS の遅延 close が新 entry
+    /// を誤削除する race を防ぐ。
+    pub attachment_id: String,
+    /// 最後に `LOBBY_PONG` (or LOGIN_LOBBY 直後の初期値) を受け取った時刻
+    /// (UNIX epoch ms)。`LOBBY_QUEUE_ENTRY_TTL_SEC` を超えると LobbyDO の Alarm
+    /// purge で stale 判定される。
+    pub last_pong_at_ms: u64,
 }
 
 /// LobbyDO の in-memory queue。
@@ -151,14 +166,57 @@ impl LobbyQueue {
         true
     }
 
-    /// handle で 1 件削除する。LOGOUT_LOBBY / WS close 時に呼ぶ。
-    pub fn remove(&mut self, handle: &str) {
-        self.entries.retain(|e| e.handle != handle);
+    /// `(handle, attachment_id)` で 1 件削除する。LOGOUT_LOBBY / WS close 時に呼ぶ。
+    /// 同 handle で別 `attachment_id` の entry (新 LOGIN による置換後) は触らない:
+    /// 旧 WS の close が遅延して届いた場合、新 entry を誤削除しない race-safe な API。
+    pub fn remove(&mut self, handle: &str, attachment_id: &str) {
+        self.entries
+            .retain(|e| !(e.handle == handle && e.attachment_id == attachment_id));
     }
 
     /// 指定 entry のスナップショットを返す (テスト用)。
     pub fn entries(&self) -> &[QueueEntry] {
         &self.entries
+    }
+
+    /// `(handle, attachment_id)` を一致させて `last_pong_at_ms` を更新する。
+    /// 一致 entry が無ければ no-op (既に dispatch / remove 済みなど)。
+    /// `LOBBY_PONG` 受信ごとに呼ぶ。
+    pub fn touch_pong(&mut self, handle: &str, attachment_id: &str, now_ms: u64) {
+        for entry in &mut self.entries {
+            if entry.handle == handle && entry.attachment_id == attachment_id {
+                entry.last_pong_at_ms = now_ms;
+                return;
+            }
+        }
+    }
+
+    /// `now_ms - last_pong_at_ms >= ttl_ms` を満たす entry を一括削除し、
+    /// 削除済 entry の `Vec` を返す。LobbyDO の Alarm purge 経路から呼び、戻り値の
+    /// `(handle, attachment_id)` を使って該当 WS にエラー送信 + close する責務は
+    /// 呼び出し側 (`lobby.rs`) が持つ。
+    ///
+    /// 境界: `last_pong_at_ms + ttl_ms == now_ms` は stale 扱い (`>=` で判定)。
+    /// `now_ms < last_pong_at_ms` のような時刻巻き戻りは実害が無いため触らない
+    /// (`saturating_sub` で 0 になり `0 >= ttl_ms` で false になる)。
+    pub fn purge_stale(&mut self, now_ms: u64, ttl_ms: u64) -> Vec<QueueEntry> {
+        let mut removed: Vec<QueueEntry> = Vec::new();
+        let mut i = 0;
+        while i < self.entries.len() {
+            if now_ms.saturating_sub(self.entries[i].last_pong_at_ms) >= ttl_ms {
+                removed.push(self.entries.swap_remove(i));
+            } else {
+                i += 1;
+            }
+        }
+        removed
+    }
+
+    /// 全 entry のうち最も古い `last_pong_at_ms` を返す。LobbyDO の Alarm を
+    /// 次回 purge 用に setAlarm するときに `min + ttl_ms` で発火時刻を計算する。
+    /// 空 queue は `None`。
+    pub fn earliest_last_pong_at_ms(&self) -> Option<u64> {
+        self.entries.iter().map(|e| e.last_pong_at_ms).min()
     }
 
     /// 同 `game_name` 内で `DirectMatchStrategy` を回し、最初に成立したペアを返す。
@@ -547,6 +605,8 @@ mod tests {
             handle: h.to_owned(),
             game_name: g.to_owned(),
             color: c,
+            attachment_id: format!("ws-{h}"),
+            last_pong_at_ms: 1_000,
         }
     }
 
@@ -613,6 +673,87 @@ mod tests {
         assert_eq!(m1.white.handle, "b");
         assert_eq!(m2.black.handle, "c");
         assert_eq!(m2.white.handle, "d");
+    }
+
+    /// `remove` は `(handle, attachment_id)` の両方一致でのみ削除する。
+    /// 同 handle で別 attachment_id の entry (新 LOGIN による置換後) は触らない。
+    #[test]
+    fn remove_uses_attachment_id_to_avoid_race() {
+        let mut q = LobbyQueue::new();
+        let mut e1 = entry("alice", "g", Color::Black);
+        e1.attachment_id = "ws-1".to_owned();
+        q.enqueue(e1, 100);
+        // 旧 WS の close が遅延しても、新 ws-1 を別 attachment_id で remove
+        // しても何も削除されない。
+        q.remove("alice", "ws-old");
+        assert_eq!(q.len(), 1);
+        // 一致する attachment_id では削除される。
+        q.remove("alice", "ws-1");
+        assert_eq!(q.len(), 0);
+    }
+
+    /// `touch_pong` は `(handle, attachment_id)` 一致時のみ `last_pong_at_ms` を更新する。
+    #[test]
+    fn touch_pong_updates_only_matching_attachment() {
+        let mut q = LobbyQueue::new();
+        let mut e = entry("alice", "g", Color::Black);
+        e.attachment_id = "ws-1".to_owned();
+        e.last_pong_at_ms = 1_000;
+        q.enqueue(e, 100);
+
+        q.touch_pong("alice", "ws-different", 5_000);
+        assert_eq!(q.entries()[0].last_pong_at_ms, 1_000);
+
+        q.touch_pong("alice", "ws-1", 5_000);
+        assert_eq!(q.entries()[0].last_pong_at_ms, 5_000);
+    }
+
+    /// `purge_stale` は `now - last_pong_at_ms >= ttl_ms` の entry を抜き、削除済 entry を返す。
+    #[test]
+    fn purge_stale_removes_entries_past_ttl() {
+        let mut q = LobbyQueue::new();
+        let mut a = entry("a", "g", Color::Black);
+        a.attachment_id = "ws-a".to_owned();
+        a.last_pong_at_ms = 1_000;
+        q.enqueue(a, 100);
+        let mut b = entry("b", "g", Color::White);
+        b.attachment_id = "ws-b".to_owned();
+        b.last_pong_at_ms = 4_000;
+        q.enqueue(b, 100);
+
+        // now=6000, ttl=5000 → a (1000) は 5000ms 経過で stale、b (4000) は 2000ms で生存。
+        let removed = q.purge_stale(6_000, 5_000);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].handle, "a");
+        assert_eq!(q.len(), 1);
+        assert_eq!(q.entries()[0].handle, "b");
+    }
+
+    /// 境界: `now - last_pong_at_ms == ttl_ms` は stale 扱い (`>=` で判定)。
+    #[test]
+    fn purge_stale_boundary_is_stale() {
+        let mut q = LobbyQueue::new();
+        let mut a = entry("a", "g", Color::Black);
+        a.attachment_id = "ws-a".to_owned();
+        a.last_pong_at_ms = 1_000;
+        q.enqueue(a, 100);
+        let removed = q.purge_stale(6_000, 5_000);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(q.len(), 0);
+    }
+
+    /// `earliest_last_pong_at_ms` は最古の last_pong を返す。空なら `None`。
+    #[test]
+    fn earliest_last_pong_returns_min() {
+        let mut q = LobbyQueue::new();
+        assert_eq!(q.earliest_last_pong_at_ms(), None);
+        let mut a = entry("a", "g", Color::Black);
+        a.last_pong_at_ms = 1_000;
+        q.enqueue(a, 100);
+        let mut b = entry("b", "g", Color::White);
+        b.last_pong_at_ms = 4_000;
+        q.enqueue(b, 100);
+        assert_eq!(q.earliest_last_pong_at_ms(), Some(1_000));
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -83,6 +83,11 @@ export interface HarnessOptions {
   wsAllowedOrigins?: string;
   adminApiToken?: string;
   lobbyQueueSizeLimit?: number;
+  /// 公開 lobby queue entry の TTL (秒、Issue #631)。`LOBBY_PONG` 受信から本値
+  /// を超えた entry は alarm で stale 判定され `LOGIN_LOBBY:incorrect queue_expired`
+  /// + WS close される。未指定時は server 既定 (300 秒) にフォールバック。
+  /// stale purge を smoke で再現するときは短い値 (例: 1) を渡す。
+  lobbyQueueEntryTtlSec?: number;
 }
 
 export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> {
@@ -128,6 +133,10 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       ALLOW_FLOODGATE_FEATURES: opts.allowFloodgateFeatures ? "true" : "false",
       WS_ALLOWED_ORIGINS: opts.wsAllowedOrigins ?? "https://example.com",
       LOBBY_QUEUE_SIZE_LIMIT: String(opts.lobbyQueueSizeLimit ?? 100),
+      // 未指定時は空文字を渡して server 側 fallback (= 300 秒既定) を使う。
+      // 数値を指定したテストでは alarm 経路で stale entry が purge される。
+      LOBBY_QUEUE_ENTRY_TTL_SEC:
+        opts.lobbyQueueEntryTtlSec === undefined ? "" : String(opts.lobbyQueueEntryTtlSec),
     },
     defaultPersistRoot: opts.persistRoot,
   });

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/lobby.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/lobby.test.ts
@@ -171,3 +171,72 @@ describe("Lobby DO matching", () => {
     ws2.close();
   });
 });
+
+/**
+ * Issue #631: stale public queue entry を Alarm で purge する経路の smoke。
+ * `LOBBY_QUEUE_ENTRY_TTL_SEC = 1` で短時間に stale 判定させ、`mf.runDurableObjectAlarm`
+ * で alarm を駆動して `LOGIN_LOBBY:incorrect queue_expired` + WS close を検証する。
+ */
+describe("Lobby DO queue TTL purge (Issue #631)", () => {
+  let mf: Miniflare;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanup = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      lobbyQueueEntryTtlSec: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanup();
+  });
+
+  test("LOBBY_PONG が来ない queued entry は alarm で queue_expired + close される", async () => {
+    const ws = await connectLobby(mf);
+    const buf = readLineFromWebSocket(ws);
+    ws.send("LOGIN_LOBBY alice+pool-z+black anything\n");
+    expect(await buf.takeLine()).toBe("LOGIN_LOBBY:alice OK");
+
+    // TTL = 1 秒なので 1.2 秒後に alarm 発火させる。Miniflare の DO alarm は
+    // 仮想時計を使わないため、wall-clock を進めるかわりに sleep で待つ。
+    await new Promise((r) => setTimeout(r, 1200));
+
+    // Lobby DO id は固定 ("default")。`getDurableObjectId` で取得して alarm を
+    // 強制発火する。
+    const ns = await mf.getDurableObjectNamespace("LOBBY");
+    const id = ns.idFromName("default");
+    const stub = ns.get(id);
+    // miniflare の DurableObjectStub は `alarm()` を直接公開しない。代替として
+    // 設定済の alarm が経過時刻になっていれば自動発火するため、再度 sleep して
+    // alarm の処理結果 (queue_expired ライン受信) を待つ。
+    void stub; // 参照は警告抑止のため確保
+
+    expect(await buf.takeLine(3000)).toBe("LOGIN_LOBBY:incorrect queue_expired");
+    // close 後の takeLine は connection closed で reject される。
+    await expect(buf.takeLine(500)).rejects.toThrow();
+  });
+
+  test("LOBBY_PONG を送り続ける queued entry は purge されず待機を継続する", async () => {
+    const ws = await connectLobby(mf);
+    const buf = readLineFromWebSocket(ws);
+    ws.send("LOGIN_LOBBY alice+pool-z+black anything\n");
+    expect(await buf.takeLine()).toBe("LOGIN_LOBBY:alice OK");
+
+    // 0.4 秒間隔で LOBBY_PONG を送り、TTL=1 秒を更新し続ける。
+    const pongTimer = setInterval(() => {
+      ws.send("LOBBY_PONG\n");
+    }, 400);
+
+    try {
+      // 1.5 秒経っても queue_expired は来ないことを確認。
+      await expect(buf.takeLine(1500)).rejects.toThrow("timeout");
+    } finally {
+      clearInterval(pongTimer);
+      ws.close();
+    }
+  });
+});

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -164,6 +164,14 @@ ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。100 件を超える同時待機は LOGIN_LOBBY を
 # queue_full で reject する保守的既定。負荷に応じて引き上げ可。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 公開マッチング queue の entry TTL (秒)。`LOBBY_PONG` 受信から本値を超えた
+# entry を Lobby DO の Alarm purge で stale 判定し、`LOGIN_LOBBY:incorrect
+# queue_expired` 送信 + WS close する (Issue #631)。network 分断や close 遅延で
+# 残った stale entry を一定時間で掃除して後続ユーザの誤マッチを防ぐ。
+# 5 分は `csa_client` の lobby 待機運用 (60 秒 blocking recv で連続 LOGIN_LOBBY
+# する設計、Issue #631 のスコープ外で client 側 keep-alive 修正は別 PR)
+# を踏まえた保守的既定。`0` / 未設定 / 非数値は 300 秒既定にフォールバック。
+LOBBY_QUEUE_ENTRY_TTL_SEC = "300"
 # 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。期限超過した
 # 未消費 token は Lobby DO の Alarm ハンドラで自動削除する。1 時間 = 3600
 # は対戦相手が招待後にゆっくり PC を起動する想定の保守的既定。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -164,6 +164,11 @@ ALLOW_FLOODGATE_FEATURES = "true"
 ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。staging では小規模通電向けに 100 で運用。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 公開マッチング queue の entry TTL (秒)。staging は smoke / E2E をテンポよく回す
+# ため短めの 60 秒に設定する (Issue #631)。本値を超えても `LOBBY_PONG` 受信で
+# 延長されるため、heartbeat 実装後はそのまま使える。production 昇格時は 300 秒
+# に揃える。`0` / 未設定 / 非数値は 300 秒既定にフォールバック。
+LOBBY_QUEUE_ENTRY_TTL_SEC = "60"
 # 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。staging は通電
 # 確認をテンポよく回すため短めの 600 秒 (10 分) で運用する。production 昇格
 # 時は 3600 秒に揃える。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -143,6 +143,11 @@ ALLOW_FLOODGATE_FEATURES = "false"
 ALLOW_VIEWER_API = "1"
 # LobbyDO 内 in-memory queue の総数上限。超過時 LOGIN_LOBBY を queue_full で reject。
 LOBBY_QUEUE_SIZE_LIMIT = "100"
+# 公開マッチング queue の entry TTL (秒)。`LOBBY_PONG` 受信から本値を超えると
+# Lobby DO の Alarm purge で stale 判定され、`LOGIN_LOBBY:incorrect queue_expired`
+# 送信 + WS close される (Issue #631)。`0` / 未設定 / 非数値は 300 秒既定にフォール
+# バック (TTL 0 = 即時 purge は許容しない)。
+LOBBY_QUEUE_ENTRY_TTL_SEC = "300"
 # 私的対局 (CHALLENGE_LOBBY) で発行される token の TTL (秒)。期限超過した
 # 未消費 token は Lobby DO の Alarm ハンドラで自動削除し、保留中の WS 接続
 # があれば切断信号を送る。Issue #582 の Workers 経路で参照する。


### PR DESCRIPTION
## Summary
- 公開 lobby queue に TTL purge を追加 (env `LOBBY_QUEUE_ENTRY_TTL_SEC`、既定 300 秒)。`LOBBY_PONG` 受信から TTL 超過した stale entry を Lobby DO の Alarm で `LOGIN_LOBBY:incorrect queue_expired` 送出 + close。
- `QueueEntry` / `LobbyAttachment::Queued` に `attachment_id` を追加し、`(handle, attachment_id)` 完全一致で remove / pong update / dispatch_match を行うよう変更。同 handle で旧 WS の close 遅延が新 entry を誤削除 / 誤 MATCHED する race を排除。
- 既存 `reschedule_challenge_alarm` を `reschedule_alarm` に統合し、`min(challenge.earliest_expiry_ms, queue.earliest_last_pong_at_ms + ttl)` で 1 本化。

## 設計メモ
- **client heartbeat 送出**: 本 PR スコープ外。server 側で `LOBBY_PONG` 受信時の `last_pong_at_ms` 更新だけ実装し、`csa_client` 側 ping 送出は別 PR で対応 (Codex review にて確認済)。
- **TTL 値**: production=300s (5 分)、staging=60s (smoke テンポ重視)、template=300s。`0` / 未設定 / 不正値は安全側既定 (300s) にフォールバック。
- **race 解消**: Codex review で指摘された `dispatch_match` 経路も `attachment_id` 照合に揃え、旧 WS の close 遅延 + 新 LOGIN_LOBBY による entry 置換シナリオで誤 `MATCHED` 送信が起きないよう完全一致条件で gate。

## 影響ファイル
- `crates/rshogi-csa-server-workers/src/lobby.rs` (+181 / -44): alarm 統一 / `Queued` attachment / `LOBBY_PONG` heartbeat / dispatch_match 照合
- `crates/rshogi-csa-server-workers/src/lobby_protocol.rs` (+153): `QueueEntry` フィールド追加 / `touch_pong` / `purge_stale` / `earliest_last_pong_at_ms`
- `crates/rshogi-csa-server-workers/src/config.rs` (+55): `LOBBY_QUEUE_ENTRY_TTL_SEC` const + parser + tests
- `crates/rshogi-csa-server-workers/wrangler.{production,staging,toml.example}.toml`: env 値追加
- `crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts`, `lobby.test.ts`: TTL purge fixture (2 件)

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --tests` 警告 0
- [x] `cargo test -p rshogi-csa-server-workers --lib`: 285 pass
- [x] `cargo test -p rshogi-csa-server-workers --test wrangler_template_consistency --test wrangler_environment_toml_consistency`: 全 pass
- [x] `cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown --release`: OK
- [x] `pnpm test:smoke` (miniflare): 26 pass (Issue #631 新規 fixture 2 件含む)
- [ ] CI で integration / GH Actions が green を待つ
- [ ] staging へ deploy 後、`LOBBY_QUEUE_ENTRY_TTL_SEC=60` で 1 分待機 → `queue_expired` ログ観測

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)