### PR TITLE
perf(nnue/psqt): add/sub_psqt_weights を SIMD 化 (NPS +3.0%)

### DIFF
--- a/.claude/skills/selfplay/SKILL.md
+++ b/.claude/skills/selfplay/SKILL.md
@@ -47,52 +47,69 @@ production は release より約 1.5% 低い instruction/node を達成する。
 
 各モデルに対して**必要十分な feature を指定**してビルドすること。feature が不足するとモデル読み込み失敗、過剰だと不要なコードパスや accumulator フィールドが残り NPS にバイアスが生じる。
 
-**モデル → feature 対応表**:
+**最新の feature 名は必ず実コードを確認すること**:
+```bash
+grep -E '^[a-z][a-z0-9-]+ =' /mnt/nvme1/development/rshogi/crates/rshogi-core/Cargo.toml
+```
+
+**モデル → feature 対応表**（2026-05 時点）:
 
 feature は以下の4カテゴリの組み合わせで構成する:
 
 1. **dispatch 除去**: `layerstack-only`（LayerStack モデルでは常に指定）
-2. **L1 サイズ**: `layerstacks-1536` / `layerstacks-768` / `layerstacks-512`（**必ず1つだけ**。複数同時有効は cycles +5.5% 退行）
+2. **L1×L2 サイズ**: 以下を**1つだけ**指定。複数同時有効は cycles +5.5% 退行
+   - `layerstacks-1536x16x32`（**default**, L0=1536, L1=16, L2=32, v100/v101 等の最新系）
+   - `layerstacks-1536x32x32`（L0=1536, L1=32, L2=32, v87/v88 等の旧 L1=32 系）
+   - `layerstacks-768x16x32`
+   - `layerstacks-512x16x32`
 3. **アーキテクチャ拡張**: `nnue-psqt`, `nnue-threat`（モデルに応じて）
-4. **最適化**: `nnue-progress-diff`（L1=1536 で有効。L1=768 では cache pressure 増加により cycles +2〜6% 退行するため指定しない）
+4. **最適化**: `nnue-progress-diff`（L1=1536 で有効。L0=768 系では cache pressure 増加により cycles +2〜6% 退行するため指定しない）
 
 | モデル種別 | 例 | 必須 feature |
 |---|---|---|
-| LayerStack 1536 | v87 | `layerstack-only,layerstacks-1536,nnue-progress-diff` |
-| LayerStack 1536 + PSQT | v88 | `layerstack-only,layerstacks-1536,nnue-psqt,nnue-progress-diff` |
-| LayerStack 1536 + Threat | v89, v91-1536 | `layerstack-only,layerstacks-1536,nnue-threat` |
-| LayerStack 1536 + PSQT + Threat | v90 | `layerstack-only,layerstacks-1536,nnue-psqt,nnue-threat` |
-| LayerStack 768 + Threat | v91-768 系 | `layerstack-only,layerstacks-768,nnue-threat` |
-| LayerStack 512 | | `layerstack-only,layerstacks-512` |
+| LayerStack 1536x16x32 (新標準) | v100 | `layerstack-only,nnue-progress-diff`（default で `layerstacks-1536x16x32`） |
+| LayerStack 1536x16x32 + PSQT | v101 | `layerstack-only,nnue-psqt,nnue-progress-diff` |
+| LayerStack 1536x32x32 | v87 (旧) | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-1536x32x32,nnue-progress-diff` |
+| LayerStack 1536x32x32 + PSQT | v88 (旧) | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-1536x32x32,nnue-psqt,nnue-progress-diff` |
+| LayerStack 1536x16x32 + Threat | v89, v91-1536 | `layerstack-only,nnue-threat` |
+| LayerStack 1536x16x32 + PSQT + Threat | v90 | `layerstack-only,nnue-psqt,nnue-threat` |
+| LayerStack 768x16x32 + Threat | v91-768 系 | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-768x16x32,nnue-threat` |
+| LayerStack 512x16x32 | | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-512x16x32` |
 | HalfKA_HM | danbo-v20 等 | (feature 指定なし、デフォルトで可) |
 
 **注意**:
-- `layerstacks-1536` はデフォルト feature に含まれる。768/512 モデル用にビルドする際は
-  `--no-default-features` で外す。その場合 `search-no-pass-rules`（デフォルトに含まれる）も
-  明示的に再指定すること。
-- `nnue-progress-diff` は L1=1536 限定の最適化。L1=768 では `StackEntryLayerStacks` の cache pressure 増加で退行する。
+- `layerstacks-1536x16x32` がデフォルト feature。`1536x32x32`/`768x16x32`/`512x16x32` 等を使うには
+  `--no-default-features` で外し、`search-no-pass-rules`（デフォルト含）を再指定する。
+- `nnue-progress-diff` は L0=1536 限定の最適化。L0=768/512 では `StackEntryLayerStacks` の cache pressure 増加で退行する。
+- 過去の `layerstacks-1536`（L1/L2 を区別しない）feature は廃止済み。`layerstacks-1536x16x32` または `layerstacks-1536x32x32` を使うこと。
 
 ```bash
-# 768 + Threat モデル用の例
+# 768x16x32 + Threat モデル用の例
 cargo build --profile production -p rshogi-usi \
   --no-default-features \
-  --features search-no-pass-rules,layerstack-only,layerstacks-768,nnue-threat
+  --features search-no-pass-rules,layerstack-only,layerstacks-768x16x32,nnue-threat
 ```
 
 **`layerstack-only` の効果**: HalfKP/HalfKA/HalfKA_HM のコードを除去し、`evaluate_dispatch` を直接呼び出しにバイパスする。LayerStack モデル同士の比較では常に指定すべき。
 
 **ビルド例**:
 ```bash
-# v87 用（LayerStack 1536, PSQT なし）
-cargo build --profile production -p rshogi-usi --features layerstack-only
-cp target/production/rshogi-usi target/production/rshogi-usi-ls1536
+# v100 用（LayerStack 1536x16x32, PSQT なし）— default feature を活用
+cargo build --profile production -p rshogi-usi --features layerstack-only,nnue-progress-diff
+cp target/production/rshogi-usi engines/rshogi-usi-1536x16x32-<purpose>
 
-# v88 用（LayerStack 1536 + PSQT）
-cargo build --profile production -p rshogi-usi --features layerstack-only,nnue-psqt
-cp target/production/rshogi-usi target/production/rshogi-usi-ls1536-psqt
+# v101 用（LayerStack 1536x16x32 + PSQT）
+cargo build --profile production -p rshogi-usi --features layerstack-only,nnue-psqt,nnue-progress-diff
+cp target/production/rshogi-usi engines/rshogi-usi-1536x16x32-psqt-<purpose>
 ```
 
 **重要**: `cargo build` は同一 profile で feature が異なっても同じ出力パスに書き出す。異なる feature のバイナリが必要な場合は、ビルド直後に別名にコピーすること。2つ目のビルドで1つ目が上書きされる。
+
+### バイナリ退避先
+
+長期保持したい評価用バイナリは **`engines/`** ディレクトリ（gitignored）に置く。
+`target/production/` は `cargo clean` で消える可能性、`/tmp/` は再起動で揮発するため。
+命名規則と既存バイナリの一覧は `engines/README.md` を参照。
 
 ## 実行手順
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ eval/*
 # Ignore tool-generated manifests under run outputs
 runs/
 
+# Retained USI engine binaries for evaluation runs (large binaries, model-specific)
+engines/*
+!engines/.gitkeep
+!engines/README.md
+
 # Avoid re-introducing accidentally generated manifest in tools crate root
 crates/tools/manifest.json
 

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -241,7 +241,8 @@ fn psqt_add_or_sub<const ADD: bool>(
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     {
         // SAFETY: v128 i32x4 load/store は連続 16 bytes。psqt_acc/weights とも 36 bytes
-        // 確保済み。
+        // 確保済み。WASM v128.load/store はアライメントヒントが advisory（非強制）なため、
+        // [i32; 9] の 4 バイトアラインポインタを *const v128 にキャストしても安全。
         unsafe {
             use std::arch::wasm32::*;
             let acc_ptr = psqt_acc.as_mut_ptr();
@@ -273,13 +274,15 @@ fn psqt_add_or_sub<const ADD: bool>(
         all(target_arch = "wasm32", target_feature = "simd128"),
     )))]
     {
-        // SAFETY: weights は 9 i32 連続が保証されている。
-        for bucket in 0..NUM_LAYER_STACK_BUCKETS {
-            let w = unsafe { *weights.add(bucket) };
+        // SAFETY: weights は 9 i32 連続が保証されている。slice 化することで
+        // 以降のループ本体を safe に保つ。
+        let w_slice: &[i32] =
+            unsafe { std::slice::from_raw_parts(weights, NUM_LAYER_STACK_BUCKETS) };
+        for (acc, &w) in psqt_acc.iter_mut().zip(w_slice) {
             if ADD {
-                psqt_acc[bucket] = psqt_acc[bucket].wrapping_add(w);
+                *acc = acc.wrapping_add(w);
             } else {
-                psqt_acc[bucket] = psqt_acc[bucket].wrapping_sub(w);
+                *acc = acc.wrapping_sub(w);
             }
         }
     }
@@ -629,7 +632,9 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
             "psqt_weights index out of bounds: offset={offset}, len={}",
             self.psqt_weights.len()
         );
-        // SAFETY: 同上。weights ポインタは 9 i32 連続を指す。
+        // SAFETY: debug_assert で境界確認済み。release では呼び出し元 (refresh / diff) が
+        // active_indices を経由しており、index は features の有効範囲内。weights ポインタは
+        // 9 i32 連続を指す。
         let weights_ptr = unsafe { self.psqt_weights.as_ptr().add(offset) };
         psqt_add_or_sub::<false>(psqt_acc, weights_ptr);
     }

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -98,6 +98,193 @@ pub struct FeatureTransformerLayerStacks<const L1: usize> {
     pub(crate) has_threat: bool,
 }
 
+/// PSQT アキュムレータ ([i32; NUM_LAYER_STACK_BUCKETS=9]) への 9-i32 ベクトル加減算。
+///
+/// `ADD = true` で `*acc += weights[0..9]`、`false` で `*acc -= weights[0..9]`。
+/// 9 = NUM_LAYER_STACK_BUCKETS は power-of-2 でないため:
+///
+/// - AVX-512F: 16-lane を 9 lane mask で 1 命令（BW 不要、`add_epi32` は AVX-512F のみで OK）
+/// - AVX2: 8 lane + 1 scalar
+/// - SSE2 / NEON / WASM SIMD128: 4 + 4 + 1 scalar
+/// - スカラー fallback
+///
+/// 各 cfg ブロックは互いに排他（後段ブロックは前段の `not(target_feature = ...)` で除外）
+/// のため、コンパイル時にちょうど一つの SIMD パス（または scalar fallback）が選択される。
+///
+/// # オーバーフロー挙動
+/// 旧スカラー実装は `*acc += weights[bucket]` で debug build では i32 overflow check が
+/// 走っていた。新実装は SIMD intrinsics (`_mm*_add_epi32` 等) で wrapping、scalar
+/// fallback も `wrapping_add` で明示 wrap。実用上 PSQT 値は ±数千オーダーで、
+/// HALFKA_HM_DIMENSIONS の累積でも i32 (±2.1e9) を溢れることはなく、挙動差は実害なし。
+///
+/// # Safety
+/// `weights` は少なくとも 9 個の i32 が連続して読める必要がある（呼び出し元が保証）。
+#[cfg(feature = "nnue-psqt")]
+#[inline(always)]
+fn psqt_add_or_sub<const ADD: bool>(
+    psqt_acc: &mut [i32; NUM_LAYER_STACK_BUCKETS],
+    weights: *const i32,
+) {
+    const { assert!(NUM_LAYER_STACK_BUCKETS == 9, "psqt_add_or_sub assumes 9 buckets") }
+
+    // AVX-512F: 9 lane mask で 1 命令
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    {
+        // SAFETY: 9 lane mask = 0x01FF。psqt_acc は [i32; 9] = 36 bytes、weights も 9 i32
+        // 連続。mask されたレーンのみ load/store するため境界外アクセスなし。
+        unsafe {
+            use std::arch::x86_64::*;
+            let mask: __mmask16 = 0x01FF;
+            let acc_ptr = psqt_acc.as_mut_ptr();
+            let a = _mm512_maskz_loadu_epi32(mask, acc_ptr);
+            let w = _mm512_maskz_loadu_epi32(mask, weights);
+            let result = if ADD {
+                _mm512_add_epi32(a, w)
+            } else {
+                _mm512_sub_epi32(a, w)
+            };
+            _mm512_mask_storeu_epi32(acc_ptr, mask, result);
+        }
+    }
+
+    // AVX2: 8 lane (i32×8 = 32 bytes) + 1 scalar
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "avx2",
+        not(target_feature = "avx512f")
+    ))]
+    {
+        // SAFETY: psqt_acc は [i32; 9] = 36 bytes、先頭 32 bytes (8 lane) は安全に
+        // load/store 可能。weights も 9 i32 連続なので 8 i32 load 安全。残り 1 lane は
+        // scalar で処理。
+        unsafe {
+            use std::arch::x86_64::*;
+            let acc_ptr = psqt_acc.as_mut_ptr();
+            let a = _mm256_loadu_si256(acc_ptr as *const __m256i);
+            let w = _mm256_loadu_si256(weights as *const __m256i);
+            let result = if ADD {
+                _mm256_add_epi32(a, w)
+            } else {
+                _mm256_sub_epi32(a, w)
+            };
+            _mm256_storeu_si256(acc_ptr as *mut __m256i, result);
+            let w8 = *weights.add(8);
+            if ADD {
+                psqt_acc[8] = psqt_acc[8].wrapping_add(w8);
+            } else {
+                psqt_acc[8] = psqt_acc[8].wrapping_sub(w8);
+            }
+        }
+    }
+
+    // SSE2: 4 + 4 + 1
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "sse2",
+        not(target_feature = "avx2"),
+        not(target_feature = "avx512f")
+    ))]
+    {
+        // SAFETY: psqt_acc/weights とも 9 i32 = 36 bytes 連続。0..4 と 4..8 の 16 bytes
+        // load/store は安全。
+        unsafe {
+            use std::arch::x86_64::*;
+            let acc_ptr = psqt_acc.as_mut_ptr();
+            for chunk in [0usize, 4] {
+                let a = _mm_loadu_si128(acc_ptr.add(chunk) as *const __m128i);
+                let w = _mm_loadu_si128(weights.add(chunk) as *const __m128i);
+                let result = if ADD {
+                    _mm_add_epi32(a, w)
+                } else {
+                    _mm_sub_epi32(a, w)
+                };
+                _mm_storeu_si128(acc_ptr.add(chunk) as *mut __m128i, result);
+            }
+            let w8 = *weights.add(8);
+            if ADD {
+                psqt_acc[8] = psqt_acc[8].wrapping_add(w8);
+            } else {
+                psqt_acc[8] = psqt_acc[8].wrapping_sub(w8);
+            }
+        }
+    }
+
+    // NEON (aarch64): 4 + 4 + 1
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    {
+        // SAFETY: NEON i32x4 load/store は psqt_acc / weights の連続 4 i32 を扱う。
+        // 9 i32 = 36 bytes 確保済み。0..4 と 4..8 を別 register で処理し、8 番目を
+        // scalar で更新。
+        unsafe {
+            use std::arch::aarch64::*;
+            let acc_ptr = psqt_acc.as_mut_ptr();
+            for chunk in [0usize, 4] {
+                let a = vld1q_s32(acc_ptr.add(chunk));
+                let w = vld1q_s32(weights.add(chunk));
+                let result = if ADD {
+                    vaddq_s32(a, w)
+                } else {
+                    vsubq_s32(a, w)
+                };
+                vst1q_s32(acc_ptr.add(chunk), result);
+            }
+            let w8 = *weights.add(8);
+            if ADD {
+                psqt_acc[8] = psqt_acc[8].wrapping_add(w8);
+            } else {
+                psqt_acc[8] = psqt_acc[8].wrapping_sub(w8);
+            }
+        }
+    }
+
+    // WASM SIMD128: 4 + 4 + 1
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        // SAFETY: v128 i32x4 load/store は連続 16 bytes。psqt_acc/weights とも 36 bytes
+        // 確保済み。
+        unsafe {
+            use std::arch::wasm32::*;
+            let acc_ptr = psqt_acc.as_mut_ptr();
+            for chunk in [0usize, 4] {
+                let a = v128_load(acc_ptr.add(chunk) as *const v128);
+                let w = v128_load(weights.add(chunk) as *const v128);
+                let result = if ADD {
+                    i32x4_add(a, w)
+                } else {
+                    i32x4_sub(a, w)
+                };
+                v128_store(acc_ptr.add(chunk) as *mut v128, result);
+            }
+            let w8 = *weights.add(8);
+            if ADD {
+                psqt_acc[8] = psqt_acc[8].wrapping_add(w8);
+            } else {
+                psqt_acc[8] = psqt_acc[8].wrapping_sub(w8);
+            }
+        }
+    }
+
+    // スカラー fallback
+    #[cfg(not(any(
+        all(target_arch = "x86_64", target_feature = "avx512f"),
+        all(target_arch = "x86_64", target_feature = "avx2"),
+        all(target_arch = "x86_64", target_feature = "sse2"),
+        all(target_arch = "aarch64", target_feature = "neon"),
+        all(target_arch = "wasm32", target_feature = "simd128"),
+    )))]
+    {
+        // SAFETY: weights は 9 i32 連続が保証されている。
+        for bucket in 0..NUM_LAYER_STACK_BUCKETS {
+            let w = unsafe { *weights.add(bucket) };
+            if ADD {
+                psqt_acc[bucket] = psqt_acc[bucket].wrapping_add(w);
+            } else {
+                psqt_acc[bucket] = psqt_acc[bucket].wrapping_sub(w);
+            }
+        }
+    }
+}
+
 impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     /// ファイルから読み込み（非圧縮形式）
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Self> {
@@ -413,6 +600,9 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     }
 
     /// PSQT 重みを加算
+    ///
+    /// `psqt_acc[bucket] += psqt_weights[index * 9 + bucket]` を 9 bucket 分まとめて実行する。
+    /// 内部実装は `psqt_add_or_sub::<true>` で SIMD 化されている。
     #[cfg(feature = "nnue-psqt")]
     #[inline]
     fn add_psqt_weights(&self, psqt_acc: &mut [i32; NUM_LAYER_STACK_BUCKETS], index: usize) {
@@ -422,9 +612,11 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
             "psqt_weights index out of bounds: offset={offset}, len={}",
             self.psqt_weights.len()
         );
-        for (bucket, acc) in psqt_acc.iter_mut().enumerate() {
-            *acc += self.psqt_weights[offset + bucket];
-        }
+        // SAFETY: debug_assert で境界確認済み。release では呼び出し元 (refresh / diff) が
+        // active_indices を経由しており、index は features の有効範囲内。weights ポインタは
+        // 9 i32 連続を指す。
+        let weights_ptr = unsafe { self.psqt_weights.as_ptr().add(offset) };
+        psqt_add_or_sub::<true>(psqt_acc, weights_ptr);
     }
 
     /// PSQT 重みを減算
@@ -437,9 +629,9 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
             "psqt_weights index out of bounds: offset={offset}, len={}",
             self.psqt_weights.len()
         );
-        for (bucket, acc) in psqt_acc.iter_mut().enumerate() {
-            *acc -= self.psqt_weights[offset + bucket];
-        }
+        // SAFETY: 同上。weights ポインタは 9 i32 連続を指す。
+        let weights_ptr = unsafe { self.psqt_weights.as_ptr().add(offset) };
+        psqt_add_or_sub::<false>(psqt_acc, weights_ptr);
     }
 
     /// 差分計算を使わずにAccumulatorを計算

--- a/engines/README.md
+++ b/engines/README.md
@@ -1,0 +1,33 @@
+# engines/
+
+評価対象として長期保持したい USI エンジンバイナリの置き場。
+
+## 方針
+
+- `target/production/` は `cargo clean` で消える可能性があるため、評価で繰り返し使うバイナリは
+  ここに退避する。
+- `/tmp/` は再起動で揮発するので NG。
+- `.gitignore` で本体は除外、README と `.gitkeep` のみコミット対象。
+
+## 命名規則
+
+```
+rshogi-usi-<arch>-<flags>-<purpose>
+```
+
+- `<arch>`: NNUE アーキテクチャ。例 `1536x16x32`, `768x16x32`, `halfkahm`
+- `<flags>`: 有効化した特徴。`psqt`, `threat`, `progdiff` 等。複数は `-` 連結
+- `<purpose>`: 用途識別子。例 `v100v101cmp`, `baseline`, `spsa-tuned`
+
+例:
+- `rshogi-usi-1536x16x32-v100v101cmp` — v100 vs v101 比較用、PSQT なし
+- `rshogi-usi-1536x16x32-psqt-v100v101cmp` — v101 評価用、PSQT 有効
+
+## 現在の保持バイナリ
+
+| ファイル | 対応モデル | feature | 用途 | ビルド日 |
+|---|---|---|---|---|
+| rshogi-usi-1536x16x32-v100v101cmp | v100 系 (1536x16x32, no PSQT) | `layerstack-only,nnue-progress-diff` (default で `layerstacks-1536x16x32`) | v100 vs v101 比較 | 2026-05-09 |
+| rshogi-usi-1536x16x32-psqt-v100v101cmp | v101 系 (1536x16x32, PSQT) | `layerstack-only,nnue-psqt,nnue-progress-diff` | v101 評価 | TBD |
+
+ビルド profile は **production** で統一（公平な NPS 比較のため）。


### PR DESCRIPTION
## Summary

- PSQT 差分更新の 9 i32 vector 加減算を SIMD 化（AVX-512 / AVX2 / SSE2 / NEON / WASM SIMD128 + scalar fallback）
- search_only_ab 計測で **NPS +3.02%, cycles/node -2.86%, instructions/node -2.83%**
- v101 (PSQT 有効) の NPS handicap が -7.7% → -4.9% に改善 → PSQT が持ち駒含めて評価精度向上させる効果 (depth 16 で nodes -22%) が NPS 低下に打ち消される問題が緩和
- 副次: \`engines/\` ディレクトリ新設（gitignored、評価用バイナリの長期保持先）、selfplay スキルの旧 feature 名 (\`layerstacks-1536\` 廃止) を最新化

## 実装

ヘルパー関数 \`psqt_add_or_sub::<const ADD: bool>\` で 6 経路網羅:

| 経路 | 処理 |
|---|---|
| AVX-512F | 9 lane mask (\`__mmask16 = 0x01FF\`) で 1 命令 |
| AVX2 | 8 lane + 残 1 lane scalar |
| SSE2 / NEON / WASM SIMD128 | 4 + 4 + 1 (chunk loop) |
| scalar fallback | \`wrapping_add/sub\` × 9 |

各 cfg ブロックは互いに排他（後段は前段 SIMD feature の \`not(target_feature = ...)\` で除外）のため、コンパイル時にちょうど一つの経路が選ばれる。早期 return なし。

## 計測 (search_only_ab, ABBA × 20局面 × 5sec/move = 80 runs)

\`\`\`
engine       runs          nodes      time_ms      avg_nps    cycles/node
baseline       40      111681275       199979       558465         7625.7   ← 旧 scalar
candidate      40      115062603       199985       575356         7407.6   ← 新 SIMD

candidate vs baseline: NPS +3.02%, cycles/node -2.86%, instructions/node -2.83%
\`\`\`

環境: AMD Ryzen 9 5950X (AVX2 path), production profile (\`lto=fat, target-cpu=native\`)

## 関連 Issue（後続検討）

- B: PSQT データレイアウト転置（feature-first → bucket-first）でさらに 4–8× SIMD 並列化
- C: PSQT lazy 計算（差分更新を遅延、eval 時のみ計算）

両方とも Issue 起票予定。

## Test plan

- [x] \`cargo test -p rshogi-core --features nnue-psqt --release\` 全 pass (762 + 2 PSQT 専用)
- [x] SSE2-only ビルド (\`-C target-feature=+sse2,-avx2,-avx,-sse4.1,-sse3\`) で test pass
- [x] AVX2 explicit (\`-C target-feature=+avx2\`) で test pass
- [x] default (\`target-cpu=native\`) で test pass
- [x] \`cargo clippy -p rshogi-core --features nnue-psqt --tests\` warning なし
- [x] \`cargo fmt\` 適用済み
- [x] search_only_ab で NPS 計測（+3.02%）
- [ ] byo 1000ms 対局での実際の NPS 改善確認（PR merge 前提で別途実施予定、v100-200 vs v101-200 で SPRT）

## 独立レビュー

別 agent による独立コードレビュー実施済み（致命的 bug なし、Major M1-M3 / Minor m1-m8）。指摘されたうち以下を反映:
- M3: i32 wrap セマンティクス変更を docstring に明記
- m6: \`debug_assert_eq!\` → \`const { assert!(...) }\` (既存 \`add_threat_weights\` 規範と整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)