### PR TITLE
ci: GitHub Actions を SHA pin + Node 24 対応版へ bump

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c7d609261ba189a1b88efd790853001aa9640e1d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@c7d609261ba189a1b88efd790853001aa9640e1d # v1
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c7d609261ba189a1b88efd790853001aa9640e1d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@c7d609261ba189a1b88efd790853001aa9640e1d # v1
+        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/cloudflare-drift-check.yml
+++ b/.github/workflows/cloudflare-drift-check.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       # `git log -1 --format=%H -- <paths>` で deploy-trigger path に触れた main 上の
       # 最新 commit を取るため full history が必要。`fetch-depth: 0`。
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       # `csa-deploy-drift` label が repo に未作成だと `gh issue create --label` が

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -148,11 +148,11 @@ jobs:
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
         if: steps.check.outputs.can_deploy == 'true'
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_deploy == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.check.outputs.can_deploy == 'true'
         with:
           shared-key: wasm32
@@ -185,7 +185,7 @@ jobs:
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         if: steps.check.outputs.can_deploy == 'true'
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json
@@ -367,11 +367,11 @@ jobs:
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
         if: steps.check.outputs.can_deploy == 'true'
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_deploy == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.check.outputs.can_deploy == 'true'
         with:
           shared-key: wasm32
@@ -400,7 +400,7 @@ jobs:
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         if: steps.check.outputs.can_deploy == 'true'
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json

--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -130,7 +130,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::warning::staging deploy skipped (environment secrets not configured)."
           fi
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.check.outputs.can_deploy == 'true'
         with:
           # https://github.com/SH11235/rshogi/issues/639: drift detection の基準値となる DEPLOY_TRIGGER_SHA を
@@ -148,11 +148,11 @@ jobs:
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
         if: steps.check.outputs.can_deploy == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_deploy == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         if: steps.check.outputs.can_deploy == 'true'
         with:
           shared-key: wasm32
@@ -178,19 +178,19 @@ jobs:
       - name: Cache worker-build binary
         if: steps.check.outputs.can_deploy == 'true'
         id: cache-worker-build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cargo/bin/worker-build
           key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
         if: steps.check.outputs.can_deploy == 'true'
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.check.outputs.can_deploy == 'true'
         with:
           node-version-file: crates/rshogi-csa-server-workers/.node-version
@@ -226,7 +226,7 @@ jobs:
           echo "DEPLOY_TRIGGER_SHA=$sha"
       - name: Deploy via wrangler-action
         if: steps.check.outputs.can_deploy == 'true'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -324,7 +324,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::warning::FORCE DEPLOY: drain bypassed. reason=$FORCE_DEPLOY_REASON"
           fi
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.check.outputs.can_deploy == 'true'
         with:
           # https://github.com/SH11235/rshogi/issues/639: 同 staging job の checkout コメント参照。drift detection 用
@@ -367,11 +367,11 @@ jobs:
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
         if: steps.check.outputs.can_deploy == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_deploy == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         if: steps.check.outputs.can_deploy == 'true'
         with:
           shared-key: wasm32
@@ -393,19 +393,19 @@ jobs:
       - name: Cache worker-build binary
         if: steps.check.outputs.can_deploy == 'true'
         id: cache-worker-build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cargo/bin/worker-build
           key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
         if: steps.check.outputs.can_deploy == 'true'
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.check.outputs.can_deploy == 'true'
         with:
           node-version-file: crates/rshogi-csa-server-workers/.node-version
@@ -436,7 +436,7 @@ jobs:
           echo "DEPLOY_TRIGGER_SHA=$sha"
       - name: Deploy via wrangler-action
         if: steps.check.outputs.can_deploy == 'true'
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,8 +35,8 @@ jobs:
     outputs:
       rust_code: ${{ steps.filter.outputs.rust_code }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -61,7 +61,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_code == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -74,7 +74,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_code == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -85,10 +85,10 @@ jobs:
         with:
           components: clippy
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           cache-on-failure: true
       - name: Run Clippy
@@ -104,7 +104,7 @@ jobs:
     if: needs.changes.outputs.rust_code == 'true'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -113,10 +113,10 @@ jobs:
           clang --version || true
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           cache-on-failure: true
       - name: Run tests
@@ -131,7 +131,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust_code == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-audit
       - name: Run security audit
@@ -172,7 +172,7 @@ jobs:
       # wasm32 標準の codegen に任せる（host target 用の baseline 設定の意図とも整合）。
       RUSTFLAGS: ""
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - name: Add wasm32 target to pinned toolchain
         # `rust-toolchain.toml` が channel を 1.93.1 に pin しているため、
@@ -188,10 +188,10 @@ jobs:
           echo "Adding wasm32-unknown-unknown to toolchain $CHANNEL"
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           cache-on-failure: true
           # host target キャッシュ (`lint` / `test` job) と完全分離する。

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,10 +85,10 @@ jobs:
         with:
           components: clippy
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
       - name: Run Clippy
@@ -113,10 +113,10 @@ jobs:
           clang --version || true
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
       - name: Run tests
@@ -188,10 +188,10 @@ jobs:
           echo "Adding wasm32-unknown-unknown to toolchain $CHANNEL"
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
           # host target キャッシュ (`lint` / `test` job) と完全分離する。

--- a/.github/workflows/synthetic-csa-production.yml
+++ b/.github/workflows/synthetic-csa-production.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 5
     environment: rshogi-csa-server-workers-production
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
       # `csa-synthetic-failure` label が repo 未作成だと `gh issue create --label`

--- a/.github/workflows/synthetic-csa-staging.yml
+++ b/.github/workflows/synthetic-csa-staging.yml
@@ -91,14 +91,14 @@ jobs:
           rustup default "$CHANNEL"
       - name: Setup sccache
         if: steps.check.outputs.can_run == 'true'
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_run == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
       # native release build 用 cache key。`deploy-workers.yml` 等が使う wasm32
       # group とは別 namespace にして cache key の衝突 (`RUSTFLAGS` 不一致での
       # cache miss / 汚染) を防ぐ。
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.check.outputs.can_run == 'true'
         with:
           shared-key: csa-synthetic-native

--- a/.github/workflows/synthetic-csa-staging.yml
+++ b/.github/workflows/synthetic-csa-staging.yml
@@ -56,7 +56,7 @@ jobs:
       # 既定 stable (x86-64) で問題なし。明示空文字で defensive に上書き。
       RUSTFLAGS: ""
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
       - name: Ensure csa-synthetic-failure label exists
@@ -91,14 +91,14 @@ jobs:
           rustup default "$CHANNEL"
       - name: Setup sccache
         if: steps.check.outputs.can_run == 'true'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         if: steps.check.outputs.can_run == 'true'
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
       # native release build 用 cache key。`deploy-workers.yml` 等が使う wasm32
       # group とは別 namespace にして cache key の衝突 (`RUSTFLAGS` 不一致での
       # cache miss / 汚染) を防ぐ。
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         if: steps.check.outputs.can_run == 'true'
         with:
           shared-key: csa-synthetic-native
@@ -243,7 +243,7 @@ jobs:
       # success 時も保存しておくと「正常 run の baseline」と比較できる。
       - name: Upload logs and records
         if: always() && steps.check.outputs.can_run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: synthetic-csa-staging-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -56,10 +56,10 @@ jobs:
           CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # `rust-ci.yml` の `wasm-build` job、`deploy-workers.yml` と
           # 同じ wasm32 sysroot キャッシュ namespace を共有する。
@@ -88,7 +88,7 @@ jobs:
       - name: Install worker-build
         if: steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json
           run_install: false

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -49,17 +49,17 @@ jobs:
       # ターゲットで warning を大量発生させる。
       RUSTFLAGS: ""
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
       - name: Add wasm32 target to pinned toolchain
         run: |
           CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)
           rustup target add --toolchain "$CHANNEL" wasm32-unknown-unknown
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Enable sccache
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           # `rust-ci.yml` の `wasm-build` job、`deploy-workers.yml` と
           # 同じ wasm32 sysroot キャッシュ namespace を共有する。
@@ -81,18 +81,18 @@ jobs:
       #   `deploy-workers.yml` の同箇所と同契約。
       - name: Cache worker-build binary
         id: cache-worker-build
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cargo/bin/worker-build
           key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
       - name: Install worker-build
         if: steps.cache-worker-build.outputs.cache-hit != 'true'
         run: cargo install -q worker-build@^0.8 --locked
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@5d445ecbfcb90fdf1556a629d018c79e97ff973b # v6.0.6
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: crates/rshogi-csa-server-workers/.node-version
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

- GitHub Actions Runner の Node.js 20 deprecation warning に対応する。`setup-node@v4` / `pnpm/action-setup@v4` 等の Node 20 ランタイム製 action を最新の Node 24 対応版に bump。
- 全 action を **commit SHA で pin** し、inline コメントでバージョンを併記する。
- `dtolnay/rust-toolchain@stable` と `taiki-e/install-action@cargo-audit` は tag 名がパラメータとして機能する (toolchain 種別 / 対象 tool 選択) ため SHA pin せず据え置く。

## 主な bump

| Action | Before | After |
|---|---|---|
| actions/checkout | v5 | v6.0.2 |
| actions/setup-node | v4 | v6.4.0 |
| actions/cache | v4 | v5.0.5 |
| actions/upload-artifact | v4 | v7.0.1 |
| pnpm/action-setup | v4 | v6.0.6 |
| Swatinem/rust-cache | v2 | v2.9.1 |
| mozilla-actions/sccache-action | v0.0.9 | v0.0.10 |
| cloudflare/wrangler-action | v3 | v3.15.0 |
| dorny/paths-filter | v3 | v4.0.1 |
| anthropics/claude-code-action | v1 (tag) | v1 (SHA pin) |

## 影響範囲

8 workflow:
- claude-code-review.yml / claude.yml
- cloudflare-drift-check.yml
- deploy-workers.yml (Node 20 警告対象)
- rust-ci.yml
- synthetic-csa-production.yml / synthetic-csa-staging.yml
- workers-smoke.yml (Node 20 警告対象)

## 期限

- 2026-06-02: GitHub Actions runner の default Node が 24 に切替
- 2026-09-16: Node 20 ランタイムが runner から完全削除

## Test plan

- [ ] PR CI (rust-ci.yml / workers-smoke.yml) が green になる
- [ ] deprecation warning が消えていることを Actions の annotation で確認
- [ ] 副作用 (cache miss / pnpm version 解決失敗 等) が出ていないことを log で確認
  - pnpm/action-setup v6 は \`packageManager\` field (= \`pnpm@10.33.2\` in \`crates/rshogi-csa-server-workers/package.json\`) から version 解決する設計に変更済み
- [ ] (deploy-workers.yml は staging 自動 deploy が走る) deploy が完走 + smoke check が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)