### PR TITLE
feat(csa-server-workers): structured_log! macro 新設 + 全 console_log! を JSON 化 (#625 Phase A)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -18,8 +18,8 @@
 //! 本実装範囲では admin invoke endpoint や 1 万件超の bulk 並列化は Non-goals
 //! (設計 v3 §10)。
 //!
-//! 進捗ログは logfmt 構造化 (`event=…_progress listed=… elapsed_ms=…`) で
-//! `console_log!` に流す。Cloudflare Workers の Logs / tail で grep 可能。
+//! 進捗ログは [`structured_log!`](crate::structured_log) で JSON 化して
+//! Cloudflare Workers の Logs / tail へ流す ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A)。
 //! いかなる失敗 (R2 binding 解決失敗 / list 失敗 / get 失敗 / put 失敗 /
 //! parse 失敗) も `Err` を返さず ログのみ残して `Ok` で抜ける契約。
 //! `scheduled` handler が次回 cron 起動を妨げないようにするため、伝播禁止。
@@ -111,7 +111,7 @@ mod imp {
         BackfillStats, KIFU_BY_ID_PREFIX, LiveEntryGameId, META_SUFFIX, MetaForIndexKey, PAGE_SIZE,
         SWEEP_DEADLINE_MS, SWEEP_MAX_PAGES, SweepStats,
     };
-    use worker::{Date, Env, Result, console_log};
+    use worker::{Date, Env, Result};
 
     use crate::config::ConfigKeys;
     use crate::games_index::games_index_key;
@@ -134,7 +134,11 @@ mod imp {
         let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!("[backfill] event=games_index_backfill_bucket_failed err={:?}", e);
+                crate::structured_log!(
+                    event: "games_index_backfill_bucket_failed",
+                    component: "backfill",
+                    err: format!("{e:?}"),
+                );
                 return Ok(stats);
             }
         };
@@ -142,7 +146,11 @@ mod imp {
         let page = match bucket.list().prefix(KIFU_BY_ID_PREFIX).limit(PAGE_SIZE).execute().await {
             Ok(p) => p,
             Err(e) => {
-                console_log!("[backfill] event=games_index_backfill_list_failed err={:?}", e);
+                crate::structured_log!(
+                    event: "games_index_backfill_list_failed",
+                    component: "backfill",
+                    err: format!("{e:?}"),
+                );
                 return Ok(stats);
             }
         };
@@ -159,10 +167,11 @@ mod imp {
             let fetched = match bucket.get(&key).execute().await {
                 Ok(o) => o,
                 Err(e) => {
-                    console_log!(
-                        "[backfill] event=games_index_backfill_get_failed key={} err={:?}",
-                        key,
-                        e,
+                    crate::structured_log!(
+                        event: "games_index_backfill_get_failed",
+                        component: "backfill",
+                        key: key,
+                        err: format!("{e:?}"),
                     );
                     stats.skipped = stats.skipped.saturating_add(1);
                     continue;
@@ -180,10 +189,11 @@ mod imp {
             let bytes = match body.bytes().await {
                 Ok(b) => b,
                 Err(e) => {
-                    console_log!(
-                        "[backfill] event=games_index_backfill_read_failed key={} err={:?}",
-                        key,
-                        e,
+                    crate::structured_log!(
+                        event: "games_index_backfill_read_failed",
+                        component: "backfill",
+                        key: key,
+                        err: format!("{e:?}"),
                     );
                     stats.skipped = stats.skipped.saturating_add(1);
                     continue;
@@ -192,10 +202,11 @@ mod imp {
             let meta: MetaForIndexKey = match serde_json::from_slice(&bytes) {
                 Ok(v) => v,
                 Err(e) => {
-                    console_log!(
-                        "[backfill] event=games_index_backfill_parse_failed key={} err={:?}",
-                        key,
-                        e,
+                    crate::structured_log!(
+                        event: "games_index_backfill_parse_failed",
+                        component: "backfill",
+                        key: key,
+                        err: format!("{e:?}"),
                     );
                     stats.skipped = stats.skipped.saturating_add(1);
                     continue;
@@ -205,10 +216,11 @@ mod imp {
             let index_key = match games_index_key(meta.ended_at_ms, &meta.game_id) {
                 Ok(k) => k,
                 Err(e) => {
-                    console_log!(
-                        "[backfill] event=games_index_backfill_key_failed game_id={} err={:?}",
-                        meta.game_id,
-                        e,
+                    crate::structured_log!(
+                        event: "games_index_backfill_key_failed",
+                        component: "backfill",
+                        game_id: meta.game_id,
+                        err: format!("{e:?}"),
                     );
                     stats.skipped = stats.skipped.saturating_add(1);
                     continue;
@@ -218,11 +230,12 @@ mod imp {
             // body は meta の wire そのまま。`GamesIndexEntry` の wire と等価
             // (両方とも export_kifu_to_r2 で同一 JSON を put している)。
             if let Err(e) = bucket.put(&index_key, bytes).execute().await {
-                console_log!(
-                    "[backfill] event=games_index_backfill_put_failed game_id={} index_key={} err={:?}",
-                    meta.game_id,
-                    index_key,
-                    e,
+                crate::structured_log!(
+                    event: "games_index_backfill_put_failed",
+                    component: "backfill",
+                    game_id: meta.game_id,
+                    index_key: index_key,
+                    err: format!("{e:?}"),
                 );
                 stats.skipped = stats.skipped.saturating_add(1);
                 continue;
@@ -231,12 +244,13 @@ mod imp {
         }
 
         let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
-        console_log!(
-            "[backfill] event=games_index_backfill_progress listed={} put={} skipped={} elapsed_ms={}",
-            stats.listed,
-            stats.put,
-            stats.skipped,
-            elapsed_ms,
+        crate::structured_log!(
+            event: "games_index_backfill_progress",
+            component: "backfill",
+            listed: stats.listed,
+            put: stats.put,
+            skipped: stats.skipped,
+            elapsed_ms: elapsed_ms,
         );
         Ok(stats)
     }
@@ -270,7 +284,11 @@ mod imp {
         let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!("[backfill] event=live_orphan_sweep_bucket_failed err={:?}", e);
+                crate::structured_log!(
+                    event: "live_orphan_sweep_bucket_failed",
+                    component: "backfill",
+                    err: format!("{e:?}"),
+                );
                 return Ok(stats);
             }
         };
@@ -294,10 +312,11 @@ mod imp {
             let page = match builder.execute().await {
                 Ok(p) => p,
                 Err(e) => {
-                    console_log!(
-                        "[backfill] event=live_orphan_sweep_list_failed pages={} err={:?}",
-                        stats.pages,
-                        e,
+                    crate::structured_log!(
+                        event: "live_orphan_sweep_list_failed",
+                        component: "backfill",
+                        pages: stats.pages,
+                        err: format!("{e:?}"),
                     );
                     break;
                 }
@@ -329,11 +348,12 @@ mod imp {
                 let head_result = match bucket.head(&meta_key).await {
                     Ok(o) => o,
                     Err(e) => {
-                        console_log!(
-                            "[backfill] event=live_orphan_sweep_head_failed game_id={} meta_key={} err={:?}",
-                            game_id,
-                            meta_key,
-                            e,
+                        crate::structured_log!(
+                            event: "live_orphan_sweep_head_failed",
+                            component: "backfill",
+                            game_id: game_id,
+                            meta_key: meta_key,
+                            err: format!("{e:?}"),
                         );
                         if Date::now().as_millis().saturating_sub(started_at_ms)
                             >= SWEEP_DEADLINE_MS
@@ -355,11 +375,12 @@ mod imp {
                 }
 
                 if let Err(e) = bucket.delete(&live_key).await {
-                    console_log!(
-                        "[backfill] event=live_orphan_sweep_delete_failed game_id={} live_key={} err={:?}",
-                        game_id,
-                        live_key,
-                        e,
+                    crate::structured_log!(
+                        event: "live_orphan_sweep_delete_failed",
+                        component: "backfill",
+                        game_id: game_id,
+                        live_key: live_key,
+                        err: format!("{e:?}"),
                     );
                     if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
                         stats.deadline_reached = true;
@@ -379,9 +400,10 @@ mod imp {
                 break;
             }
             if stats.pages >= SWEEP_MAX_PAGES {
-                console_log!(
-                    "[backfill] event=live_orphan_sweep_max_pages_reached pages={}",
-                    stats.pages,
+                crate::structured_log!(
+                    event: "live_orphan_sweep_max_pages_reached",
+                    component: "backfill",
+                    pages: stats.pages,
                 );
                 break;
             }
@@ -394,29 +416,31 @@ mod imp {
         }
 
         let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
-        console_log!(
-            "[backfill] event=live_orphan_sweep_progress listed={} deleted={} pages={} deadline_reached={} elapsed_ms={}",
-            stats.listed,
-            stats.deleted,
-            stats.pages,
-            stats.deadline_reached,
-            elapsed_ms,
+        crate::structured_log!(
+            event: "live_orphan_sweep_progress",
+            component: "backfill",
+            listed: stats.listed,
+            deleted: stats.deleted,
+            pages: stats.pages,
+            deadline_reached: stats.deadline_reached,
+            elapsed_ms: elapsed_ms,
         );
         Ok(stats)
     }
 
     /// `live-games-index/<key>` の本文を読んで `game_id` field を返す。
     ///
-    /// 失敗はすべて logfmt で記録した上で `None` を返し、呼び出し側で entry
+    /// 失敗はすべて構造化ログで記録した上で `None` を返し、呼び出し側で entry
     /// を skip させる (sweep 全体を停止しない)。
     async fn read_live_entry_game_id(bucket: &worker::Bucket, key: &str) -> Option<String> {
         let fetched = match bucket.get(key).execute().await {
             Ok(o) => o,
             Err(e) => {
-                console_log!(
-                    "[backfill] event=live_orphan_sweep_get_failed key={} err={:?}",
-                    key,
-                    e,
+                crate::structured_log!(
+                    event: "live_orphan_sweep_get_failed",
+                    component: "backfill",
+                    key: key,
+                    err: format!("{e:?}"),
                 );
                 return None;
             }
@@ -426,10 +450,11 @@ mod imp {
         let bytes = match body.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[backfill] event=live_orphan_sweep_read_failed key={} err={:?}",
-                    key,
-                    e,
+                crate::structured_log!(
+                    event: "live_orphan_sweep_read_failed",
+                    component: "backfill",
+                    key: key,
+                    err: format!("{e:?}"),
                 );
                 return None;
             }
@@ -437,10 +462,11 @@ mod imp {
         match serde_json::from_slice::<LiveEntryGameId>(&bytes) {
             Ok(v) => Some(v.game_id),
             Err(e) => {
-                console_log!(
-                    "[backfill] event=live_orphan_sweep_parse_failed key={} err={:?}",
-                    key,
-                    e,
+                crate::structured_log!(
+                    event: "live_orphan_sweep_parse_failed",
+                    component: "backfill",
+                    key: key,
+                    err: format!("{e:?}"),
                 );
                 None
             }

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -122,8 +122,8 @@ impl ConfigKeys {
     /// / `no` / `off` または未設定で無効（= 該当 endpoint は 404 で既存ルーティング
     /// にフォールスルー）。production rollout 時の kill-switch を兼ね、本値を
     /// `"0"` に切り替えて redeploy することで viewer API を即時無効化できる。
-    /// 設定不正値は安全側に倒し（無効化）、`worker::console_log!` で警告ログを
-    /// 出す。
+    /// 設定不正値は安全側に倒し（無効化）、[`structured_log!`](crate::structured_log)
+    /// で警告ログを出す。
     pub const ALLOW_VIEWER_API: &'static str = "ALLOW_VIEWER_API";
     /// 私的対局 (`CHALLENGE_LOBBY` および `LOGIN_LOBBY <handle>+private-<token>+free`)
     /// 経路を opt-in 有効化するブール変数 (https://github.com/SH11235/rshogi/issues/635)。
@@ -139,7 +139,8 @@ impl ConfigKeys {
     ///
     /// staging では起動経路実装の動作確認時のみ `"true"` に切り替える。
     /// 設定不正値 (`true` / `false` / 数字 / yes/no/on/off 以外) は `ALLOW_VIEWER_API`
-    /// と同じく安全側 (= 無効化) に倒し、`worker::console_log!` で警告ログを出す。
+    /// と同じく安全側 (= 無効化) に倒し、[`structured_log!`](crate::structured_log)
+    /// で警告ログを出す。
     pub const PRIVATE_CHALLENGE_ENABLED: &'static str = "PRIVATE_CHALLENGE_ENABLED";
 
     /// deploy 対象コードの provenance commit sha (`DEPLOY_TRIGGER_SHA`)。
@@ -479,7 +480,8 @@ pub fn resolve_clock_spec_from_presets_map(
 ///
 /// 値の解釈は [`rshogi_csa_server::config::parse_truthy_bool_env`] に委ねる。
 /// 設定不正値（`true` / `false` / 数字 / yes/no/on/off 以外）は安全側に倒し
-/// （= viewer API 無効化）、`worker::console_log!` で警告ログを 1 回だけ出す。
+/// （= viewer API 無効化）、[`structured_log!`](crate::structured_log) で
+/// 警告ログを 1 回だけ出す。
 /// production rollout 時の kill-switch を兼ねる: 値を `"0"` に切り替えて
 /// redeploy することで該当 endpoint を即時 404 化できる。
 #[cfg(target_arch = "wasm32")]
@@ -488,7 +490,11 @@ pub fn is_viewer_api_enabled(env: &worker::Env) -> bool {
     match rshogi_csa_server::config::parse_truthy_bool_env(raw.as_deref()) {
         Ok(v) => v,
         Err(e) => {
-            worker::console_log!("[viewer_api] event=invalid_allow_viewer_api err={e}");
+            crate::structured_log!(
+                event: "invalid_allow_viewer_api",
+                component: "viewer_api",
+                err: format!("{e}"),
+            );
             false
         }
     }
@@ -500,7 +506,8 @@ pub fn is_viewer_api_enabled(env: &worker::Env) -> bool {
 ///
 /// 値の解釈は [`rshogi_csa_server::config::parse_truthy_bool_env`] に委ねる。
 /// 設定不正値（`true` / `false` / 数字 / yes/no/on/off 以外）は安全側に倒し
-/// （= private challenge 無効化）、`worker::console_log!` で警告ログを出す。
+/// （= private challenge 無効化）、[`structured_log!`](crate::structured_log)
+/// で警告ログを出す。
 ///
 /// 無効時は LobbyDO の `dispatch_pending_line` 入口で早期 reject し、
 /// `CHALLENGE_LOBBY:incorrect unsupported` / `LOGIN_LOBBY:incorrect unsupported`
@@ -512,7 +519,11 @@ pub fn is_private_challenge_enabled(env: &worker::Env) -> bool {
     match rshogi_csa_server::config::parse_truthy_bool_env(raw.as_deref()) {
         Ok(v) => v,
         Err(e) => {
-            worker::console_log!("[lobby] event=invalid_private_challenge_enabled err={e}");
+            crate::structured_log!(
+                event: "invalid_private_challenge_enabled",
+                component: "lobby",
+                err: format!("{e}"),
+            );
             false
         }
     }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use worker::{
     Date, Delay, DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State,
-    WebSocket, WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
+    WebSocket, WebSocketIncomingMessage, WebSocketPair, durable_object, wasm_bindgen,
 };
 
 use rshogi_core::types::EnteringKingRule;
@@ -358,7 +358,10 @@ impl DurableObject for GameRoom {
             .serialize_attachment(&pending)
             .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
 
-        console_log!("[GameRoom] websocket upgrade accepted");
+        crate::structured_log!(
+            event: "websocket_upgrade_accepted",
+            component: "game_room",
+        );
 
         Ok(ResponseBuilder::new().with_status(101).with_websocket(pair.client).empty())
     }
@@ -375,10 +378,11 @@ impl DurableObject for GameRoom {
             WebSocketIncomingMessage::Binary(b) => b.len(),
         };
         if raw_len > MAX_WS_LINE_BYTES {
-            console_log!(
-                "[GameRoom] event=ws_message_too_big bytes={} limit={}",
-                raw_len,
-                MAX_WS_LINE_BYTES,
+            crate::structured_log!(
+                event: "ws_message_too_big",
+                component: "game_room",
+                bytes: raw_len,
+                limit: MAX_WS_LINE_BYTES,
             );
             let _ = ws.close(Some(1009), Some("message too big".to_owned()));
             return Ok(());
@@ -419,7 +423,11 @@ impl DurableObject for GameRoom {
         // 得ないが、診断のためにエラー内容をログへ残す。現実装では Player 以外 (Pending /
         // corrupt) は slot 解放できないので何もせず return する。
         let att: Option<WsAttachment> = ws.deserialize_attachment().unwrap_or_else(|e| {
-            console_log!("[GameRoom] websocket_close: deserialize_attachment failed: {e:?}");
+            crate::structured_log!(
+                event: "websocket_close_deserialize_failed",
+                component: "game_room",
+                err: format!("{e:?}"),
+            );
             None
         });
         let Some(WsAttachment::Player { role, .. }) = att else {
@@ -454,7 +462,11 @@ impl DurableObject for GameRoom {
             if let Err(e) = self.enter_grace_window(role, grace_duration).await {
                 // grace 経路のセットアップに失敗したら旧経路 (即時 force_abnormal)
                 // にフォールバックして部屋が宙ぶらりんにならないようにする。
-                console_log!("[GameRoom] enter_grace_window failed; fallback to abnormal: {e:?}");
+                crate::structured_log!(
+                    event: "enter_grace_window_failed",
+                    component: "game_room",
+                    err: format!("{e:?}"),
+                );
             } else {
                 return Ok(());
             }
@@ -583,7 +595,13 @@ impl GameRoom {
             game_name: game_name.clone(),
         });
         if let MatchResult::Conflict { reason } = evaluate_match(&next_slots) {
-            console_log!("[GameRoom] LOGIN rejected (conflict: {reason})");
+            crate::structured_log!(
+                event: "login_rejected",
+                component: "game_room",
+                handle: handle,
+                role: format!("{role:?}"),
+                reason: reason,
+            );
             send_line(ws, &LoginReply::Incorrect.to_line())?;
             return Ok(());
         }
@@ -645,7 +663,11 @@ impl GameRoom {
         if let StartMatchGuard::AlreadyFinished =
             classify_start_match_guard(finished_present, false, None)
         {
-            console_log!("[GameRoom] start_match aborted: already finished");
+            crate::structured_log!(
+                event: "start_match_aborted",
+                component: "game_room",
+                reason: "already_finished",
+            );
             self.abort_pending_match_with_error("##[ERROR] room already finished").await?;
             return Ok(false);
         }
@@ -660,7 +682,11 @@ impl GameRoom {
         if let StartMatchGuard::AlreadyMatched =
             classify_start_match_guard(false, cfg_present, None)
         {
-            console_log!("[GameRoom] start_match aborted: KEY_CONFIG already present");
+            crate::structured_log!(
+                event: "start_match_aborted",
+                component: "game_room",
+                reason: "key_config_already_present",
+            );
             self.abort_pending_match_with_error("##[ERROR] match already in progress")
                 .await?;
             return Ok(false);
@@ -674,8 +700,11 @@ impl GameRoom {
         if let StartMatchGuard::AlarmPending(kind) =
             classify_start_match_guard(false, false, existing_kind)
         {
-            console_log!(
-                "[GameRoom] start_match aborted: pending_alarm_kind={kind:?} already present"
+            crate::structured_log!(
+                event: "start_match_aborted",
+                component: "game_room",
+                reason: "pending_alarm_kind_present",
+                pending_alarm_kind: format!("{kind:?}"),
             );
             self.abort_pending_match_with_error("##[ERROR] match already has pending alarm")
                 .await?;
@@ -705,8 +734,11 @@ impl GameRoom {
         let clock_spec = match resolve_clock_spec_for_game(&self.env, game_name) {
             Ok(spec) => spec,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] clock spec resolution failed for game_name '{game_name}': {e:?}; rejecting pending match"
+                crate::structured_log!(
+                    event: "clock_spec_resolution_failed",
+                    component: "game_room",
+                    game_name: game_name,
+                    err: format!("{e:?}"),
                 );
                 self.abort_pending_match_with_error(&format!(
                     "##[ERROR] clock spec for '{game_name}' could not be resolved"
@@ -731,8 +763,10 @@ impl GameRoom {
         let grace = match resolve_reconnect_grace(&self.env) {
             Ok(d) => d,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] reconnect grace config error (aborting pending match): {e}"
+                crate::structured_log!(
+                    event: "reconnect_grace_config_error",
+                    component: "game_room",
+                    err: format!("{e}"),
                 );
                 self.abort_pending_match_with_error("##[ERROR] reconnect grace config error")
                     .await?;
@@ -747,8 +781,11 @@ impl GameRoom {
         {
             Ok(r) => r,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] buoy '{game_name}' reservation failed: {e:?}; rejecting pending match"
+                crate::structured_log!(
+                    event: "buoy_reservation_failed",
+                    component: "game_room",
+                    game_name: game_name,
+                    err: format!("{e:?}"),
                 );
                 self.abort_pending_match_with_error(&format!(
                     "##[ERROR] buoy '{game_name}' reservation failed"
@@ -761,7 +798,11 @@ impl GameRoom {
             BuoyReservation::Missing => None,
             BuoyReservation::Reserved(initial_sfen) => initial_sfen,
             BuoyReservation::Exhausted => {
-                console_log!("[GameRoom] buoy '{game_name}' exhausted; rejecting pending match");
+                crate::structured_log!(
+                    event: "buoy_exhausted",
+                    component: "game_room",
+                    game_name: game_name,
+                );
                 self.abort_pending_match_with_error(&format!(
                     "##[ERROR] buoy '{game_name}' exhausted"
                 ))
@@ -921,13 +962,22 @@ impl GameRoom {
         let result = {
             let mut borrow = self.core.borrow_mut();
             let Some(core) = borrow.as_mut() else {
-                console_log!("[GameRoom] handle_game_line: core missing (handle={handle})");
+                crate::structured_log!(
+                    event: "handle_game_line_core_missing",
+                    component: "game_room",
+                    handle: handle,
+                );
                 return Ok(());
             };
             match core.handle_line(color, &csa, now) {
                 Ok(r) => r,
                 Err(e) => {
-                    console_log!("[GameRoom] handle_line error: {e:?}");
+                    crate::structured_log!(
+                        event: "handle_line_error",
+                        component: "game_room",
+                        handle: handle,
+                        err: format!("{e:?}"),
+                    );
                     return Ok(());
                 }
             }
@@ -1115,7 +1165,11 @@ impl GameRoom {
                 _ => {}
             }
             if let Err(e) = send_line(ws, line) {
-                console_log!("[GameRoom] spectator queue flush failed (ignored): {e:?}");
+                crate::structured_log!(
+                    event: "spectator_queue_flush_failed",
+                    component: "game_room",
+                    err: format!("{e:?}"),
+                );
             }
         }
         // snapshot 終了状態へ戻す (`snapshot_in_progress = false`, queue は空)。
@@ -1414,10 +1468,12 @@ impl GameRoom {
             if put_result.is_some() {
                 return Ok(BuoyReservation::Reserved(reserved_initial_sfen));
             }
-            console_log!(
-                "[GameRoom] buoy '{}' reservation etag mismatch, retry {}/{MAX_ATTEMPTS}",
-                game_name.as_str(),
-                attempt + 1,
+            crate::structured_log!(
+                event: "buoy_reservation_etag_mismatch",
+                component: "game_room",
+                game_name: game_name.as_str(),
+                attempt: attempt + 1,
+                max_attempts: MAX_ATTEMPTS,
             );
         }
         Err(Error::RustError(format!(
@@ -1583,7 +1639,8 @@ impl GameRoom {
         // `ServerError::Storage` を伝播するが、Workers DO で Err を返すと alarm /
         // ws close が抜ける副作用があるため、kifu export と同じ silent log 方針で
         // 終局処理の前進を優先する。失敗は `try_persist_floodgate_history` 内で
-        // `console_log!` のみで吸収するため呼び出し側は `Result` を待たない。
+        // [`structured_log!`](crate::structured_log) のみで吸収するため呼び出し側は
+        // `Result` を待たない。
         self.try_persist_floodgate_history(game_result, &code, ended_at_ms).await;
 
         // export 全成功なら `exported_at_ms` を埋め、retry 経路は不要。
@@ -1655,10 +1712,11 @@ impl GameRoom {
     /// は確定しているので運用上 export 欠損として観測できる。
     async fn schedule_export_retry(&self, pending: ExportPendingState) {
         if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
-            console_log!(
-                "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
-                pending.game_id,
-                e,
+            crate::structured_log!(
+                event: "export_pending_put_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                err: format!("{e:?}"),
             );
             return;
         }
@@ -1668,36 +1726,40 @@ impl GameRoom {
             .put(KEY_PENDING_ALARM_KIND, &PendingAlarmKind::ExportRetry)
             .await
         {
-            console_log!(
-                "[GameRoom] event=export_retry_kind_put_failed game_id={} err={:?}",
-                pending.game_id,
-                e,
+            crate::structured_log!(
+                event: "export_retry_kind_put_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                err: format!("{e:?}"),
             );
             return;
         }
         let Some(delay_ms) = next_retry_delay_ms(pending.attempt) else {
             // 最初の予約で `attempt = 0` のため到達しない契約。防御的に log のみ。
-            console_log!(
-                "[GameRoom] event=export_retry_initial_exhausted game_id={} attempt={}",
-                pending.game_id,
-                pending.attempt,
+            crate::structured_log!(
+                event: "export_retry_initial_exhausted",
+                component: "game_room",
+                game_id: pending.game_id,
+                attempt: pending.attempt,
             );
             return;
         };
         if let Err(e) = self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await {
-            console_log!(
-                "[GameRoom] event=export_retry_alarm_set_failed game_id={} delay_ms={} err={:?}",
-                pending.game_id,
-                delay_ms,
-                e,
+            crate::structured_log!(
+                event: "export_retry_alarm_set_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                delay_ms: delay_ms,
+                err: format!("{e:?}"),
             );
         } else {
-            console_log!(
-                "[GameRoom] event=export_retry_scheduled game_id={} attempt={} delay_ms={} failed_count={}",
-                pending.game_id,
-                pending.attempt,
-                delay_ms,
-                pending.failed_keys.len(),
+            crate::structured_log!(
+                event: "export_retry_scheduled",
+                component: "game_room",
+                game_id: pending.game_id,
+                attempt: pending.attempt,
+                delay_ms: delay_ms,
+                failed_count: pending.failed_keys.len(),
             );
         }
     }
@@ -1715,7 +1777,10 @@ impl GameRoom {
         let Some(mut pending) = pending else {
             // pending が無い (race / 旧 deploy 状態の cleanup) は alarm タグだけ
             // 片付けて終了する。`KEY_FINISHED` 経路は既に確定済の前提。
-            console_log!("[GameRoom] event=export_retry_no_pending");
+            crate::structured_log!(
+                event: "export_retry_no_pending",
+                component: "game_room",
+            );
             let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
             let _ = self.state.storage().delete_alarm().await;
             return Ok(());
@@ -1724,11 +1789,12 @@ impl GameRoom {
         let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=export_retry_bucket_missing game_id={} attempt={} err={:?}",
-                    pending.game_id,
-                    pending.attempt,
-                    e,
+                crate::structured_log!(
+                    event: "export_retry_bucket_missing",
+                    component: "game_room",
+                    game_id: pending.game_id,
+                    attempt: pending.attempt,
+                    err: format!("{e:?}"),
                 );
                 // bucket binding 不在 = config 不正。retry を進めても解決しない
                 // ので alarm を停止し pending は残置 (deploy 修正で再開する想定
@@ -1749,20 +1815,22 @@ impl GameRoom {
             };
             match bucket.put(&failed.key, body).execute().await {
                 Ok(_) => {
-                    console_log!(
-                        "[GameRoom] event=export_retry_put_ok game_id={} key={} attempt={}",
-                        pending.game_id,
-                        failed.key,
-                        pending.attempt,
+                    crate::structured_log!(
+                        event: "export_retry_put_ok",
+                        component: "game_room",
+                        game_id: pending.game_id,
+                        key: failed.key,
+                        attempt: pending.attempt,
                     );
                 }
                 Err(e) => {
-                    console_log!(
-                        "[GameRoom] event=export_retry_put_failed game_id={} key={} attempt={} err={:?}",
-                        pending.game_id,
-                        failed.key,
-                        pending.attempt,
-                        e,
+                    crate::structured_log!(
+                        event: "export_retry_put_failed",
+                        component: "game_room",
+                        game_id: pending.game_id,
+                        key: failed.key,
+                        attempt: pending.attempt,
+                        err: format!("{e:?}"),
                     );
                     still_failed.push(failed);
                 }
@@ -1781,19 +1849,21 @@ impl GameRoom {
         pending.attempt = next_attempt;
 
         if is_exhausted(next_attempt) {
-            console_log!(
-                "[GameRoom] event=export_retry_exhausted game_id={} attempt={} remaining={}",
-                pending.game_id,
-                next_attempt,
-                pending.failed_keys.len(),
+            crate::structured_log!(
+                event: "export_retry_exhausted",
+                component: "game_room",
+                game_id: pending.game_id,
+                attempt: next_attempt,
+                remaining: pending.failed_keys.len(),
             );
             // pending を最新 attempt で書き直して観測性を保ち、alarm/タグだけ
             // 停止する。
             if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
-                console_log!(
-                    "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
-                    pending.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "export_pending_put_failed",
+                    component: "game_room",
+                    game_id: pending.game_id,
+                    err: format!("{e:?}"),
                 );
             }
             let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
@@ -1802,10 +1872,11 @@ impl GameRoom {
         }
 
         if let Err(e) = self.state.storage().put(KEY_EXPORT_PENDING, &pending).await {
-            console_log!(
-                "[GameRoom] event=export_pending_put_failed game_id={} err={:?}",
-                pending.game_id,
-                e,
+            crate::structured_log!(
+                event: "export_pending_put_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                err: format!("{e:?}"),
             );
             return Ok(());
         }
@@ -1814,19 +1885,21 @@ impl GameRoom {
             return Ok(());
         };
         if let Err(e) = self.state.storage().set_alarm(Duration::from_millis(delay_ms)).await {
-            console_log!(
-                "[GameRoom] event=export_retry_alarm_set_failed game_id={} delay_ms={} err={:?}",
-                pending.game_id,
-                delay_ms,
-                e,
+            crate::structured_log!(
+                event: "export_retry_alarm_set_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                delay_ms: delay_ms,
+                err: format!("{e:?}"),
             );
         } else {
-            console_log!(
-                "[GameRoom] event=export_retry_rescheduled game_id={} attempt={} delay_ms={} failed_count={}",
-                pending.game_id,
-                next_attempt,
-                delay_ms,
-                pending.failed_keys.len(),
+            crate::structured_log!(
+                event: "export_retry_rescheduled",
+                component: "game_room",
+                game_id: pending.game_id,
+                attempt: next_attempt,
+                delay_ms: delay_ms,
+                failed_count: pending.failed_keys.len(),
             );
         }
         Ok(())
@@ -1837,10 +1910,11 @@ impl GameRoom {
     /// retry 自体を破壊しないため)。
     async fn complete_export_retry(&self, pending: &ExportPendingState) {
         if let Err(e) = self.state.storage().delete(KEY_EXPORT_PENDING).await {
-            console_log!(
-                "[GameRoom] event=export_pending_delete_failed game_id={} err={:?}",
-                pending.game_id,
-                e,
+            crate::structured_log!(
+                event: "export_pending_delete_failed",
+                component: "game_room",
+                game_id: pending.game_id,
+                err: format!("{e:?}"),
             );
         }
         let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
@@ -1854,30 +1928,34 @@ impl GameRoom {
             Ok(Some(mut finished)) => {
                 finished.exported_at_ms = Some(now_ms);
                 if let Err(e) = self.state.storage().put(KEY_FINISHED, &finished).await {
-                    console_log!(
-                        "[GameRoom] event=export_retry_finished_update_failed game_id={} err={:?}",
-                        pending.game_id,
-                        e,
+                    crate::structured_log!(
+                        event: "export_retry_finished_update_failed",
+                        component: "game_room",
+                        game_id: pending.game_id,
+                        err: format!("{e:?}"),
                     );
                 } else {
-                    console_log!(
-                        "[GameRoom] event=export_retry_completed game_id={} attempt={}",
-                        pending.game_id,
-                        pending.attempt,
+                    crate::structured_log!(
+                        event: "export_retry_completed",
+                        component: "game_room",
+                        game_id: pending.game_id,
+                        attempt: pending.attempt,
                     );
                 }
             }
             Ok(None) => {
-                console_log!(
-                    "[GameRoom] event=export_retry_finished_missing game_id={}",
-                    pending.game_id,
+                crate::structured_log!(
+                    event: "export_retry_finished_missing",
+                    component: "game_room",
+                    game_id: pending.game_id,
                 );
             }
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=export_retry_finished_load_failed game_id={} err={:?}",
-                    pending.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "export_retry_finished_load_failed",
+                    component: "game_room",
+                    game_id: pending.game_id,
+                    err: format!("{e:?}"),
                 );
             }
         }
@@ -1895,8 +1973,9 @@ impl GameRoom {
     /// - `Pending(state)`: 1 つ以上 PUT 失敗で retry 用の本文 + 失敗 key 一覧を
     ///   保持。`finalize_if_ended` は本値を `KEY_EXPORT_PENDING` に永続化する。
     /// - `Skipped`: bucket binding 不在 / `load_moves` 失敗 / SFEN 不正 / serialize
-    ///   失敗等の「retry しても解決しない致命的失敗」。本関数内で `console_log!`
-    ///   で吸収済みなので呼び出し側は何もしない (`exported_at_ms = None` だけ残る)。
+    ///   失敗等の「retry しても解決しない致命的失敗」。本関数内で
+    ///   [`structured_log!`](crate::structured_log) で吸収済みなので呼び出し側は
+    ///   何もしない (`exported_at_ms = None` だけ残る)。
     ///
     /// 本関数は `Result` ではなく `ExportAttempt` を返す。R2 PUT 失敗を上位に
     /// 伝播させると `finalize_if_ended` が中断し WS close / `KEY_FINISHED` put が
@@ -1914,7 +1993,11 @@ impl GameRoom {
             None => {
                 // PersistedConfig 未確定 = AGREE 前の致命的経路で finalize に
                 // 入った race。CSA 本文を組み立てる材料がないので skip する。
-                console_log!("[GameRoom] event=export_skip reason=config_missing");
+                crate::structured_log!(
+                    event: "export_skip",
+                    component: "game_room",
+                    reason: "config_missing",
+                );
                 return ExportAttempt::Skipped;
             }
         };
@@ -1922,10 +2005,12 @@ impl GameRoom {
         let moves_rows = match self.load_moves().await {
             Ok(rows) => rows,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=export_skip game_id={} reason=load_moves:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "export_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "load_moves",
+                    err: format!("{e:?}"),
                 );
                 return ExportAttempt::Skipped;
             }
@@ -1961,10 +2046,12 @@ impl GameRoom {
             Some(sfen) => match position_section_from_sfen(sfen) {
                 Ok(p) => p,
                 Err(reason) => {
-                    console_log!(
-                        "[GameRoom] event=export_skip game_id={} reason=invalid_sfen:{}",
-                        cfg.game_id,
-                        reason,
+                    crate::structured_log!(
+                        event: "export_skip",
+                        component: "game_room",
+                        game_id: cfg.game_id,
+                        reason: "invalid_sfen",
+                        detail: reason,
                     );
                     return ExportAttempt::Skipped;
                 }
@@ -1995,10 +2082,12 @@ impl GameRoom {
         let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=export_skip game_id={} reason=bucket_binding:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "export_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "bucket_binding",
+                    err: format!("{e:?}"),
                 );
                 return ExportAttempt::Skipped;
             }
@@ -2014,12 +2103,13 @@ impl GameRoom {
             (by_id_key.as_str(), "by_id_key"),
         ] {
             if let Err(e) = bucket.put(key, csa_bytes.clone()).execute().await {
-                console_log!(
-                    "[GameRoom] event=export_put_failed game_id={} {}={} err={:?}",
-                    cfg.game_id,
-                    label,
-                    key,
-                    e,
+                crate::structured_log!(
+                    event: "export_put_failed",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    label: label,
+                    key: key,
+                    err: format!("{e:?}"),
                 );
                 failed_keys.push(FailedExportObject {
                     key: key.to_owned(),
@@ -2066,10 +2156,12 @@ impl GameRoom {
         let body = match serde_json::to_vec(&entry) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=games_index_skip game_id={} reason=serialize:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "games_index_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "serialize",
+                    err: format!("{e:?}"),
                 );
                 // CSA 本文 PUT は試行済 (failed_keys に積まれているかも) だが、
                 // meta/index は serialize 失敗で本経路で PUT 試行できていない。
@@ -2087,11 +2179,12 @@ impl GameRoom {
 
         let meta_key = kifu_by_id_meta_key(&cfg.game_id);
         if let Err(e) = bucket.put(&meta_key, body.clone()).execute().await {
-            console_log!(
-                "[GameRoom] event=kifu_by_id_meta_put_failed game_id={} meta_key={} err={:?}",
-                cfg.game_id,
-                meta_key,
-                e,
+            crate::structured_log!(
+                event: "kifu_by_id_meta_put_failed",
+                component: "game_room",
+                game_id: cfg.game_id,
+                meta_key: meta_key,
+                err: format!("{e:?}"),
             );
             failed_keys.push(FailedExportObject {
                 key: meta_key.clone(),
@@ -2102,10 +2195,12 @@ impl GameRoom {
         let index_key = match games_index_key(ended_at_ms, &cfg.game_id) {
             Ok(k) => k,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=games_index_skip game_id={} reason=key:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "games_index_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "key",
+                    err: format!("{e:?}"),
                 );
                 // games-index key 生成失敗は retry 不可。pending には CSA / meta
                 // のみ残す。index PUT が抜けるため `from_partial_attempt` で
@@ -2120,11 +2215,12 @@ impl GameRoom {
             }
         };
         if let Err(e) = bucket.put(&index_key, body.clone()).execute().await {
-            console_log!(
-                "[GameRoom] event=games_index_put_failed game_id={} inv_key={} err={:?}",
-                cfg.game_id,
-                index_key,
-                e,
+            crate::structured_log!(
+                event: "games_index_put_failed",
+                component: "game_room",
+                game_id: cfg.game_id,
+                inv_key: index_key,
+                err: format!("{e:?}"),
             );
             failed_keys.push(FailedExportObject {
                 key: index_key.clone(),
@@ -2133,10 +2229,11 @@ impl GameRoom {
         }
 
         if failed_keys.is_empty() {
-            console_log!(
-                "[GameRoom] event=export_complete game_id={} key={}",
-                cfg.game_id,
-                date_key,
+            crate::structured_log!(
+                event: "export_complete",
+                component: "game_room",
+                game_id: cfg.game_id,
+                key: date_key,
             );
         }
         // 4 オブジェクトすべての PUT を試行できた経路。`failed_keys` の中身で
@@ -2146,9 +2243,10 @@ impl GameRoom {
 
     /// Floodgate 履歴 1 件を `FLOODGATE_HISTORY_BUCKET` に永続化する。`ALLOW_FLOODGATE_FEATURES`
     /// が opt-in されており、binding が設定されているときだけ append する。
-    /// すべての失敗は `console_log!` で握り潰して呼び出し側 `finalize_if_ended` の
-    /// 終局確定の前進を止めない（best-effort）。`Result` を返さないことで
-    /// シグネチャと振る舞いを一致させ、「Err を返し得る」と誤読される余地を消す。
+    /// すべての失敗は [`structured_log!`](crate::structured_log) で握り潰して呼び出し側
+    /// `finalize_if_ended` の終局確定の前進を止めない（best-effort）。`Result` を
+    /// 返さないことでシグネチャと振る舞いを一致させ、「Err を返し得る」と誤読される
+    /// 余地を消す。
     async fn try_persist_floodgate_history(
         &self,
         game_result: &rshogi_csa_server::game::result::GameResult,
@@ -2162,7 +2260,11 @@ impl GameRoom {
                 // `Err` 経路は `parse_allow_floodgate_features` の解析エラーまたは
                 // `validate_floodgate_feature_gate` の opt-in 漏れ等の **設定不正**。
                 // opt-in 未有効 (`Ok(None)`) と区別がつくよう "config error" を明示する。
-                console_log!("[GameRoom] floodgate history config error: {e}");
+                crate::structured_log!(
+                    event: "floodgate_history_config_error",
+                    component: "game_room",
+                    err: format!("{e}"),
+                );
                 return;
             }
         };
@@ -2185,7 +2287,11 @@ impl GameRoom {
         };
 
         if let Err(e) = storage.append(&entry).await {
-            console_log!("[GameRoom] floodgate history append failed: {e:?}");
+            crate::structured_log!(
+                event: "floodgate_history_append_failed",
+                component: "game_room",
+                err: format!("{e:?}"),
+            );
         }
     }
 
@@ -2256,14 +2362,14 @@ impl GameRoom {
                 let next_bytes = current_bytes.saturating_add(line.len());
                 if next_items > MAX_SPECTATOR_QUEUE_ITEMS || next_bytes > MAX_SPECTATOR_QUEUE_BYTES
                 {
-                    console_log!(
-                        "[GameRoom] event=spectator_queue_overflow room_id={} items={} bytes={} \
-                         limit_items={} limit_bytes={}",
-                        room_id,
-                        next_items,
-                        next_bytes,
-                        MAX_SPECTATOR_QUEUE_ITEMS,
-                        MAX_SPECTATOR_QUEUE_BYTES,
+                    crate::structured_log!(
+                        event: "spectator_queue_overflow",
+                        component: "game_room",
+                        room_id: room_id,
+                        items: next_items,
+                        bytes: next_bytes,
+                        limit_items: MAX_SPECTATOR_QUEUE_ITEMS,
+                        limit_bytes: MAX_SPECTATOR_QUEUE_BYTES,
                     );
                     let _ = ws.close(Some(1009), Some("spectator queue overflow".to_owned()));
                     continue;
@@ -2277,12 +2383,20 @@ impl GameRoom {
                     pending_queue,
                 };
                 if let Err(e) = ws.serialize_attachment(&updated) {
-                    console_log!("[GameRoom] spectator queue serialize failed (ignored): {e:?}");
+                    crate::structured_log!(
+                        event: "spectator_queue_serialize_failed",
+                        component: "game_room",
+                        err: format!("{e:?}"),
+                    );
                 }
                 continue;
             }
             if let Err(e) = send_line(&ws, line) {
-                console_log!("[GameRoom] spectator send failed (ignored): {e:?}");
+                crate::structured_log!(
+                    event: "spectator_send_failed",
+                    component: "game_room",
+                    err: format!("{e:?}"),
+                );
             }
         }
         Ok(())
@@ -2357,13 +2471,28 @@ impl GameRoom {
                 *self.config.borrow_mut() = Some(cfg);
             }
             ReplaySummary::InvalidSfen { reason } => {
-                console_log!("[GameRoom] replay CoreRoom::new failed: {reason}");
+                crate::structured_log!(
+                    event: "replay_invalid_sfen",
+                    component: "game_room",
+                    reason: reason,
+                );
             }
             ReplaySummary::UnknownColor { ply, color } => {
-                console_log!("[GameRoom] replay: unknown color '{color}' at ply={ply}");
+                crate::structured_log!(
+                    event: "replay_unknown_color",
+                    component: "game_room",
+                    ply: ply,
+                    color: color,
+                );
             }
             ReplaySummary::MoveReplayFailed { ply, line, reason } => {
-                console_log!("[GameRoom] replay move ply={ply} line='{line}' failed: {reason}");
+                crate::structured_log!(
+                    event: "replay_move_failed",
+                    component: "game_room",
+                    ply: ply,
+                    line: line,
+                    reason: reason,
+                );
             }
         }
 
@@ -2433,8 +2562,9 @@ impl GameRoom {
     ///
     /// `cfg.play_started_at_ms` が `None` の場合は live index put が成立しない
     /// (= mark_play_started 前) ため早期 return する。すべての失敗 (key
-    /// validation / serialize / R2 put) を `console_log!` で吸収し、`Result`
-    /// は返さない。put 成功時のみ `live_index_put_done` を `true` にセットする。
+    /// validation / serialize / R2 put) を [`structured_log!`](crate::structured_log)
+    /// で吸収し、`Result` は返さない。put 成功時のみ `live_index_put_done` を
+    /// `true` にセットする。
     async fn try_put_live_games_index(&self, cfg: &PersistedConfig) {
         let Some(started_at_ms) = cfg.play_started_at_ms else {
             return;
@@ -2443,10 +2573,12 @@ impl GameRoom {
         let key = match live_games_index_key(started_at_ms, &cfg.game_id) {
             Ok(k) => k,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_skip game_id={} reason=key:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "key",
+                    err: format!("{e:?}"),
                 );
                 return;
             }
@@ -2465,10 +2597,12 @@ impl GameRoom {
         let body = match serde_json::to_vec(&entry) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_skip game_id={} reason=serialize:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "serialize",
+                    err: format!("{e:?}"),
                 );
                 return;
             }
@@ -2477,10 +2611,12 @@ impl GameRoom {
         let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_skip game_id={} reason=bucket:{}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "bucket",
+                    err: format!("{e}"),
                 );
                 return;
             }
@@ -2491,11 +2627,12 @@ impl GameRoom {
                 self.live_index_put_done.set(true);
             }
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_put_failed game_id={} key={} err={:?}",
-                    cfg.game_id,
-                    key,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_put_failed",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    key: key,
+                    err: format!("{e:?}"),
                 );
             }
         }
@@ -2521,10 +2658,12 @@ impl GameRoom {
         let key = match live_games_index_key(started_at_ms, &cfg.game_id) {
             Ok(k) => k,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_delete_skip game_id={} reason=key:{:?}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_delete_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "key",
+                    err: format!("{e:?}"),
                 );
                 return;
             }
@@ -2533,10 +2672,12 @@ impl GameRoom {
         let bucket = match self.env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(b) => b,
             Err(e) => {
-                console_log!(
-                    "[GameRoom] event=live_games_index_delete_skip game_id={} reason=bucket:{}",
-                    cfg.game_id,
-                    e,
+                crate::structured_log!(
+                    event: "live_games_index_delete_skip",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    reason: "bucket",
+                    err: format!("{e}"),
                 );
                 return;
             }
@@ -2546,12 +2687,13 @@ impl GameRoom {
             match bucket.delete(&key).await {
                 Ok(_) => return,
                 Err(e) => {
-                    console_log!(
-                        "[GameRoom] event=live_games_index_delete_failed attempt={} game_id={} key={} err={:?}",
-                        attempt + 1,
-                        cfg.game_id,
-                        key,
-                        e,
+                    crate::structured_log!(
+                        event: "live_games_index_delete_failed",
+                        component: "game_room",
+                        game_id: cfg.game_id,
+                        key: key,
+                        attempt: attempt + 1,
+                        err: format!("{e:?}"),
                     );
                     // 最終 attempt の後は backoff せず giveup ログへ抜ける。
                     if let Some(&backoff_ms) = LIVE_INDEX_DELETE_BACKOFF_MS.get(attempt as usize) {
@@ -2560,11 +2702,12 @@ impl GameRoom {
                 }
             }
         }
-        console_log!(
-            "[GameRoom] event=live_games_index_delete_giveup game_id={} key={} attempts={}",
-            cfg.game_id,
-            key,
-            LIVE_INDEX_DELETE_MAX_ATTEMPTS,
+        crate::structured_log!(
+            event: "live_games_index_delete_giveup",
+            component: "game_room",
+            game_id: cfg.game_id,
+            key: key,
+            attempts: LIVE_INDEX_DELETE_MAX_ATTEMPTS,
         );
     }
 
@@ -2584,15 +2727,19 @@ impl GameRoom {
     /// `MoveReplayFailed` を起こすのを防ぐ。現状は `KEY_FINISHED` ガードで弾かれる
     /// 経路だが、二重防御として moves 行を確実に削除しておく。
     ///
-    /// 失敗は best-effort で `console_log!` のみに落とし、`Result` には漏らさない
-    /// (呼び出し側 `finalize_if_ended` の WS close / live-games-index delete などの
-    /// 終局処理を止めないため)。`KEY_FINISHED` put が成功している前提で呼び出すため、
-    /// 削除失敗で moves が残っても、後続 `ensure_core_loaded` は finished ガードで
-    /// 早期 return し replay は走らない。
+    /// 失敗は best-effort で [`structured_log!`](crate::structured_log) のみに落とし、
+    /// `Result` には漏らさない (呼び出し側 `finalize_if_ended` の WS close /
+    /// live-games-index delete などの終局処理を止めないため)。`KEY_FINISHED` put が
+    /// 成功している前提で呼び出すため、削除失敗で moves が残っても、後続
+    /// `ensure_core_loaded` は finished ガードで早期 return し replay は走らない。
     async fn clear_moves(&self) {
         let sql = self.state.storage().sql();
         if let Err(e) = sql.exec("DELETE FROM moves", None) {
-            console_log!("[GameRoom] event=clear_moves_failed err={:?}", e);
+            crate::structured_log!(
+                event: "clear_moves_failed",
+                component: "game_room",
+                err: format!("{e:?}"),
+            );
         }
     }
 
@@ -2697,9 +2844,11 @@ impl GameRoom {
             let delay = grace_deadline_ms.saturating_sub(now_ms).saturating_add(ALARM_SAFETY_MS);
             self.state.storage().set_alarm(Duration::from_millis(delay)).await?;
         }
-        console_log!(
-            "[GameRoom] entered grace window: role={role:?} grace_secs={}",
-            grace_duration.as_secs()
+        crate::structured_log!(
+            event: "entered_grace_window",
+            component: "game_room",
+            role: format!("{role:?}"),
+            grace_secs: grace_duration.as_secs(),
         );
         Ok(())
     }
@@ -2792,7 +2941,11 @@ impl GameRoom {
         let role = match color_from_str(&pending.disconnected_color) {
             Ok(c) => Role::from_core(c),
             Err(e) => {
-                console_log!("[GameRoom] grace alarm: invalid color in registry: {e}");
+                crate::structured_log!(
+                    event: "grace_alarm_invalid_color",
+                    component: "game_room",
+                    err: format!("{e}"),
+                );
                 self.delete_grace_alarm_state().await?;
                 return Ok(());
             }
@@ -2841,9 +2994,11 @@ impl GameRoom {
         let pending: Option<PendingReconnect> =
             self.state.storage().get(KEY_GRACE_REGISTRY).await.ok().flatten();
         let Some(pending) = pending else {
-            console_log!(
-                "[GameRoom] reconnect rejected: no pending entry (game_id={})",
-                req.game_id
+            crate::structured_log!(
+                event: "reconnect_rejected",
+                component: "game_room",
+                reason: "no_pending_entry",
+                game_id: req.game_id.as_str(),
             );
             send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
             return Ok(());
@@ -2854,10 +3009,12 @@ impl GameRoom {
         let cfg_game_id = self.config.borrow().as_ref().map(|c| c.game_id.clone());
         if cfg_game_id.as_deref() != Some(req.game_id.as_str()) {
             // DO instance が想定と違う対局に紐づいている (game_id 未一致)。
-            console_log!(
-                "[GameRoom] reconnect rejected: game_id mismatch (req={}, current={:?})",
-                req.game_id,
-                cfg_game_id
+            crate::structured_log!(
+                event: "reconnect_rejected",
+                component: "game_room",
+                reason: "game_id_mismatch",
+                requested_game_id: req.game_id.as_str(),
+                current_game_id: format!("{cfg_game_id:?}"),
             );
             send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
             return Ok(());
@@ -2868,19 +3025,23 @@ impl GameRoom {
         match outcome {
             ReconnectMatchOutcome::Accepted => {}
             ReconnectMatchOutcome::Rejected => {
-                console_log!(
-                    "[GameRoom] reconnect rejected: handle/color/token mismatch (handle={}, role={:?})",
-                    handle,
-                    role
+                crate::structured_log!(
+                    event: "reconnect_rejected",
+                    component: "game_room",
+                    reason: "handle_color_token_mismatch",
+                    handle: handle,
+                    role: format!("{role:?}"),
                 );
                 send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
                 return Ok(());
             }
             ReconnectMatchOutcome::Expired => {
-                console_log!(
-                    "[GameRoom] reconnect rejected: grace expired (deadline_ms={}, now_ms={})",
-                    pending.deadline_ms,
-                    now_ms
+                crate::structured_log!(
+                    event: "reconnect_rejected",
+                    component: "game_room",
+                    reason: "grace_expired",
+                    deadline_ms: pending.deadline_ms,
+                    now_ms: now_ms,
                 );
                 send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
                 return Ok(());
@@ -2945,7 +3106,12 @@ impl GameRoom {
             // CoreRoom 不在 (異常系)。alarm を解除して保守的に振る舞う。
             let _ = self.state.storage().delete_alarm().await;
         }
-        console_log!("[GameRoom] reconnect succeeded: handle={} role={:?}", handle, role);
+        crate::structured_log!(
+            event: "reconnect_succeeded",
+            component: "game_room",
+            handle: handle,
+            role: format!("{role:?}"),
+        );
         Ok(())
     }
 
@@ -3008,7 +3174,10 @@ impl GameRoom {
             }
         }
 
-        console_log!("[GameRoom] agree timeout fired; releasing pending match");
+        crate::structured_log!(
+            event: "agree_timeout_fired",
+            component: "game_room",
+        );
         // `abort_pending_match_with_error` と同じ pending 解放ロジックを再利用
         // して、両 player に `##[ERROR] agree_timeout` を返した上で slot を空に
         // 戻す。

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -70,11 +70,14 @@ pub(crate) mod spectator_snapshot;
 pub mod ws_route;
 pub mod x1_paths;
 
-// `observability` は `structured_log!` macro を提供する。`#[macro_export]` で
-// crate root に export されるため `pub use` 等は不要。本 mod 自体はホスト
-// target でも import 可能 (macro 定義は wasm32 限定の `worker::` 呼び出しを
-// 含むため、展開はホストでは失敗する点に注意)。
-pub mod observability;
+// `observability` は `structured_log!` macro を提供する。`#[macro_export]` は
+// crate root に export するため、外部 crate からの `use` 用途で `pub mod` 化
+// する必要はない (本 crate は cdylib として Workers ランタイム単独消費される
+// 想定で、library API として外部公開もしない)。`pub(crate)` でシグナルを
+// 「内部利用のみ」に絞り、誤って library 公開と誤読されないようにする。
+// macro 定義は wasm32 限定の `worker::` 呼び出しを含むため、ホスト target
+// では展開時に失敗する点に注意。
+pub(crate) mod observability;
 
 #[cfg(target_arch = "wasm32")]
 mod game_room;

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -70,6 +70,12 @@ pub(crate) mod spectator_snapshot;
 pub mod ws_route;
 pub mod x1_paths;
 
+// `observability` は `structured_log!` macro を提供する。`#[macro_export]` で
+// crate root に export されるため `pub use` 等は不要。本 mod 自体はホスト
+// target でも import 可能 (macro 定義は wasm32 限定の `worker::` 呼び出しを
+// 含むため、展開はホストでは失敗する点に注意)。
+pub mod observability;
+
 #[cfg(target_arch = "wasm32")]
 mod game_room;
 #[cfg(target_arch = "wasm32")]
@@ -145,18 +151,20 @@ pub async fn scheduled(
 
     if run_backfill {
         if let Err(e) = backfill::run_games_index_backfill(&env).await {
-            worker::console_log!(
-                "[scheduled] event=games_index_backfill_failed cron={} err={:?}",
-                cron,
-                e,
+            crate::structured_log!(
+                event: "games_index_backfill_failed",
+                component: "scheduled",
+                cron: cron,
+                err: format!("{e:?}"),
             );
         }
     }
     if let Err(e) = backfill::run_live_orphan_sweep(&env).await {
-        worker::console_log!(
-            "[scheduled] event=live_orphan_sweep_failed cron={} err={:?}",
-            cron,
-            e,
+        crate::structured_log!(
+            event: "live_orphan_sweep_failed",
+            component: "scheduled",
+            cron: cron,
+            err: format!("{e:?}"),
         );
     }
 }

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -850,6 +850,12 @@ impl Lobby {
         .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
 
         send_line(ws, &format!("LOGIN_LOBBY:{handle} OK pending_match_dispatch_pending"))?;
+        // 私的対局 token は診断用途で平文ログに残す (旧 console_log! と同等の挙動を
+        // 保つ移行)。CHALLENGE_LOBBY 発行時の TTL (`CHALLENGE_TTL_SEC`、既定
+        // 3600 秒) で自動失効するため、Tail Workers / R2 archive (#625 Phase B)
+        // 経由で漏えいしてもリプレイ攻撃ウィンドウは限定的。token を無害化したい
+        // 場合は本フィールドを `token_prefix: token.as_str().chars().take(8).collect::<String>()`
+        // 等に差し替える (本 PR スコープでは保留)。
         crate::structured_log!(
             event: "login_lobby_private",
             component: "lobby",

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use worker::{
     Date, DurableObject, Env, Error, Request, Response, ResponseBuilder, Result, State, WebSocket,
-    WebSocketIncomingMessage, WebSocketPair, console_log, durable_object, wasm_bindgen,
+    WebSocketIncomingMessage, WebSocketPair, durable_object, wasm_bindgen,
 };
 
 use crate::config::{
@@ -166,7 +166,10 @@ impl DurableObject for Lobby {
         server
             .serialize_attachment(&LobbyAttachment::Pending)
             .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
-        console_log!("[Lobby] websocket upgrade accepted");
+        crate::structured_log!(
+            event: "websocket_upgrade_accepted",
+            component: "lobby",
+        );
 
         Ok(ResponseBuilder::new().with_status(101).with_websocket(pair.client).empty())
     }
@@ -182,10 +185,11 @@ impl DurableObject for Lobby {
             WebSocketIncomingMessage::Binary(b) => b.len(),
         };
         if raw_len > MAX_WS_LINE_BYTES {
-            console_log!(
-                "[Lobby] event=ws_message_too_big bytes={} limit={}",
-                raw_len,
-                MAX_WS_LINE_BYTES,
+            crate::structured_log!(
+                event: "ws_message_too_big",
+                component: "lobby",
+                bytes: raw_len,
+                limit: MAX_WS_LINE_BYTES,
             );
             let _ = ws.close(Some(1009), Some("message too big".to_owned()));
             return Ok(());
@@ -234,9 +238,12 @@ impl DurableObject for Lobby {
                 ..
             })) => {
                 self.queue.borrow_mut().remove(&handle, &attachment_id);
-                console_log!(
-                    "[Lobby] queued client closed: handle={handle} attachment_id={attachment_id} queue_size={}",
-                    self.queue.borrow().len()
+                crate::structured_log!(
+                    event: "queued_client_closed",
+                    component: "lobby",
+                    handle: handle,
+                    attachment_id: attachment_id,
+                    queue_size: self.queue.borrow().len(),
                 );
                 // queue 状態が変わった (entry 削除) ので alarm の earliest を更新する。
                 self.reschedule_alarm().await?;
@@ -294,16 +301,21 @@ impl Lobby {
     /// すことで両 DO の挙動を対称化する。overhead は `CLOCK_PRESETS` の 1 KB 程度
     /// JSON を 1 回パースするだけで、LOGIN は人手駆動の頻度のため許容範囲。
     ///
-    /// パース失敗時は空 HashMap として扱い、`console_log!` で警告を残して strict
-    /// mode を無効化する（preset 設定不正で全 LOGIN がブロックされる事態を避ける
-    /// 安全側挙動。`CLOCK_PRESETS` 値そのものは `parse_clock_presets` の起動時
-    /// テストでカバーする）。空 HashMap = preset 未宣言 = strict mode 無効。
+    /// パース失敗時は空 HashMap として扱い、[`structured_log!`](crate::structured_log)
+    /// で警告を残して strict mode を無効化する（preset 設定不正で全 LOGIN が
+    /// ブロックされる事態を避ける安全側挙動。`CLOCK_PRESETS` 値そのものは
+    /// `parse_clock_presets` の起動時テストでカバーする）。
+    /// 空 HashMap = preset 未宣言 = strict mode 無効。
     fn clock_presets(&self) -> HashMap<String, ClockSpec> {
         let raw = self.env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
         match parse_clock_presets(raw.as_deref()) {
             Ok(map) => map,
             Err(e) => {
-                console_log!("[Lobby] event=invalid_clock_presets err={e}");
+                crate::structured_log!(
+                    event: "invalid_clock_presets",
+                    component: "lobby",
+                    err: format!("{e}"),
+                );
                 HashMap::new()
             }
         }
@@ -500,13 +512,14 @@ impl Lobby {
         .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
 
         send_line(ws, &build_login_ok_line(&req.handle))?;
-        console_log!(
-            "[Lobby] LOGIN_LOBBY: handle={} game_name={} color={:?} attachment_id={} queue_size={}",
-            req.handle,
-            req.game_name,
-            req.color,
-            attachment_id,
-            self.queue.borrow().len()
+        crate::structured_log!(
+            event: "login_lobby",
+            component: "lobby",
+            handle: req.handle,
+            game_name: req.game_name,
+            color: format!("{:?}", req.color),
+            attachment_id: attachment_id,
+            queue_size: self.queue.borrow().len(),
         );
 
         // ペアリング判定をその場で実行。成立したら両 WS に MATCHED を送って close。
@@ -532,7 +545,12 @@ impl Lobby {
         match line {
             "LOGOUT_LOBBY" => {
                 self.queue.borrow_mut().remove(handle, attachment_id);
-                console_log!("[Lobby] LOGOUT_LOBBY: handle={handle} attachment_id={attachment_id}");
+                crate::structured_log!(
+                    event: "logout_lobby",
+                    component: "lobby",
+                    handle: handle,
+                    attachment_id: attachment_id,
+                );
                 let _ = ws.close(Some(1000), Some("logout"));
                 // queue が縮んだので alarm を再評価。
                 self.reschedule_alarm().await?;
@@ -547,7 +565,11 @@ impl Lobby {
                 Ok(())
             }
             _ => {
-                console_log!("[Lobby] queued client sent unexpected line: {line}");
+                crate::structured_log!(
+                    event: "queued_unexpected_line",
+                    component: "lobby",
+                    line: line,
+                );
                 Ok(())
             }
         }
@@ -599,13 +621,14 @@ impl Lobby {
                 Color::White => sent_white = true,
             }
         }
-        console_log!(
-            "[Lobby] MATCHED dispatched: room_id={} black={} white={} (sent_black={} sent_white={})",
-            room_id,
-            matched.black.handle,
-            matched.white.handle,
-            sent_black,
-            sent_white,
+        crate::structured_log!(
+            event: "matched_dispatched",
+            component: "lobby",
+            room_id: room_id,
+            black_handle: matched.black.handle,
+            white_handle: matched.white.handle,
+            sent_black: sent_black,
+            sent_white: sent_white,
         );
         if !sent_black || !sent_white {
             // 片方の WS が close 済みなどで MATCHED が届かなかった場合、queue から
@@ -614,9 +637,12 @@ impl Lobby {
             // するため最終的に復帰できるが、サーバ側でも警告ログを残して
             // observability を確保する。GameRoom DO 側の login deadline (将来 PR で
             // 実装予定) でも片側不在は救済される。
-            console_log!(
-                "[Lobby] WARN: MATCHED dispatch incomplete. Black/white client may be orphaned, \
-                 client retry expected after recv timeout: room_id={room_id}"
+            crate::structured_log!(
+                event: "matched_dispatch_incomplete",
+                component: "lobby",
+                room_id: room_id,
+                sent_black: sent_black,
+                sent_white: sent_white,
             );
         }
         Ok(())
@@ -713,12 +739,13 @@ impl Lobby {
                 self.reschedule_alarm_with(&reg).await?;
                 let ttl_sec = ttl.as_secs();
                 send_line(ws, &build_challenge_ok_line(token.as_str(), ttl_sec))?;
-                console_log!(
-                    "[Lobby] CHALLENGE_LOBBY: issued token inviter={} opponent={} preset={} ttl_sec={}",
-                    req.inviter,
-                    req.opponent,
-                    req.clock_preset,
-                    ttl_sec,
+                crate::structured_log!(
+                    event: "challenge_lobby_issued",
+                    component: "lobby",
+                    inviter: req.inviter,
+                    opponent: req.opponent,
+                    preset: req.clock_preset,
+                    ttl_sec: ttl_sec,
                 );
             }
             Err(IssueError::SelfChallenge) => {
@@ -823,10 +850,12 @@ impl Lobby {
         .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
 
         send_line(ws, &format!("LOGIN_LOBBY:{handle} OK pending_match_dispatch_pending"))?;
-        console_log!(
-            "[Lobby] LOGIN_LOBBY private: handle={handle} token={} attachment_id={}",
-            token.as_str(),
-            attachment_id,
+        crate::structured_log!(
+            event: "login_lobby_private",
+            component: "lobby",
+            handle: handle,
+            token: token.as_str(),
+            attachment_id: attachment_id,
         );
         Ok(())
     }
@@ -844,8 +873,12 @@ impl Lobby {
         reg.unmark_ws_logged_in(&token_obj, &PlayerName::new(handle), attachment_id);
         self.save_challenge_registry(&reg).await?;
         self.reschedule_alarm_with(&reg).await?;
-        console_log!(
-            "[Lobby] private LOGIN ws closed: handle={handle} token={token} attachment_id={attachment_id}"
+        crate::structured_log!(
+            event: "private_login_ws_closed",
+            component: "lobby",
+            handle: handle,
+            token: token,
+            attachment_id: attachment_id,
         );
         Ok(())
     }
@@ -869,8 +902,11 @@ impl Lobby {
             }
             "LOBBY_PONG" => Ok(()),
             _ => {
-                console_log!(
-                    "[Lobby] private pending client sent unexpected line: handle={handle} line={line}"
+                crate::structured_log!(
+                    event: "private_pending_unexpected_line",
+                    component: "lobby",
+                    handle: handle,
+                    line: line,
                 );
                 Ok(())
             }
@@ -900,7 +936,11 @@ impl Lobby {
         }
         self.disconnect_pending_websockets(&expired).await;
         self.save_challenge_registry(&reg).await?;
-        console_log!("[Lobby] challenge purge_expired: removed={}", expired.len());
+        crate::structured_log!(
+            event: "challenge_purge_expired",
+            component: "lobby",
+            removed: expired.len(),
+        );
         Ok(())
     }
 
@@ -936,7 +976,11 @@ impl Lobby {
                 let _ = ws.close(Some(1000), Some("queue_expired"));
             }
         }
-        console_log!("[Lobby] queue purge_stale: removed={}", removed.len());
+        crate::structured_log!(
+            event: "queue_purge_stale",
+            component: "lobby",
+            removed: removed.len(),
+        );
         Ok(())
     }
 
@@ -1013,8 +1057,10 @@ fn evict_old_websockets_with_handle(state: &State, current_ws: &WebSocket, handl
         } = attachment
         {
             if existing == handle {
-                console_log!(
-                    "[Lobby] evict old queued WS with duplicate handle: handle={existing}"
+                crate::structured_log!(
+                    event: "evict_duplicate_handle_ws",
+                    component: "lobby",
+                    handle: existing,
                 );
                 let _ = ws.close(Some(1000), Some("evicted_by_new_login"));
             }

--- a/crates/rshogi-csa-server-workers/src/observability.rs
+++ b/crates/rshogi-csa-server-workers/src/observability.rs
@@ -1,0 +1,75 @@
+//! 構造化ログ macro。
+//!
+//! Cloudflare Workers Logs / Tail Workers / dashboard から JSON フィールドで
+//! aggregate / grep できるよう、全 log を 1 行 JSON で出力する。
+//! ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A)
+//!
+//! # 必須キー
+//!
+//! - `event`: snake_case の event 名 (例: `"logout_lobby"`, `"start_match_aborted"`)。
+//!   alert / aggregation の primary 軸。
+//! - `component`: 発火元 module 名 (例: `"lobby"`, `"game_room"`, `"backfill"`)。
+//!   `[component]` プレフィックス文化からの移行先。
+//!
+//! # 任意キー
+//!
+//! 文脈に応じて `game_id` / `room_id` / `handle` / `role` / `err` 等、
+//! [`serde::Serialize`] を実装した任意の値を乗せられる。識別子名がそのまま
+//! JSON キーになる ([`stringify!`] 経由)。
+//!
+//! # `ts_ms` の自動付与
+//!
+//! Cloudflare Logs Engine 側でも timestamp は付くが、Tail Workers / R2 archive
+//! 経路で再度 millisec 精度を引き直したいケースのために、本 macro は
+//! [`worker::Date::now`] から `ts_ms` を自動付与する。
+//!
+//! # 使い方
+//!
+//! ```ignore
+//! use crate::structured_log;
+//!
+//! structured_log!(
+//!     event: "logout_lobby",
+//!     component: "lobby",
+//!     handle: handle,
+//!     attachment_id: attachment_id,
+//! );
+//! ```
+//!
+//! `err={:?}` のような Debug 表示が欲しい場合は呼び出し側で
+//! [`format!`] してから渡す:
+//!
+//! ```ignore
+//! structured_log!(
+//!     event: "games_index_backfill_get_failed",
+//!     component: "backfill",
+//!     key: key,
+//!     err: format!("{e:?}"),
+//! );
+//! ```
+//!
+//! # ホスト target
+//!
+//! 本 macro は [`worker::Date::now`] と [`worker::console_log!`] を経由する
+//! ため、wasm32 でのみ展開される ([`worker`] crate がホスト target で参照
+//! 不可)。ホスト test 経路では呼び出さない契約。
+
+/// 構造化ログ ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A) の唯一の出力経路。
+///
+/// 詳細は [`crate::observability`] module の doc を参照。
+#[macro_export]
+macro_rules! structured_log {
+    (
+        event: $event:expr,
+        component: $component:expr
+        $(, $k:ident : $v:expr)* $(,)?
+    ) => {{
+        let payload = ::serde_json::json!({
+            "ts_ms": ::worker::Date::now().as_millis(),
+            "event": $event,
+            "component": $component,
+            $(stringify!($k): $v,)*
+        });
+        ::worker::console_log!("{}", payload);
+    }};
+}

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -429,7 +429,7 @@ async fn collect_index_page(
     let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
         Ok(b) => b,
         Err(e) => {
-            console_log_failed("kifu_bucket_binding", client_kind, &e.to_string());
+            log_viewer_api_failed("kifu_bucket_binding", client_kind, &e.to_string());
             let err = no_store_error("Storage unavailable", 503)?;
             return Ok(BuildOutcome::ErrorNoStore(err));
         }
@@ -443,7 +443,7 @@ async fn collect_index_page(
     let page = match builder.execute().await {
         Ok(p) => p,
         Err(e) => {
-            console_log_failed(&format!("{event_root}_list"), client_kind, &e.to_string());
+            log_viewer_api_failed(&format!("{event_root}_list"), client_kind, &e.to_string());
             let err = no_store_error("Storage error", 502)?;
             return Ok(BuildOutcome::ErrorNoStore(err));
         }
@@ -457,7 +457,7 @@ async fn collect_index_page(
         let fetched = match bucket.get(&key).execute().await {
             Ok(o) => o,
             Err(e) => {
-                console_log_failed(
+                log_viewer_api_failed(
                     &format!("{event_root}_get"),
                     client_kind,
                     &format!("key={key} err={e}"),
@@ -477,7 +477,7 @@ async fn collect_index_page(
         let bytes = match body.bytes().await {
             Ok(b) => b,
             Err(e) => {
-                console_log_failed(
+                log_viewer_api_failed(
                     &format!("{event_root}_read"),
                     client_kind,
                     &format!("key={key} err={e}"),
@@ -488,7 +488,7 @@ async fn collect_index_page(
         match serde_json::from_slice::<serde_json::Value>(&bytes) {
             Ok(v) => entries.push(v),
             Err(e) => {
-                console_log_failed(
+                log_viewer_api_failed(
                     &format!("{event_root}_parse"),
                     client_kind,
                     &format!("key={key} err={e}"),
@@ -559,7 +559,7 @@ async fn build_single_game(
     let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
         Ok(b) => b,
         Err(e) => {
-            console_log_failed("kifu_bucket_binding", client_kind, &e.to_string());
+            log_viewer_api_failed("kifu_bucket_binding", client_kind, &e.to_string());
             return Ok(SingleBuildOutcome::ErrorNoStore(no_store_error(
                 "Storage unavailable",
                 503,
@@ -571,7 +571,11 @@ async fn build_single_game(
     let csa_obj = match bucket.get(&by_id_key).execute().await {
         Ok(o) => o,
         Err(e) => {
-            console_log_failed("kifu_by_id_get", client_kind, &format!("key={by_id_key} err={e}"));
+            log_viewer_api_failed(
+                "kifu_by_id_get",
+                client_kind,
+                &format!("key={by_id_key} err={e}"),
+            );
             return Ok(SingleBuildOutcome::ErrorNoStore(no_store_error("Storage error", 502)?));
         }
     };
@@ -584,7 +588,11 @@ async fn build_single_game(
     let csa_text = match body.text().await {
         Ok(t) => t,
         Err(e) => {
-            console_log_failed("kifu_by_id_read", client_kind, &format!("key={by_id_key} err={e}"));
+            log_viewer_api_failed(
+                "kifu_by_id_read",
+                client_kind,
+                &format!("key={by_id_key} err={e}"),
+            );
             return Ok(SingleBuildOutcome::ErrorNoStore(no_store_error("Storage error", 502)?));
         }
     };
@@ -601,7 +609,7 @@ async fn build_single_game(
             return Ok(SingleBuildOutcome::ErrorNoStore(no_store_error("Not Found", 404)?));
         }
         Err(e) => {
-            console_log_failed(
+            log_viewer_api_failed(
                 "kifu_by_id_meta_lookup",
                 client_kind,
                 &format!("game_id={game_id} err={e}"),
@@ -735,7 +743,7 @@ fn set_cache_control(resp: &mut Response, value: &str) -> Result<()> {
 /// `cache.get` が `Err` を返した場合 (Cache API 自体の障害) は `None` を返して
 /// miss と同じくフォールバック (R2 から再 fetch) させる。ただし運用上の観測性が
 /// 必要なため、`event` (`<root>_cache_get`) と `client_kind` 付きの logfmt を
-/// `console_log_failed` で残す (Issue #653)。サイレント抑制すると staging /
+/// `log_viewer_api_failed` で残す (Issue #653)。サイレント抑制すると staging /
 /// 本番で Cache API が一切機能していない事象に気付けない。
 async fn cache_get_origin_neutral(
     cache_key: &str,
@@ -747,7 +755,7 @@ async fn cache_get_origin_neutral(
         Ok(Some(resp)) => Some(resp),
         Ok(None) => None,
         Err(e) => {
-            console_log_failed(event, client_kind, &e.to_string());
+            log_viewer_api_failed(event, client_kind, &e.to_string());
             None
         }
     }
@@ -766,14 +774,18 @@ async fn cache_put_origin_neutral(
     let put_response = match resp.cloned() {
         Ok(c) => c,
         Err(e) => {
-            console_log_failed(&format!("{event_root}_cache_clone"), client_kind, &e.to_string());
+            log_viewer_api_failed(
+                &format!("{event_root}_cache_clone"),
+                client_kind,
+                &e.to_string(),
+            );
             return;
         }
     };
     let cache = worker::Cache::default();
     if let Err(e) = cache.put(cache_key.to_string(), put_response).await {
         // best-effort: cache.put に失敗しても元応答は返せる。log のみ残す。
-        console_log_failed(&format!("{event_root}_cache_put"), client_kind, &e.to_string());
+        log_viewer_api_failed(&format!("{event_root}_cache_put"), client_kind, &e.to_string());
     }
 }
 
@@ -781,7 +793,7 @@ async fn cache_put_origin_neutral(
 /// 呼出側クライアントを特定する `client_kind` を持たせる
 /// (https://github.com/SH11235/rshogi/issues/564 設計 v4 §3)。`client_kind` は [`normalize_client_kind`] により
 /// `[a-z0-9-]{1,64}` に正規化済みの ASCII 文字列、または `unknown` / `invalid`。
-fn console_log_failed(event: &str, client_kind: &str, detail: &str) {
+fn log_viewer_api_failed(event: &str, client_kind: &str, detail: &str) {
     crate::structured_log!(
         event: event,
         component: "viewer_api",

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -777,12 +777,17 @@ async fn cache_put_origin_neutral(
     }
 }
 
-/// 失敗ログを logfmt で出す統一窓口。viewer API の経路別 event 名と、
+/// 失敗ログを構造化 JSON で出す統一窓口。viewer API の経路別 event 名と、
 /// 呼出側クライアントを特定する `client_kind` を持たせる
 /// (https://github.com/SH11235/rshogi/issues/564 設計 v4 §3)。`client_kind` は [`normalize_client_kind`] により
 /// `[a-z0-9-]{1,64}` に正規化済みの ASCII 文字列、または `unknown` / `invalid`。
 fn console_log_failed(event: &str, client_kind: &str, detail: &str) {
-    worker::console_log!("[viewer_api] event={event} client_kind={client_kind} detail={detail}");
+    crate::structured_log!(
+        event: event,
+        component: "viewer_api",
+        client_kind: client_kind,
+        detail: detail,
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- 新規 `crates/rshogi-csa-server-workers/src/observability.rs`: `structured_log!` macro を `#[macro_export]` で crate root に公開
- 全 `console_log!` (108 ヶ所、6 ファイル) を JSON 構造化ログへ移行
- `[component]` プレフィックス文化 / `event=name key=value` logfmt 残骸を一掃
- 不要になった `worker::console_log` import を 3 ファイルで除去
- doc コメントの `console_log!` 言及を `structured_log!` link に更新

## 背景

`docs/csa-server/deployment.md:701-705, 759-761` で「現状は文字列ログのみ」「`game_id` 等の構造化フィールドを JSON 形式へ移行は未対応」と明記。Cloudflare Workers Logs / Tail Workers / dashboard から JSON フィールドで aggregate / grep できる前提条件として、Phase A (ログ統一) を本 PR で消化する。

24/7 無人運用 (#625 Phase B alert / Phase C synthetic) と統合できるよう、macro 設計と必須キーを揃えた。

## 設計

### 必須キー

- `event`: snake_case の event 名 (例: `"logout_lobby"`, `"start_match_aborted"`)。alert / aggregation の primary 軸
- `component`: 発火元 module 名 (例: `"lobby"`, `"game_room"`, `"backfill"`)。旧 `[component]` プレフィックス相当

### 任意キー

`game_id` / `room_id` / `handle` / `role` / `err` 等、`serde::Serialize` を実装した任意の値を乗せられる。識別子名がそのまま JSON キーになる (`stringify!` 経由)。

### `ts_ms` の自動付与

`worker::Date::now()` から millisec 精度を引き、Tail Workers / R2 archive 経路で再現可能にする。

### err 表現の規約

呼び出し側で `format!("{e:?}")` (Debug) / `format!("{e}")` (Display) してから渡す。Debug の有無を call site で明示する規約。

## ファイル別 migration 数

| ファイル | site 数 |
|---|---|
| `lib.rs` (scheduled handler) | 2 |
| `backfill.rs` | 17 |
| `viewer_api.rs` | 1 |
| `config.rs` | 2 |
| `lobby.rs` | 16 |
| `game_room.rs` | 70 |
| **合計** | **108** |

## Codex review

`codex:codex-rescue` subagent で review 済み (1 周目で APPROVE)。観点別評価:

1. macro 設計: OK (`event:` / `component:` 必須 + `key: value` 列挙、可読性と誤用防止のバランス妥当)
2. 必須キーの選択: OK (call site 文脈差を doc 明示、`websocket_upgrade_accepted` は handle 確定前で可)
3. err 表現: OK (Debug/Display 使い分けが call site で読める)
4. 移行漏れ: OK (`console_log!` 直呼び出し残存ゼロ、元 key の情報欠落なし)
5. CLAUDE.md 準拠: OK (YAGNI / pub macro doc / unwrap なし)

## 検証

- `cargo build --target wasm32-unknown-unknown -p rshogi-csa-server-workers`: 成功
- `cargo clippy -p rshogi-csa-server-workers --tests -- -D warnings`: 警告ゼロ
- `cargo test -p rshogi-csa-server-workers`: 285 + 1 + 13 + 17 + 5 = 321 全 pass
- doctest 2 件は `ignore` (`crate::structured_log` パス参照のため)

## 次フェーズ (本 PR スコープ外)

- **Phase B**: Workers Logs (Tail Workers) → R2 archive、Cloudflare Notifications → Slack webhook
- **Phase C**: synthetic monitoring (#630 と統合)

## Test plan

- [x] cargo build --target wasm32-unknown-unknown 成功
- [x] cargo clippy --tests -D warnings 警告ゼロ
- [x] cargo test 321 件全 pass
- [x] Codex APPROVE
- [ ] (運用) deploy 後、Workers Logs dashboard で JSON parse 表示を確認
- [ ] (Phase B 着手前) 本 PR の JSON output で実際に grep / aggregate できることを 1 件サンプリング確認

Refs #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)