### PR TITLE
refactor(nnue): FeatureSet enum を PascalCase 表記に rename (Issue #728 PR2)

### DIFF
--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -802,7 +802,7 @@ mod tests {
         for spec in &halfka_specs {
             assert_eq!(
                 spec.feature_set,
-                crate::nnue::spec::FeatureSet::HalfKA,
+                crate::nnue::spec::FeatureSet::HalfKaSplit,
                 "HalfKA spec has wrong feature_set: {spec:?}"
             );
         }
@@ -810,7 +810,7 @@ mod tests {
         for spec in &halfka_hm_specs {
             assert_eq!(
                 spec.feature_set,
-                crate::nnue::spec::FeatureSet::HalfKA_hm,
+                crate::nnue::spec::FeatureSet::HalfKaHmMerged,
                 "HalfKA_hm spec has wrong feature_set: {spec:?}"
             );
         }

--- a/crates/rshogi-core/src/nnue/halfka/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l1024.rs
@@ -17,7 +17,7 @@ use crate::nnue::aliases::{
 
 crate::define_l1_variants!(
     enum HalfKA_L1024,
-    feature_set HalfKA,
+    feature_set HalfKaSplit,
     l1 1024,
     acc crate::nnue::network_halfka::AccumulatorHalfKA<1024>,
     stack AccumulatorStackHalfKA<1024>,
@@ -48,7 +48,7 @@ mod tests {
 
         // 8-64 CReLU
         let spec = &HalfKA_L1024::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
         assert_eq!(spec.l1, 1024);
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKA_L1024::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA-1024-"),
-                "Architecture name should start with 'HalfKA-1024-', got: {name}"
+                name.starts_with("HalfKaSplit-1024-"),
+                "Architecture name should start with 'HalfKaSplit-1024-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l256.rs
@@ -13,7 +13,7 @@ use crate::nnue::aliases::{HalfKA256CReLU, HalfKA256Pairwise, HalfKA256SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_L256,
-    feature_set HalfKA,
+    feature_set HalfKaSplit,
     l1 256,
     acc crate::nnue::network_halfka::AccumulatorHalfKA<256>,
     stack AccumulatorStackHalfKA<256>,
@@ -34,7 +34,7 @@ mod tests {
         assert_eq!(HalfKA_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKA_L256::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
         assert_eq!(spec.l1, 256);
         assert_eq!(spec.l2, 32);
         assert_eq!(spec.l3, 32);
@@ -55,10 +55,10 @@ mod tests {
     fn test_architecture_name_format() {
         for spec in HalfKA_L256::SUPPORTED_SPECS {
             let name = spec.name();
-            // HalfKA-256-L2-L3-Activation 形式
+            // HalfKaSplit-256-L2-L3-Activation 形式
             assert!(
-                name.starts_with("HalfKA-256-"),
-                "Architecture name should start with 'HalfKA-256-', got: {name}"
+                name.starts_with("HalfKaSplit-256-"),
+                "Architecture name should start with 'HalfKaSplit-256-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l512.rs
@@ -17,7 +17,7 @@ use crate::nnue::aliases::{
 
 crate::define_l1_variants!(
     enum HalfKA_L512,
-    feature_set HalfKA,
+    feature_set HalfKaSplit,
     l1 512,
     acc crate::nnue::network_halfka::AccumulatorHalfKA<512>,
     stack AccumulatorStackHalfKA<512>,
@@ -48,7 +48,7 @@ mod tests {
 
         // 8-64 CReLU
         let spec = &HalfKA_L512::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
         assert_eq!(spec.l1, 512);
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKA_L512::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA-512-"),
-                "Architecture name should start with 'HalfKA-512-', got: {name}"
+                name.starts_with("HalfKaSplit-512-"),
+                "Architecture name should start with 'HalfKaSplit-512-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka/l768.rs
@@ -13,7 +13,7 @@ use crate::nnue::aliases::{HalfKA768CReLU, HalfKA768Pairwise, HalfKA768SCReLU};
 
 crate::define_l1_variants!(
     enum HalfKA_L768,
-    feature_set HalfKA,
+    feature_set HalfKaSplit,
     l1 768,
     acc crate::nnue::network_halfka::AccumulatorHalfKA<768>,
     stack AccumulatorStackHalfKA<768>,
@@ -36,7 +36,7 @@ mod tests {
 
         // 16-64 CReLU
         let spec = &HalfKA_L768::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
         assert_eq!(spec.l1, 768);
         assert_eq!(spec.l2, 16);
         assert_eq!(spec.l3, 64);
@@ -56,8 +56,8 @@ mod tests {
         for spec in HalfKA_L768::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA-768-"),
-                "Architecture name should start with 'HalfKA-768-', got: {name}"
+                name.starts_with("HalfKaSplit-768-"),
+                "Architecture name should start with 'HalfKaSplit-768-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka/mod.rs
@@ -432,7 +432,7 @@ mod tests {
 
         // 全て HalfKA
         for spec in &specs {
-            assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+            assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
         }
     }
 
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn test_architecture_spec_consistency() {
         for spec in HalfKANetwork::supported_specs() {
-            assert_eq!(spec.feature_set, FeatureSet::HalfKA);
+            assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
             assert!(spec.l1 == 256 || spec.l1 == 512 || spec.l1 == 768 || spec.l1 == 1024);
             assert!(spec.l2 > 0 && spec.l2 <= 128);
             assert!(spec.l3 > 0 && spec.l3 <= 128);

--- a/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
@@ -17,7 +17,7 @@ use crate::nnue::aliases::{
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L1024,
-    feature_set HalfKA_hm,
+    feature_set HalfKaHmMerged,
     l1 1024,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<1024>,
     stack AccumulatorStackHalfKA_hm<1024>,
@@ -48,7 +48,7 @@ mod tests {
 
         // 8-64 CReLU
         let spec = &HalfKA_hm_L1024::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 1024);
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKA_hm_L1024::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm-1024-"),
-                "Architecture name should start with 'HalfKA_hm-1024-', got: {name}"
+                name.starts_with("HalfKaHmMerged-1024-"),
+                "Architecture name should start with 'HalfKaHmMerged-1024-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
@@ -13,7 +13,7 @@ use crate::nnue::aliases::{HalfKA_hm256CReLU, HalfKA_hm256Pairwise, HalfKA_hm256
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L256,
-    feature_set HalfKA_hm,
+    feature_set HalfKaHmMerged,
     l1 256,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<256>,
     stack AccumulatorStackHalfKA_hm<256>,
@@ -34,7 +34,7 @@ mod tests {
         assert_eq!(HalfKA_hm_L256::SUPPORTED_SPECS.len(), 3);
 
         let spec = &HalfKA_hm_L256::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 256);
         assert_eq!(spec.l2, 32);
         assert_eq!(spec.l3, 32);
@@ -55,10 +55,10 @@ mod tests {
     fn test_architecture_name_format() {
         for spec in HalfKA_hm_L256::SUPPORTED_SPECS {
             let name = spec.name();
-            // HalfKA_hm-256-L2-L3-Activation 形式
+            // HalfKaHmMerged-256-L2-L3-Activation 形式
             assert!(
-                name.starts_with("HalfKA_hm-256-"),
-                "Architecture name should start with 'HalfKA_hm-256-', got: {name}"
+                name.starts_with("HalfKaHmMerged-256-"),
+                "Architecture name should start with 'HalfKaHmMerged-256-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
@@ -17,7 +17,7 @@ use crate::nnue::aliases::{
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L512,
-    feature_set HalfKA_hm,
+    feature_set HalfKaHmMerged,
     l1 512,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<512>,
     stack AccumulatorStackHalfKA_hm<512>,
@@ -48,7 +48,7 @@ mod tests {
 
         // 8-64 CReLU
         let spec = &HalfKA_hm_L512::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 512);
         assert_eq!(spec.l2, 8);
         assert_eq!(spec.l3, 64);
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKA_hm_L512::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm-512-"),
-                "Architecture name should start with 'HalfKA_hm-512-', got: {name}"
+                name.starts_with("HalfKaHmMerged-512-"),
+                "Architecture name should start with 'HalfKaHmMerged-512-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
@@ -13,7 +13,7 @@ use crate::nnue::aliases::{HalfKA_hm768CReLU, HalfKA_hm768Pairwise, HalfKA_hm768
 
 crate::define_l1_variants!(
     enum HalfKA_hm_L768,
-    feature_set HalfKA_hm,
+    feature_set HalfKaHmMerged,
     l1 768,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<768>,
     stack AccumulatorStackHalfKA_hm<768>,
@@ -36,7 +36,7 @@ mod tests {
 
         // 16-64 CReLU
         let spec = &HalfKA_hm_L768::SUPPORTED_SPECS[0];
-        assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+        assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 768);
         assert_eq!(spec.l2, 16);
         assert_eq!(spec.l3, 64);
@@ -56,8 +56,8 @@ mod tests {
         for spec in HalfKA_hm_L768::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm-768-"),
-                "Architecture name should start with 'HalfKA_hm-768-', got: {name}"
+                name.starts_with("HalfKaHmMerged-768-"),
+                "Architecture name should start with 'HalfKaHmMerged-768-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
@@ -432,7 +432,7 @@ mod tests {
 
         // 全て HalfKA_hm
         for spec in &specs {
-            assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+            assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         }
     }
 
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn test_architecture_spec_consistency() {
         for spec in HalfKA_hmNetwork::supported_specs() {
-            assert_eq!(spec.feature_set, FeatureSet::HalfKA_hm);
+            assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
             assert!(spec.l1 == 256 || spec.l1 == 512 || spec.l1 == 768 || spec.l1 == 1024);
             assert!(spec.l2 > 0 && spec.l2 <= 128);
             assert!(spec.l3 > 0 && spec.l3 <= 128);

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l1024.rs
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKaHmSplit_L1024::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm_split-1024-"),
-                "Architecture name should start with 'HalfKA_hm_split-1024-', got: {name}"
+                name.starts_with("HalfKaHmSplit-1024-"),
+                "Architecture name should start with 'HalfKaHmSplit-1024-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l256.rs
@@ -57,10 +57,10 @@ mod tests {
     fn test_architecture_name_format() {
         for spec in HalfKaHmSplit_L256::SUPPORTED_SPECS {
             let name = spec.name();
-            // HalfKA_hm_split-256-L2-L3-Activation 形式
+            // HalfKaHmSplit-256-L2-L3-Activation 形式
             assert!(
-                name.starts_with("HalfKA_hm_split-256-"),
-                "Architecture name should start with 'HalfKA_hm_split-256-', got: {name}"
+                name.starts_with("HalfKaHmSplit-256-"),
+                "Architecture name should start with 'HalfKaHmSplit-256-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l512.rs
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKaHmSplit_L512::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm_split-512-"),
-                "Architecture name should start with 'HalfKA_hm_split-512-', got: {name}"
+                name.starts_with("HalfKaHmSplit-512-"),
+                "Architecture name should start with 'HalfKaHmSplit-512-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm_split/l768.rs
@@ -58,8 +58,8 @@ mod tests {
         for spec in HalfKaHmSplit_L768::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_hm_split-768-"),
-                "Architecture name should start with 'HalfKA_hm_split-768-', got: {name}"
+                name.starts_with("HalfKaHmSplit-768-"),
+                "Architecture name should start with 'HalfKaHmSplit-768-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l1024.rs
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKaMerged_L1024::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_merged-1024-"),
-                "Architecture name should start with 'HalfKA_merged-1024-', got: {name}"
+                name.starts_with("HalfKaMerged-1024-"),
+                "Architecture name should start with 'HalfKaMerged-1024-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l256.rs
@@ -55,10 +55,10 @@ mod tests {
     fn test_architecture_name_format() {
         for spec in HalfKaMerged_L256::SUPPORTED_SPECS {
             let name = spec.name();
-            // HalfKA_merged-256-L2-L3-Activation 形式
+            // HalfKaMerged-256-L2-L3-Activation 形式
             assert!(
-                name.starts_with("HalfKA_merged-256-"),
-                "Architecture name should start with 'HalfKA_merged-256-', got: {name}"
+                name.starts_with("HalfKaMerged-256-"),
+                "Architecture name should start with 'HalfKaMerged-256-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l512.rs
@@ -68,8 +68,8 @@ mod tests {
         for spec in HalfKaMerged_L512::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_merged-512-"),
-                "Architecture name should start with 'HalfKA_merged-512-', got: {name}"
+                name.starts_with("HalfKaMerged-512-"),
+                "Architecture name should start with 'HalfKaMerged-512-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_merged/l768.rs
@@ -56,8 +56,8 @@ mod tests {
         for spec in HalfKaMerged_L768::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
-                name.starts_with("HalfKA_merged-768-"),
-                "Architecture name should start with 'HalfKA_merged-768-', got: {name}"
+                name.starts_with("HalfKaMerged-768-"),
+                "Architecture name should start with 'HalfKaMerged-768-', got: {name}"
             );
         }
     }

--- a/crates/rshogi-core/src/nnue/macros.rs
+++ b/crates/rshogi-core/src/nnue/macros.rs
@@ -21,7 +21,7 @@
 /// ```ignore
 /// define_l1_variants!(
 ///     enum HalfKA_hm_L512,
-///     feature_set HalfKA_hm,
+///     feature_set HalfKaHmMerged,
 ///     l1 512,
 ///     acc AccumulatorHalfKA_hm<512>,
 ///     stack AccumulatorStackHalfKA_hm<512>,

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -355,8 +355,8 @@ impl NNUENetwork {
                         parsed.feature_set
                     }
                     NNUEArchitectureOverride::HalfKP => FeatureSet::HalfKP,
-                    NNUEArchitectureOverride::HalfKA_hm => FeatureSet::HalfKA_hm,
-                    NNUEArchitectureOverride::HalfKA => FeatureSet::HalfKA,
+                    NNUEArchitectureOverride::HalfKA_hm => FeatureSet::HalfKaHmMerged,
+                    NNUEArchitectureOverride::HalfKA => FeatureSet::HalfKaSplit,
                     NNUEArchitectureOverride::LayerStacks
                     | NNUEArchitectureOverride::LayerStacksPSQT => FeatureSet::LayerStacks,
                 };
@@ -427,11 +427,11 @@ impl NNUENetwork {
                 let l3 = detection.spec.l3;
 
                 match detection.spec.feature_set {
-                    FeatureSet::HalfKA_hm => {
+                    FeatureSet::HalfKaHmMerged => {
                         let network = HalfKA_hmNetwork::read(reader, l1, l2, l3, activation)?;
                         Ok(Self::HalfKA_hm(network))
                     }
-                    FeatureSet::HalfKA => {
+                    FeatureSet::HalfKaSplit => {
                         let network = HalfKANetwork::read(reader, l1, l2, l3, activation)?;
                         Ok(Self::HalfKA(network))
                     }
@@ -1126,10 +1126,10 @@ pub fn detect_format(bytes: &[u8], file_size: u64) -> io::Result<NnueFormatInfo>
             // アーキテクチャ名を決定
             let architecture = match feature_set {
                 FeatureSet::LayerStacks => "LayerStacks".to_string(),
-                FeatureSet::HalfKA_hm => format!("HalfKA_hm{}", l1),
-                FeatureSet::HalfKA => format!("HalfKA{}", l1),
-                FeatureSet::HalfKaMerged => format!("HalfKA_merged{}", l1),
-                FeatureSet::HalfKaHmSplit => format!("HalfKA_hm_split{}", l1),
+                FeatureSet::HalfKaHmMerged => format!("HalfKaHmMerged{}", l1),
+                FeatureSet::HalfKaSplit => format!("HalfKaSplit{}", l1),
+                FeatureSet::HalfKaMerged => format!("HalfKaMerged{}", l1),
+                FeatureSet::HalfKaHmSplit => format!("HalfKaHmSplit{}", l1),
                 FeatureSet::HalfKP => format!("HalfKP{}", l1),
             };
 
@@ -1869,7 +1869,7 @@ mod tests {
             detect_format(&bytes, unknown_file_size).expect("Should fallback to header parsing");
 
         // ヘッダーからパースした値が使われることを確認
-        assert_eq!(info.architecture, "HalfKA_hm512");
+        assert_eq!(info.architecture, "HalfKaHmMerged512");
         assert_eq!(info.l1_dimension, 512);
         assert_eq!(info.l2_dimension, 8);
         assert_eq!(info.l3_dimension, 96);

--- a/crates/rshogi-core/src/nnue/spec.rs
+++ b/crates/rshogi-core/src/nnue/spec.rs
@@ -5,18 +5,18 @@
 /// 特徴量セット
 ///
 /// NNUEネットワークの入力特徴量の種類を表す。
+/// 命名規則: `HalfKa{Hm?}{Merged|Split}` で mirror 有無 + plane 種別を明示する。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FeatureSet {
     /// HalfKP (classic NNUE)
     HalfKP,
-    /// HalfKA_hm^ (Half-Mirror + MergedPlane)
-    #[allow(non_camel_case_types)]
-    HalfKA_hm,
-    /// HalfKA (非ミラー + SplitPlane)
-    HalfKA,
-    /// HalfKaMerged (非ミラー + MergedPlane)
+    /// Half-Mirror + MergedPlane
+    HalfKaHmMerged,
+    /// 非ミラー + SplitPlane
+    HalfKaSplit,
+    /// 非ミラー + MergedPlane
     HalfKaMerged,
-    /// HalfKaHmSplit (Half-Mirror + SplitPlane)
+    /// Half-Mirror + SplitPlane
     HalfKaHmSplit,
     /// LayerStacks (実験的)
     LayerStacks,
@@ -27,12 +27,10 @@ impl FeatureSet {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::HalfKP => "HalfKP",
-            Self::HalfKA_hm => "HalfKA_hm",
-            Self::HalfKA => "HalfKA",
-            // arch 文字列 (trainer の arch_feature_name) と一致させる。
-            // `parse_feature_set_from_arch` はこの underscore 名で判定する。
-            Self::HalfKaMerged => "HalfKA_merged",
-            Self::HalfKaHmSplit => "HalfKA_hm_split",
+            Self::HalfKaHmMerged => "HalfKaHmMerged",
+            Self::HalfKaSplit => "HalfKaSplit",
+            Self::HalfKaMerged => "HalfKaMerged",
+            Self::HalfKaHmSplit => "HalfKaHmSplit",
             Self::LayerStacks => "LayerStacks",
         }
     }
@@ -137,7 +135,7 @@ impl ArchitectureSpec {
 
     /// アーキテクチャ名を生成
     ///
-    /// 例: "HalfKA_hm-512-8-96-CReLU"
+    /// 例: "HalfKaHmMerged-512-8-96-CReLU"
     pub fn name(&self) -> String {
         format!("{}-{}-{}-{}-{}", self.feature_set, self.l1, self.l2, self.l3, self.activation)
     }
@@ -232,9 +230,9 @@ pub fn parse_feature_set_from_arch(arch_str: &str) -> Result<FeatureSet, String>
             "HalfKA_hm_split" | "HalfKaHmSplit" => return Ok(FeatureSet::HalfKaHmSplit),
 
             // mirror + merged: underscore / PascalCase の同義綴り。
-            "HalfKA_hm" | "HalfKaHmMerged" => return Ok(FeatureSet::HalfKA_hm),
+            "HalfKA_hm" | "HalfKaHmMerged" => return Ok(FeatureSet::HalfKaHmMerged),
             // 非ミラー + split: PascalCase 綴り (underscore 綴りは plane 暗黙の "HalfKA" 経由)。
-            "HalfKaSplit" => return Ok(FeatureSet::HalfKA),
+            "HalfKaSplit" => return Ok(FeatureSet::HalfKaSplit),
 
             // "HalfKA" 単独は plane 暗黙: bullet-shogi 互換のため input_dim で
             // disambiguate する (HALFKA_HM_DIMENSIONS なら HalfKA_hm、等)。
@@ -243,8 +241,8 @@ pub fn parse_feature_set_from_arch(arch_str: &str) -> Result<FeatureSet, String>
                     "HalfKA architecture is missing input dimensions in arch string.".to_string()
                 })?;
                 return match input_dim {
-                    HALFKA_HM_DIMENSIONS => Ok(FeatureSet::HalfKA_hm),
-                    HALFKA_DIMENSIONS => Ok(FeatureSet::HalfKA),
+                    HALFKA_HM_DIMENSIONS => Ok(FeatureSet::HalfKaHmMerged),
+                    HALFKA_DIMENSIONS => Ok(FeatureSet::HalfKaSplit),
                     HALFKA_MERGED_DIMENSIONS => Ok(FeatureSet::HalfKaMerged),
                     HALFKA_HM_SPLIT_DIMENSIONS => Ok(FeatureSet::HalfKaHmSplit),
                     _ => Err(format!("Unknown HalfKA input dimensions: {input_dim}")),
@@ -627,89 +625,125 @@ const KNOWN_PAYLOADS: &[(FeatureSet, usize, usize, usize, u64)] = &[
     (FeatureSet::HalfKP, 1024, 8, 32, network_payload_halfkp_pairwise(1024, 8, 32)),
     (FeatureSet::HalfKP, 1024, 8, 64, network_payload_halfkp_pairwise(1024, 8, 64)),
     // HalfKA_hm (CReLU/SCReLU)
-    (FeatureSet::HalfKA_hm, 256, 32, 32, network_payload_halfka_hm(256, 32, 32)),
-    (FeatureSet::HalfKA_hm, 512, 8, 64, network_payload_halfka_hm(512, 8, 64)),
-    (FeatureSet::HalfKA_hm, 512, 8, 96, network_payload_halfka_hm(512, 8, 96)),
-    (FeatureSet::HalfKA_hm, 512, 32, 32, network_payload_halfka_hm(512, 32, 32)),
-    (FeatureSet::HalfKA_hm, 768, 16, 64, network_payload_halfka_hm(768, 16, 64)),
-    (FeatureSet::HalfKA_hm, 1024, 8, 32, network_payload_halfka_hm(1024, 8, 32)),
-    (FeatureSet::HalfKA_hm, 1024, 8, 64, network_payload_halfka_hm(1024, 8, 64)),
-    (FeatureSet::HalfKA_hm, 1024, 8, 96, network_payload_halfka_hm(1024, 8, 96)),
+    (FeatureSet::HalfKaHmMerged, 256, 32, 32, network_payload_halfka_hm(256, 32, 32)),
+    (FeatureSet::HalfKaHmMerged, 512, 8, 64, network_payload_halfka_hm(512, 8, 64)),
+    (FeatureSet::HalfKaHmMerged, 512, 8, 96, network_payload_halfka_hm(512, 8, 96)),
+    (FeatureSet::HalfKaHmMerged, 512, 32, 32, network_payload_halfka_hm(512, 32, 32)),
+    (FeatureSet::HalfKaHmMerged, 768, 16, 64, network_payload_halfka_hm(768, 16, 64)),
+    (FeatureSet::HalfKaHmMerged, 1024, 8, 32, network_payload_halfka_hm(1024, 8, 32)),
+    (FeatureSet::HalfKaHmMerged, 1024, 8, 64, network_payload_halfka_hm(1024, 8, 64)),
+    (FeatureSet::HalfKaHmMerged, 1024, 8, 96, network_payload_halfka_hm(1024, 8, 96)),
     // HalfKA_hm (PairwiseCReLU)
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         256,
         32,
         32,
         network_payload_halfka_hm_pairwise(256, 32, 32),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         512,
         8,
         64,
         network_payload_halfka_hm_pairwise(512, 8, 64),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         512,
         8,
         96,
         network_payload_halfka_hm_pairwise(512, 8, 96),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         512,
         32,
         32,
         network_payload_halfka_hm_pairwise(512, 32, 32),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         768,
         16,
         64,
         network_payload_halfka_hm_pairwise(768, 16, 64),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         1024,
         8,
         32,
         network_payload_halfka_hm_pairwise(1024, 8, 32),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         1024,
         8,
         64,
         network_payload_halfka_hm_pairwise(1024, 8, 64),
     ),
     (
-        FeatureSet::HalfKA_hm,
+        FeatureSet::HalfKaHmMerged,
         1024,
         8,
         96,
         network_payload_halfka_hm_pairwise(1024, 8, 96),
     ),
     // HalfKA (CReLU/SCReLU)
-    (FeatureSet::HalfKA, 256, 32, 32, network_payload_halfka(256, 32, 32)),
-    (FeatureSet::HalfKA, 512, 8, 64, network_payload_halfka(512, 8, 64)),
-    (FeatureSet::HalfKA, 512, 8, 96, network_payload_halfka(512, 8, 96)),
-    (FeatureSet::HalfKA, 512, 32, 32, network_payload_halfka(512, 32, 32)),
-    (FeatureSet::HalfKA, 768, 16, 64, network_payload_halfka(768, 16, 64)),
-    (FeatureSet::HalfKA, 1024, 8, 32, network_payload_halfka(1024, 8, 32)),
-    (FeatureSet::HalfKA, 1024, 8, 64, network_payload_halfka(1024, 8, 64)),
-    (FeatureSet::HalfKA, 1024, 8, 96, network_payload_halfka(1024, 8, 96)),
+    (FeatureSet::HalfKaSplit, 256, 32, 32, network_payload_halfka(256, 32, 32)),
+    (FeatureSet::HalfKaSplit, 512, 8, 64, network_payload_halfka(512, 8, 64)),
+    (FeatureSet::HalfKaSplit, 512, 8, 96, network_payload_halfka(512, 8, 96)),
+    (FeatureSet::HalfKaSplit, 512, 32, 32, network_payload_halfka(512, 32, 32)),
+    (FeatureSet::HalfKaSplit, 768, 16, 64, network_payload_halfka(768, 16, 64)),
+    (FeatureSet::HalfKaSplit, 1024, 8, 32, network_payload_halfka(1024, 8, 32)),
+    (FeatureSet::HalfKaSplit, 1024, 8, 64, network_payload_halfka(1024, 8, 64)),
+    (FeatureSet::HalfKaSplit, 1024, 8, 96, network_payload_halfka(1024, 8, 96)),
     // HalfKA (PairwiseCReLU)
-    (FeatureSet::HalfKA, 256, 32, 32, network_payload_halfka_pairwise(256, 32, 32)),
-    (FeatureSet::HalfKA, 512, 8, 64, network_payload_halfka_pairwise(512, 8, 64)),
-    (FeatureSet::HalfKA, 512, 8, 96, network_payload_halfka_pairwise(512, 8, 96)),
-    (FeatureSet::HalfKA, 512, 32, 32, network_payload_halfka_pairwise(512, 32, 32)),
-    (FeatureSet::HalfKA, 768, 16, 64, network_payload_halfka_pairwise(768, 16, 64)),
-    (FeatureSet::HalfKA, 1024, 8, 32, network_payload_halfka_pairwise(1024, 8, 32)),
-    (FeatureSet::HalfKA, 1024, 8, 64, network_payload_halfka_pairwise(1024, 8, 64)),
-    (FeatureSet::HalfKA, 1024, 8, 96, network_payload_halfka_pairwise(1024, 8, 96)),
+    (
+        FeatureSet::HalfKaSplit,
+        256,
+        32,
+        32,
+        network_payload_halfka_pairwise(256, 32, 32),
+    ),
+    (FeatureSet::HalfKaSplit, 512, 8, 64, network_payload_halfka_pairwise(512, 8, 64)),
+    (FeatureSet::HalfKaSplit, 512, 8, 96, network_payload_halfka_pairwise(512, 8, 96)),
+    (
+        FeatureSet::HalfKaSplit,
+        512,
+        32,
+        32,
+        network_payload_halfka_pairwise(512, 32, 32),
+    ),
+    (
+        FeatureSet::HalfKaSplit,
+        768,
+        16,
+        64,
+        network_payload_halfka_pairwise(768, 16, 64),
+    ),
+    (
+        FeatureSet::HalfKaSplit,
+        1024,
+        8,
+        32,
+        network_payload_halfka_pairwise(1024, 8, 32),
+    ),
+    (
+        FeatureSet::HalfKaSplit,
+        1024,
+        8,
+        64,
+        network_payload_halfka_pairwise(1024, 8, 64),
+    ),
+    (
+        FeatureSet::HalfKaSplit,
+        1024,
+        8,
+        96,
+        network_payload_halfka_pairwise(1024, 8, 96),
+    ),
     // HalfKaMerged (CReLU/SCReLU)
     (
         FeatureSet::HalfKaMerged,
@@ -1043,8 +1077,10 @@ mod tests {
     #[test]
     fn test_feature_set_display() {
         assert_eq!(FeatureSet::HalfKP.as_str(), "HalfKP");
-        assert_eq!(FeatureSet::HalfKA_hm.as_str(), "HalfKA_hm");
-        assert_eq!(FeatureSet::HalfKA.as_str(), "HalfKA");
+        assert_eq!(FeatureSet::HalfKaHmMerged.as_str(), "HalfKaHmMerged");
+        assert_eq!(FeatureSet::HalfKaSplit.as_str(), "HalfKaSplit");
+        assert_eq!(FeatureSet::HalfKaMerged.as_str(), "HalfKaMerged");
+        assert_eq!(FeatureSet::HalfKaHmSplit.as_str(), "HalfKaHmSplit");
         assert_eq!(FeatureSet::LayerStacks.as_str(), "LayerStacks");
     }
 
@@ -1084,8 +1120,8 @@ mod tests {
 
     #[test]
     fn test_architecture_spec_name() {
-        let spec = ArchitectureSpec::new(FeatureSet::HalfKA_hm, 512, 8, 96, Activation::CReLU);
-        assert_eq!(spec.name(), "HalfKA_hm-512-8-96-CReLU");
+        let spec = ArchitectureSpec::new(FeatureSet::HalfKaHmMerged, 512, 8, 96, Activation::CReLU);
+        assert_eq!(spec.name(), "HalfKaHmMerged-512-8-96-CReLU");
 
         let spec2 = ArchitectureSpec::new(FeatureSet::HalfKP, 256, 32, 32, Activation::SCReLU);
         assert_eq!(spec2.name(), "HalfKP-256-32-32-SCReLU");
@@ -1101,21 +1137,21 @@ mod tests {
                 "Features=HalfKA_hm[73305->512x2],Network=AffineTransform[1<-96]"
             )
             .unwrap(),
-            FeatureSet::HalfKA_hm
+            FeatureSet::HalfKaHmMerged
         );
         assert_eq!(
             parse_feature_set_from_arch(
                 "Features=HalfKA[138510->512x2],Network=AffineTransform[1<-96]"
             )
             .unwrap(),
-            FeatureSet::HalfKA
+            FeatureSet::HalfKaSplit
         );
         assert_eq!(
             parse_feature_set_from_arch(
                 "Features=HalfKA[73305->512x2],Network=AffineTransform[1<-96]"
             )
             .unwrap(),
-            FeatureSet::HalfKA_hm
+            FeatureSet::HalfKaHmMerged
         );
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKP[125388->256x2]").unwrap(),
@@ -1146,7 +1182,7 @@ mod tests {
             parse_feature_set_keyword("Features=HalfKA,Network=AffineTransform[1<-96]"),
             Some("HalfKA")
         );
-        // 新名 emit 用 keyword
+        // PascalCase 表記の keyword
         assert_eq!(
             parse_feature_set_keyword("Features=HalfKaHmMerged[73305->1024x2]"),
             Some("HalfKaHmMerged")
@@ -1160,12 +1196,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_feature_set_legacy_aliases() {
+    fn test_parse_feature_set_underscore_aliases() {
         // underscore 表記の keyword (HalfKA_hm / HalfKA_merged / HalfKA_hm_split) が
         // 対応する enum 値に解決すること。
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKA_hm[73305->1024x2]").unwrap(),
-            FeatureSet::HalfKA_hm
+            FeatureSet::HalfKaHmMerged
         );
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKA_merged[138510->512x2]").unwrap(),
@@ -1178,12 +1214,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_feature_set_new_aliases() {
+    fn test_parse_feature_set_pascal_case_aliases() {
         // PascalCase 表記の keyword (HalfKaHmMerged / HalfKaMerged / HalfKaHmSplit /
         // HalfKaSplit) が対応する enum 値に解決すること。
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKaHmMerged[73305->1024x2]").unwrap(),
-            FeatureSet::HalfKA_hm
+            FeatureSet::HalfKaHmMerged
         );
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKaMerged[138510->512x2]").unwrap(),
@@ -1195,25 +1231,29 @@ mod tests {
         );
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKaSplit[138510->512x2]").unwrap(),
-            FeatureSet::HalfKA
+            FeatureSet::HalfKaSplit
         );
     }
 
     #[test]
-    fn test_parse_feature_set_old_new_alias_equivalence() {
-        // 旧名 / 新名のどちらでも同 enum 値が得られること (rename 後互換の核)。
+    fn test_parse_feature_set_alias_equivalence() {
+        // underscore 表記と PascalCase 表記のどちらでも同 enum 値が得られること
+        // (両綴り受理の核となる不変条件)。
         let pairs: &[(&str, &str)] = &[
             ("Features=HalfKA_hm[73305->1024x2]", "Features=HalfKaHmMerged[73305->1024x2]"),
             ("Features=HalfKA_merged[138510->512x2]", "Features=HalfKaMerged[138510->512x2]"),
             ("Features=HalfKA_hm_split[73305->512x2]", "Features=HalfKaHmSplit[73305->512x2]"),
         ];
-        for (legacy, modern) in pairs {
-            let legacy_resolved = parse_feature_set_from_arch(legacy).unwrap();
-            let modern_resolved = parse_feature_set_from_arch(modern).unwrap();
-            assert_eq!(legacy_resolved, modern_resolved, "legacy={legacy} vs modern={modern}",);
+        for (underscore, pascal_case) in pairs {
+            let underscore_resolved = parse_feature_set_from_arch(underscore).unwrap();
+            let pascal_resolved = parse_feature_set_from_arch(pascal_case).unwrap();
+            assert_eq!(
+                underscore_resolved, pascal_resolved,
+                "underscore={underscore} vs pascal_case={pascal_case}",
+            );
         }
-        // "HalfKA" は plane 暗黙のため input_dim でしか曖昧解消できず、
-        // 新名 "HalfKaSplit" が同等 (非ミラー Split) になる代表ケースを確認。
+        // "HalfKA" 単独は plane 暗黙のため input_dim でしか曖昧解消できない。
+        // 非ミラー Split に解決する代表ケースを確認 (PascalCase "HalfKaSplit" と等価)。
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKA[138510->512x2]").unwrap(),
             parse_feature_set_from_arch("Features=HalfKaSplit[138510->512x2]").unwrap(),
@@ -1239,7 +1279,7 @@ mod tests {
                  (ClippedReLU[64](AffineTransform[64<-8](ClippedReLU[8](\
                  AffineTransformSparseInput[8<-1024](InputSlice[1024(0:1024)]))))),\
                  fv_scale=28",
-                FeatureSet::HalfKA,
+                FeatureSet::HalfKaSplit,
             ),
             (
                 "Features=HalfKA_merged(Friend)[131949->512x2],Network=AffineTransform\
@@ -1260,7 +1300,7 @@ mod tests {
                  (ClippedReLU[64](AffineTransform[64<-8](ClippedReLU[8](\
                  AffineTransformSparseInput[8<-1024](InputSlice[1024(0:1024)]))))),\
                  fv_scale=28",
-                FeatureSet::HalfKA_hm,
+                FeatureSet::HalfKaHmMerged,
             ),
             // simple-arch SCReLU (HalfKA_hm) — SqrClippedReLU 単独で keyword 経路へ
             (
@@ -1268,7 +1308,7 @@ mod tests {
                  (SqrClippedReLU[64](AffineTransform[64<-8](SqrClippedReLU[8](\
                  AffineTransformSparseInput[8<-1024](InputSlice[1024(0:1024)]))))),\
                  fv_scale=28",
-                FeatureSet::HalfKA_hm,
+                FeatureSet::HalfKaHmMerged,
             ),
             // simple-arch Pairwise (HalfKA_hm 512/2)
             (
@@ -1276,7 +1316,7 @@ mod tests {
                  AffineTransform[1<-64](ClippedReLU[64](AffineTransform[64<-8]\
                  (ClippedReLU[8](AffineTransformSparseInput[8<-512]\
                  (InputSlice[512(0:512)]))))),fv_scale=28",
-                FeatureSet::HalfKA_hm,
+                FeatureSet::HalfKaHmMerged,
             ),
             // bullet-shogi LayerStacks bucketed (FT_OUT=1536, 混在活性化)
             (
@@ -1288,7 +1328,7 @@ mod tests {
             // bucketless SCReLU 1024x2 (bullet-shogi スタイルの `^` 付き keyword)
             (
                 "Features=HalfKA_hm^[73305->1024x2]-SCReLU,fv_scale=16,l2=8,l3=96,qa=127,qb=64",
-                FeatureSet::HalfKA_hm,
+                FeatureSet::HalfKaHmMerged,
             ),
         ];
         for (arch, expected) in cases {
@@ -1313,7 +1353,7 @@ mod tests {
         let arch = "Features=HalfKA_hm(Friend)[73305->1024x2],Network=AffineTransform\
                     [1<-64](SqrClippedReLU[64](AffineTransform[64<-8](SqrClippedReLU[8](\
                     AffineTransformSparseInput[8<-2048](InputSlice[2048(0:2048)]))))),fv_scale=14";
-        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKA_hm);
+        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKaHmMerged);
     }
 
     #[test]
@@ -1323,7 +1363,7 @@ mod tests {
         let arch = "Features=HalfKA_hm(Friend)[73305->1024x2],Network=AffineTransform\
                     [1<-64](ClippedReLU[64](AffineTransform[64<-8](ClippedReLU[8](\
                     AffineTransformSparseInput[8<-2048](InputSlice[2048(0:2048)]))))),fv_scale=14";
-        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKA_hm);
+        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKaHmMerged);
     }
 
     #[test]
@@ -1334,7 +1374,7 @@ mod tests {
         let arch = "Features=HalfKA_hm(Friend)[73305->512x2],Network=AffineTransform\
                     [1<-96](ClippedReLU[96](AffineTransform[96<-8](ClippedReLU[8](\
                     AffineTransformSparseInput[8<-1024](InputSlice[1024(0:1024)]))))),fv_scale=14";
-        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKA_hm);
+        assert_eq!(parse_feature_set_from_arch(arch).unwrap(), FeatureSet::HalfKaHmMerged);
     }
 
     #[test]
@@ -1521,10 +1561,10 @@ mod tests {
         // - outw: 96 (i8)
         // - padding: 63 (64バイトアライメント)
         // total = 141,847,232
-        let result = detect_architecture_from_size(141_847_232, 105, Some(FeatureSet::HalfKA));
+        let result = detect_architecture_from_size(141_847_232, 105, Some(FeatureSet::HalfKaSplit));
         assert!(result.is_some(), "bullet-shogi HalfKA 512-8-96 should be detected");
         let result = result.unwrap();
-        assert_eq!(result.spec.feature_set, FeatureSet::HalfKA);
+        assert_eq!(result.spec.feature_set, FeatureSet::HalfKaSplit);
         assert_eq!(result.spec.l1, 512);
         assert_eq!(result.spec.l2, 8);
         assert_eq!(result.spec.l3, 96);
@@ -1544,8 +1584,11 @@ mod tests {
 
         // パディング 0 (hash有り、nnue-pytorch 形式)
         let file_size_no_padding = header_size + payload + 8;
-        let result =
-            detect_architecture_from_size(file_size_no_padding, arch_len, Some(FeatureSet::HalfKA));
+        let result = detect_architecture_from_size(
+            file_size_no_padding,
+            arch_len,
+            Some(FeatureSet::HalfKaSplit),
+        );
         assert!(result.is_some());
         let result = result.unwrap();
         assert_eq!(result.spec.l1, 512);
@@ -1557,7 +1600,7 @@ mod tests {
             let result = detect_architecture_from_size(
                 file_size_with_padding,
                 arch_len,
-                Some(FeatureSet::HalfKA),
+                Some(FeatureSet::HalfKaSplit),
             );
             assert!(result.is_some(), "Should detect with padding={padding}");
             let result = result.unwrap();
@@ -1570,7 +1613,7 @@ mod tests {
         let result = detect_architecture_from_size(
             file_size_too_much_padding,
             arch_len,
-            Some(FeatureSet::HalfKA),
+            Some(FeatureSet::HalfKaSplit),
         );
         assert!(result.is_none(), "padding=64 should not be detected");
     }


### PR DESCRIPTION
## Summary

- \`FeatureSet\` enum variant を underscore 表記から PascalCase に rename
  - \`HalfKA_hm\` → \`HalfKaHmMerged\`
  - \`HalfKA\` → \`HalfKaSplit\`
- \`as_str()\` / \`ArchitectureSpec::name()\` / \`NnueFormatInfo.architecture\` を全部新名ベースに統一
- \`#[allow(non_camel_case_types)]\` を削除
- 既存 .bin (underscore 表記 emit) は PR #729 で入った両綴り受理 parser で引き続きロード可

## Scope (PR 2)

Issue #728 PR 分割案 4 本のうち rename 第 2 段。当初の prompt 案は「PR 2 = spec.rs 中心 / PR 3 = 機械的参照 ~41 ファイル」と分かれていたが、Rust の enum variant rename では const alias が pattern match で使えないため「enum rename だけで build green」は技術的に不可能。よって本 PR では:

- **PR 2 (本 PR)**: enum + \`as_str()\` + 全 FeatureSet variant 参照 (spec.rs 内 + 外部 12 ファイル + macro-style ref) + name-format test 16 件の prefix 更新
- **PR 3 (次)**: aliases.rs の型エイリアス (\`HalfKA_hm256CReLU\` 等 ~78 個) + 関連 struct 名 (\`HalfKANetwork\` / \`HalfKA_hmStack\` 等) — enum variant とは独立した naming layer

## 変更ファイル (22 / +196/-153)

- \`crates/rshogi-core/src/nnue/spec.rs\`: enum 定義 / \`as_str()\` / Display / \`ArchitectureSpec::name()\` doc 例 / parser 解決先 / test 関数 4 件 (alias テスト名も \`underscore_aliases\` / \`pascal_case_aliases\` / \`alias_equivalence\` に時間中立な名前へ)
- \`crates/rshogi-core/src/nnue/network.rs\`: \`detect_format()\` の \`NnueFormatInfo.architecture\` 合成 + 対応 test
- \`crates/rshogi-core/src/nnue/evaluator.rs\`, \`network.rs\`, \`halfka/*\`, \`halfka_hm/*\`, \`macros.rs\`: \`FeatureSet::HalfKA_hm\` / \`FeatureSet::HalfKA\` 参照を新名へ
- \`crates/rshogi-core/src/nnue/halfka_hm/*\`, \`halfka_hm_split/*\`, \`halfka_merged/*\`, \`halfka/*\`: \`name.starts_with(\"...-\")\` 形式の name-format test 16 件の prefix を新名 (\"HalfKaHmMerged-...\" 等) に更新

## Test plan

- [x] \`cargo fmt -p rshogi-core\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo test --workspace --lib\` 全 pass (rshogi-core 873)
- [x] 実機 USI ロード確認 (release build with \`--features rshogi-usi/nnue-psqt\`):
  - v0.1.0 release attach 7 .bin (HalfKP / HalfKA / HalfKA_merged / HalfKA_hm_split / HalfKA_hm × CReLU + HalfKA_hm × SCReLU/Pairwise) で \`readyok\`
  - bullet-shogi v101-400 (HalfKA_hm 1536 LayerStacks bucketed) で \`readyok\`

## 後方互換

PR #729 (parser 両綴り受理) merged 済のため、underscore 表記の既存 .bin header (\"HalfKA_hm\", \"HalfKA_merged\", ...) は引き続き正しい enum 値に解決される。

Closes part of #728 (PR 2/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)