### PR TITLE
feat(nnue): Simple アーキ 5 feature set に SCReLU / Pairwise 活性化対応を追加

### DIFF
--- a/crates/rshogi-core/src/nnue/aliases.rs
+++ b/crates/rshogi-core/src/nnue/aliases.rs
@@ -7,96 +7,174 @@
 pub use crate::nnue::network_halfka_hm::{
     // L1=256, L2=32, L3=32
     HalfKA_hm256CReLU,
+    HalfKA_hm256Pairwise,
+    HalfKA_hm256SCReLU,
     // L1=512, L2=8, L3=64
     HalfKA_hm512_8_64CReLU,
+    HalfKA_hm512_8_64Pairwise,
+    HalfKA_hm512_8_64SCReLU,
     // L1=512, L2=32, L3=32
     HalfKA_hm512_32_32CReLU,
+    HalfKA_hm512_32_32Pairwise,
+    HalfKA_hm512_32_32SCReLU,
     // L1=512, L2=8, L3=96
     HalfKA_hm512CReLU,
+    HalfKA_hm512Pairwise,
+    HalfKA_hm512SCReLU,
     // L1=768, L2=16, L3=64
     HalfKA_hm768CReLU,
+    HalfKA_hm768Pairwise,
+    HalfKA_hm768SCReLU,
     // L1=1024, L2=8, L3=32
     HalfKA_hm1024_8_32CReLU,
+    HalfKA_hm1024_8_32Pairwise,
+    HalfKA_hm1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
     HalfKA_hm1024_8_64CReLU,
+    HalfKA_hm1024_8_64Pairwise,
+    HalfKA_hm1024_8_64SCReLU,
     // L1=1024, L2=8, L3=96
     HalfKA_hm1024CReLU,
+    HalfKA_hm1024Pairwise,
+    HalfKA_hm1024SCReLU,
 };
 
 // HalfKA 型エイリアス
 pub use crate::nnue::network_halfka::{
     // L1=256, L2=32, L3=32
     HalfKA256CReLU,
+    HalfKA256Pairwise,
+    HalfKA256SCReLU,
     // L1=512, L2=8, L3=64
     HalfKA512_8_64CReLU,
+    HalfKA512_8_64Pairwise,
+    HalfKA512_8_64SCReLU,
     // L1=512, L2=32, L3=32
     HalfKA512_32_32CReLU,
+    HalfKA512_32_32Pairwise,
+    HalfKA512_32_32SCReLU,
     // L1=512, L2=8, L3=96
     HalfKA512CReLU,
+    HalfKA512Pairwise,
+    HalfKA512SCReLU,
     // L1=768, L2=16, L3=64
     HalfKA768CReLU,
+    HalfKA768Pairwise,
+    HalfKA768SCReLU,
     // L1=1024, L2=8, L3=32
     HalfKA1024_8_32CReLU,
+    HalfKA1024_8_32Pairwise,
+    HalfKA1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
     HalfKA1024_8_64CReLU,
+    HalfKA1024_8_64Pairwise,
+    HalfKA1024_8_64SCReLU,
     // L1=1024, L2=8, L3=96
     HalfKA1024CReLU,
+    HalfKA1024Pairwise,
+    HalfKA1024SCReLU,
 };
 
 // HalfKaMerged 型エイリアス
 pub use crate::nnue::network_halfka_merged::{
     // L1=256, L2=32, L3=32
     HalfKaMerged256CReLU,
+    HalfKaMerged256Pairwise,
+    HalfKaMerged256SCReLU,
     // L1=512, L2=8, L3=64
     HalfKaMerged512_8_64CReLU,
+    HalfKaMerged512_8_64Pairwise,
+    HalfKaMerged512_8_64SCReLU,
     // L1=512, L2=32, L3=32
     HalfKaMerged512_32_32CReLU,
+    HalfKaMerged512_32_32Pairwise,
+    HalfKaMerged512_32_32SCReLU,
     // L1=512, L2=8, L3=96
     HalfKaMerged512CReLU,
+    HalfKaMerged512Pairwise,
+    HalfKaMerged512SCReLU,
     // L1=768, L2=16, L3=64
     HalfKaMerged768CReLU,
+    HalfKaMerged768Pairwise,
+    HalfKaMerged768SCReLU,
     // L1=1024, L2=8, L3=32
     HalfKaMerged1024_8_32CReLU,
+    HalfKaMerged1024_8_32Pairwise,
+    HalfKaMerged1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
     HalfKaMerged1024_8_64CReLU,
+    HalfKaMerged1024_8_64Pairwise,
+    HalfKaMerged1024_8_64SCReLU,
     // L1=1024, L2=8, L3=96
     HalfKaMerged1024CReLU,
+    HalfKaMerged1024Pairwise,
+    HalfKaMerged1024SCReLU,
 };
 
 // HalfKaHmSplit 型エイリアス
 pub use crate::nnue::network_halfka_hm_split::{
     // L1=256, L2=32, L3=32
     HalfKaHmSplit256CReLU,
+    HalfKaHmSplit256Pairwise,
+    HalfKaHmSplit256SCReLU,
     // L1=512, L2=8, L3=64
     HalfKaHmSplit512_8_64CReLU,
+    HalfKaHmSplit512_8_64Pairwise,
+    HalfKaHmSplit512_8_64SCReLU,
     // L1=512, L2=32, L3=32
     HalfKaHmSplit512_32_32CReLU,
+    HalfKaHmSplit512_32_32Pairwise,
+    HalfKaHmSplit512_32_32SCReLU,
     // L1=512, L2=8, L3=96
     HalfKaHmSplit512CReLU,
+    HalfKaHmSplit512Pairwise,
+    HalfKaHmSplit512SCReLU,
     // L1=768, L2=16, L3=64
     HalfKaHmSplit768CReLU,
+    HalfKaHmSplit768Pairwise,
+    HalfKaHmSplit768SCReLU,
     // L1=1024, L2=8, L3=32
     HalfKaHmSplit1024_8_32CReLU,
+    HalfKaHmSplit1024_8_32Pairwise,
+    HalfKaHmSplit1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
     HalfKaHmSplit1024_8_64CReLU,
+    HalfKaHmSplit1024_8_64Pairwise,
+    HalfKaHmSplit1024_8_64SCReLU,
     // L1=1024, L2=8, L3=96
     HalfKaHmSplit1024CReLU,
+    HalfKaHmSplit1024Pairwise,
+    HalfKaHmSplit1024SCReLU,
 };
 
 // HalfKP 型エイリアス
 pub use crate::nnue::network_halfkp::{
     // L1=256, L2=32, L3=32
     HalfKP256CReLU,
+    HalfKP256Pairwise,
+    HalfKP256SCReLU,
     // L1=512, L2=8, L3=64
     HalfKP512_8_64CReLU,
+    HalfKP512_8_64Pairwise,
+    HalfKP512_8_64SCReLU,
     // L1=512, L2=32, L3=32
     HalfKP512_32_32CReLU,
+    HalfKP512_32_32Pairwise,
+    HalfKP512_32_32SCReLU,
     // L1=512, L2=8, L3=96
     HalfKP512CReLU,
+    HalfKP512Pairwise,
+    HalfKP512SCReLU,
     // L1=768, L2=16, L3=64
     HalfKP768CReLU,
+    HalfKP768Pairwise,
+    HalfKP768SCReLU,
     // L1=1024, L2=8, L3=32
     HalfKP1024_8_32CReLU,
+    HalfKP1024_8_32Pairwise,
+    HalfKP1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
     HalfKP1024_8_64CReLU,
+    HalfKP1024_8_64Pairwise,
+    HalfKP1024_8_64SCReLU,
 };

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -788,15 +788,15 @@ mod tests {
 
         // HalfKA サポートアーキテクチャ数
         let halfka_specs = HalfKANetwork::supported_specs();
-        assert_eq!(halfka_specs.len(), 8); // 256:1 + 512:3 + 768:1 + 1024:3
+        assert_eq!(halfka_specs.len(), 24); // (256:1 + 512:3 + 768:1 + 1024:3) × 3 活性化
 
         // HalfKA_hm サポートアーキテクチャ数
         let halfka_hm_specs = HalfKA_hmNetwork::supported_specs();
-        assert_eq!(halfka_hm_specs.len(), 8); // 256:1 + 512:3 + 768:1 + 1024:3
+        assert_eq!(halfka_hm_specs.len(), 24); // (256:1 + 512:3 + 768:1 + 1024:3) × 3 活性化
 
         // HalfKP サポートアーキテクチャ数
         let halfkp_specs = HalfKPNetwork::supported_specs();
-        assert_eq!(halfkp_specs.len(), 7); // 256:1 + 512:3 + 768:1 + 1024:2
+        assert_eq!(halfkp_specs.len(), 21); // (256:1 + 512:3 + 768:1 + 1024:2) × 3 活性化
 
         // 全アーキテクチャで feature_set が正しいことを確認
         for spec in &halfka_specs {

--- a/crates/rshogi-core/src/nnue/halfka/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l1024.rs
@@ -9,7 +9,11 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA1024_8_32CReLU, HalfKA1024_8_64CReLU, HalfKA1024CReLU};
+use crate::nnue::aliases::{
+    HalfKA1024_8_32CReLU, HalfKA1024_8_32Pairwise, HalfKA1024_8_32SCReLU, HalfKA1024_8_64CReLU,
+    HalfKA1024_8_64Pairwise, HalfKA1024_8_64SCReLU, HalfKA1024CReLU, HalfKA1024Pairwise,
+    HalfKA1024SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKA_L1024,
@@ -20,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKA1024_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKA1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA1024_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)    => CReLU8x96     : HalfKA1024CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKA1024CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA1024SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA1024Pairwise,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)    => CReLU8x32     : HalfKA1024_8_32CReLU,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKA1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKA1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKA1024_8_32Pairwise,
     }
 );
 
@@ -34,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_L1024::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKA_L1024::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKA_L1024::SUPPORTED_SPECS[0];
@@ -43,16 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKA_L1024::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
-
-        // 8-32 CReLU
-        let spec = &HalfKA_L1024::SUPPORTED_SPECS[2];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 32);
     }
 
     #[test]
@@ -74,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_L1024::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_L1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l256.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKA256CReLU;
+use crate::nnue::aliases::{HalfKA256CReLU, HalfKA256Pairwise, HalfKA256SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_L256,
@@ -19,7 +19,9 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKA<256>,
 
     variants {
-        (32, 32, CReLU)    => CReLU32x32        : HalfKA256CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKA256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA256Pairwise,
     }
 );
 
@@ -29,7 +31,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_L256::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKA_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKA_L256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKA);
@@ -61,13 +63,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor が正しく設定されているかテスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_L256::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_L256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の妥当な範囲チェック

--- a/crates/rshogi-core/src/nnue/halfka/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l512.rs
@@ -9,7 +9,11 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA512_8_64CReLU, HalfKA512_32_32CReLU, HalfKA512CReLU};
+use crate::nnue::aliases::{
+    HalfKA512_8_64CReLU, HalfKA512_8_64Pairwise, HalfKA512_8_64SCReLU, HalfKA512_32_32CReLU,
+    HalfKA512_32_32Pairwise, HalfKA512_32_32SCReLU, HalfKA512CReLU, HalfKA512Pairwise,
+    HalfKA512SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKA_L512,
@@ -20,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU)    => CReLU8x64      : HalfKA512_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKA512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA512_8_64Pairwise,
         // L2=8, L3=96
-        (8,  96, CReLU)    => CReLU8x96      : HalfKA512CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKA512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA512Pairwise,
         // L2=32, L3=32
-        (32, 32, CReLU)    => CReLU32x32     : HalfKA512_32_32CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKA512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA512_32_32Pairwise,
     }
 );
 
@@ -34,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_L512::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKA_L512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKA_L512::SUPPORTED_SPECS[0];
@@ -43,11 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKA_L512::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
     }
 
     #[test]
@@ -69,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_L512::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_L512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l768.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKA768CReLU;
+use crate::nnue::aliases::{HalfKA768CReLU, HalfKA768Pairwise, HalfKA768SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_L768,
@@ -20,7 +20,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)    => CReLU16x64    : HalfKA768CReLU,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKA768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKA768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKA768Pairwise,
     }
 );
 
@@ -30,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_L768::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKA_L768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
         let spec = &HalfKA_L768::SUPPORTED_SPECS[0];
@@ -60,12 +62,13 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_L768::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_L768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 }

--- a/crates/rshogi-core/src/nnue/halfka/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka/mod.rs
@@ -427,8 +427,8 @@ mod tests {
     #[test]
     fn test_supported_specs_combined() {
         let specs = HalfKANetwork::supported_specs();
-        // 256: 1, 512: 3, 768: 1, 1024: 3
-        assert_eq!(specs.len(), 8);
+        // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
+        assert_eq!(specs.len(), 24);
 
         // 全て HalfKA
         for spec in &specs {

--- a/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
@@ -9,7 +9,11 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA_hm1024_8_32CReLU, HalfKA_hm1024_8_64CReLU, HalfKA_hm1024CReLU};
+use crate::nnue::aliases::{
+    HalfKA_hm1024_8_32CReLU, HalfKA_hm1024_8_32Pairwise, HalfKA_hm1024_8_32SCReLU,
+    HalfKA_hm1024_8_64CReLU, HalfKA_hm1024_8_64Pairwise, HalfKA_hm1024_8_64SCReLU,
+    HalfKA_hm1024CReLU, HalfKA_hm1024Pairwise, HalfKA_hm1024SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L1024,
@@ -20,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKA_hm1024_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKA_hm1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA_hm1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA_hm1024_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)    => CReLU8x96     : HalfKA_hm1024CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKA_hm1024CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA_hm1024SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA_hm1024Pairwise,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)    => CReLU8x32     : HalfKA_hm1024_8_32CReLU,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKA_hm1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKA_hm1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKA_hm1024_8_32Pairwise,
     }
 );
 
@@ -34,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L1024::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKA_hm_L1024::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKA_hm_L1024::SUPPORTED_SPECS[0];
@@ -43,16 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKA_hm_L1024::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
-
-        // 8-32 CReLU
-        let spec = &HalfKA_hm_L1024::SUPPORTED_SPECS[2];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 32);
     }
 
     #[test]
@@ -74,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_hm_L1024::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_hm_L1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKA_hm256CReLU;
+use crate::nnue::aliases::{HalfKA_hm256CReLU, HalfKA_hm256Pairwise, HalfKA_hm256SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L256,
@@ -19,7 +19,9 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKA_hm<256>,
 
     variants {
-        (32, 32, CReLU)    => CReLU32x32        : HalfKA_hm256CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKA_hm256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA_hm256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA_hm256Pairwise,
     }
 );
 
@@ -29,7 +31,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L256::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKA_hm_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKA_hm_L256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
@@ -61,13 +63,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor が正しく設定されているかテスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_hm_L256::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_hm_L256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の妥当な範囲チェック

--- a/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
@@ -9,7 +9,11 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA_hm512_8_64CReLU, HalfKA_hm512_32_32CReLU, HalfKA_hm512CReLU};
+use crate::nnue::aliases::{
+    HalfKA_hm512_8_64CReLU, HalfKA_hm512_8_64Pairwise, HalfKA_hm512_8_64SCReLU,
+    HalfKA_hm512_32_32CReLU, HalfKA_hm512_32_32Pairwise, HalfKA_hm512_32_32SCReLU,
+    HalfKA_hm512CReLU, HalfKA_hm512Pairwise, HalfKA_hm512SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L512,
@@ -20,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU)    => CReLU8x64      : HalfKA_hm512_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKA_hm512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA_hm512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA_hm512_8_64Pairwise,
         // L2=8, L3=96
-        (8,  96, CReLU)    => CReLU8x96      : HalfKA_hm512CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKA_hm512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA_hm512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA_hm512Pairwise,
         // L2=32, L3=32
-        (32, 32, CReLU)    => CReLU32x32     : HalfKA_hm512_32_32CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKA_hm512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA_hm512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA_hm512_32_32Pairwise,
     }
 );
 
@@ -34,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L512::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKA_hm_L512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKA_hm_L512::SUPPORTED_SPECS[0];
@@ -43,11 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKA_hm_L512::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
     }
 
     #[test]
@@ -69,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_hm_L512::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_hm_L512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKA_hm768CReLU;
+use crate::nnue::aliases::{HalfKA_hm768CReLU, HalfKA_hm768Pairwise, HalfKA_hm768SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L768,
@@ -20,7 +20,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)    => CReLU16x64    : HalfKA_hm768CReLU,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKA_hm768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKA_hm768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKA_hm768Pairwise,
     }
 );
 
@@ -30,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L768::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKA_hm_L768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
         let spec = &HalfKA_hm_L768::SUPPORTED_SPECS[0];
@@ -60,12 +62,13 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKA_hm_L768::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKA_hm_L768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 }

--- a/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
@@ -427,8 +427,8 @@ mod tests {
     #[test]
     fn test_supported_specs_combined() {
         let specs = HalfKA_hmNetwork::supported_specs();
-        // 256: 1, 512: 3, 768: 1, 1024: 3
-        assert_eq!(specs.len(), 8);
+        // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
+        assert_eq!(specs.len(), 24);
 
         // 全て HalfKA_hm
         for spec in &specs {

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
@@ -10,7 +10,9 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKaHmSplit1024_8_32CReLU, HalfKaHmSplit1024_8_64CReLU, HalfKaHmSplit1024CReLU,
+    HalfKaHmSplit1024_8_32CReLU, HalfKaHmSplit1024_8_32Pairwise, HalfKaHmSplit1024_8_32SCReLU,
+    HalfKaHmSplit1024_8_64CReLU, HalfKaHmSplit1024_8_64Pairwise, HalfKaHmSplit1024_8_64SCReLU,
+    HalfKaHmSplit1024CReLU, HalfKaHmSplit1024Pairwise, HalfKaHmSplit1024SCReLU,
 };
 
 crate::define_l1_variants!(
@@ -22,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKaHmSplit1024_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaHmSplit1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaHmSplit1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaHmSplit1024_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)    => CReLU8x96     : HalfKaHmSplit1024CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaHmSplit1024CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaHmSplit1024SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaHmSplit1024Pairwise,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)    => CReLU8x32     : HalfKaHmSplit1024_8_32CReLU,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKaHmSplit1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKaHmSplit1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKaHmSplit1024_8_32Pairwise,
     }
 );
 
@@ -36,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaHmSplit_L1024::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaHmSplit_L1024::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKaHmSplit_L1024::SUPPORTED_SPECS[0];
@@ -45,16 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKaHmSplit_L1024::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
-
-        // 8-32 CReLU
-        let spec = &HalfKaHmSplit_L1024::SUPPORTED_SPECS[2];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 32);
     }
 
     #[test]
@@ -76,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaHmSplit_L1024::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaHmSplit_L1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
@@ -9,7 +9,9 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKaHmSplit256CReLU;
+use crate::nnue::aliases::{
+    HalfKaHmSplit256CReLU, HalfKaHmSplit256Pairwise, HalfKaHmSplit256SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKaHmSplit_L256,
@@ -19,7 +21,9 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKaHmSplit<256>,
 
     variants {
-        (32, 32, CReLU)    => CReLU32x32        : HalfKaHmSplit256CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaHmSplit256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaHmSplit256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaHmSplit256Pairwise,
     }
 );
 
@@ -29,7 +33,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaHmSplit_L256::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKaHmSplit_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKaHmSplit_L256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaHmSplit);
@@ -61,13 +65,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor が正しく設定されているかテスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaHmSplit_L256::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaHmSplit_L256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の妥当な範囲チェック

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
@@ -10,7 +10,9 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKaHmSplit512_8_64CReLU, HalfKaHmSplit512_32_32CReLU, HalfKaHmSplit512CReLU,
+    HalfKaHmSplit512_8_64CReLU, HalfKaHmSplit512_8_64Pairwise, HalfKaHmSplit512_8_64SCReLU,
+    HalfKaHmSplit512_32_32CReLU, HalfKaHmSplit512_32_32Pairwise, HalfKaHmSplit512_32_32SCReLU,
+    HalfKaHmSplit512CReLU, HalfKaHmSplit512Pairwise, HalfKaHmSplit512SCReLU,
 };
 
 crate::define_l1_variants!(
@@ -22,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU)    => CReLU8x64      : HalfKaHmSplit512_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaHmSplit512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaHmSplit512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaHmSplit512_8_64Pairwise,
         // L2=8, L3=96
-        (8,  96, CReLU)    => CReLU8x96      : HalfKaHmSplit512CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaHmSplit512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaHmSplit512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaHmSplit512Pairwise,
         // L2=32, L3=32
-        (32, 32, CReLU)    => CReLU32x32     : HalfKaHmSplit512_32_32CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaHmSplit512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaHmSplit512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaHmSplit512_32_32Pairwise,
     }
 );
 
@@ -36,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaHmSplit_L512::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaHmSplit_L512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKaHmSplit_L512::SUPPORTED_SPECS[0];
@@ -45,11 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKaHmSplit_L512::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
     }
 
     #[test]
@@ -71,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaHmSplit_L512::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaHmSplit_L512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
@@ -9,7 +9,9 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKaHmSplit768CReLU;
+use crate::nnue::aliases::{
+    HalfKaHmSplit768CReLU, HalfKaHmSplit768Pairwise, HalfKaHmSplit768SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKaHmSplit_L768,
@@ -20,7 +22,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)    => CReLU16x64    : HalfKaHmSplit768CReLU,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKaHmSplit768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKaHmSplit768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKaHmSplit768Pairwise,
     }
 );
 
@@ -30,7 +34,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaHmSplit_L768::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKaHmSplit_L768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
         let spec = &HalfKaHmSplit_L768::SUPPORTED_SPECS[0];
@@ -60,12 +64,13 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaHmSplit_L768::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaHmSplit_L768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 }

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/mod.rs
@@ -435,8 +435,8 @@ mod tests {
     #[test]
     fn test_supported_specs_combined() {
         let specs = HalfKaHmSplitNetwork::supported_specs();
-        // 256: 1, 512: 3, 768: 1, 1024: 3
-        assert_eq!(specs.len(), 8);
+        // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
+        assert_eq!(specs.len(), 24);
 
         // 全て HalfKaHmSplit
         for spec in &specs {

--- a/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
@@ -10,7 +10,9 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKaMerged1024_8_32CReLU, HalfKaMerged1024_8_64CReLU, HalfKaMerged1024CReLU,
+    HalfKaMerged1024_8_32CReLU, HalfKaMerged1024_8_32Pairwise, HalfKaMerged1024_8_32SCReLU,
+    HalfKaMerged1024_8_64CReLU, HalfKaMerged1024_8_64Pairwise, HalfKaMerged1024_8_64SCReLU,
+    HalfKaMerged1024CReLU, HalfKaMerged1024Pairwise, HalfKaMerged1024SCReLU,
 };
 
 crate::define_l1_variants!(
@@ -22,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKaMerged1024_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaMerged1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaMerged1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaMerged1024_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)    => CReLU8x96     : HalfKaMerged1024CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaMerged1024CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaMerged1024SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaMerged1024Pairwise,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)    => CReLU8x32     : HalfKaMerged1024_8_32CReLU,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKaMerged1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKaMerged1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKaMerged1024_8_32Pairwise,
     }
 );
 
@@ -36,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaMerged_L1024::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaMerged_L1024::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKaMerged_L1024::SUPPORTED_SPECS[0];
@@ -45,16 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKaMerged_L1024::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
-
-        // 8-32 CReLU
-        let spec = &HalfKaMerged_L1024::SUPPORTED_SPECS[2];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 32);
     }
 
     #[test]
@@ -76,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaMerged_L1024::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaMerged_L1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKaMerged256CReLU;
+use crate::nnue::aliases::{HalfKaMerged256CReLU, HalfKaMerged256Pairwise, HalfKaMerged256SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKaMerged_L256,
@@ -19,7 +19,9 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKaMerged<256>,
 
     variants {
-        (32, 32, CReLU)    => CReLU32x32        : HalfKaMerged256CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaMerged256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaMerged256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaMerged256Pairwise,
     }
 );
 
@@ -29,7 +31,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaMerged_L256::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKaMerged_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKaMerged_L256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaMerged);
@@ -61,13 +63,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor が正しく設定されているかテスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaMerged_L256::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaMerged_L256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の妥当な範囲チェック

--- a/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
@@ -10,7 +10,9 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKaMerged512_8_64CReLU, HalfKaMerged512_32_32CReLU, HalfKaMerged512CReLU,
+    HalfKaMerged512_8_64CReLU, HalfKaMerged512_8_64Pairwise, HalfKaMerged512_8_64SCReLU,
+    HalfKaMerged512_32_32CReLU, HalfKaMerged512_32_32Pairwise, HalfKaMerged512_32_32SCReLU,
+    HalfKaMerged512CReLU, HalfKaMerged512Pairwise, HalfKaMerged512SCReLU,
 };
 
 crate::define_l1_variants!(
@@ -22,11 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU)    => CReLU8x64      : HalfKaMerged512_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaMerged512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaMerged512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaMerged512_8_64Pairwise,
         // L2=8, L3=96
-        (8,  96, CReLU)    => CReLU8x96      : HalfKaMerged512CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaMerged512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaMerged512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaMerged512Pairwise,
         // L2=32, L3=32
-        (32, 32, CReLU)    => CReLU32x32     : HalfKaMerged512_32_32CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaMerged512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaMerged512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaMerged512_32_32Pairwise,
     }
 );
 
@@ -36,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaMerged_L512::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaMerged_L512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKaMerged_L512::SUPPORTED_SPECS[0];
@@ -45,11 +53,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKaMerged_L512::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
     }
 
     #[test]
@@ -71,13 +74,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaMerged_L512::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaMerged_L512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
@@ -9,7 +9,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKaMerged768CReLU;
+use crate::nnue::aliases::{HalfKaMerged768CReLU, HalfKaMerged768Pairwise, HalfKaMerged768SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKaMerged_L768,
@@ -20,7 +20,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)    => CReLU16x64    : HalfKaMerged768CReLU,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKaMerged768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKaMerged768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKaMerged768Pairwise,
     }
 );
 
@@ -30,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKaMerged_L768::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKaMerged_L768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
         let spec = &HalfKaMerged_L768::SUPPORTED_SPECS[0];
@@ -60,12 +62,13 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKaMerged_L768::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKaMerged_L768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 }

--- a/crates/rshogi-core/src/nnue/halfka_merged/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/mod.rs
@@ -429,8 +429,8 @@ mod tests {
     #[test]
     fn test_supported_specs_combined() {
         let specs = HalfKaMergedNetwork::supported_specs();
-        // 256: 1, 512: 3, 768: 1, 1024: 3
-        assert_eq!(specs.len(), 8);
+        // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
+        assert_eq!(specs.len(), 24);
 
         // 全て HalfKaMerged
         for spec in &specs {

--- a/crates/rshogi-core/src/nnue/halfkp/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l1024.rs
@@ -7,7 +7,10 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKP1024_8_32CReLU, HalfKP1024_8_64CReLU};
+use crate::nnue::aliases::{
+    HalfKP1024_8_32CReLU, HalfKP1024_8_32Pairwise, HalfKP1024_8_32SCReLU, HalfKP1024_8_64CReLU,
+    HalfKP1024_8_64Pairwise, HalfKP1024_8_64SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKPL1024,
@@ -18,9 +21,13 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)    => CReLU8x32     : HalfKP1024_8_32CReLU,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKP1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKP1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKP1024_8_32Pairwise,
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKP1024_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKP1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKP1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKP1024_8_64Pairwise,
     }
 );
 
@@ -30,7 +37,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKPL1024::SUPPORTED_SPECS.len(), 2);
+        assert_eq!(HalfKPL1024::SUPPORTED_SPECS.len(), 6);
 
         // 8-32 CReLU
         let spec = &HalfKPL1024::SUPPORTED_SPECS[0];
@@ -39,11 +46,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 32);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-64 CReLU
-        let spec = &HalfKPL1024::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 64);
     }
 
     #[test]
@@ -65,13 +67,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKPL1024::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKPL1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfkp/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l256.rs
@@ -7,7 +7,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKP256CReLU;
+use crate::nnue::aliases::{HalfKP256CReLU, HalfKP256Pairwise, HalfKP256SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKPL256,
@@ -17,7 +17,9 @@ crate::define_l1_variants!(
     stack AccumulatorStackHalfKP<256>,
 
     variants {
-        (32, 32, CReLU)    => CReLU32x32       : HalfKP256CReLU,
+        (32, 32, CReLU)         => CReLU32x32       : HalfKP256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32      : HalfKP256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32    : HalfKP256Pairwise,
     }
 );
 
@@ -27,7 +29,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKPL256::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKPL256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKPL256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKP);
@@ -56,13 +58,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKPL256::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKPL256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の妥当な範囲チェック

--- a/crates/rshogi-core/src/nnue/halfkp/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l512.rs
@@ -7,7 +7,11 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKP512_8_64CReLU, HalfKP512_32_32CReLU, HalfKP512CReLU};
+use crate::nnue::aliases::{
+    HalfKP512_8_64CReLU, HalfKP512_8_64Pairwise, HalfKP512_8_64SCReLU, HalfKP512_32_32CReLU,
+    HalfKP512_32_32Pairwise, HalfKP512_32_32SCReLU, HalfKP512CReLU, HalfKP512Pairwise,
+    HalfKP512SCReLU,
+};
 
 crate::define_l1_variants!(
     enum HalfKPL512,
@@ -18,11 +22,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)    => CReLU8x64     : HalfKP512_8_64CReLU,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKP512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKP512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKP512_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)    => CReLU8x96     : HalfKP512CReLU,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKP512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKP512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKP512Pairwise,
         // L2=32, L3=32 バリアント
-        (32, 32, CReLU)    => CReLU32x32    : HalfKP512_32_32CReLU,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKP512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKP512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKP512_32_32Pairwise,
     }
 );
 
@@ -32,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKPL512::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKPL512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
         let spec = &HalfKPL512::SUPPORTED_SPECS[0];
@@ -41,11 +51,6 @@ mod tests {
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
         assert_eq!(spec.activation, Activation::CReLU);
-
-        // 8-96 CReLU
-        let spec = &HalfKPL512::SUPPORTED_SPECS[1];
-        assert_eq!(spec.l2, 8);
-        assert_eq!(spec.l3, 96);
     }
 
     #[test]
@@ -67,13 +72,14 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKPL512::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKPL512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 
     /// マクロ生成: L2/L3 の組み合わせが複数あることを確認

--- a/crates/rshogi-core/src/nnue/halfkp/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/l768.rs
@@ -7,7 +7,7 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::HalfKP768CReLU;
+use crate::nnue::aliases::{HalfKP768CReLU, HalfKP768Pairwise, HalfKP768SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKPL768,
@@ -18,7 +18,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)    => CReLU16x64    : HalfKP768CReLU,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKP768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKP768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKP768Pairwise,
     }
 );
 
@@ -28,7 +30,7 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKPL768::SUPPORTED_SPECS.len(), 1);
+        assert_eq!(HalfKPL768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
         let spec = &HalfKPL768::SUPPORTED_SPECS[0];
@@ -58,12 +60,13 @@ mod tests {
         }
     }
 
-    /// マクロ生成: 活性化関数の output_dim_divisor テスト
+    /// マクロ生成: 3 種の活性化関数がすべて登録されていることを確認
     #[test]
-    fn test_activation_output_dim_divisor() {
-        for spec in HalfKPL768::SUPPORTED_SPECS {
-            assert_eq!(spec.activation, Activation::CReLU);
-            assert_eq!(spec.activation.output_dim_divisor(), 1);
-        }
+    fn test_supported_activations() {
+        let activations: Vec<_> =
+            HalfKPL768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+        assert!(activations.contains(&Activation::CReLU));
+        assert!(activations.contains(&Activation::SCReLU));
+        assert!(activations.contains(&Activation::PairwiseCReLU));
     }
 }

--- a/crates/rshogi-core/src/nnue/halfkp/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfkp/mod.rs
@@ -424,8 +424,8 @@ mod tests {
     #[test]
     fn test_supported_specs_combined() {
         let specs = HalfKPNetwork::supported_specs();
-        // 256: 1, 512: 3, 768: 1, 1024: 2
-        assert_eq!(specs.len(), 7);
+        // (256: 1, 512: 3, 768: 1, 1024: 2) × 3 活性化 (CReLU/SCReLU/Pairwise)
+        assert_eq!(specs.len(), 21);
 
         // 全て HalfKP
         for spec in &specs {

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -1518,39 +1518,71 @@ fn parse_qa_from_arch(arch_str: &str) -> Option<i16> {
 // 型エイリアス
 // =============================================================================
 
-use super::activation::CReLU;
+use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 /// HalfKA 256x2-32-32 CReLU
 pub type HalfKA256CReLU = NetworkHalfKA<256, 512, 512, 32, 32, CReLU>;
+/// HalfKA 256x2-32-32 SCReLU
+pub type HalfKA256SCReLU = NetworkHalfKA<256, 512, 512, 32, 32, SCReLU>;
+/// HalfKA 256x2-32-32 PairwiseCReLU
+pub type HalfKA256Pairwise = NetworkHalfKA<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKA 512x2-8-64 CReLU
 pub type HalfKA512_8_64CReLU = NetworkHalfKA<512, 1024, 1024, 8, 64, CReLU>;
+/// HalfKA 512x2-8-64 SCReLU
+pub type HalfKA512_8_64SCReLU = NetworkHalfKA<512, 1024, 1024, 8, 64, SCReLU>;
+/// HalfKA 512x2-8-64 PairwiseCReLU
+pub type HalfKA512_8_64Pairwise = NetworkHalfKA<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=96
 /// HalfKA 512x2-8-96 CReLU
 pub type HalfKA512CReLU = NetworkHalfKA<512, 1024, 1024, 8, 96, CReLU>;
+/// HalfKA 512x2-8-96 SCReLU
+pub type HalfKA512SCReLU = NetworkHalfKA<512, 1024, 1024, 8, 96, SCReLU>;
+/// HalfKA 512x2-8-96 PairwiseCReLU
+pub type HalfKA512Pairwise = NetworkHalfKA<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKA 512x2-32-32 CReLU
 pub type HalfKA512_32_32CReLU = NetworkHalfKA<512, 1024, 1024, 32, 32, CReLU>;
+/// HalfKA 512x2-32-32 SCReLU
+pub type HalfKA512_32_32SCReLU = NetworkHalfKA<512, 1024, 1024, 32, 32, SCReLU>;
+/// HalfKA 512x2-32-32 PairwiseCReLU
+pub type HalfKA512_32_32Pairwise = NetworkHalfKA<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKA 1024x2-8-64 CReLU
 pub type HalfKA1024_8_64CReLU = NetworkHalfKA<1024, 2048, 2048, 8, 64, CReLU>;
+/// HalfKA 1024x2-8-64 SCReLU
+pub type HalfKA1024_8_64SCReLU = NetworkHalfKA<1024, 2048, 2048, 8, 64, SCReLU>;
+/// HalfKA 1024x2-8-64 PairwiseCReLU
+pub type HalfKA1024_8_64Pairwise = NetworkHalfKA<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=96
 /// HalfKA 1024x2-8-96 CReLU
 pub type HalfKA1024CReLU = NetworkHalfKA<1024, 2048, 2048, 8, 96, CReLU>;
+/// HalfKA 1024x2-8-96 SCReLU
+pub type HalfKA1024SCReLU = NetworkHalfKA<1024, 2048, 2048, 8, 96, SCReLU>;
+/// HalfKA 1024x2-8-96 PairwiseCReLU
+pub type HalfKA1024Pairwise = NetworkHalfKA<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKA 1024x2-8-32 CReLU
 pub type HalfKA1024_8_32CReLU = NetworkHalfKA<1024, 2048, 2048, 8, 32, CReLU>;
+/// HalfKA 1024x2-8-32 SCReLU
+pub type HalfKA1024_8_32SCReLU = NetworkHalfKA<1024, 2048, 2048, 8, 32, SCReLU>;
+/// HalfKA 1024x2-8-32 PairwiseCReLU
+pub type HalfKA1024_8_32Pairwise = NetworkHalfKA<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 /// HalfKA 768x2-16-64 CReLU
 pub type HalfKA768CReLU = NetworkHalfKA<768, 1536, 1536, 16, 64, CReLU>;
+/// HalfKA 768x2-16-64 SCReLU
+pub type HalfKA768SCReLU = NetworkHalfKA<768, 1536, 1536, 16, 64, SCReLU>;
+/// HalfKA 768x2-16-64 PairwiseCReLU
+pub type HalfKA768Pairwise = NetworkHalfKA<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -1516,39 +1516,71 @@ fn parse_qa_from_arch(arch_str: &str) -> Option<i16> {
 // 型エイリアス
 // =============================================================================
 
-use super::activation::CReLU;
+use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 /// HalfKA_hm 256x2-32-32 CReLU
 pub type HalfKA_hm256CReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, CReLU>;
+/// HalfKA_hm 256x2-32-32 SCReLU
+pub type HalfKA_hm256SCReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, SCReLU>;
+/// HalfKA_hm 256x2-32-32 PairwiseCReLU
+pub type HalfKA_hm256Pairwise = NetworkHalfKA_hm<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKA_hm 512x2-8-64 CReLU
 pub type HalfKA_hm512_8_64CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, CReLU>;
+/// HalfKA_hm 512x2-8-64 SCReLU
+pub type HalfKA_hm512_8_64SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, SCReLU>;
+/// HalfKA_hm 512x2-8-64 PairwiseCReLU
+pub type HalfKA_hm512_8_64Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=96
 /// HalfKA_hm 512x2-8-96 CReLU
 pub type HalfKA_hm512CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, CReLU>;
+/// HalfKA_hm 512x2-8-96 SCReLU
+pub type HalfKA_hm512SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, SCReLU>;
+/// HalfKA_hm 512x2-8-96 PairwiseCReLU
+pub type HalfKA_hm512Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKA_hm 512x2-32-32 CReLU
 pub type HalfKA_hm512_32_32CReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, CReLU>;
+/// HalfKA_hm 512x2-32-32 SCReLU
+pub type HalfKA_hm512_32_32SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, SCReLU>;
+/// HalfKA_hm 512x2-32-32 PairwiseCReLU
+pub type HalfKA_hm512_32_32Pairwise = NetworkHalfKA_hm<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKA_hm 1024x2-8-64 CReLU
 pub type HalfKA_hm1024_8_64CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, CReLU>;
+/// HalfKA_hm 1024x2-8-64 SCReLU
+pub type HalfKA_hm1024_8_64SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, SCReLU>;
+/// HalfKA_hm 1024x2-8-64 PairwiseCReLU
+pub type HalfKA_hm1024_8_64Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=96
 /// HalfKA_hm 1024x2-8-96 CReLU
 pub type HalfKA_hm1024CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, CReLU>;
+/// HalfKA_hm 1024x2-8-96 SCReLU
+pub type HalfKA_hm1024SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, SCReLU>;
+/// HalfKA_hm 1024x2-8-96 PairwiseCReLU
+pub type HalfKA_hm1024Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKA_hm 1024x2-8-32 CReLU
 pub type HalfKA_hm1024_8_32CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, CReLU>;
+/// HalfKA_hm 1024x2-8-32 SCReLU
+pub type HalfKA_hm1024_8_32SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, SCReLU>;
+/// HalfKA_hm 1024x2-8-32 PairwiseCReLU
+pub type HalfKA_hm1024_8_32Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 /// HalfKA_hm 768x2-16-64 CReLU
 pub type HalfKA_hm768CReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, CReLU>;
+/// HalfKA_hm 768x2-16-64 SCReLU
+pub type HalfKA_hm768SCReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, SCReLU>;
+/// HalfKA_hm 768x2-16-64 PairwiseCReLU
+pub type HalfKA_hm768Pairwise = NetworkHalfKA_hm<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -1519,39 +1519,74 @@ fn parse_qa_from_arch(arch_str: &str) -> Option<i16> {
 // 型エイリアス
 // =============================================================================
 
-use super::activation::CReLU;
+use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 /// HalfKaHmSplit 256x2-32-32 CReLU
 pub type HalfKaHmSplit256CReLU = NetworkHalfKaHmSplit<256, 512, 512, 32, 32, CReLU>;
+/// HalfKaHmSplit 256x2-32-32 SCReLU
+pub type HalfKaHmSplit256SCReLU = NetworkHalfKaHmSplit<256, 512, 512, 32, 32, SCReLU>;
+/// HalfKaHmSplit 256x2-32-32 PairwiseCReLU
+pub type HalfKaHmSplit256Pairwise = NetworkHalfKaHmSplit<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKaHmSplit 512x2-8-64 CReLU
 pub type HalfKaHmSplit512_8_64CReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 8, 64, CReLU>;
+/// HalfKaHmSplit 512x2-8-64 SCReLU
+pub type HalfKaHmSplit512_8_64SCReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 8, 64, SCReLU>;
+/// HalfKaHmSplit 512x2-8-64 PairwiseCReLU
+pub type HalfKaHmSplit512_8_64Pairwise = NetworkHalfKaHmSplit<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=96
 /// HalfKaHmSplit 512x2-8-96 CReLU
 pub type HalfKaHmSplit512CReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 8, 96, CReLU>;
+/// HalfKaHmSplit 512x2-8-96 SCReLU
+pub type HalfKaHmSplit512SCReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 8, 96, SCReLU>;
+/// HalfKaHmSplit 512x2-8-96 PairwiseCReLU
+pub type HalfKaHmSplit512Pairwise = NetworkHalfKaHmSplit<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKaHmSplit 512x2-32-32 CReLU
 pub type HalfKaHmSplit512_32_32CReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 32, 32, CReLU>;
+/// HalfKaHmSplit 512x2-32-32 SCReLU
+pub type HalfKaHmSplit512_32_32SCReLU = NetworkHalfKaHmSplit<512, 1024, 1024, 32, 32, SCReLU>;
+/// HalfKaHmSplit 512x2-32-32 PairwiseCReLU
+pub type HalfKaHmSplit512_32_32Pairwise =
+    NetworkHalfKaHmSplit<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKaHmSplit 1024x2-8-64 CReLU
 pub type HalfKaHmSplit1024_8_64CReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 64, CReLU>;
+/// HalfKaHmSplit 1024x2-8-64 SCReLU
+pub type HalfKaHmSplit1024_8_64SCReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 64, SCReLU>;
+/// HalfKaHmSplit 1024x2-8-64 PairwiseCReLU
+pub type HalfKaHmSplit1024_8_64Pairwise =
+    NetworkHalfKaHmSplit<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=96
 /// HalfKaHmSplit 1024x2-8-96 CReLU
 pub type HalfKaHmSplit1024CReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 96, CReLU>;
+/// HalfKaHmSplit 1024x2-8-96 SCReLU
+pub type HalfKaHmSplit1024SCReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 96, SCReLU>;
+/// HalfKaHmSplit 1024x2-8-96 PairwiseCReLU
+pub type HalfKaHmSplit1024Pairwise = NetworkHalfKaHmSplit<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKaHmSplit 1024x2-8-32 CReLU
 pub type HalfKaHmSplit1024_8_32CReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 32, CReLU>;
+/// HalfKaHmSplit 1024x2-8-32 SCReLU
+pub type HalfKaHmSplit1024_8_32SCReLU = NetworkHalfKaHmSplit<1024, 2048, 2048, 8, 32, SCReLU>;
+/// HalfKaHmSplit 1024x2-8-32 PairwiseCReLU
+pub type HalfKaHmSplit1024_8_32Pairwise =
+    NetworkHalfKaHmSplit<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 /// HalfKaHmSplit 768x2-16-64 CReLU
 pub type HalfKaHmSplit768CReLU = NetworkHalfKaHmSplit<768, 1536, 1536, 16, 64, CReLU>;
+/// HalfKaHmSplit 768x2-16-64 SCReLU
+pub type HalfKaHmSplit768SCReLU = NetworkHalfKaHmSplit<768, 1536, 1536, 16, 64, SCReLU>;
+/// HalfKaHmSplit 768x2-16-64 PairwiseCReLU
+pub type HalfKaHmSplit768Pairwise = NetworkHalfKaHmSplit<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -1521,39 +1521,73 @@ fn parse_qa_from_arch(arch_str: &str) -> Option<i16> {
 // 型エイリアス
 // =============================================================================
 
-use super::activation::CReLU;
+use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 /// HalfKaMerged 256x2-32-32 CReLU
 pub type HalfKaMerged256CReLU = NetworkHalfKaMerged<256, 512, 512, 32, 32, CReLU>;
+/// HalfKaMerged 256x2-32-32 SCReLU
+pub type HalfKaMerged256SCReLU = NetworkHalfKaMerged<256, 512, 512, 32, 32, SCReLU>;
+/// HalfKaMerged 256x2-32-32 PairwiseCReLU
+pub type HalfKaMerged256Pairwise = NetworkHalfKaMerged<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKaMerged 512x2-8-64 CReLU
 pub type HalfKaMerged512_8_64CReLU = NetworkHalfKaMerged<512, 1024, 1024, 8, 64, CReLU>;
+/// HalfKaMerged 512x2-8-64 SCReLU
+pub type HalfKaMerged512_8_64SCReLU = NetworkHalfKaMerged<512, 1024, 1024, 8, 64, SCReLU>;
+/// HalfKaMerged 512x2-8-64 PairwiseCReLU
+pub type HalfKaMerged512_8_64Pairwise = NetworkHalfKaMerged<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=96
 /// HalfKaMerged 512x2-8-96 CReLU
 pub type HalfKaMerged512CReLU = NetworkHalfKaMerged<512, 1024, 1024, 8, 96, CReLU>;
+/// HalfKaMerged 512x2-8-96 SCReLU
+pub type HalfKaMerged512SCReLU = NetworkHalfKaMerged<512, 1024, 1024, 8, 96, SCReLU>;
+/// HalfKaMerged 512x2-8-96 PairwiseCReLU
+pub type HalfKaMerged512Pairwise = NetworkHalfKaMerged<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKaMerged 512x2-32-32 CReLU
 pub type HalfKaMerged512_32_32CReLU = NetworkHalfKaMerged<512, 1024, 1024, 32, 32, CReLU>;
+/// HalfKaMerged 512x2-32-32 SCReLU
+pub type HalfKaMerged512_32_32SCReLU = NetworkHalfKaMerged<512, 1024, 1024, 32, 32, SCReLU>;
+/// HalfKaMerged 512x2-32-32 PairwiseCReLU
+pub type HalfKaMerged512_32_32Pairwise = NetworkHalfKaMerged<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKaMerged 1024x2-8-64 CReLU
 pub type HalfKaMerged1024_8_64CReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 64, CReLU>;
+/// HalfKaMerged 1024x2-8-64 SCReLU
+pub type HalfKaMerged1024_8_64SCReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 64, SCReLU>;
+/// HalfKaMerged 1024x2-8-64 PairwiseCReLU
+pub type HalfKaMerged1024_8_64Pairwise =
+    NetworkHalfKaMerged<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=96
 /// HalfKaMerged 1024x2-8-96 CReLU
 pub type HalfKaMerged1024CReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 96, CReLU>;
+/// HalfKaMerged 1024x2-8-96 SCReLU
+pub type HalfKaMerged1024SCReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 96, SCReLU>;
+/// HalfKaMerged 1024x2-8-96 PairwiseCReLU
+pub type HalfKaMerged1024Pairwise = NetworkHalfKaMerged<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKaMerged 1024x2-8-32 CReLU
 pub type HalfKaMerged1024_8_32CReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 32, CReLU>;
+/// HalfKaMerged 1024x2-8-32 SCReLU
+pub type HalfKaMerged1024_8_32SCReLU = NetworkHalfKaMerged<1024, 2048, 2048, 8, 32, SCReLU>;
+/// HalfKaMerged 1024x2-8-32 PairwiseCReLU
+pub type HalfKaMerged1024_8_32Pairwise =
+    NetworkHalfKaMerged<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 /// HalfKaMerged 768x2-16-64 CReLU
 pub type HalfKaMerged768CReLU = NetworkHalfKaMerged<768, 1536, 1536, 16, 64, CReLU>;
+/// HalfKaMerged 768x2-16-64 SCReLU
+pub type HalfKaMerged768SCReLU = NetworkHalfKaMerged<768, 1536, 1536, 16, 64, SCReLU>;
+/// HalfKaMerged 768x2-16-64 PairwiseCReLU
+pub type HalfKaMerged768Pairwise = NetworkHalfKaMerged<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -1578,38 +1578,66 @@ fn parse_fv_scale_from_arch(arch_str: &str) -> Option<i32> {
 // 型エイリアス
 // =============================================================================
 
-use super::activation::CReLU;
+use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 // CReLU/SCReLU: L1_INPUT=512, Pairwise: L1_INPUT=256
 /// HalfKP 256x2-32-32 CReLU
 pub type HalfKP256CReLU = NetworkHalfKP<256, 512, 512, 32, 32, CReLU>;
+/// HalfKP 256x2-32-32 SCReLU
+pub type HalfKP256SCReLU = NetworkHalfKP<256, 512, 512, 32, 32, SCReLU>;
+/// HalfKP 256x2-32-32 PairwiseCReLU
+pub type HalfKP256Pairwise = NetworkHalfKP<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024
 // CReLU/SCReLU: L1_INPUT=1024, Pairwise: L1_INPUT=512
 /// HalfKP 512x2-8-96 CReLU
 pub type HalfKP512CReLU = NetworkHalfKP<512, 1024, 1024, 8, 96, CReLU>;
+/// HalfKP 512x2-8-96 SCReLU
+pub type HalfKP512SCReLU = NetworkHalfKP<512, 1024, 1024, 8, 96, SCReLU>;
+/// HalfKP 512x2-8-96 PairwiseCReLU
+pub type HalfKP512Pairwise = NetworkHalfKP<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKP 512x2-8-64 CReLU
 pub type HalfKP512_8_64CReLU = NetworkHalfKP<512, 1024, 1024, 8, 64, CReLU>;
+/// HalfKP 512x2-8-64 SCReLU
+pub type HalfKP512_8_64SCReLU = NetworkHalfKP<512, 1024, 1024, 8, 64, SCReLU>;
+/// HalfKP 512x2-8-64 PairwiseCReLU
+pub type HalfKP512_8_64Pairwise = NetworkHalfKP<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKP 512x2-32-32 CReLU
 pub type HalfKP512_32_32CReLU = NetworkHalfKP<512, 1024, 1024, 32, 32, CReLU>;
+/// HalfKP 512x2-32-32 SCReLU
+pub type HalfKP512_32_32SCReLU = NetworkHalfKP<512, 1024, 1024, 32, 32, SCReLU>;
+/// HalfKP 512x2-32-32 PairwiseCReLU
+pub type HalfKP512_32_32Pairwise = NetworkHalfKP<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKP 1024x2-8-32 CReLU
 pub type HalfKP1024_8_32CReLU = NetworkHalfKP<1024, 2048, 2048, 8, 32, CReLU>;
+/// HalfKP 1024x2-8-32 SCReLU
+pub type HalfKP1024_8_32SCReLU = NetworkHalfKP<1024, 2048, 2048, 8, 32, SCReLU>;
+/// HalfKP 1024x2-8-32 PairwiseCReLU
+pub type HalfKP1024_8_32Pairwise = NetworkHalfKP<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKP 1024x2-8-64 CReLU
 pub type HalfKP1024_8_64CReLU = NetworkHalfKP<1024, 2048, 2048, 8, 64, CReLU>;
+/// HalfKP 1024x2-8-64 SCReLU
+pub type HalfKP1024_8_64SCReLU = NetworkHalfKP<1024, 2048, 2048, 8, 64, SCReLU>;
+/// HalfKP 1024x2-8-64 PairwiseCReLU
+pub type HalfKP1024_8_64Pairwise = NetworkHalfKP<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 // CReLU/SCReLU: L1_INPUT=1536, Pairwise: L1_INPUT=768
 /// HalfKP 768x2-16-64 CReLU
 pub type HalfKP768CReLU = NetworkHalfKP<768, 1536, 1536, 16, 64, CReLU>;
+/// HalfKP 768x2-16-64 SCReLU
+pub type HalfKP768SCReLU = NetworkHalfKP<768, 1536, 1536, 16, 64, SCReLU>;
+/// HalfKP 768x2-16-64 PairwiseCReLU
+pub type HalfKP768Pairwise = NetworkHalfKP<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト

--- a/crates/rshogi-core/src/nnue/spec.rs
+++ b/crates/rshogi-core/src/nnue/spec.rs
@@ -405,6 +405,26 @@ pub const fn network_payload_halfkp(l1: usize, l2: usize, l3: usize) -> u64 {
         as u64
 }
 
+/// HalfKP の network_payload を計算（PairwiseCReLU 版）
+///
+/// PairwiseCReLU は活性化で次元を半減させるため、L1 層の dense 入力は
+/// `pad32(l1)`（CReLU/SCReLU の `pad32(l1 * 2)` ではない）。
+pub const fn network_payload_halfkp_pairwise(l1: usize, l2: usize, l3: usize) -> u64 {
+    const HALFKP_DIMENSIONS: usize = 125388;
+
+    let ft_bias = l1 * 2;
+    let ft_weight = HALFKP_DIMENSIONS * l1 * 2;
+    let l1_bias = l2 * 4;
+    let l1_weight = pad32(l1) * l2;
+    let l2_bias = l3 * 4;
+    let l2_weight = pad32(l2) * l3;
+    let output_bias = 4;
+    let output_weight = l3;
+
+    (ft_bias + ft_weight + l1_bias + l1_weight + l2_bias + l2_weight + output_bias + output_weight)
+        as u64
+}
+
 /// HalfKA_hm の network_payload を計算
 pub const fn network_payload_halfka_hm(l1: usize, l2: usize, l3: usize) -> u64 {
     const HALFKA_HM_DIMENSIONS: usize = 73305;
@@ -413,6 +433,23 @@ pub const fn network_payload_halfka_hm(l1: usize, l2: usize, l3: usize) -> u64 {
     let ft_weight = HALFKA_HM_DIMENSIONS * l1 * 2;
     let l1_bias = l2 * 4;
     let l1_weight = pad32(l1 * 2) * l2;
+    let l2_bias = l3 * 4;
+    let l2_weight = pad32(l2) * l3;
+    let output_bias = 4;
+    let output_weight = l3;
+
+    (ft_bias + ft_weight + l1_bias + l1_weight + l2_bias + l2_weight + output_bias + output_weight)
+        as u64
+}
+
+/// HalfKA_hm の network_payload を計算（PairwiseCReLU 版）
+pub const fn network_payload_halfka_hm_pairwise(l1: usize, l2: usize, l3: usize) -> u64 {
+    const HALFKA_HM_DIMENSIONS: usize = 73305;
+
+    let ft_bias = l1 * 2;
+    let ft_weight = HALFKA_HM_DIMENSIONS * l1 * 2;
+    let l1_bias = l2 * 4;
+    let l1_weight = pad32(l1) * l2;
     let l2_bias = l3 * 4;
     let l2_weight = pad32(l2) * l3;
     let output_bias = 4;
@@ -439,6 +476,23 @@ pub const fn network_payload_halfka(l1: usize, l2: usize, l3: usize) -> u64 {
         as u64
 }
 
+/// HalfKA の network_payload を計算（PairwiseCReLU 版）
+pub const fn network_payload_halfka_pairwise(l1: usize, l2: usize, l3: usize) -> u64 {
+    const HALFKA_DIMENSIONS: usize = 138510;
+
+    let ft_bias = l1 * 2;
+    let ft_weight = HALFKA_DIMENSIONS * l1 * 2;
+    let l1_bias = l2 * 4;
+    let l1_weight = pad32(l1) * l2;
+    let l2_bias = l3 * 4;
+    let l2_weight = pad32(l2) * l3;
+    let output_bias = 4;
+    let output_weight = l3;
+
+    (ft_bias + ft_weight + l1_bias + l1_weight + l2_bias + l2_weight + output_bias + output_weight)
+        as u64
+}
+
 /// HalfKaMerged の network_payload を計算
 pub const fn network_payload_halfka_merged(l1: usize, l2: usize, l3: usize) -> u64 {
     const HALFKA_MERGED_DIMENSIONS: usize = 131949;
@@ -447,6 +501,23 @@ pub const fn network_payload_halfka_merged(l1: usize, l2: usize, l3: usize) -> u
     let ft_weight = HALFKA_MERGED_DIMENSIONS * l1 * 2;
     let l1_bias = l2 * 4;
     let l1_weight = pad32(l1 * 2) * l2;
+    let l2_bias = l3 * 4;
+    let l2_weight = pad32(l2) * l3;
+    let output_bias = 4;
+    let output_weight = l3;
+
+    (ft_bias + ft_weight + l1_bias + l1_weight + l2_bias + l2_weight + output_bias + output_weight)
+        as u64
+}
+
+/// HalfKaMerged の network_payload を計算（PairwiseCReLU 版）
+pub const fn network_payload_halfka_merged_pairwise(l1: usize, l2: usize, l3: usize) -> u64 {
+    const HALFKA_MERGED_DIMENSIONS: usize = 131949;
+
+    let ft_bias = l1 * 2;
+    let ft_weight = HALFKA_MERGED_DIMENSIONS * l1 * 2;
+    let l1_bias = l2 * 4;
+    let l1_weight = pad32(l1) * l2;
     let l2_bias = l3 * 4;
     let l2_weight = pad32(l2) * l3;
     let output_bias = 4;
@@ -473,6 +544,23 @@ pub const fn network_payload_halfka_hm_split(l1: usize, l2: usize, l3: usize) ->
         as u64
 }
 
+/// HalfKaHmSplit の network_payload を計算（PairwiseCReLU 版）
+pub const fn network_payload_halfka_hm_split_pairwise(l1: usize, l2: usize, l3: usize) -> u64 {
+    const HALFKA_HM_SPLIT_DIMENSIONS: usize = 76950;
+
+    let ft_bias = l1 * 2;
+    let ft_weight = HALFKA_HM_SPLIT_DIMENSIONS * l1 * 2;
+    let l1_bias = l2 * 4;
+    let l1_weight = pad32(l1) * l2;
+    let l2_bias = l3 * 4;
+    let l2_weight = pad32(l2) * l3;
+    let output_bias = 4;
+    let output_weight = l3;
+
+    (ft_bias + ft_weight + l1_bias + l1_weight + l2_bias + l2_weight + output_bias + output_weight)
+        as u64
+}
+
 /// アーキテクチャ検出結果
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ArchDetectionResult {
@@ -490,10 +578,13 @@ pub struct ArchDetectionResult {
 /// サポートされているアーキテクチャの network_payload テーブル
 ///
 /// (FeatureSet, L1, L2, L3, network_payload)
-/// 活性化関数はファイルサイズに影響しないため、ここでは CReLU を仮定。
-/// 実際の活性化関数はヘッダーから判定する。
+/// CReLU/SCReLU は同一ファイルサイズ（活性化はスケール係数）なので 1 行で兼ねる。
+/// PairwiseCReLU は L1 層の dense 入力次元が半分になるためファイルサイズが異なり、
+/// 同じ (FeatureSet, L1, L2, L3) に対して別行を持つ。
+/// `detect_architecture_from_size` はサイズ一致でアーキを特定し、活性化は
+/// ヘッダーから別途判定するため、CReLU/Pairwise の 2 行併存で問題ない。
 const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
-    // HalfKP
+    // HalfKP (CReLU/SCReLU)
     (FeatureSet::HalfKP, 256, 32, 32, network_payload_halfkp(256, 32, 32)),
     (FeatureSet::HalfKP, 512, 8, 64, network_payload_halfkp(512, 8, 64)),
     (FeatureSet::HalfKP, 512, 8, 96, network_payload_halfkp(512, 8, 96)),
@@ -501,7 +592,15 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
     (FeatureSet::HalfKP, 768, 16, 64, network_payload_halfkp(768, 16, 64)),
     (FeatureSet::HalfKP, 1024, 8, 32, network_payload_halfkp(1024, 8, 32)),
     (FeatureSet::HalfKP, 1024, 8, 64, network_payload_halfkp(1024, 8, 64)),
-    // HalfKA_hm
+    // HalfKP (PairwiseCReLU)
+    (FeatureSet::HalfKP, 256, 32, 32, network_payload_halfkp_pairwise(256, 32, 32)),
+    (FeatureSet::HalfKP, 512, 8, 64, network_payload_halfkp_pairwise(512, 8, 64)),
+    (FeatureSet::HalfKP, 512, 8, 96, network_payload_halfkp_pairwise(512, 8, 96)),
+    (FeatureSet::HalfKP, 512, 32, 32, network_payload_halfkp_pairwise(512, 32, 32)),
+    (FeatureSet::HalfKP, 768, 16, 64, network_payload_halfkp_pairwise(768, 16, 64)),
+    (FeatureSet::HalfKP, 1024, 8, 32, network_payload_halfkp_pairwise(1024, 8, 32)),
+    (FeatureSet::HalfKP, 1024, 8, 64, network_payload_halfkp_pairwise(1024, 8, 64)),
+    // HalfKA_hm (CReLU/SCReLU)
     (FeatureSet::HalfKA_hm, 256, 32, 32, network_payload_halfka_hm(256, 32, 32)),
     (FeatureSet::HalfKA_hm, 512, 8, 64, network_payload_halfka_hm(512, 8, 64)),
     (FeatureSet::HalfKA_hm, 512, 8, 96, network_payload_halfka_hm(512, 8, 96)),
@@ -510,7 +609,64 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
     (FeatureSet::HalfKA_hm, 1024, 8, 32, network_payload_halfka_hm(1024, 8, 32)),
     (FeatureSet::HalfKA_hm, 1024, 8, 64, network_payload_halfka_hm(1024, 8, 64)),
     (FeatureSet::HalfKA_hm, 1024, 8, 96, network_payload_halfka_hm(1024, 8, 96)),
-    // HalfKA
+    // HalfKA_hm (PairwiseCReLU)
+    (
+        FeatureSet::HalfKA_hm,
+        256,
+        32,
+        32,
+        network_payload_halfka_hm_pairwise(256, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        512,
+        8,
+        64,
+        network_payload_halfka_hm_pairwise(512, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        512,
+        8,
+        96,
+        network_payload_halfka_hm_pairwise(512, 8, 96),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        512,
+        32,
+        32,
+        network_payload_halfka_hm_pairwise(512, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        768,
+        16,
+        64,
+        network_payload_halfka_hm_pairwise(768, 16, 64),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        1024,
+        8,
+        32,
+        network_payload_halfka_hm_pairwise(1024, 8, 32),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        1024,
+        8,
+        64,
+        network_payload_halfka_hm_pairwise(1024, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKA_hm,
+        1024,
+        8,
+        96,
+        network_payload_halfka_hm_pairwise(1024, 8, 96),
+    ),
+    // HalfKA (CReLU/SCReLU)
     (FeatureSet::HalfKA, 256, 32, 32, network_payload_halfka(256, 32, 32)),
     (FeatureSet::HalfKA, 512, 8, 64, network_payload_halfka(512, 8, 64)),
     (FeatureSet::HalfKA, 512, 8, 96, network_payload_halfka(512, 8, 96)),
@@ -519,7 +675,16 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
     (FeatureSet::HalfKA, 1024, 8, 32, network_payload_halfka(1024, 8, 32)),
     (FeatureSet::HalfKA, 1024, 8, 64, network_payload_halfka(1024, 8, 64)),
     (FeatureSet::HalfKA, 1024, 8, 96, network_payload_halfka(1024, 8, 96)),
-    // HalfKaMerged
+    // HalfKA (PairwiseCReLU)
+    (FeatureSet::HalfKA, 256, 32, 32, network_payload_halfka_pairwise(256, 32, 32)),
+    (FeatureSet::HalfKA, 512, 8, 64, network_payload_halfka_pairwise(512, 8, 64)),
+    (FeatureSet::HalfKA, 512, 8, 96, network_payload_halfka_pairwise(512, 8, 96)),
+    (FeatureSet::HalfKA, 512, 32, 32, network_payload_halfka_pairwise(512, 32, 32)),
+    (FeatureSet::HalfKA, 768, 16, 64, network_payload_halfka_pairwise(768, 16, 64)),
+    (FeatureSet::HalfKA, 1024, 8, 32, network_payload_halfka_pairwise(1024, 8, 32)),
+    (FeatureSet::HalfKA, 1024, 8, 64, network_payload_halfka_pairwise(1024, 8, 64)),
+    (FeatureSet::HalfKA, 1024, 8, 96, network_payload_halfka_pairwise(1024, 8, 96)),
+    // HalfKaMerged (CReLU/SCReLU)
     (
         FeatureSet::HalfKaMerged,
         256,
@@ -564,7 +729,64 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
         96,
         network_payload_halfka_merged(1024, 8, 96),
     ),
-    // HalfKaHmSplit
+    // HalfKaMerged (PairwiseCReLU)
+    (
+        FeatureSet::HalfKaMerged,
+        256,
+        32,
+        32,
+        network_payload_halfka_merged_pairwise(256, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        512,
+        8,
+        64,
+        network_payload_halfka_merged_pairwise(512, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        512,
+        8,
+        96,
+        network_payload_halfka_merged_pairwise(512, 8, 96),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        512,
+        32,
+        32,
+        network_payload_halfka_merged_pairwise(512, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        768,
+        16,
+        64,
+        network_payload_halfka_merged_pairwise(768, 16, 64),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        1024,
+        8,
+        32,
+        network_payload_halfka_merged_pairwise(1024, 8, 32),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        1024,
+        8,
+        64,
+        network_payload_halfka_merged_pairwise(1024, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKaMerged,
+        1024,
+        8,
+        96,
+        network_payload_halfka_merged_pairwise(1024, 8, 96),
+    ),
+    // HalfKaHmSplit (CReLU/SCReLU)
     (
         FeatureSet::HalfKaHmSplit,
         256,
@@ -620,6 +842,63 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
         8,
         96,
         network_payload_halfka_hm_split(1024, 8, 96),
+    ),
+    // HalfKaHmSplit (PairwiseCReLU)
+    (
+        FeatureSet::HalfKaHmSplit,
+        256,
+        32,
+        32,
+        network_payload_halfka_hm_split_pairwise(256, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        512,
+        8,
+        64,
+        network_payload_halfka_hm_split_pairwise(512, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        512,
+        8,
+        96,
+        network_payload_halfka_hm_split_pairwise(512, 8, 96),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        512,
+        32,
+        32,
+        network_payload_halfka_hm_split_pairwise(512, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        768,
+        16,
+        64,
+        network_payload_halfka_hm_split_pairwise(768, 16, 64),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        1024,
+        8,
+        32,
+        network_payload_halfka_hm_split_pairwise(1024, 8, 32),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        1024,
+        8,
+        64,
+        network_payload_halfka_hm_split_pairwise(1024, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKaHmSplit,
+        1024,
+        8,
+        96,
+        network_payload_halfka_hm_split_pairwise(1024, 8, 96),
     ),
 ];
 


### PR DESCRIPTION
## 概要

rshogi engine の Simple アーキ 5 feature set（HalfKP / HalfKA / HalfKA_hm / HalfKaMerged / HalfKaHmSplit）に **SCReLU + PairwiseCReLU 活性化のロード対応**を追加する。

これまで `define_l1_variants!` マクロの `variants {}` テーブルは `CReLU` のみで、SCReLU / Pairwise の `.bin` は load reject されていた（rshogi-nnue PR #204 §H が指摘）。#165 Phase B（CReLU / SCReLU / Pairwise 3-way スイープ、trainer 側 Pairwise 学習は PR #204 で対応済）に必要。

## 変更内容（33 files, +875 / −294）

`NetworkHalfKA<L1, FT_OUT, L1_INPUT, L2, L3, A: FtActivation>` は既に活性化ジェネリック。今回は **variant テーブルへの配線**と **Pairwise のサイズ検出**が主体：

- **型エイリアス**（5× `network_half*.rs`）: 既存 `*CReLU` エイリアスごとに `*SCReLU` / `*Pairwise` を追加。SCReLU は `A` 差し替えのみ。Pairwise は `L1_INPUT` を `L1*2` → `L1` に（`OUTPUT_DIM_DIVISOR=2` で FT 出力が半減するため）。
- **`aliases.rs`**: 新エイリアスを再エクスポート。
- **variant テーブル**（20× `half*/l*.rs`）: 各 `(l2,l3,CReLU)` 行に `(l2,l3,SCReLU)` / `(l2,l3,PairwiseCReLU)` を追加。
- **`spec.rs`**: Pairwise 用 `network_payload_*_pairwise`（`l1_weight = pad32(l1) * l2`、CReLU の `pad32(l1*2)*l2` と 1 項のみ差分）を 5 feature set 分追加し、`KNOWN_PAYLOADS` に Pairwise 行を追加。SCReLU は活性化がファイルサイズを変えないため payload 変更不要。
- テスト: `SUPPORTED_SPECS.len()` を ×3 に更新、`test_activation_output_dim_divisor` を `test_supported_activations` に置換。

## 検証

```
cargo fmt && cargo clippy --tests -p rshogi-core   # warning なし
cargo test -p rshogi-core --lib nnue::             # 357 passed
```

**SCReLU 実モデルでロード検証**: #165 Phase B の `simple-512x2-8-64-halfka-hm-merged SCReLU`（`fv_scale=56`）を `bench_nnue_eval` でロード → `Architecture: HalfKA_hm-512-8-64-SCReLU` として load + eval 成功。既存 CReLU モデルの回帰なし。

Pairwise は `.bin` が未生成（Phase B Pairwise run 未実施）のため end-to-end ロード検証は未。compile 時の `L1_INPUT == L1*2 || L1_INPUT == L1` アサーション、ユニットテスト、payload 式が trainer の SimpleWeights Pairwise レイアウト（`combined_dim = ft_out`）と一致することで担保。Phase B Pairwise モデル生成後にロード確認を推奨。

既知の pre-existing 失敗 `test_accumulator_stack_variant_fallback` / `test_evaluate_fallback` は origin/main でも発生する global-state flake で本 PR と無関係。

## レビュー

- local Codex review: **Approve**
- local Claude review: **Approve**（35 Pairwise エイリアスの `L1_INPUT=L1`、payload 式、網羅性すべて検証）

## 関連

- #719 / #720（Simple アーキ feature set 追加・名前統一、本 PR の前提）
- rshogi-nnue #165 Phase B / #204（Pairwise 学習対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
