### PR TITLE
feat(csa-client): rate_limited retry_after=<sec> を honoring して retry storm を抑える (#682)

### DIFF
--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -91,7 +91,7 @@ pub use events::{
     NoopSessionEventSink, ReconnectState, SearchInfoEmitPolicy, SearchInfoSnapshot, SearchOrigin,
     SessionError, SessionEventSink, SessionOutcome, SessionProgress, Side, SinkError,
 };
-pub use protocol::{CsaConnection, GameResult, GameSummary};
+pub use protocol::{CsaConnection, GameResult, GameSummary, extract_retry_after_sec};
 pub use record::{GameRecord, RecordedMove};
 pub use session::{
     run_game_session, run_game_session_with_events, run_resumed_session,

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -91,7 +91,9 @@ pub use events::{
     NoopSessionEventSink, ReconnectState, SearchInfoEmitPolicy, SearchInfoSnapshot, SearchOrigin,
     SessionError, SessionEventSink, SessionOutcome, SessionProgress, Side, SinkError,
 };
-pub use protocol::{CsaConnection, GameResult, GameSummary, extract_retry_after_sec};
+pub use protocol::{
+    CsaConnection, GameResult, GameSummary, compute_effective_retry_delay, extract_retry_after_sec,
+};
 pub use record::{GameRecord, RecordedMove};
 pub use session::{
     run_game_session, run_game_session_with_events, run_resumed_session,

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -221,16 +221,22 @@ fn compute_effective_retry_delay(err_msg: &str, retry_delay: Duration) -> Durati
 const SHUTDOWN_POLL: Duration = Duration::from_millis(200);
 
 fn sleep_with_shutdown(delay: Duration, shutdown: &AtomicBool) -> bool {
-    let deadline = Instant::now() + delay;
+    let deadline = Instant::now().checked_add(delay);
     loop {
         if shutdown.load(Ordering::SeqCst) {
             return false;
         }
-        let now = Instant::now();
-        if now >= deadline {
-            return true;
-        }
-        std::thread::sleep((deadline - now).min(SHUTDOWN_POLL));
+        let sleep_for = match deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return true;
+                }
+                remaining.min(SHUTDOWN_POLL)
+            }
+            None => SHUTDOWN_POLL,
+        };
+        std::thread::sleep(sleep_for);
     }
 }
 
@@ -1294,6 +1300,21 @@ mod tests {
         assert!(
             elapsed < Duration::from_millis(50),
             "事前 shutdown は即座に return すべき: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn sleep_with_shutdown_handles_huge_delay_when_shutdown_already_set() {
+        // server が異常に大きい retry_after を返しても Instant 加算 overflow で
+        // panic せず、shutdown が立っていれば即座に抜ける。
+        let shutdown = AtomicBool::new(true);
+        let start = Instant::now();
+        let completed = sleep_with_shutdown(Duration::from_secs(u64::MAX), &shutdown);
+        let elapsed = start.elapsed();
+        assert!(!completed);
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "巨大 delay でも事前 shutdown は即座に return すべき: {elapsed:?}"
         );
     }
 

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -25,7 +25,7 @@ use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::events::SessionOutcome;
 use rshogi_csa_client::jsonl::write_game_jsonl;
-use rshogi_csa_client::protocol::{CsaConnection, GameResult};
+use rshogi_csa_client::protocol::{CsaConnection, GameResult, extract_retry_after_sec};
 use rshogi_csa_client::record::save_record;
 use rshogi_csa_client::session::{run_game_session, run_resumed_session};
 use rshogi_csa_client::transport::{ConnectOpts, TransportTarget};
@@ -194,6 +194,23 @@ struct Cli {
     no_engine_stderr_passthrough_flag: bool,
 }
 
+/// 連続対局ループで `acquire_lobby_match` / `run_one_game` が `Err` を返したときの
+/// 次 sleep 時間を決める。server の `rate_limited retry_after=<sec>` を honoring し、
+/// 既存の指数バックオフ (`retry_delay`) と比べて長い方を採用する。
+///
+/// retry_after を強制 max しない理由: 単発の `retry_after=1` 等で penalty 累積中の
+/// バックオフを巻き戻すと retry storm を再開してしまう。「server が要求する最小
+/// 待機」と「client が決めた指数バックオフ」の両方を満たす最短時間として `max` を取る。
+///
+/// `err_msg` に `retry_after=` トークンが含まれない / 数値 parse 失敗時は
+/// `retry_delay` をそのまま返す。
+fn compute_effective_retry_delay(err_msg: &str, retry_delay: Duration) -> Duration {
+    match extract_retry_after_sec(err_msg) {
+        Some(sec) => Duration::from_secs(sec).max(retry_delay),
+        None => retry_delay,
+    }
+}
+
 /// CLI で `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` のいずれかが
 /// 明示指定された場合のみ `Some(bool)` を返す。未指定時は `None` を返し、TOML/環境変数の
 /// 値をそのまま温存する。`overrides_with` のため両方指定後に最後に勝った方の flag のみ
@@ -287,8 +304,17 @@ fn main() -> Result<()> {
                     if shutdown.load(Ordering::SeqCst) {
                         break;
                     }
-                    log::info!("{}秒後にリトライ...", retry_delay.as_secs());
-                    std::thread::sleep(retry_delay);
+                    let effective = compute_effective_retry_delay(&e.to_string(), retry_delay);
+                    if effective > retry_delay {
+                        log::warn!(
+                            "サーバから retry_after を受信。{}秒後にリトライ (バックオフ {}秒を上書き)...",
+                            effective.as_secs(),
+                            retry_delay.as_secs()
+                        );
+                    } else {
+                        log::info!("{}秒後にリトライ...", effective.as_secs());
+                    }
+                    std::thread::sleep(effective);
                     retry_delay =
                         (retry_delay * 2).min(Duration::from_secs(config.retry.max_delay_sec));
                     continue;
@@ -346,8 +372,17 @@ fn main() -> Result<()> {
                 }
                 // エラー後はエンジンを再起動（不整合な状態の可能性）
                 engine.quit();
-                log::info!("{}秒後にリトライ...", retry_delay.as_secs());
-                std::thread::sleep(retry_delay);
+                let effective = compute_effective_retry_delay(&e.to_string(), retry_delay);
+                if effective > retry_delay {
+                    log::warn!(
+                        "サーバから retry_after を受信。{}秒後にリトライ (バックオフ {}秒を上書き)...",
+                        effective.as_secs(),
+                        retry_delay.as_secs()
+                    );
+                } else {
+                    log::info!("{}秒後にリトライ...", effective.as_secs());
+                }
+                std::thread::sleep(effective);
                 retry_delay =
                     (retry_delay * 2).min(Duration::from_secs(config.retry.max_delay_sec));
                 engine = spawn_engine(&config)?;
@@ -1151,6 +1186,55 @@ mod tests {
     fn cli_engine_stderr_passthrough_no_flag_only_returns_some_false() {
         let cli = parse_cli(&["--no-engine-stderr-passthrough"]);
         assert_eq!(cli_engine_stderr_passthrough(&cli), Some(false));
+    }
+
+    // ───────────────────────────────────────────────
+    // `compute_effective_retry_delay` の挙動を pin する。retry_after は
+    // 「server が要求する最小待機」、retry_delay は「client の指数バックオフ」で、
+    // 両方を満たす最短時間として max を取る契約 (#682)。
+    // ───────────────────────────────────────────────
+
+    #[test]
+    fn compute_effective_retry_delay_uses_retry_after_when_longer() {
+        // server の retry_after=10 がバックオフ 2s より長いので 10s が採用される。
+        let actual = compute_effective_retry_delay(
+            "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10",
+            Duration::from_secs(2),
+        );
+        assert_eq!(actual, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_keeps_backoff_when_longer() {
+        // 既存の指数バックオフ 60s が server 指定 5s より長いケース。バックオフを
+        // 維持して storm を抑える契約。
+        let actual = compute_effective_retry_delay(
+            "ログイン失敗: LOGIN:incorrect rate_limited retry_after=5",
+            Duration::from_secs(60),
+        );
+        assert_eq!(actual, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_falls_back_when_no_token() {
+        // retry_after を含まない error msg では retry_delay をそのまま返す
+        // (= 既存挙動を温存)。
+        let actual = compute_effective_retry_delay(
+            "対局エラー: connection reset by peer",
+            Duration::from_secs(8),
+        );
+        assert_eq!(actual, Duration::from_secs(8));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_handles_zero() {
+        // retry_after=0 は 0s を返し、retry_delay が 0 でなければ retry_delay が
+        // 採用される (max).
+        let actual = compute_effective_retry_delay(
+            "LOGIN_LOBBY:incorrect rate_limited retry_after=0",
+            Duration::from_secs(3),
+        );
+        assert_eq!(actual, Duration::from_secs(3));
     }
 
     /// `--engine-stderr-passthrough --no-engine-stderr-passthrough` の順で指定された場合は

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -16,7 +16,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgAction, Parser, ValueEnum};
@@ -211,6 +211,29 @@ fn compute_effective_retry_delay(err_msg: &str, retry_delay: Duration) -> Durati
     }
 }
 
+/// `delay` が経過するか `shutdown` が立つまで待機する。`shutdown` 検出時は早期に
+/// `false` を返し、呼び出し側はループを抜けるべき (= サーバ指定の長い `retry_after`
+/// を honor する間に Ctrl-C しても即座に終了できる)。
+///
+/// 単純な `std::thread::sleep(delay)` は signal を観測できないため、`SHUTDOWN_POLL`
+/// 刻みで分割 sleep して shutdown を polling する。粒度は「Ctrl-C から終了までの
+/// 体感遅延」と「polling overhead」のトレードオフで 200ms 固定 (#682 follow-up)。
+const SHUTDOWN_POLL: Duration = Duration::from_millis(200);
+
+fn sleep_with_shutdown(delay: Duration, shutdown: &AtomicBool) -> bool {
+    let deadline = Instant::now() + delay;
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            return false;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return true;
+        }
+        std::thread::sleep((deadline - now).min(SHUTDOWN_POLL));
+    }
+}
+
 /// CLI で `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` のいずれかが
 /// 明示指定された場合のみ `Some(bool)` を返す。未指定時は `None` を返し、TOML/環境変数の
 /// 値をそのまま温存する。`overrides_with` のため両方指定後に最後に勝った方の flag のみ
@@ -314,7 +337,9 @@ fn main() -> Result<()> {
                     } else {
                         log::info!("{}秒後にリトライ...", effective.as_secs());
                     }
-                    std::thread::sleep(effective);
+                    if !sleep_with_shutdown(effective, &shutdown) {
+                        break;
+                    }
                     retry_delay =
                         (retry_delay * 2).min(Duration::from_secs(config.retry.max_delay_sec));
                     continue;
@@ -382,7 +407,9 @@ fn main() -> Result<()> {
                 } else {
                     log::info!("{}秒後にリトライ...", effective.as_secs());
                 }
-                std::thread::sleep(effective);
+                if !sleep_with_shutdown(effective, &shutdown) {
+                    break;
+                }
                 retry_delay =
                     (retry_delay * 2).min(Duration::from_secs(config.retry.max_delay_sec));
                 engine = spawn_engine(&config)?;
@@ -1235,6 +1262,64 @@ mod tests {
             Duration::from_secs(3),
         );
         assert_eq!(actual, Duration::from_secs(3));
+    }
+
+    // ───────────────────────────────────────────────
+    // `sleep_with_shutdown` の挙動を pin する。retry_after で長時間 sleep する間も
+    // Ctrl-C (= shutdown 立ち) を即座に観測して loop を抜けられる契約 (#682 follow-up)。
+    // ───────────────────────────────────────────────
+
+    #[test]
+    fn sleep_with_shutdown_completes_when_shutdown_remains_clear() {
+        // shutdown が立たないまま delay が経過したら true を返す。
+        let shutdown = AtomicBool::new(false);
+        let start = Instant::now();
+        let completed = sleep_with_shutdown(Duration::from_millis(120), &shutdown);
+        let elapsed = start.elapsed();
+        assert!(completed, "delay 経過時は true を返すべき");
+        assert!(
+            elapsed >= Duration::from_millis(120),
+            "delay 未満で帰ってはいけない: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn sleep_with_shutdown_returns_false_when_shutdown_set_before_call() {
+        // 既に shutdown が立っている場合は最初の poll で false。
+        let shutdown = AtomicBool::new(true);
+        let start = Instant::now();
+        let completed = sleep_with_shutdown(Duration::from_secs(60), &shutdown);
+        let elapsed = start.elapsed();
+        assert!(!completed);
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "事前 shutdown は即座に return すべき: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn sleep_with_shutdown_returns_false_when_shutdown_set_during_sleep() {
+        // 別スレッドから sleep 中に shutdown を立てると、SHUTDOWN_POLL の粒度で
+        // 即座に抜けられること。`retry_after=900` 等の長時間 sleep でも 200ms 程度で
+        // 終了する契約を pin する。
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let signal = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            shutdown_clone.store(true, Ordering::SeqCst);
+        });
+
+        let start = Instant::now();
+        let completed = sleep_with_shutdown(Duration::from_secs(60), &shutdown);
+        let elapsed = start.elapsed();
+        signal.join().expect("signal thread");
+
+        assert!(!completed, "shutdown 検出時は false を返すべき");
+        // 200ms poll + 50ms 起床遅延 + 余裕で 1s 以内に return すること。
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "shutdown 検出後は SHUTDOWN_POLL 粒度で抜けるべき: {elapsed:?}"
+        );
     }
 
     /// `--engine-stderr-passthrough --no-engine-stderr-passthrough` の順で指定された場合は

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -25,7 +25,7 @@ use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::events::SessionOutcome;
 use rshogi_csa_client::jsonl::write_game_jsonl;
-use rshogi_csa_client::protocol::{CsaConnection, GameResult, extract_retry_after_sec};
+use rshogi_csa_client::protocol::{CsaConnection, GameResult, compute_effective_retry_delay};
 use rshogi_csa_client::record::save_record;
 use rshogi_csa_client::session::{run_game_session, run_resumed_session};
 use rshogi_csa_client::transport::{ConnectOpts, TransportTarget};
@@ -194,23 +194,6 @@ struct Cli {
     no_engine_stderr_passthrough_flag: bool,
 }
 
-/// 連続対局ループで `acquire_lobby_match` / `run_one_game` が `Err` を返したときの
-/// 次 sleep 時間を決める。server の `rate_limited retry_after=<sec>` を honoring し、
-/// 既存の指数バックオフ (`retry_delay`) と比べて長い方を採用する。
-///
-/// retry_after を強制 max しない理由: 単発の `retry_after=1` 等で penalty 累積中の
-/// バックオフを巻き戻すと retry storm を再開してしまう。「server が要求する最小
-/// 待機」と「client が決めた指数バックオフ」の両方を満たす最短時間として `max` を取る。
-///
-/// `err_msg` に `retry_after=` トークンが含まれない / 数値 parse 失敗時は
-/// `retry_delay` をそのまま返す。
-fn compute_effective_retry_delay(err_msg: &str, retry_delay: Duration) -> Duration {
-    match extract_retry_after_sec(err_msg) {
-        Some(sec) => Duration::from_secs(sec).max(retry_delay),
-        None => retry_delay,
-    }
-}
-
 /// `delay` が経過するか `shutdown` が立つまで待機する。`shutdown` 検出時は早期に
 /// `false` を返し、呼び出し側はループを抜けるべき (= サーバ指定の長い `retry_after`
 /// を honor する間に Ctrl-C しても即座に終了できる)。
@@ -234,10 +217,32 @@ fn sleep_with_shutdown(delay: Duration, shutdown: &AtomicBool) -> bool {
                 }
                 remaining.min(SHUTDOWN_POLL)
             }
+            // overflow (例: `retry_after=u64::MAX`): deadline を計算できないので
+            // shutdown が立つまで SHUTDOWN_POLL 刻みで polling し続ける。実害は
+            // 低い (server が `u64::MAX` を返す事は無く、shutdown は必ずいずれ立つ)。
             None => SHUTDOWN_POLL,
         };
         std::thread::sleep(sleep_for);
     }
+}
+
+/// retry sleep の log 出力 + `sleep_with_shutdown` の組合わせを 1 か所に集約する。
+/// `acquire_lobby_match` / `run_one_game` の Err arm がそれぞれ同じブロックを
+/// 持つと将来の log フォーマット変更で片方の修正が漏れるため、helper 化している。
+///
+/// 戻り値は `sleep_with_shutdown` をそのまま転送し、`false` のとき呼び出し側は
+/// 連続対局ループを抜けるべき。
+fn sleep_retry(effective: Duration, backoff: Duration, shutdown: &AtomicBool) -> bool {
+    if effective > backoff {
+        log::warn!(
+            "サーバから retry_after を受信。{}秒後にリトライ (バックオフ {}秒を上書き)...",
+            effective.as_secs(),
+            backoff.as_secs()
+        );
+    } else {
+        log::info!("{}秒後にリトライ...", effective.as_secs());
+    }
+    sleep_with_shutdown(effective, shutdown)
 }
 
 /// CLI で `--engine-stderr-passthrough` / `--no-engine-stderr-passthrough` のいずれかが
@@ -334,16 +339,7 @@ fn main() -> Result<()> {
                         break;
                     }
                     let effective = compute_effective_retry_delay(&e.to_string(), retry_delay);
-                    if effective > retry_delay {
-                        log::warn!(
-                            "サーバから retry_after を受信。{}秒後にリトライ (バックオフ {}秒を上書き)...",
-                            effective.as_secs(),
-                            retry_delay.as_secs()
-                        );
-                    } else {
-                        log::info!("{}秒後にリトライ...", effective.as_secs());
-                    }
-                    if !sleep_with_shutdown(effective, &shutdown) {
+                    if !sleep_retry(effective, retry_delay, &shutdown) {
                         break;
                     }
                     retry_delay =
@@ -404,16 +400,7 @@ fn main() -> Result<()> {
                 // エラー後はエンジンを再起動（不整合な状態の可能性）
                 engine.quit();
                 let effective = compute_effective_retry_delay(&e.to_string(), retry_delay);
-                if effective > retry_delay {
-                    log::warn!(
-                        "サーバから retry_after を受信。{}秒後にリトライ (バックオフ {}秒を上書き)...",
-                        effective.as_secs(),
-                        retry_delay.as_secs()
-                    );
-                } else {
-                    log::info!("{}秒後にリトライ...", effective.as_secs());
-                }
-                if !sleep_with_shutdown(effective, &shutdown) {
+                if !sleep_retry(effective, retry_delay, &shutdown) {
                     break;
                 }
                 retry_delay =
@@ -1222,57 +1209,9 @@ mod tests {
     }
 
     // ───────────────────────────────────────────────
-    // `compute_effective_retry_delay` の挙動を pin する。retry_after は
-    // 「server が要求する最小待機」、retry_delay は「client の指数バックオフ」で、
-    // 両方を満たす最短時間として max を取る契約 (#682)。
-    // ───────────────────────────────────────────────
-
-    #[test]
-    fn compute_effective_retry_delay_uses_retry_after_when_longer() {
-        // server の retry_after=10 がバックオフ 2s より長いので 10s が採用される。
-        let actual = compute_effective_retry_delay(
-            "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10",
-            Duration::from_secs(2),
-        );
-        assert_eq!(actual, Duration::from_secs(10));
-    }
-
-    #[test]
-    fn compute_effective_retry_delay_keeps_backoff_when_longer() {
-        // 既存の指数バックオフ 60s が server 指定 5s より長いケース。バックオフを
-        // 維持して storm を抑える契約。
-        let actual = compute_effective_retry_delay(
-            "ログイン失敗: LOGIN:incorrect rate_limited retry_after=5",
-            Duration::from_secs(60),
-        );
-        assert_eq!(actual, Duration::from_secs(60));
-    }
-
-    #[test]
-    fn compute_effective_retry_delay_falls_back_when_no_token() {
-        // retry_after を含まない error msg では retry_delay をそのまま返す
-        // (= 既存挙動を温存)。
-        let actual = compute_effective_retry_delay(
-            "対局エラー: connection reset by peer",
-            Duration::from_secs(8),
-        );
-        assert_eq!(actual, Duration::from_secs(8));
-    }
-
-    #[test]
-    fn compute_effective_retry_delay_handles_zero() {
-        // retry_after=0 は 0s を返し、retry_delay が 0 でなければ retry_delay が
-        // 採用される (max).
-        let actual = compute_effective_retry_delay(
-            "LOGIN_LOBBY:incorrect rate_limited retry_after=0",
-            Duration::from_secs(3),
-        );
-        assert_eq!(actual, Duration::from_secs(3));
-    }
-
-    // ───────────────────────────────────────────────
     // `sleep_with_shutdown` の挙動を pin する。retry_after で長時間 sleep する間も
     // Ctrl-C (= shutdown 立ち) を即座に観測して loop を抜けられる契約 (#682 follow-up)。
+    // `compute_effective_retry_delay` の test は protocol.rs 側に集約。
     // ───────────────────────────────────────────────
 
     #[test]

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -619,13 +619,24 @@ fn is_login_ok(response: &str) -> bool {
 /// assert_eq!(extract_retry_after_sec("LOGIN:incorrect unknown_game_name"), None);
 /// ```
 pub fn extract_retry_after_sec(err_msg: &str) -> Option<u64> {
-    err_msg
-        .split("retry_after=")
-        .nth(1)?
-        .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
-        .next()?
-        .parse()
-        .ok()
+    err_msg.split("retry_after=").nth(1)?.split_whitespace().next()?.parse().ok()
+}
+
+/// 連続対局ループで `Err` を受けたときに採用する次 sleep 時間を決める。
+/// server の `rate_limited retry_after=<sec>` (extract_retry_after_sec で抽出) を
+/// honoring し、既存の指数バックオフ (`retry_delay`) と比べて長い方を採用する。
+///
+/// retry_after を強制 max しない理由: 単発の `retry_after=1` 等で penalty 累積中の
+/// バックオフを巻き戻すと retry storm を再開してしまう。「server が要求する最小
+/// 待機」と「client が決めた指数バックオフ」の両方を満たす最短時間として `max` を取る。
+///
+/// `err_msg` に `retry_after=` トークンが含まれない / 数値 parse 失敗時は
+/// `retry_delay` をそのまま返す。
+pub fn compute_effective_retry_delay(err_msg: &str, retry_delay: Duration) -> Duration {
+    match extract_retry_after_sec(err_msg) {
+        Some(sec) => Duration::from_secs(sec).max(retry_delay),
+        None => retry_delay,
+    }
 }
 
 #[cfg(test)]
@@ -694,5 +705,54 @@ mod tests {
     fn extract_retry_after_sec_handles_zero() {
         // 0 秒も valid な値として通す (server が即時 retry を許可するケース)。
         assert_eq!(extract_retry_after_sec("LOGIN:incorrect rate_limited retry_after=0"), Some(0));
+    }
+
+    // ───────────────────────────────────────────────
+    // `compute_effective_retry_delay` の挙動を pin する。retry_after は
+    // 「server が要求する最小待機」、retry_delay は「client の指数バックオフ」で、
+    // 両方を満たす最短時間として max を取る契約 (#682)。
+    // ───────────────────────────────────────────────
+
+    #[test]
+    fn compute_effective_retry_delay_uses_retry_after_when_longer() {
+        // server の retry_after=10 がバックオフ 2s より長いので 10s が採用される。
+        let actual = compute_effective_retry_delay(
+            "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10",
+            Duration::from_secs(2),
+        );
+        assert_eq!(actual, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_keeps_backoff_when_longer() {
+        // 既存の指数バックオフ 60s が server 指定 5s より長いケース。バックオフを
+        // 維持して storm を抑える契約。
+        let actual = compute_effective_retry_delay(
+            "ログイン失敗: LOGIN:incorrect rate_limited retry_after=5",
+            Duration::from_secs(60),
+        );
+        assert_eq!(actual, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_falls_back_when_no_token() {
+        // retry_after を含まない error msg では retry_delay をそのまま返す
+        // (= 既存挙動を温存)。
+        let actual = compute_effective_retry_delay(
+            "対局エラー: connection reset by peer",
+            Duration::from_secs(8),
+        );
+        assert_eq!(actual, Duration::from_secs(8));
+    }
+
+    #[test]
+    fn compute_effective_retry_delay_handles_zero() {
+        // retry_after=0 は 0s を返し、retry_delay が 0 でなければ retry_delay が
+        // 採用される (max).
+        let actual = compute_effective_retry_delay(
+            "LOGIN_LOBBY:incorrect rate_limited retry_after=0",
+            Duration::from_secs(3),
+        );
+        assert_eq!(actual, Duration::from_secs(3));
     }
 }

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -594,3 +594,105 @@ pub(crate) fn parse_game_result(line: &str) -> Option<GameResult> {
 fn is_login_ok(response: &str) -> bool {
     response.starts_with("LOGIN:") && response.ends_with(" OK")
 }
+
+/// CSA サーバから返された `LOGIN:incorrect rate_limited retry_after=<sec>` /
+/// `LOGIN_LOBBY:incorrect rate_limited retry_after=<sec>` の `<sec>` を抽出する。
+///
+/// 本 helper は `bail!` などで `anyhow::Error` の表示文字列に変換された後も呼べる
+/// よう、入力は任意の `&str` を受け付け、`retry_after=` トークンに続く非空白の数値
+/// 列を greedy に parse する。トークンが含まれていない / 数値として parse できない
+/// 場合は `None` を返し、呼び出し側は既存の指数バックオフのみで retry する。
+///
+/// # 例
+///
+/// ```
+/// use rshogi_csa_client::protocol::extract_retry_after_sec;
+///
+/// assert_eq!(
+///     extract_retry_after_sec("LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10"),
+///     Some(10)
+/// );
+/// assert_eq!(
+///     extract_retry_after_sec("ログイン失敗: LOGIN:incorrect rate_limited retry_after=5"),
+///     Some(5)
+/// );
+/// assert_eq!(extract_retry_after_sec("LOGIN:incorrect unknown_game_name"), None);
+/// ```
+pub fn extract_retry_after_sec(err_msg: &str) -> Option<u64> {
+    err_msg
+        .split("retry_after=")
+        .nth(1)?
+        .split(|c: char| c.is_whitespace() || c == ',' || c == ';')
+        .next()?
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_retry_after_sec_parses_lobby_login_format() {
+        // `acquire_lobby_match` が `bail!("[Lobby] LOGIN_LOBBY 拒否: {rest}")` を
+        // 出した場合の、anyhow Error display 形式そのまま。
+        assert_eq!(
+            extract_retry_after_sec(
+                "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10"
+            ),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn extract_retry_after_sec_parses_login_format() {
+        // `protocol::login` の `bail!("ログイン失敗: {response}")` 経由。
+        assert_eq!(
+            extract_retry_after_sec("ログイン失敗: LOGIN:incorrect rate_limited retry_after=5"),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn extract_retry_after_sec_handles_raw_server_response() {
+        // server の生 raw 行 (= prefix なし) でも parse できる。
+        assert_eq!(
+            extract_retry_after_sec("LOGIN_LOBBY:incorrect rate_limited retry_after=42"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn extract_retry_after_sec_returns_none_for_other_reasons() {
+        // `unknown_game_name` / `already_logged_in` 等の retry_after を伴わない
+        // reason は None を返し、呼び出し側は既存の指数バックオフだけを使う。
+        assert_eq!(extract_retry_after_sec("LOGIN:incorrect unknown_game_name"), None);
+        assert_eq!(extract_retry_after_sec("ログイン失敗: 接続が切断されました"), None);
+        assert_eq!(extract_retry_after_sec(""), None);
+    }
+
+    #[test]
+    fn extract_retry_after_sec_returns_none_for_non_numeric_value() {
+        // `retry_after=` の後に非数値が来た場合は安全側で None を返す。
+        assert_eq!(extract_retry_after_sec("LOGIN:incorrect rate_limited retry_after=NaN"), None);
+    }
+
+    #[test]
+    fn extract_retry_after_sec_handles_trailing_text() {
+        // 後続にスペース区切りで他のトークンが続いても、最初の数値だけを抽出する。
+        assert_eq!(extract_retry_after_sec("rate_limited retry_after=30 source=lobby"), Some(30));
+    }
+
+    #[test]
+    fn extract_retry_after_sec_uses_first_occurrence() {
+        // 複数回出現するケース (異常系) では最初の値を採用する。`split.nth(1)` の
+        // 仕様確認も兼ねる。
+        assert_eq!(extract_retry_after_sec("retry_after=7 retry_after=99"), Some(7));
+    }
+
+    #[test]
+    fn extract_retry_after_sec_handles_zero() {
+        // 0 秒も valid な値として通す (server が即時 retry を許可するケース)。
+        assert_eq!(extract_retry_after_sec("LOGIN:incorrect rate_limited retry_after=0"), Some(0));
+    }
+}

--- a/crates/rshogi-csa-client/tests/rate_limit_retry_after.rs
+++ b/crates/rshogi-csa-client/tests/rate_limit_retry_after.rs
@@ -7,12 +7,11 @@
 //! 1. server の raw 応答が `protocol::login` の `bail!("ログイン失敗: {response}")`
 //!    を経て `anyhow::Error` の display 文字列に乗っても、
 //!    `extract_retry_after_sec` が `<sec>` を抽出できること (round-trip)。
-//! 2. 抽出された `<sec>` を `compute_effective_retry_delay` 相当のロジック
-//!    (= `Duration::from_secs(sec).max(retry_delay)`) に流すと、次 sleep が
-//!    `<sec>` 秒以上になること。
+//! 2. 同 Err msg を `compute_effective_retry_delay` (lib pub fn) に流すと、次
+//!    sleep が `<sec>` 秒以上になること。
 //!
 //! 実 sleep 時間そのものを計測する test は flaky になりがちなので避けている。
-//! main loop の sleep 配線そのものは `src/main.rs` の `compute_effective_retry_delay`
+//! main loop の sleep 配線そのものは `src/main.rs` の `sleep_with_shutdown`
 //! unit test で pin している。
 
 use std::io::{BufRead, BufReader, Write};
@@ -20,7 +19,9 @@ use std::net::TcpListener;
 use std::thread;
 use std::time::Duration;
 
-use rshogi_csa_client::protocol::{CsaConnection, extract_retry_after_sec};
+use rshogi_csa_client::protocol::{
+    CsaConnection, compute_effective_retry_delay, extract_retry_after_sec,
+};
 
 /// 1 接続を受け取り、与えた `handler` を別スレッドで実行する mock CSA TCP サーバ。
 /// `csa_reconnect_protocol.rs` と同じ pattern。
@@ -55,17 +56,6 @@ fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
         writeln!(writer, "{}", line).expect("write line");
     }
     writer.flush().expect("flush");
-}
-
-/// `compute_effective_retry_delay` (main.rs 内) と同じ計算式。crate root から
-/// 直接呼べないため integration test 側で再実装する。仕様変更時は両者を同時に
-/// 更新する必要がある契約を pin するため、helper を `pub` にせず integration
-/// test 側で再実装している (= 仕様の二重 pin)。
-fn effective_delay(err_msg: &str, retry_delay: Duration) -> Duration {
-    match extract_retry_after_sec(err_msg) {
-        Some(sec) => Duration::from_secs(sec).max(retry_delay),
-        None => retry_delay,
-    }
 }
 
 #[test]
@@ -103,7 +93,7 @@ fn login_rate_limited_effective_delay_respects_retry_after() {
 
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     let err = conn.login("alice", "pw").expect_err("expected rate_limited");
-    let actual = effective_delay(&err.to_string(), Duration::from_secs(1));
+    let actual = compute_effective_retry_delay(&err.to_string(), Duration::from_secs(1));
 
     assert!(
         actual >= Duration::from_secs(5),
@@ -123,7 +113,7 @@ fn login_rate_limited_keeps_backoff_when_longer() {
 
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     let err = conn.login("alice", "pw").expect_err("expected rate_limited");
-    let actual = effective_delay(&err.to_string(), Duration::from_secs(60));
+    let actual = compute_effective_retry_delay(&err.to_string(), Duration::from_secs(60));
 
     assert_eq!(actual, Duration::from_secs(60));
 }
@@ -139,7 +129,7 @@ fn login_non_rate_limited_falls_back_to_backoff() {
 
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     let err = conn.login("alice", "pw").expect_err("expected login failure");
-    let actual = effective_delay(&err.to_string(), Duration::from_secs(4));
+    let actual = compute_effective_retry_delay(&err.to_string(), Duration::from_secs(4));
 
     assert_eq!(actual, Duration::from_secs(4));
 }
@@ -152,6 +142,6 @@ fn lobby_login_rate_limited_response_round_trips() {
     // あることを pin する (raw transport 経由の round-trip 確認)。
     let lobby_err_msg = "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10";
     assert_eq!(extract_retry_after_sec(lobby_err_msg), Some(10));
-    let actual = effective_delay(lobby_err_msg, Duration::from_secs(2));
+    let actual = compute_effective_retry_delay(lobby_err_msg, Duration::from_secs(2));
     assert_eq!(actual, Duration::from_secs(10));
 }

--- a/crates/rshogi-csa-client/tests/rate_limit_retry_after.rs
+++ b/crates/rshogi-csa-client/tests/rate_limit_retry_after.rs
@@ -1,0 +1,157 @@
+//! `rate_limited retry_after=<sec>` honoring (#682) の integration test。
+//!
+//! mock CSA TCP サーバが `LOGIN:incorrect rate_limited retry_after=<sec>` /
+//! `LOGIN_LOBBY:incorrect rate_limited retry_after=<sec>` を返したときの client
+//! 側動作を 2 段で pin する:
+//!
+//! 1. server の raw 応答が `protocol::login` の `bail!("ログイン失敗: {response}")`
+//!    を経て `anyhow::Error` の display 文字列に乗っても、
+//!    `extract_retry_after_sec` が `<sec>` を抽出できること (round-trip)。
+//! 2. 抽出された `<sec>` を `compute_effective_retry_delay` 相当のロジック
+//!    (= `Duration::from_secs(sec).max(retry_delay)`) に流すと、次 sleep が
+//!    `<sec>` 秒以上になること。
+//!
+//! 実 sleep 時間そのものを計測する test は flaky になりがちなので避けている。
+//! main loop の sleep 配線そのものは `src/main.rs` の `compute_effective_retry_delay`
+//! unit test で pin している。
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+use rshogi_csa_client::protocol::{CsaConnection, extract_retry_after_sec};
+
+/// 1 接続を受け取り、与えた `handler` を別スレッドで実行する mock CSA TCP サーバ。
+/// `csa_reconnect_protocol.rs` と同じ pattern。
+fn spawn_mock_tcp_server<F>(handler: F) -> u16
+where
+    F: FnOnce(&mut BufReader<std::net::TcpStream>, &mut std::net::TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    thread::Builder::new()
+        .name("mock-csa-rate-limit".to_string())
+        .spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+            let mut writer = stream.try_clone().expect("clone stream");
+            let mut reader = BufReader::new(stream);
+            handler(&mut reader, &mut writer);
+        })
+        .expect("spawn");
+    port
+}
+
+fn read_line(reader: &mut BufReader<std::net::TcpStream>) -> String {
+    let mut buf = String::new();
+    reader.read_line(&mut buf).expect("read line");
+    buf.trim_end_matches(['\r', '\n']).to_owned()
+}
+
+fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
+    for line in lines {
+        writeln!(writer, "{}", line).expect("write line");
+    }
+    writer.flush().expect("flush");
+}
+
+/// `compute_effective_retry_delay` (main.rs 内) と同じ計算式。crate root から
+/// 直接呼べないため integration test 側で再実装する。仕様変更時は両者を同時に
+/// 更新する必要がある契約を pin するため、helper を `pub` にせず integration
+/// test 側で再実装している (= 仕様の二重 pin)。
+fn effective_delay(err_msg: &str, retry_delay: Duration) -> Duration {
+    match extract_retry_after_sec(err_msg) {
+        Some(sec) => Duration::from_secs(sec).max(retry_delay),
+        None => retry_delay,
+    }
+}
+
+#[test]
+fn login_rate_limited_response_propagates_retry_after_to_helper() {
+    // server が `LOGIN:incorrect rate_limited retry_after=7` を返したとき、
+    // `CsaConnection::login` は `bail!("ログイン失敗: ...")` で Err を返す。
+    // その Err の display を `extract_retry_after_sec` に流すと 7 が取れる。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:incorrect rate_limited retry_after=7"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    let err = conn.login("alice", "pw").expect_err("expected rate_limited");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("rate_limited"),
+        "error msg should contain rate_limited token: {msg}"
+    );
+    assert_eq!(
+        extract_retry_after_sec(&msg),
+        Some(7),
+        "extract_retry_after_sec should parse 7 from bail msg: {msg}"
+    );
+}
+
+#[test]
+fn login_rate_limited_effective_delay_respects_retry_after() {
+    // バックオフ 1s だが server が retry_after=5 を要求 → 次 sleep は 5s 以上。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:incorrect rate_limited retry_after=5"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    let err = conn.login("alice", "pw").expect_err("expected rate_limited");
+    let actual = effective_delay(&err.to_string(), Duration::from_secs(1));
+
+    assert!(
+        actual >= Duration::from_secs(5),
+        "next sleep must be >= retry_after (5s), got {actual:?}"
+    );
+    assert_eq!(actual, Duration::from_secs(5));
+}
+
+#[test]
+fn login_rate_limited_keeps_backoff_when_longer() {
+    // バックオフ 60s が server retry_after=3 より長いケース。retry_after で
+    // バックオフを巻き戻さない契約 (storm 再開防止) を pin する。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:incorrect rate_limited retry_after=3"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    let err = conn.login("alice", "pw").expect_err("expected rate_limited");
+    let actual = effective_delay(&err.to_string(), Duration::from_secs(60));
+
+    assert_eq!(actual, Duration::from_secs(60));
+}
+
+#[test]
+fn login_non_rate_limited_falls_back_to_backoff() {
+    // `unknown_game_name` 等の retry_after を伴わない reason ではバックオフ
+    // をそのまま使う (既存挙動温存)。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:incorrect unknown_game_name"]);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    let err = conn.login("alice", "pw").expect_err("expected login failure");
+    let actual = effective_delay(&err.to_string(), Duration::from_secs(4));
+
+    assert_eq!(actual, Duration::from_secs(4));
+}
+
+#[test]
+fn lobby_login_rate_limited_response_round_trips() {
+    // `acquire_lobby_match` (private) は raw `LOGIN_LOBBY` を生で送り、応答を
+    // `[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10` の形で
+    // bail する。同形式の Err msg が `extract_retry_after_sec` で parse 可能で
+    // あることを pin する (raw transport 経由の round-trip 確認)。
+    let lobby_err_msg = "[Lobby] LOGIN_LOBBY 拒否: incorrect rate_limited retry_after=10";
+    assert_eq!(extract_retry_after_sec(lobby_err_msg), Some(10));
+    let actual = effective_delay(lobby_err_msg, Duration::from_secs(2));
+    assert_eq!(actual, Duration::from_secs(10));
+}


### PR DESCRIPTION
## Summary

- `rshogi-csa-client` の連続対局ループで、server が返す `LOGIN(_LOBBY):incorrect rate_limited retry_after=<sec>` を honoring し、bounded retry storm (max 6 試行 / penalty 中の再 LOGIN 連射) を抑える (#682)。
- 既存の指数バックオフ (`config.retry.initial_delay_sec` → `max_delay_sec`) と `max(retry_after, retry_delay)` で組み合わせ、retry_after による backoff 巻き戻し (= storm 再開) を防ぐ契約。
- 同時に Codex review で検出された 2 件をハーデニング: shutdown 非対応な long sleep 中の Ctrl-C 不能 (`sleep_with_shutdown` 化) と、`Instant + Duration` overflow panic (`checked_add` + `saturating_duration_since`)。

## 実装

### Step 1: `protocol::extract_retry_after_sec` (pub fn)

`bail!` で `anyhow::Error` の display に乗っても抽出できるよう `&str` を受けて `retry_after=` トークン以降の非空白数値列を greedy に parse。non-numeric / 不在は `None`。lib root へ re-export。

### Step 2: `main::compute_effective_retry_delay`

`max(Duration::from_secs(retry_after), retry_delay)` で次 sleep 時間を決定。retry_after 単独では backoff を巻き戻さない (= retry_after=1 でも累積 60s バックオフは維持される)。

### Step 3: `main::sleep_with_shutdown`

`SHUTDOWN_POLL = 200ms` 刻みで shutdown を polling、検出時は `false` を返し caller は早期 break。`Instant::now().checked_add(delay)` + `saturating_duration_since` で `retry_after=u64::MAX` 等の異常値でも panic しない。

### Step 4: 配線

`acquire_lobby_match` / `run_one_game` 両 Err arm の `std::thread::sleep(...)` を `if !sleep_with_shutdown(effective, &shutdown) { break; }` に置換。retry_after を採用したケースは warn でログ出力。

## Codex review history

- 1st (350eefb9): Codex から Request Changes — 「`std::thread::sleep(effective)` が shutdown を観測できない、`retry_after=900` 等の long sleep 中に Ctrl-C しても最大 15 分終了しない」
- 2nd (681ef2ee): `sleep_with_shutdown` 導入で対応 → Codex から Approve、ただし Codex 自身が `Instant + Duration` overflow panic を検出して追加修正
- 3rd (6fcd758c): Codex の hardening fix を取り込み

## Test plan

新規 17 件 (unit 12 + integration 5) を追加、既存 41 件は維持。`cargo fmt` / `cargo clippy --tests -- -D warnings` / `cargo test -p rshogi-csa-client` 全 pass、警告ゼロ。

- [x] `protocol::tests::extract_retry_after_sec_*` (8 件): lobby/login/raw 形式 round-trip、None 系 (unknown_game_name / 空文字 / 非数値)、複数出現、0 秒、後続トークン
- [x] `main::tests::compute_effective_retry_delay_*` (4 件): retry_after 採用 / backoff 維持 / token 無し / 0 秒
- [x] `main::tests::sleep_with_shutdown_*` (4 件): 通常完走 / 事前 shutdown / sleep 中 shutdown (別スレッド) / 巨大 delay + 事前 shutdown (overflow 回避)
- [x] `tests/rate_limit_retry_after.rs` (5 件、新規 file): TCP mock で raw `LOGIN:incorrect rate_limited retry_after=N` を返したときの `bail!` 経由 round-trip + effective delay
- [x] doc-test: `extract_retry_after_sec` の `///` 例

## Closes

Closes #682

## Refs

- 親 issue: #622 (rate limit 本体、PR3a 投入前の client 側保証)
- 設計 doc: `docs/csa-server/rate_limit_design.md` §6.1 (csa-client は exponential backoff retry する旨を明示済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)