### PR TITLE
refactor(nnue): architecture_name を architecture_spec().name() に統一

### DIFF
--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -244,7 +244,7 @@ impl NNUEEvaluator {
     // =========================================================================
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         self.net.architecture_name()
     }
 

--- a/crates/rshogi-core/src/nnue/halfka/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l1024.rs
@@ -20,11 +20,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKA1024_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKA1024_8_64CReLU,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96     : HalfKA1024CReLU,
+        (8,  96, CReLU)    => CReLU8x96     : HalfKA1024CReLU,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU,         "CReLU")    => CReLU8x32     : HalfKA1024_8_32CReLU,
+        (8,  32, CReLU)    => CReLU8x32     : HalfKA1024_8_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l256.rs
@@ -19,7 +19,7 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKA<256>,
 
     variants {
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32        : HalfKA256CReLU,
+        (32, 32, CReLU)    => CReLU32x32        : HalfKA256CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l512.rs
@@ -20,11 +20,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64      : HalfKA512_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64      : HalfKA512_8_64CReLU,
         // L2=8, L3=96
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96      : HalfKA512CReLU,
+        (8,  96, CReLU)    => CReLU8x96      : HalfKA512CReLU,
         // L2=32, L3=32
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32     : HalfKA512_32_32CReLU,
+        (32, 32, CReLU)    => CReLU32x32     : HalfKA512_32_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l768.rs
@@ -20,7 +20,7 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU,         "CReLU")    => CReLU16x64    : HalfKA768CReLU,
+        (16, 64, CReLU)    => CReLU16x64    : HalfKA768CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka/mod.rs
@@ -242,7 +242,7 @@ impl HalfKANetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::L256(net) => net.architecture_name(),
             Self::L512(net) => net.architecture_name(),

--- a/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
@@ -20,11 +20,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKA_hm1024_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKA_hm1024_8_64CReLU,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96     : HalfKA_hm1024CReLU,
+        (8,  96, CReLU)    => CReLU8x96     : HalfKA_hm1024CReLU,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU,         "CReLU")    => CReLU8x32     : HalfKA_hm1024_8_32CReLU,
+        (8,  32, CReLU)    => CReLU8x32     : HalfKA_hm1024_8_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
@@ -19,7 +19,7 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKA_hm<256>,
 
     variants {
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32        : HalfKA_hm256CReLU,
+        (32, 32, CReLU)    => CReLU32x32        : HalfKA_hm256CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
@@ -20,11 +20,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64      : HalfKA_hm512_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64      : HalfKA_hm512_8_64CReLU,
         // L2=8, L3=96
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96      : HalfKA_hm512CReLU,
+        (8,  96, CReLU)    => CReLU8x96      : HalfKA_hm512CReLU,
         // L2=32, L3=32
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32     : HalfKA_hm512_32_32CReLU,
+        (32, 32, CReLU)    => CReLU32x32     : HalfKA_hm512_32_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
@@ -20,7 +20,7 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU,         "CReLU")    => CReLU16x64    : HalfKA_hm768CReLU,
+        (16, 64, CReLU)    => CReLU16x64    : HalfKA_hm768CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
@@ -242,7 +242,7 @@ impl HalfKA_hmNetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::L256(net) => net.architecture_name(),
             Self::L512(net) => net.architecture_name(),

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
@@ -22,11 +22,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKaHmSplit1024_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKaHmSplit1024_8_64CReLU,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96     : HalfKaHmSplit1024CReLU,
+        (8,  96, CReLU)    => CReLU8x96     : HalfKaHmSplit1024CReLU,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU,         "CReLU")    => CReLU8x32     : HalfKaHmSplit1024_8_32CReLU,
+        (8,  32, CReLU)    => CReLU8x32     : HalfKaHmSplit1024_8_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
@@ -19,7 +19,7 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKaHmSplit<256>,
 
     variants {
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32        : HalfKaHmSplit256CReLU,
+        (32, 32, CReLU)    => CReLU32x32        : HalfKaHmSplit256CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
@@ -22,11 +22,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64      : HalfKaHmSplit512_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64      : HalfKaHmSplit512_8_64CReLU,
         // L2=8, L3=96
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96      : HalfKaHmSplit512CReLU,
+        (8,  96, CReLU)    => CReLU8x96      : HalfKaHmSplit512CReLU,
         // L2=32, L3=32
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32     : HalfKaHmSplit512_32_32CReLU,
+        (32, 32, CReLU)    => CReLU32x32     : HalfKaHmSplit512_32_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
@@ -20,7 +20,7 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU,         "CReLU")    => CReLU16x64    : HalfKaHmSplit768CReLU,
+        (16, 64, CReLU)    => CReLU16x64    : HalfKaHmSplit768CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/mod.rs
@@ -242,7 +242,7 @@ impl HalfKaHmSplitNetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::L256(net) => net.architecture_name(),
             Self::L512(net) => net.architecture_name(),

--- a/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
@@ -22,11 +22,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKaMerged1024_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKaMerged1024_8_64CReLU,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96     : HalfKaMerged1024CReLU,
+        (8,  96, CReLU)    => CReLU8x96     : HalfKaMerged1024CReLU,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU,         "CReLU")    => CReLU8x32     : HalfKaMerged1024_8_32CReLU,
+        (8,  32, CReLU)    => CReLU8x32     : HalfKaMerged1024_8_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
@@ -19,7 +19,7 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKaMerged<256>,
 
     variants {
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32        : HalfKaMerged256CReLU,
+        (32, 32, CReLU)    => CReLU32x32        : HalfKaMerged256CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
@@ -22,11 +22,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64      : HalfKaMerged512_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64      : HalfKaMerged512_8_64CReLU,
         // L2=8, L3=96
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96      : HalfKaMerged512CReLU,
+        (8,  96, CReLU)    => CReLU8x96      : HalfKaMerged512CReLU,
         // L2=32, L3=32
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32     : HalfKaMerged512_32_32CReLU,
+        (32, 32, CReLU)    => CReLU32x32     : HalfKaMerged512_32_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
@@ -20,7 +20,7 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU,         "CReLU")    => CReLU16x64    : HalfKaMerged768CReLU,
+        (16, 64, CReLU)    => CReLU16x64    : HalfKaMerged768CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfka_merged/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/mod.rs
@@ -242,7 +242,7 @@ impl HalfKaMergedNetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::L256(net) => net.architecture_name(),
             Self::L512(net) => net.architecture_name(),

--- a/crates/rshogi-core/src/nnue/halfkp/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l1024.rs
@@ -18,9 +18,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU,         "CReLU")    => CReLU8x32     : HalfKP1024_8_32CReLU,
+        (8,  32, CReLU)    => CReLU8x32     : HalfKP1024_8_32CReLU,
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKP1024_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKP1024_8_64CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfkp/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l256.rs
@@ -17,7 +17,7 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKP<256>,
 
     variants {
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32       : HalfKP256CReLU,
+        (32, 32, CReLU)    => CReLU32x32       : HalfKP256CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfkp/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l512.rs
@@ -18,11 +18,11 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU,         "CReLU")    => CReLU8x64     : HalfKP512_8_64CReLU,
+        (8,  64, CReLU)    => CReLU8x64     : HalfKP512_8_64CReLU,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU,         "CReLU")    => CReLU8x96     : HalfKP512CReLU,
+        (8,  96, CReLU)    => CReLU8x96     : HalfKP512CReLU,
         // L2=32, L3=32 バリアント
-        (32, 32, CReLU,         "CReLU")    => CReLU32x32    : HalfKP512_32_32CReLU,
+        (32, 32, CReLU)    => CReLU32x32    : HalfKP512_32_32CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfkp/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l768.rs
@@ -18,7 +18,7 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU,         "CReLU")    => CReLU16x64    : HalfKP768CReLU,
+        (16, 64, CReLU)    => CReLU16x64    : HalfKP768CReLU,
     }
 );
 

--- a/crates/rshogi-core/src/nnue/halfkp/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/mod.rs
@@ -240,7 +240,7 @@ impl HalfKPNetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::L256(net) => net.architecture_name(),
             Self::L512(net) => net.architecture_name(),

--- a/crates/rshogi-core/src/nnue/macros.rs
+++ b/crates/rshogi-core/src/nnue/macros.rs
@@ -44,7 +44,7 @@ macro_rules! define_l1_variants {
 
         variants {
             $(
-                ($l2:literal, $l3:literal, $act:ident, $act_name:literal)
+                ($l2:literal, $l3:literal, $act:ident)
                     => $Var:ident : $Ty:ty
             ),+ $(,)?
         }
@@ -165,18 +165,12 @@ macro_rules! define_l1_variants {
             }
 
             /// アーキテクチャ名を取得
-            pub fn architecture_name(&self) -> &'static str {
-                match self {
-                    $(
-                        Self::$Var(_) => concat!(
-                            stringify!($FeatureSet), "-",
-                            stringify!($L1), "-",
-                            stringify!($l2), "-",
-                            stringify!($l3), "-",
-                            $act_name
-                        ),
-                    )+
-                }
+            ///
+            /// `architecture_spec().name()` に委譲する。feature set 名は
+            /// `FeatureSet::as_str()`、活性化名は `Activation::as_str()` を
+            /// 単一の真実源とし、判定と display 名の決定ロジックを共通化する。
+            pub fn architecture_name(&self) -> String {
+                self.architecture_spec().name()
             }
 
             /// アーキテクチャ仕様を取得

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -501,14 +501,14 @@ impl NNUENetwork {
     }
 
     /// アーキテクチャ名を取得
-    pub fn architecture_name(&self) -> &'static str {
+    pub fn architecture_name(&self) -> String {
         match self {
             Self::HalfKA(net) => net.architecture_name(),
             Self::HalfKA_hm(net) => net.architecture_name(),
             Self::HalfKaMerged(net) => net.architecture_name(),
             Self::HalfKaHmSplit(net) => net.architecture_name(),
             Self::HalfKP(net) => net.architecture_name(),
-            Self::LayerStacks(_) => "LayerStacks",
+            Self::LayerStacks(_) => "LayerStacks".to_string(),
         }
     }
 

--- a/crates/tools/src/bench_nnue_eval_tool.rs
+++ b/crates/tools/src/bench_nnue_eval_tool.rs
@@ -703,7 +703,7 @@ pub fn run() -> Result<()> {
             let mut evaluator =
                 NNUEEvaluator::new_with_position(Arc::clone(&network), &positions[0]);
             let result =
-                bench_evaluator(&mut evaluator, &positions, cli.warmup, cli.iterations, arch_name);
+                bench_evaluator(&mut evaluator, &positions, cli.warmup, cli.iterations, &arch_name);
 
             result.print();
 
@@ -735,7 +735,7 @@ pub fn run() -> Result<()> {
                     bucket_mode,
                     cli.warmup,
                     cli.iterations,
-                    arch_name,
+                    &arch_name,
                 )?;
             });
         }


### PR DESCRIPTION
## 概要

PR #719（HalfKaMerged / HalfKaHmSplit feature set 追加、merge 済）の follow-up。`architecture_name()` が `define_l1_variants!` マクロ内で `stringify!($FeatureSet)` により独自に feature set 名を文字列化していたため、`FeatureSet::as_str()` が返す canonical 名と display 名が乖離していた問題を解消する。

具体的には、新 feature set の display 名が CamelCase（`HalfKaMerged-512-8-64-CReLU`）になり、`as_str()` / `ArchitectureSpec::name()` の underscore 形式（`HalfKA_merged`）と不一致だった。

## 変更内容

**判定（parse）と display 名決定のロジックを共通化**し、`FeatureSet::as_str()` / `Activation::as_str()` を単一の真実源とする：

- `macros.rs` `define_l1_variants!`: `architecture_name()` を `self.architecture_spec().name()` への委譲に変更。`ArchitectureSpec::name()` は `as_str()` 経由なので、これで feature set 名・活性化名のロジックが 1 箇所に統一される。戻り値 `&'static str` → `String`。
- 不要化した `$act_name:literal` マクロ引数を除去（全 20 `half*/l*.rs` の variant 定義から `, "CReLU"` 等を削除）。
- 戻り値型カスケード `&'static str` → `String`: `half*/mod.rs::architecture_name()` ×5、`NNUENetwork::architecture_name()`、`NNUEEvaluator::architecture_name()`。
- `bench_nnue_eval_tool.rs`: 呼び出し側を `&arch_name` に修正。

## 挙動の変化

- 既存 feature set（HalfKP / HalfKA / HalfKA_hm）の CReLU/SCReLU variant: `architecture_name()` 出力は不変。
- Pairwise variant: 旧 `$act_name` が短縮形 `"Pairwise"` だったため `...-Pairwise` → `...-PairwiseCReLU`（`Activation::as_str()` 準拠）に変わる。display 専用文字列で、`.bin` ヘッダに書き戻されず再パースもされないため正当性に影響なし。
- 新 feature set: `HalfKaMerged-...` → `HalfKA_merged-...` に統一（canonical 形式）。

## 検証

```
cargo clippy --tests -p rshogi-core -p tools   # warning なし
cargo test -p rshogi-core --lib nnue::          # 357 passed
```

rshogi-nnue #165 Phase A の 5 feature-set モデル（Simple `512x2-8-64`, CReLU, sb60）を engine で実ロード → 全 5 種 load + eval 成功、display 名も canonical 形式に統一されることを `bench_nnue_eval` で確認：

```
halfkp           -> HalfKP-512-8-64-CReLU
halfka-split     -> HalfKA-512-8-64-CReLU
halfka-merged    -> HalfKA_merged-512-8-64-CReLU
halfka-hm-split  -> HalfKA_hm_split-512-8-64-CReLU
halfka-hm-merged -> HalfKA_hm-512-8-64-CReLU
```

既知の pre-existing 失敗 `test_accumulator_stack_variant_fallback` / `test_evaluate_fallback` は origin/main でも発生する flake で本 PR と無関係。

## レビュー

- local Codex review: **Approve**

## 関連

- #719（HalfKaMerged / HalfKaHmSplit feature set 追加、本 PR の前提）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
