### PR TITLE
ci(pulumi-preview): action を SHA pin + Node 24 対応版へ bump

### DIFF
--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -57,12 +57,12 @@ jobs:
     env:
       PULUMI_DIR: infra/pulumi
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         with:
           package_json_file: ${{ env.PULUMI_DIR }}/package.json
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ${{ env.PULUMI_DIR }}/.node-version
           cache: 'pnpm'
@@ -110,14 +110,14 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::warning::Pulumi preview skipped (PULUMI_ACCESS_TOKEN not configured)."
           fi
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.check.outputs.can_preview == 'true'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
         if: steps.check.outputs.can_preview == 'true'
         with:
           package_json_file: ${{ env.PULUMI_DIR }}/package.json
           run_install: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.check.outputs.can_preview == 'true'
         with:
           node-version-file: ${{ env.PULUMI_DIR }}/.node-version
@@ -127,7 +127,7 @@ jobs:
         if: steps.check.outputs.can_preview == 'true'
         working-directory: ${{ env.PULUMI_DIR }}
         run: pnpm install --frozen-lockfile
-      - uses: pulumi/actions@v6
+      - uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
         if: steps.check.outputs.can_preview == 'true'
         with:
           command: preview


### PR DESCRIPTION
## Summary

- #677 で追加された \`pulumi-preview.yml\` は #678 の bump スコープ外だったため Node 20 ランタイム製 action のままだった。
- 同 PR と同じ基準 (commit SHA pin + バージョンコメント併記) に揃える。

## bump

| Action | Before | After (Node 24) |
|---|---|---|
| actions/checkout | v5 | v6.0.2 |
| pnpm/action-setup | v4 | v6.0.6 |
| actions/setup-node | v4 | v6.4.0 |
| pulumi/actions | v6 (v6.6.1, node20) | **v7.0.0 (node24)** |

\`pulumi/actions\` は v6.6.1 までが Node 20 ランタイム、v7.0.0 で Node 24 化。input schema (\`command\`, \`stack-name\`, \`work-dir\` 等) は v7 で互換維持されている (action.yml inputs を diff で確認済み)。

## 残タスク

- \`cloudflare/wrangler-action\` は v3.15.0 / main 共に node20 のまま。Cloudflare 側で Node 24 対応 PR が open 中。別 issue (本 PR と並行で起票) で追跡。

## Test plan

- [ ] PR CI で \`Validate Pulumi project (no secrets)\` job が green になる
- [ ] deprecation warning が消える
- [ ] (workflow_dispatch 経路の \`pulumi preview\` は手動起動なので、次回 dispatch 時に preview が完走することを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)