### PR TITLE
refactor(nnue): FeatureSet 関連型 / type alias を PascalCase に rename (Issue #728 PR3)

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -5,8 +5,8 @@
 //! # 設計
 //!
 //! **「Accumulator は L1 だけで決まる」** を活用し、4バリアントに集約:
-//! - HalfKA(HalfKAStack): L256/L512/L1024 を内包
-//! - HalfKA_hm(HalfKA_hmStack): L256/L512/L1024 を内包
+//! - HalfKA(HalfKaSplitStack): L256/L512/L1024 を内包
+//! - HalfKA_hm(HalfKaHmMergedStack): L256/L512/L1024 を内包
 //! - HalfKP(HalfKPStack): L256/L512 を内包
 //! - LayerStacks: 1536次元 + 9バケット
 //!
@@ -14,8 +14,8 @@
 
 use super::accumulator::DirtyPiece;
 use super::accumulator_layer_stacks::LayerStacksAccStack;
-use super::halfka::HalfKAStack;
-use super::halfka_hm::HalfKA_hmStack;
+use super::halfka::HalfKaSplitStack;
+use super::halfka_hm::HalfKaHmMergedStack;
 use super::halfka_hm_split::HalfKaHmSplitStack;
 use super::halfka_merged::HalfKaMergedStack;
 use super::halfkp::HalfKPStack;
@@ -29,16 +29,16 @@ use super::network::NNUENetwork;
 /// # 4バリアント構造
 ///
 /// L1 サイズのみで分類し、L2/L3/活性化は内部で処理:
-/// - **HalfKA**: L256/L512/L1024 を HalfKAStack で管理
-/// - **HalfKA_hm**: L256/L512/L1024 を HalfKA_hmStack で管理
+/// - **HalfKA**: L256/L512/L1024 を HalfKaSplitStack で管理
+/// - **HalfKA_hm**: L256/L512/L1024 を HalfKaHmMergedStack で管理
 /// - **HalfKP**: L256/L512 を HalfKPStack で管理
 /// - **LayerStacks**: 1536次元 + 9バケット
 #[allow(non_camel_case_types)]
 pub enum AccumulatorStackVariant {
     /// HalfKA 特徴量セット（L256/L512/L1024）
-    HalfKA(HalfKAStack),
+    HalfKA(HalfKaSplitStack),
     /// HalfKA_hm 特徴量セット（L256/L512/L1024）
-    HalfKA_hm(HalfKA_hmStack),
+    HalfKA_hm(HalfKaHmMergedStack),
     /// HalfKaMerged 特徴量セット（L256/L512/L1024）
     HalfKaMerged(HalfKaMergedStack),
     /// HalfKaHmSplit 特徴量セット（L256/L512/L1024）
@@ -55,8 +55,8 @@ impl AccumulatorStackVariant {
     /// 指定されたネットワークのアーキテクチャに対応するスタックバリアントを生成する。
     pub fn from_network(network: &NNUENetwork) -> Self {
         match network {
-            NNUENetwork::HalfKA(net) => Self::HalfKA(HalfKAStack::from_network(net)),
-            NNUENetwork::HalfKA_hm(net) => Self::HalfKA_hm(HalfKA_hmStack::from_network(net)),
+            NNUENetwork::HalfKA(net) => Self::HalfKA(HalfKaSplitStack::from_network(net)),
+            NNUENetwork::HalfKA_hm(net) => Self::HalfKA_hm(HalfKaHmMergedStack::from_network(net)),
             NNUENetwork::HalfKaMerged(net) => {
                 Self::HalfKaMerged(HalfKaMergedStack::from_network(net))
             }
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_push_pop_index_consistency_halfka_hm() {
-        let mut stack = HalfKA_hmStack::default();
+        let mut stack = HalfKaHmMergedStack::default();
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -261,9 +261,9 @@ mod tests {
     fn test_halfka_hm_stack_l1_sizes() {
         use crate::nnue::network_halfka_hm::AccumulatorStackHalfKA_hm;
 
-        let l256_stack = HalfKA_hmStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
-        let l512_stack = HalfKA_hmStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
-        let l1024_stack = HalfKA_hmStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
+        let l256_stack = HalfKaHmMergedStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
+        let l512_stack = HalfKaHmMergedStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
+        let l1024_stack = HalfKaHmMergedStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
 
         assert_eq!(l256_stack.l1_size(), 256);
         assert_eq!(l512_stack.l1_size(), 512);
@@ -312,13 +312,13 @@ mod tests {
         // 各スタックのサイズを確認（デバッグ用）
         let variant_size = size_of::<AccumulatorStackVariant>();
         let layer_stacks_size = size_of::<LayerStacksAccStack>();
-        let halfka_stack_size = size_of::<HalfKA_hmStack>();
+        let halfka_stack_size = size_of::<HalfKaHmMergedStack>();
         let halfkp_stack_size = size_of::<HalfKPStack>();
 
         // 新設計では最大のバリアントのサイズ + タグになる
         // 各サブスタックも enum なので効率的
         eprintln!("AccumulatorStackVariant size: {variant_size} bytes");
-        eprintln!("HalfKA_hmStack size: {halfka_stack_size} bytes");
+        eprintln!("HalfKaHmMergedStack size: {halfka_stack_size} bytes");
         eprintln!("HalfKPStack size: {halfkp_stack_size} bytes");
         eprintln!("LayerStacks size: {layer_stacks_size} bytes");
 

--- a/crates/rshogi-core/src/nnue/aliases.rs
+++ b/crates/rshogi-core/src/nnue/aliases.rs
@@ -6,37 +6,37 @@
 // HalfKA_hm 型エイリアス
 pub use crate::nnue::network_halfka_hm::{
     // L1=256, L2=32, L3=32
-    HalfKA_hm256CReLU,
-    HalfKA_hm256Pairwise,
-    HalfKA_hm256SCReLU,
+    HalfKaHmMerged256CReLU,
+    HalfKaHmMerged256Pairwise,
+    HalfKaHmMerged256SCReLU,
     // L1=512, L2=8, L3=64
-    HalfKA_hm512_8_64CReLU,
-    HalfKA_hm512_8_64Pairwise,
-    HalfKA_hm512_8_64SCReLU,
+    HalfKaHmMerged512_8_64CReLU,
+    HalfKaHmMerged512_8_64Pairwise,
+    HalfKaHmMerged512_8_64SCReLU,
     // L1=512, L2=32, L3=32
-    HalfKA_hm512_32_32CReLU,
-    HalfKA_hm512_32_32Pairwise,
-    HalfKA_hm512_32_32SCReLU,
+    HalfKaHmMerged512_32_32CReLU,
+    HalfKaHmMerged512_32_32Pairwise,
+    HalfKaHmMerged512_32_32SCReLU,
     // L1=512, L2=8, L3=96
-    HalfKA_hm512CReLU,
-    HalfKA_hm512Pairwise,
-    HalfKA_hm512SCReLU,
+    HalfKaHmMerged512CReLU,
+    HalfKaHmMerged512Pairwise,
+    HalfKaHmMerged512SCReLU,
     // L1=768, L2=16, L3=64
-    HalfKA_hm768CReLU,
-    HalfKA_hm768Pairwise,
-    HalfKA_hm768SCReLU,
+    HalfKaHmMerged768CReLU,
+    HalfKaHmMerged768Pairwise,
+    HalfKaHmMerged768SCReLU,
     // L1=1024, L2=8, L3=32
-    HalfKA_hm1024_8_32CReLU,
-    HalfKA_hm1024_8_32Pairwise,
-    HalfKA_hm1024_8_32SCReLU,
+    HalfKaHmMerged1024_8_32CReLU,
+    HalfKaHmMerged1024_8_32Pairwise,
+    HalfKaHmMerged1024_8_32SCReLU,
     // L1=1024, L2=8, L3=64
-    HalfKA_hm1024_8_64CReLU,
-    HalfKA_hm1024_8_64Pairwise,
-    HalfKA_hm1024_8_64SCReLU,
+    HalfKaHmMerged1024_8_64CReLU,
+    HalfKaHmMerged1024_8_64Pairwise,
+    HalfKaHmMerged1024_8_64SCReLU,
     // L1=1024, L2=8, L3=96
-    HalfKA_hm1024CReLU,
-    HalfKA_hm1024Pairwise,
-    HalfKA_hm1024SCReLU,
+    HalfKaHmMerged1024CReLU,
+    HalfKaHmMerged1024Pairwise,
+    HalfKaHmMerged1024SCReLU,
 };
 
 // HalfKA 型エイリアス

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -32,8 +32,8 @@ use std::sync::Arc;
 use super::accumulator::{AccumulatorCacheGeneric, DirtyPiece};
 use super::accumulator_layer_stacks::LayerStacksAccCache;
 use super::accumulator_stack_variant::AccumulatorStackVariant;
-use super::halfka::HalfKAStack;
-use super::halfka_hm::HalfKA_hmStack;
+use super::halfka::HalfKaSplitStack;
+use super::halfka_hm::HalfKaHmMergedStack;
 use super::halfkp::HalfKPStack;
 use super::network::NNUENetwork;
 use super::spec::ArchitectureSpec;
@@ -340,9 +340,9 @@ impl NNUEEvaluator {
     /// HalfKA アキュムレータを更新
     #[inline]
     fn update_halfka_accumulator(
-        net: &super::halfka::HalfKANetwork,
+        net: &super::halfka::HalfKaSplitNetwork,
         pos: &Position,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         cache: &mut Option<AccumulatorCacheGeneric>,
     ) {
         if stack.is_current_computed() {
@@ -380,9 +380,9 @@ impl NNUEEvaluator {
     /// HalfKA_hm アキュムレータを更新
     #[inline]
     fn update_halfka_hm_accumulator(
-        net: &super::halfka_hm::HalfKA_hmNetwork,
+        net: &super::halfka_hm::HalfKaHmMergedNetwork,
         pos: &Position,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         cache: &mut Option<AccumulatorCacheGeneric>,
     ) {
         if stack.is_current_computed() {
@@ -587,29 +587,26 @@ mod tests {
         use crate::nnue::network_halfkp::AccumulatorStackHalfKP;
 
         // HalfKA スタックの各 L1 サイズ
-        let halfka_nm_l256 = AccumulatorStackVariant::HalfKA(HalfKAStack::L256(
+        let halfka_nm_l256 = AccumulatorStackVariant::HalfKA(HalfKaSplitStack::L256(
             AccumulatorStackHalfKA::<256>::new(),
         ));
-        let halfka_nm_l512 = AccumulatorStackVariant::HalfKA(HalfKAStack::L512(
+        let halfka_nm_l512 = AccumulatorStackVariant::HalfKA(HalfKaSplitStack::L512(
             AccumulatorStackHalfKA::<512>::new(),
         ));
-        let halfka_nm_l1024 = AccumulatorStackVariant::HalfKA(HalfKAStack::L1024(
+        let halfka_nm_l1024 = AccumulatorStackVariant::HalfKA(HalfKaSplitStack::L1024(
             AccumulatorStackHalfKA::<1024>::new(),
         ));
 
         // HalfKA_hm スタックの各 L1 サイズ
-        let halfka_hm_l256 =
-            AccumulatorStackVariant::HalfKA_hm(HalfKA_hmStack::L256(AccumulatorStackHalfKA_hm::<
-                256,
-            >::new()));
-        let halfka_hm_l512 =
-            AccumulatorStackVariant::HalfKA_hm(HalfKA_hmStack::L512(AccumulatorStackHalfKA_hm::<
-                512,
-            >::new()));
-        let halfka_hm_l1024 =
-            AccumulatorStackVariant::HalfKA_hm(HalfKA_hmStack::L1024(AccumulatorStackHalfKA_hm::<
-                1024,
-            >::new()));
+        let halfka_hm_l256 = AccumulatorStackVariant::HalfKA_hm(HalfKaHmMergedStack::L256(
+            AccumulatorStackHalfKA_hm::<256>::new(),
+        ));
+        let halfka_hm_l512 = AccumulatorStackVariant::HalfKA_hm(HalfKaHmMergedStack::L512(
+            AccumulatorStackHalfKA_hm::<512>::new(),
+        ));
+        let halfka_hm_l1024 = AccumulatorStackVariant::HalfKA_hm(HalfKaHmMergedStack::L1024(
+            AccumulatorStackHalfKA_hm::<1024>::new(),
+        ));
 
         // HalfKP スタックの各 L1 サイズ
         let halfkp_l256 = AccumulatorStackVariant::HalfKP(HalfKPStack::L256(
@@ -655,7 +652,7 @@ mod tests {
         let dirty = DirtyPiece::default();
 
         // HalfKA L512
-        let mut stack = AccumulatorStackVariant::HalfKA(HalfKAStack::L512(
+        let mut stack = AccumulatorStackVariant::HalfKA(HalfKaSplitStack::L512(
             AccumulatorStackHalfKA::<512>::new(),
         ));
         stack.reset();
@@ -666,10 +663,9 @@ mod tests {
         // パニックしなければ成功
 
         // HalfKA_hm L512
-        let mut stack =
-            AccumulatorStackVariant::HalfKA_hm(HalfKA_hmStack::L512(AccumulatorStackHalfKA_hm::<
-                512,
-            >::new()));
+        let mut stack = AccumulatorStackVariant::HalfKA_hm(HalfKaHmMergedStack::L512(
+            AccumulatorStackHalfKA_hm::<512>::new(),
+        ));
         stack.reset();
         stack.push(dirty);
         stack.push(dirty);
@@ -782,16 +778,16 @@ mod tests {
     /// network.rs の NNUENetwork enum が全アーキテクチャをカバーしていることの確認
     #[test]
     fn test_network_enum_coverage() {
-        use crate::nnue::halfka::HalfKANetwork;
-        use crate::nnue::halfka_hm::HalfKA_hmNetwork;
+        use crate::nnue::halfka::HalfKaSplitNetwork;
+        use crate::nnue::halfka_hm::HalfKaHmMergedNetwork;
         use crate::nnue::halfkp::HalfKPNetwork;
 
         // HalfKA サポートアーキテクチャ数
-        let halfka_specs = HalfKANetwork::supported_specs();
+        let halfka_specs = HalfKaSplitNetwork::supported_specs();
         assert_eq!(halfka_specs.len(), 24); // (256:1 + 512:3 + 768:1 + 1024:3) × 3 活性化
 
         // HalfKA_hm サポートアーキテクチャ数
-        let halfka_hm_specs = HalfKA_hmNetwork::supported_specs();
+        let halfka_hm_specs = HalfKaHmMergedNetwork::supported_specs();
         assert_eq!(halfka_hm_specs.len(), 24); // (256:1 + 512:3 + 768:1 + 1024:3) × 3 活性化
 
         // HalfKP サポートアーキテクチャ数

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -13,7 +13,7 @@ use super::bona_piece_halfka_hm::{halfka_index, is_hm_mirror, king_bucket, pack_
 use super::constants::HALFKA_HM_DIMENSIONS;
 #[cfg(feature = "nnue-psqt")]
 use super::constants::NUM_LAYER_STACK_BUCKETS;
-use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKA_hm_FeatureSet};
+use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKaHmMergedFeatureSet};
 use super::leb128::read_compressed_tensor_i16_all;
 use super::stats::{count_refresh, count_update};
 #[cfg(feature = "nnue-threat")]
@@ -719,7 +719,7 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKA_hm_FeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaHmMergedFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 // 玉が移動した場合は全計算
@@ -860,7 +860,7 @@ impl<const L1: usize> FeatureTransformerLayerStacks<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKA_hm_FeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaHmMergedFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 count_refresh!();

--- a/crates/rshogi-core/src/nnue/features/half_ka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/features/half_ka_hm_split.rs
@@ -20,7 +20,6 @@ use crate::position::Position;
 use crate::types::{Color, Square};
 
 /// HalfKaHmSplit 特徴量
-#[allow(non_camel_case_types)]
 pub struct HalfKaHmSplit;
 
 impl Feature for HalfKaHmSplit {

--- a/crates/rshogi-core/src/nnue/features/half_ka_merged.rs
+++ b/crates/rshogi-core/src/nnue/features/half_ka_merged.rs
@@ -18,7 +18,6 @@ use crate::position::Position;
 use crate::types::{Color, Square};
 
 /// HalfKaMerged 特徴量
-#[allow(non_camel_case_types)]
 pub struct HalfKaMerged;
 
 impl Feature for HalfKaMerged {

--- a/crates/rshogi-core/src/nnue/features/mod.rs
+++ b/crates/rshogi-core/src/nnue/features/mod.rs
@@ -145,16 +145,15 @@ impl FeatureSet for HalfKPFeatureSet {
 }
 
 // =============================================================================
-// HalfKA_hmFeatureSet - HalfKA_hm^ NNUE 用の FeatureSet
+// HalfKaHmMergedFeatureSet - HalfKA_hm^ NNUE 用の FeatureSet
 // =============================================================================
 
 /// HalfKA_hm^ 用の FeatureSet（nnue-pytorch互換）
 ///
 /// Half-Mirror King + All pieces with Factorization
-#[allow(non_camel_case_types)]
-pub struct HalfKA_hm_FeatureSet;
+pub struct HalfKaHmMergedFeatureSet;
 
-impl FeatureSet for HalfKA_hm_FeatureSet {
+impl FeatureSet for HalfKaHmMergedFeatureSet {
     const DIMENSIONS: usize = HalfKA_hm::DIMENSIONS;
     const MAX_ACTIVE: usize = HalfKA_hm::MAX_ACTIVE;
     const REFRESH_TRIGGERS: &'static [TriggerEvent] = &[TriggerEvent::FriendKingMoved];
@@ -194,13 +193,13 @@ impl FeatureSet for HalfKA_hm_FeatureSet {
 }
 
 // =============================================================================
-// HalfKAFeatureSet - HalfKA NNUE 用の FeatureSet
+// HalfKaSplitFeatureSet - HalfKA NNUE 用の FeatureSet
 // =============================================================================
 
 /// HalfKA 用の FeatureSet（non-mirror）
-pub struct HalfKAFeatureSet;
+pub struct HalfKaSplitFeatureSet;
 
-impl FeatureSet for HalfKAFeatureSet {
+impl FeatureSet for HalfKaSplitFeatureSet {
     const DIMENSIONS: usize = HalfKA::DIMENSIONS;
     const MAX_ACTIVE: usize = HalfKA::MAX_ACTIVE;
     const REFRESH_TRIGGERS: &'static [TriggerEvent] = &[TriggerEvent::FriendKingMoved];
@@ -238,7 +237,6 @@ impl FeatureSet for HalfKAFeatureSet {
 // =============================================================================
 
 /// HalfKaMerged 用の FeatureSet（non-mirror、両玉を 1 plane に畳む）
-#[allow(non_camel_case_types)]
 pub struct HalfKaMergedFeatureSet;
 
 impl FeatureSet for HalfKaMergedFeatureSet {
@@ -285,7 +283,6 @@ impl FeatureSet for HalfKaMergedFeatureSet {
 // =============================================================================
 
 /// HalfKaHmSplit 用の FeatureSet（Half-Mirror、両玉別 plane）
-#[allow(non_camel_case_types)]
 pub struct HalfKaHmSplitFeatureSet;
 
 impl FeatureSet for HalfKaHmSplitFeatureSet {

--- a/crates/rshogi-core/src/nnue/halfka/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka/mod.rs
@@ -8,7 +8,7 @@
 //! # 構造
 //!
 //! ```text
-//! HalfKANetwork
+//! HalfKaSplitNetwork
 //! ├── L256(HalfKA_L256)
 //! │   ├── CReLU_32_32
 //! │   ├── SCReLU_32_32
@@ -45,34 +45,34 @@ use crate::types::Value;
 ///
 /// L1 サイズごとにバリアントを持つ。
 /// L2/L3/活性化の追加で変更不要（L1 enum 内に閉じる）。
-pub enum HalfKANetwork {
+pub enum HalfKaSplitNetwork {
     L256(HalfKA_L256),
     L512(HalfKA_L512),
     L768(HalfKA_L768),
     L1024(HalfKA_L1024),
 }
 
-impl HalfKANetwork {
+impl HalfKaSplitNetwork {
     /// 評価値を計算
     #[inline(always)]
-    pub fn evaluate(&self, pos: &Position, stack: &HalfKAStack) -> Value {
+    pub fn evaluate(&self, pos: &Position, stack: &HalfKaSplitStack) -> Value {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => net.evaluate(pos, st),
-            (Self::L512(net), HalfKAStack::L512(st)) => net.evaluate(pos, st),
-            (Self::L768(net), HalfKAStack::L768(st)) => net.evaluate(pos, st),
-            (Self::L1024(net), HalfKAStack::L1024(st)) => net.evaluate(pos, st),
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => net.evaluate(pos, st),
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => net.evaluate(pos, st),
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => net.evaluate(pos, st),
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => net.evaluate(pos, st),
             _ => unreachable!("L1 mismatch: network={}, stack={}", self.l1_size(), stack.l1_size()),
         }
     }
 
     /// Accumulator をフル再計算
     #[inline(always)]
-    pub fn refresh_accumulator(&self, pos: &Position, stack: &mut HalfKAStack) {
+    pub fn refresh_accumulator(&self, pos: &Position, stack: &mut HalfKaSplitStack) {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => net.refresh_accumulator(pos, st),
-            (Self::L512(net), HalfKAStack::L512(st)) => net.refresh_accumulator(pos, st),
-            (Self::L768(net), HalfKAStack::L768(st)) => net.refresh_accumulator(pos, st),
-            (Self::L1024(net), HalfKAStack::L1024(st)) => net.refresh_accumulator(pos, st),
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => net.refresh_accumulator(pos, st),
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => net.refresh_accumulator(pos, st),
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => net.refresh_accumulator(pos, st),
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => net.refresh_accumulator(pos, st),
             _ => unreachable!("L1 mismatch"),
         }
     }
@@ -82,20 +82,20 @@ impl HalfKANetwork {
     pub fn refresh_accumulator_with_cache(
         &self,
         pos: &Position,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         cache: &mut AccumulatorCacheGeneric,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => {
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L512(net), HalfKAStack::L512(st)) => {
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L768(net), HalfKAStack::L768(st)) => {
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L1024(net), HalfKAStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
             _ => unreachable!("L1 mismatch"),
@@ -108,20 +108,20 @@ impl HalfKANetwork {
         &self,
         pos: &Position,
         dirty: &DirtyPiece,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         source_idx: usize,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => {
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L512(net), HalfKAStack::L512(st)) => {
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L768(net), HalfKAStack::L768(st)) => {
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L1024(net), HalfKAStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
             _ => unreachable!("L1 mismatch"),
@@ -134,21 +134,21 @@ impl HalfKANetwork {
         &self,
         pos: &Position,
         dirty: &DirtyPiece,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         source_idx: usize,
         cache: &mut AccumulatorCacheGeneric,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => {
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L512(net), HalfKAStack::L512(st)) => {
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L768(net), HalfKAStack::L768(st)) => {
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L1024(net), HalfKAStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
             _ => unreachable!("L1 mismatch"),
@@ -160,20 +160,20 @@ impl HalfKANetwork {
     pub fn forward_update_incremental(
         &self,
         pos: &Position,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         source_idx: usize,
     ) -> bool {
         match (self, stack) {
-            (Self::L256(net), HalfKAStack::L256(st)) => {
+            (Self::L256(net), HalfKaSplitStack::L256(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L512(net), HalfKAStack::L512(st)) => {
+            (Self::L512(net), HalfKaSplitStack::L512(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L768(net), HalfKAStack::L768(st)) => {
+            (Self::L768(net), HalfKaSplitStack::L768(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L1024(net), HalfKAStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaSplitStack::L1024(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
             _ => unreachable!("L1 mismatch"),
@@ -275,23 +275,23 @@ impl HalfKANetwork {
 /// HalfKA Accumulator スタック（L1 のみで決まる）
 ///
 /// L2/L3/活性化の追加で変更不要。
-pub enum HalfKAStack {
+pub enum HalfKaSplitStack {
     L256(AccumulatorStackHalfKA<256>),
     L512(AccumulatorStackHalfKA<512>),
     L768(AccumulatorStackHalfKA<768>),
     L1024(AccumulatorStackHalfKA<1024>),
 }
 
-impl HalfKAStack {
+impl HalfKaSplitStack {
     /// ネットワークに対応するスタックを生成
     ///
     /// バリアントマッチを使用し、新しい L1 追加時にコンパイル時に漏れ検知。
-    pub fn from_network(net: &HalfKANetwork) -> Self {
+    pub fn from_network(net: &HalfKaSplitNetwork) -> Self {
         match net {
-            HalfKANetwork::L256(_) => Self::L256(AccumulatorStackHalfKA::<256>::new()),
-            HalfKANetwork::L512(_) => Self::L512(AccumulatorStackHalfKA::<512>::new()),
-            HalfKANetwork::L768(_) => Self::L768(AccumulatorStackHalfKA::<768>::new()),
-            HalfKANetwork::L1024(_) => Self::L1024(AccumulatorStackHalfKA::<1024>::new()),
+            HalfKaSplitNetwork::L256(_) => Self::L256(AccumulatorStackHalfKA::<256>::new()),
+            HalfKaSplitNetwork::L512(_) => Self::L512(AccumulatorStackHalfKA::<512>::new()),
+            HalfKaSplitNetwork::L768(_) => Self::L768(AccumulatorStackHalfKA::<768>::new()),
+            HalfKaSplitNetwork::L1024(_) => Self::L1024(AccumulatorStackHalfKA::<1024>::new()),
         }
     }
 
@@ -400,7 +400,7 @@ impl HalfKAStack {
     }
 }
 
-impl Default for HalfKAStack {
+impl Default for HalfKaSplitStack {
     fn default() -> Self {
         Self::L512(AccumulatorStackHalfKA::<512>::new())
     }
@@ -414,19 +414,19 @@ mod tests {
     #[test]
     fn test_halfka_stack_from_network_l1_size() {
         // L256 ネットワークを仮定したスタック
-        let stack = HalfKAStack::L256(AccumulatorStackHalfKA::<256>::new());
+        let stack = HalfKaSplitStack::L256(AccumulatorStackHalfKA::<256>::new());
         assert_eq!(stack.l1_size(), 256);
 
-        let stack = HalfKAStack::L512(AccumulatorStackHalfKA::<512>::new());
+        let stack = HalfKaSplitStack::L512(AccumulatorStackHalfKA::<512>::new());
         assert_eq!(stack.l1_size(), 512);
 
-        let stack = HalfKAStack::L1024(AccumulatorStackHalfKA::<1024>::new());
+        let stack = HalfKaSplitStack::L1024(AccumulatorStackHalfKA::<1024>::new());
         assert_eq!(stack.l1_size(), 1024);
     }
 
     #[test]
     fn test_supported_specs_combined() {
-        let specs = HalfKANetwork::supported_specs();
+        let specs = HalfKaSplitNetwork::supported_specs();
         // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
         assert_eq!(specs.len(), 24);
 
@@ -439,7 +439,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L256）
     #[test]
     fn test_push_pop_index_consistency_l256() {
-        let mut stack = HalfKAStack::L256(AccumulatorStackHalfKA::<256>::new());
+        let mut stack = HalfKaSplitStack::L256(AccumulatorStackHalfKA::<256>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -461,7 +461,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L512）
     #[test]
     fn test_push_pop_index_consistency_l512() {
-        let mut stack = HalfKAStack::L512(AccumulatorStackHalfKA::<512>::new());
+        let mut stack = HalfKaSplitStack::L512(AccumulatorStackHalfKA::<512>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -477,7 +477,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L1024）
     #[test]
     fn test_push_pop_index_consistency_l1024() {
-        let mut stack = HalfKAStack::L1024(AccumulatorStackHalfKA::<1024>::new());
+        let mut stack = HalfKaSplitStack::L1024(AccumulatorStackHalfKA::<1024>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -493,7 +493,7 @@ mod tests {
     /// deep push/pop テスト（探索木の深さをシミュレート）
     #[test]
     fn test_deep_push_pop() {
-        let mut stack = HalfKAStack::default();
+        let mut stack = HalfKaSplitStack::default();
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -516,7 +516,7 @@ mod tests {
     /// アーキテクチャの仕様一覧の一貫性テスト
     #[test]
     fn test_architecture_spec_consistency() {
-        for spec in HalfKANetwork::supported_specs() {
+        for spec in HalfKaSplitNetwork::supported_specs() {
             assert_eq!(spec.feature_set, FeatureSet::HalfKaSplit);
             assert!(spec.l1 == 256 || spec.l1 == 512 || spec.l1 == 768 || spec.l1 == 1024);
             assert!(spec.l2 > 0 && spec.l2 <= 128);

--- a/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l1024.rs
@@ -10,13 +10,13 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKA_hm1024_8_32CReLU, HalfKA_hm1024_8_32Pairwise, HalfKA_hm1024_8_32SCReLU,
-    HalfKA_hm1024_8_64CReLU, HalfKA_hm1024_8_64Pairwise, HalfKA_hm1024_8_64SCReLU,
-    HalfKA_hm1024CReLU, HalfKA_hm1024Pairwise, HalfKA_hm1024SCReLU,
+    HalfKaHmMerged1024_8_32CReLU, HalfKaHmMerged1024_8_32Pairwise, HalfKaHmMerged1024_8_32SCReLU,
+    HalfKaHmMerged1024_8_64CReLU, HalfKaHmMerged1024_8_64Pairwise, HalfKaHmMerged1024_8_64SCReLU,
+    HalfKaHmMerged1024CReLU, HalfKaHmMerged1024Pairwise, HalfKaHmMerged1024SCReLU,
 };
 
 crate::define_l1_variants!(
-    enum HalfKA_hm_L1024,
+    enum HalfKaHmMergedL1024,
     feature_set HalfKaHmMerged,
     l1 1024,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<1024>,
@@ -24,17 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64 バリアント
-        (8,  64, CReLU)         => CReLU8x64     : HalfKA_hm1024_8_64CReLU,
-        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA_hm1024_8_64SCReLU,
-        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA_hm1024_8_64Pairwise,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaHmMerged1024_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaHmMerged1024_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaHmMerged1024_8_64Pairwise,
         // L2=8, L3=96 バリアント
-        (8,  96, CReLU)         => CReLU8x96     : HalfKA_hm1024CReLU,
-        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA_hm1024SCReLU,
-        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA_hm1024Pairwise,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaHmMerged1024CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaHmMerged1024SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaHmMerged1024Pairwise,
         // L2=8, L3=32 バリアント
-        (8,  32, CReLU)         => CReLU8x32     : HalfKA_hm1024_8_32CReLU,
-        (8,  32, SCReLU)        => SCReLU8x32    : HalfKA_hm1024_8_32SCReLU,
-        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKA_hm1024_8_32Pairwise,
+        (8,  32, CReLU)         => CReLU8x32     : HalfKaHmMerged1024_8_32CReLU,
+        (8,  32, SCReLU)        => SCReLU8x32    : HalfKaHmMerged1024_8_32SCReLU,
+        (8,  32, PairwiseCReLU) => Pairwise8x32  : HalfKaHmMerged1024_8_32Pairwise,
     }
 );
 
@@ -44,10 +44,10 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L1024::SUPPORTED_SPECS.len(), 9);
+        assert_eq!(HalfKaHmMergedL1024::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
-        let spec = &HalfKA_hm_L1024::SUPPORTED_SPECS[0];
+        let spec = &HalfKaHmMergedL1024::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 1024);
         assert_eq!(spec.l2, 8);
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_l1_size() {
-        for spec in HalfKA_hm_L1024::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL1024::SUPPORTED_SPECS {
             assert_eq!(spec.l1, 1024);
         }
     }
@@ -65,7 +65,7 @@ mod tests {
     /// マクロ生成: architecture_name() の命名規則テスト
     #[test]
     fn test_architecture_name_format() {
-        for spec in HalfKA_hm_L1024::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL1024::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
                 name.starts_with("HalfKaHmMerged-1024-"),
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn test_supported_activations() {
         let activations: Vec<_> =
-            HalfKA_hm_L1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+            HalfKaHmMergedL1024::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
         assert!(activations.contains(&Activation::CReLU));
         assert!(activations.contains(&Activation::SCReLU));
         assert!(activations.contains(&Activation::PairwiseCReLU));
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn test_multiple_l2_l3_combinations() {
         let combinations: Vec<_> =
-            HalfKA_hm_L1024::SUPPORTED_SPECS.iter().map(|s| (s.l2, s.l3)).collect();
+            HalfKaHmMergedL1024::SUPPORTED_SPECS.iter().map(|s| (s.l2, s.l3)).collect();
 
         assert!(combinations.contains(&(8, 64)), "Should support L2=8, L3=64");
         assert!(combinations.contains(&(8, 96)), "Should support L2=8, L3=96");

--- a/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l256.rs
@@ -9,19 +9,21 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA_hm256CReLU, HalfKA_hm256Pairwise, HalfKA_hm256SCReLU};
+use crate::nnue::aliases::{
+    HalfKaHmMerged256CReLU, HalfKaHmMerged256Pairwise, HalfKaHmMerged256SCReLU,
+};
 
 crate::define_l1_variants!(
-    enum HalfKA_hm_L256,
+    enum HalfKaHmMergedL256,
     feature_set HalfKaHmMerged,
     l1 256,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<256>,
     stack AccumulatorStackHalfKA_hm<256>,
 
     variants {
-        (32, 32, CReLU)         => CReLU32x32    : HalfKA_hm256CReLU,
-        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA_hm256SCReLU,
-        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA_hm256Pairwise,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaHmMerged256CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaHmMerged256SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaHmMerged256Pairwise,
     }
 );
 
@@ -31,9 +33,9 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L256::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaHmMergedL256::SUPPORTED_SPECS.len(), 3);
 
-        let spec = &HalfKA_hm_L256::SUPPORTED_SPECS[0];
+        let spec = &HalfKaHmMergedL256::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 256);
         assert_eq!(spec.l2, 32);
@@ -45,7 +47,7 @@ mod tests {
     fn test_l1_size() {
         // 静的メソッドでのテスト用にダミーのネットワークを読み込む必要があるが、
         // ファイルがないのでここではスペックの確認のみ
-        for spec in HalfKA_hm_L256::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL256::SUPPORTED_SPECS {
             assert_eq!(spec.l1, 256);
         }
     }
@@ -53,7 +55,7 @@ mod tests {
     /// マクロ生成: architecture_name() の命名規則テスト
     #[test]
     fn test_architecture_name_format() {
-        for spec in HalfKA_hm_L256::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL256::SUPPORTED_SPECS {
             let name = spec.name();
             // HalfKaHmMerged-256-L2-L3-Activation 形式
             assert!(
@@ -67,7 +69,7 @@ mod tests {
     #[test]
     fn test_supported_activations() {
         let activations: Vec<_> =
-            HalfKA_hm_L256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+            HalfKaHmMergedL256::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
         assert!(activations.contains(&Activation::CReLU));
         assert!(activations.contains(&Activation::SCReLU));
         assert!(activations.contains(&Activation::PairwiseCReLU));
@@ -76,7 +78,7 @@ mod tests {
     /// マクロ生成: L2/L3 の妥当な範囲チェック
     #[test]
     fn test_l2_l3_valid_range() {
-        for spec in HalfKA_hm_L256::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL256::SUPPORTED_SPECS {
             assert!(
                 spec.l2 > 0 && spec.l2 <= 128,
                 "L2 should be in range (0, 128], got: {}",

--- a/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l512.rs
@@ -10,13 +10,13 @@ use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
 use crate::nnue::aliases::{
-    HalfKA_hm512_8_64CReLU, HalfKA_hm512_8_64Pairwise, HalfKA_hm512_8_64SCReLU,
-    HalfKA_hm512_32_32CReLU, HalfKA_hm512_32_32Pairwise, HalfKA_hm512_32_32SCReLU,
-    HalfKA_hm512CReLU, HalfKA_hm512Pairwise, HalfKA_hm512SCReLU,
+    HalfKaHmMerged512_8_64CReLU, HalfKaHmMerged512_8_64Pairwise, HalfKaHmMerged512_8_64SCReLU,
+    HalfKaHmMerged512_32_32CReLU, HalfKaHmMerged512_32_32Pairwise, HalfKaHmMerged512_32_32SCReLU,
+    HalfKaHmMerged512CReLU, HalfKaHmMerged512Pairwise, HalfKaHmMerged512SCReLU,
 };
 
 crate::define_l1_variants!(
-    enum HalfKA_hm_L512,
+    enum HalfKaHmMergedL512,
     feature_set HalfKaHmMerged,
     l1 512,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<512>,
@@ -24,17 +24,17 @@ crate::define_l1_variants!(
 
     variants {
         // L2=8, L3=64
-        (8,  64, CReLU)         => CReLU8x64     : HalfKA_hm512_8_64CReLU,
-        (8,  64, SCReLU)        => SCReLU8x64    : HalfKA_hm512_8_64SCReLU,
-        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKA_hm512_8_64Pairwise,
+        (8,  64, CReLU)         => CReLU8x64     : HalfKaHmMerged512_8_64CReLU,
+        (8,  64, SCReLU)        => SCReLU8x64    : HalfKaHmMerged512_8_64SCReLU,
+        (8,  64, PairwiseCReLU) => Pairwise8x64  : HalfKaHmMerged512_8_64Pairwise,
         // L2=8, L3=96
-        (8,  96, CReLU)         => CReLU8x96     : HalfKA_hm512CReLU,
-        (8,  96, SCReLU)        => SCReLU8x96    : HalfKA_hm512SCReLU,
-        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKA_hm512Pairwise,
+        (8,  96, CReLU)         => CReLU8x96     : HalfKaHmMerged512CReLU,
+        (8,  96, SCReLU)        => SCReLU8x96    : HalfKaHmMerged512SCReLU,
+        (8,  96, PairwiseCReLU) => Pairwise8x96  : HalfKaHmMerged512Pairwise,
         // L2=32, L3=32
-        (32, 32, CReLU)         => CReLU32x32    : HalfKA_hm512_32_32CReLU,
-        (32, 32, SCReLU)        => SCReLU32x32   : HalfKA_hm512_32_32SCReLU,
-        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKA_hm512_32_32Pairwise,
+        (32, 32, CReLU)         => CReLU32x32    : HalfKaHmMerged512_32_32CReLU,
+        (32, 32, SCReLU)        => SCReLU32x32   : HalfKaHmMerged512_32_32SCReLU,
+        (32, 32, PairwiseCReLU) => Pairwise32x32 : HalfKaHmMerged512_32_32Pairwise,
     }
 );
 
@@ -44,10 +44,10 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L512::SUPPORTED_SPECS.len(), 9);
+        assert_eq!(HalfKaHmMergedL512::SUPPORTED_SPECS.len(), 9);
 
         // 8-64 CReLU
-        let spec = &HalfKA_hm_L512::SUPPORTED_SPECS[0];
+        let spec = &HalfKaHmMergedL512::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 512);
         assert_eq!(spec.l2, 8);
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_l1_size() {
-        for spec in HalfKA_hm_L512::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL512::SUPPORTED_SPECS {
             assert_eq!(spec.l1, 512);
         }
     }
@@ -65,7 +65,7 @@ mod tests {
     /// マクロ生成: architecture_name() の命名規則テスト
     #[test]
     fn test_architecture_name_format() {
-        for spec in HalfKA_hm_L512::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL512::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
                 name.starts_with("HalfKaHmMerged-512-"),
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn test_supported_activations() {
         let activations: Vec<_> =
-            HalfKA_hm_L512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+            HalfKaHmMergedL512::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
         assert!(activations.contains(&Activation::CReLU));
         assert!(activations.contains(&Activation::SCReLU));
         assert!(activations.contains(&Activation::PairwiseCReLU));
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn test_multiple_l2_l3_combinations() {
         let combinations: Vec<_> =
-            HalfKA_hm_L512::SUPPORTED_SPECS.iter().map(|s| (s.l2, s.l3)).collect();
+            HalfKaHmMergedL512::SUPPORTED_SPECS.iter().map(|s| (s.l2, s.l3)).collect();
 
         assert!(combinations.contains(&(8, 64)), "Should support L2=8, L3=64");
         assert!(combinations.contains(&(8, 96)), "Should support L2=8, L3=96");

--- a/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/l768.rs
@@ -9,10 +9,12 @@ use crate::position::Position;
 use crate::types::Value;
 
 // 型エイリアスを aliases 経由でインポート
-use crate::nnue::aliases::{HalfKA_hm768CReLU, HalfKA_hm768Pairwise, HalfKA_hm768SCReLU};
+use crate::nnue::aliases::{
+    HalfKaHmMerged768CReLU, HalfKaHmMerged768Pairwise, HalfKaHmMerged768SCReLU,
+};
 
 crate::define_l1_variants!(
-    enum HalfKA_hm_L768,
+    enum HalfKaHmMergedL768,
     feature_set HalfKaHmMerged,
     l1 768,
     acc crate::nnue::network_halfka_hm::AccumulatorHalfKA_hm<768>,
@@ -20,9 +22,9 @@ crate::define_l1_variants!(
 
     variants {
         // L2=16, L3=64 バリアント
-        (16, 64, CReLU)         => CReLU16x64    : HalfKA_hm768CReLU,
-        (16, 64, SCReLU)        => SCReLU16x64   : HalfKA_hm768SCReLU,
-        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKA_hm768Pairwise,
+        (16, 64, CReLU)         => CReLU16x64    : HalfKaHmMerged768CReLU,
+        (16, 64, SCReLU)        => SCReLU16x64   : HalfKaHmMerged768SCReLU,
+        (16, 64, PairwiseCReLU) => Pairwise16x64 : HalfKaHmMerged768Pairwise,
     }
 );
 
@@ -32,10 +34,10 @@ mod tests {
 
     #[test]
     fn test_supported_specs() {
-        assert_eq!(HalfKA_hm_L768::SUPPORTED_SPECS.len(), 3);
+        assert_eq!(HalfKaHmMergedL768::SUPPORTED_SPECS.len(), 3);
 
         // 16-64 CReLU
-        let spec = &HalfKA_hm_L768::SUPPORTED_SPECS[0];
+        let spec = &HalfKaHmMergedL768::SUPPORTED_SPECS[0];
         assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
         assert_eq!(spec.l1, 768);
         assert_eq!(spec.l2, 16);
@@ -45,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_l1_size() {
-        for spec in HalfKA_hm_L768::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL768::SUPPORTED_SPECS {
             assert_eq!(spec.l1, 768);
         }
     }
@@ -53,7 +55,7 @@ mod tests {
     /// マクロ生成: architecture_name() の命名規則テスト
     #[test]
     fn test_architecture_name_format() {
-        for spec in HalfKA_hm_L768::SUPPORTED_SPECS {
+        for spec in HalfKaHmMergedL768::SUPPORTED_SPECS {
             let name = spec.name();
             assert!(
                 name.starts_with("HalfKaHmMerged-768-"),
@@ -66,7 +68,7 @@ mod tests {
     #[test]
     fn test_supported_activations() {
         let activations: Vec<_> =
-            HalfKA_hm_L768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
+            HalfKaHmMergedL768::SUPPORTED_SPECS.iter().map(|s| s.activation).collect();
         assert!(activations.contains(&Activation::CReLU));
         assert!(activations.contains(&Activation::SCReLU));
         assert!(activations.contains(&Activation::PairwiseCReLU));

--- a/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
+++ b/crates/rshogi-core/src/nnue/halfka_hm/mod.rs
@@ -8,16 +8,16 @@
 //! # 構造
 //!
 //! ```text
-//! HalfKA_hmNetwork
-//! ├── L256(HalfKA_hm_L256)
+//! HalfKaHmMergedNetwork
+//! ├── L256(HalfKaHmMergedL256)
 //! │   ├── CReLU_32_32
 //! │   ├── SCReLU_32_32
 //! │   └── Pairwise_32_32
-//! ├── L512(HalfKA_hm_L512)
+//! ├── L512(HalfKaHmMergedL512)
 //! │   ├── CReLU_8_96
 //! │   ├── SCReLU_8_96
 //! │   └── Pairwise_8_96
-//! └── L1024(HalfKA_hm_L1024)
+//! └── L1024(HalfKaHmMergedL1024)
 //!     ├── CReLU_8_96
 //!     ├── SCReLU_8_96
 //!     ├── Pairwise_8_96
@@ -30,10 +30,10 @@ mod l256;
 mod l512;
 mod l768;
 
-pub use l256::HalfKA_hm_L256;
-pub use l512::HalfKA_hm_L512;
-pub use l768::HalfKA_hm_L768;
-pub use l1024::HalfKA_hm_L1024;
+pub use l256::HalfKaHmMergedL256;
+pub use l512::HalfKaHmMergedL512;
+pub use l768::HalfKaHmMergedL768;
+pub use l1024::HalfKaHmMergedL1024;
 
 use crate::nnue::accumulator::{AccumulatorCacheGeneric, DirtyPiece};
 use crate::nnue::network_halfka_hm::AccumulatorStackHalfKA_hm;
@@ -45,34 +45,34 @@ use crate::types::Value;
 ///
 /// L1 サイズごとにバリアントを持つ。
 /// L2/L3/活性化の追加で変更不要（L1 enum 内に閉じる）。
-pub enum HalfKA_hmNetwork {
-    L256(HalfKA_hm_L256),
-    L512(HalfKA_hm_L512),
-    L768(HalfKA_hm_L768),
-    L1024(HalfKA_hm_L1024),
+pub enum HalfKaHmMergedNetwork {
+    L256(HalfKaHmMergedL256),
+    L512(HalfKaHmMergedL512),
+    L768(HalfKaHmMergedL768),
+    L1024(HalfKaHmMergedL1024),
 }
 
-impl HalfKA_hmNetwork {
+impl HalfKaHmMergedNetwork {
     /// 評価値を計算
     #[inline(always)]
-    pub fn evaluate(&self, pos: &Position, stack: &HalfKA_hmStack) -> Value {
+    pub fn evaluate(&self, pos: &Position, stack: &HalfKaHmMergedStack) -> Value {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => net.evaluate(pos, st),
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => net.evaluate(pos, st),
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => net.evaluate(pos, st),
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => net.evaluate(pos, st),
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => net.evaluate(pos, st),
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => net.evaluate(pos, st),
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => net.evaluate(pos, st),
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => net.evaluate(pos, st),
             _ => unreachable!("L1 mismatch: network={}, stack={}", self.l1_size(), stack.l1_size()),
         }
     }
 
     /// Accumulator をフル再計算
     #[inline(always)]
-    pub fn refresh_accumulator(&self, pos: &Position, stack: &mut HalfKA_hmStack) {
+    pub fn refresh_accumulator(&self, pos: &Position, stack: &mut HalfKaHmMergedStack) {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => net.refresh_accumulator(pos, st),
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => net.refresh_accumulator(pos, st),
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => net.refresh_accumulator(pos, st),
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => net.refresh_accumulator(pos, st),
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => net.refresh_accumulator(pos, st),
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => net.refresh_accumulator(pos, st),
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => net.refresh_accumulator(pos, st),
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => net.refresh_accumulator(pos, st),
             _ => unreachable!("L1 mismatch"),
         }
     }
@@ -82,20 +82,20 @@ impl HalfKA_hmNetwork {
     pub fn refresh_accumulator_with_cache(
         &self,
         pos: &Position,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         cache: &mut AccumulatorCacheGeneric,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => {
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => {
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => {
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => {
                 net.refresh_accumulator_with_cache(pos, st, cache)
             }
             _ => unreachable!("L1 mismatch"),
@@ -108,20 +108,20 @@ impl HalfKA_hmNetwork {
         &self,
         pos: &Position,
         dirty: &DirtyPiece,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         source_idx: usize,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => {
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => {
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => {
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => {
                 net.update_accumulator(pos, dirty, st, source_idx)
             }
             _ => unreachable!("L1 mismatch"),
@@ -134,21 +134,21 @@ impl HalfKA_hmNetwork {
         &self,
         pos: &Position,
         dirty: &DirtyPiece,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         source_idx: usize,
         cache: &mut AccumulatorCacheGeneric,
     ) {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => {
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => {
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => {
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => {
                 net.update_accumulator_with_cache(pos, dirty, st, source_idx, cache)
             }
             _ => unreachable!("L1 mismatch"),
@@ -160,20 +160,20 @@ impl HalfKA_hmNetwork {
     pub fn forward_update_incremental(
         &self,
         pos: &Position,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         source_idx: usize,
     ) -> bool {
         match (self, stack) {
-            (Self::L256(net), HalfKA_hmStack::L256(st)) => {
+            (Self::L256(net), HalfKaHmMergedStack::L256(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L512(net), HalfKA_hmStack::L512(st)) => {
+            (Self::L512(net), HalfKaHmMergedStack::L512(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L768(net), HalfKA_hmStack::L768(st)) => {
+            (Self::L768(net), HalfKaHmMergedStack::L768(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
-            (Self::L1024(net), HalfKA_hmStack::L1024(st)) => {
+            (Self::L1024(net), HalfKaHmMergedStack::L1024(st)) => {
                 net.forward_update_incremental(pos, st, source_idx)
             }
             _ => unreachable!("L1 mismatch"),
@@ -209,19 +209,19 @@ impl HalfKA_hmNetwork {
 
         match l1 {
             256 => {
-                let net = HalfKA_hm_L256::read(reader, l2, l3, activation)?;
+                let net = HalfKaHmMergedL256::read(reader, l2, l3, activation)?;
                 Ok(Self::L256(net))
             }
             512 => {
-                let net = HalfKA_hm_L512::read(reader, l2, l3, activation)?;
+                let net = HalfKaHmMergedL512::read(reader, l2, l3, activation)?;
                 Ok(Self::L512(net))
             }
             768 => {
-                let net = HalfKA_hm_L768::read(reader, l2, l3, activation)?;
+                let net = HalfKaHmMergedL768::read(reader, l2, l3, activation)?;
                 Ok(Self::L768(net))
             }
             1024 => {
-                let net = HalfKA_hm_L1024::read(reader, l2, l3, activation)?;
+                let net = HalfKaHmMergedL1024::read(reader, l2, l3, activation)?;
                 Ok(Self::L1024(net))
             }
             _ => Err(std::io::Error::new(
@@ -264,10 +264,10 @@ impl HalfKA_hmNetwork {
     /// サポートするアーキテクチャ一覧
     pub fn supported_specs() -> Vec<ArchitectureSpec> {
         let mut specs = Vec::new();
-        specs.extend_from_slice(HalfKA_hm_L256::SUPPORTED_SPECS);
-        specs.extend_from_slice(HalfKA_hm_L512::SUPPORTED_SPECS);
-        specs.extend_from_slice(HalfKA_hm_L768::SUPPORTED_SPECS);
-        specs.extend_from_slice(HalfKA_hm_L1024::SUPPORTED_SPECS);
+        specs.extend_from_slice(HalfKaHmMergedL256::SUPPORTED_SPECS);
+        specs.extend_from_slice(HalfKaHmMergedL512::SUPPORTED_SPECS);
+        specs.extend_from_slice(HalfKaHmMergedL768::SUPPORTED_SPECS);
+        specs.extend_from_slice(HalfKaHmMergedL1024::SUPPORTED_SPECS);
         specs
     }
 }
@@ -275,23 +275,25 @@ impl HalfKA_hmNetwork {
 /// HalfKA_hm Accumulator スタック（L1 のみで決まる）
 ///
 /// L2/L3/活性化の追加で変更不要。
-pub enum HalfKA_hmStack {
+pub enum HalfKaHmMergedStack {
     L256(AccumulatorStackHalfKA_hm<256>),
     L512(AccumulatorStackHalfKA_hm<512>),
     L768(AccumulatorStackHalfKA_hm<768>),
     L1024(AccumulatorStackHalfKA_hm<1024>),
 }
 
-impl HalfKA_hmStack {
+impl HalfKaHmMergedStack {
     /// ネットワークに対応するスタックを生成
     ///
     /// バリアントマッチを使用し、新しい L1 追加時にコンパイル時に漏れ検知。
-    pub fn from_network(net: &HalfKA_hmNetwork) -> Self {
+    pub fn from_network(net: &HalfKaHmMergedNetwork) -> Self {
         match net {
-            HalfKA_hmNetwork::L256(_) => Self::L256(AccumulatorStackHalfKA_hm::<256>::new()),
-            HalfKA_hmNetwork::L512(_) => Self::L512(AccumulatorStackHalfKA_hm::<512>::new()),
-            HalfKA_hmNetwork::L768(_) => Self::L768(AccumulatorStackHalfKA_hm::<768>::new()),
-            HalfKA_hmNetwork::L1024(_) => Self::L1024(AccumulatorStackHalfKA_hm::<1024>::new()),
+            HalfKaHmMergedNetwork::L256(_) => Self::L256(AccumulatorStackHalfKA_hm::<256>::new()),
+            HalfKaHmMergedNetwork::L512(_) => Self::L512(AccumulatorStackHalfKA_hm::<512>::new()),
+            HalfKaHmMergedNetwork::L768(_) => Self::L768(AccumulatorStackHalfKA_hm::<768>::new()),
+            HalfKaHmMergedNetwork::L1024(_) => {
+                Self::L1024(AccumulatorStackHalfKA_hm::<1024>::new())
+            }
         }
     }
 
@@ -400,7 +402,7 @@ impl HalfKA_hmStack {
     }
 }
 
-impl Default for HalfKA_hmStack {
+impl Default for HalfKaHmMergedStack {
     fn default() -> Self {
         Self::L512(AccumulatorStackHalfKA_hm::<512>::new())
     }
@@ -414,19 +416,19 @@ mod tests {
     #[test]
     fn test_halfka_stack_from_network_l1_size() {
         // L256 ネットワークを仮定したスタック
-        let stack = HalfKA_hmStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
+        let stack = HalfKaHmMergedStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
         assert_eq!(stack.l1_size(), 256);
 
-        let stack = HalfKA_hmStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
+        let stack = HalfKaHmMergedStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
         assert_eq!(stack.l1_size(), 512);
 
-        let stack = HalfKA_hmStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
+        let stack = HalfKaHmMergedStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
         assert_eq!(stack.l1_size(), 1024);
     }
 
     #[test]
     fn test_supported_specs_combined() {
-        let specs = HalfKA_hmNetwork::supported_specs();
+        let specs = HalfKaHmMergedNetwork::supported_specs();
         // (256: 1, 512: 3, 768: 1, 1024: 3) × 3 活性化 (CReLU/SCReLU/Pairwise)
         assert_eq!(specs.len(), 24);
 
@@ -439,7 +441,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L256）
     #[test]
     fn test_push_pop_index_consistency_l256() {
-        let mut stack = HalfKA_hmStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
+        let mut stack = HalfKaHmMergedStack::L256(AccumulatorStackHalfKA_hm::<256>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -461,7 +463,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L512）
     #[test]
     fn test_push_pop_index_consistency_l512() {
-        let mut stack = HalfKA_hmStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
+        let mut stack = HalfKaHmMergedStack::L512(AccumulatorStackHalfKA_hm::<512>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -477,7 +479,7 @@ mod tests {
     /// push/pop の対称性と状態の一貫性テスト（L1024）
     #[test]
     fn test_push_pop_index_consistency_l1024() {
-        let mut stack = HalfKA_hmStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
+        let mut stack = HalfKaHmMergedStack::L1024(AccumulatorStackHalfKA_hm::<1024>::new());
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -493,7 +495,7 @@ mod tests {
     /// deep push/pop テスト（探索木の深さをシミュレート）
     #[test]
     fn test_deep_push_pop() {
-        let mut stack = HalfKA_hmStack::default();
+        let mut stack = HalfKaHmMergedStack::default();
         let dirty = DirtyPiece::default();
 
         stack.reset();
@@ -516,7 +518,7 @@ mod tests {
     /// アーキテクチャの仕様一覧の一貫性テスト
     #[test]
     fn test_architecture_spec_consistency() {
-        for spec in HalfKA_hmNetwork::supported_specs() {
+        for spec in HalfKaHmMergedNetwork::supported_specs() {
             assert_eq!(spec.feature_set, FeatureSet::HalfKaHmMerged);
             assert!(spec.l1 == 256 || spec.l1 == 512 || spec.l1 == 768 || spec.l1 == 1024);
             assert!(spec.l2 > 0 && spec.l2 <= 128);

--- a/crates/rshogi-core/src/nnue/macros.rs
+++ b/crates/rshogi-core/src/nnue/macros.rs
@@ -20,16 +20,16 @@
 ///
 /// ```ignore
 /// define_l1_variants!(
-///     enum HalfKA_hm_L512,
+///     enum HalfKaHmMergedL512,
 ///     feature_set HalfKaHmMerged,
 ///     l1 512,
 ///     acc AccumulatorHalfKA_hm<512>,
 ///     stack AccumulatorStackHalfKA_hm<512>,
 ///
 ///     variants {
-///         (8,  96, CReLU,        "CReLU")    => CReLU_8_96     : HalfKA_hm512CReLU,
-///         (8,  96, SCReLU,       "SCReLU")   => SCReLU_8_96    : HalfKA_hm512SCReLU,
-///         (8,  96, PairwiseCReLU,"Pairwise") => Pairwise_8_96  : HalfKA_hm512Pairwise,
+///         (8,  96, CReLU,        "CReLU")    => CReLU_8_96     : HalfKaHmMerged512CReLU,
+///         (8,  96, SCReLU,       "SCReLU")   => SCReLU_8_96    : HalfKaHmMerged512SCReLU,
+///         (8,  96, PairwiseCReLU,"Pairwise") => Pairwise_8_96  : HalfKaHmMerged512Pairwise,
 ///     }
 /// );
 /// ```

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -81,8 +81,8 @@ pub use diff::get_changed_features;
 pub use feature_transformer::FeatureTransformer;
 pub use feature_transformer_layer_stacks::FeatureTransformerLayerStacks;
 pub use features::{
-    Feature, FeatureSet, HalfKA, HalfKA_hm, HalfKA_hm_FeatureSet, HalfKAFeatureSet, HalfKP,
-    HalfKPFeatureSet, TriggerEvent,
+    Feature, FeatureSet, HalfKA, HalfKA_hm, HalfKP, HalfKPFeatureSet, HalfKaHmMergedFeatureSet,
+    HalfKaSplitFeatureSet, TriggerEvent,
 };
 pub use layer_stacks::{
     LayerStackBucket, LayerStacks, compute_bucket_index, compute_king_ranks,

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -9,8 +9,8 @@
 //!
 //! ```text
 //! NNUENetwork
-//! ├── HalfKA(HalfKANetwork)   // L256/L512/L1024 を内包
-//! ├── HalfKA_hm(HalfKA_hmNetwork)   // L256/L512/L1024 を内包
+//! ├── HalfKA(HalfKaSplitNetwork)   // L256/L512/L1024 を内包
+//! ├── HalfKA_hm(HalfKaHmMergedNetwork)   // L256/L512/L1024 を内包
 //! ├── HalfKP(HalfKPNetwork)   // L256/L512 を内包
 //! └── LayerStacks(Box<NetworkLayerStacks>)
 //! ```
@@ -24,8 +24,8 @@ use super::activation::detect_activation_from_arch;
 use super::bona_piece::BonaPiece;
 use super::bona_piece_halfka_hm::FE_OLD_END;
 use super::constants::{MAX_ARCH_LEN, NNUE_VERSION, NNUE_VERSION_HALFKA};
-use super::halfka::{HalfKANetwork, HalfKAStack};
-use super::halfka_hm::{HalfKA_hmNetwork, HalfKA_hmStack};
+use super::halfka::{HalfKaSplitNetwork, HalfKaSplitStack};
+use super::halfka_hm::{HalfKaHmMergedNetwork, HalfKaHmMergedStack};
 use super::halfka_hm_split::{HalfKaHmSplitNetwork, HalfKaHmSplitStack};
 use super::halfka_merged::{HalfKaMergedNetwork, HalfKaMergedStack};
 use super::halfkp::{HalfKPNetwork, HalfKPStack};
@@ -259,8 +259,8 @@ pub fn reset_layer_stack_progress_kpabs_weights() {
 /// NNUEネットワーク（4バリアント階層構造）
 ///
 /// **「Accumulator は L1 だけで決まる」** を活用した設計:
-/// - HalfKA(HalfKANetwork): L256/L512/L1024 を内包
-/// - HalfKA_hm(HalfKA_hmNetwork): L256/L512/L1024 を内包
+/// - HalfKA(HalfKaSplitNetwork): L256/L512/L1024 を内包
+/// - HalfKA_hm(HalfKaHmMergedNetwork): L256/L512/L1024 を内包
 /// - HalfKP(HalfKPNetwork): L256/L512 を内包
 /// - LayerStacks: 1536次元 + 9バケット
 ///
@@ -268,10 +268,10 @@ pub fn reset_layer_stack_progress_kpabs_weights() {
 /// 詳細は `halfka/` や `halfkp/` のモジュールで管理される。
 pub enum NNUENetwork {
     /// HalfKA 特徴量セット（L256/L512/L1024）
-    HalfKA(HalfKANetwork),
+    HalfKA(HalfKaSplitNetwork),
     /// HalfKA_hm 特徴量セット（L256/L512/L1024）
     #[allow(non_camel_case_types)]
-    HalfKA_hm(HalfKA_hmNetwork),
+    HalfKA_hm(HalfKaHmMergedNetwork),
     /// HalfKaMerged 特徴量セット（L256/L512/L1024）
     HalfKaMerged(HalfKaMergedNetwork),
     /// HalfKaHmSplit 特徴量セット（L256/L512/L1024）
@@ -290,12 +290,12 @@ impl NNUENetwork {
 
     /// HalfKA_hm でサポートされているアーキテクチャ一覧
     pub fn supported_halfka_hm_specs() -> Vec<super::spec::ArchitectureSpec> {
-        HalfKA_hmNetwork::supported_specs()
+        HalfKaHmMergedNetwork::supported_specs()
     }
 
     /// HalfKA でサポートされているアーキテクチャ一覧
     pub fn supported_halfka_specs() -> Vec<super::spec::ArchitectureSpec> {
-        HalfKANetwork::supported_specs()
+        HalfKaSplitNetwork::supported_specs()
     }
 
     /// ファイルから読み込み（バージョン自動判別）
@@ -428,11 +428,11 @@ impl NNUENetwork {
 
                 match detection.spec.feature_set {
                     FeatureSet::HalfKaHmMerged => {
-                        let network = HalfKA_hmNetwork::read(reader, l1, l2, l3, activation)?;
+                        let network = HalfKaHmMergedNetwork::read(reader, l1, l2, l3, activation)?;
                         Ok(Self::HalfKA_hm(network))
                     }
                     FeatureSet::HalfKaSplit => {
-                        let network = HalfKANetwork::read(reader, l1, l2, l3, activation)?;
+                        let network = HalfKaSplitNetwork::read(reader, l1, l2, l3, activation)?;
                         Ok(Self::HalfKA(network))
                     }
                     FeatureSet::HalfKaMerged => {
@@ -535,7 +535,7 @@ impl NNUENetwork {
     }
 
     /// HalfKA_hm アキュムレータをフル再計算
-    pub fn refresh_accumulator_halfka_hm(&self, pos: &Position, stack: &mut HalfKA_hmStack) {
+    pub fn refresh_accumulator_halfka_hm(&self, pos: &Position, stack: &mut HalfKaHmMergedStack) {
         match self {
             Self::HalfKA_hm(net) => net.refresh_accumulator(pos, stack),
             _ => panic!("This method is only for HalfKA_hm architecture."),
@@ -543,7 +543,7 @@ impl NNUENetwork {
     }
 
     /// HalfKA アキュムレータをフル再計算
-    pub fn refresh_accumulator_halfka(&self, pos: &Position, stack: &mut HalfKAStack) {
+    pub fn refresh_accumulator_halfka(&self, pos: &Position, stack: &mut HalfKaSplitStack) {
         match self {
             Self::HalfKA(net) => net.refresh_accumulator(pos, stack),
             _ => panic!("This method is only for HalfKA architecture."),
@@ -555,7 +555,7 @@ impl NNUENetwork {
         &self,
         pos: &Position,
         dirty: &super::accumulator::DirtyPiece,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         source_idx: usize,
     ) {
         match self {
@@ -569,7 +569,7 @@ impl NNUENetwork {
         &self,
         pos: &Position,
         dirty: &super::accumulator::DirtyPiece,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         source_idx: usize,
     ) {
         match self {
@@ -582,7 +582,7 @@ impl NNUENetwork {
     pub fn forward_update_incremental_halfka_hm(
         &self,
         pos: &Position,
-        stack: &mut HalfKA_hmStack,
+        stack: &mut HalfKaHmMergedStack,
         source_idx: usize,
     ) -> bool {
         match self {
@@ -595,7 +595,7 @@ impl NNUENetwork {
     pub fn forward_update_incremental_halfka(
         &self,
         pos: &Position,
-        stack: &mut HalfKAStack,
+        stack: &mut HalfKaSplitStack,
         source_idx: usize,
     ) -> bool {
         match self {
@@ -605,7 +605,7 @@ impl NNUENetwork {
     }
 
     /// HalfKA_hm 評価
-    pub fn evaluate_halfka_hm(&self, pos: &Position, stack: &HalfKA_hmStack) -> Value {
+    pub fn evaluate_halfka_hm(&self, pos: &Position, stack: &HalfKaHmMergedStack) -> Value {
         match self {
             Self::HalfKA_hm(net) => net.evaluate(pos, stack),
             _ => panic!("This method is only for HalfKA_hm architecture."),
@@ -613,7 +613,7 @@ impl NNUENetwork {
     }
 
     /// HalfKA 評価
-    pub fn evaluate_halfka(&self, pos: &Position, stack: &HalfKAStack) -> Value {
+    pub fn evaluate_halfka(&self, pos: &Position, stack: &HalfKaSplitStack) -> Value {
         match self {
             Self::HalfKA(net) => net.evaluate(pos, stack),
             _ => panic!("This method is only for HalfKA architecture."),
@@ -985,7 +985,7 @@ pub fn is_nnue_initialized() -> bool {
 /// NNUE フォーマット情報
 #[derive(Debug, Clone)]
 pub struct NnueFormatInfo {
-    /// アーキテクチャ名（例: "HalfKA1024", "HalfKA_hm1024", "LayerStacks", "HalfKP256"）
+    /// アーキテクチャ名（例: "HalfKA1024", "HalfKaHmMerged1024", "LayerStacks", "HalfKP256"）
     pub architecture: String,
 
     /// L1 次元（例: 256, 512, 1024, 1536）
@@ -1252,7 +1252,7 @@ fn ensure_progress_bucket<const L1: usize>(
 fn update_and_evaluate_halfka_hm(
     network: &NNUENetwork,
     pos: &Position,
-    stack: &mut HalfKA_hmStack,
+    stack: &mut HalfKaHmMergedStack,
 ) -> Value {
     // アキュムレータの更新
     if !stack.is_current_computed() {
@@ -1288,7 +1288,7 @@ fn update_and_evaluate_halfka_hm(
 fn update_and_evaluate_halfka(
     network: &NNUENetwork,
     pos: &Position,
-    stack: &mut HalfKAStack,
+    stack: &mut HalfKaSplitStack,
 ) -> Value {
     // アキュムレータの更新
     if !stack.is_current_computed() {
@@ -1415,7 +1415,7 @@ pub fn is_layer_stacks_loaded() -> bool {
     get_network().is_some_and(|n| n.is_layer_stacks())
 }
 
-/// ロードされたNNUEがHalfKA_hm256アーキテクチャかどうか
+/// ロードされたNNUEがHalfKaHmMerged256アーキテクチャかどうか
 pub fn is_halfka_hm_256_loaded() -> bool {
     get_network().is_some_and(|n| n.is_halfka_hm() && n.l1_size() == 256)
 }
@@ -1425,7 +1425,7 @@ pub fn is_halfka_256_loaded() -> bool {
     get_network().is_some_and(|n| n.is_halfka() && n.l1_size() == 256)
 }
 
-/// ロードされたNNUEがHalfKA_hm512アーキテクチャかどうか
+/// ロードされたNNUEがHalfKaHmMerged512アーキテクチャかどうか
 pub fn is_halfka_hm_512_loaded() -> bool {
     get_network().is_some_and(|n| n.is_halfka_hm() && n.l1_size() == 512)
 }
@@ -1435,7 +1435,7 @@ pub fn is_halfka_512_loaded() -> bool {
     get_network().is_some_and(|n| n.is_halfka() && n.l1_size() == 512)
 }
 
-/// ロードされたNNUEがHalfKA_hm1024アーキテクチャかどうか
+/// ロードされたNNUEがHalfKaHmMerged1024アーキテクチャかどうか
 pub fn is_halfka_hm_1024_loaded() -> bool {
     get_network().is_some_and(|n| n.is_halfka_hm() && n.l1_size() == 1024)
 }
@@ -1584,7 +1584,7 @@ pub fn ensure_accumulator_computed(
 fn update_accumulator_only_halfka_hm(
     network: &NNUENetwork,
     pos: &Position,
-    stack: &mut HalfKA_hmStack,
+    stack: &mut HalfKaHmMergedStack,
 ) {
     if stack.is_current_computed() {
         count_already_computed!();
@@ -1613,7 +1613,11 @@ fn update_accumulator_only_halfka_hm(
 /// HalfKA アキュムレータを更新のみ（評価なし）
 #[cfg(not(feature = "layerstack-only"))]
 #[inline]
-fn update_accumulator_only_halfka(network: &NNUENetwork, pos: &Position, stack: &mut HalfKAStack) {
+fn update_accumulator_only_halfka(
+    network: &NNUENetwork,
+    pos: &Position,
+    stack: &mut HalfKaSplitStack,
+) {
     if stack.is_current_computed() {
         count_already_computed!();
         return;
@@ -2254,9 +2258,9 @@ mod tests {
         let mut pos = crate::position::Position::new();
         pos.set_sfen(SFEN_HIRATE).unwrap();
 
-        // HalfKA_hmStack を作成して評価
-        use crate::nnue::halfka_hm::HalfKA_hmStack;
-        let mut stack = HalfKA_hmStack::from_network(match &network {
+        // HalfKaHmMergedStack を作成して評価
+        use crate::nnue::halfka_hm::HalfKaHmMergedStack;
+        let mut stack = HalfKaHmMergedStack::from_network(match &network {
             NNUENetwork::HalfKA_hm(net) => net,
             _ => unreachable!(),
         });
@@ -2315,9 +2319,9 @@ mod tests {
         let mut pos = crate::position::Position::new();
         pos.set_sfen(SFEN_HIRATE).unwrap();
 
-        // HalfKA_hmStack を作成して評価
-        use crate::nnue::halfka_hm::HalfKA_hmStack;
-        let mut stack = HalfKA_hmStack::from_network(match &network {
+        // HalfKaHmMergedStack を作成して評価
+        use crate::nnue::halfka_hm::HalfKaHmMergedStack;
+        let mut stack = HalfKaHmMergedStack::from_network(match &network {
             NNUENetwork::HalfKA_hm(net) => net,
             _ => unreachable!(),
         });

--- a/crates/rshogi-core/src/nnue/network_halfka.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka.rs
@@ -50,7 +50,7 @@ use super::accumulator::{
 };
 use super::activation::FtActivation;
 use super::constants::{FV_SCALE_HALFKA, HALFKA_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
-use super::features::{Feature, FeatureSet, HalfKA, HalfKAFeatureSet};
+use super::features::{Feature, FeatureSet, HalfKA, HalfKaSplitFeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
 use crate::position::Position;
 use crate::types::{Color, Value};
@@ -427,7 +427,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
 
             accumulation.copy_from_slice(&self.biases);
 
-            let active_indices = HalfKAFeatureSet::collect_active_indices(pos, perspective);
+            let active_indices = HalfKaSplitFeatureSet::collect_active_indices(pos, perspective);
             for index in active_indices.iter() {
                 self.add_weights(accumulation, index);
             }
@@ -446,11 +446,12 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKAFeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaSplitFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 acc.accumulation[p].0.copy_from_slice(&self.biases);
-                let active_indices = HalfKAFeatureSet::collect_active_indices(pos, perspective);
+                let active_indices =
+                    HalfKaSplitFeatureSet::collect_active_indices(pos, perspective);
                 for index in active_indices.iter() {
                     self.add_weights(&mut acc.accumulation[p].0, index);
                 }
@@ -485,7 +486,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKAFeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaSplitFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 self.refresh_perspective_with_cache(
@@ -543,7 +544,7 @@ impl<const L1: usize> FeatureTransformerHalfKA<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKAFeatureSet::collect_active_indices(pos, perspective);
+        let active_indices = HalfKaSplitFeatureSet::collect_active_indices(pos, perspective);
 
         let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
         let len = active_indices.len();

--- a/crates/rshogi-core/src/nnue/network_halfka_hm.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm.rs
@@ -19,21 +19,21 @@
 //!
 //! | 型エイリアス | L1 | L2 | L3 | 活性化 |
 //! |-------------|------|-----|-----|--------|
-//! | HalfKA_hm256CReLU | 256 | 32 | 32 | CReLU |
-//! | HalfKA_hm256SCReLU | 256 | 32 | 32 | SCReLU |
-//! | HalfKA_hm256Pairwise | 256 | 32 | 32 | PairwiseCReLU |
-//! | HalfKA_hm512CReLU | 512 | 8 | 96 | CReLU |
-//! | HalfKA_hm512SCReLU | 512 | 8 | 96 | SCReLU |
-//! | HalfKA_hm512Pairwise | 512 | 8 | 96 | PairwiseCReLU |
-//! | HalfKA_hm512_32_32CReLU | 512 | 32 | 32 | CReLU |
-//! | HalfKA_hm512_32_32SCReLU | 512 | 32 | 32 | SCReLU |
-//! | HalfKA_hm512_32_32Pairwise | 512 | 32 | 32 | PairwiseCReLU |
-//! | HalfKA_hm1024CReLU | 1024 | 8 | 96 | CReLU |
-//! | HalfKA_hm1024SCReLU | 1024 | 8 | 96 | SCReLU |
-//! | HalfKA_hm1024Pairwise | 1024 | 8 | 96 | PairwiseCReLU |
-//! | HalfKA_hm1024_8_32CReLU | 1024 | 8 | 32 | CReLU |
-//! | HalfKA_hm1024_8_32SCReLU | 1024 | 8 | 32 | SCReLU |
-//! | HalfKA_hm1024_8_32Pairwise | 1024 | 8 | 32 | PairwiseCReLU |
+//! | HalfKaHmMerged256CReLU | 256 | 32 | 32 | CReLU |
+//! | HalfKaHmMerged256SCReLU | 256 | 32 | 32 | SCReLU |
+//! | HalfKaHmMerged256Pairwise | 256 | 32 | 32 | PairwiseCReLU |
+//! | HalfKaHmMerged512CReLU | 512 | 8 | 96 | CReLU |
+//! | HalfKaHmMerged512SCReLU | 512 | 8 | 96 | SCReLU |
+//! | HalfKaHmMerged512Pairwise | 512 | 8 | 96 | PairwiseCReLU |
+//! | HalfKaHmMerged512_32_32CReLU | 512 | 32 | 32 | CReLU |
+//! | HalfKaHmMerged512_32_32SCReLU | 512 | 32 | 32 | SCReLU |
+//! | HalfKaHmMerged512_32_32Pairwise | 512 | 32 | 32 | PairwiseCReLU |
+//! | HalfKaHmMerged1024CReLU | 1024 | 8 | 96 | CReLU |
+//! | HalfKaHmMerged1024SCReLU | 1024 | 8 | 96 | SCReLU |
+//! | HalfKaHmMerged1024Pairwise | 1024 | 8 | 96 | PairwiseCReLU |
+//! | HalfKaHmMerged1024_8_32CReLU | 1024 | 8 | 32 | CReLU |
+//! | HalfKaHmMerged1024_8_32SCReLU | 1024 | 8 | 32 | SCReLU |
+//! | HalfKaHmMerged1024_8_32Pairwise | 1024 | 8 | 32 | PairwiseCReLU |
 //!
 //! # 特徴量
 //!
@@ -50,7 +50,7 @@ use super::accumulator::{
 };
 use super::activation::FtActivation;
 use super::constants::{FV_SCALE_HALFKA, HALFKA_HM_DIMENSIONS, MAX_ARCH_LEN, NNUE_VERSION_HALFKA};
-use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKA_hm_FeatureSet};
+use super::features::{Feature, FeatureSet, HalfKA_hm, HalfKaHmMergedFeatureSet};
 use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
 use crate::position::Position;
 use crate::types::{Color, Value};
@@ -427,7 +427,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
 
             accumulation.copy_from_slice(&self.biases);
 
-            let active_indices = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
+            let active_indices = HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective);
             for index in active_indices.iter() {
                 self.add_weights(accumulation, index);
             }
@@ -446,11 +446,12 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKA_hm_FeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaHmMergedFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 acc.accumulation[p].0.copy_from_slice(&self.biases);
-                let active_indices = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
+                let active_indices =
+                    HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective);
                 for index in active_indices.iter() {
                     self.add_weights(&mut acc.accumulation[p].0, index);
                 }
@@ -485,7 +486,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
     ) {
         for perspective in [Color::Black, Color::White] {
             let p = perspective as usize;
-            let reset = HalfKA_hm_FeatureSet::needs_refresh(dirty_piece, perspective);
+            let reset = HalfKaHmMergedFeatureSet::needs_refresh(dirty_piece, perspective);
 
             if reset {
                 self.refresh_perspective_with_cache(
@@ -543,7 +544,7 @@ impl<const L1: usize> FeatureTransformerHalfKA_hm<L1> {
         cache: &mut AccumulatorCacheGeneric,
     ) {
         let king_sq = pos.king_square(perspective);
-        let active_indices = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
+        let active_indices = HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective);
 
         let mut sorted_buf = [0u32; MAX_ACTIVE_FEATURES];
         let len = active_indices.len();
@@ -1829,67 +1830,67 @@ use super::activation::{CReLU, PairwiseCReLU, SCReLU};
 
 // L1=256, FT_OUT=512
 /// HalfKA_hm 256x2-32-32 CReLU
-pub type HalfKA_hm256CReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, CReLU>;
+pub type HalfKaHmMerged256CReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, CReLU>;
 /// HalfKA_hm 256x2-32-32 SCReLU
-pub type HalfKA_hm256SCReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, SCReLU>;
+pub type HalfKaHmMerged256SCReLU = NetworkHalfKA_hm<256, 512, 512, 32, 32, SCReLU>;
 /// HalfKA_hm 256x2-32-32 PairwiseCReLU
-pub type HalfKA_hm256Pairwise = NetworkHalfKA_hm<256, 512, 256, 32, 32, PairwiseCReLU>;
+pub type HalfKaHmMerged256Pairwise = NetworkHalfKA_hm<256, 512, 256, 32, 32, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=64
 /// HalfKA_hm 512x2-8-64 CReLU
-pub type HalfKA_hm512_8_64CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, CReLU>;
+pub type HalfKaHmMerged512_8_64CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, CReLU>;
 /// HalfKA_hm 512x2-8-64 SCReLU
-pub type HalfKA_hm512_8_64SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, SCReLU>;
+pub type HalfKaHmMerged512_8_64SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 64, SCReLU>;
 /// HalfKA_hm 512x2-8-64 PairwiseCReLU
-pub type HalfKA_hm512_8_64Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 64, PairwiseCReLU>;
+pub type HalfKaHmMerged512_8_64Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 64, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=8, L3=96
 /// HalfKA_hm 512x2-8-96 CReLU
-pub type HalfKA_hm512CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, CReLU>;
+pub type HalfKaHmMerged512CReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, CReLU>;
 /// HalfKA_hm 512x2-8-96 SCReLU
-pub type HalfKA_hm512SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, SCReLU>;
+pub type HalfKaHmMerged512SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 8, 96, SCReLU>;
 /// HalfKA_hm 512x2-8-96 PairwiseCReLU
-pub type HalfKA_hm512Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 96, PairwiseCReLU>;
+pub type HalfKaHmMerged512Pairwise = NetworkHalfKA_hm<512, 1024, 512, 8, 96, PairwiseCReLU>;
 
 // L1=512, FT_OUT=1024, L2=32, L3=32
 /// HalfKA_hm 512x2-32-32 CReLU
-pub type HalfKA_hm512_32_32CReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, CReLU>;
+pub type HalfKaHmMerged512_32_32CReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, CReLU>;
 /// HalfKA_hm 512x2-32-32 SCReLU
-pub type HalfKA_hm512_32_32SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, SCReLU>;
+pub type HalfKaHmMerged512_32_32SCReLU = NetworkHalfKA_hm<512, 1024, 1024, 32, 32, SCReLU>;
 /// HalfKA_hm 512x2-32-32 PairwiseCReLU
-pub type HalfKA_hm512_32_32Pairwise = NetworkHalfKA_hm<512, 1024, 512, 32, 32, PairwiseCReLU>;
+pub type HalfKaHmMerged512_32_32Pairwise = NetworkHalfKA_hm<512, 1024, 512, 32, 32, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=64
 /// HalfKA_hm 1024x2-8-64 CReLU
-pub type HalfKA_hm1024_8_64CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, CReLU>;
+pub type HalfKaHmMerged1024_8_64CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, CReLU>;
 /// HalfKA_hm 1024x2-8-64 SCReLU
-pub type HalfKA_hm1024_8_64SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, SCReLU>;
+pub type HalfKaHmMerged1024_8_64SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 64, SCReLU>;
 /// HalfKA_hm 1024x2-8-64 PairwiseCReLU
-pub type HalfKA_hm1024_8_64Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
+pub type HalfKaHmMerged1024_8_64Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 64, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=96
 /// HalfKA_hm 1024x2-8-96 CReLU
-pub type HalfKA_hm1024CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, CReLU>;
+pub type HalfKaHmMerged1024CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, CReLU>;
 /// HalfKA_hm 1024x2-8-96 SCReLU
-pub type HalfKA_hm1024SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, SCReLU>;
+pub type HalfKaHmMerged1024SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 96, SCReLU>;
 /// HalfKA_hm 1024x2-8-96 PairwiseCReLU
-pub type HalfKA_hm1024Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
+pub type HalfKaHmMerged1024Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 96, PairwiseCReLU>;
 
 // L1=1024, FT_OUT=2048, L2=8, L3=32
 /// HalfKA_hm 1024x2-8-32 CReLU
-pub type HalfKA_hm1024_8_32CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, CReLU>;
+pub type HalfKaHmMerged1024_8_32CReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, CReLU>;
 /// HalfKA_hm 1024x2-8-32 SCReLU
-pub type HalfKA_hm1024_8_32SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, SCReLU>;
+pub type HalfKaHmMerged1024_8_32SCReLU = NetworkHalfKA_hm<1024, 2048, 2048, 8, 32, SCReLU>;
 /// HalfKA_hm 1024x2-8-32 PairwiseCReLU
-pub type HalfKA_hm1024_8_32Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
+pub type HalfKaHmMerged1024_8_32Pairwise = NetworkHalfKA_hm<1024, 2048, 1024, 8, 32, PairwiseCReLU>;
 
 // L1=768, FT_OUT=1536, L2=16, L3=64
 /// HalfKA_hm 768x2-16-64 CReLU
-pub type HalfKA_hm768CReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, CReLU>;
+pub type HalfKaHmMerged768CReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, CReLU>;
 /// HalfKA_hm 768x2-16-64 SCReLU
-pub type HalfKA_hm768SCReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, SCReLU>;
+pub type HalfKaHmMerged768SCReLU = NetworkHalfKA_hm<768, 1536, 1536, 16, 64, SCReLU>;
 /// HalfKA_hm 768x2-16-64 PairwiseCReLU
-pub type HalfKA_hm768Pairwise = NetworkHalfKA_hm<768, 1536, 768, 16, 64, PairwiseCReLU>;
+pub type HalfKaHmMerged768Pairwise = NetworkHalfKA_hm<768, 1536, 768, 16, 64, PairwiseCReLU>;
 
 // =============================================================================
 // テスト
@@ -1960,8 +1961,8 @@ mod tests {
     #[test]
     fn test_type_aliases() {
         // 型エイリアスがコンパイルできることを確認
-        fn _check_halfka_256_crelu(_: HalfKA_hm256CReLU) {}
-        fn _check_halfka_512_crelu(_: HalfKA_hm512CReLU) {}
-        fn _check_halfka_1024_crelu(_: HalfKA_hm1024CReLU) {}
+        fn _check_halfka_256_crelu(_: HalfKaHmMerged256CReLU) {}
+        fn _check_halfka_512_crelu(_: HalfKaHmMerged512CReLU) {}
+        fn _check_halfka_1024_crelu(_: HalfKaHmMerged1024CReLU) {}
     }
 }

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -1068,9 +1068,9 @@ mod tests {
         pos.set_sfen(SFEN_HIRATE).unwrap();
 
         // アクティブ特徴量を確認
-        use crate::nnue::features::{FeatureSet, HalfKA_hm_FeatureSet};
+        use crate::nnue::features::{FeatureSet, HalfKaHmMergedFeatureSet};
         use crate::types::Color;
-        let active_black = HalfKA_hm_FeatureSet::collect_active_indices(&pos, Color::Black);
+        let active_black = HalfKaHmMergedFeatureSet::collect_active_indices(&pos, Color::Black);
         eprintln!("Active features for Black: {} features", active_black.len());
         let first_5: Vec<usize> = active_black.iter().take(5).collect();
         eprintln!("  First 5 indices: {first_5:?}");

--- a/crates/tools/src/eval_sfens_tool.rs
+++ b/crates/tools/src/eval_sfens_tool.rs
@@ -16,7 +16,7 @@ use std::mem::size_of;
 use std::path::PathBuf;
 
 use rshogi_core::nnue::{
-    AccumulatorLayerStacks, AffineTransform, FeatureSet, HalfKA_hm_FeatureSet,
+    AccumulatorLayerStacks, AffineTransform, FeatureSet, HalfKaHmMergedFeatureSet,
     LayerStackBucketMode, LayerStacksNetwork, NNUE_PYTORCH_L3, NNUENetwork, NetworkLayerStacks,
     SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, compute_layer_stack_progress8kpabs_bucket_index,
     get_layer_stack_progress_kpabs_weights, set_layer_stack_bucket_mode,
@@ -187,7 +187,7 @@ fn recompute_ft_scalar<
     for (dst, &b) in acc.iter_mut().zip(network.feature_transformer.biases.0.iter()) {
         *dst = i32::from(b);
     }
-    let active = HalfKA_hm_FeatureSet::collect_active_indices(pos, perspective);
+    let active = HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective);
     for index in active.iter() {
         let offset = index * L1;
         for (i, dst) in acc.iter_mut().enumerate() {
@@ -216,8 +216,8 @@ fn dump_debug_first<
     eprintln!("[debug] side_to_move={:?}", pos.side_to_move());
     eprintln!("[debug] bucket={bucket_index} raw={raw} score={score}");
 
-    let black_active = HalfKA_hm_FeatureSet::collect_active_indices(pos, Color::Black);
-    let white_active = HalfKA_hm_FeatureSet::collect_active_indices(pos, Color::White);
+    let black_active = HalfKaHmMergedFeatureSet::collect_active_indices(pos, Color::Black);
+    let white_active = HalfKaHmMergedFeatureSet::collect_active_indices(pos, Color::White);
     eprintln!(
         "[debug] active_features black={} white={}",
         black_active.len(),


### PR DESCRIPTION
## Summary

- \`FeatureSet\` enum variant 名以外の identifier (関連型 / type alias / struct 名) を PascalCase に統一
- 機械的 rename。動作 / API binary 互換性に変化なし
- 不要な \`#[allow(non_camel_case_types)]\` 5 ヶ所を削除

## 対象 identifier

| 旧 | 新 |
|---|---|
| \`HalfKA_hm_FeatureSet\` | \`HalfKaHmMergedFeatureSet\` |
| \`HalfKA_hm_L{256,512,768,1024}\` (struct) | \`HalfKaHmMergedL{N}\` |
| \`HalfKA_hm{Stack, Network, FeatureSet}\` | \`HalfKaHmMerged{...}\` |
| \`HalfKA_hm{N}*{CReLU,SCReLU,Pairwise}\` (aliases.rs ~24 個) | \`HalfKaHmMerged{N}{...}\` |
| \`HalfKA{Stack, Network, FeatureSet}\` | \`HalfKaSplit{...}\` |

## 残置した名前 (スコープ外)

- \`HalfKA_hm_split\` 文字列 literal (parser alias / test arch / エラーメッセージ) — canonical 文字列として正当な使用、保持
- bare struct \`HalfKA_hm\` / \`HalfKA\` (features/half_ka_hm.rs / features/half_ka.rs)、\`NetworkHalfKA_hm\` / \`AccumulatorHalfKA_hm\` / \`BonaPieceHalfKA_hm\` 等 — Issue #728 PR 3 の rename 表が enum 関連型に限定だったため別 PR で
- file / directory rename (\`nnue/halfka/\` → \`nnue/halfka_split/\`、\`bona_piece_halfka.rs\` → \`bona_piece_halfka_split.rs\` 等) — PR 4 (optional) スコープ

## 削除した \`#[allow(non_camel_case_types)]\` (5 ヶ所)

- \`features/mod.rs\`: \`HalfKaHmMergedFeatureSet\` (本 PR で rename した struct、新名は CamelCase)
- \`features/mod.rs\`: \`HalfKaMergedFeatureSet\` / \`HalfKaHmSplitFeatureSet\` (元から CamelCase で redundant)
- \`features/half_ka_merged.rs\`: \`HalfKaMerged\` (同上)
- \`features/half_ka_hm_split.rs\`: \`HalfKaHmSplit\` (同上)

CLAUDE.md「警告抑止のために安易に \`#[allow(...)]\` ... を付けることは禁止」に照らした cleanup。

## Test plan

- [x] \`cargo fmt -p rshogi-core\` clean
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo test --workspace --lib\` 全 pass (rshogi-core 873 + 他で計 1742)
- [x] 実機 USI ロード確認 (release build with \`--features rshogi-usi/nnue-psqt\`): v0.1.0 release attach 7 .bin (HalfKP / HalfKA / HalfKA_merged / HalfKA_hm_split / HalfKA_hm × CReLU + HalfKA_hm × SCReLU/Pairwise) + bullet-shogi v101-400 (HalfKA_hm 1536 LayerStacks bucketed) 計 8 model で \`readyok\`

Closes part of #728 (PR 3/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)