### PR TITLE
chore(csa-server): cron trigger を 2→1 に統合

### DIFF
--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -121,34 +121,51 @@ pub async fn fetch(
     router::handle_fetch(req, env).await
 }
 
-/// Backfill + sweep を両方走らせる cron 文字列 (毎時 0 分)。
+/// `[event(scheduled)]` ハンドラ (`scheduled`) を起動する単一 cron 文字列。
 ///
-/// `wrangler.{production,staging,toml.example}.toml` の `[triggers] crons` 配列
-/// 第 1 要素と一致させる。`scheduled` ハンドラは `event.cron()` の文字列マッチで
-/// backfill 実行可否を分岐するため、wrangler 側の表記を変える場合は本定数も
-/// 同期更新する (`tests/wrangler_environment_toml_consistency.rs` /
-/// `wrangler_template_consistency.rs` で gate)。
-pub const BACKFILL_CRON: &str = "0 * * * *";
+/// 0 / 15 / 30 / 45 分の 4 回発火する。`wrangler.{production,staging,toml.example}.toml`
+/// の `[triggers] crons` 配列と一致させる (`tests/wrangler_environment_toml_consistency.rs`
+/// / `wrangler_template_consistency.rs` で gate)。
+///
+/// 以前は backfill 用 (`0 * * * *`) と sweep-only 用 (`15,30,45 * * * *`) の 2 cron に
+/// 分けていたが、Cloudflare の account あたり cron trigger 上限 (5) に収めるため 1 cron に
+/// 統合した。発火時刻の分は `event.schedule()` から求め、[`BACKFILL_MINUTE`] のときだけ
+/// backfill を実行する。
+pub const SCHEDULED_CRON: &str = "0,15,30,45 * * * *";
 
-/// Sweep のみ走らせる cron 文字列 (15 / 30 / 45 分)。
+/// backfill (`run_games_index_backfill`) を実行する分 (0-59)。
 ///
-/// https://github.com/SH11235/rshogi/issues/629 で導入した orphan sweep 高頻度化用。`try_delete_live_games_index`
-/// が R2 transient で失敗した場合の復旧遅延を 1 時間 → 15 分に短縮する目的で、
-/// 本 cron では backfill (Class A put 増) を走らせず sweep のみ実行する。
-pub const SWEEP_ONLY_CRON: &str = "15,30,45 * * * *";
+/// [`SCHEDULED_CRON`] の 4 発火のうち、スケジュール時刻の「時の何分か」がこの値に一致する
+/// 発火でのみ backfill + sweep を行う。それ以外の発火は sweep のみ。
+pub const BACKFILL_MINUTE: i64 = 0;
+
+/// epoch ミリ秒から「時の何分か」(0-59) を求める純粋関数。
+///
+/// [`scheduled`] が単一 cron [`SCHEDULED_CRON`] の発火 (0/15/30/45 分) を
+/// `event.schedule()` の値で区別するために使う。`event.schedule()` は f64 を
+/// 返すが、現在の epoch ミリ秒 (~1.7e12) は f64 仮数部 (53bit ≈ 9e15) に収まり
+/// 整数部に精度劣化はない。`scheduled` 本体は wasm32 限定のため host target からは
+/// テスト経由でのみ到達する → `backfill` 等と同じく wasm32 + test ゲートする。
+#[cfg(any(target_arch = "wasm32", test))]
+fn minute_of_hour(epoch_ms: f64) -> i64 {
+    // 60_000 ミリ秒で割って 60 で剰余を取る。epoch は常に非負なので剰余も 0-59。
+    (epoch_ms / 60_000.0) as i64 % 60
+}
 
 /// Workers ランタイムの scheduled イベント (cron trigger)。
 ///
-/// `wrangler.toml` の `[triggers] crons` で 2 つの cron を登録している
-/// (https://github.com/SH11235/rshogi/issues/551 / https://github.com/SH11235/rshogi/issues/629):
+/// `wrangler.toml` の `[triggers] crons` で単一 cron [`SCHEDULED_CRON`]
+/// (`0,15,30,45 * * * *`) を登録しており、0 / 15 / 30 / 45 分の 4 回発火する。
+/// 単一 cron なので `event.cron()` は 4 発火すべてで同じ文字列を返す。発火の
+/// 区別は [`minute_of_hour`] に `event.schedule()` を渡して「時の何分か」を求めて
+/// 行う。`event.schedule()` は cron の予定時刻 (実起動時刻ではない) の epoch
+/// ミリ秒なので、起動が数秒遅延しても分判定は予定どおり安定する:
 ///
-/// - [`BACKFILL_CRON`] (`0 * * * *`): `run_games_index_backfill` →
-///   `run_live_orphan_sweep` を順次実行する (= 既存挙動)。
-/// - [`SWEEP_ONLY_CRON`] (`15,30,45 * * * *`): `run_live_orphan_sweep` のみ。
-///   delete best-effort 失敗時の復旧遅延を 15 分以内に詰めるための高頻度経路。
-///
-/// `event.cron()` 文字列で分岐し、未知の cron 文字列に対しては安全側に倒して
-/// 既存挙動 (backfill + sweep) と等価動作する (= 設定変更時の暫定挙動を保証)。
+/// - 分が [`BACKFILL_MINUTE`] (0 分) のとき: `run_games_index_backfill` →
+///   `run_live_orphan_sweep` を順次実行する。
+/// - それ以外 (15 / 30 / 45 分) のとき: `run_live_orphan_sweep` のみ。
+///   delete best-effort 失敗時の復旧遅延を 15 分以内に詰めるための高頻度経路
+///   (https://github.com/SH11235/rshogi/issues/629)。
 ///
 /// 各ジョブは内部的に best-effort で失敗を握り潰し `Result::Ok` で返すため、
 /// scheduled handler 側ではさらに伝播禁止 (cron の継続可用性を最優先する) で
@@ -162,9 +179,9 @@ pub async fn scheduled(
     _ctx: worker::ScheduleContext,
 ) {
     let cron = event.cron();
-    // SWEEP_ONLY_CRON では backfill を skip。それ以外は既存挙動 (backfill +
-    // sweep) を保つ。未知 cron 文字列は安全側 = 全部走らせる。
-    let run_backfill = cron != SWEEP_ONLY_CRON;
+    // 単一 cron のため発火の区別は cron 文字列でなくスケジュール時刻の分で行う。
+    let minute = minute_of_hour(event.schedule());
+    let run_backfill = minute == BACKFILL_MINUTE;
 
     if run_backfill {
         if let Err(e) = backfill::run_games_index_backfill(&env).await {
@@ -191,19 +208,59 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cron_constants_are_distinct() {
-        // 同一文字列に揃えると `event.cron()` 分岐が崩れる (sweep-only cron で
-        // backfill が走る、または backfill cron で sweep がスキップされる)。
-        assert_ne!(BACKFILL_CRON, SWEEP_ONLY_CRON);
+    fn scheduled_cron_has_5_fields() {
+        // Cloudflare Workers cron expression は 5 field (minute hour dom month dow)。
+        let fields: Vec<&str> = SCHEDULED_CRON.split_whitespace().collect();
+        assert_eq!(fields.len(), 5, "cron expression must have 5 fields, got {SCHEDULED_CRON:?}");
     }
 
     #[test]
-    fn cron_constants_have_5_fields() {
-        // Cloudflare Workers cron expression は 5 field (minute hour dom month dow)。
-        // 6 field (秒つき) や 7 field (年つき) は受け付けないため、定数側で固定。
-        for cron in [BACKFILL_CRON, SWEEP_ONLY_CRON] {
-            let fields: Vec<&str> = cron.split_whitespace().collect();
-            assert_eq!(fields.len(), 5, "cron expression must have 5 fields, got {cron:?}");
-        }
+    fn scheduled_cron_minute_field_contains_backfill_minute() {
+        // SCHEDULED_CRON の分フィールドに BACKFILL_MINUTE が含まれないと backfill が
+        // 永久に発火しない。分フィールドがカンマ区切りリスト形式 (`"0,15,30,45"`)
+        // であることを前提とする (range `"0-59"` / step `"*/15"` 記法は
+        // SCHEDULED_CRON では未使用なので考慮しない)。
+        let minute_field = SCHEDULED_CRON.split_whitespace().next().expect("cron must have fields");
+        let minutes: Vec<&str> = minute_field.split(',').collect();
+        assert!(
+            minutes.contains(&BACKFILL_MINUTE.to_string().as_str()),
+            "SCHEDULED_CRON minute field {minute_field:?} must include BACKFILL_MINUTE ({BACKFILL_MINUTE})",
+        );
+    }
+
+    #[test]
+    fn minute_of_hour_maps_epoch_ms_to_minute() {
+        // 0/15/30/45 分の各発火がそのまま分に落ちる。
+        assert_eq!(minute_of_hour(0.0), 0);
+        assert_eq!(minute_of_hour(900_000.0), 15);
+        assert_eq!(minute_of_hour(1_800_000.0), 30);
+        assert_eq!(minute_of_hour(2_700_000.0), 45);
+        // 1 時間ちょうど (3_600_000 ms) は剰余で 0 分に巻き戻る。
+        assert_eq!(minute_of_hour(3_600_000.0), 0);
+        assert_eq!(minute_of_hour(4_500_000.0), 15);
+    }
+
+    #[test]
+    fn minute_of_hour_truncates_sub_minute_delay() {
+        // cron 予定時刻からの起動遅延 (< 60s) は整数切り捨てで吸収され、
+        // 予定分に丸められる。45s 遅れた 0 分発火は 0 分、30s 遅れた 15 分発火は
+        // 15 分のまま。
+        assert_eq!(minute_of_hour(45_000.0), 0);
+        assert_eq!(minute_of_hour(900_000.0 + 30_000.0), 15);
+    }
+
+    #[test]
+    fn minute_of_hour_handles_current_epoch_scale() {
+        // 現在スケール (~1.7e12 ms) の epoch でも 0/15/30/45 分が正しく落ち、
+        // f64 仮数部の精度劣化が無いことを確認する。
+        // base = 2026-01-01T00:00:00Z = 1_767_225_600_000 ms (60_000 の倍数)。
+        let base = 1_767_225_600_000.0_f64;
+        assert_eq!(minute_of_hour(base), 0);
+        assert_eq!(minute_of_hour(base + 900_000.0), 15);
+        assert_eq!(minute_of_hour(base + 1_800_000.0), 30);
+        assert_eq!(minute_of_hour(base + 2_700_000.0), 45);
+        // 分境界の前後: :00:00.001 と :00:59.999 はどちらも 0 分に落ちる。
+        assert_eq!(minute_of_hour(base + 1.0), 0);
+        assert_eq!(minute_of_hour(base + 59_999.0), 0);
     }
 }

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -202,30 +202,24 @@ fn assert_no_runtime_injected_keys(env: &EnvironmentBindings) {
     );
 }
 
-/// https://github.com/SH11235/rshogi/issues/551 で追加した `[triggers] crons` が各 deploy 環境に宣言されていることを
-/// 固定する。`[event(scheduled)]` ハンドラは production / staging 両方で稼働させる
-/// 契約 (片方だけ宣言だと backfill / orphan sweep が動かず orphan が滞留する)。
+/// `[triggers] crons` が各 deploy 環境に宣言されていることを固定する。
+/// `[event(scheduled)]` ハンドラは production / staging 両方で稼働させる契約
+/// (片方だけ宣言だと backfill / orphan sweep が動かず orphan が滞留する)。
 ///
-/// https://github.com/SH11235/rshogi/issues/629 で cron を 1 → 2 に増やした (sweep のみ 15 分間隔)。両 cron が
-/// 必ず宣言されていること、かつ `lib.rs::BACKFILL_CRON` /
-/// `lib.rs::SWEEP_ONLY_CRON` 定数と文字列が一致していることを assert する
-/// (定数を変更したのに wrangler 側を更新し忘れる事故を防ぐ)。
-fn assert_declares_backfill_cron_trigger(env: &EnvironmentBindings) {
-    assert!(
-        env.crons.contains(&rshogi_csa_server_workers::BACKFILL_CRON.to_owned()),
-        "{file} ({label}) [triggers] crons must contain BACKFILL_CRON ({backfill:?}); got: {crons:?}",
+/// backfill 用と sweep-only 用の 2 cron は Cloudflare の account あたり cron
+/// trigger 上限 (5) に収めるため単一 cron に統合済み。`[triggers] crons` が
+/// **ちょうど `[SCHEDULED_CRON]` 1 件** であることを assert する。`contains`
+/// ではなく完全一致にするのは、旧 cron (`0 * * * *` 等) が残留して 2 件のままだと
+/// 統合の目的 (cron 数削減) が達成されず account 上限超過が再発するため。
+fn assert_declares_scheduled_cron_trigger(env: &EnvironmentBindings) {
+    assert_eq!(
+        env.crons,
+        vec![rshogi_csa_server_workers::SCHEDULED_CRON.to_owned()],
+        "{file} ({label}) [triggers] crons must be exactly [SCHEDULED_CRON] ({scheduled:?}); \
+         旧 cron が残ると account cron 上限超過が再発する。got: {crons:?}",
         file = env.file_name,
         label = env.label,
-        backfill = rshogi_csa_server_workers::BACKFILL_CRON,
-        crons = env.crons,
-    );
-    assert!(
-        env.crons.contains(&rshogi_csa_server_workers::SWEEP_ONLY_CRON.to_owned()),
-        "{file} ({label}) [triggers] crons must contain SWEEP_ONLY_CRON ({sweep:?}) for orphan sweep \
-         high-frequency path (https://github.com/SH11235/rshogi/issues/629); got: {crons:?}",
-        file = env.file_name,
-        label = env.label,
-        sweep = rshogi_csa_server_workers::SWEEP_ONLY_CRON,
+        scheduled = rshogi_csa_server_workers::SCHEDULED_CRON,
         crons = env.crons,
     );
 }
@@ -377,8 +371,8 @@ fn wrangler_production_declares_sqlite_migration_for_game_room() {
 }
 
 #[test]
-fn wrangler_production_declares_backfill_cron_trigger() {
-    assert_declares_backfill_cron_trigger(&PRODUCTION);
+fn wrangler_production_declares_scheduled_cron_trigger() {
+    assert_declares_scheduled_cron_trigger(&PRODUCTION);
 }
 
 // --- staging -------------------------------------------------------------
@@ -414,8 +408,8 @@ fn wrangler_staging_declares_sqlite_migration_for_game_room() {
 }
 
 #[test]
-fn wrangler_staging_declares_backfill_cron_trigger() {
-    assert_declares_backfill_cron_trigger(&STAGING);
+fn wrangler_staging_declares_scheduled_cron_trigger() {
+    assert_declares_scheduled_cron_trigger(&STAGING);
 }
 
 #[test]

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -161,27 +161,22 @@ fn wrangler_template_vars_keys_match_config_keys() {
     assert_bidirectional("vars_keys", &expected, &TEMPLATE.vars_keys);
 }
 
-/// https://github.com/SH11235/rshogi/issues/551 で追加した `[triggers] crons` が template に宣言されていることを
-/// 固定する。`[event(scheduled)]` ハンドラと cron trigger は同 PR で導入したので、
-/// 片方だけが残ったまま運用者が `cp wrangler.toml.example wrangler.toml` した場合
-/// に handler が永久 dormant にならないよう、template 側で必須化する。
+/// `[triggers] crons` が template に宣言されていることを固定する。
+/// `[event(scheduled)]` ハンドラと cron trigger は同 PR で導入したので、片方
+/// だけが残ったまま運用者が `cp wrangler.toml.example wrangler.toml` した場合に
+/// handler が永久 dormant にならないよう、template 側で必須化する。
 ///
-/// https://github.com/SH11235/rshogi/issues/629 で sweep のみ高頻度 (15 分間隔) cron を追加したため、両 cron が
-/// 必ず宣言されていること、かつ `lib.rs::BACKFILL_CRON` /
-/// `lib.rs::SWEEP_ONLY_CRON` 定数と文字列が一致していることを assert する。
+/// backfill 用と sweep-only 用の 2 cron は Cloudflare の account あたり cron
+/// trigger 上限 (5) に収めるため単一 cron に統合済み。`[triggers] crons` が
+/// **ちょうど `[SCHEDULED_CRON]` 1 件** であることを assert する (旧 cron 残留を
+/// 検知するため `contains` ではなく完全一致)。
 #[test]
-fn wrangler_template_declares_backfill_cron_trigger() {
-    assert!(
-        TEMPLATE.crons.contains(&rshogi_csa_server_workers::BACKFILL_CRON.to_owned()),
-        "wrangler.toml.example [triggers] crons must contain BACKFILL_CRON ({backfill:?}); got: {crons:?}",
-        backfill = rshogi_csa_server_workers::BACKFILL_CRON,
-        crons = TEMPLATE.crons,
-    );
-    assert!(
-        TEMPLATE.crons.contains(&rshogi_csa_server_workers::SWEEP_ONLY_CRON.to_owned()),
-        "wrangler.toml.example [triggers] crons must contain SWEEP_ONLY_CRON ({sweep:?}) for orphan sweep \
-         high-frequency path (https://github.com/SH11235/rshogi/issues/629); got: {crons:?}",
-        sweep = rshogi_csa_server_workers::SWEEP_ONLY_CRON,
+fn wrangler_template_declares_scheduled_cron_trigger() {
+    assert_eq!(
+        TEMPLATE.crons,
+        vec![rshogi_csa_server_workers::SCHEDULED_CRON.to_owned()],
+        "wrangler.toml.example [triggers] crons must be exactly [SCHEDULED_CRON] ({scheduled:?}); got: {crons:?}",
+        scheduled = rshogi_csa_server_workers::SCHEDULED_CRON,
         crons = TEMPLATE.crons,
     );
 }

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -125,24 +125,30 @@ binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-prod"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
-# (https://github.com/SH11235/rshogi/issues/629 で 1 → 2 に分離)。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を単一 cron で起動する。
+# Cloudflare の account あたり cron trigger 上限 (5) に収めるため、以前の
+# backfill 用 (`0 * * * *`) と sweep-only 用 (`15,30,45 * * * *`) の 2 cron を
+# 1 cron に統合した。
 #
-# - `0 * * * *` (毎時 0 分):
+# 単一 cron `0,15,30,45 * * * *` は 0 / 15 / 30 / 45 分の 4 回発火する:
+#
+# - 0 分:
 #   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-#   `live-games-index/` の orphan を掃除する (https://github.com/SH11235/rshogi/issues/551)。backfill は 1 run =
-#   1 page (1000 件) のみ。
-# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan を掃除する。backfill は 1 run = 1 page
+#   (1000 件) のみ。
+# - 15 / 30 / 45 分:
 #   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
 #   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
-#   sweep のみ高頻度化する (https://github.com/SH11235/rshogi/issues/629)。sweep は 1 cron 内で pagination
-#   loop し、cron 30s 制限内で複数 page を処理する。
+#   sweep のみ高頻度化する。sweep は 1 cron 内で pagination loop し、
+#   cron 30s 制限内で複数 page を処理する。
 #
-# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
-# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
-# 定数も同期更新すること (wrangler test が違反を検知する)。
+# 単一 cron なので発火の区別は cron 文字列でできない。`lib.rs::scheduled` が
+# `event.schedule()` 由来の「時の何分か」を見て分岐する。cron 文字列を変更する
+# 場合は `lib.rs` の `SCHEDULED_CRON` 定数も同期更新すること (wrangler test が
+# 違反を検知する)。分フィールドには必ず `BACKFILL_MINUTE` (0) を含めること —
+# 0 分を外すと backfill が無音で永久停止する (sweep は全発火で走る)。
 [triggers]
-crons = ["0 * * * *", "15,30,45 * * * *"]
+crons = ["0,15,30,45 * * * *"]
 
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、本番 client URL に応じて運用者が更新する。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -113,24 +113,30 @@ binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-staging"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
-# (https://github.com/SH11235/rshogi/issues/629 で 1 → 2 に分離)。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を単一 cron で起動する。
+# Cloudflare の account あたり cron trigger 上限 (5) に収めるため、以前の
+# backfill 用 (`0 * * * *`) と sweep-only 用 (`15,30,45 * * * *`) の 2 cron を
+# 1 cron に統合した。
 #
-# - `0 * * * *` (毎時 0 分):
+# 単一 cron `0,15,30,45 * * * *` は 0 / 15 / 30 / 45 分の 4 回発火する:
+#
+# - 0 分:
 #   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-#   `live-games-index/` の orphan を掃除する (https://github.com/SH11235/rshogi/issues/551)。backfill は 1 run =
-#   1 page (1000 件) のみ。
-# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan を掃除する。backfill は 1 run = 1 page
+#   (1000 件) のみ。
+# - 15 / 30 / 45 分:
 #   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
 #   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
-#   sweep のみ高頻度化する (https://github.com/SH11235/rshogi/issues/629)。sweep は 1 cron 内で pagination
-#   loop し、cron 30s 制限内で複数 page を処理する。
+#   sweep のみ高頻度化する。sweep は 1 cron 内で pagination loop し、
+#   cron 30s 制限内で複数 page を処理する。
 #
-# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
-# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
-# 定数も同期更新すること (wrangler test が違反を検知する)。
+# 単一 cron なので発火の区別は cron 文字列でできない。`lib.rs::scheduled` が
+# `event.schedule()` 由来の「時の何分か」を見て分岐する。cron 文字列を変更する
+# 場合は `lib.rs` の `SCHEDULED_CRON` 定数も同期更新すること (wrangler test が
+# 違反を検知する)。分フィールドには必ず `BACKFILL_MINUTE` (0) を含めること —
+# 0 分を外すと backfill が無音で永久停止する (sweep は全発火で走る)。
 [triggers]
-crons = ["0 * * * *", "15,30,45 * * * *"]
+crons = ["0,15,30,45 * * * *"]
 
 # --- 環境変数 ---
 # `[vars]` の値は機密でないが、staging client の Origin に応じて運用者が更新する。

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -81,24 +81,30 @@ bucket_name = "local-floodgate-history-dev"
 preview_bucket_name = "local-floodgate-history-dev"
 
 # --- Cron triggers ---
-# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を 2 つの cron で起動する
-# (Issue #629 で 1 → 2 に分離)。
+# `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を単一 cron で起動する。
+# Cloudflare の account あたり cron trigger 上限 (5) に収めるため、以前の
+# backfill 用 (`0 * * * *`) と sweep-only 用 (`15,30,45 * * * *`) の 2 cron を
+# 1 cron に統合した。
 #
-# - `0 * * * *` (毎時 0 分):
+# 単一 cron `0,15,30,45 * * * *` は 0 / 15 / 30 / 45 分の 4 回発火する:
+#
+# - 0 分:
 #   `kifu-by-id/<id>.meta.json` から `games-index/` を補完 (backfill) し、
-#   `live-games-index/` の orphan を掃除する (Issue #551)。backfill は 1 run =
-#   1 page (1000 件) のみ。bulk 1 万件超は admin invoke 経路を別途検討。
-# - `15,30,45 * * * *` (15 / 30 / 45 分):
+#   `live-games-index/` の orphan を掃除する。backfill は 1 run = 1 page
+#   (1000 件) のみ。bulk 1 万件超は admin invoke 経路を別途検討。
+# - 15 / 30 / 45 分:
 #   `live-games-index/` の orphan 掃除のみを行う (backfill はスキップ)。
 #   delete best-effort 失敗からの復旧遅延を 1 時間 → 15 分に短縮するため、
-#   sweep のみ高頻度化する (Issue #629)。sweep は 1 cron 内で pagination
-#   loop し、cron 30s 制限内で複数 page を処理する。
+#   sweep のみ高頻度化する。sweep は 1 cron 内で pagination loop し、
+#   cron 30s 制限内で複数 page を処理する。
 #
-# どちらの cron も `lib.rs::scheduled` で `event.cron()` を見て分岐する。
-# 文字列を変更する場合は `lib.rs` の `BACKFILL_CRON` / `SWEEP_ONLY_CRON`
-# 定数も同期更新すること (wrangler test が違反を検知する)。
+# 単一 cron なので発火の区別は cron 文字列でできない。`lib.rs::scheduled` が
+# `event.schedule()` 由来の「時の何分か」を見て分岐する。cron 文字列を変更する
+# 場合は `lib.rs` の `SCHEDULED_CRON` 定数も同期更新すること (wrangler test が
+# 違反を検知する)。分フィールドには必ず `BACKFILL_MINUTE` (0) を含めること —
+# 0 分を外すと backfill が無音で永久停止する (sweep は全発火で走る)。
 [triggers]
-crons = ["0 * * * *", "15,30,45 * * * *"]
+crons = ["0,15,30,45 * * * *"]
 
 # --- 変数 ---
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。ブラウザ経由

--- a/docs/csa-server/viewer_access_control.md
+++ b/docs/csa-server/viewer_access_control.md
@@ -186,10 +186,10 @@ stale window」「export retry pending」に起因する。
   ただし transient error / deadline / page 上限・meta PUT 失敗等で sweep が
   1 回で完了しない経路は残るため「削除済 entry が再出現しない」絶対保証は
   与えない。通常は次回 cron 周期で収束を試みる
-- **orphan 掃除の頻度**: `SWEEP_ONLY_CRON = "15,30,45 * * * *"` (15 分間隔、
-  https://github.com/SH11235/rshogi/issues/629)。R2 list deadline (25s) や
-  page 上限 (100 page) に達すると 1 cron 内で完了しない場合がある (次 cron で
-  継続)
+- **orphan 掃除の頻度**: 単一 cron `SCHEDULED_CRON = "0,15,30,45 * * * *"`
+  (15 分間隔) の各発火で sweep する (0 分は backfill も併走)。R2 list deadline
+  (25s) や page 上限 (100 page) に達すると 1 cron 内で完了しない場合がある
+  (次 cron で継続)
 - **list の網羅性**: 保証しない (1 page 上限あり、`next_cursor` で連結)
 
 ### 7.5 viewer 運用目標 (informative, 計測値ではない)


### PR DESCRIPTION
## 概要

`rshogi-csa-server-workers` の cron trigger を 2 個から 1 個に統合する。Cloudflare の cron trigger は account あたり 5 個が上限で、複数 Worker の宣言合計が上限に達しているため、本 Worker の cron 数を減らして枠を空ける。

統合前:
- `0 * * * *` — backfill + orphan sweep
- `15,30,45 * * * *` — orphan sweep のみ

統合後:
- `0,15,30,45 * * * *` の単一 cron（production / staging とも 2→1）

## 変更内容

### `src/lib.rs`
- `BACKFILL_CRON` / `SWEEP_ONLY_CRON` を単一 cron 定数 `SCHEDULED_CRON = "0,15,30,45 * * * *"` と `BACKFILL_MINUTE: i64 = 0` に置換。
- 単一 cron では `event.cron()` が 4 発火すべてで同じ文字列を返すため、発火の区別は `event.schedule()`（cron 予定時刻の epoch ミリ秒）から「時の何分か」を求めて行う。純粋関数 `minute_of_hour(epoch_ms: f64) -> i64` に切り出し（`#[cfg(any(target_arch = "wasm32", test))]` ゲート）、host target でユニットテスト可能にした。
- `scheduled` ハンドラ: `minute == BACKFILL_MINUTE`（0 分）のときだけ backfill、それ以外は sweep のみ。backfill は毎時 0 分・sweep は 0/15/30/45 分という従来の頻度を維持する（挙動等価）。

### `wrangler.{production,staging,toml.example}.toml`
- `[triggers] crons` を `["0,15,30,45 * * * *"]` に統合。
- cron コメントを単一 cron + `event.schedule()` 分岐の説明に更新。「分フィールドには必ず 0 を含めること（外すと backfill が無音停止）」の運用不変条件を明記。

### テスト
- `wrangler_{environment_toml,template}_consistency.rs`: cron 宣言の検証を `contains` から `assert_eq!(crons, [SCHEDULED_CRON])` の完全一致に強化（旧 cron 残留＝統合失敗を検知）。
- `lib.rs`: `minute_of_hour` のユニットテスト 3 件（0/15/30/45 分、起動遅延 <60s の切り捨て吸収、現在 epoch スケールでの境界）と `SCHEDULED_CRON` の field 数 / backfill 分含有テストを追加。

## 検証

worktree で以下を全 pass 確認:
- `cargo fmt`
- `cargo clippy -p rshogi-csa-server-workers --tests`（警告ゼロ）
- `cargo test -p rshogi-csa-server-workers`（lib 327 / env 17 / template 5 すべて pass）
- `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`（`scheduled` / `event.schedule()` の型チェック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)