### PR TITLE
refactor(csa-server-workers/tests): readLineFromWebSocket を ws_test_helpers.ts に共有化 (#699 follow-up)

### DIFF
--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/lobby.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/lobby.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import type { Miniflare, WebSocket } from "miniflare";
 import { DEFAULT_TEST_CF_CONNECTING_IP, createMiniflare, makeTempPersistRoot } from "./harness";
+import { readLineFromWebSocket } from "./ws_test_helpers";
 
 /**
  * `/ws/lobby` route と `Lobby` Durable Object のマッチング動作を Miniflare で
@@ -9,64 +10,6 @@ import { DEFAULT_TEST_CF_CONNECTING_IP, createMiniflare, makeTempPersistRoot } f
  * 既存 `GameRoom` DO への引き渡しまでの完全 E2E (1 局完走) は本 smoke のスコープ外
  * (csa_client `--lobby` mode を含む実装が揃ってから別 smoke で検証する)。
  */
-
-interface LobbyLineBuffer {
-  takeLine(timeoutMs?: number): Promise<string>;
-}
-
-function readLineFromWebSocket(ws: WebSocket): LobbyLineBuffer {
-  let buffer = "";
-  const queue: string[] = [];
-  const waiters: Array<{ resolve: (s: string) => void; reject: (e: Error) => void }> = [];
-  let closed = false;
-
-  ws.addEventListener("message", (ev) => {
-    const data =
-      typeof ev.data === "string" ? ev.data : new TextDecoder().decode(ev.data as ArrayBuffer);
-    buffer += data;
-    while (true) {
-      const idx = buffer.indexOf("\n");
-      if (idx < 0) break;
-      const line = buffer.slice(0, idx);
-      buffer = buffer.slice(idx + 1);
-      const w = waiters.shift();
-      if (w) w.resolve(line);
-      else queue.push(line);
-    }
-  });
-  ws.addEventListener("close", () => {
-    closed = true;
-    while (waiters.length > 0) {
-      const w = waiters.shift();
-      w?.reject(new Error("connection closed"));
-    }
-  });
-
-  return {
-    takeLine(timeoutMs = 3000): Promise<string> {
-      if (queue.length > 0) return Promise.resolve(queue.shift()!);
-      if (closed) return Promise.reject(new Error("connection closed"));
-      return new Promise<string>((resolve, reject) => {
-        const entry = {
-          resolve: (s: string) => {
-            clearTimeout(timer);
-            resolve(s);
-          },
-          reject: (e: Error) => {
-            clearTimeout(timer);
-            reject(e);
-          },
-        };
-        const timer = setTimeout(() => {
-          const i = waiters.indexOf(entry);
-          if (i >= 0) waiters.splice(i, 1);
-          reject(new Error(`takeLine timeout after ${timeoutMs}ms`));
-        }, timeoutMs);
-        waiters.push(entry);
-      });
-    },
-  };
-}
 
 async function connectLobby(
   mf: Miniflare,

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/rate_limit.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/rate_limit.test.ts
@@ -5,6 +5,7 @@ import {
   createMiniflare,
   makeTempPersistRoot,
 } from "./harness";
+import { readLineFromWebSocket } from "./ws_test_helpers";
 
 /**
  * Issue #622 PR3a: rate limit / abuse protection の Miniflare 経由 E2E。
@@ -53,71 +54,6 @@ async function connectLobbyWithIp(
   }
   res.webSocket.accept();
   return res.webSocket;
-}
-
-/**
- * WebSocket から 1 行 (`\n` 区切り) を取り出す簡易バッファ。`lobby.test.ts` の
- * 同等関数を本 smoke に複製している (harness 側に出すと scope が広すぎる)。
- */
-function readLineFromWebSocket(
-  ws: WebSocket,
-): { takeLine(timeoutMs?: number): Promise<string> } {
-  let buffer = "";
-  const queue: string[] = [];
-  const waiters: Array<{
-    resolve: (s: string) => void;
-    reject: (e: Error) => void;
-  }> = [];
-  let closed = false;
-
-  ws.addEventListener("message", (ev) => {
-    const data =
-      typeof ev.data === "string"
-        ? ev.data
-        : new TextDecoder().decode(ev.data as ArrayBuffer);
-    buffer += data;
-    while (true) {
-      const idx = buffer.indexOf("\n");
-      if (idx < 0) break;
-      const line = buffer.slice(0, idx);
-      buffer = buffer.slice(idx + 1);
-      const w = waiters.shift();
-      if (w) w.resolve(line);
-      else queue.push(line);
-    }
-  });
-  ws.addEventListener("close", () => {
-    closed = true;
-    while (waiters.length > 0) {
-      const w = waiters.shift();
-      w?.reject(new Error("connection closed"));
-    }
-  });
-
-  return {
-    takeLine(timeoutMs = 3000): Promise<string> {
-      if (queue.length > 0) return Promise.resolve(queue.shift()!);
-      if (closed) return Promise.reject(new Error("connection closed"));
-      return new Promise<string>((resolve, reject) => {
-        const entry = {
-          resolve: (s: string) => {
-            clearTimeout(timer);
-            resolve(s);
-          },
-          reject: (e: Error) => {
-            clearTimeout(timer);
-            reject(e);
-          },
-        };
-        const timer = setTimeout(() => {
-          const i = waiters.indexOf(entry);
-          if (i >= 0) waiters.splice(i, 1);
-          reject(new Error(`takeLine timeout after ${timeoutMs}ms`));
-        }, timeoutMs);
-        waiters.push(entry);
-      });
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/ws_test_helpers.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/ws_test_helpers.ts
@@ -27,7 +27,7 @@ export interface WebSocketLineBuffer {
 }
 
 /**
- * `WebSocket` から行単位読み取り用の [`WebSocketLineBuffer`] を組み立てる。
+ * `WebSocket` から行単位読み取り用の {@link WebSocketLineBuffer} を組み立てる。
  *
  * 使用例:
  * ```ts

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/ws_test_helpers.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/ws_test_helpers.ts
@@ -1,0 +1,109 @@
+import type { WebSocket } from "miniflare";
+
+/**
+ * Miniflare 4 の `WebSocket` を行 (`\n` 区切り) 単位で読み取るためのバッファ。
+ *
+ * `lobby.test.ts` (issue #631 / #582) と `rate_limit.test.ts` (issue #622 PR3a)
+ * の inline 重複ヘルパを共有化したもの (PR #699 claude[bot] review P2 follow-up)。
+ *
+ * **デフォルト 3000 ms timeout の根拠**: 共有化前の 2 inline 版がいずれも
+ * 3000 ms を採用していた。本値で smoke が green である観測実績を保つために
+ * 不変条件として固定する (`harness.ts::CsaClient.recvLine` の 5000 ms とは
+ * 別の値域 — そちらは LOGIN handshake 経路用で本ヘルパとは責務が異なる)。
+ *
+ * **listener 二重登録の警告**: 本関数は 1 度の呼び出しごとに `message` /
+ * `close` listener を 1 セット登録する。同 `ws` で複数 buffer を作ると同一
+ * フレームが両 buffer の queue に積まれて test の正答性が壊れるため、同一 WS に
+ * 対しては必ず 1 buffer のみを使う契約。
+ */
+export interface WebSocketLineBuffer {
+  /**
+   * 次の 1 行を取り出す。`\n` までのフレーム断片が揃ってない場合は新フレーム
+   * 到着まで待ち、`timeoutMs` 経過で `Error("takeLine timeout after Xms")` で
+   * reject。WS が close されると以降の呼び出しは即 `Error("connection closed")`
+   * で reject。
+   */
+  takeLine(timeoutMs?: number): Promise<string>;
+}
+
+/**
+ * `WebSocket` から行単位読み取り用の [`WebSocketLineBuffer`] を組み立てる。
+ *
+ * 使用例:
+ * ```ts
+ * const ws = await connectLobby(mf);
+ * const buf = readLineFromWebSocket(ws);
+ * ws.send("LOGIN_LOBBY alice+game-eval+black anything\n");
+ * expect(await buf.takeLine()).toBe("LOGIN_LOBBY:alice OK");
+ * ```
+ */
+export function readLineFromWebSocket(ws: WebSocket): WebSocketLineBuffer {
+  let buffer = "";
+  const queue: string[] = [];
+  // queue (= 既受信フレーム) と waiters (= 受信前 takeLine 呼び出し) を分けて
+  // 持つのは「フレーム → takeLine」「takeLine → フレーム」両方向の到着順序を
+  // race-free に扱うため。フレーム到着時に waiters があれば最古を resolve、
+  // なければ queue に積み、takeLine 呼び出し時に queue があれば即返却、
+  // なければ自分を waiters に積む — どちらの順序でも 1 フレーム = 1 takeLine
+  // の対応が崩れない。
+  const waiters: Array<{
+    resolve: (s: string) => void;
+    reject: (e: Error) => void;
+  }> = [];
+  let closed = false;
+
+  ws.addEventListener("message", (ev) => {
+    const data =
+      typeof ev.data === "string"
+        ? ev.data
+        : new TextDecoder().decode(ev.data as ArrayBuffer);
+    buffer += data;
+    while (true) {
+      const idx = buffer.indexOf("\n");
+      if (idx < 0) break;
+      const line = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 1);
+      const w = waiters.shift();
+      if (w) w.resolve(line);
+      else queue.push(line);
+    }
+  });
+  ws.addEventListener("close", () => {
+    // close 後に未解決の waiters を放置すると test 側 Promise が未 settle で
+    // hang する (vitest が timeout で気付くまで遅延が発生)。明示的に reject
+    // して即時失敗に倒す。
+    closed = true;
+    while (waiters.length > 0) {
+      const w = waiters.shift();
+      w?.reject(new Error("connection closed"));
+    }
+  });
+
+  return {
+    takeLine(timeoutMs = 3000): Promise<string> {
+      if (queue.length > 0) return Promise.resolve(queue.shift()!);
+      if (closed) return Promise.reject(new Error("connection closed"));
+      return new Promise<string>((resolve, reject) => {
+        const entry = {
+          resolve: (s: string) => {
+            clearTimeout(timer);
+            resolve(s);
+          },
+          reject: (e: Error) => {
+            clearTimeout(timer);
+            reject(e);
+          },
+        };
+        // timeout 発火時に waiters から自分を抜く: 抜き忘れると後続フレームが
+        // 自分の resolve を呼んで二重解決を起こす (Promise 仕様で no-op だが
+        // queue 側の bookkeeping が腐る)。
+        const timer = setTimeout(() => {
+          const i = waiters.indexOf(entry);
+          if (i >= 0) waiters.splice(i, 1);
+          reject(new Error(`takeLine timeout after ${timeoutMs}ms`));
+        }, timeoutMs);
+        waiters.push(entry);
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

PR #699 (issue #622 PR3a) merge 後、claude[bot] review P2 で指摘された `tests/miniflare_smoke/lobby.test.ts` と `tests/miniflare_smoke/rate_limit.test.ts` 間の `readLineFromWebSocket` 重複を解消する。

## Why

両 inline 版は実装が完全一致 (formatting のみ差異) で、将来 timeout 既定値や close handler 挙動を変更したいときに両ファイルを同時に修正する必要があり、維持性が悪い。テスト専用 helper として切り出すことで:

- 仕様変更の単一窓口化 (例: timeout 既定値の調整、エラー文字列フォーマット)
- 第 3 の smoke (`game_room` 直接通電 test 等、将来追加見込み) からの再利用が低コストで可能に

## What

新設 `tests/miniflare_smoke/ws_test_helpers.ts`:
- `WebSocketLineBuffer` interface (略語回避、`WsLineBuffer` ではなく)
- `readLineFromWebSocket(ws): WebSocketLineBuffer` 関数
- 旧 inline 2 版と **bytewise-identical** な挙動 (3000 ms 既定 timeout、`"connection closed"` / `"takeLine timeout after Xms"` エラー文言、queue 優先 / `waiters.splice` cleanup の lifecycle 全て一致)
- module / 関数内コメントは **WHY 中心** (`CLAUDE.md` 規約準拠)

`tests/miniflare_smoke/lobby.test.ts`:
- inline \`interface LobbyLineBuffer\` + \`function readLineFromWebSocket\` 削除
- import \`readLineFromWebSocket\` from \`./ws_test_helpers\` 追加

`tests/miniflare_smoke/rate_limit.test.ts`:
- inline \`function readLineFromWebSocket\` (`harness 側に出すと scope が広すぎる` という当時のコメント含む) 削除
- import \`readLineFromWebSocket\` from \`./ws_test_helpers\` 追加

## Codex CLI レビュー実施

1st: APPROVE_WITH_NITS (comment WHY 化 + `WsLineBuffer` → `WebSocketLineBuffer` リネーム) → 全反映後 2nd: APPROVE。

## Test plan

- [x] \`cargo fmt && cargo clippy -p rshogi-csa-server-workers --tests --all-targets -- -D warnings\` clean
- [x] \`cargo test -p rshogi-csa-server-workers\` 305 lib + 35 integration tests 全 pass
- [x] \`pnpm run test:smoke\` 11 files / 34 tests 全 pass (共有化後も挙動不変を実証)
- [ ] CI workers-smoke / rust-ci pass

Refs: #622 #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)