### PR TITLE
perf(nnue): Simple-arch FT 差分更新に sub+add 融合 fast path (Issue #724 P1)

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator.rs
+++ b/crates/rshogi-core/src/nnue/accumulator.rs
@@ -8,7 +8,7 @@
 //! AccumulatorStack は探索時の Accumulator と DirtyPiece を管理するスタック。
 //! StateInfo から Accumulator を分離し、do_move での初期化コストを削減する。
 
-use super::bona_piece::{BonaPiece, ExtBonaPiece};
+use super::bona_piece::ExtBonaPiece;
 use super::constants::{NUM_REFRESH_TRIGGERS, TRANSFORMED_FEATURE_DIMENSIONS};
 use super::piece_list::PieceNumber;
 use crate::types::{Color, MAX_PLY, Square, Value};
@@ -738,18 +738,13 @@ impl Default for AccumulatorStack {
 ///
 /// アキュムレータ値は1つの連続した AlignedBox に格納し、
 /// エントリごとにスライスで参照する（162個の個別ヒープ割り当てを回避）。
-///
-/// 差分は LayerStacks 版（`AccumulatorCacheLayerStacks`）と同じく PieceList
-/// スナップショットの slot 比較方式で求める。ソート済み index 配列のマージ差分
-/// と異なり `sort_unstable` と IndexList 構築が不要。
 pub struct AccumulatorCacheGeneric {
     /// 全エントリのアキュムレータ値を連続格納 [NUM_ENTRIES * l1]
     accumulations: AlignedBox<i16>,
-    /// 各エントリの PieceList スナップショット（perspective 固有の fb/fw 配列）
-    ///
-    /// `[NUM_ENTRIES][PieceNumber::NB]`。`BonaPiece::ZERO` は空きスロット。
-    /// cache hit 時に現在の PieceList と slot-wise 比較して差分を求める。
-    piece_lists: Box<[[BonaPiece; PieceNumber::NB]]>,
+    /// 各エントリのアクティブ特徴インデックス（ソート済み）
+    active_indices: Box<[[u32; MAX_ACTIVE_FEATURES]]>,
+    /// 各エントリの有効特徴数
+    num_active: Box<[u16]>,
     /// 各エントリの有効フラグ
     valid: Box<[bool]>,
     /// L1 サイズ
@@ -764,8 +759,8 @@ impl AccumulatorCacheGeneric {
     pub fn new(l1: usize) -> Self {
         Self {
             accumulations: AlignedBox::new_zeroed(NUM_CACHE_ENTRIES * l1),
-            piece_lists: vec![[BonaPiece::ZERO; PieceNumber::NB]; NUM_CACHE_ENTRIES]
-                .into_boxed_slice(),
+            active_indices: vec![[0u32; MAX_ACTIVE_FEATURES]; NUM_CACHE_ENTRIES].into_boxed_slice(),
+            num_active: vec![0u16; NUM_CACHE_ENTRIES].into_boxed_slice(),
             valid: vec![false; NUM_CACHE_ENTRIES].into_boxed_slice(),
             l1,
         }
@@ -792,73 +787,93 @@ impl AccumulatorCacheGeneric {
         &mut self.accumulations[start..start + self.l1]
     }
 
-    /// PieceList スナップショット差分で refresh を実行（Stockfish 風 slot 比較方式）
+    /// キャッシュからの差分で refresh を実行
     ///
-    /// キャッシュが有効な場合、現在の PieceList とキャッシュ済み PieceList を
-    /// slot-wise に比較し、変化した slot のみ `idx_fn` で feature index を算出して
-    /// add/sub を適用する。キャッシュが無効な場合は biases から full refresh する。
-    ///
-    /// 旧実装（ソート済み index 配列のマージ差分）と比較して、`collect_active_indices`
-    /// による IndexList 構築と `sort_unstable` を省く。i16 の wrapping 加減算は
-    /// 可換群をなし `idx_fn` は非 ZERO BonaPiece 上で単射なので、slot 比較差分は
-    /// マージ差分と bit 単位で一致する（同じ feature index 集合 C\N を sub、
-    /// N\C を add する。同一 BonaPiece が slot 間を移動した場合は -idx +idx で
-    /// 相殺する）。
-    ///
-    /// `piece_list` は perspective 固有の PieceList スライス（HalfKA 系は全 40 slot、
-    /// HalfKP は玉を除く 38 slot）。長さは feature set ごとに固定で、同一キャッシュ
-    /// への呼び出しでは常に同じ。
-    pub(crate) fn refresh_or_cache<FI, FA, FS>(
+    /// キャッシュが有効な場合、現在のアクティブ特徴量との差分を計算し、
+    /// add/sub のみでアキュムレータを更新する。
+    /// キャッシュが無効な場合は通常の full refresh を行い、キャッシュを更新する。
+    pub(crate) fn refresh_or_cache<FA, FS>(
         &mut self,
         king_sq: Square,
         perspective: Color,
-        piece_list: &[BonaPiece],
+        active: &[u32],
         biases: &[i16],
         accumulation: &mut [i16],
-        idx_fn: FI,
         add_fn: FA,
         sub_fn: FS,
     ) where
-        FI: Fn(BonaPiece) -> usize,
         FA: Fn(&mut [i16], usize),
         FS: Fn(&mut [i16], usize),
     {
-        debug_assert!(
-            piece_list.len() <= PieceNumber::NB,
-            "piece_list overflow: {}",
-            piece_list.len()
-        );
         let entry_idx = king_sq.raw() as usize * 2 + perspective as usize;
 
         if self.valid[entry_idx] {
-            // キャッシュ有効 → PieceList slot 差分
+            // キャッシュが有効 → 差分更新
             accumulation.copy_from_slice(self.acc_slice(entry_idx));
-            let cached = &self.piece_lists[entry_idx];
-            for (i, &current_bp) in piece_list.iter().enumerate() {
-                let cached_bp = cached[i];
-                if cached_bp != current_bp {
-                    if cached_bp != BonaPiece::ZERO {
-                        sub_fn(accumulation, idx_fn(cached_bp));
-                    }
-                    if current_bp != BonaPiece::ZERO {
-                        add_fn(accumulation, idx_fn(current_bp));
-                    }
-                }
-            }
+
+            // ソート済み配列のマージベース差分（O(n)）
+            let cached = &self.active_indices[entry_idx][..self.num_active[entry_idx] as usize];
+            Self::apply_diff(cached, active, accumulation, &add_fn, &sub_fn);
         } else {
             // キャッシュ無効 → バイアスから full refresh
             accumulation.copy_from_slice(biases);
-            for &bp in piece_list {
-                if bp != BonaPiece::ZERO {
-                    add_fn(accumulation, idx_fn(bp));
-                }
+            for &idx in active {
+                add_fn(accumulation, idx as usize);
             }
         }
 
         // キャッシュを更新
         self.acc_slice_mut(entry_idx).copy_from_slice(accumulation);
-        self.piece_lists[entry_idx][..piece_list.len()].copy_from_slice(piece_list);
+        debug_assert!(
+            active.len() <= MAX_ACTIVE_FEATURES,
+            "active features overflow: {}",
+            active.len()
+        );
+        let n = active.len().min(MAX_ACTIVE_FEATURES);
+        self.active_indices[entry_idx][..n].copy_from_slice(&active[..n]);
+        self.num_active[entry_idx] = n as u16;
         self.valid[entry_idx] = true;
+    }
+
+    /// ソート済み配列のマージベース差分を適用
+    #[inline]
+    fn apply_diff<FA, FS>(
+        cached: &[u32],
+        current: &[u32],
+        accumulation: &mut [i16],
+        add_fn: &FA,
+        sub_fn: &FS,
+    ) where
+        FA: Fn(&mut [i16], usize),
+        FS: Fn(&mut [i16], usize),
+    {
+        let mut ci = 0;
+        let mut ni = 0;
+
+        while ci < cached.len() && ni < current.len() {
+            let c = cached[ci];
+            let n = current[ni];
+            if c < n {
+                sub_fn(accumulation, c as usize);
+                ci += 1;
+            } else if c > n {
+                add_fn(accumulation, n as usize);
+                ni += 1;
+            } else {
+                ci += 1;
+                ni += 1;
+            }
+        }
+
+        while ci < cached.len() {
+            sub_fn(accumulation, cached[ci] as usize);
+            ci += 1;
+        }
+
+        while ni < current.len() {
+            add_fn(accumulation, current[ni] as usize);
+            ni += 1;
+        }
     }
 }
 

--- a/crates/rshogi-core/src/nnue/accumulator.rs
+++ b/crates/rshogi-core/src/nnue/accumulator.rs
@@ -124,6 +124,21 @@ impl<const N: usize> IndexList<N> {
         self.len as usize
     }
 
+    /// i 番目の要素を取得
+    ///
+    /// `i < len()` を呼び出し側が保証すること（fast path 判定で長さを確認済みの
+    /// 箇所から使う）。範囲外アクセスは debug ビルドでパニックする。
+    #[inline]
+    pub fn get(&self, i: usize) -> usize {
+        debug_assert!(
+            i < self.len as usize,
+            "IndexList::get: i={i} out of bounds (len={})",
+            self.len
+        );
+        // SAFETY: i < len なので indices[i] は push 済みで初期化されている
+        unsafe { self.indices[i].assume_init() as usize }
+    }
+
     /// 要素を逆順に並べ替え
     #[inline]
     pub fn reverse(&mut self) {

--- a/crates/rshogi-core/src/nnue/accumulator.rs
+++ b/crates/rshogi-core/src/nnue/accumulator.rs
@@ -126,16 +126,15 @@ impl<const N: usize> IndexList<N> {
 
     /// i 番目の要素を取得
     ///
-    /// `i < len()` を呼び出し側が保証すること（fast path 判定で長さを確認済みの
-    /// 箇所から使う）。範囲外アクセスは debug ビルドでパニックする。
+    /// `i >= len()` の場合はパニックする。`assume_init()` を含む safe public API
+    /// なので、release ビルドでも境界を検査して未初期化領域へのアクセス（UB）を
+    /// 防ぐ。fast path 判定で長さを確認済みの呼び出し（`get(0)`/`get(1)` を
+    /// `len()` が 1/2 と確定した文脈で呼ぶ）では、コンパイラがこの検査を除去する。
     #[inline]
     pub fn get(&self, i: usize) -> usize {
-        debug_assert!(
-            i < self.len as usize,
-            "IndexList::get: i={i} out of bounds (len={})",
-            self.len
-        );
-        // SAFETY: i < len なので indices[i] は push 済みで初期化されている
+        assert!(i < self.len as usize, "IndexList::get: i={i} out of bounds (len={})", self.len);
+        // SAFETY: 直前の assert! で i < len を保証。0..len の範囲は push 済みで
+        // 初期化されているため assume_init は健全。
         unsafe { self.indices[i].assume_init() as usize }
     }
 

--- a/crates/rshogi-core/src/nnue/accumulator.rs
+++ b/crates/rshogi-core/src/nnue/accumulator.rs
@@ -8,7 +8,7 @@
 //! AccumulatorStack は探索時の Accumulator と DirtyPiece を管理するスタック。
 //! StateInfo から Accumulator を分離し、do_move での初期化コストを削減する。
 
-use super::bona_piece::ExtBonaPiece;
+use super::bona_piece::{BonaPiece, ExtBonaPiece};
 use super::constants::{NUM_REFRESH_TRIGGERS, TRANSFORMED_FEATURE_DIMENSIONS};
 use super::piece_list::PieceNumber;
 use crate::types::{Color, MAX_PLY, Square, Value};
@@ -738,13 +738,18 @@ impl Default for AccumulatorStack {
 ///
 /// アキュムレータ値は1つの連続した AlignedBox に格納し、
 /// エントリごとにスライスで参照する（162個の個別ヒープ割り当てを回避）。
+///
+/// 差分は LayerStacks 版（`AccumulatorCacheLayerStacks`）と同じく PieceList
+/// スナップショットの slot 比較方式で求める。ソート済み index 配列のマージ差分
+/// と異なり `sort_unstable` と IndexList 構築が不要。
 pub struct AccumulatorCacheGeneric {
     /// 全エントリのアキュムレータ値を連続格納 [NUM_ENTRIES * l1]
     accumulations: AlignedBox<i16>,
-    /// 各エントリのアクティブ特徴インデックス（ソート済み）
-    active_indices: Box<[[u32; MAX_ACTIVE_FEATURES]]>,
-    /// 各エントリの有効特徴数
-    num_active: Box<[u16]>,
+    /// 各エントリの PieceList スナップショット（perspective 固有の fb/fw 配列）
+    ///
+    /// `[NUM_ENTRIES][PieceNumber::NB]`。`BonaPiece::ZERO` は空きスロット。
+    /// cache hit 時に現在の PieceList と slot-wise 比較して差分を求める。
+    piece_lists: Box<[[BonaPiece; PieceNumber::NB]]>,
     /// 各エントリの有効フラグ
     valid: Box<[bool]>,
     /// L1 サイズ
@@ -759,8 +764,8 @@ impl AccumulatorCacheGeneric {
     pub fn new(l1: usize) -> Self {
         Self {
             accumulations: AlignedBox::new_zeroed(NUM_CACHE_ENTRIES * l1),
-            active_indices: vec![[0u32; MAX_ACTIVE_FEATURES]; NUM_CACHE_ENTRIES].into_boxed_slice(),
-            num_active: vec![0u16; NUM_CACHE_ENTRIES].into_boxed_slice(),
+            piece_lists: vec![[BonaPiece::ZERO; PieceNumber::NB]; NUM_CACHE_ENTRIES]
+                .into_boxed_slice(),
             valid: vec![false; NUM_CACHE_ENTRIES].into_boxed_slice(),
             l1,
         }
@@ -787,93 +792,73 @@ impl AccumulatorCacheGeneric {
         &mut self.accumulations[start..start + self.l1]
     }
 
-    /// キャッシュからの差分で refresh を実行
+    /// PieceList スナップショット差分で refresh を実行（Stockfish 風 slot 比較方式）
     ///
-    /// キャッシュが有効な場合、現在のアクティブ特徴量との差分を計算し、
-    /// add/sub のみでアキュムレータを更新する。
-    /// キャッシュが無効な場合は通常の full refresh を行い、キャッシュを更新する。
-    pub(crate) fn refresh_or_cache<FA, FS>(
+    /// キャッシュが有効な場合、現在の PieceList とキャッシュ済み PieceList を
+    /// slot-wise に比較し、変化した slot のみ `idx_fn` で feature index を算出して
+    /// add/sub を適用する。キャッシュが無効な場合は biases から full refresh する。
+    ///
+    /// 旧実装（ソート済み index 配列のマージ差分）と比較して、`collect_active_indices`
+    /// による IndexList 構築と `sort_unstable` を省く。i16 の wrapping 加減算は
+    /// 可換群をなし `idx_fn` は非 ZERO BonaPiece 上で単射なので、slot 比較差分は
+    /// マージ差分と bit 単位で一致する（同じ feature index 集合 C\N を sub、
+    /// N\C を add する。同一 BonaPiece が slot 間を移動した場合は -idx +idx で
+    /// 相殺する）。
+    ///
+    /// `piece_list` は perspective 固有の PieceList スライス（HalfKA 系は全 40 slot、
+    /// HalfKP は玉を除く 38 slot）。長さは feature set ごとに固定で、同一キャッシュ
+    /// への呼び出しでは常に同じ。
+    pub(crate) fn refresh_or_cache<FI, FA, FS>(
         &mut self,
         king_sq: Square,
         perspective: Color,
-        active: &[u32],
+        piece_list: &[BonaPiece],
         biases: &[i16],
         accumulation: &mut [i16],
+        idx_fn: FI,
         add_fn: FA,
         sub_fn: FS,
     ) where
+        FI: Fn(BonaPiece) -> usize,
         FA: Fn(&mut [i16], usize),
         FS: Fn(&mut [i16], usize),
     {
+        debug_assert!(
+            piece_list.len() <= PieceNumber::NB,
+            "piece_list overflow: {}",
+            piece_list.len()
+        );
         let entry_idx = king_sq.raw() as usize * 2 + perspective as usize;
 
         if self.valid[entry_idx] {
-            // キャッシュが有効 → 差分更新
+            // キャッシュ有効 → PieceList slot 差分
             accumulation.copy_from_slice(self.acc_slice(entry_idx));
-
-            // ソート済み配列のマージベース差分（O(n)）
-            let cached = &self.active_indices[entry_idx][..self.num_active[entry_idx] as usize];
-            Self::apply_diff(cached, active, accumulation, &add_fn, &sub_fn);
+            let cached = &self.piece_lists[entry_idx];
+            for (i, &current_bp) in piece_list.iter().enumerate() {
+                let cached_bp = cached[i];
+                if cached_bp != current_bp {
+                    if cached_bp != BonaPiece::ZERO {
+                        sub_fn(accumulation, idx_fn(cached_bp));
+                    }
+                    if current_bp != BonaPiece::ZERO {
+                        add_fn(accumulation, idx_fn(current_bp));
+                    }
+                }
+            }
         } else {
             // キャッシュ無効 → バイアスから full refresh
             accumulation.copy_from_slice(biases);
-            for &idx in active {
-                add_fn(accumulation, idx as usize);
+            for &bp in piece_list {
+                if bp != BonaPiece::ZERO {
+                    add_fn(accumulation, idx_fn(bp));
+                }
             }
         }
 
         // キャッシュを更新
         self.acc_slice_mut(entry_idx).copy_from_slice(accumulation);
-        debug_assert!(
-            active.len() <= MAX_ACTIVE_FEATURES,
-            "active features overflow: {}",
-            active.len()
-        );
-        let n = active.len().min(MAX_ACTIVE_FEATURES);
-        self.active_indices[entry_idx][..n].copy_from_slice(&active[..n]);
-        self.num_active[entry_idx] = n as u16;
+        self.piece_lists[entry_idx][..piece_list.len()].copy_from_slice(piece_list);
         self.valid[entry_idx] = true;
-    }
-
-    /// ソート済み配列のマージベース差分を適用
-    #[inline]
-    fn apply_diff<FA, FS>(
-        cached: &[u32],
-        current: &[u32],
-        accumulation: &mut [i16],
-        add_fn: &FA,
-        sub_fn: &FS,
-    ) where
-        FA: Fn(&mut [i16], usize),
-        FS: Fn(&mut [i16], usize),
-    {
-        let mut ci = 0;
-        let mut ni = 0;
-
-        while ci < cached.len() && ni < current.len() {
-            let c = cached[ci];
-            let n = current[ni];
-            if c < n {
-                sub_fn(accumulation, c as usize);
-                ci += 1;
-            } else if c > n {
-                add_fn(accumulation, n as usize);
-                ni += 1;
-            } else {
-                ci += 1;
-                ni += 1;
-            }
-        }
-
-        while ci < cached.len() {
-            sub_fn(accumulation, cached[ci] as usize);
-            ci += 1;
-        }
-
-        while ni < current.len() {
-            add_fn(accumulation, current[ni] as usize);
-            ni += 1;
-        }
     }
 }
 

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -467,12 +467,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -512,12 +507,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -618,12 +608,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
                 let accumulation =
                     &mut stack.entry_at_mut(current_idx).accumulator.accumulation[p].0;
 
-                for index in removed.iter() {
-                    self.sub_weights(accumulation, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(accumulation, index);
-                }
+                self.apply_diff_fused(accumulation, &removed, &added);
             }
         }
 
@@ -732,6 +717,208 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         #[allow(unreachable_code)]
         for (acc, &w) in accumulation.iter_mut().zip(weights) {
             *acc = acc.wrapping_sub(w);
+        }
+    }
+
+    /// index 番目の重み行（L1 要素）を取得
+    #[inline]
+    fn weight_row(&self, index: usize) -> &[i16] {
+        let offset = index * L1;
+        &self.weights[offset..offset + L1]
+    }
+
+    /// removed/added を融合した差分更新（fast path）
+    ///
+    /// `removed`/`added` がともに 1 要素なら sub+add を 1 パスに、ともに 2 要素なら
+    /// 2 組を 1 パスに融合する。それ以外は従来どおり sub ループ → add ループの
+    /// 2 パスにフォールバックする。do_move の大半は quiet（1 sub+1 add）/
+    /// capture（2 sub+2 add）なので fast path に乗る。
+    ///
+    /// i16 の wrapping 加減算は可換群をなすため、融合パスは `sub_weights` ループ
+    /// → `add_weights` ループと bit 単位で一致する。LayerStacks の
+    /// `try_apply_dirty_piece_fast` は DirtyPiece から特徴 index を再計算するが、
+    /// ここでは `append_changed_indices` が生成済みの IndexList を再利用して
+    /// 再計算を避ける。
+    #[inline]
+    fn apply_diff_fused(
+        &self,
+        accumulation: &mut [i16],
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        match (removed.len(), added.len()) {
+            (1, 1) => {
+                self.apply_sub_add_fused(accumulation, removed.get(0), added.get(0));
+            }
+            (2, 2) => {
+                self.apply_double_sub_add_fused(
+                    accumulation,
+                    removed.get(0),
+                    added.get(0),
+                    removed.get(1),
+                    added.get(1),
+                );
+            }
+            _ => {
+                for index in removed.iter() {
+                    self.sub_weights(accumulation, index);
+                }
+                for index in added.iter() {
+                    self.add_weights(accumulation, index);
+                }
+            }
+        }
+    }
+
+    /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
+    #[inline]
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+        let sub_weights = self.weight_row(sub_index);
+        let add_weights = self.weight_row(add_index);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY:
+            // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
+            //   32 バイト境界に揃う。weight 行は AlignedBox 先頭が 64 バイト
+            //   アライン、各行は L1×2 バイト（L1 は 16 の倍数）なので全行先頭も
+            //   32 バイト境界に揃い、aligned load/store が安全。
+            // - L1 要素を 16 要素ずつ L1/16 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行は 16 バイト境界にある。
+            // - L1 要素を 8 要素ずつ L1/8 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec = _mm_load_si128(sub_ptr.add(i * 8) as *const __m128i);
+                    let add_vec = _mm_load_si128(add_ptr.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((acc, &sub_w), &add_w) in
+            accumulation.iter_mut().zip(sub_weights.iter()).zip(add_weights.iter())
+        {
+            *acc = acc.wrapping_sub(sub_w).wrapping_add(add_w);
+        }
+    }
+
+    /// `acc = acc - sub0 + add0 - sub1 + add1` を 1 パスで適用
+    #[inline]
+    fn apply_double_sub_add_fused(
+        &self,
+        accumulation: &mut [i16],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        let sub_weights0 = self.weight_row(sub_index0);
+        let add_weights0 = self.weight_row(add_index0);
+        let sub_weights1 = self.weight_row(sub_index1);
+        let add_weights1 = self.weight_row(add_index1);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
+            // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY: accumulation / 4 本の weight 行は 16 バイト境界。
+            // L1 要素を 8 要素ずつ L1/8 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec0 = _mm_load_si128(sub_ptr0.add(i * 8) as *const __m128i);
+                    let add_vec0 = _mm_load_si128(add_ptr0.add(i * 8) as *const __m128i);
+                    let sub_vec1 = _mm_load_si128(sub_ptr1.add(i * 8) as *const __m128i);
+                    let add_vec1 = _mm_load_si128(add_ptr1.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(
+                        _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((((acc, &sub_w0), &add_w0), &sub_w1), &add_w1) in accumulation
+            .iter_mut()
+            .zip(sub_weights0.iter())
+            .zip(add_weights0.iter())
+            .zip(sub_weights1.iter())
+            .zip(add_weights1.iter())
+        {
+            *acc = acc
+                .wrapping_sub(sub_w0)
+                .wrapping_add(add_w0)
+                .wrapping_sub(sub_w1)
+                .wrapping_add(add_w1);
         }
     }
 

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -46,9 +46,10 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
+use super::bona_piece_halfka::{halfka_index, king_index};
 use super::constants::{FV_SCALE_HALFKA, HALFKA_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
 use super::features::{Feature, FeatureSet, HalfKA, HalfKAFeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
@@ -543,22 +544,20 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKAFeatureSet::collect_active_indices(pos, perspective);
-
-        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
-        let len = active_indices.len();
-        for (i, idx) in active_indices.iter().enumerate() {
-            sorted_buf[i] = idx as u32;
-        }
-        let sorted = &mut sorted_buf[..len];
-        sorted.sort_unstable();
+        let k_index = king_index(king_sq, perspective);
+        let piece_list = if perspective == Color::Black {
+            pos.piece_list().piece_list_fb()
+        } else {
+            pos.piece_list().piece_list_fw()
+        };
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            sorted,
+            piece_list,
             &self.biases,
             accumulation,
+            move |bp| halfka_index(k_index, bp.value() as usize),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -539,7 +539,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -559,8 +559,21 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| self.add_weights(acc, idx),
-            |acc, idx| self.sub_weights(acc, idx),
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
+                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
+                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
+                // コンパイル時定数として確定する。
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.add_weights(arr, idx);
+            },
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: 上記と同じ理由で安全
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.sub_weights(arr, idx);
+            },
         );
     }
 
@@ -618,7 +631,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -670,7 +683,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -742,7 +755,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -772,7 +785,12 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+    fn apply_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -837,7 +855,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -539,7 +539,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -559,21 +559,8 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
-                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
-                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
-                // コンパイル時定数として確定する。
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.add_weights(arr, idx);
-            },
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: 上記と同じ理由で安全
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.sub_weights(arr, idx);
-            },
+            |acc, idx| self.add_weights(acc, idx),
+            |acc, idx| self.sub_weights(acc, idx),
         );
     }
 
@@ -631,7 +618,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -683,7 +670,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -755,7 +742,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -785,12 +772,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(
-        &self,
-        accumulation: &mut [i16; L1],
-        sub_index: usize,
-        add_index: usize,
-    ) {
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -855,7 +837,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -46,10 +46,9 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
-use super::bona_piece_halfka::{halfka_index, king_index};
 use super::constants::{FV_SCALE_HALFKA, HALFKA_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
 use super::features::{Feature, FeatureSet, HalfKA, HalfKAFeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
@@ -544,20 +543,22 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let k_index = king_index(king_sq, perspective);
-        let piece_list = if perspective == Color::Black {
-            pos.piece_list().piece_list_fb()
-        } else {
-            pos.piece_list().piece_list_fw()
-        };
+        let active_indices = HalfKAFeatureSet::collect_active_indices(pos, perspective);
+
+        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
+        let len = active_indices.len();
+        for (i, idx) in active_indices.iter().enumerate() {
+            sorted_buf[i] = idx as u32;
+        }
+        let sorted = &mut sorted_buf[..len];
+        sorted.sort_unstable();
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            piece_list,
+            sorted,
             &self.biases,
             accumulation,
-            move |bp| halfka_index(k_index, bp.value() as usize),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -46,9 +46,10 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
+use super::bona_piece_halfka_hm::{halfka_index, is_hm_mirror, king_bucket, pack_bonapiece};
 use super::constants::{FV_SCALE_HALFKA, HALFKA_HM_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
 use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKA_hm_FeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
@@ -543,22 +544,21 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
-
-        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
-        let len = active_indices.len();
-        for (i, idx) in active_indices.iter().enumerate() {
-            sorted_buf[i] = idx as u32;
-        }
-        let sorted = &mut sorted_buf[..len];
-        sorted.sort_unstable();
+        let kb = king_bucket(king_sq, perspective);
+        let hm = is_hm_mirror(king_sq, perspective);
+        let piece_list = if perspective == Color::Black {
+            pos.piece_list().piece_list_fb()
+        } else {
+            pos.piece_list().piece_list_fw()
+        };
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            sorted,
+            piece_list,
             &self.biases,
             accumulation,
+            move |bp| halfka_index(kb, pack_bonapiece(bp, hm)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -465,6 +465,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
                     &mut added,
                 );
 
+                self.prefetch_diff_weights(&removed, &added);
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
                 self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
@@ -505,6 +506,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
                     &mut added,
                 );
 
+                self.prefetch_diff_weights(&removed, &added);
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
                 self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
@@ -725,6 +727,31 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     fn weight_row(&self, index: usize) -> &[i16] {
         let offset = index * L1;
         &self.weights[offset..offset + L1]
+    }
+
+    /// 差分 weight 行の先頭キャッシュラインを prefetch する（P5 試行）
+    ///
+    /// `apply_diff_fused` 直前の `copy_from_slice`（L1 サイズ）と weight 行ロードを
+    /// オーバーラップさせる狙い。
+    #[inline]
+    fn prefetch_diff_weights(
+        &self,
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        #[cfg(target_arch = "x86_64")]
+        {
+            use std::arch::x86_64::_mm_prefetch;
+            let base = self.weights.as_ptr();
+            for idx in removed.iter().chain(added.iter()) {
+                // SAFETY: idx は append_changed_indices が生成した有効 feature index で
+                // idx*L1 は weights 配列内を指す。_mm_prefetch は無効アドレスでも
+                // faulting しないヒント命令で副作用はない。
+                unsafe {
+                    _mm_prefetch(base.add(idx * L1) as *const i8, 3);
+                }
+            }
+        }
     }
 
     /// removed/added を融合した差分更新（fast path）

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -467,12 +467,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -512,12 +507,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -618,12 +608,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
                 let accumulation =
                     &mut stack.entry_at_mut(current_idx).accumulator.accumulation[p].0;
 
-                for index in removed.iter() {
-                    self.sub_weights(accumulation, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(accumulation, index);
-                }
+                self.apply_diff_fused(accumulation, &removed, &added);
             }
         }
 
@@ -732,6 +717,208 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         #[allow(unreachable_code)]
         for (acc, &w) in accumulation.iter_mut().zip(weights) {
             *acc = acc.wrapping_sub(w);
+        }
+    }
+
+    /// index 番目の重み行（L1 要素）を取得
+    #[inline]
+    fn weight_row(&self, index: usize) -> &[i16] {
+        let offset = index * L1;
+        &self.weights[offset..offset + L1]
+    }
+
+    /// removed/added を融合した差分更新（fast path）
+    ///
+    /// `removed`/`added` がともに 1 要素なら sub+add を 1 パスに、ともに 2 要素なら
+    /// 2 組を 1 パスに融合する。それ以外は従来どおり sub ループ → add ループの
+    /// 2 パスにフォールバックする。do_move の大半は quiet（1 sub+1 add）/
+    /// capture（2 sub+2 add）なので fast path に乗る。
+    ///
+    /// i16 の wrapping 加減算は可換群をなすため、融合パスは `sub_weights` ループ
+    /// → `add_weights` ループと bit 単位で一致する。LayerStacks の
+    /// `try_apply_dirty_piece_fast` は DirtyPiece から特徴 index を再計算するが、
+    /// ここでは `append_changed_indices` が生成済みの IndexList を再利用して
+    /// 再計算を避ける。
+    #[inline]
+    fn apply_diff_fused(
+        &self,
+        accumulation: &mut [i16],
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        match (removed.len(), added.len()) {
+            (1, 1) => {
+                self.apply_sub_add_fused(accumulation, removed.get(0), added.get(0));
+            }
+            (2, 2) => {
+                self.apply_double_sub_add_fused(
+                    accumulation,
+                    removed.get(0),
+                    added.get(0),
+                    removed.get(1),
+                    added.get(1),
+                );
+            }
+            _ => {
+                for index in removed.iter() {
+                    self.sub_weights(accumulation, index);
+                }
+                for index in added.iter() {
+                    self.add_weights(accumulation, index);
+                }
+            }
+        }
+    }
+
+    /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
+    #[inline]
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+        let sub_weights = self.weight_row(sub_index);
+        let add_weights = self.weight_row(add_index);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY:
+            // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
+            //   32 バイト境界に揃う。weight 行は AlignedBox 先頭が 64 バイト
+            //   アライン、各行は L1×2 バイト（L1 は 16 の倍数）なので全行先頭も
+            //   32 バイト境界に揃い、aligned load/store が安全。
+            // - L1 要素を 16 要素ずつ L1/16 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行は 16 バイト境界にある。
+            // - L1 要素を 8 要素ずつ L1/8 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec = _mm_load_si128(sub_ptr.add(i * 8) as *const __m128i);
+                    let add_vec = _mm_load_si128(add_ptr.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((acc, &sub_w), &add_w) in
+            accumulation.iter_mut().zip(sub_weights.iter()).zip(add_weights.iter())
+        {
+            *acc = acc.wrapping_sub(sub_w).wrapping_add(add_w);
+        }
+    }
+
+    /// `acc = acc - sub0 + add0 - sub1 + add1` を 1 パスで適用
+    #[inline]
+    fn apply_double_sub_add_fused(
+        &self,
+        accumulation: &mut [i16],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        let sub_weights0 = self.weight_row(sub_index0);
+        let add_weights0 = self.weight_row(add_index0);
+        let sub_weights1 = self.weight_row(sub_index1);
+        let add_weights1 = self.weight_row(add_index1);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
+            // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY: accumulation / 4 本の weight 行は 16 バイト境界。
+            // L1 要素を 8 要素ずつ L1/8 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec0 = _mm_load_si128(sub_ptr0.add(i * 8) as *const __m128i);
+                    let add_vec0 = _mm_load_si128(add_ptr0.add(i * 8) as *const __m128i);
+                    let sub_vec1 = _mm_load_si128(sub_ptr1.add(i * 8) as *const __m128i);
+                    let add_vec1 = _mm_load_si128(add_ptr1.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(
+                        _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((((acc, &sub_w0), &add_w0), &sub_w1), &add_w1) in accumulation
+            .iter_mut()
+            .zip(sub_weights0.iter())
+            .zip(add_weights0.iter())
+            .zip(sub_weights1.iter())
+            .zip(add_weights1.iter())
+        {
+            *acc = acc
+                .wrapping_sub(sub_w0)
+                .wrapping_add(add_w0)
+                .wrapping_sub(sub_w1)
+                .wrapping_add(add_w1);
         }
     }
 

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -46,10 +46,9 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
-use super::bona_piece_halfka_hm::{halfka_index, is_hm_mirror, king_bucket, pack_bonapiece};
 use super::constants::{FV_SCALE_HALFKA, HALFKA_HM_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
 use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKA_hm_FeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
@@ -544,21 +543,22 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let kb = king_bucket(king_sq, perspective);
-        let hm = is_hm_mirror(king_sq, perspective);
-        let piece_list = if perspective == Color::Black {
-            pos.piece_list().piece_list_fb()
-        } else {
-            pos.piece_list().piece_list_fw()
-        };
+        let active_indices = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
+
+        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
+        let len = active_indices.len();
+        for (i, idx) in active_indices.iter().enumerate() {
+            sorted_buf[i] = idx as u32;
+        }
+        let sorted = &mut sorted_buf[..len];
+        sorted.sort_unstable();
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            piece_list,
+            sorted,
             &self.biases,
             accumulation,
-            move |bp| halfka_index(kb, pack_bonapiece(bp, hm)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -539,7 +539,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -559,21 +559,8 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
-                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
-                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
-                // コンパイル時定数として確定する。
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.add_weights(arr, idx);
-            },
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: 上記と同じ理由で安全
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.sub_weights(arr, idx);
-            },
+            |acc, idx| self.add_weights(acc, idx),
+            |acc, idx| self.sub_weights(acc, idx),
         );
     }
 
@@ -631,7 +618,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -683,7 +670,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -755,7 +742,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -785,12 +772,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(
-        &self,
-        accumulation: &mut [i16; L1],
-        sub_index: usize,
-        add_index: usize,
-    ) {
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -855,7 +837,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -465,7 +465,6 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
                     &mut added,
                 );
 
-                self.prefetch_diff_weights(&removed, &added);
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
                 self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
@@ -506,7 +505,6 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
                     &mut added,
                 );
 
-                self.prefetch_diff_weights(&removed, &added);
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
                 self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
@@ -727,31 +725,6 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     fn weight_row(&self, index: usize) -> &[i16] {
         let offset = index * L1;
         &self.weights[offset..offset + L1]
-    }
-
-    /// 差分 weight 行の先頭キャッシュラインを prefetch する（P5 試行）
-    ///
-    /// `apply_diff_fused` 直前の `copy_from_slice`（L1 サイズ）と weight 行ロードを
-    /// オーバーラップさせる狙い。
-    #[inline]
-    fn prefetch_diff_weights(
-        &self,
-        removed: &IndexList<MAX_CHANGED_FEATURES>,
-        added: &IndexList<MAX_CHANGED_FEATURES>,
-    ) {
-        #[cfg(target_arch = "x86_64")]
-        {
-            use std::arch::x86_64::_mm_prefetch;
-            let base = self.weights.as_ptr();
-            for idx in removed.iter().chain(added.iter()) {
-                // SAFETY: idx は append_changed_indices が生成した有効 feature index で
-                // idx*L1 は weights 配列内を指す。_mm_prefetch は無効アドレスでも
-                // faulting しないヒント命令で副作用はない。
-                unsafe {
-                    _mm_prefetch(base.add(idx * L1) as *const i8, 3);
-                }
-            }
-        }
     }
 
     /// removed/added を融合した差分更新（fast path）

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -539,7 +539,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -559,8 +559,21 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| self.add_weights(acc, idx),
-            |acc, idx| self.sub_weights(acc, idx),
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
+                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
+                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
+                // コンパイル時定数として確定する。
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.add_weights(arr, idx);
+            },
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: 上記と同じ理由で安全
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.sub_weights(arr, idx);
+            },
         );
     }
 
@@ -618,7 +631,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -670,7 +683,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -742,7 +755,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -772,7 +785,12 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+    fn apply_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -837,7 +855,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -470,12 +470,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -515,12 +510,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -621,12 +611,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
                 let accumulation =
                     &mut stack.entry_at_mut(current_idx).accumulator.accumulation[p].0;
 
-                for index in removed.iter() {
-                    self.sub_weights(accumulation, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(accumulation, index);
-                }
+                self.apply_diff_fused(accumulation, &removed, &added);
             }
         }
 
@@ -735,6 +720,208 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         #[allow(unreachable_code)]
         for (acc, &w) in accumulation.iter_mut().zip(weights) {
             *acc = acc.wrapping_sub(w);
+        }
+    }
+
+    /// index 番目の重み行（L1 要素）を取得
+    #[inline]
+    fn weight_row(&self, index: usize) -> &[i16] {
+        let offset = index * L1;
+        &self.weights[offset..offset + L1]
+    }
+
+    /// removed/added を融合した差分更新（fast path）
+    ///
+    /// `removed`/`added` がともに 1 要素なら sub+add を 1 パスに、ともに 2 要素なら
+    /// 2 組を 1 パスに融合する。それ以外は従来どおり sub ループ → add ループの
+    /// 2 パスにフォールバックする。do_move の大半は quiet（1 sub+1 add）/
+    /// capture（2 sub+2 add）なので fast path に乗る。
+    ///
+    /// i16 の wrapping 加減算は可換群をなすため、融合パスは `sub_weights` ループ
+    /// → `add_weights` ループと bit 単位で一致する。LayerStacks の
+    /// `try_apply_dirty_piece_fast` は DirtyPiece から特徴 index を再計算するが、
+    /// ここでは `append_changed_indices` が生成済みの IndexList を再利用して
+    /// 再計算を避ける。
+    #[inline]
+    fn apply_diff_fused(
+        &self,
+        accumulation: &mut [i16],
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        match (removed.len(), added.len()) {
+            (1, 1) => {
+                self.apply_sub_add_fused(accumulation, removed.get(0), added.get(0));
+            }
+            (2, 2) => {
+                self.apply_double_sub_add_fused(
+                    accumulation,
+                    removed.get(0),
+                    added.get(0),
+                    removed.get(1),
+                    added.get(1),
+                );
+            }
+            _ => {
+                for index in removed.iter() {
+                    self.sub_weights(accumulation, index);
+                }
+                for index in added.iter() {
+                    self.add_weights(accumulation, index);
+                }
+            }
+        }
+    }
+
+    /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
+    #[inline]
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+        let sub_weights = self.weight_row(sub_index);
+        let add_weights = self.weight_row(add_index);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY:
+            // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
+            //   32 バイト境界に揃う。weight 行は AlignedBox 先頭が 64 バイト
+            //   アライン、各行は L1×2 バイト（L1 は 16 の倍数）なので全行先頭も
+            //   32 バイト境界に揃い、aligned load/store が安全。
+            // - L1 要素を 16 要素ずつ L1/16 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行は 16 バイト境界にある。
+            // - L1 要素を 8 要素ずつ L1/8 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec = _mm_load_si128(sub_ptr.add(i * 8) as *const __m128i);
+                    let add_vec = _mm_load_si128(add_ptr.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((acc, &sub_w), &add_w) in
+            accumulation.iter_mut().zip(sub_weights.iter()).zip(add_weights.iter())
+        {
+            *acc = acc.wrapping_sub(sub_w).wrapping_add(add_w);
+        }
+    }
+
+    /// `acc = acc - sub0 + add0 - sub1 + add1` を 1 パスで適用
+    #[inline]
+    fn apply_double_sub_add_fused(
+        &self,
+        accumulation: &mut [i16],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        let sub_weights0 = self.weight_row(sub_index0);
+        let add_weights0 = self.weight_row(add_index0);
+        let sub_weights1 = self.weight_row(sub_index1);
+        let add_weights1 = self.weight_row(add_index1);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
+            // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY: accumulation / 4 本の weight 行は 16 バイト境界。
+            // L1 要素を 8 要素ずつ L1/8 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec0 = _mm_load_si128(sub_ptr0.add(i * 8) as *const __m128i);
+                    let add_vec0 = _mm_load_si128(add_ptr0.add(i * 8) as *const __m128i);
+                    let sub_vec1 = _mm_load_si128(sub_ptr1.add(i * 8) as *const __m128i);
+                    let add_vec1 = _mm_load_si128(add_ptr1.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(
+                        _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((((acc, &sub_w0), &add_w0), &sub_w1), &add_w1) in accumulation
+            .iter_mut()
+            .zip(sub_weights0.iter())
+            .zip(add_weights0.iter())
+            .zip(sub_weights1.iter())
+            .zip(add_weights1.iter())
+        {
+            *acc = acc
+                .wrapping_sub(sub_w0)
+                .wrapping_add(add_w0)
+                .wrapping_sub(sub_w1)
+                .wrapping_add(add_w1);
         }
     }
 

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -542,7 +542,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -562,21 +562,8 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
-                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
-                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
-                // コンパイル時定数として確定する。
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.add_weights(arr, idx);
-            },
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: 上記と同じ理由で安全
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.sub_weights(arr, idx);
-            },
+            |acc, idx| self.add_weights(acc, idx),
+            |acc, idx| self.sub_weights(acc, idx),
         );
     }
 
@@ -634,7 +621,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -686,7 +673,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -758,7 +745,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -788,12 +775,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(
-        &self,
-        accumulation: &mut [i16; L1],
-        sub_index: usize,
-        add_index: usize,
-    ) {
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -858,7 +840,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -46,9 +46,10 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
+use super::bona_piece_halfka_hm_split::{halfka_index, is_hm_mirror, king_bucket, pack_bonapiece};
 use super::constants::{
     FV_SCALE_HALFKA, HALFKA_HM_SPLIT_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA,
 };
@@ -546,22 +547,21 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKaHmSplitFeatureSet::collect_active_indices(pos, perspective);
-
-        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
-        let len = active_indices.len();
-        for (i, idx) in active_indices.iter().enumerate() {
-            sorted_buf[i] = idx as u32;
-        }
-        let sorted = &mut sorted_buf[..len];
-        sorted.sort_unstable();
+        let kb = king_bucket(king_sq, perspective);
+        let hm = is_hm_mirror(king_sq, perspective);
+        let piece_list = if perspective == Color::Black {
+            pos.piece_list().piece_list_fb()
+        } else {
+            pos.piece_list().piece_list_fw()
+        };
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            sorted,
+            piece_list,
             &self.biases,
             accumulation,
+            move |bp| halfka_index(kb, pack_bonapiece(bp, hm)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -46,10 +46,9 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
-use super::bona_piece_halfka_hm_split::{halfka_index, is_hm_mirror, king_bucket, pack_bonapiece};
 use super::constants::{
     FV_SCALE_HALFKA, HALFKA_HM_SPLIT_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA,
 };
@@ -547,21 +546,22 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let kb = king_bucket(king_sq, perspective);
-        let hm = is_hm_mirror(king_sq, perspective);
-        let piece_list = if perspective == Color::Black {
-            pos.piece_list().piece_list_fb()
-        } else {
-            pos.piece_list().piece_list_fw()
-        };
+        let active_indices = HalfKaHmSplitFeatureSet::collect_active_indices(pos, perspective);
+
+        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
+        let len = active_indices.len();
+        for (i, idx) in active_indices.iter().enumerate() {
+            sorted_buf[i] = idx as u32;
+        }
+        let sorted = &mut sorted_buf[..len];
+        sorted.sort_unstable();
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            piece_list,
+            sorted,
             &self.biases,
             accumulation,
-            move |bp| halfka_index(kb, pack_bonapiece(bp, hm)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -542,7 +542,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -562,8 +562,21 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| self.add_weights(acc, idx),
-            |acc, idx| self.sub_weights(acc, idx),
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
+                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
+                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
+                // コンパイル時定数として確定する。
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.add_weights(arr, idx);
+            },
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: 上記と同じ理由で安全
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.sub_weights(arr, idx);
+            },
         );
     }
 
@@ -621,7 +634,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -673,7 +686,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -745,7 +758,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -775,7 +788,12 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+    fn apply_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -840,7 +858,7 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -542,7 +542,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -562,8 +562,21 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| self.add_weights(acc, idx),
-            |acc, idx| self.sub_weights(acc, idx),
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
+                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
+                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
+                // コンパイル時定数として確定する。
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.add_weights(arr, idx);
+            },
+            |acc, idx| {
+                debug_assert_eq!(acc.len(), L1);
+                // SAFETY: 上記と同じ理由で安全
+                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
+                self.sub_weights(arr, idx);
+            },
         );
     }
 
@@ -621,7 +634,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -673,7 +686,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -745,7 +758,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -775,7 +788,12 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+    fn apply_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -840,7 +858,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16],
+        accumulation: &mut [i16; L1],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -470,12 +470,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -515,12 +510,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -621,12 +611,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
                 let accumulation =
                     &mut stack.entry_at_mut(current_idx).accumulator.accumulation[p].0;
 
-                for index in removed.iter() {
-                    self.sub_weights(accumulation, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(accumulation, index);
-                }
+                self.apply_diff_fused(accumulation, &removed, &added);
             }
         }
 
@@ -735,6 +720,208 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         #[allow(unreachable_code)]
         for (acc, &w) in accumulation.iter_mut().zip(weights) {
             *acc = acc.wrapping_sub(w);
+        }
+    }
+
+    /// index 番目の重み行（L1 要素）を取得
+    #[inline]
+    fn weight_row(&self, index: usize) -> &[i16] {
+        let offset = index * L1;
+        &self.weights[offset..offset + L1]
+    }
+
+    /// removed/added を融合した差分更新（fast path）
+    ///
+    /// `removed`/`added` がともに 1 要素なら sub+add を 1 パスに、ともに 2 要素なら
+    /// 2 組を 1 パスに融合する。それ以外は従来どおり sub ループ → add ループの
+    /// 2 パスにフォールバックする。do_move の大半は quiet（1 sub+1 add）/
+    /// capture（2 sub+2 add）なので fast path に乗る。
+    ///
+    /// i16 の wrapping 加減算は可換群をなすため、融合パスは `sub_weights` ループ
+    /// → `add_weights` ループと bit 単位で一致する。LayerStacks の
+    /// `try_apply_dirty_piece_fast` は DirtyPiece から特徴 index を再計算するが、
+    /// ここでは `append_changed_indices` が生成済みの IndexList を再利用して
+    /// 再計算を避ける。
+    #[inline]
+    fn apply_diff_fused(
+        &self,
+        accumulation: &mut [i16],
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        match (removed.len(), added.len()) {
+            (1, 1) => {
+                self.apply_sub_add_fused(accumulation, removed.get(0), added.get(0));
+            }
+            (2, 2) => {
+                self.apply_double_sub_add_fused(
+                    accumulation,
+                    removed.get(0),
+                    added.get(0),
+                    removed.get(1),
+                    added.get(1),
+                );
+            }
+            _ => {
+                for index in removed.iter() {
+                    self.sub_weights(accumulation, index);
+                }
+                for index in added.iter() {
+                    self.add_weights(accumulation, index);
+                }
+            }
+        }
+    }
+
+    /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
+    #[inline]
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
+        let sub_weights = self.weight_row(sub_index);
+        let add_weights = self.weight_row(add_index);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY:
+            // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
+            //   32 バイト境界に揃う。weight 行は AlignedBox 先頭が 64 バイト
+            //   アライン、各行は L1×2 バイト（L1 は 16 の倍数）なので全行先頭も
+            //   32 バイト境界に揃い、aligned load/store が安全。
+            // - L1 要素を 16 要素ずつ L1/16 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行は 16 バイト境界にある。
+            // - L1 要素を 8 要素ずつ L1/8 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec = _mm_load_si128(sub_ptr.add(i * 8) as *const __m128i);
+                    let add_vec = _mm_load_si128(add_ptr.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((acc, &sub_w), &add_w) in
+            accumulation.iter_mut().zip(sub_weights.iter()).zip(add_weights.iter())
+        {
+            *acc = acc.wrapping_sub(sub_w).wrapping_add(add_w);
+        }
+    }
+
+    /// `acc = acc - sub0 + add0 - sub1 + add1` を 1 パスで適用
+    #[inline]
+    fn apply_double_sub_add_fused(
+        &self,
+        accumulation: &mut [i16],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        let sub_weights0 = self.weight_row(sub_index0);
+        let add_weights0 = self.weight_row(add_index0);
+        let sub_weights1 = self.weight_row(sub_index1);
+        let add_weights1 = self.weight_row(add_index1);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
+            // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY: accumulation / 4 本の weight 行は 16 バイト境界。
+            // L1 要素を 8 要素ずつ L1/8 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec0 = _mm_load_si128(sub_ptr0.add(i * 8) as *const __m128i);
+                    let add_vec0 = _mm_load_si128(add_ptr0.add(i * 8) as *const __m128i);
+                    let sub_vec1 = _mm_load_si128(sub_ptr1.add(i * 8) as *const __m128i);
+                    let add_vec1 = _mm_load_si128(add_ptr1.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(
+                        _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((((acc, &sub_w0), &add_w0), &sub_w1), &add_w1) in accumulation
+            .iter_mut()
+            .zip(sub_weights0.iter())
+            .zip(add_weights0.iter())
+            .zip(sub_weights1.iter())
+            .zip(add_weights1.iter())
+        {
+            *acc = acc
+                .wrapping_sub(sub_w0)
+                .wrapping_add(add_w0)
+                .wrapping_sub(sub_w1)
+                .wrapping_add(add_w1);
         }
     }
 

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -542,7 +542,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         &self,
         pos: &Position,
         perspective: Color,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
@@ -562,21 +562,8 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
             sorted,
             &self.biases,
             accumulation,
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: acc は refresh_perspective_with_cache が &mut [i16; L1] から
-                // refresh_or_cache に渡したスライス。キャッシュも同じ L1 で確保され
-                // 長さは常に L1 に一致する。固定長配列化で SIMD ループ長が
-                // コンパイル時定数として確定する。
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.add_weights(arr, idx);
-            },
-            |acc, idx| {
-                debug_assert_eq!(acc.len(), L1);
-                // SAFETY: 上記と同じ理由で安全
-                let arr: &mut [i16; L1] = unsafe { &mut *(acc.as_mut_ptr() as *mut [i16; L1]) };
-                self.sub_weights(arr, idx);
-            },
+            |acc, idx| self.add_weights(acc, idx),
+            |acc, idx| self.sub_weights(acc, idx),
         );
     }
 
@@ -634,7 +621,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// 重みを加算（SIMD最適化版）
     #[inline]
-    fn add_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn add_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -686,7 +673,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// 重みを減算（SIMD最適化版）
     #[inline]
-    fn sub_weights(&self, accumulation: &mut [i16; L1], index: usize) {
+    fn sub_weights(&self, accumulation: &mut [i16], index: usize) {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
@@ -758,7 +745,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
     #[inline]
     fn apply_diff_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         removed: &IndexList<MAX_CHANGED_FEATURES>,
         added: &IndexList<MAX_CHANGED_FEATURES>,
     ) {
@@ -788,12 +775,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 
     /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
     #[inline]
-    fn apply_sub_add_fused(
-        &self,
-        accumulation: &mut [i16; L1],
-        sub_index: usize,
-        add_index: usize,
-    ) {
+    fn apply_sub_add_fused(&self, accumulation: &mut [i16], sub_index: usize, add_index: usize) {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
@@ -858,7 +840,7 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
     #[inline]
     fn apply_double_sub_add_fused(
         &self,
-        accumulation: &mut [i16; L1],
+        accumulation: &mut [i16],
         sub_index0: usize,
         add_index0: usize,
         sub_index1: usize,

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -46,9 +46,10 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
+use super::bona_piece_halfka_merged::{halfka_index, king_index, pack_bonapiece};
 use super::constants::{
     FV_SCALE_HALFKA, HALFKA_MERGED_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA,
 };
@@ -546,22 +547,20 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKaMergedFeatureSet::collect_active_indices(pos, perspective);
-
-        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
-        let len = active_indices.len();
-        for (i, idx) in active_indices.iter().enumerate() {
-            sorted_buf[i] = idx as u32;
-        }
-        let sorted = &mut sorted_buf[..len];
-        sorted.sort_unstable();
+        let k_index = king_index(king_sq, perspective);
+        let piece_list = if perspective == Color::Black {
+            pos.piece_list().piece_list_fb()
+        } else {
+            pos.piece_list().piece_list_fw()
+        };
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            sorted,
+            piece_list,
             &self.biases,
             accumulation,
+            move |bp| halfka_index(k_index, pack_bonapiece(bp)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -46,10 +46,9 @@ use std::sync::OnceLock;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned, AlignedBox, AlignedI16, DirtyPiece, IndexList,
-    MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
-use super::bona_piece_halfka_merged::{halfka_index, king_index, pack_bonapiece};
 use super::constants::{
     FV_SCALE_HALFKA, HALFKA_MERGED_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA,
 };
@@ -547,20 +546,22 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let k_index = king_index(king_sq, perspective);
-        let piece_list = if perspective == Color::Black {
-            pos.piece_list().piece_list_fb()
-        } else {
-            pos.piece_list().piece_list_fw()
-        };
+        let active_indices = HalfKaMergedFeatureSet::collect_active_indices(pos, perspective);
+
+        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
+        let len = active_indices.len();
+        for (i, idx) in active_indices.iter().enumerate() {
+            sorted_buf[i] = idx as u32;
+        }
+        let sorted = &mut sorted_buf[..len];
+        sorted.sort_unstable();
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            piece_list,
+            sorted,
             &self.biases,
             accumulation,
-            move |bp| halfka_index(k_index, pack_bonapiece(bp)),
             |acc, idx| self.add_weights(acc, idx),
             |acc, idx| self.sub_weights(acc, idx),
         );

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -40,14 +40,12 @@ use std::marker::PhantomData;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned as AlignedGeneric, AlignedBox, AlignedI16, DirtyPiece,
-    IndexList, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    IndexList, MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
-use super::bona_piece::halfkp_index;
 use super::constants::{FV_SCALE, HALFKP_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION};
 use super::features::{Feature, FeatureSet, HalfKP, HalfKPFeatureSet};
 use super::network::get_fv_scale_override;
-use super::piece_list::PieceNumber;
 use crate::position::Position;
 use crate::types::{Color, Value};
 
@@ -626,26 +624,23 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        // HalfKP の feature index は後手視点で玉位置を反転する。
-        let king_sq_idx = if perspective == Color::Black {
-            king_sq
-        } else {
-            king_sq.inverse()
-        };
-        // 玉（PieceNumber::KING 以降）を除く 38 slot を渡す。
-        let piece_list = if perspective == Color::Black {
-            pos.piece_list().piece_list_fb()
-        } else {
-            pos.piece_list().piece_list_fw()
-        };
+        let active_indices = HalfKPFeatureSet::collect_active_indices(pos, perspective);
+
+        // IndexList を u32 のソート済み配列に変換
+        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
+        let len = active_indices.len();
+        for (i, idx) in active_indices.iter().enumerate() {
+            sorted_buf[i] = idx as u32;
+        }
+        let sorted = &mut sorted_buf[..len];
+        sorted.sort_unstable();
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            &piece_list[..PieceNumber::KING as usize],
+            sorted,
             &self.biases.0,
             accumulation,
-            move |bp| halfkp_index(king_sq_idx, bp),
             |acc, idx| {
                 debug_assert_eq!(acc.len(), L1);
                 // SAFETY: acc は呼び出し元で &mut [i16; L1] から作られたスライス。

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -40,12 +40,14 @@ use std::marker::PhantomData;
 
 use super::accumulator::{
     AccumulatorCacheGeneric, Aligned as AlignedGeneric, AlignedBox, AlignedI16, DirtyPiece,
-    IndexList, MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
+    IndexList, MAX_CHANGED_FEATURES, MAX_PATH_LENGTH,
 };
 use super::activation::FtActivation;
+use super::bona_piece::halfkp_index;
 use super::constants::{FV_SCALE, HALFKP_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION};
 use super::features::{Feature, FeatureSet, HalfKP, HalfKPFeatureSet};
 use super::network::get_fv_scale_override;
+use super::piece_list::PieceNumber;
 use crate::position::Position;
 use crate::types::{Color, Value};
 
@@ -624,23 +626,26 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKPFeatureSet::collect_active_indices(pos, perspective);
-
-        // IndexList を u32 のソート済み配列に変換
-        let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
-        let len = active_indices.len();
-        for (i, idx) in active_indices.iter().enumerate() {
-            sorted_buf[i] = idx as u32;
-        }
-        let sorted = &mut sorted_buf[..len];
-        sorted.sort_unstable();
+        // HalfKP の feature index は後手視点で玉位置を反転する。
+        let king_sq_idx = if perspective == Color::Black {
+            king_sq
+        } else {
+            king_sq.inverse()
+        };
+        // 玉（PieceNumber::KING 以降）を除く 38 slot を渡す。
+        let piece_list = if perspective == Color::Black {
+            pos.piece_list().piece_list_fb()
+        } else {
+            pos.piece_list().piece_list_fw()
+        };
 
         cache.refresh_or_cache(
             king_sq,
             perspective,
-            sorted,
+            &piece_list[..PieceNumber::KING as usize],
             &self.biases.0,
             accumulation,
+            move |bp| halfkp_index(king_sq_idx, bp),
             |acc, idx| {
                 debug_assert_eq!(acc.len(), L1);
                 // SAFETY: acc は呼び出し元で &mut [i16; L1] から作られたスライス。

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -543,12 +543,7 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -593,12 +588,7 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
 
                 acc.accumulation[p].0.copy_from_slice(&prev_acc.accumulation[p].0);
 
-                for index in removed.iter() {
-                    self.sub_weights(&mut acc.accumulation[p].0, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(&mut acc.accumulation[p].0, index);
-                }
+                self.apply_diff_fused(&mut acc.accumulation[p].0, &removed, &added);
             }
         }
 
@@ -712,12 +702,7 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
                 let accumulation =
                     &mut stack.entry_at_mut(current_idx).accumulator.accumulation[p].0;
 
-                for index in removed.iter() {
-                    self.sub_weights(accumulation, index);
-                }
-                for index in added.iter() {
-                    self.add_weights(accumulation, index);
-                }
+                self.apply_diff_fused(accumulation, &removed, &added);
             }
         }
 
@@ -832,6 +817,213 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         #[allow(unreachable_code)]
         for (acc, &w) in accumulation.iter_mut().zip(weights) {
             *acc = acc.wrapping_sub(w);
+        }
+    }
+
+    /// index 番目の重み行（L1 要素）を取得
+    #[inline]
+    fn weight_row(&self, index: usize) -> &[i16] {
+        let offset = index * L1;
+        &self.weights[offset..offset + L1]
+    }
+
+    /// removed/added を融合した差分更新（fast path）
+    ///
+    /// `removed`/`added` がともに 1 要素なら sub+add を 1 パスに、ともに 2 要素なら
+    /// 2 組を 1 パスに融合する。それ以外は従来どおり sub ループ → add ループの
+    /// 2 パスにフォールバックする。do_move の大半は quiet（1 sub+1 add）/
+    /// capture（2 sub+2 add）なので fast path に乗る。
+    ///
+    /// i16 の wrapping 加減算は可換群をなすため、融合パスは `sub_weights` ループ
+    /// → `add_weights` ループと bit 単位で一致する。LayerStacks の
+    /// `try_apply_dirty_piece_fast` は DirtyPiece から特徴 index を再計算するが、
+    /// ここでは `append_changed_indices` が生成済みの IndexList を再利用して
+    /// 再計算を避ける。
+    #[inline]
+    fn apply_diff_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        removed: &IndexList<MAX_CHANGED_FEATURES>,
+        added: &IndexList<MAX_CHANGED_FEATURES>,
+    ) {
+        match (removed.len(), added.len()) {
+            (1, 1) => {
+                self.apply_sub_add_fused(accumulation, removed.get(0), added.get(0));
+            }
+            (2, 2) => {
+                self.apply_double_sub_add_fused(
+                    accumulation,
+                    removed.get(0),
+                    added.get(0),
+                    removed.get(1),
+                    added.get(1),
+                );
+            }
+            _ => {
+                for index in removed.iter() {
+                    self.sub_weights(accumulation, index);
+                }
+                for index in added.iter() {
+                    self.add_weights(accumulation, index);
+                }
+            }
+        }
+    }
+
+    /// `acc = acc - weights[sub_index] + weights[add_index]` を 1 パスで適用
+    #[inline]
+    fn apply_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
+        let sub_weights = self.weight_row(sub_index);
+        let add_weights = self.weight_row(add_index);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY:
+            // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
+            //   32 バイト境界に揃う。weight 行は AlignedBox 先頭が 64 バイト
+            //   アライン、各行は L1×2 バイト（L1 は 16 の倍数）なので全行先頭も
+            //   32 バイト境界に揃い、aligned load/store が安全。
+            // - L1 要素を 16 要素ずつ L1/16 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行は 16 バイト境界にある。
+            // - L1 要素を 8 要素ずつ L1/8 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec = _mm_load_si128(sub_ptr.add(i * 8) as *const __m128i);
+                    let add_vec = _mm_load_si128(add_ptr.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((acc, &sub_w), &add_w) in
+            accumulation.iter_mut().zip(sub_weights.iter()).zip(add_weights.iter())
+        {
+            *acc = acc.wrapping_sub(sub_w).wrapping_add(add_w);
+        }
+    }
+
+    /// `acc = acc - sub0 + add0 - sub1 + add1` を 1 パスで適用
+    #[inline]
+    fn apply_double_sub_add_fused(
+        &self,
+        accumulation: &mut [i16; L1],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        let sub_weights0 = self.weight_row(sub_index0);
+        let add_weights0 = self.weight_row(add_index0);
+        let sub_weights1 = self.weight_row(sub_index1);
+        let add_weights1 = self.weight_row(add_index1);
+
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        {
+            // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
+            // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 16) {
+                    let acc_vec = _mm256_load_si256(acc_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "sse2",
+            not(target_feature = "avx2")
+        ))]
+        {
+            // SAFETY: accumulation / 4 本の weight 行は 16 バイト境界。
+            // L1 要素を 8 要素ずつ L1/8 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 8) {
+                    let acc_vec = _mm_load_si128(acc_ptr.add(i * 8) as *const __m128i);
+                    let sub_vec0 = _mm_load_si128(sub_ptr0.add(i * 8) as *const __m128i);
+                    let add_vec0 = _mm_load_si128(add_ptr0.add(i * 8) as *const __m128i);
+                    let sub_vec1 = _mm_load_si128(sub_ptr1.add(i * 8) as *const __m128i);
+                    let add_vec1 = _mm_load_si128(add_ptr1.add(i * 8) as *const __m128i);
+                    let result = _mm_add_epi16(
+                        _mm_add_epi16(_mm_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm_store_si128(acc_ptr.add(i * 8) as *mut __m128i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        for ((((acc, &sub_w0), &add_w0), &sub_w1), &add_w1) in accumulation
+            .iter_mut()
+            .zip(sub_weights0.iter())
+            .zip(add_weights0.iter())
+            .zip(sub_weights1.iter())
+            .zip(add_weights1.iter())
+        {
+            *acc = acc
+                .wrapping_sub(sub_w0)
+                .wrapping_add(add_w0)
+                .wrapping_sub(sub_w1)
+                .wrapping_add(add_w1);
         }
     }
 


### PR DESCRIPTION
## Summary

Issue #724 の Simple-arch（HalfKP / 4 HalfKA 系）NNUE FT アキュムレータ最適化。perf 計測ベースで P1〜P5 を検証し、**P1（差分更新の sub+add 融合 fast path）のみ採用**。P2 / P3 / P5 は計測の結果 NO-GO（試行 commit + revert を投資ログとして残置）。

## 採用: P1 — 差分更新の sub+add 融合 fast path

HalfKP + 4 HalfKA 系の差分更新は `removed` を全 L1 `sub_weights` → `added` を全 L1 `add_weights` の 2 パス（アキュムレータを 2 回 load+store）だった。do_move の大半は quiet（1 sub+1 add）/ capture（2 sub+2 add）なので、`removed`/`added` がともに 1 または 2 要素のとき sub+add を 1 パスに融合する fast path を追加。それ以外は従来の 2 パスにフォールバックする。

fast path 判定は `append_changed_indices` が生成済みの `IndexList` の長さを再利用する。i16 wrapping 加減算は可換群をなすため、融合パスは 2 パスと bit 単位で一致する（探索ツリー不変）。対象: `network_halfkp.rs` / `network_halfka{,_hm,_merged,_hm_split}.rs` の `update_accumulator` / `update_accumulator_with_cache` / `forward_update_incremental`。

### per-architecture NPS 計測

`search_only_ab`（abba パターン, 4 局面 8s movetime, CPU0 pin, release build, baseline a880a141 → P1）:

| Arch | NPS | cycles/node | instructions/node |
|---|---:|---:|---:|
| HalfKP | **+1.92%** | -1.92% | -0.64% |
| HalfKaHmSplit | **+0.85%** | -0.82% | -0.70% |
| HalfKaMerged | +0.26% | -0.23% | -0.68% |
| HalfKA_hm | +0.13% | -0.13% | -0.59% |
| HalfKA | -0.19% | +0.19% | -0.57% |

※上表は rounds=2（16 run/engine）共通計測。HalfKA_hm の rounds=3 専用計測では NPS +0.40% / cycles/node -0.39% / instructions/node -0.68%。

**instructions/node は全 5 アーキで -0.57〜-0.70% 減少**（P1 は全アーキで確実に処理量を削減）。NPS は HalfKP で大きく改善、HalfKA は CPI 相殺によりノイズ域（instructions は減少しており実害なし）。

perf プロファイル（production build, `benchmark --internal`, HalfKA_hm）: `update_accumulator_halfka_hm` 5.81% → 1.87% + `apply_diff_fused` 2.37%（アキュムレータ更新計 5.81% → 4.24%）。

### bit 一致確認

固定 `go depth` 探索で全 5 アーキ × 複数局面（startpos / 中盤 3 局面）の nodes・score・bestmove が baseline と完全一致。

## 試行ログ（NO-GO / 申し送り）

| 候補 | 内容 | 実測 | 判定 |
|---|---|---|---|
| P2 | cache refresh を PieceList slot 比較方式に変更 | NPS **-0.72%**（回帰） | NO-GO（試行 commit + revert） |
| P3 | HalfKA 系 accumulator 引数を `&mut [i16; L1]` に統一 | NPS **±0%**（avx2 codegen 不変） | NO-GO（試行 commit + revert） |
| P5 | 差分 weight 行の prefetch | NPS **+0.26%**（ノイズ域・限界的） | NO-GO（試行 commit + revert） |
| P4 | AVX-512BW パス追加 | 本機 Zen3 が AVX-512 非対応で検証不可 | 別 session 申し送り |

- **P2**: 旧マージ差分は cache に計算済み feature index を保持し hit 時の index 再計算が不要だったが、slot 比較方式は BonaPiece を保持し `idx_fn` を再呼び出しする。`sort_unstable` 除去の利得をストール増が上回った。
- **P3**: `add_weights`/`sub_weights` の avx2 パスは既に生ポインタ実装で、`&mut [i16; L1]` 化は codegen を変えず instructions も bit 単位で不変。
- **P5**: prefetch は cycles/node -0.30% と方向は正だが、+0.26% NPS はノイズ床（±0.1-0.2%）の 2 倍程度・予測帯下限未満。`unsafe` prefetch を 5 ファイルへ展開するコストに見合わず見送り。

## commit list

- `3f7afb16` P1（採用）
- `acd7276c` / `0f5fbf65` P3 試行 + revert
- `461ee4c1` / `570a2840` P2 試行 + revert
- `fd5eaaa1` / `4cc4825e` P5 試行 + revert
- `63b27ec9` review 指摘修正（`IndexList::get` を release でも境界検査）

## Test plan

- `cargo fmt --check` / `cargo clippy --tests -p rshogi-core`: PASS（警告ゼロ）
- `cargo test -p rshogi-core --lib nnue::`: 357 pass（既知 flake `test_evaluate_fallback` / `test_accumulator_stack_variant_fallback` の 2 件のみ、origin/main でも失敗）
- bit 一致: 全 5 アーキ × 固定 `go depth` 探索で nodes/score/bestmove 完全一致
- local review: `codex:codex-rescue` + `claude` の 2 系統で Approve

## 関連

Issue #724（P1 採用、P2 / P3 / P5 は NO-GO、P4 は AVX-512 機へ申し送り）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
