### PR TITLE
feat(csa-client): killpg で engine 死亡時の孫プロセス reap (#618)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,7 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
+ "nix",
  "rshogi-core",
  "rshogi-csa",
  "rshogi-csa-server",

--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -62,6 +62,14 @@ rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 # コード側のため feature gate せず常時必須。
 libc = "0.2"
 
+# `nix` は engine 死亡時の process group 単位 kill (`killpg`) を unsafe を
+# 使わず safe wrapper 経由で呼ぶために unix 限定で依存。`signal` feature だけ
+# あれば `killpg` / `Signal::SIGKILL` / `Pid::from_raw` が揃う。
+# version は workspace 上 (ctrlc 経由) で既に解決されている `0.31` 系に揃え、
+# Cargo.lock の dup を回避する。
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }
+
 # CSA-over-WebSocket 用の sync ハンドシェイク + フレーミング。
 # rustls + webpki ルートで TLS を実装し、native-tls 経由の OpenSSL 依存を避ける。
 tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"], optional = true }

--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -287,14 +287,25 @@ impl UsiEngine {
             stderr_passthrough,
         } = opts;
         let mut cmd = Command::new(path);
-        // 子プロセスを独立したプロセスグループで起動
+        // 子プロセスを独立したプロセスグループで起動。
+        // `Drop` / `quit()` 内 timeout 後に `killpg(pgid, SIGKILL)` で
+        // process group ごと kill するための前段。pgid == child.id() となる。
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;
-            // SAFETY: setpgid は async-signal-safe
+            // SAFETY:
+            // - `pre_exec` クロージャは fork 後 exec 前の片側スレッド context で
+            //   実行され、`libc::setpgid` は async-signal-safe (POSIX.1-2017 に
+            //   定義された signal-safe API) なので allocation / lock を呼ばない。
+            // - `setpgid(0, 0)` は呼び出し元プロセスを leader とする新規 PG を
+            //   作るのみ。失敗時は -1 を返すので `last_os_error()` を `Err` で返し、
+            //   spawn 自体を失敗させて以降の killpg が「孫が同じ PG に居ない」状態
+            //   で SIGKILL を撒く事故を防ぐ。
             unsafe {
                 cmd.pre_exec(|| {
-                    libc::setpgid(0, 0);
+                    if libc::setpgid(0, 0) == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
                     Ok(())
                 });
             }
@@ -570,14 +581,29 @@ impl UsiEngine {
         }
         if !matches!(self.child.try_wait(), Ok(Some(_))) {
             log::warn!("[USI] quit タイムアウト、kill します");
-            let _ = self.child.kill();
+            kill_engine_process_tree(&mut self.child);
             let _ = self.child.wait();
         }
-        // stderr handle bounded join (graceful path のみ実施)
+        // stderr handle bounded join (graceful path のみ実施)。
+        //
+        // direct child が `quit` で正常終了しても、engine が fork した孫が
+        // stderr fd を継承していると reader thread は EOF を観測できず join が
+        // timeout する (#618)。timeout 後は process group ごと SIGKILL で
+        // 孫の stderr fd を強制 close し、reader thread を確実に終了させる。
+        // child は既に終了済みでも、`killpg` は同じ pgid に属する live な孫
+        // にだけ届くため副作用は無い。
         if let Some(handle) = self.stderr_reader_handle.take()
             && let Err(unfinished) = join_handle_bounded(handle, STDERR_JOIN_WAIT_GRACEFUL)
         {
-            drop(unfinished);
+            log::warn!(
+                "[USI] stderr reader join timeout (graceful)、孫プロセスへ killpg を発行します (#618)"
+            );
+            kill_engine_process_tree(&mut self.child);
+            // direct child は既に reaping 済みでも try_wait/wait は idempotent。
+            // killpg 後 reader thread が EOF で抜けるまでもう一度 short join。
+            if let Err(unfinished) = join_handle_bounded(unfinished, STDERR_JOIN_WAIT_DROP) {
+                drop(unfinished);
+            }
         }
         self.quit_sent = true;
     }
@@ -783,18 +809,32 @@ impl UsiEngine {
     pub fn drain(&self) {
         while self.rx.try_recv().is_ok() {}
     }
+
+    /// テスト専用: engine subprocess の raw pid を返す。`pre_exec(setpgid(0,0))`
+    /// により pgid と同値となる。`/proc/<pid>/stat` から孫の pgid 一致を検証する
+    /// regression test (#618) からのみ使用する。
+    #[doc(hidden)]
+    pub fn child_pid_for_test(&self) -> u32 {
+        self.child.id()
+    }
 }
 
 impl Drop for UsiEngine {
     fn drop(&mut self) {
-        // 既存 fast path を維持: send("quit") + sleep 100ms + kill + wait。
+        // 既存 fast path を維持: send("quit") + sleep 100ms + killpg + wait。
         // engine 死亡確定 (BrokenPipe) の場合 send 経由で `engine_exited_error()`
         // が走り 200ms wait を払うが、Drop 全体の遅延は最大 ~400ms に bounded。
         // panic-on-drop / test runner 経路で 3.5 秒+ の遅延を回避する設計。
+        //
+        // `kill_engine_process_tree` は unix では `killpg(pgid, SIGKILL)` を発行し、
+        // engine が fork した孫プロセス (stderr fd 継承パターン) にも SIGKILL を
+        // 届ける。kernel が孫の stderr fd を強制 close することで、stderr reader
+        // thread が EOF で抜け、leak を防ぐ (#618)。reap は direct child のみ
+        // `self.child.wait()` で行う (孫は init が reap)。
         if !self.quit_sent {
             let _ = self.send("quit");
             std::thread::sleep(Duration::from_millis(100));
-            let _ = self.child.kill();
+            kill_engine_process_tree(&mut self.child);
             let _ = self.child.wait();
         }
         // stderr handle が残っていれば best-effort で cleanup (bounded join 100ms、
@@ -805,6 +845,40 @@ impl Drop for UsiEngine {
             drop(unfinished);
         }
     }
+}
+
+/// engine 死亡確定時に `Child` および孫プロセスへ kill signal を送る共通 helper。
+///
+/// Unix では `pre_exec(setpgid(0,0))` で子プロセスを独立 process group に
+/// 置いているため、`killpg(pgid, SIGKILL)` を発行することで engine が fork
+/// した孫プロセスにも一括で SIGKILL が届く。孫が継承した stderr fd は kernel
+/// が強制 close するので、parent の stderr reader thread は EOF で終了する
+/// (PR #596 review で議論された stderr reader leak の根因対策)。
+///
+/// 注意: `wait()` で reap できるのは direct child のみ。孫プロセスは grand-
+/// parent (init / systemd) が reap する。本 helper は kill だけを担当し、
+/// reap は呼び出し側が `child.wait()` で direct child について行う前提。
+///
+/// `killpg` 失敗時 (例: child の id が i32 範囲外、または既に process group
+/// が空になっている) は `child.kill()` に fallback し、最低限の直系 child
+/// kill を保証する。
+///
+/// 非 Unix プラットフォームでは process group の概念がないため `child.kill()`
+/// に直接委譲する (Windows の Job Object 化は別 issue 扱い)。
+fn kill_engine_process_tree(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        // `child.id()` は raw pid (u32)。`setpgid(0,0)` 後は pgid と同値。
+        // i32 範囲外なら killpg は発行できないので fallback に回す。
+        if let Ok(pid_raw) = i32::try_from(child.id()) {
+            let pgid = nix::unistd::Pid::from_raw(pid_raw);
+            if nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL).is_ok() {
+                return;
+            }
+            // killpg 失敗 (ESRCH 等) → child 単独 kill に fallback。
+        }
+    }
+    let _ = child.kill();
 }
 
 /// `option name <NAME> type ...` からオプション名を抽出

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -309,3 +309,122 @@ exit 1
         "passthrough=true でも ring buffer に末尾 (line A / line B 両方) が積まれているはず: {msg}"
     );
 }
+
+// ───────────────────────────────────────────────
+// Fixture 8 (Linux only): engine が fork した孫プロセスが stderr fd を継承
+//   している状況で、`UsiEngine::drop` の `killpg(pgid, SIGKILL)` により
+//   孫プロセスにも SIGKILL が届き (reap は init / systemd 側) 、stderr reader
+//   thread が EOF を観測して leak しないこと。
+//
+//   Issue #618: 既存の `child.kill()` 単独では孫が継承した stderr fd が
+//   残り、reader thread が EOF を観測できず leak していた。
+//
+//   検証手順:
+//   1. mock USI engine が fork して長 sleep の孫を生成、孫 pid を tmp file へ書く。
+//   2. UsiEngine::spawn → handshake 完了。
+//   3. drop(engine) で kill_engine_process_tree() が走る。
+//   4. 孫 pid を /proc から polling で確認:
+//      - drop 直後に setpgid(0,0) が反映済み: 孫の pgid == child の pid
+//      - drop 後 1 秒以内に /proc/<pid>/stat が消滅 / state=Z (= SIGKILL 到達)
+//   `/proc` を直接読むため Linux 限定 fixture。Linux 以外 (macOS / *BSD) は skip。
+// ───────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+#[test]
+fn descendant_process_killed_via_killpg_on_drop() {
+    use std::time::Instant;
+
+    // tmpfile に孫 pid を書く同期チャネル。test 側は read で「孫が起動したか」を待つ。
+    let pid_file = std::env::temp_dir().join(format!(
+        "csa_client_grandchild_pid_{}_{}.txt",
+        std::process::id(),
+        SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst),
+    ));
+    // 既存 file が残っていれば除去 (sequence 衝突の hedge)。
+    let _ = std::fs::remove_file(&pid_file);
+
+    // mock USI engine: fork して sleep の孫を background 起動。
+    // - 孫は stderr を継承 (`exec 2>&-` を孫側で呼ばない)。
+    // - 孫 pid を pid_file へ書き出し、親側 handshake を完了させた上で `read` で待機。
+    // - 親 (engine) が SIGKILL されたら孫は孤児化、killpg なら孫も SIGKILL。
+    let script = format!(
+        r#"#!/usr/bin/env bash
+# 孫プロセスを background で fork。stderr は継承 (close しない)。
+( exec sleep 60 ) &
+GRANDCHILD_PID=$!
+printf '%s\n' "$GRANDCHILD_PID" > {pid_file}
+read line  # usi
+echo "id name mock_grandchild"
+echo "usiok"
+read line  # isready
+echo "readyok"
+# 親はこのまま read で待機。Drop で SIGKILL されるのを待つ。
+read line
+"#,
+        pid_file = pid_file.display(),
+    );
+    let path = write_mock_script("grandchild_killpg", &script);
+    let opts: HashMap<String, toml::Value> = HashMap::new();
+    let engine =
+        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
+    let parent_pid = engine.child_pid_for_test();
+
+    // 孫 pid が pid_file に書かれるまで待つ (最大 2 秒)。
+    let grandchild_pid = {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(s) = std::fs::read_to_string(&pid_file)
+                && let Ok(pid) = s.trim().parse::<i32>()
+            {
+                break pid;
+            }
+            if Instant::now() >= deadline {
+                panic!("孫プロセス pid が {pid_file:?} に書かれませんでした");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    };
+
+    // 孫の pgid が parent_pid と一致することを /proc/<pid>/stat から確認。
+    // /proc/<pid>/stat の format: pid (comm) state ppid pgrp ...
+    // comm にはスペースが含まれ得るため、最後の `)` で分割してから token 化する。
+    let stat = std::fs::read_to_string(format!("/proc/{grandchild_pid}/stat"))
+        .expect("/proc/<pid>/stat 読み取りに失敗");
+    let after_comm =
+        stat.rsplit_once(')').expect("stat に ')' がない (format 不正)").1.trim_start();
+    let mut tokens = after_comm.split_whitespace();
+    let _state = tokens.next().expect("state token");
+    let _ppid = tokens.next().expect("ppid token");
+    let pgrp: i32 = tokens.next().expect("pgrp token").parse().expect("pgrp parse");
+    assert_eq!(
+        pgrp, parent_pid as i32,
+        "孫 pgid は parent (engine) pid と一致しているはず (setpgid 検証)"
+    );
+
+    // drop でプロセスツリー kill。
+    drop(engine);
+
+    // 孫 pid が消滅または zombie 状態 (Z) になるのを 2 秒 polling で確認。
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut ok = false;
+    while Instant::now() < deadline {
+        match std::fs::read_to_string(format!("/proc/{grandchild_pid}/stat")) {
+            Err(_) => {
+                ok = true;
+                break;
+            }
+            Ok(stat) => {
+                let after_comm = stat.rsplit_once(')').map(|s| s.1.trim_start()).unwrap_or("");
+                let state = after_comm.split_whitespace().next().unwrap_or("");
+                if state == "Z" {
+                    ok = true;
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(ok, "孫プロセス {grandchild_pid} は drop 後 2 秒以内に kill されるはず (#618)");
+
+    // tmp file 掃除 (best-effort)。
+    let _ = std::fs::remove_file(&pid_file);
+}


### PR DESCRIPTION
## Summary

- `UsiEngine::Drop` / `quit()` での `child.kill()` を `kill_engine_process_tree()` ヘルパーに集約し、unix では `nix::sys::signal::killpg(pgid, SIGKILL)` で process group ごと kill する経路に切り替えた。`pre_exec(setpgid(0, 0))` で確保していた pgid を活用し、engine が fork した孫プロセス (stderr fd 継承パターン) も SIGKILL で kernel が fd を強制 close することで、stderr reader thread の leak (#618) を解消する。
- `quit()` の graceful path でも stderr reader join が timeout した場合に killpg を再発行する経路を追加 (graceful child exit 後に孫が stderr を握り続けるケースに対応)。
- 設計レビューの方針どおり `unsafe` は新規持ち込みなし。`nix` 0.31 を `[target.'cfg(unix)'.dependencies]` に追加 (workspace の ctrlc 経由で既に lockfile 在中、dup なし)。`signal` feature 1 つで必要な API が全部揃う最小構成。
- `pre_exec` 内の `setpgid` 戻り値を `last_os_error()` で `Err` 化し、失敗時に spawn 自体を fail させる (既存の "戻り値無視" を解消)。
- regression test (Linux only) を `engine_stderr_diagnostic.rs` に追加: mock USI engine が `( exec sleep 60 ) &` で孫を fork し、`/proc/<pid>/stat` から孫の `pgrp` が parent (engine) pid と一致することを確認した上で `drop(engine)` 後 2 秒以内に孫が消滅 / state=Z になることを polling で検証。

## Design notes

- 選択肢 1 (nix safe wrapper) を採用。設計レビュー (Codex) で `nix::sys::signal::killpg` が `pub fn ... -> Result<()>` の safe API であること、利用側に `unsafe` が不要であることを確認済み。
- `kill_engine_process_tree` は kill のみを担当し、reap は呼び出し側が `child.wait()` で direct child について行う (孫は init / systemd が reap)。
- `killpg` 失敗時 (i32 範囲外 / ESRCH 等) は `child.kill()` に fallback。
- Windows は `#[cfg(unix)]` 以外では従来 `child.kill()` を維持。Job Object 化は別 issue (本 PR の scope 外)。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rshogi-csa-client --tests` (警告 0)
- [x] `cargo test -p rshogi-csa-client` 全 pass
- [x] 新規 fixture `descendant_process_killed_via_killpg_on_drop` (Linux only) pass
- [x] 既存 `engine_stderr_diagnostic` 7 fixture すべて pass
- [ ] CI green

## 関連

Closes #618
Refs #603 (本 issue は #603 拡張 2 として分離)
Refs #593 (csa_client 2 instance race の root cause、stderr diagnostic の元)
Refs PR #596 (review 議論で stderr reader leak が表面化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)