### PR TITLE
perf(nnue/psqt): Finny Tables (AccCacheEntry) に PSQT accumulator を追加

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -101,10 +101,20 @@ impl<const L1: usize> Default for AccumulatorLayerStacks<L1> {
 /// refresh 時に現在の `PieceList` との slot-wise 比較で差分駒を抽出し、
 /// 差分のみ add/sub でアキュムレータを更新することで、
 /// `append_active_indices` + `sort_unstable` のオーバーヘッドを回避する。
+///
+/// `nnue-psqt` feature 有効時は PSQT アキュムレータも同時にキャッシュし、
+/// 玉移動時の PSQT フル再計算（40 駒 × 9 bucket = 360 i32 加算）を
+/// slot 差分（通常 0〜数 slot）に置き換える。
 #[repr(C, align(64))]
 struct AccCacheEntry<const L1: usize> {
     /// キャッシュされたアキュムレータ値
     accumulation: [i16; L1],
+    /// キャッシュされた PSQT アキュムレータ値
+    ///
+    /// `refresh_or_cache_with_psqt` の `add_psqt_fn` / `sub_psqt_fn` で
+    /// main acc と同一の差分タイミングで更新される。
+    #[cfg(feature = "nnue-psqt")]
+    psqt_accumulation: [i32; NUM_LAYER_STACK_BUCKETS],
     /// キャッシュ時点の `PieceList`（perspective 固有の fb または fw 配列）
     ///
     /// `PieceNumber::NB = 40` 固定長。BonaPiece::ZERO は slot 未使用を表す。
@@ -118,6 +128,8 @@ impl<const L1: usize> AccCacheEntry<L1> {
     fn new_invalid() -> Self {
         Self {
             accumulation: [0; L1],
+            #[cfg(feature = "nnue-psqt")]
+            psqt_accumulation: [0; NUM_LAYER_STACK_BUCKETS],
             piece_list: [BonaPiece::ZERO; PieceNumber::NB],
             valid: false,
         }
@@ -226,6 +238,91 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
 
         // キャッシュを更新
         entry.accumulation.copy_from_slice(accumulation);
+        entry.piece_list.copy_from_slice(piece_list);
+        entry.valid = true;
+    }
+
+    /// PSQT 付きキャッシュ refresh（Stockfish 風 piece_list 差分方式）
+    ///
+    /// main acc と PSQT acc を同一の slot 差分で更新する。各 slot 差分につき
+    /// main FT の add/sub に加えて PSQT の add/sub（9-i32 SIMD）を呼ぶ。
+    /// cache miss 時は両方を biases から full refresh する。
+    ///
+    /// 既存の `refresh_or_cache` と比較して PSQT を Finny Tables に載せる経路:
+    /// 玉移動時の PSQT フル再計算（40 駒 × 9 bucket = 360 i32 加算）を
+    /// slot 差分（通常 0〜数 slot）に置き換える。
+    ///
+    /// # 引数
+    ///
+    /// 上記 `refresh_or_cache` に加えて:
+    /// - `psqt_biases`: PSQT バイアス [NUM_LAYER_STACK_BUCKETS]（実体は通常ゼロ）
+    /// - `psqt_acc`: 更新先の PSQT アキュムレータ
+    /// - `add_psqt_fn`: PSQT 加算関数（9-i32 SIMD: `add_psqt_weights`）
+    /// - `sub_psqt_fn`: PSQT 減算関数（9-i32 SIMD: `sub_psqt_weights`）
+    #[cfg(feature = "nnue-psqt")]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn refresh_or_cache_with_psqt<FI, FA, FS, FAP, FSP>(
+        &mut self,
+        king_sq: Square,
+        perspective: Color,
+        piece_list: &[BonaPiece; PieceNumber::NB],
+        biases: &[i16; L1],
+        psqt_biases: &[i32; NUM_LAYER_STACK_BUCKETS],
+        accumulation: &mut [i16; L1],
+        psqt_acc: &mut [i32; NUM_LAYER_STACK_BUCKETS],
+        idx_fn: FI,
+        add_fn: FA,
+        sub_fn: FS,
+        add_psqt_fn: FAP,
+        sub_psqt_fn: FSP,
+    ) where
+        FI: Fn(BonaPiece) -> usize,
+        FA: Fn(&mut [i16; L1], usize),
+        FS: Fn(&mut [i16; L1], usize),
+        FAP: Fn(&mut [i32; NUM_LAYER_STACK_BUCKETS], usize),
+        FSP: Fn(&mut [i32; NUM_LAYER_STACK_BUCKETS], usize),
+    {
+        let entry = &mut self.entries[king_sq.raw() as usize][perspective as usize];
+
+        if entry.valid {
+            crate::nnue::stats::count_cache_hit!();
+            accumulation.copy_from_slice(&entry.accumulation);
+            *psqt_acc = entry.psqt_accumulation;
+
+            let mut diff_count = 0usize;
+            for (cached_bp, &current_bp) in entry.piece_list.iter().copied().zip(piece_list.iter())
+            {
+                if cached_bp != current_bp {
+                    if cached_bp != BonaPiece::ZERO {
+                        let idx = idx_fn(cached_bp);
+                        sub_fn(accumulation, idx);
+                        sub_psqt_fn(psqt_acc, idx);
+                        diff_count += 1;
+                    }
+                    if current_bp != BonaPiece::ZERO {
+                        let idx = idx_fn(current_bp);
+                        add_fn(accumulation, idx);
+                        add_psqt_fn(psqt_acc, idx);
+                        diff_count += 1;
+                    }
+                }
+            }
+            crate::nnue::stats::count_refresh_diff!(diff_count);
+        } else {
+            crate::nnue::stats::count_cache_miss!();
+            accumulation.copy_from_slice(biases);
+            *psqt_acc = *psqt_biases;
+            for &bp in piece_list.iter() {
+                if bp != BonaPiece::ZERO {
+                    let idx = idx_fn(bp);
+                    add_fn(accumulation, idx);
+                    add_psqt_fn(psqt_acc, idx);
+                }
+            }
+        }
+
+        entry.accumulation.copy_from_slice(accumulation);
+        entry.psqt_accumulation = *psqt_acc;
         entry.piece_list.copy_from_slice(piece_list);
         entry.valid = true;
     }
@@ -881,5 +978,148 @@ mod tests {
         );
         // hit: 15 - 10 = 5
         assert_eq!(acc2[0], 5);
+    }
+
+    /// PSQT 拡張: cold start → main acc / PSQT acc 双方を full refresh で計算
+    #[cfg(feature = "nnue-psqt")]
+    #[test]
+    fn test_psqt_refresh_or_cache_cold_start() {
+        let mut cache = AccumulatorCacheLayerStacks::<TEST_L1>::new();
+        let king_sq = Square::SQ_55;
+        let perspective = Color::Black;
+
+        let biases = [0i16; TEST_L1];
+        let psqt_biases = [0i32; NUM_LAYER_STACK_BUCKETS];
+
+        let mut piece_list = [BonaPiece::ZERO; PieceNumber::NB];
+        piece_list[0] = BonaPiece(5);
+        piece_list[1] = BonaPiece(10);
+
+        let mut acc = [0i16; TEST_L1];
+        let mut psqt_acc = [0i32; NUM_LAYER_STACK_BUCKETS];
+        cache.refresh_or_cache_with_psqt(
+            king_sq,
+            perspective,
+            &piece_list,
+            &biases,
+            &psqt_biases,
+            &mut acc,
+            &mut psqt_acc,
+            |bp| bp.0 as usize,
+            |a, idx| a[0] = a[0].wrapping_add(idx as i16),
+            |a, idx| a[0] = a[0].wrapping_sub(idx as i16),
+            |p, idx| {
+                // bucket b に対し idx + b を加える（bucket ごとに区別できる値）
+                for (b, v) in p.iter_mut().enumerate() {
+                    *v = v.wrapping_add(idx as i32 + b as i32);
+                }
+            },
+            |p, idx| {
+                for (b, v) in p.iter_mut().enumerate() {
+                    *v = v.wrapping_sub(idx as i32 + b as i32);
+                }
+            },
+        );
+
+        assert_eq!(acc[0], 15);
+        // bucket b: (5+b) + (10+b) = 15 + 2*b
+        for (b, v) in psqt_acc.iter().enumerate() {
+            assert_eq!(*v, 15 + 2 * b as i32, "bucket {b}");
+        }
+
+        let entry = &cache.entries[king_sq.raw() as usize][perspective as usize];
+        assert!(entry.valid);
+        assert_eq!(entry.psqt_accumulation, psqt_acc);
+    }
+
+    /// PSQT 拡張: 2 回目のキャッシュヒット時に PSQT も差分で更新される
+    #[cfg(feature = "nnue-psqt")]
+    #[test]
+    fn test_psqt_refresh_or_cache_hit_updates_psqt() {
+        let mut cache = AccumulatorCacheLayerStacks::<TEST_L1>::new();
+        let king_sq = Square::SQ_55;
+        let perspective = Color::Black;
+        let biases = [0i16; TEST_L1];
+        let psqt_biases = [0i32; NUM_LAYER_STACK_BUCKETS];
+
+        let add_main = |a: &mut [i16; TEST_L1], idx: usize| {
+            a[0] = a[0].wrapping_add(idx as i16);
+        };
+        let sub_main = |a: &mut [i16; TEST_L1], idx: usize| {
+            a[0] = a[0].wrapping_sub(idx as i16);
+        };
+        let add_psqt = |p: &mut [i32; NUM_LAYER_STACK_BUCKETS], idx: usize| {
+            for (b, v) in p.iter_mut().enumerate() {
+                *v = v.wrapping_add(idx as i32 + b as i32);
+            }
+        };
+        let sub_psqt = |p: &mut [i32; NUM_LAYER_STACK_BUCKETS], idx: usize| {
+            for (b, v) in p.iter_mut().enumerate() {
+                *v = v.wrapping_sub(idx as i32 + b as i32);
+            }
+        };
+
+        // 1 回目: slot 0-2 = [5, 10, 15]
+        let mut pl1 = [BonaPiece::ZERO; PieceNumber::NB];
+        pl1[0] = BonaPiece(5);
+        pl1[1] = BonaPiece(10);
+        pl1[2] = BonaPiece(15);
+        let mut acc1 = [0i16; TEST_L1];
+        let mut psqt1 = [0i32; NUM_LAYER_STACK_BUCKETS];
+        cache.refresh_or_cache_with_psqt(
+            king_sq,
+            perspective,
+            &pl1,
+            &biases,
+            &psqt_biases,
+            &mut acc1,
+            &mut psqt1,
+            |bp| bp.0 as usize,
+            add_main,
+            sub_main,
+            add_psqt,
+            sub_psqt,
+        );
+
+        // 2 回目: slot 2 の 15 → 20 に変化
+        let mut pl2 = pl1;
+        pl2[2] = BonaPiece(20);
+        let mut acc2 = [0i16; TEST_L1];
+        let mut psqt2 = [0i32; NUM_LAYER_STACK_BUCKETS];
+        cache.refresh_or_cache_with_psqt(
+            king_sq,
+            perspective,
+            &pl2,
+            &biases,
+            &psqt_biases,
+            &mut acc2,
+            &mut psqt2,
+            |bp| bp.0 as usize,
+            add_main,
+            sub_main,
+            add_psqt,
+            sub_psqt,
+        );
+
+        // cache hit 経由の結果が full refresh と完全一致することを確認
+        let mut cache2 = AccumulatorCacheLayerStacks::<TEST_L1>::new();
+        let mut acc_full = [0i16; TEST_L1];
+        let mut psqt_full = [0i32; NUM_LAYER_STACK_BUCKETS];
+        cache2.refresh_or_cache_with_psqt(
+            king_sq,
+            perspective,
+            &pl2,
+            &biases,
+            &psqt_biases,
+            &mut acc_full,
+            &mut psqt_full,
+            |bp| bp.0 as usize,
+            add_main,
+            sub_main,
+            add_psqt,
+            sub_psqt,
+        );
+        assert_eq!(acc2, acc_full, "main acc: cache hit vs full refresh");
+        assert_eq!(psqt2, psqt_full, "psqt acc: cache hit vs full refresh");
     }
 }

--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -113,6 +113,12 @@ struct AccCacheEntry<const L1: usize> {
     ///
     /// `refresh_or_cache_with_psqt` の `add_psqt_fn` / `sub_psqt_fn` で
     /// main acc と同一の差分タイミングで更新される。
+    ///
+    /// メモリフットプリント: `nnue-psqt` 有効時、各エントリは
+    /// `accumulation (2 × L1 bytes)` + `psqt_accumulation (36 bytes)` +
+    /// `piece_list (40 × 2 bytes)` + `valid (1 byte)` で構成され、64-byte
+    /// 境界にアライメントされる。L1=1536 で約 3,188 bytes + パディング。
+    /// `Square::NUM = 81` × 2 perspective = 162 エントリ ≈ 520 KB。
     #[cfg(feature = "nnue-psqt")]
     psqt_accumulation: [i32; NUM_LAYER_STACK_BUCKETS],
     /// キャッシュ時点の `PieceList`（perspective 固有の fb または fw 配列）
@@ -255,10 +261,20 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
     /// # 引数
     ///
     /// 上記 `refresh_or_cache` に加えて:
-    /// - `psqt_biases`: PSQT バイアス [NUM_LAYER_STACK_BUCKETS]（実体は通常ゼロ）
+    /// - `psqt_biases`: PSQT バイアス [NUM_LAYER_STACK_BUCKETS]（実体は対称差設計で常にゼロ、
+    ///   ただし cache hit 時は参照せず `entry.psqt_accumulation` を直接ロードする）
     /// - `psqt_acc`: 更新先の PSQT アキュムレータ
     /// - `add_psqt_fn`: PSQT 加算関数（9-i32 SIMD: `add_psqt_weights`）
     /// - `sub_psqt_fn`: PSQT 減算関数（9-i32 SIMD: `sub_psqt_weights`）
+    ///
+    /// # 引数数について
+    ///
+    /// 引数 11 個（うちクロージャ 5 つ）+ `#[allow(clippy::too_many_arguments)]`
+    /// 指定。構造体で束ねる選択肢もあるが、ホットパス（per-do_move 呼び出し）で
+    /// クロージャを呼び出すため **モノモルフィズム + インライン展開が必須**。
+    /// generic Fn パラメータの直接渡しが現状最も高速で、構造体経由（特に
+    /// `Box<dyn Fn>` での動的 dispatch）は NPS 退行のリスクがある。
+    /// 可読性は犠牲になるが性能優先の設計。
     #[cfg(feature = "nnue-psqt")]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn refresh_or_cache_with_psqt<FI, FA, FS, FAP, FSP>(

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -851,15 +851,26 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
 
             if reset {
                 count_refresh!();
-                // 玉が移動した場合はキャッシュ経由で refresh
-                self.refresh_perspective_with_cache(pos, perspective, acc.get_mut(p), cache);
-
-                // PSQT はキャッシュ非対象なのでフル再計算
+                // 玉が移動した場合はキャッシュ経由で refresh。
+                // PSQT も Finny Tables (AccCacheEntry) 経由で差分更新する。
                 #[cfg(feature = "nnue-psqt")]
-                if self.has_psqt {
-                    let mut active_indices = IndexList::new();
-                    append_active_indices(pos, perspective, &mut active_indices);
-                    self.refresh_psqt(&active_indices, &mut acc.psqt_accumulation[p]);
+                {
+                    // 同一 struct の異なるフィールドへの可変参照を同時に渡す。
+                    // accumulation: [..; 2] と psqt_accumulation: [..; 2] は別フィールドなので
+                    // 可変借用は競合しない。
+                    let main_acc = &mut acc.accumulation[p];
+                    let psqt_acc_slot = &mut acc.psqt_accumulation[p];
+                    self.refresh_perspective_with_cache(
+                        pos,
+                        perspective,
+                        main_acc,
+                        psqt_acc_slot,
+                        cache,
+                    );
+                }
+                #[cfg(not(feature = "nnue-psqt"))]
+                {
+                    self.refresh_perspective_with_cache(pos, perspective, acc.get_mut(p), cache);
                 }
             } else {
                 count_update!();
@@ -977,14 +988,22 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
         for perspective in [Color::Black, Color::White] {
             count_refresh!();
             let p = perspective as usize;
-            self.refresh_perspective_with_cache(pos, perspective, acc.get_mut(p), cache);
-
-            // PSQT はキャッシュ非対象なのでフル再計算
+            // PSQT も Finny Tables (AccCacheEntry) 経由で差分更新する。
             #[cfg(feature = "nnue-psqt")]
-            if self.has_psqt {
-                let mut active_indices = IndexList::new();
-                append_active_indices(pos, perspective, &mut active_indices);
-                self.refresh_psqt(&active_indices, &mut acc.psqt_accumulation[p]);
+            {
+                let main_acc = &mut acc.accumulation[p];
+                let psqt_acc_slot = &mut acc.psqt_accumulation[p];
+                self.refresh_perspective_with_cache(
+                    pos,
+                    perspective,
+                    main_acc,
+                    psqt_acc_slot,
+                    cache,
+                );
+            }
+            #[cfg(not(feature = "nnue-psqt"))]
+            {
+                self.refresh_perspective_with_cache(pos, perspective, acc.get_mut(p), cache);
             }
 
             // Threat はキャッシュ非対象なのでフル再計算
@@ -1008,11 +1027,16 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     /// 現在の `PieceList` を直接 cache に渡し、cache 内で slot-wise 差分
     /// を取って add/sub を適用する。`append_active_indices` + `sort_unstable`
     /// のオーバーヘッドを回避する。
+    ///
+    /// `nnue-psqt` 有効かつ `has_psqt == true` の場合は PSQT acc も
+    /// 同時に cache 経由で差分更新する（Finny Tables に PSQT を載せる経路）。
+    #[allow(clippy::too_many_arguments)]
     fn refresh_perspective_with_cache(
         &self,
         pos: &Position,
         perspective: Color,
         accumulation: &mut [i16; L1],
+        #[cfg(feature = "nnue-psqt")] psqt_acc: &mut [i32; NUM_LAYER_STACK_BUCKETS],
         cache: &mut AccumulatorCacheLayerStacks<L1>,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -1024,6 +1048,25 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
         } else {
             pos.piece_list().piece_list_fw()
         };
+
+        #[cfg(feature = "nnue-psqt")]
+        if self.has_psqt {
+            cache.refresh_or_cache_with_psqt(
+                king_sq,
+                perspective,
+                piece_list,
+                &self.biases.0,
+                &self.psqt_biases,
+                accumulation,
+                psqt_acc,
+                move |bp| halfka_index(kb, pack_bonapiece(bp, hm)),
+                |acc, idx| self.add_weights(acc, idx),
+                |acc, idx| self.sub_weights(acc, idx),
+                |pacc, idx| self.add_psqt_weights(pacc, idx),
+                |pacc, idx| self.sub_psqt_weights(pacc, idx),
+            );
+            return;
+        }
 
         cache.refresh_or_cache(
             king_sq,

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -1030,6 +1030,13 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     ///
     /// `nnue-psqt` 有効かつ `has_psqt == true` の場合は PSQT acc も
     /// 同時に cache 経由で差分更新する（Finny Tables に PSQT を載せる経路）。
+    /// `has_psqt == false` のときは `psqt_acc` 引数は渡されるが参照されず、
+    /// 既存の `cache.refresh_or_cache()` パスにフォールスルーする。
+    ///
+    /// **シグネチャ注記**: `nnue-psqt` feature 有効時のみ `psqt_acc` 引数が
+    /// 追加される（`#[cfg(feature = "nnue-psqt")]` 付き）。Rust の有効な
+    /// cfg-gated parameter パターンだが、呼び出し側も同様の cfg ブロックで
+    /// 括る必要がある。
     #[allow(clippy::too_many_arguments)]
     fn refresh_perspective_with_cache(
         &self,


### PR DESCRIPTION
## 概要

玉移動時の PSQT フル再計算（40 駒 × 9 bucket = 360 i32 加算）を
main accumulator と同じく Finny Tables (`AccCacheEntry`) 経由の
slot-wise 差分更新に置き換える。

Refs: #433

## 変更点

- `AccCacheEntry<L1>` に `#[cfg(feature = \"nnue-psqt\")] psqt_accumulation: [i32; NUM_LAYER_STACK_BUCKETS]` を追加
- `AccumulatorCacheLayerStacks::refresh_or_cache_with_psqt` を新設：
  main acc と PSQT acc を同一の slot 差分で同時に add/sub（cache miss 時は両方 full refresh）
- `feature_transformer_layer_stacks::refresh_perspective_with_cache` で `has_psqt` 時に新 API を呼び出し
- `update_accumulator_with_cache` / `refresh_accumulator_with_cache` の reset 経路から
  従来の余分な PSQT フル再計算 (`append_active_indices` + `refresh_psqt`) を削除
- 既存 PSQT 9-i32 SIMD (`psqt_add_or_sub`, PR #687 でマージ) をそのまま再利用

非 PSQT ビルド（`layerstack-only,nnue-progress-diff`）は cfg gate で従来挙動を保持。

## 計測

production profile, target-cpu=native, hash 256MB, 20 局面 × ABBA × 5sec
（並走 SPRT/学習プロセスありの環境のため wall-time NPS は変動しうる。
判断指標は cycles/node の改善で行う）

| 指標 | baseline | candidate | delta |
|---|---|---|---|
| cycles/node | 8475.4 | 8332.5 | **-1.69%** |
| instructions/node | 13536.8 | 13336.8 | **-1.48%** |
| NPS | 483674 | 490632 | +1.44% |

baseline: `rshogi-usi-1536x16x32-psqt-v100v101cmp-simd` (PR #687 マージ後、PSQT 9-i32 SIMD のみ)
candidate: 本 PR のビルド

cycles/node -1.69% は採用閾値 (>= -1.0%) を超えており、評価値 bit-exact 一致のため採用候補。

## 評価値 bit-exact 確認

5 局面で `go nodes 500000` 実行し、baseline / candidate の score / nodes / pv を
全 depth で比較:

- 5/5 局面で bestmove 一致
- 共通 depth 1..max まで `info depth` 行（time/nps/hashfull を除く）が **完全一致**

検証局面:
1. `position startpos` (max depth 20)
2. `position sfen +Bn1g2s1l/2skg2r1/...` (max depth 18, 玉露出局面)
3. `position startpos moves 7g7f` (max depth 21)
4. `position sfen 4r4/3sk1g2/...` (max depth 18, 駒得局面)
5. `position sfen 1n1gk2nl/1r3sg2/...` (max depth 18, 中盤)

## テスト

```
cargo test -p rshogi-core --features layerstack-only,nnue-psqt,nnue-progress-diff --release psqt
```

- `test_psqt_refresh_matches_incremental` ✓ (既存)
- `test_psqt_known_values` ✓ (既存)
- `test_psqt_refresh_or_cache_cold_start` ✓ (新規)
- `test_psqt_refresh_or_cache_hit_updates_psqt` ✓ (新規, cache hit 差分 vs full refresh の bit-exact 確認)

全体 765 tests pass、clippy 警告なし。

## Test plan

- [x] cargo fmt / clippy
- [x] cargo test (PSQT 有効 / 無効 両方)
- [x] 評価値 bit-exact 確認 (5 局面 × `go nodes 500000`)
- [x] cycles/node 計測 (20 局面 × ABBA × 5sec)
- [ ] SPRT 棋力検証 (オプション。bit-exact のため不要だが念のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)