### PR TITLE
feat(infra): ADMIN_API_TOKEN を Pulumi ESC 経由で同期する secret-sync workflow を追加 (#690)

### DIFF
--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -1,0 +1,211 @@
+# Pulumi ESC を single source of truth とする Worker secret 同期 workflow。
+#
+# 役割: ESC environment に格納された Cloudflare Worker secret 群を
+# `wrangler secret bulk` 経由で実 Worker (staging / production) に流し込む。
+#
+# Phase 2-D ([#690](https://github.com/SH11235/rshogi/issues/690), umbrella
+# [#675](https://github.com/SH11235/rshogi/issues/675)) で導入。Phase 1 で「Worker
+# script / DO / vars / secrets / cron triggers は wrangler 管理継続」と決めた
+# 方針のうち、**secret 値だけ ESC に集約** する転換 phase。
+#
+# ## アーキテクチャ (採用案 B: ESC + workflow_dispatch + wrangler kick)
+#
+# - 候補 A (Pulumi `WorkersScript` の `secret_text` binding): WASM Worker の
+#   marshal error が `@pulumi/cloudflare` v6 で未解決のため不採用。
+# - 候補 C (台帳のみ管理): 自動化目的を満たさないため不採用。
+# - 採用 B: ESC に値を置き、本 workflow を `workflow_dispatch` で手動起動して
+#   `wrangler secret bulk` を kick する。Pulumi 側は WorkersScript を import
+#   しないので marshal error を踏まない。
+#
+# ## deploy-workers.yml と独立させた理由
+#
+# 本 workflow を `deploy-workers.yml` に統合せず別 file にしたのは、secret
+# rotation を Worker code deploy から decouple するため:
+# - Worker code を変えずに secret だけ rotate したい (token 漏洩対応等) ケースで
+#   `secret-sync.yml` を単独 dispatch すれば Worker upload を skip できる
+# - `deploy-workers.yml` は push trigger で staging に流れるが、secret 同期は
+#   常に手動操作 (workflow_dispatch のみ) に限定したい (誤って毎 push で
+#   secret を上書きしないように)
+#
+# ## ESC environment 構造の規約
+#
+# ESC environment の YAML は `values.workerSecrets.<KEY>` 配下に Worker secret
+# を置く規約とする。例:
+#   values:
+#     workerSecrets:
+#       ADMIN_API_TOKEN:
+#         fn::secret:
+#           ciphertext: <encrypted>
+# `workerSecrets` キーが存在しない場合は本 workflow は fail (空 secret push を
+# 防ぐ fail-closed 既定)。`environmentVariables` 等の fallback は意図的に
+# 用意しない (運用台帳を 1 通りに揃える)。
+#
+# ## 必要 secrets (GitHub repository / environment secret)
+#
+# - `PULUMI_ACCESS_TOKEN`: Pulumi Cloud Personal Access Token
+#   (pulumi-preview.yml と同じ secret を流用)。ESC environment 読み取り権限が必要。
+# - `CLOUDFLARE_API_TOKEN`: wrangler 経由 Cloudflare API 呼び出し用 token
+#   (deploy-workers.yml と同じ secret を流用)。`Workers Scripts: Edit` scope 必須。
+#
+# 詳細手順 (ESC への secret 投入 / rotation 手順 / 反映確認) は
+# `docs/csa-server/iac.md` §9 「Secret 管理 (Phase 2-D 以降)」参照。
+
+name: Sync Worker Secrets (Pulumi ESC → wrangler)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment (selects ESC env + wrangler config)'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+# 最小権限: secret を Cloudflare へ push するだけなので contents:read のみで足りる。
+# OIDC 認証 (id-token: write) は使わず、PULUMI_ACCESS_TOKEN / CLOUDFLARE_API_TOKEN
+# 経由の従来型 PAT 認証で動作する (既存 secret を流用するため、追加の OIDC 設定
+# 工事を発生させない)。
+permissions:
+  contents: read
+
+# 同 environment への secret 同期を二重起動させない (rotation 中に別 dispatch が
+# 走ると ESC 側 race で古い値が後勝ちになる恐れがあるため)。
+concurrency:
+  group: secret-sync-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync ${{ inputs.environment }} secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Phase 2-B 既知 quirks #9 対策: workflow_dispatch でも main ブランチからの
+    # 起動のみ許可する (任意ブランチで dispatch されると古い workflow definition
+    # が走り、誤った ESC env から secret が引かれる事故を防ぐ)。
+    if: github.ref == 'refs/heads/main'
+    # GitHub Environment を deploy-workers.yml と完全一致で揃える。
+    # repo 設定で定義済の environment secret (CLOUDFLARE_API_TOKEN) を読むため、
+    # かつ Required reviewers / Deployment branches 等の protection rule を
+    # secret rotation 経路にも一様適用するため。
+    environment: rshogi-csa-server-workers-${{ inputs.environment }}
+    env:
+      WORKERS_DIR: crates/rshogi-csa-server-workers
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+        with:
+          # version は本リポ全 workflow で 10.24.0 系に揃えている (deploy-workers.yml /
+          # pulumi-preview.yml では package_json_file から解決される packageManager 経由)。
+          # 本 workflow は明示指定で揺らぎを排除する。
+          version: 10.24.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # 本リポ root には .node-version が無いため、wrangler を install する
+          # workers crate の .node-version (24.15.0) を使う。`pnpm install` 先と
+          # node toolchain を同一に揃える。
+          node-version-file: ${{ env.WORKERS_DIR }}/.node-version
+          cache: 'pnpm'
+          cache-dependency-path: ${{ env.WORKERS_DIR }}/pnpm-lock.yaml
+
+      - name: Install Node deps (wrangler)
+        working-directory: ${{ env.WORKERS_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      # ESC CLI 単独 install。`environment` / `keys` 入力を渡さなければ pure install
+      # モードとして動き、後続 step で `esc env open ...` を直接叩ける。env 変数の
+      # 自動 export は使わず、明示的に `esc env open --format json` で値を取得する
+      # ことで「ESC のどのキーを wrangler に渡すか」を YAML 上で明示する。
+      - uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1.5.0 (2025-10-07)
+
+      # ESC environment から workerSecrets サブツリーを抽出。
+      # ESC env 名規約: `sh11235/rshogi-csa-server-workers-<environment>`
+      # `workerSecrets` キーが空 / 不在なら fail-closed (空 push で既存 secret を
+      # 上書き / 消去しないため)。
+      - name: Fetch worker secrets from Pulumi ESC
+        id: fetch
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          ESC_ENV: sh11235/rshogi-csa-server-workers-${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PULUMI_ACCESS_TOKEN}" ]; then
+            echo "::error::PULUMI_ACCESS_TOKEN secret is not configured for this repository"
+            exit 1
+          fi
+          tmpdir=$(mktemp -d)
+          # job 失敗 / 成功どちらでも plaintext 一時 file を必ず削除する保険
+          # (runner ephemeral だが、自己文書化と明示的 hardening として trap を入れる)。
+          trap 'rm -rf "${tmpdir}"' EXIT
+          esc_json="${tmpdir}/esc.json"
+          secrets_json="${tmpdir}/secrets.json"
+          # `esc env open` は ESC environment を解決して values ツリーを JSON で出力する。
+          # secret 値は plaintext で展開されるため runner 内のみで扱い、log には絶対に
+          # 出さない (jq 後の値も echo しない)。
+          esc env open "${ESC_ENV}" --format json > "${esc_json}"
+          # `.workerSecrets` の型 + 非空を厳格チェック (string / array / null すり抜け防止)。
+          if ! jq -e '.workerSecrets | type == "object" and length > 0' "${esc_json}" > /dev/null; then
+            echo "::error::ESC env '${ESC_ENV}' に非空 object の 'workerSecrets' が見つかりません。"
+            echo "::error::Expected shape: values.workerSecrets.<KEY> (see docs/csa-server/iac.md §9)."
+            exit 1
+          fi
+          # 必須 key の欠落チェック (本リポは ADMIN_API_TOKEN 1 件固定)。
+          # 追加時は本 list を同時更新する運用契約。
+          required_keys=(ADMIN_API_TOKEN)
+          missing=$(jq -r --argjson req "$(printf '%s\n' "${required_keys[@]}" | jq -R . | jq -s .)" \
+            '($req - (.workerSecrets | keys)) | join(", ")' "${esc_json}")
+          if [ -n "${missing}" ]; then
+            echo "::error::ESC env '${ESC_ENV}' に必須 key 不足: ${missing}"
+            exit 1
+          fi
+          # wrangler secret bulk が要求する shape は flat {KEY: "value"}。
+          # workerSecrets サブツリーをそのまま flat object として書き出す。
+          jq '.workerSecrets' "${esc_json}" > "${secrets_json}"
+          # log には鍵名のみ出して値は出さない (key 集合の確認用)。
+          key_count=$(jq 'length' "${secrets_json}")
+          echo "Fetched ${key_count} secret key(s) from ${ESC_ENV}:"
+          jq -r 'keys[]' "${secrets_json}" | sed 's/^/  - /'
+          echo "secrets_json=${secrets_json}" >> "$GITHUB_OUTPUT"
+
+      # wrangler secret bulk: ESC から取得した flat JSON を 1 回の API 呼び出しで
+      # まとめて push する。`--config wrangler.<env>.toml` で worker name を解決
+      # するのは既存 deploy-workers.yml と同じ規約 (本リポは `--env` ではなく
+      # 環境ごとに別 toml file を使う運用)。
+      - name: Push secrets to Cloudflare Worker
+        working-directory: ${{ env.WORKERS_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          SECRETS_JSON: ${{ steps.fetch.outputs.secrets_json }}
+          WRANGLER_ENV: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN secret is not configured for this repository"
+            exit 1
+          fi
+          config_file="wrangler.${WRANGLER_ENV}.toml"
+          if [ ! -f "${config_file}" ]; then
+            echo "::error::${WORKERS_DIR}/${config_file} not found"
+            exit 1
+          fi
+          # `--no-install` で grace shutdown 等の偶発 install を抑止 (前 step の
+          # `pnpm install --frozen-lockfile` で既に lockfile 通り揃っている前提)。
+          npx --no-install wrangler secret bulk "${SECRETS_JSON}" --config "${config_file}"
+
+      - name: Summarize
+        if: always()
+        env:
+          ESC_ENV: sh11235/rshogi-csa-server-workers-${{ inputs.environment }}
+          WRANGLER_ENV: ${{ inputs.environment }}
+        run: |
+          {
+            echo "## Secret sync summary"
+            echo
+            echo "- ESC environment: \`${ESC_ENV}\`"
+            echo "- Wrangler config: \`${WORKERS_DIR}/wrangler.${WRANGLER_ENV}.toml\`"
+            echo
+            echo "確認: \`cd ${WORKERS_DIR} && npx wrangler secret list --config wrangler.${WRANGLER_ENV}.toml\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/csa-server/iac.md
+++ b/docs/csa-server/iac.md
@@ -296,10 +296,142 @@ Self-managed backend (R2 / S3 等) を使う場合は `PULUMI_CONFIG_PASSPHRASE`
 依存になり commit 可否が変わるので、Phase 2 で backend 移行する場合は
 本セクションを更新する。
 
-## 8. 参考
+## 9. Secret 管理 (Phase 2-D 以降)
+
+[#690](https://github.com/SH11235/rshogi/issues/690) で **Worker secret の値だけ
+Pulumi ESC を single source of truth に集約** した。Worker script / DO / vars /
+cron triggers の管理境界 (§3) は変えず、secret 値のみ「ESC に置き、
+`secret-sync.yml` で wrangler 経由 Cloudflare に流す」運用に移行する。
+
+§4.3 は Phase 1 時点での「wrangler 直叩きで `secret put`」手順を記録した
+historical 節として残す (旧手順を急遽踏みたい emergency rotation 用に温存)。
+通常 rotation は本 §9 の手順で行うこと。
+
+### 9.1 アーキテクチャ (採用案 B)
+
+```
+┌─ Pulumi ESC (sh11235 org) ──────────────────────────────────┐
+│ env: sh11235/rshogi-csa-server-workers-staging              │
+│   values.workerSecrets.ADMIN_API_TOKEN  (encrypted)          │
+│ env: sh11235/rshogi-csa-server-workers-production           │
+│   values.workerSecrets.ADMIN_API_TOKEN  (encrypted)          │
+└──────────────────────────────────┬──────────────────────────┘
+                                   │ (1) esc env open --format json
+                                   ▼
+                        ┌──────────────────────────┐
+                        │ secret-sync.yml          │
+                        │ (workflow_dispatch only) │
+                        └──────────────┬───────────┘
+                                       │ (2) wrangler secret bulk
+                                       ▼
+                  ┌──────────────────────────────────────┐
+                  │ Cloudflare Worker secret store       │
+                  │   ADMIN_API_TOKEN (per env)          │
+                  └──────────────────────────────────────┘
+```
+
+候補比較:
+
+| 案 | 概要 | 採否 | 理由 |
+|---|---|---|---|
+| A | Pulumi `WorkersScript` の `secret_text` binding で declarative 管理 | 不採用 | `@pulumi/cloudflare` v6 の WASM Worker marshal error が未解決 (§3 参照) |
+| B | ESC + `workflow_dispatch` + wrangler kick | **採用** | Worker script を Pulumi 配下に入れずに secret 値だけ集約できる |
+| C | 台帳のみ管理 (人手で wrangler 叩く) | 不採用 | 自動化目的を満たさない |
+
+### 9.2 ESC environment 構造の規約
+
+ESC environment 名は **per-repo per-env**:
+
+- `sh11235/rshogi-csa-server-workers-staging`
+- `sh11235/rshogi-csa-server-workers-production`
+
+YAML 構造の規約:
+
+```yaml
+values:
+  workerSecrets:
+    ADMIN_API_TOKEN:
+      fn::secret:
+        ciphertext: <encrypted ciphertext>
+    # 将来 Worker secret を追加するときは workerSecrets 配下にキーを足す
+```
+
+`values.workerSecrets` 配下のキー名がそのまま `wrangler secret bulk` に渡され、
+Worker code 側 `env.var("KEY")` で参照される名前と一致する必要がある。
+`workerSecrets` キーが空 / 不在のまま `secret-sync.yml` を起動すると
+fail-closed で abort する (空 push で既存 secret を消去 / 上書きしない既定)。
+
+### 9.3 通常の secret 追加 / rotation 手順
+
+```bash
+# 1. ESC env を編集して新値を投入 (standalone esc CLI 経由)
+esc env edit sh11235/rshogi-csa-server-workers-staging
+#   → エディタが開くので values.workerSecrets.<KEY> を fn::secret で追加 / 更新
+#   (詳細は https://www.pulumi.com/docs/esc/cli/commands/esc_env_edit/ 参照)
+#   ※ Pulumi CLI を入れているなら `pulumi env edit ...` でも同等
+
+# 2. ESC 単体で値を確認 (workflow を流さずに dry-run したい場合)
+esc env open sh11235/rshogi-csa-server-workers-staging --format json | \
+    jq '.workerSecrets | keys'
+#   ※ workflow と同じ standalone `esc` CLI を使う。Pulumi CLI 経由なら `pulumi env open ...`
+
+# 3. workflow_dispatch で wrangler 同期を kick
+gh workflow run secret-sync.yml --repo SH11235/rshogi -f environment=staging
+
+# 4. workflow log で「Fetched N secret key(s)」「Successfully created secret for key: ...」
+#    を確認
+gh run watch --repo SH11235/rshogi   # or: gh run list --workflow secret-sync.yml --repo SH11235/rshogi
+
+# 5. Cloudflare 側に反映されたか確認
+cd crates/rshogi-csa-server-workers
+npx wrangler secret list --config wrangler.staging.toml
+#   → ADMIN_API_TOKEN: SECRET_TEXT が並んでいれば成功
+```
+
+production も同手順で `staging` を `production` に置換するだけ。
+
+### 9.4 secret-sync.yml の責務範囲
+
+- **やること**:
+  - 指定 `environment` の ESC env を `esc env open --format json` で読み出す
+  - `.workerSecrets` を flat JSON object として書き出し、`wrangler secret bulk`
+    で 1 回の API 呼び出しで投入
+  - `Step Summary` に同期対象の ESC env 名 / wrangler config 名 / 反映確認コマンドを残す
+- **やらないこと**:
+  - Worker script 本体の deploy (= `deploy-workers.yml` の責務)
+  - ESC 側の値変更 (= 運用者が `esc env edit` で行う)
+  - 同期失敗時の自動 rollback (= ESC 値を戻して再 dispatch する手動 rollback 運用)
+
+### 9.5 必要 GitHub secret / 権限
+
+| key | 用途 | 流用元 |
+|---|---|---|
+| `PULUMI_ACCESS_TOKEN` | ESC env 読み取り | `pulumi-preview.yml` で既設定 |
+| `CLOUDFLARE_API_TOKEN` | `wrangler secret bulk` の Cloudflare API 呼び出し | `deploy-workers.yml` で既設定 (`Workers Scripts: Edit` scope を含むこと) |
+
+`secret-sync.yml` は `workflow_dispatch` のみ受け付け、かつ `if: github.ref == 'refs/heads/main'`
+で main 起動限定 (Phase 2-B 既知 quirks #9 対策)。任意ブランチで dispatch
+しても job 段で skip される。
+
+### 9.6 トラブルシュート
+
+- **`ESC env '...' does not contain a non-empty 'workerSecrets' object`**: ESC env
+  の YAML 構造が §9.2 規約に合っていない。`esc env get <env>` で `values`
+  ツリーを確認し、`workerSecrets` 配下にキーがあるか見る。
+- **`wrangler secret bulk` が 401 / 403**: `CLOUDFLARE_API_TOKEN` の scope に
+  `Workers Scripts: Edit` が含まれていない可能性。Cloudflare dashboard で token
+  scope を確認 (deploy-workers.yml が動いていれば deploy 用 scope は満たすが、
+  Cloudflare 側で scope を絞った別 token を使っている場合は要拡張)。
+- **`esc env open` が "no such environment"**: ESC env 名の typo か、
+  `PULUMI_ACCESS_TOKEN` の発行 org が `sh11235` 以外。`pulumi whoami` で確認。
+
+## 10. 参考
 
 - 設計判断 / 背景: [#675](https://github.com/SH11235/rshogi/issues/675) (umbrella)
 - Phase 1 実装単位: [#676](https://github.com/SH11235/rshogi/issues/676)
+- Phase 2-D (本 §9): [#690](https://github.com/SH11235/rshogi/issues/690)
 - [Pulumi Cloudflare Provider Registry](https://www.pulumi.com/registry/packages/cloudflare/)
 - [Pulumi Cloud Individual tier](https://www.pulumi.com/pricing/)
+- [Pulumi ESC docs](https://www.pulumi.com/docs/esc/)
+- [`pulumi/esc-action`](https://github.com/pulumi/esc-action)
 - 既存 wrangler 運用 runbook: [`deployment.md`](deployment.md)


### PR DESCRIPTION
## Summary

Cloudflare IaC umbrella rshogi #675 の **Phase 2-D (secret 移行)** 実装。Phase 1 で wrangler 管理継続と決めた Worker secret 群のうち、値の真値だけを **Pulumi ESC** に集約し、`workflow_dispatch` で `wrangler secret bulk` を kick する secret-sync workflow を追加。

- 採用 Architecture B (Pulumi ESC + GitHub Actions の workflow_dispatch で wrangler kick)
  - 不採用: A (WorkersScript secret_text binding) は WASM marshal error 不可、C (台帳のみ手動運用) は自動化目的を満たさず
- ESC environment は per-repo per-env: `sh11235/rshogi-csa-server-workers-{staging,production}`
- 既存 `deploy-workers.yml` と独立 (workflow_dispatch trigger、deploy 経路と decoupling)

## Scope

| 追加 / 変更 | ファイル | 概要 |
|---|---|---|
| 新規 | `.github/workflows/secret-sync.yml` | workflow_dispatch trigger、ESC `workerSecrets` を fail-closed 抽出 → `wrangler secret bulk --config wrangler.<env>.toml` |
| 編集 | `docs/csa-server/iac.md` | §9 (Phase 2-D Secret 管理) を新規追加 + §8→§10 リネーム。runbook / rotation / トラブルシュート整備 |

対象 secret: `ADMIN_API_TOKEN` (production / staging で別値、計 2)

## 設計判断のポイント

- `pulumi/esc-action@v1.5.0` で standalone ESC CLI install (`esc env open` 形式)
- ESC YAML 構造: `values.workerSecrets.<KEY>` flat 配置 + `fn::secret`
- workflow `if: github.ref == 'refs/heads/main'` で job 直下 ref hardening (Phase 2-B 既知 quirks #9 対策)
- `environment: rshogi-csa-server-workers-${{ inputs.environment }}` で deploy-workers.yml と GitHub Environment を統一 (secret/approval 境界一致)
- jq で `.workerSecrets | type == "object" and length > 0` の厳格 check + 必須 key (`ADMIN_API_TOKEN`) 欠落チェックで fail-closed
- tmpdir に `trap 'rm -rf' EXIT` で plaintext file の明示的 hardening
- `cancel-in-progress: false` (rotation 途中 cancel で partial-state 残存を防ぐ)

## レビュー履歴

Codex CLI レビュー実施 (1st: Request changes [J] environment 欠落 + Minor 3 件 → 全修正後 2nd: **Approve**)。

## Test plan

- [ ] CI green (pulumi-preview / 既存 workflow に副作用なし)
- [ ] merge 後 manager が ESC environment 2 件を作成 (`esc env init sh11235/rshogi-csa-server-workers-{staging,production}`)
- [ ] `ADMIN_API_TOKEN` を 2 ESC env に投入 (`esc env set ... --secret`)
- [ ] staging で `gh workflow run secret-sync.yml -f environment=staging` 実行 → `wrangler secret list --config wrangler.staging.toml` で `ADMIN_API_TOKEN` 反映確認
- [ ] production も同手順で展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)