### PR TITLE
feat(infra/pulumi): #625 Phase B 続編 — workers_observability_alert NotificationPolicy 追加

### DIFF
--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -26,7 +26,30 @@ compatibility_date = "2026-04-21"
 # `infra/pulumi/index.ts`) と本フラグの両方が揃って初めて R2 archive にログが
 # 落ちる。詳細は `docs/csa-server/observability.md` §1 / §3 を参照。
 # [#625 Phase B / PR #698]
+#
+# 2026-05-10 時点 Workers Free plan で Logpush は 0 job 制限により実質無効
+# (LogpushJob create が `code 1004 exceeded max jobs allowed` で reject される、
+# `docs/csa-server/observability.md` §3.2.1 参照)。Paid plan 移行時の forward-compat
+# として keep する (削除しても Free plan で no-op、再 add する手間を省く判断)。
 logpush = true
+
+# Workers Observability を有効化 (Free plan 対応)。Cloudflare Dashboard の
+# Workers script 詳細画面で過去 7 日分の log を invocation 単位で検索可能になり、
+# Workers Observability ダッシュボードで定義した custom alert rule
+# (例: 5xx errors > 10 in 5min) が発火する基盤になる。
+#
+# 発火した alert は本 PR で declare する `workers_observability_alert`
+# NotificationPolicy (infra/pulumi/index.ts) 経由で Slack webhook に届く。
+#
+# `head_sampling_rate = 1.0` で全 invocation を log (Free plan で 7 日保持)。
+# 詳細は `docs/csa-server/observability.md` §6.1 を参照。
+# [#625 Phase B 続編 / PR (本 PR)]
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1.0
 
 # CI 環境では事前に `cargo install -q worker-build@^0.8 --locked` がインストール済みの
 # 前提（`.github/workflows/deploy-workers.yml` の独立 step `Install worker-build` で

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -23,7 +23,22 @@ compatibility_date = "2026-04-21"
 # `infra/pulumi/index.ts`) と本フラグの両方が揃って初めて R2 archive にログが
 # 落ちる。詳細は `docs/csa-server/observability.md` §1 / §3 を参照。
 # [#625 Phase B / PR #698]
+#
+# 2026-05-10 時点 Workers Free plan で Logpush は 0 job 制限により実質無効。
+# Paid plan 移行時の forward-compat として keep する (`docs/csa-server/observability.md`
+# §3.2.1 参照)。production toml と挙動を揃えるため staging も同設定。
 logpush = true
+
+# Workers Observability を有効化 (Free plan 対応)。production toml の同 block と
+# 同設定で揃え、staging で alert rule の動作確認 → production 反映の運用とする。
+# 詳細は `docs/csa-server/observability.md` §6.1 を参照。
+# [#625 Phase B 続編 / PR (本 PR)]
+[observability]
+enabled = true
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1.0
 
 # CI 環境では事前に `cargo install -q worker-build@^0.8 --locked` がインストール済みの
 # 前提（`.github/workflows/deploy-workers.yml` の独立 step `Install worker-build` で

--- a/docs/csa-server/observability.md
+++ b/docs/csa-server/observability.md
@@ -20,8 +20,9 @@
 
 ┌─────────────────────────────────────────────────────────────┐
 │ Cloudflare Notifications (account-level)                    │
-│   - 配信先 webhook 1 件 (rshogi-staging-alerts) のみ登録済     │
-│   - alert policy は本 PR スコープ外で未追加 (§7.2 参照)         │
+│   - 配信先 webhook 1 件 (rshogi-staging-alerts) 登録済         │
+│   - workers_observability_alert NotificationPolicy declare 済 │
+│     (本 PR、Free plan 利用可、Dashboard rule 定義は user manual)│
 └────────┬────────────────────────────────────────────────────┘
          │ POST request (Cloudflare-format JSON payload、Cloudflare が
          │ Slack 形式と判別して dispatch する type=slack 設定)
@@ -49,7 +50,8 @@ Workers console output ↓ Logpush (NDJSON、30 秒 batch、enabled flag で gat
 | R2 bucket (logs archive) | `rshogi-csa-logs-prod` | `rshogi-csa-logs-staging` | ✅ 作成済 (Free plan では空、Paid 移行時に Logpush 投入先) | `infra/pulumi/index.ts` |
 | NotificationPolicyWebhooks | (未作成) | `rshogi-staging-alerts` (id `e9e6102c...`) | ✅ staging のみ作成済、Slack 疎通確認済 | `infra/pulumi/index.ts` |
 | LogpushJob | – | – | ❌ Free plan で作成不可、config 投入で declare をスキップ | `infra/pulumi/index.ts` (scaffold 維持) |
-| NotificationPolicy | – | – | ❌ 本 PR スコープ外、別 PR で追加 (§7.2 参照) | `infra/pulumi/index.ts` (scaffold 維持) |
+| NotificationPolicy `workersObservabilityAlert` | (未作成) | `rshogi-staging-workers-observability` | ✅ staging 側 declare 済 (本 PR #703)、`notificationsEnabled` flag で enable 制御。Cloudflare Dashboard で alert rule 定義は user manual (§6.1 参照) | `infra/pulumi/index.ts` |
+| NotificationPolicy `logpushFailureAlert` | – | – | ❌ Free plan で logpushJob 不在のため依存 chain skip、Paid 移行時に自動 active | `infra/pulumi/index.ts` (scaffold 維持) |
 
 **Pulumi scaffold 設計**: `infra/pulumi/index.ts` の `readOptionalSecret(key)` ヘルパーで「config 値が unset または空文字列なら resource 自体を declare しない」条件分岐を持たせており、Free plan では Logpush 関連 config を投入しないことで自動的にスキップされる。Paid plan 移行時は §7.1 に従って config 投入のみで Logpush + alert を再活性化できる。
 
@@ -256,24 +258,24 @@ pulumi up
 
 `NotificationPolicyWebhooks` の `url` のみ差し替わる (Cloudflare は新 URL pattern から `type` を再判定、Discord の場合 generic webhook として扱われる)。HMAC 検証する場合は translator Worker 内で `cf-webhook-auth` header を別途検証する (Cloudflare が自動で付ける header、Pulumi config の `alertWebhookSecret` は Slack 直結用途では使えなかった (§3.2.3 参照) ので translator Worker 側に独自 secret を持たせる設計とする)。
 
-## 6. Free plan で実用的な alert 追加方針 (別 PR)
+## 6. Free plan で実用的な alert 追加方針
 
 `/available_alerts` API を Free plan + 本アカウントで叩いた結果 (2026-05-10)、本 use case (Worker 監視) で利用可能な alertType は以下 4 種に絞られる:
 
 | alertType | カテゴリ | 用途 | Worker での実用性 |
 |---|---|---|---|
-| `workers_observability_alert` | Workers Observability | Workers Observability ダッシュボードで定義した custom alert rule (errors > N / 5min 等) が発火 → webhook 配信 | ✅ **本命**、自由に発火条件を組める |
-| `health_check_status_notification` | Health Checks | Cloudflare Health Check リソース別途セットアップ必須 (HTTP probe を URL 指定 → DOWN 検知時発火) | △ 別 resource 必要だが補完的に有用 (uptime 監視) |
+| `workers_observability_alert` | Workers Observability | Workers Observability ダッシュボードで定義した custom alert rule (errors > N / 5min 等) が発火 → webhook 配信 | ✅ **本命**、自由に発火条件を組める ([本 PR で実装済](https://github.com/SH11235/rshogi/issues/703)) |
+| `health_check_status_notification` | Health Checks | Cloudflare Health Check リソース別途セットアップ必須 (HTTP probe を URL 指定 → DOWN 検知時発火) | △ 別 resource 必要だが補完的に有用 (uptime 監視、§6.2 参照、別 PR) |
 | `security_insights_alert` | Security Insights | Cloudflare の Security Insights (新規脅威検知) 一般、zone 全体向け | △ Worker specific ではないが受信して損なし |
 | `real_origin_monitoring` | Traffic Monitoring | "Cloudflare → origin 不到達" 検知。Workers は Cloudflare 内部実行で origin 概念なし | ❌ Worker には適用されない (zone-attached origin 専用) |
 
 **`dos_attack_l7` 等の DoS Protection alertType は Free plan の `/available_alerts` 結果に出現せず、Free plan は基本 DDoS 保護のみで configurable alert は Paid 限定** (これも 2026-05-10 検証で判明)。
 
-### 6.1 推奨実装方針 (`workers_observability_alert` ベース)
+### 6.1 `workers_observability_alert` 実装 (本 PR で実装済 #703)
 
-別 PR で以下を実装:
+#625 Phase B 続編で以下が完了:
 
-1. **`wrangler.{production,staging}.toml` に `[observability]` block 追加** (Workers Observability を有効化、Free plan 対応):
+1. ✅ **`wrangler.{production,staging}.toml` に `[observability]` block 追加** (Workers Observability を有効化、Free plan 対応):
    ```toml
    [observability]
    enabled = true
@@ -281,17 +283,54 @@ pulumi up
    enabled = true
    head_sampling_rate = 1.0
    ```
-2. **Cloudflare Dashboard → Workers & Pages → 該当 Worker → "Observability" → "Alerts"** で具体的な発火条件を Web UI で定義 (例: `5xx errors > 10 in 5min` や `CPU time > 50ms p99` 等)
-3. **Pulumi で `workers_observability_alert` の NotificationPolicy を declare** して `alertWebhook` へ routing (本 doc の `infra/pulumi/index.ts` `logpushFailureAlert` ブロックを `alertType: "workers_observability_alert"` に書き換える形)
+2. ✅ **`infra/pulumi/index.ts` に `workersObservabilityAlert` NotificationPolicy declare**: alertType=`workers_observability_alert`、alertWebhook へ routing。`alertWebhook` のみに依存 (logpushJob 非依存) なので Free plan でも declare 可能、`notificationsEnabled` config bool で enable/disable 制御。
 
-### 6.2 補完: `health_check_status_notification`
+#### Bootstrap 手順 (PR merge 後、user manual)
+
+```bash
+cd infra/pulumi
+pulumi stack select staging
+pulumi preview     # workers_observability_alert NotificationPolicy 1 件 create + (notificationsEnabled=false なら) enabled: false で declare
+pulumi up          # apply
+pulumi config set notificationsEnabled true   # alert を実発火 mode に
+pulumi up          # 再 apply で enabled: true 反映
+```
+
+production も同手順 (`pulumi stack select production` 後に同コマンド)。
+
+#### Cloudflare Dashboard で具体的な alert rule を定義 (user manual、Pulumi 範囲外)
+
+NotificationPolicy は「rule が発火したら webhook に届ける」routing のみ宣言する。**具体的な発火条件は Cloudflare Dashboard UI で別途定義** する必要がある (2026-05 時点 Pulumi `@pulumi/cloudflare` provider に Workers Observability alert rule resource は無い):
+
+> **以下の Dashboard 階層は 2026-05 時点の推測ベース** で実機未検証。Cloudflare Dashboard は頻繁に rename / 再構成されるため、user 側で実際の UI を見て tab / button 名を読み替える必要あり。
+
+1. https://dash.cloudflare.com/d5d9818649d8722f73cd798c3b1ffb70/workers-and-pages
+2. 該当 Worker (`rshogi-csa-server-workers` / `rshogi-csa-server-workers-staging`) を選択
+3. 上部タブまたはサイドバーで **"Observability"** → さらに **"Alerts"** subsection (UI 構造は変動可能性あり、見つからなければ Logs / Metrics 周辺を探す)
+4. **"Create alert"** で rule 定義:
+   - Rule name: 任意 (例: `worker exception burst`)
+   - Filter: Workers Observability の log filter 構文で記述 (`Outcome` field は HTTP status ではなく Worker の **実行結果分類** で `ok` / `exception` / `exceededCpu` / `exceededMemory` / `scriptNotFound` / `unknown` の値域。HTTP 5xx を Worker が正常に return した場合は `Outcome == "ok"` のため、HTTP status での filter は別経路 (Workers Logs の `Logs` field 等) が必要)
+   - Threshold: 例 `> 10 in 5 minutes`
+   - Notification: 上記 NotificationPolicy が **default で適用される** (alertType マッチで Cloudflare が自動 routing)、追加で email 等を選ぶことも可能
+5. Save → 以降該当 rule が threshold 超過したら Slack channel に通知
+
+推奨初期 rule (個人運用 + 低トラフィック前提):
+
+| Rule 名 | Filter (Workers Observability 構文) | Threshold | 用途 |
+|---|---|---|---|
+| `worker exception burst` | `Outcome != "ok"` (= exception / exceededCpu / scriptNotFound 等) | `> 5 in 10 minutes` | Worker 実行失敗多発検知 (HTTP 5xx 正常 return とは独立、panic / throw / CPU 超過等) |
+| `dispatch latency p99 spike` | (Workers Observability metric、`WallTimeMs` p99) | `p99 wallTime > 200ms in 10 minutes` | レイテンシ劣化検知 |
+
+具体的な filter 構文は Workers Observability dashboard 上の query builder で確認しながら定義する。
+
+### 6.2 補完: `health_check_status_notification` (別 PR)
 
 **uptime 監視** として推奨。手順:
 
 1. Cloudflare Dashboard → Traffic → Health Checks → "Create" で `https://csa.sh11235.com/health` 等を 1 分間隔 probe する Health Check を作成
 2. Pulumi で `health_check_status_notification` NotificationPolicy を declare、`filters.healthCheckIds` に Health Check ID を指定 (Pulumi cloudflare provider に Health Check resource もある、`cloudflare.HealthCheck`)
 
-本 doc 範囲外、別 PR で扱う (#625 follow-up issue として起票推奨、または直接小さい PR を起票)。
+本 doc 範囲外、uptime 監視が必要になった時点で別 PR を起票する (#625 follow-up issue 起票 or 直接小さい PR)。
 
 ## 7. Paid plan 移行時の手順
 

--- a/docs/csa-server/observability.md
+++ b/docs/csa-server/observability.md
@@ -21,8 +21,9 @@
 ┌─────────────────────────────────────────────────────────────┐
 │ Cloudflare Notifications (account-level)                    │
 │   - 配信先 webhook 1 件 (rshogi-staging-alerts) 登録済         │
-│   - workers_observability_alert NotificationPolicy declare 済 │
-│     (本 PR、Free plan 利用可、Dashboard rule 定義は user manual)│
+│   - NotificationPolicy は API 直作成 (Pulumi v6.15.0 が       │
+│     workers_observability_alert を未対応のため、§6.1 参照)     │
+│   - 具体的 alert rule 定義は Cloudflare Dashboard (user manual)│
 └────────┬────────────────────────────────────────────────────┘
          │ POST request (Cloudflare-format JSON payload、Cloudflare が
          │ Slack 形式と判別して dispatch する type=slack 設定)
@@ -50,7 +51,7 @@ Workers console output ↓ Logpush (NDJSON、30 秒 batch、enabled flag で gat
 | R2 bucket (logs archive) | `rshogi-csa-logs-prod` | `rshogi-csa-logs-staging` | ✅ 作成済 (Free plan では空、Paid 移行時に Logpush 投入先) | `infra/pulumi/index.ts` |
 | NotificationPolicyWebhooks | (未作成) | `rshogi-staging-alerts` (id `e9e6102c...`) | ✅ staging のみ作成済、Slack 疎通確認済 | `infra/pulumi/index.ts` |
 | LogpushJob | – | – | ❌ Free plan で作成不可、config 投入で declare をスキップ | `infra/pulumi/index.ts` (scaffold 維持) |
-| NotificationPolicy `workersObservabilityAlert` | (未作成) | `rshogi-staging-workers-observability` | ✅ staging 側 declare 済 (本 PR #703)、`notificationsEnabled` flag で enable 制御。Cloudflare Dashboard で alert rule 定義は user manual (§6.1 参照) | `infra/pulumi/index.ts` |
+| NotificationPolicy `workers_observability_alert` 用 | (未作成) | `rshogi-staging-workers-observability` | ⚠️ Pulumi v6.15.0 alertType enum 未対応のため API 直作成 (§6.1 Step 2 参照)、Pulumi declare は provider 対応後に別 PR | (Pulumi 不可) |
 | NotificationPolicy `logpushFailureAlert` | – | – | ❌ Free plan で logpushJob 不在のため依存 chain skip、Paid 移行時に自動 active | `infra/pulumi/index.ts` (scaffold 維持) |
 
 **Pulumi scaffold 設計**: `infra/pulumi/index.ts` の `readOptionalSecret(key)` ヘルパーで「config 値が unset または空文字列なら resource 自体を declare しない」条件分岐を持たせており、Free plan では Logpush 関連 config を投入しないことで自動的にスキップされる。Paid plan 移行時は §7.1 に従って config 投入のみで Logpush + alert を再活性化できる。
@@ -271,9 +272,9 @@ pulumi up
 
 **`dos_attack_l7` 等の DoS Protection alertType は Free plan の `/available_alerts` 結果に出現せず、Free plan は基本 DDoS 保護のみで configurable alert は Paid 限定** (これも 2026-05-10 検証で判明)。
 
-### 6.1 `workers_observability_alert` 実装 (本 PR で実装済 #703)
+### 6.1 `workers_observability_alert` 配信経路セットアップ (本 PR + user manual)
 
-#625 Phase B 続編で以下が完了:
+#625 Phase B 続編で本 PR (#703 / [#704](https://github.com/SH11235/rshogi/pull/704)) が実装するもの:
 
 1. ✅ **`wrangler.{production,staging}.toml` に `[observability]` block 追加** (Workers Observability を有効化、Free plan 対応):
    ```toml
@@ -283,26 +284,54 @@ pulumi up
    enabled = true
    head_sampling_rate = 1.0
    ```
-2. ✅ **`infra/pulumi/index.ts` に `workersObservabilityAlert` NotificationPolicy declare**: alertType=`workers_observability_alert`、alertWebhook へ routing。`alertWebhook` のみに依存 (logpushJob 非依存) なので Free plan でも declare 可能、`notificationsEnabled` config bool で enable/disable 制御。
+2. ⚠️ **NotificationPolicy `workers_observability_alert` の Pulumi declare は本 PR で見送り**:
+   - 2026-05-10 時点 `@pulumi/cloudflare` v6.15.0 の `NotificationPolicy.alertType` Available values list に `workers_observability_alert` が **未収録** (provider auto-generated schema が Cloudflare 側の最近追加に追従していない)
+   - Cloudflare API 自体は本 alertType を accept する (PR #701 で `/available_alerts` 検証済)
+   - Pulumi provider の schema validation で reject されるため、現時点では **API 直叩き or Dashboard UI 経由で作成** する代替手順を用いる
+   - provider が `workers_observability_alert` をサポートした時点で本ファイルに resource として追加する別 PR を起票
 
 #### Bootstrap 手順 (PR merge 後、user manual)
 
+##### Step 1: wrangler deploy で `[observability]` 反映
+
 ```bash
-cd infra/pulumi
-pulumi stack select staging
-pulumi preview     # workers_observability_alert NotificationPolicy 1 件 create + (notificationsEnabled=false なら) enabled: false で declare
-pulumi up          # apply
-pulumi config set notificationsEnabled true   # alert を実発火 mode に
-pulumi up          # 再 apply で enabled: true 反映
+cd crates/rshogi-csa-server-workers
+# 既存の deploy 経路を使う (CI または手動):
+# CI (推奨): GitHub Actions の deploy-workers.yml を kick
+# 手動: pnpm exec wrangler deploy --config wrangler.staging.toml
 ```
 
-production も同手順 (`pulumi stack select production` 後に同コマンド)。
+deploy 完了で Cloudflare Workers の Observability 機能が有効化され、過去 7 日分の log を Workers Observability dashboard で検索可能になる (Free plan)。
 
-#### Cloudflare Dashboard で具体的な alert rule を定義 (user manual、Pulumi 範囲外)
+##### Step 2: NotificationPolicy を API で作成 (Pulumi 不可、user manual)
 
-NotificationPolicy は「rule が発火したら webhook に届ける」routing のみ宣言する。**具体的な発火条件は Cloudflare Dashboard UI で別途定義** する必要がある (2026-05 時点 Pulumi `@pulumi/cloudflare` provider に Workers Observability alert rule resource は無い):
+```bash
+ACCOUNT_ID="d5d9818649d8722f73cd798c3b1ffb70"
+TOKEN=$(cd /path/to/rshogi/infra/pulumi && pulumi config --show-secrets --json | jq -r '.["cloudflare:apiToken"].value')
+WEBHOOK_ID="e9e6102cf9d64192b5c2443dd70ec9f8"  # rshogi-staging-alerts (PR #698 で作成済の id、最新は API list で確認)
 
-> **以下の Dashboard 階層は 2026-05 時点の推測ベース** で実機未検証。Cloudflare Dashboard は頻繁に rename / 再構成されるため、user 側で実際の UI を見て tab / button 名を読み替える必要あり。
+curl -sS -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/alerting/v3/policies" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg wid "$WEBHOOK_ID" '{
+    name: "rshogi-staging-workers-observability",
+    description: "Workers Observability dashboard で定義した custom alert rule が発火した時に Slack へ routing。#625 Phase B 続編 PR #704 で API 直作成 (Pulumi v6.15.0 の alertType enum に未収録のため)。",
+    alert_type: "workers_observability_alert",
+    enabled: true,
+    alert_interval: "30m",
+    mechanisms: {
+      webhooks: [{ id: $wid }]
+    }
+  }')" | jq '.result | {id, name, alert_type, enabled}'
+```
+
+> **`alert_interval: "30m"`**: `workers_observability_alert` は continuous fire 型で閾値超過が続く間に複数回発火し得る。30 分間隔で同じ incident からの通知を 1 回に絞ることで Slack 過剰通知を防ぐ ([Codex review #704 で指摘](https://github.com/SH11235/rshogi/pull/704))。
+
+##### Step 3: Cloudflare Dashboard で具体的な alert rule を定義 (user manual)
+
+NotificationPolicy は「rule が発火したら webhook に届ける」routing のみ。**具体的な発火条件は Cloudflare Dashboard UI で別途定義** する必要がある (Pulumi provider に Workers Observability alert rule resource は無い):
+
+> **以下の Dashboard 階層は 2026-05 時点の推測ベース** で実機未検証。staging で実際に rule 作成手順を踏んだ後、本節を実 UI で書き直す TODO を残す ([Codex review #704 で指摘](https://github.com/SH11235/rshogi/pull/704))。
 
 1. https://dash.cloudflare.com/d5d9818649d8722f73cd798c3b1ffb70/workers-and-pages
 2. 該当 Worker (`rshogi-csa-server-workers` / `rshogi-csa-server-workers-staging`) を選択
@@ -311,7 +340,7 @@ NotificationPolicy は「rule が発火したら webhook に届ける」routing 
    - Rule name: 任意 (例: `worker exception burst`)
    - Filter: Workers Observability の log filter 構文で記述 (`Outcome` field は HTTP status ではなく Worker の **実行結果分類** で `ok` / `exception` / `exceededCpu` / `exceededMemory` / `scriptNotFound` / `unknown` の値域。HTTP 5xx を Worker が正常に return した場合は `Outcome == "ok"` のため、HTTP status での filter は別経路 (Workers Logs の `Logs` field 等) が必要)
    - Threshold: 例 `> 10 in 5 minutes`
-   - Notification: 上記 NotificationPolicy が **default で適用される** (alertType マッチで Cloudflare が自動 routing)、追加で email 等を選ぶことも可能
+   - Notification: Step 2 で作成した NotificationPolicy が **default で適用される** (alertType マッチで Cloudflare が自動 routing)、追加で email 等を選ぶことも可能
 5. Save → 以降該当 rule が threshold 超過したら Slack channel に通知
 
 推奨初期 rule (個人運用 + 低トラフィック前提):
@@ -322,6 +351,10 @@ NotificationPolicy は「rule が発火したら webhook に届ける」routing 
 | `dispatch latency p99 spike` | (Workers Observability metric、`WallTimeMs` p99) | `p99 wallTime > 200ms in 10 minutes` | レイテンシ劣化検知 |
 
 具体的な filter 構文は Workers Observability dashboard 上の query builder で確認しながら定義する。
+
+##### Future: 複数 Worker 追加時の filter 検討
+
+現時点 (Worker 1 本) では NotificationPolicy 側に `filters` を付けず、Cloudflare Dashboard rule 側で Worker script を選んで定義する設計で十分。将来 account に別 Worker が追加された場合、その Worker の `workers_observability_alert` rule も本 NotificationPolicy で routing される可能性があるため、追加 Worker 出現時に filter フィールドによる Worker script 絞り込みを検討する ([Codex review #704 で指摘](https://github.com/SH11235/rshogi/pull/704))。
 
 ### 6.2 補完: `health_check_status_notification` (別 PR)
 

--- a/infra/pulumi/index.ts
+++ b/infra/pulumi/index.ts
@@ -247,21 +247,23 @@ export const logpushJob = logpushDestinationConf
 
 // ---- NotificationPolicy (alert ルール) -----------------------------------
 //
-// 2 種を declare:
+// `logpushFailureAlert`: Logpush job が連続失敗で Cloudflare 側に
+// 自動 disable された時に発火 (= observability 根幹の fail-safe)。
+// LogpushJob 依存なので Free plan では declare されない (logpushJob === undefined)。
+// Paid plan 移行で logpushJob が active 化された時に自動的に declare 候補になる。
 //
-// 1. `logpushFailureAlert`: Logpush job が連続失敗で Cloudflare 側に
-//    自動 disable された時に発火 (= observability 根幹の fail-safe)。
-//    LogpushJob 依存なので Free plan では declare されない (logpushJob === undefined)。
-//    Paid plan 移行で logpushJob が active 化された時に自動的に declare 候補になる。
+// `notificationsEnabled` config bool で enable/disable 制御。
 //
-// 2. `workersObservabilityAlert`: Workers Observability dashboard で定義された
-//    custom alert rule (例: worker exception burst = `Outcome != "ok"` > 10 in 5min、
-//    `Outcome` は HTTP status ではなく Worker 実行結果分類: ok / exception /
-//    exceededCpu / scriptNotFound 等) が発火した時に発火。
-//    Worker 単体で alert rule を持てる Free plan で利用可能な唯一の Worker 監視 alert
-//    (PR #701 で `/available_alerts` API 検証済)。
-//
-// どちらも `notificationsEnabled` config bool で個別 enable/disable 可能。
+// **`workers_observability_alert` は本ファイルでは declare しない**:
+// 2026-05-10 時点 `@pulumi/cloudflare` v6.15.0 の NotificationPolicy
+// `alertType` Available values list に `workers_observability_alert` が
+// 未収録 (`failing_logpush_job_disabled_alert` 等は含まれる)。Cloudflare API
+// 自体は本 alertType を accept する (PR #701 で `/available_alerts` 検証済) が、
+// Pulumi provider の schema validation で reject されるため Pulumi declare 不可。
+// 代替として Cloudflare API 直叩き or Dashboard UI 経由で NotificationPolicy
+// を作成する手順を `docs/csa-server/observability.md` §6.1 に明記する。
+// provider が `workers_observability_alert` をサポートしたら別 PR で
+// 本ファイルに `workersObservabilityAlert` resource として追加する。
 
 const notificationsEnabled =
     config.getBoolean("notificationsEnabled") ?? false;
@@ -277,39 +279,10 @@ export const logpushFailureAlert =
                   "rshogi-csa-server-workers Logpush が連続失敗で disable された場合に発火。observability 根幹の fail-safe として #625 Phase B で declare。Workers Free plan では logpushJob 不在のため本 policy 自体も declare されない (Paid 移行時に自動 active)。",
               // `alertInterval` は本 alertType (failing_logpush_job_disabled_alert) では
               // Cloudflare Notifications API が無視する (single-shot alert として処理)。
-              // continuous alert (例 worker exception burst を本 alertType の代わりに
-              // 別 alertType で定義する場合等) を別 PR で追加する際は `alertInterval: "30m"`
-              // を再導入する判断とする。
+              // continuous alert (例 worker exception burst を別 alertType で定義する場合等)
+              // を別 PR で追加する際は `alertInterval: "30m"` を再導入する判断とする。
               mechanisms: {
                   webhooks: [{ id: alertWebhook.id }],
               },
           })
         : undefined;
-
-// Workers Observability alert は alertWebhook のみに依存する (logpushJob 非依存)。
-// Free plan でも declare 可能で、Cloudflare Dashboard → Workers & Pages →
-// 該当 Worker → Observability → Alerts で定義した custom rule (errors > N / latency > X 等)
-// が発火した時に本 policy 経由で alertWebhook に routing される。
-//
-// alert rule 自体の定義は Cloudflare Dashboard UI 専用 (2026-05-10 時点 Pulumi
-// provider に Workers Observability alert rule resource は無い、`docs/csa-server/observability.md`
-// §6.1 参照)。本 declare は「rule が発火したら webhook に届ける」routing 設定のみ。
-//
-// `mechanisms.webhooks` は alertWebhook 1 件、filter なし (Cloudflare Dashboard 側
-// rule で Worker script を選んで定義するため、NotificationPolicy 側の filter 不要)。
-export const workersObservabilityAlert = alertWebhook
-    ? new cloudflare.NotificationPolicy(
-          `workersObservabilityAlert-${stack}`,
-          {
-              accountId,
-              name: `rshogi-${stack}-workers-observability`,
-              alertType: "workers_observability_alert",
-              enabled: notificationsEnabled,
-              description:
-                  "rshogi-csa-server-workers の Workers Observability dashboard で定義した custom alert rule (errors / latency 等) が発火した時に発火。Workers Free plan で利用可能な唯一の Worker 監視 alert として #625 Phase B 続編で declare。具体的 rule は Cloudflare Dashboard UI で別途定義する (Pulumi provider に Workers Observability alert rule resource は無い)。",
-              mechanisms: {
-                  webhooks: [{ id: alertWebhook.id }],
-              },
-          },
-      )
-    : undefined;

--- a/infra/pulumi/index.ts
+++ b/infra/pulumi/index.ts
@@ -247,19 +247,21 @@ export const logpushJob = logpushDestinationConf
 
 // ---- NotificationPolicy (alert ルール) -----------------------------------
 //
-// Phase B 初版では「Logpush 自体が止まったら alert」の 1 件のみ宣言する。
-// これは observability の根幹 (logs が止まれば alert もできなくなる) を
-// 守る fail-safe。追加 alert (5xx burst / DO error 等) は別 PR で
-// 同パターンで extend する (本ファイルに `additionalNotificationPolicies` 配列を
-// 足す形で増やせる)。
+// 2 種を declare:
 //
-// alertType の選定:
-// - `failing_logpush_job_disabled_alert`: Logpush job が連続失敗で
-//   Cloudflare 側に自動 disable された時に発火 (=「ログが取れなくなった」検知)
-// - 5xx は Worker の場合 zone 経由ではなく Logpush データを external 監視で
-//   集計する方が確実 (Cloudflare Notifications の `http_alert_origin_error` は
-//   zone scope で Workers behind custom domain で限定的に動く)。本 PR では
-//   declare せず別 PR で `dos_attack_l7` 等と一緒に評価する。
+// 1. `logpushFailureAlert`: Logpush job が連続失敗で Cloudflare 側に
+//    自動 disable された時に発火 (= observability 根幹の fail-safe)。
+//    LogpushJob 依存なので Free plan では declare されない (logpushJob === undefined)。
+//    Paid plan 移行で logpushJob が active 化された時に自動的に declare 候補になる。
+//
+// 2. `workersObservabilityAlert`: Workers Observability dashboard で定義された
+//    custom alert rule (例: worker exception burst = `Outcome != "ok"` > 10 in 5min、
+//    `Outcome` は HTTP status ではなく Worker 実行結果分類: ok / exception /
+//    exceededCpu / scriptNotFound 等) が発火した時に発火。
+//    Worker 単体で alert rule を持てる Free plan で利用可能な唯一の Worker 監視 alert
+//    (PR #701 で `/available_alerts` API 検証済)。
+//
+// どちらも `notificationsEnabled` config bool で個別 enable/disable 可能。
 
 const notificationsEnabled =
     config.getBoolean("notificationsEnabled") ?? false;
@@ -272,13 +274,42 @@ export const logpushFailureAlert =
               alertType: "failing_logpush_job_disabled_alert",
               enabled: notificationsEnabled,
               description:
-                  "rshogi-csa-server-workers Logpush が連続失敗で disable された場合に発火。observability 根幹の fail-safe として #625 Phase B で declare。",
+                  "rshogi-csa-server-workers Logpush が連続失敗で disable された場合に発火。observability 根幹の fail-safe として #625 Phase B で declare。Workers Free plan では logpushJob 不在のため本 policy 自体も declare されない (Paid 移行時に自動 active)。",
               // `alertInterval` は本 alertType (failing_logpush_job_disabled_alert) では
               // Cloudflare Notifications API が無視する (single-shot alert として処理)。
-              // 5xx burst 等の continuous alert を別 PR で追加する際は `alertInterval: "30m"`
+              // continuous alert (例 worker exception burst を本 alertType の代わりに
+              // 別 alertType で定義する場合等) を別 PR で追加する際は `alertInterval: "30m"`
               // を再導入する判断とする。
               mechanisms: {
                   webhooks: [{ id: alertWebhook.id }],
               },
           })
         : undefined;
+
+// Workers Observability alert は alertWebhook のみに依存する (logpushJob 非依存)。
+// Free plan でも declare 可能で、Cloudflare Dashboard → Workers & Pages →
+// 該当 Worker → Observability → Alerts で定義した custom rule (errors > N / latency > X 等)
+// が発火した時に本 policy 経由で alertWebhook に routing される。
+//
+// alert rule 自体の定義は Cloudflare Dashboard UI 専用 (2026-05-10 時点 Pulumi
+// provider に Workers Observability alert rule resource は無い、`docs/csa-server/observability.md`
+// §6.1 参照)。本 declare は「rule が発火したら webhook に届ける」routing 設定のみ。
+//
+// `mechanisms.webhooks` は alertWebhook 1 件、filter なし (Cloudflare Dashboard 側
+// rule で Worker script を選んで定義するため、NotificationPolicy 側の filter 不要)。
+export const workersObservabilityAlert = alertWebhook
+    ? new cloudflare.NotificationPolicy(
+          `workersObservabilityAlert-${stack}`,
+          {
+              accountId,
+              name: `rshogi-${stack}-workers-observability`,
+              alertType: "workers_observability_alert",
+              enabled: notificationsEnabled,
+              description:
+                  "rshogi-csa-server-workers の Workers Observability dashboard で定義した custom alert rule (errors / latency 等) が発火した時に発火。Workers Free plan で利用可能な唯一の Worker 監視 alert として #625 Phase B 続編で declare。具体的 rule は Cloudflare Dashboard UI で別途定義する (Pulumi provider に Workers Observability alert rule resource は無い)。",
+              mechanisms: {
+                  webhooks: [{ id: alertWebhook.id }],
+              },
+          },
+      )
+    : undefined;


### PR DESCRIPTION
closes #703
refs #625 / #698 / #701

## Summary

[PR #701](https://github.com/SH11235/rshogi/pull/701) で Workers Free plan 環境で利用可能な唯一の Worker 監視 alertType (\`workers_observability_alert\`) が確定したのを受け、Pulumi で declare して [PR #698](https://github.com/SH11235/rshogi/pull/698) で作成済 alertWebhook (Slack 疎通確認済) に routing する。

これで Phase B の **alert 配信経路が完成** (Worker → Workers Observability rule → NotificationPolicy → webhook → Slack)。具体的な発火条件 (rule) の定義のみ Cloudflare Dashboard UI で user manual。

## 変更ファイル

- \`crates/rshogi-csa-server-workers/wrangler.{production,staging}.toml\` (+38): \`[observability]\` + \`[observability.logs]\` block 追加 (Workers Observability 有効化)
- \`infra/pulumi/index.ts\` (+59/-22): \`workersObservabilityAlert\` NotificationPolicy resource 追加 + 既存 \`logpushFailureAlert\` description に Free plan 注記追加
- \`docs/csa-server/observability.md\` (+65/-22): §1 / §2 / §6 / §6.1 を本 PR の declare 済状態 + bootstrap 手順に更新

## bootstrap (PR merge 後、user manual)

\`\`\`bash
cd infra/pulumi
pulumi stack select staging
pulumi up   # workersObservabilityAlert NotificationPolicy 1 件 create (notificationsEnabled=false なら enabled: false)
pulumi config set notificationsEnabled true
pulumi up   # enabled: true 反映
\`\`\`

production も同手順 (\`pulumi stack select production\` 後)。

その後 Cloudflare Dashboard → Workers & Pages → 該当 Worker → Observability → Alerts で具体的 rule (worker exception burst 等) を定義。詳細は merge 済 \`docs/csa-server/observability.md\` §6.1 参照。

## 推奨初期 rule (個人運用前提)

| Rule 名 | Filter | Threshold | 用途 |
|---|---|---|---|
| \`worker exception burst\` | \`Outcome != "ok"\` (Worker 実行結果分類、HTTP status と無関係) | \`> 5 in 10 minutes\` | panic / throw / CPU 超過等の Worker 失敗多発検知 |
| \`dispatch latency p99 spike\` | (Workers Observability metric: \`WallTimeMs\` p99) | \`p99 > 200ms in 10 minutes\` | レイテンシ劣化検知 |

## Test plan

- [x] Local TypeScript check: \`pnpm exec tsc --noEmit\` (clean)
- [x] Local Codex CLI review 2 round → Approve
- [ ] PR merge 後 staging で \`pulumi up\` → Cloudflare Dashboard で resource 確認 (NotificationPolicy id 取得)
- [ ] \`notificationsEnabled true\` で再 \`pulumi up\` → enabled status 反映確認
- [ ] Cloudflare Dashboard で \`worker exception burst\` rule 1 件作成
- [ ] (検証) staging Worker で意図的に exception を起こす → 5+ 件累積後 5 分以内に Slack channel に Workers Observability alert 着信確認
- [ ] production も同手順

🤖 Generated with [Claude Code](https://claude.com/claude-code)