### PR TITLE
perf(nnue): Simple-arch FT に AVX-512BW SIMD パスを追加 (Issue #724 P4)

### DIFF
--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -622,7 +622,36 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -674,7 +703,36 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_sub_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -776,7 +834,35 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_sub_add_fused の AVX2 パスと同様、accumulation /
+            // weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec = _mm512_load_si512(sub_ptr.add(i * 32) as *const __m512i);
+                    let add_vec = _mm512_load_si512(add_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY:
             // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
@@ -848,7 +934,42 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         let sub_weights1 = self.weight_row(sub_index1);
         let add_weights1 = self.weight_row(add_index1);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_double_sub_add_fused の AVX2 パスと同様、accumulation /
+            // 4 本の weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec0 = _mm512_load_si512(sub_ptr0.add(i * 32) as *const __m512i);
+                    let add_vec0 = _mm512_load_si512(add_ptr0.add(i * 32) as *const __m512i);
+                    let sub_vec1 = _mm512_load_si512(sub_ptr1.add(i * 32) as *const __m512i);
+                    let add_vec1 = _mm512_load_si512(add_ptr1.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(
+                        _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm512_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
             // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -622,7 +622,36 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -674,7 +703,36 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_sub_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -776,7 +834,35 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_sub_add_fused の AVX2 パスと同様、accumulation /
+            // weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec = _mm512_load_si512(sub_ptr.add(i * 32) as *const __m512i);
+                    let add_vec = _mm512_load_si512(add_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY:
             // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
@@ -848,7 +934,42 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         let sub_weights1 = self.weight_row(sub_index1);
         let add_weights1 = self.weight_row(add_index1);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_double_sub_add_fused の AVX2 パスと同様、accumulation /
+            // 4 本の weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec0 = _mm512_load_si512(sub_ptr0.add(i * 32) as *const __m512i);
+                    let add_vec0 = _mm512_load_si512(add_ptr0.add(i * 32) as *const __m512i);
+                    let sub_vec1 = _mm512_load_si512(sub_ptr1.add(i * 32) as *const __m512i);
+                    let add_vec1 = _mm512_load_si512(add_ptr1.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(
+                        _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm512_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
             // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -625,7 +625,36 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -677,7 +706,36 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_sub_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -779,7 +837,35 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_sub_add_fused の AVX2 パスと同様、accumulation /
+            // weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec = _mm512_load_si512(sub_ptr.add(i * 32) as *const __m512i);
+                    let add_vec = _mm512_load_si512(add_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY:
             // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
@@ -851,7 +937,42 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
         let sub_weights1 = self.weight_row(sub_index1);
         let add_weights1 = self.weight_row(add_index1);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_double_sub_add_fused の AVX2 パスと同様、accumulation /
+            // 4 本の weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec0 = _mm512_load_si512(sub_ptr0.add(i * 32) as *const __m512i);
+                    let add_vec0 = _mm512_load_si512(add_ptr0.add(i * 32) as *const __m512i);
+                    let sub_vec1 = _mm512_load_si512(sub_ptr1.add(i * 32) as *const __m512i);
+                    let add_vec1 = _mm512_load_si512(add_ptr1.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(
+                        _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm512_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
             // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -625,7 +625,36 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -677,7 +706,36 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_sub_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -779,7 +837,35 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_sub_add_fused の AVX2 パスと同様、accumulation /
+            // weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec = _mm512_load_si512(sub_ptr.add(i * 32) as *const __m512i);
+                    let add_vec = _mm512_load_si512(add_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY:
             // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
@@ -851,7 +937,42 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
         let sub_weights1 = self.weight_row(sub_index1);
         let add_weights1 = self.weight_row(add_index1);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_double_sub_add_fused の AVX2 パスと同様、accumulation /
+            // 4 本の weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec0 = _mm512_load_si512(sub_ptr0.add(i * 32) as *const __m512i);
+                    let add_vec0 = _mm512_load_si512(add_ptr0.add(i * 32) as *const __m512i);
+                    let sub_vec1 = _mm512_load_si512(sub_ptr1.add(i * 32) as *const __m512i);
+                    let add_vec1 = _mm512_load_si512(add_ptr1.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(
+                        _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm512_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
             // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -720,7 +720,36 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -775,7 +804,36 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         let offset = index * L1;
         let weights = &self.weights[offset..offset + L1];
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY:
+            // - accumulation / weight 行はいずれも 64 バイト境界（accumulation は
+            //   AlignedI16<L1> 由来、weight 行は AlignedBox 先頭 64 バイト + 各行
+            //   L1×2 バイトで L1 は 32 の倍数）。aligned load/store が安全。
+            // - L1 要素を 32 要素ずつ L1/32 回で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let weight_ptr = weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let weight_vec = _mm512_load_si512(weight_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_sub_epi16(acc_vec, weight_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             unsafe {
                 use std::arch::x86_64::*;
@@ -881,7 +939,35 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         let sub_weights = self.weight_row(sub_index);
         let add_weights = self.weight_row(add_index);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_sub_add_fused の AVX2 パスと同様、accumulation /
+            // weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec = _mm512_load_si512(sub_ptr.add(i * 32) as *const __m512i);
+                    let add_vec = _mm512_load_si512(add_ptr.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec), add_vec);
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY:
             // - accumulation は AlignedI16<L1>（#[repr(C, align(64))]）由来で
@@ -953,7 +1039,42 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
         let sub_weights1 = self.weight_row(sub_index1);
         let add_weights1 = self.weight_row(add_index1);
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx512f",
+            target_feature = "avx512bw"
+        ))]
+        {
+            // SAFETY: apply_double_sub_add_fused の AVX2 パスと同様、accumulation /
+            // 4 本の weight 行は 64 バイト境界。L1 要素を 32 要素ずつ L1/32 回で走査。
+            unsafe {
+                use std::arch::x86_64::*;
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+                for i in 0..(L1 / 32) {
+                    let acc_vec = _mm512_load_si512(acc_ptr.add(i * 32) as *const __m512i);
+                    let sub_vec0 = _mm512_load_si512(sub_ptr0.add(i * 32) as *const __m512i);
+                    let add_vec0 = _mm512_load_si512(add_ptr0.add(i * 32) as *const __m512i);
+                    let sub_vec1 = _mm512_load_si512(sub_ptr1.add(i * 32) as *const __m512i);
+                    let add_vec1 = _mm512_load_si512(add_ptr1.add(i * 32) as *const __m512i);
+                    let result = _mm512_add_epi16(
+                        _mm512_add_epi16(_mm512_sub_epi16(acc_vec, sub_vec0), add_vec0),
+                        _mm512_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm512_store_si512(acc_ptr.add(i * 32) as *mut __m512i, result);
+                }
+            }
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
         {
             // SAFETY: apply_sub_add_fused と同様（accumulation / 4 本の weight 行
             // はいずれも 32 バイト境界）。L1 要素を 16 要素ずつ L1/16 回で走査。


### PR DESCRIPTION
## Summary

Issue #724 **P4**。Simple-arch（HalfKP / 4 HalfKA 系）NNUE FT の差分更新・refresh で使う 4 関数（`add_weights` / `sub_weights` / `apply_sub_add_fused` / `apply_double_sub_add_fused`、5 ファイル計 **20 関数**）に **AVX-512BW SIMD 経路**を追加。

これまで AVX-512 対応 CPU でも AVX2（256bit, 16 i16/レジスタ）で動作していた。LayerStacks FT が実装済みの AVX-512BW 経路（512bit, 32 i16/レジスタ, `L1/32` 回走査）を移植する。

## 変更内容

- 各関数の AVX2 ブロック直前に AVX-512BW ブロックを追加（`feature_transformer_layer_stacks.rs` の同名 4 関数から逐次移植）。
- 既存 AVX2 ブロックの cfg に `not(target_feature = "avx512bw")` を追加（AVX-512 と AVX2 が同時有効なときの二重定義を防止。SSE2 ブロックの `not(avx2)` と同じ排他構造）。**AVX2 / SSE2 / scalar の本体は無変更**。
- i16 の element-wise 加減算は lane 幅非依存のため、AVX-512（32-wide）/ AVX2（16-wide）/ SSE2（8-wide）/ scalar はすべて同一結果を返す。
- L1（256 / 512 / 768 / 1024）はすべて 32 の倍数で、AVX-512 の `L1/32` 完全走査・64 バイト境界 aligned load/store の要件を満たす。

対象 5 ファイル: `network_halfkp.rs` / `network_halfka.rs` / `network_halfka_hm.rs` / `network_halfka_merged.rs` / `network_halfka_hm_split.rs`。

## 検証（開発機 Ryzen 5950X / Zen3 — AVX-512 非対応）

Zen3 は AVX-512 非対応のため AVX-512 経路の**実行・NPS 実測は不可**。以下を確認:

- 通常ビルド `cargo build -p rshogi-core --lib`: PASS（Zen3 では avx512 ブロックは cfg で除外され AVX2 経路が有効）。
- **AVX-512 コンパイル検証**: `cargo rustc -p rshogi-core --lib -- -C target-feature=+avx512f,+avx512bw` で avx512 ブロックを実コンパイル → 成功（型・構文を検証。Zen3 では実行不可）。
- `cargo fmt --check` / `cargo clippy --tests -p rshogi-core`: PASS（警告ゼロ）。
- `cargo test -p rshogi-core --lib nnue::`: 357 pass（既知 flake `test_evaluate_fallback` / `test_accumulator_stack_variant_fallback` の 2 件のみ、origin/main でも失敗）。
- **bit 一致**: 全 5 アーキ × 固定 `go depth` 探索で、Zen3 ビルド（AVX2 経路）の nodes / score / bestmove が P1 マージ済 main と完全一致 — AVX2 cfg への `not(avx512bw)` 追加が Zen3 挙動を変えないことを確認。
- local review: `codex:codex-rescue` + `claude` の 2 系統で APPROVE（演算正当性・cfg 排他性・SAFETY 根拠・Zen3 不変性をレビュー、Major/Minor 指摘なし）。

**AVX-512 機での NPS 実測は本 PR の範囲外**（開発機 Zen3 で検証不可）。AVX-512 対応 CPU での実測を次 session に申し送り。

## Test plan

- 上記検証セクション参照。
- AVX-512 機があれば `search_only_ab` で NPS A/B（baseline = AVX2 経路 / candidate = AVX-512 経路）を計測すること。

## 関連

Issue #724 P4（AVX-512BW パス）。P1（sub+add 融合）は PR #725 でマージ済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
