### PR TITLE
fix(usi): Simple系アーキで LS_PROGRESS_COEFF を要求しないよう isready guard を限定

### DIFF
--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -324,14 +324,19 @@ impl UsiEngine {
                 // EvalFile 未指定だが Material 有効 or NNUE 既ロード → 何もしない
             }
         }
-        // progress8kpabs モードで LS_PROGRESS_COEFF 未指定の場合はエラー
-        // NNUE が未ロード（Material 評価）の場合は bucket mode は使われないのでスキップ
-        if get_network().is_some() {
+        // progress8kpabs bucket mode で LS_PROGRESS_COEFF 未指定の場合はエラー。
+        // bucket mode は LayerStacks ネットワーク専用。Simple系アーキ
+        // (HalfKP/HalfKA/HalfKA_hm/HalfKaMerged/HalfKaHmSplit) や Material 評価では
+        // 使われないため、ロード済みネットワークが LayerStacks のときだけ検査する。
+        {
             use rshogi_core::nnue::{
-                LayerStackBucketMode, get_layer_stack_bucket_mode,
+                LayerStackBucketMode, NNUENetwork, get_layer_stack_bucket_mode,
                 get_layer_stack_progress_kpabs_weights,
             };
-            if get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
+            let is_layer_stacks =
+                matches!(get_network().as_deref(), Some(NNUENetwork::LayerStacks(_)));
+            if is_layer_stacks
+                && get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
                 && get_layer_stack_progress_kpabs_weights().iter().all(|&w| w == 0.0)
             {
                 panic!(


### PR DESCRIPTION
## 概要

`rshogi-usi` の `isready` ハンドラにある `LS_BUCKET_MODE=progress8kpabs` guard が、ロード済みネットワークの種別を問わず発火していた。`LS_BUCKET_MODE` / progress8kpabs バケッティングは **LayerStacks 専用**の機構だが、guard が `get_network().is_some()`（=何らかの NNUE がロード済み）だけを条件にしていたため、Simple系アーキのモデル（HalfKP / HalfKA / HalfKA_hm / HalfKaMerged / HalfKaHmSplit）をロードすると `LS_PROGRESS_COEFF` を要求して `isready` で panic していた。

`LayerStackBucketMode` の既定値は `Progress8KPAbs`（かつ唯一の variant）なので、Simple系モデルは **USI エンジンで一切ロードできない**状態だった。

### 影響

これは #165（rshogi-nnue の活性化スイープ）SPRT 全体をブロックしていた — Phase A/B のモデルは全て Simple系 HalfKA アーキで、progress.bin を持たない。`bench_nnue_eval` は `NNUENetwork::load()` を直接呼ぶため `isready` 経路を通らず、この panic が露見していなかった。

## 修正

guard をロード済みネットワークが `NNUENetwork::LayerStacks(_)` の場合に限定する:

```rust
let is_layer_stacks =
    matches!(get_network().as_deref(), Some(NNUENetwork::LayerStacks(_)));
if is_layer_stacks
    && get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
    && get_layer_stack_progress_kpabs_weights().iter().all(|&w| w == 0.0)
{ panic!(...) }
```

- LayerStacks ネットワーク + progress 重み未設定 → 従来どおり panic（保護動作は維持）。
- Simple系 5 アーキ・Material 評価 → guard をスキップ。

`evaluate_dispatch` は Simple系 5 variant を専用の `update_and_evaluate_*` にルーティングし、bucket mode / progress 重みを参照するのは `LayerStacks` 経路のみ（`network.rs:1185`）。Simple系で guard をスキップしても eval に影響しないことを確認済み。

## 検証

```
cargo clippy -p rshogi-usi --release   # warning なし
```

- 修正前: Simple系 HalfKA_hm SCReLU `.bin` を `setoption EvalFile` → `isready` で panic（`main.rs:337`）。
- 修正後: 同モデルが `readyok` → `position startpos` → `go depth 6` → `bestmove` まで正常動作（FV_SCALE 56 / 28 両方）。

## レビュー

- local Codex review: **Approve**
- local Claude review: **Approve**（保護動作維持・Simple系/Material スキップの安全性・downstream 依存なしを確認）

## 関連

- #719 / #721（Simple系 feature set / 活性化のロード対応）
- rshogi-nnue #165 活性化スイープ SPRT の前提

🤖 Generated with [Claude Code](https://claude.com/claude-code)
