### PR TITLE
refactor(nnue): AccumulatorStackVariant に cfg gate を追加し HalfKX specific preset の workaround を撤去 (Issue #742)

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -151,13 +151,11 @@ edition-universal = [
 ]
 
 # HalfKX family (全 FT / activation dispatch)。
-# 最小 LS data 構造 (ls-arch + ls-size-512x16x32) 同梱の理由は edition-halfkp-crelu の注記参照。
 edition-halfkx     = ["edition-halfkx-any"]
 edition-halfkx-any = [
   "mode-family", "halfkx-arch",
   "ft-halfkp", "ft-halfka_split", "ft-halfka_merged", "ft-halfka_hm_split", "ft-halfka_hm_merged",
   "halfkx-activation-crelu", "halfkx-activation-screlu", "halfkx-activation-pairwise",
-  "ls-arch", "ls-size-512x16x32",
 ]
 
 # LayerStack family (全 size / 全 ext dispatch、現状 FT は halfka_hm_merged のみ)
@@ -170,22 +168,20 @@ edition-ls-any-any-any = [
 ]
 
 # HalfKP specific (suisho5 等)。
-# 注: 現状 `AccumulatorStackVariant::LayerStacks` variant が cfg gate なしで常在の
-# ため、ls-size-* がゼロの build では LS data 構造が空 enum 化して dead code 警告が
-# 出る。これを避けるため最小 LS data 構造 (ls-arch + ls-size-512x16x32) を同梱して
-# いる。AccumulatorStackVariant に cfg gate を入れる別 refactor で純粋 HalfKX
-# specific 化予定。
+# `AccumulatorStackVariant::LayerStacks` / `NNUENetwork::LayerStacks` の enum variant
+# と LS 実行時 state (acc_cache field) は `ls-arch` で cfg gate されるため、HalfKX
+# specific edition には含めない。`LayerStacksAccCache` 型と `evaluate_dispatch` の
+# シグネチャは public API 互換のため非 ls-arch build にも残るが、HalfKX-only run では
+# `Option<LayerStacksAccCache>` は常に `None` を取る。
 edition-halfkp-crelu = [
   "mode-specific", "halfkx-arch",
   "ft-halfkp", "halfkx-activation-crelu",
-  "ls-arch", "ls-size-512x16x32",
 ]
 
-# HalfKaHmMerged HalfKX specific。LS 同梱の理由は edition-halfkp-crelu の注記参照。
+# HalfKaHmMerged HalfKX specific。
 edition-halfka_hm_merged-screlu = [
   "mode-specific", "halfkx-arch",
   "ft-halfka_hm_merged", "halfkx-activation-screlu",
-  "ls-arch", "ls-size-512x16x32",
 ]
 
 # LayerStack specific (1536x16x32、全 ext 組合せ)。L0=1536 系は progress-diff 同梱。

--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -723,6 +723,7 @@ impl LayerStacksAccStack {
     }
 
     /// 現在のエントリの dirty_piece を設定
+    #[cfg(feature = "ls-arch")]
     #[inline]
     pub fn set_current_dirty_piece(&mut self, dirty: DirtyPiece) {
         ls_match!(self, s => s.current_mut().dirty_piece = dirty);

--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -13,6 +13,7 @@
 //! L2/L3/活性化の追加時にこのファイルの変更は不要。
 
 use super::accumulator::DirtyPiece;
+#[cfg(feature = "ls-arch")]
 use super::accumulator_layer_stacks::LayerStacksAccStack;
 use super::halfka_hm_merged::HalfKaHmMergedStack;
 use super::halfka_hm_split::HalfKaHmSplitStack;
@@ -46,6 +47,7 @@ pub enum AccumulatorStackVariant {
     /// HalfKP 特徴量セット（L256/L512）
     HalfKP(HalfKPStack),
     /// LayerStacks（L1=1536/768 + 9バケット）
+    #[cfg(feature = "ls-arch")]
     LayerStacks(LayerStacksAccStack),
 }
 
@@ -66,6 +68,7 @@ impl AccumulatorStackVariant {
                 Self::HalfKaHmSplit(HalfKaHmSplitStack::from_network(net))
             }
             NNUENetwork::HalfKP(net) => Self::HalfKP(HalfKPStack::from_network(net)),
+            #[cfg(feature = "ls-arch")]
             NNUENetwork::LayerStacks(net) => Self::LayerStacks(net.new_acc_stack()),
         }
     }
@@ -95,6 +98,7 @@ impl AccumulatorStackVariant {
                 stack.l1_size() == net.l1_size()
             }
             (Self::HalfKP(stack), NNUENetwork::HalfKP(net)) => stack.l1_size() == net.l1_size(),
+            #[cfg(feature = "ls-arch")]
             (Self::LayerStacks(st), NNUENetwork::LayerStacks(net)) => {
                 st.architecture_dims()
                     == (
@@ -116,6 +120,7 @@ impl AccumulatorStackVariant {
             Self::HalfKaMerged(stack) => stack.reset(),
             Self::HalfKaHmSplit(stack) => stack.reset(),
             Self::HalfKP(stack) => stack.reset(),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(stack) => stack.reset(),
         }
     }
@@ -129,6 +134,7 @@ impl AccumulatorStackVariant {
             Self::HalfKaMerged(stack) => stack.push(dirty_piece),
             Self::HalfKaHmSplit(stack) => stack.push(dirty_piece),
             Self::HalfKP(stack) => stack.push(dirty_piece),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(stack) => {
                 stack.push();
                 stack.set_current_dirty_piece(dirty_piece);
@@ -145,6 +151,7 @@ impl AccumulatorStackVariant {
             Self::HalfKaMerged(stack) => stack.pop(),
             Self::HalfKaHmSplit(stack) => stack.pop(),
             Self::HalfKP(stack) => stack.pop(),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(stack) => stack.pop(),
         }
     }
@@ -171,6 +178,7 @@ mod tests {
         let stack = AccumulatorStackVariant::default();
         assert!(stack.is_halfkp());
         assert!(matches!(stack, AccumulatorStackVariant::HalfKP(_)));
+        #[cfg(feature = "ls-arch")]
         assert!(!matches!(stack, AccumulatorStackVariant::LayerStacks(_)));
         assert!(!matches!(stack, AccumulatorStackVariant::HalfKaSplit(_)));
         assert!(!matches!(stack, AccumulatorStackVariant::HalfKaHmMerged(_)));
@@ -315,7 +323,6 @@ mod tests {
 
         // 各スタックのサイズを確認（デバッグ用）
         let variant_size = size_of::<AccumulatorStackVariant>();
-        let layer_stacks_size = size_of::<LayerStacksAccStack>();
         let halfka_stack_size = size_of::<HalfKaHmMergedStack>();
         let halfkp_stack_size = size_of::<HalfKPStack>();
 
@@ -324,7 +331,11 @@ mod tests {
         eprintln!("AccumulatorStackVariant size: {variant_size} bytes");
         eprintln!("HalfKaHmMergedStack size: {halfka_stack_size} bytes");
         eprintln!("HalfKPStack size: {halfkp_stack_size} bytes");
-        eprintln!("LayerStacks size: {layer_stacks_size} bytes");
+        #[cfg(feature = "ls-arch")]
+        {
+            let layer_stacks_size = size_of::<LayerStacksAccStack>();
+            eprintln!("LayerStacks size: {layer_stacks_size} bytes");
+        }
 
         // 列挙型のサイズは最大のバリアントのサイズ + タグ
         assert!(variant_size > 0);

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -30,6 +30,7 @@
 use std::sync::Arc;
 
 use super::accumulator::{AccumulatorCacheGeneric, DirtyPiece};
+#[cfg(feature = "ls-arch")]
 use super::accumulator_layer_stacks::LayerStacksAccCache;
 use super::accumulator_stack_variant::AccumulatorStackVariant;
 use super::halfka_hm_merged::HalfKaHmMergedStack;
@@ -60,6 +61,7 @@ pub struct NNUEEvaluator {
     stack: AccumulatorStackVariant,
     /// LayerStacks 用 AccumulatorCaches（Finny Tables）
     /// LayerStacks アーキテクチャ以外では None
+    #[cfg(feature = "ls-arch")]
     acc_cache: Option<LayerStacksAccCache>,
     /// 非LayerStacks用 AccumulatorCaches（Finny Tables）
     /// HalfKP/HalfKaSplit/HalfKaHmMerged で使用。LayerStacks では None
@@ -79,12 +81,13 @@ impl NNUEEvaluator {
     /// ```
     pub fn new_with_position(net: Arc<NNUENetwork>, pos: &Position) -> Self {
         let stack = AccumulatorStackVariant::from_network(&net);
+        #[cfg(feature = "ls-arch")]
         let acc_cache = if let NNUENetwork::LayerStacks(ls_net) = &*net {
             Some(ls_net.new_acc_cache())
         } else {
             None
         };
-        let acc_cache_generic = if !matches!(*net, NNUENetwork::LayerStacks(_)) {
+        let acc_cache_generic = if !net.is_layer_stacks() {
             Some(AccumulatorCacheGeneric::new(net.l1_size()))
         } else {
             None
@@ -92,6 +95,7 @@ impl NNUEEvaluator {
         let mut evaluator = Self {
             net,
             stack,
+            #[cfg(feature = "ls-arch")]
             acc_cache,
             acc_cache_generic,
         };
@@ -109,12 +113,13 @@ impl NNUEEvaluator {
     ///
     /// - `pos`: 初期化する局面
     pub fn clone_for_thread(&self, pos: &Position) -> Self {
+        #[cfg(feature = "ls-arch")]
         let acc_cache = if let NNUENetwork::LayerStacks(ls_net) = &*self.net {
             Some(ls_net.new_acc_cache())
         } else {
             None
         };
-        let acc_cache_generic = if !matches!(*self.net, NNUENetwork::LayerStacks(_)) {
+        let acc_cache_generic = if !self.net.is_layer_stacks() {
             Some(AccumulatorCacheGeneric::new(self.net.l1_size()))
         } else {
             None
@@ -122,6 +127,7 @@ impl NNUEEvaluator {
         let mut evaluator = Self {
             net: Arc::clone(&self.net),
             stack: AccumulatorStackVariant::from_network(&self.net),
+            #[cfg(feature = "ls-arch")]
             acc_cache,
             acc_cache_generic,
         };
@@ -232,6 +238,7 @@ impl NNUEEvaluator {
             (NNUENetwork::HalfKP(net), AccumulatorStackVariant::HalfKP(st)) => {
                 net.evaluate(pos, st)
             }
+            #[cfg(feature = "ls-arch")]
             (NNUENetwork::LayerStacks(net), AccumulatorStackVariant::LayerStacks(st)) => {
                 net.evaluate(pos, st)
             }
@@ -305,6 +312,7 @@ impl NNUEEvaluator {
                     net.refresh_accumulator(pos, st);
                 }
             }
+            #[cfg(feature = "ls-arch")]
             (NNUENetwork::LayerStacks(net), AccumulatorStackVariant::LayerStacks(st)) => {
                 net.update_accumulator(pos, st, &mut self.acc_cache);
             }
@@ -330,6 +338,7 @@ impl NNUEEvaluator {
             (NNUENetwork::HalfKP(net), AccumulatorStackVariant::HalfKP(st)) => {
                 Self::update_halfkp_accumulator(net, pos, st, &mut self.acc_cache_generic);
             }
+            #[cfg(feature = "ls-arch")]
             (NNUENetwork::LayerStacks(net), AccumulatorStackVariant::LayerStacks(st)) => {
                 net.update_accumulator(pos, st, &mut self.acc_cache);
             }

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -90,11 +90,13 @@ pub use layer_stacks::{
 };
 pub use layers::{AffineTransform, ClippedReLU};
 #[cfg(feature = "ls-arch")]
+pub use network::evaluate_layer_stacks;
+#[cfg(feature = "ls-arch")]
 pub(crate) use network::update_and_evaluate_layer_stacks_cached;
 pub use network::{
     LayerStackBucketMode, NNUENetwork, NnueFormatInfo, SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS,
     compute_layer_stack_progress8kpabs_bucket_index, compute_progress8kpabs_sum, detect_format,
-    ensure_accumulator_computed, evaluate_dispatch, evaluate_layer_stacks, get_fv_scale_override,
+    ensure_accumulator_computed, evaluate_dispatch, get_fv_scale_override,
     get_layer_stack_bucket_mode, get_layer_stack_progress_kpabs_weights, get_network, init_nnue,
     init_nnue_from_bytes, is_halfka_256_loaded, is_halfka_512_loaded, is_halfka_1024_loaded,
     is_halfka_hm_256_loaded, is_halfka_hm_512_loaded, is_halfka_hm_1024_loaded,

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -18,7 +18,9 @@
 //! **「Accumulator は L1 だけで決まる」** を活用し、L2/L3/活性化の追加時に
 //! このファイルの変更は最小限で済む。
 
-use super::accumulator_layer_stacks::{LayerStacksAccCache, LayerStacksAccStack};
+use super::accumulator_layer_stacks::LayerStacksAccCache;
+#[cfg(feature = "ls-arch")]
+use super::accumulator_layer_stacks::LayerStacksAccStack;
 use super::accumulator_stack_variant::AccumulatorStackVariant;
 use super::activation::detect_activation_from_arch;
 use super::bona_piece::BonaPiece;
@@ -29,6 +31,7 @@ use super::halfka_hm_split::{HalfKaHmSplitNetwork, HalfKaHmSplitStack};
 use super::halfka_merged::{HalfKaMergedNetwork, HalfKaMergedStack};
 use super::halfka_split::{HalfKaSplitNetwork, HalfKaSplitStack};
 use super::halfkp::{HalfKPNetwork, HalfKPStack};
+#[cfg(feature = "ls-arch")]
 use super::network_layer_stacks::LayerStacksNetwork;
 use super::spec::{Activation, FeatureSet};
 #[cfg(feature = "halfkx-arch")]
@@ -279,6 +282,7 @@ pub enum NNUENetwork {
     /// HalfKP 特徴量セット（L256/L512）
     HalfKP(HalfKPNetwork),
     /// LayerStacks（L1=1536/768 + 9バケット）
+    #[cfg(feature = "ls-arch")]
     LayerStacks(LayerStacksNetwork),
 }
 
@@ -361,33 +365,48 @@ impl NNUENetwork {
                     | NNUEArchitectureOverride::LayerStacksPSQT => FeatureSet::LayerStacks,
                 };
 
-                // PSQT オーバーライド:
-                // LayerStacks → Some(false) (PSQT 強制 OFF)
-                // LayerStacksPSQT → Some(true) (PSQT 強制 ON)
-                // Auto → None (arch_str から自動検出)
-                let psqt_override = match arch_override {
-                    NNUEArchitectureOverride::LayerStacks => Some(false),
-                    NNUEArchitectureOverride::LayerStacksPSQT => Some(true),
-                    _ => None,
-                };
-
                 // LayerStacks は特殊処理（FT が LEB128 圧縮のためファイルサイズ検出の対象外）
                 if effective_feature_set == FeatureSet::LayerStacks {
-                    reader.seek(SeekFrom::Start(0))?;
-                    let (l1_from_arch, l2_from_arch, l3_from_arch) =
-                        super::spec::parse_arch_dimensions(&arch_str);
-                    let l1 = if l1_from_arch == 0 {
-                        1536
-                    } else {
-                        l1_from_arch
-                    };
-                    let (l2, l3) = match (l2_from_arch, l3_from_arch) {
-                        (0, 0) => (16, 32),
-                        dims => dims,
-                    };
-                    let network =
-                        LayerStacksNetwork::read_with_options(reader, l1, l2, l3, psqt_override)?;
-                    return Ok(Self::LayerStacks(network));
+                    #[cfg(feature = "ls-arch")]
+                    {
+                        // PSQT オーバーライド:
+                        // LayerStacks → Some(false) (PSQT 強制 OFF)
+                        // LayerStacksPSQT → Some(true) (PSQT 強制 ON)
+                        // Auto → None (arch_str から自動検出)
+                        let psqt_override = match arch_override {
+                            NNUEArchitectureOverride::LayerStacks => Some(false),
+                            NNUEArchitectureOverride::LayerStacksPSQT => Some(true),
+                            _ => None,
+                        };
+                        reader.seek(SeekFrom::Start(0))?;
+                        let (l1_from_arch, l2_from_arch, l3_from_arch) =
+                            super::spec::parse_arch_dimensions(&arch_str);
+                        let l1 = if l1_from_arch == 0 {
+                            1536
+                        } else {
+                            l1_from_arch
+                        };
+                        let (l2, l3) = match (l2_from_arch, l3_from_arch) {
+                            (0, 0) => (16, 32),
+                            dims => dims,
+                        };
+                        let network = LayerStacksNetwork::read_with_options(
+                            reader,
+                            l1,
+                            l2,
+                            l3,
+                            psqt_override,
+                        )?;
+                        return Ok(Self::LayerStacks(network));
+                    }
+                    #[cfg(not(feature = "ls-arch"))]
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "LayerStacks NNUE model requires the `ls-arch` feature; \
+                             rebuild rshogi-core with an Edition that enables it.",
+                        ));
+                    }
                 }
 
                 // 4. ファイルサイズからアーキテクチャを検出
@@ -470,7 +489,14 @@ impl NNUENetwork {
 
     /// LayerStacks アーキテクチャかどうか
     pub fn is_layer_stacks(&self) -> bool {
-        matches!(self, Self::LayerStacks(_))
+        #[cfg(feature = "ls-arch")]
+        {
+            matches!(self, Self::LayerStacks(_))
+        }
+        #[cfg(not(feature = "ls-arch"))]
+        {
+            false
+        }
     }
 
     /// HalfKaSplit アーキテクチャかどうか
@@ -496,6 +522,7 @@ impl NNUENetwork {
             Self::HalfKaMerged(net) => net.l1_size(),
             Self::HalfKaHmSplit(net) => net.l1_size(),
             Self::HalfKP(net) => net.l1_size(),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(net) => net.l1_size(),
         }
     }
@@ -508,6 +535,7 @@ impl NNUENetwork {
             Self::HalfKaMerged(net) => net.architecture_name(),
             Self::HalfKaHmSplit(net) => net.architecture_name(),
             Self::HalfKP(net) => net.architecture_name(),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(_) => "LayerStacks".to_string(),
         }
     }
@@ -520,6 +548,7 @@ impl NNUENetwork {
             Self::HalfKaMerged(net) => net.architecture_spec(),
             Self::HalfKaHmSplit(net) => net.architecture_spec(),
             Self::HalfKP(net) => net.architecture_spec(),
+            #[cfg(feature = "ls-arch")]
             Self::LayerStacks(net) => net.architecture_spec(),
         }
     }
@@ -527,6 +556,7 @@ impl NNUENetwork {
     /// LayerStacksNetwork への参照を取得
     ///
     /// LayerStacks アーキテクチャでない場合は panic。
+    #[cfg(feature = "ls-arch")]
     pub fn as_layer_stacks(&self) -> &LayerStacksNetwork {
         match self {
             Self::LayerStacks(net) => net,
@@ -1170,6 +1200,7 @@ pub fn get_network() -> Option<Arc<NNUENetwork>> {
 /// 結果を `CACHED_PROGRESS_BUCKET` に格納して `evaluate()` 内の全駒スキャンを回避する。
 /// Threat なし環境では +3〜4% NPS、Threat あり環境では cache 圧迫で退行するため
 /// 運用モデルに応じて明示指定する。
+#[cfg(feature = "ls-arch")]
 #[inline(always)]
 pub(crate) fn update_and_evaluate_layer_stacks_cached(
     net: &LayerStacksNetwork,
@@ -1453,6 +1484,7 @@ pub fn is_halfka_1024_loaded() -> bool {
 ///
 /// # Panics
 /// NNUEが未ロードかつMaterial評価も無効の場合はパニックする。
+#[cfg(feature = "ls-arch")]
 pub fn evaluate_layer_stacks(pos: &Position, stack: &mut LayerStacksAccStack) -> Value {
     if material::is_material_enabled() {
         return material::evaluate_material(pos);
@@ -1484,6 +1516,10 @@ pub fn evaluate_dispatch(
     stack: &mut AccumulatorStackVariant,
     acc_cache: &mut Option<LayerStacksAccCache>,
 ) -> Value {
+    // ls-arch 無効ビルドでは LayerStacks variant が存在せず acc_cache は使われない。
+    #[cfg(not(feature = "ls-arch"))]
+    let _ = acc_cache;
+
     if material::is_material_enabled() {
         return material::evaluate_material(pos);
     }
@@ -1497,6 +1533,7 @@ pub fn evaluate_dispatch(
 
     // バリアントに応じて適切な評価関数を呼び出し
     match stack {
+        #[cfg(feature = "ls-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {
             let net = network.as_layer_stacks();
             update_and_evaluate_layer_stacks_cached(net, pos, s, acc_cache)
@@ -1540,6 +1577,10 @@ pub fn ensure_accumulator_computed(
     stack: &mut AccumulatorStackVariant,
     acc_cache: &mut Option<LayerStacksAccCache>,
 ) {
+    // ls-arch 無効ビルドでは LayerStacks variant が存在せず acc_cache は使われない。
+    #[cfg(not(feature = "ls-arch"))]
+    let _ = acc_cache;
+
     // NNUEがなければ何もしない
     let Some(network) = get_network() else {
         return;
@@ -1547,6 +1588,7 @@ pub fn ensure_accumulator_computed(
 
     // バリアントに応じてアキュムレータを更新（評価はしない）
     match stack {
+        #[cfg(feature = "ls-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {
             let net = network.as_layer_stacks();
             net.update_accumulator(pos, s, acc_cache);
@@ -1776,6 +1818,7 @@ mod tests {
     /// テスト結果 (epoch82.nnue):
     /// - LayerStacks として正しく認識される
     /// - 評価値: 0 (学習初期のモデル)
+    #[cfg(feature = "ls-arch")]
     #[test]
     #[ignore]
     fn test_nnue_network_auto_detect_layer_stacks() {

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -735,6 +735,7 @@ impl LayerStacksNetwork {
     }
 
     /// ファイルから読み込み（exact architecture で dispatch）
+    #[cfg(feature = "ls-arch")]
     pub fn read_with_options<R: Read + Seek>(
         reader: &mut R,
         l1: usize,
@@ -771,6 +772,7 @@ impl LayerStacksNetwork {
     }
 
     /// 評価値を計算
+    #[cfg(feature = "ls-arch")]
     pub fn evaluate(
         &self,
         pos: &Position,
@@ -807,6 +809,7 @@ impl LayerStacksNetwork {
     }
 
     /// アキュムレータを更新（キャッシュ対応）
+    #[cfg(feature = "ls-arch")]
     pub fn update_accumulator(
         &self,
         pos: &Position,
@@ -912,6 +915,7 @@ impl LayerStacksNetwork {
     }
 
     /// 新しい L1 サイズに対応する AccStack を作成
+    #[cfg(feature = "ls-arch")]
     pub fn new_acc_stack(&self) -> super::accumulator_layer_stacks::LayerStacksAccStack {
         match self {
             #[cfg(feature = "ls-size-1536x16x32")]
@@ -949,6 +953,7 @@ impl LayerStacksNetwork {
     }
 
     /// 新しい L1 サイズに対応する AccCache を作成
+    #[cfg(feature = "ls-arch")]
     pub fn new_acc_cache(&self) -> super::accumulator_layer_stacks::LayerStacksAccCache {
         match self {
             #[cfg(feature = "ls-size-1536x16x32")]
@@ -988,8 +993,10 @@ impl LayerStacksNetwork {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ls-size-1536x16x32")]
     use super::*;
     use crate::nnue::constants::{FV_SCALE_HALFKA, NNUE_PYTORCH_L1};
+    #[cfg(feature = "ls-size-1536x16x32")]
     use crate::position::{Position, SFEN_HIRATE};
 
     const TEST_L1: usize = NNUE_PYTORCH_L1;
@@ -1010,6 +1017,7 @@ mod tests {
     /// - FT weight nonzero: 2,143,627
     /// - L1 bias (bucket 0): [-15, 57, -182, -97, -202, -55, 120, 1, 87, -133, -16, 44, -27, -37, -201, -186]
     /// - Initial position score: 0 (epoch82は学習初期のため)
+    #[cfg(feature = "ls-size-1536x16x32")]
     #[test]
     #[ignore]
     fn test_load_layer_stacks_file() {

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -13,7 +13,9 @@ use crate::eval::evaluate_pass_rights;
 use crate::eval::{EvalHash, get_scaled_pass_move_bonus};
 #[cfg(feature = "ls-arch")]
 use crate::nnue::NNUENetwork;
-use crate::nnue::{AccumulatorStackVariant, LayerStacksAccCache, get_network};
+#[cfg(feature = "ls-arch")]
+use crate::nnue::LayerStacksAccCache;
+use crate::nnue::{AccumulatorStackVariant, get_network};
 use crate::position::Position;
 use crate::search::PieceToHistory;
 use crate::tt::{ProbeResult, TTData, TranspositionTable};
@@ -376,6 +378,7 @@ pub struct SearchState {
     pub nnue_stack: AccumulatorStackVariant,
     /// LayerStacks 用 AccumulatorCaches（Finny Tables）
     /// LayerStacks アーキテクチャ以外では None
+    #[cfg(feature = "ls-arch")]
     pub acc_cache: Option<LayerStacksAccCache>,
     /// check_abort呼び出しカウンター
     pub calls_cnt: i32,
@@ -404,6 +407,7 @@ impl SearchState {
             #[cfg(feature = "ls-arch")]
             network_ptr: std::ptr::null(),
             nnue_stack: AccumulatorStackVariant::new_default(),
+            #[cfg(feature = "ls-arch")]
             acc_cache: None,
             calls_cnt: 0,
             #[cfg(feature = "search-stats")]
@@ -754,26 +758,25 @@ impl SearchWorker {
                 self.state.nnue_stack.reset();
             }
             // LayerStacks 用 AccumulatorCaches を初期化
-            if network.is_layer_stacks() {
-                if let crate::nnue::NNUENetwork::LayerStacks(ls_net) = &*network {
-                    // 既存 cache があっても exact architecture が不一致なら破棄。
-                    // 同一プロセスで EvalFile をリロードして LayerStacks 形状が変わった場合、旧 cache
-                    // variant を保持したままだと `LayerStacksNetwork::update_accumulator`
-                    // の cache 経路が pattern match で外れ、Finny-table caching が静かに無効化される。
-                    let need_new_cache = match &self.state.acc_cache {
-                        None => true,
-                        Some(cache) => {
-                            cache.architecture_dims()
-                                != (
-                                    ls_net.architecture_spec().l1,
-                                    ls_net.architecture_spec().l2,
-                                    ls_net.architecture_spec().l3,
-                                )
-                        }
-                    };
-                    if need_new_cache {
-                        self.state.acc_cache = Some(ls_net.new_acc_cache());
+            #[cfg(feature = "ls-arch")]
+            if let crate::nnue::NNUENetwork::LayerStacks(ls_net) = &*network {
+                // 既存 cache があっても exact architecture が不一致なら破棄。
+                // 同一プロセスで EvalFile をリロードして LayerStacks 形状が変わった場合、旧 cache
+                // variant を保持したままだと `LayerStacksNetwork::update_accumulator`
+                // の cache 経路が pattern match で外れ、Finny-table caching が静かに無効化される。
+                let need_new_cache = match &self.state.acc_cache {
+                    None => true,
+                    Some(cache) => {
+                        cache.architecture_dims()
+                            != (
+                                ls_net.architecture_spec().l1,
+                                ls_net.architecture_spec().l2,
+                                ls_net.architecture_spec().l3,
+                            )
                     }
+                };
+                if need_new_cache {
+                    self.state.acc_cache = Some(ls_net.new_acc_cache());
                 }
                 // 新しいゲーム開始時にキャッシュを無効化（usinewgame 経由で呼ばれる）
                 if let Some(cache) = &mut self.state.acc_cache {
@@ -785,7 +788,10 @@ impl SearchWorker {
         } else {
             // NNUE未初期化の場合はデフォルト（HalfKP）でリセット
             self.state.nnue_stack.reset();
-            self.state.acc_cache = None;
+            #[cfg(feature = "ls-arch")]
+            {
+                self.state.acc_cache = None;
+            }
         }
         // check_abort頻度制御カウンターをリセット
         // これにより新しい探索開始時に即座に停止チェックが行われる

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -12,9 +12,9 @@ use std::sync::Arc;
 use crate::eval::evaluate_pass_rights;
 use crate::eval::{EvalHash, get_scaled_pass_move_bonus};
 #[cfg(feature = "ls-arch")]
-use crate::nnue::NNUENetwork;
-#[cfg(feature = "ls-arch")]
 use crate::nnue::LayerStacksAccCache;
+#[cfg(feature = "ls-arch")]
+use crate::nnue::NNUENetwork;
 use crate::nnue::{AccumulatorStackVariant, get_network};
 use crate::position::Position;
 use crate::search::PieceToHistory;

--- a/crates/rshogi-core/src/search/search_helpers.rs
+++ b/crates/rshogi-core/src/search/search_helpers.rs
@@ -131,7 +131,11 @@ pub(super) fn nnue_evaluate(st: &mut SearchState, pos: &Position) -> Value {
             return update_and_evaluate_layer_stacks_cached(net, pos, s, &mut st.acc_cache);
         }
     }
-    evaluate_dispatch(pos, &mut st.nnue_stack, &mut st.acc_cache)
+    #[cfg(feature = "ls-arch")]
+    let acc_cache = &mut st.acc_cache;
+    #[cfg(not(feature = "ls-arch"))]
+    let acc_cache = &mut None;
+    evaluate_dispatch(pos, &mut st.nnue_stack, acc_cache)
 }
 
 /// NNUE アキュムレータを計算済みにする（評価値の計算はしない）
@@ -141,7 +145,11 @@ pub(super) fn nnue_evaluate(st: &mut SearchState, pos: &Position) -> Value {
 #[cfg(feature = "use-lazy-evaluate")]
 #[inline]
 pub(super) fn ensure_nnue_accumulator(st: &mut SearchState, pos: &Position) {
-    ensure_accumulator_computed(pos, &mut st.nnue_stack, &mut st.acc_cache)
+    #[cfg(feature = "ls-arch")]
+    let acc_cache = &mut st.acc_cache;
+    #[cfg(not(feature = "ls-arch"))]
+    let acc_cache = &mut None;
+    ensure_accumulator_computed(pos, &mut st.nnue_stack, acc_cache)
 }
 
 /// do_move + nodes++ + nnue_push をまとめたラッパー

--- a/crates/rshogi-core/tests/build_rs_checks.rs
+++ b/crates/rshogi-core/tests/build_rs_checks.rs
@@ -253,9 +253,9 @@ fn ls_specific_with_ft_halfka_hm_merged_ok() {
 
 #[test]
 fn ls_arch_with_halfkx_arch_specific_ft_halfkp_ok() {
-    // mode-specific + ls-arch + halfkx-arch + ft-halfkp は許容。
-    // ft-halfkp は HalfKX 経路にルーティングされ、LS は ft-halfka_hm_merged 用ではなく
-    // 単に LS data 構造を提供するだけ (HalfKX specific preset の workaround パターン)。
+    // mode-specific + ls-arch + halfkx-arch + ft-halfkp + ls-size-* は許容。
+    // ft-halfkp は HalfKX 経路にルーティングされ、LS data 構造は ls-arch のため確保される。
+    // user が atomic feature を直接指定するこの組合せが build.rs check で reject されないことを保証する。
     let has = lookup(&[
         "mode-specific",
         "ls-arch",

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -330,11 +330,10 @@ impl UsiEngine {
         // 使われないため、ロード済みネットワークが LayerStacks のときだけ検査する。
         {
             use rshogi_core::nnue::{
-                LayerStackBucketMode, NNUENetwork, get_layer_stack_bucket_mode,
+                LayerStackBucketMode, get_layer_stack_bucket_mode,
                 get_layer_stack_progress_kpabs_weights,
             };
-            let is_layer_stacks =
-                matches!(get_network().as_deref(), Some(NNUENetwork::LayerStacks(_)));
+            let is_layer_stacks = get_network().as_deref().is_some_and(|n| n.is_layer_stacks());
             if is_layer_stacks
                 && get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
                 && get_layer_stack_progress_kpabs_weights().iter().all(|&w| w == 0.0)
@@ -1285,7 +1284,7 @@ impl UsiEngine {
         let mut stack = AccumulatorStackVariant::from_network(&network);
 
         if diagnostics {
-            #[cfg(feature = "diagnostics")]
+            #[cfg(all(feature = "diagnostics", feature = "ls-arch"))]
             {
                 use rshogi_core::nnue::{LayerStacksNetwork, NNUENetwork};
                 // diagnostics モード: LayerStacks のみ対応
@@ -1329,8 +1328,17 @@ impl UsiEngine {
                     println!("info string Error: diagnostics is only supported for LayerStacks");
                 }
             }
+            #[cfg(all(feature = "diagnostics", not(feature = "ls-arch")))]
+            {
+                let _ = &network;
+                println!(
+                    "info string Error: 'eval diag' requires the `ls-arch` feature \
+                     (LayerStacks diagnostics)"
+                );
+            }
             #[cfg(not(feature = "diagnostics"))]
             {
+                let _ = &network;
                 println!("info string Error: build with --features diagnostics to use 'eval diag'");
             }
         } else {


### PR DESCRIPTION
## Summary

Issue #735 epic Phase 2-B として、PR #741 (Phase 2-A) で導入した HalfKX specific preset の workaround を構造的に解消する refactor。

- `AccumulatorStackVariant::LayerStacks` / `NNUENetwork::LayerStacks` enum variant に `#[cfg(feature = \"ls-arch\")]` を追加
- `SearchState.acc_cache` field、`LayerStacksNetwork::{read_with_options, evaluate, update_accumulator, new_acc_stack, new_acc_cache}` を同 cfg gate
- HalfKX specific preset (`edition-halfkp-crelu` / `edition-halfka_hm_merged-screlu` / `edition-halfkx-any`) から `ls-arch + ls-size-512x16x32` workaround を撤去
- 非 ls-arch build で LayerStacks モデルロード要求された場合は `io::Error::InvalidData` を返却

## 設計判断

| 項目 | 対応 |
|---|---|
| enum variant + 実行時 state (`SearchState.acc_cache`) | cfg gate (HalfKX-only では完全に消える) |
| 公開型 (`LayerStacksAccCache` / `LayerStacksAccStack` / `LayerStacksNetwork`) | 互換維持 (内部 variant は ls-size-* で gate、ls-arch なしでは空 enum) |
| `evaluate_dispatch` / `ensure_accumulator_computed` の signature | 互換維持 (非 ls-arch では `&mut None` を渡す cfg dispatch) |
| 非 ls-arch で LS model load 要求 | `Err` 返却 (silent ignore せず明示的に失敗) |

設計意図は `crates/rshogi-core/Cargo.toml` の `edition-halfkp-crelu` コメントに明文化。

## 関連

- Closes #742
- Epic: #735
- Blocked by: #741 (Phase 2-A merge 済)
- ADR: `docs/decisions/2026-05-24-build-edition-flavor-design.md`

## Test plan

- [x] `cargo fmt --all`
- [x] `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings` warning ゼロ
- [x] `cargo test --workspace` 全 pass (914 lib + 計 1000+ tests, failed 0)
- [x] `RUSTFLAGS='-D warnings' cargo test -p rshogi-core --no-default-features --features 'search-no-pass-rules,edition-halfkp-crelu' --no-run` warning ゼロ
- [x] 全 preset edition で `RUSTFLAGS='-D warnings' cargo check -p rshogi-usi --no-default-features --features ...` 成功:
  - `edition-universal` / `edition-halfkp-crelu` / `edition-halfka_hm_merged-screlu`
  - `edition-ls-halfka_hm_merged-{1536x16x32-{none,psqt,threat,psqt_threat},1536x32x32-none,768x16x32-none,512x16x32-none}`
  - `edition-halfkx-any` / `edition-ls-any-any-any`
  - 旧 alias build (`layerstack-only,nnue-psqt,layerstacks-1536x16x32`)
- [x] local Codex review APPROVE
- [x] local Claude review APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)