### PR TITLE
refactor(nnue,tools): LS dispatch macro 共通化 + #[allow(unreachable_patterns)] 解消 (#746, #747)

### DIFF
--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -119,6 +119,8 @@ pub use network_layer_stacks::NetworkLayerStacks1536x16x32;
 #[cfg(all(feature = "ls-size-1536x32x32", feature = "ft-halfka_hm_merged"))]
 pub use network_layer_stacks::NetworkLayerStacks1536x32x32;
 pub use network_layer_stacks::{LayerStacksNetwork, LsNetByFt, NetworkLayerStacks};
+// `#[macro_export]` で crate root に出る ls_dispatch_ft_size! を nnue:: パスからも参照可能にする。
+pub use crate::ls_dispatch_ft_size;
 pub use piece_list::{PieceList, PieceNumber};
 
 // const generics 版統一実装（内部型は pub(crate) に隠蔽）

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -853,6 +853,11 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
         // (self, stack) tuple match で同じ L1 variant の組のみ matched arm を持つ。
         // 2 サイズ以上 enable のときだけ cross-pair の不一致 arm が到達可能で、
         // 単一 size build では 1 arm の match 自体が exhaustive となる。
+        //
+        // 以下の 6-pair cfg は本 file 内で 4 箇所 (本 fallback / update_accumulator
+        // の net_dims / stack_dims / fallback) に同じ式を持つ。LS サイズ追加時は
+        // すべての any(all(...)) を C(N,2) に揃えて同期更新すること (match arm は
+        // item ではないため共通 cfg を file-local macro に括り出せない)。
         match (self, stack) {
             #[cfg(feature = "ls-size-1536x16x32")]
             (

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -850,6 +850,9 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
         pos: &Position,
         stack: &super::accumulator_layer_stacks::LayerStacksAccStack,
     ) -> Value {
+        // (self, stack) tuple match で同じ L1 variant の組のみ matched arm を持つ。
+        // 2 サイズ以上 enable のときだけ cross-pair の不一致 arm が到達可能で、
+        // 単一 size build では 1 arm の match 自体が exhaustive となる。
         match (self, stack) {
             #[cfg(feature = "ls-size-1536x16x32")]
             (
@@ -871,7 +874,14 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
                 Self::L512x16x32(net),
                 super::accumulator_layer_stacks::LayerStacksAccStack::L512x16x32(st),
             ) => net.evaluate(pos, &st.current().accumulator),
-            #[allow(unreachable_patterns)]
+            #[cfg(any(
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-1536x32x32"),
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-768x16x32"),
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-512x16x32"),
+                all(feature = "ls-size-1536x32x32", feature = "ls-size-768x16x32"),
+                all(feature = "ls-size-1536x32x32", feature = "ls-size-512x16x32"),
+                all(feature = "ls-size-768x16x32", feature = "ls-size-512x16x32"),
+            ))]
             _ => panic!(
                 "LayerStacksNetwork / LayerStacksAccStack の L1 サイズが不一致 (net={:?}, stack={:?})",
                 self.architecture_dims(),
@@ -888,7 +898,26 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
         stack: &mut super::accumulator_layer_stacks::LayerStacksAccStack,
         cache: &mut Option<super::accumulator_layer_stacks::LayerStacksAccCache>,
     ) {
+        // mismatch arm の panic で表示する用に事前計算しておく (stack は match 内で
+        // mutable borrow されるため arm 内では参照できない)。2 サイズ以上 enable の
+        // ときだけ mismatch arm が到達可能なので同じ cfg gate を共有する。
+        #[cfg(any(
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-1536x32x32"),
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-768x16x32"),
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-512x16x32"),
+            all(feature = "ls-size-1536x32x32", feature = "ls-size-768x16x32"),
+            all(feature = "ls-size-1536x32x32", feature = "ls-size-512x16x32"),
+            all(feature = "ls-size-768x16x32", feature = "ls-size-512x16x32"),
+        ))]
         let net_dims = self.architecture_dims();
+        #[cfg(any(
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-1536x32x32"),
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-768x16x32"),
+            all(feature = "ls-size-1536x16x32", feature = "ls-size-512x16x32"),
+            all(feature = "ls-size-1536x32x32", feature = "ls-size-768x16x32"),
+            all(feature = "ls-size-1536x32x32", feature = "ls-size-512x16x32"),
+            all(feature = "ls-size-768x16x32", feature = "ls-size-512x16x32"),
+        ))]
         let stack_dims = stack.architecture_dims();
         macro_rules! do_update {
             ($net:expr, $stack:expr, $cache_variant:ident) => {{
@@ -972,7 +1001,14 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
             ) => {
                 do_update!(net, st, L512x16x32);
             }
-            #[allow(unreachable_patterns)]
+            #[cfg(any(
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-1536x32x32"),
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-768x16x32"),
+                all(feature = "ls-size-1536x16x32", feature = "ls-size-512x16x32"),
+                all(feature = "ls-size-1536x32x32", feature = "ls-size-768x16x32"),
+                all(feature = "ls-size-1536x32x32", feature = "ls-size-512x16x32"),
+                all(feature = "ls-size-768x16x32", feature = "ls-size-512x16x32"),
+            ))]
             _ => panic!(
                 "LayerStacksNetwork / LayerStacksAccStack の L1 サイズが不一致 (net={:?}, stack={:?})",
                 net_dims, stack_dims
@@ -1113,6 +1149,129 @@ pub enum LayerStacksNetwork {
     HalfKaSplit(LsNetByFt<HalfKaSplitSpec>),
     #[cfg(feature = "ft-halfkp")]
     HalfKP(LsNetByFt<HalfKpSpec>),
+}
+
+/// `LayerStacksNetwork` の FT × L1 軸を 1 段 match で展開する公開マクロ。
+///
+/// 5 FT × 4 L1 = 20 (FT, L1) 組合せを `all(ft-*, ls-size-*)` cfg gate 付きで列挙し、
+/// マッチした variant の内部 `&NetworkLayerStacks<L1, ..., FT>` (concrete 型) を
+/// `$inner` として body に渡す。tools crate (bench / eval / verify) の dispatch
+/// マクロをこれに統合することで、FT/L1 軸が増えたときの 3 ファイル同時更新漏れを防ぐ。
+///
+/// マッチアームは呼び出し crate 側の cfg を見て展開されるため、`rshogi-core` 側で
+/// 有効な variant を caller 側がすべては有効化していない場合に備えて `_ =>`
+/// fallback を引数として受け取る。caller のすべての (`ft-*`, `ls-size-*`) feature が
+/// 揃っている = 20 arm で exhaustive なときは fallback arm を cfg gate でドロップし、
+/// `#[allow(unreachable_patterns)]` を不要にする。
+///
+/// 構文 (既存の `with_ls_net!` 等と互換):
+/// ```ignore
+/// use rshogi_core::nnue::ls_dispatch_ft_size;
+/// ls_dispatch_ft_size!(ls_net, |net| {
+///     run_layer_stack_bench(net, /* ... */)?;
+/// }, _ => bail!("有効な LayerStacks (FT × L1) バリアントがありません"))
+/// ```
+#[macro_export]
+macro_rules! ls_dispatch_ft_size {
+    ($net:expr, |$inner:ident| $body:expr, _ => $fallback:expr $(,)?) => {
+        match $net {
+            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmMerged(
+                $crate::nnue::LsNetByFt::L1536x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x32x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmMerged(
+                $crate::nnue::LsNetByFt::L1536x32x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-768x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmMerged(
+                $crate::nnue::LsNetByFt::L768x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-512x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmMerged(
+                $crate::nnue::LsNetByFt::L512x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmSplit(
+                $crate::nnue::LsNetByFt::L1536x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x32x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmSplit(
+                $crate::nnue::LsNetByFt::L1536x32x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-768x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmSplit(
+                $crate::nnue::LsNetByFt::L768x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-512x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaHmSplit(
+                $crate::nnue::LsNetByFt::L512x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaMerged(
+                $crate::nnue::LsNetByFt::L1536x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x32x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaMerged(
+                $crate::nnue::LsNetByFt::L1536x32x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-768x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaMerged(
+                $crate::nnue::LsNetByFt::L768x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-512x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaMerged(
+                $crate::nnue::LsNetByFt::L512x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaSplit(
+                $crate::nnue::LsNetByFt::L1536x16x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x32x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaSplit(
+                $crate::nnue::LsNetByFt::L1536x32x32($inner),
+            ) => $body,
+            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-768x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaSplit($crate::nnue::LsNetByFt::L768x16x32(
+                $inner,
+            )) => $body,
+            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-512x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKaSplit($crate::nnue::LsNetByFt::L512x16x32(
+                $inner,
+            )) => $body,
+            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKP($crate::nnue::LsNetByFt::L1536x16x32(
+                $inner,
+            )) => $body,
+            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x32x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKP($crate::nnue::LsNetByFt::L1536x32x32(
+                $inner,
+            )) => $body,
+            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-768x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKP($crate::nnue::LsNetByFt::L768x16x32(
+                $inner,
+            )) => $body,
+            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-512x16x32"))]
+            $crate::nnue::LayerStacksNetwork::HalfKP($crate::nnue::LsNetByFt::L512x16x32(
+                $inner,
+            )) => $body,
+            // caller の (ft-*, ls-size-*) を 5 × 4 全部有効化したときは 20 arm が
+            // exhaustive。そのときだけ fallback arm を cfg gate でドロップして
+            // unreachable warning を避ける。
+            #[cfg(not(all(
+                feature = "ft-halfka_hm_merged",
+                feature = "ft-halfka_hm_split",
+                feature = "ft-halfka_merged",
+                feature = "ft-halfka_split",
+                feature = "ft-halfkp",
+                feature = "ls-size-1536x16x32",
+                feature = "ls-size-1536x32x32",
+                feature = "ls-size-768x16x32",
+                feature = "ls-size-512x16x32",
+            )))]
+            _ => $fallback,
+        }
+    };
 }
 
 /// LayerStacksNetwork の FT variants を網羅する dispatch マクロ。

--- a/crates/tools/src/bench_nnue_eval_tool.rs
+++ b/crates/tools/src/bench_nnue_eval_tool.rs
@@ -24,9 +24,9 @@ use clap::Parser;
 use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::nnue::{
     AccumulatorCacheLayerStacks, AccumulatorLayerStacks, DirtyPiece, LayerStackBucketMode,
-    LayerStacksNetwork, LsFeatureSpec, LsNetByFt, NNUEEvaluator, NNUENetwork, NetworkLayerStacks,
+    LsFeatureSpec, NNUEEvaluator, NNUENetwork, NetworkLayerStacks,
     SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, compute_layer_stack_progress8kpabs_bucket_index,
-    get_layer_stack_progress_kpabs_weights, parse_layer_stack_bucket_mode,
+    get_layer_stack_progress_kpabs_weights, ls_dispatch_ft_size, parse_layer_stack_bucket_mode,
     set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
     sqr_clipped_relu_transform,
 };
@@ -642,61 +642,6 @@ fn run_layer_stack_bench<
     Ok(())
 }
 
-/// LayerStacksNetwork の FT × L1 dispatch マクロ。
-///
-/// FT 軸 (5 variants) と L1 軸 (4 variants) を 1 段の match で展開する。
-/// 各 (FT, L1) 組合せを explicit に列挙することで、nested macro による dead-code
-/// 検出の誤検出を回避する。Result の `?` を呼び出し側で使えるよう、クロージャでは
-/// なく match arm 直接展開とする。
-macro_rules! with_ls_net {
-    ($ls_net:expr, |$inner:ident| $body:expr) => {
-        match $ls_net {
-            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x16x32"))]
-            LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x32x32"))]
-            LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x32x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-768x16x32"))]
-            LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L768x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-512x16x32"))]
-            LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L512x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x16x32"))]
-            LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x32x32"))]
-            LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x32x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-768x16x32"))]
-            LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L768x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-512x16x32"))]
-            LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L512x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x16x32"))]
-            LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x32x32"))]
-            LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x32x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-768x16x32"))]
-            LayerStacksNetwork::HalfKaMerged(LsNetByFt::L768x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-512x16x32"))]
-            LayerStacksNetwork::HalfKaMerged(LsNetByFt::L512x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x16x32"))]
-            LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x32x32"))]
-            LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x32x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-768x16x32"))]
-            LayerStacksNetwork::HalfKaSplit(LsNetByFt::L768x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-512x16x32"))]
-            LayerStacksNetwork::HalfKaSplit(LsNetByFt::L512x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x16x32"))]
-            LayerStacksNetwork::HalfKP(LsNetByFt::L1536x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x32x32"))]
-            LayerStacksNetwork::HalfKP(LsNetByFt::L1536x32x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-768x16x32"))]
-            LayerStacksNetwork::HalfKP(LsNetByFt::L768x16x32($inner)) => $body,
-            #[cfg(all(feature = "ft-halfkp", feature = "ls-size-512x16x32"))]
-            LayerStacksNetwork::HalfKP(LsNetByFt::L512x16x32($inner)) => $body,
-            #[allow(unreachable_patterns)]
-            _ => bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
-        }
-    };
-}
-
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     let mode = BenchMode::parse(&cli.mode)?;
@@ -770,17 +715,21 @@ pub fn run() -> Result<()> {
                 bail!("LayerStack 専用モードは LayerStacks NNUE のみ対応");
             };
 
-            with_ls_net!(ls_net, |net| {
-                run_layer_stack_bench(
-                    net,
-                    mode,
-                    &positions,
-                    bucket_mode,
-                    cli.warmup,
-                    cli.iterations,
-                    &arch_name,
-                )?;
-            });
+            ls_dispatch_ft_size!(
+                ls_net,
+                |net| {
+                    run_layer_stack_bench(
+                        net,
+                        mode,
+                        &positions,
+                        bucket_mode,
+                        cli.warmup,
+                        cli.iterations,
+                        &arch_name,
+                    )?;
+                },
+                _ => bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
+            );
         }
     }
 

--- a/crates/tools/src/eval_sfens_tool.rs
+++ b/crates/tools/src/eval_sfens_tool.rs
@@ -16,11 +16,11 @@ use std::mem::size_of;
 use std::path::PathBuf;
 
 use rshogi_core::nnue::{
-    AccumulatorLayerStacks, AffineTransform, FeatureSet, LayerStackBucketMode, LayerStacksNetwork,
-    LsFeatureSpec, LsNetByFt, NNUE_PYTORCH_L3, NNUENetwork, NetworkLayerStacks,
-    SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, compute_layer_stack_progress8kpabs_bucket_index,
-    get_layer_stack_progress_kpabs_weights, set_layer_stack_bucket_mode,
-    set_layer_stack_progress_kpabs_weights, sqr_clipped_relu_transform,
+    AccumulatorLayerStacks, AffineTransform, FeatureSet, LayerStackBucketMode, LsFeatureSpec,
+    NNUE_PYTORCH_L3, NNUENetwork, NetworkLayerStacks, SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS,
+    compute_layer_stack_progress8kpabs_bucket_index, get_layer_stack_progress_kpabs_weights,
+    ls_dispatch_ft_size, set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
+    sqr_clipped_relu_transform,
 };
 use rshogi_core::position::Position;
 use rshogi_core::types::Color;
@@ -403,56 +403,11 @@ pub fn run() -> Result<()> {
         _ => anyhow::bail!("eval_sfens は LayerStacks NNUE のみ対応"),
     };
 
-    macro_rules! with_network {
-        ($net:expr, |$inner:ident| $body:expr) => {
-            match $net {
-                #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x16x32"))]
-                LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x32x32"))]
-                LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x32x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-768x16x32"))]
-                LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L768x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-512x16x32"))]
-                LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L512x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x16x32"))]
-                LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x32x32"))]
-                LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x32x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-768x16x32"))]
-                LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L768x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-512x16x32"))]
-                LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L512x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x16x32"))]
-                LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x32x32"))]
-                LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x32x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-768x16x32"))]
-                LayerStacksNetwork::HalfKaMerged(LsNetByFt::L768x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-512x16x32"))]
-                LayerStacksNetwork::HalfKaMerged(LsNetByFt::L512x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x16x32"))]
-                LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x32x32"))]
-                LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x32x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-768x16x32"))]
-                LayerStacksNetwork::HalfKaSplit(LsNetByFt::L768x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-512x16x32"))]
-                LayerStacksNetwork::HalfKaSplit(LsNetByFt::L512x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x16x32"))]
-                LayerStacksNetwork::HalfKP(LsNetByFt::L1536x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x32x32"))]
-                LayerStacksNetwork::HalfKP(LsNetByFt::L1536x32x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfkp", feature = "ls-size-768x16x32"))]
-                LayerStacksNetwork::HalfKP(LsNetByFt::L768x16x32($inner)) => $body,
-                #[cfg(all(feature = "ft-halfkp", feature = "ls-size-512x16x32"))]
-                LayerStacksNetwork::HalfKP(LsNetByFt::L512x16x32($inner)) => $body,
-                #[allow(unreachable_patterns)]
-                _ => anyhow::bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
-            }
-        };
-    }
-
-    with_network!(ls_net, |concrete_net| run_eval_for_network(&cli, concrete_net))
+    ls_dispatch_ft_size!(
+        ls_net,
+        |concrete_net| run_eval_for_network(&cli, concrete_net),
+        _ => anyhow::bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
+    )
 }
 
 #[cfg(test)]

--- a/crates/tools/src/verify_nnue_accumulator_tool.rs
+++ b/crates/tools/src/verify_nnue_accumulator_tool.rs
@@ -22,8 +22,8 @@ use std::path::PathBuf;
 use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::nnue::{
     AccumulatorLayerStacks, LayerStackBucketMode, LayerStacksNetwork, LsFeatureSpec, NNUENetwork,
-    NetworkLayerStacks, SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, set_layer_stack_bucket_mode,
-    set_layer_stack_progress_kpabs_weights,
+    NetworkLayerStacks, SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, ls_dispatch_ft_size,
+    set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
 };
 use rshogi_core::position::Position;
 
@@ -161,87 +161,11 @@ fn load_progress_coeff_weights(coeff_path: &PathBuf) -> Result<Box<[f32]>> {
 
 /// LayerStacksNetwork の FT × L1 軸を網羅して `verify_with_network` を呼び出す。
 fn ls_verify_dispatch(net: &LayerStacksNetwork, cli: &Cli) -> Result<(usize, usize)> {
-    use rshogi_core::nnue::LsNetByFt;
-    match net {
-        #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x16x32"))]
-        LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-1536x32x32"))]
-        LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L1536x32x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-768x16x32"))]
-        LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L768x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_merged", feature = "ls-size-512x16x32"))]
-        LayerStacksNetwork::HalfKaHmMerged(LsNetByFt::L512x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x16x32"))]
-        LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-1536x32x32"))]
-        LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L1536x32x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-768x16x32"))]
-        LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L768x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_hm_split", feature = "ls-size-512x16x32"))]
-        LayerStacksNetwork::HalfKaHmSplit(LsNetByFt::L512x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x16x32"))]
-        LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-1536x32x32"))]
-        LayerStacksNetwork::HalfKaMerged(LsNetByFt::L1536x32x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-768x16x32"))]
-        LayerStacksNetwork::HalfKaMerged(LsNetByFt::L768x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_merged", feature = "ls-size-512x16x32"))]
-        LayerStacksNetwork::HalfKaMerged(LsNetByFt::L512x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x16x32"))]
-        LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-1536x32x32"))]
-        LayerStacksNetwork::HalfKaSplit(LsNetByFt::L1536x32x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-768x16x32"))]
-        LayerStacksNetwork::HalfKaSplit(LsNetByFt::L768x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfka_split", feature = "ls-size-512x16x32"))]
-        LayerStacksNetwork::HalfKaSplit(LsNetByFt::L512x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x16x32"))]
-        LayerStacksNetwork::HalfKP(LsNetByFt::L1536x16x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfkp", feature = "ls-size-1536x32x32"))]
-        LayerStacksNetwork::HalfKP(LsNetByFt::L1536x32x32(inner)) => {
-            verify_with_network(cli, inner)
-        }
-        #[cfg(all(feature = "ft-halfkp", feature = "ls-size-768x16x32"))]
-        LayerStacksNetwork::HalfKP(LsNetByFt::L768x16x32(inner)) => verify_with_network(cli, inner),
-        #[cfg(all(feature = "ft-halfkp", feature = "ls-size-512x16x32"))]
-        LayerStacksNetwork::HalfKP(LsNetByFt::L512x16x32(inner)) => verify_with_network(cli, inner),
-        #[allow(unreachable_patterns)]
+    ls_dispatch_ft_size!(
+        net,
+        |inner| verify_with_network(cli, inner),
         _ => anyhow::bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
-    }
+    )
 }
 
 pub fn run() -> Result<()> {


### PR DESCRIPTION
## Summary

- **Issue #746**: `rshogi-core` に `#[macro_export] ls_dispatch_ft_size!` を新設し、tools の 3 binary (`bench_nnue_eval` / `eval_sfens` / `verify_nnue_accumulator`) で個別に列挙していた 5 FT × 4 L1 = 20 arm の dispatch を共通化。FT/L1 軸が追加されたとき 1 箇所だけ更新すれば済む。
- **Issue #747**: 既存 5 箇所の `#[allow(unreachable_patterns)]` を cfg-gated fallback に置換。
  - `LsNetByFt::evaluate` / `update_accumulator`: 「≥2 ls-size 同時 enable」の C(4,2)=6 pair `any(all(...))` cfg で wildcard arm を gate。`update_accumulator` の `net_dims` / `stack_dims` 変数も同じ cfg を共有し未使用変数 warning を回避。
  - tools 共通マクロ: `#[cfg(not(all(5 ft + 4 ls-size 全 enable)))]` で fallback arm を gate。caller の `_ => bail!(...)` を受け取る形式に再設計。

## 設計判断

- 共通マクロは `rshogi-core::nnue::ls_dispatch_ft_size`。`#[macro_export]` で crate root に出し、`pub use crate::ls_dispatch_ft_size;` で `nnue::` パスからも参照可能。
- 既存 `ls_match_ft!` / `ls_match_size!` (private) は `LayerStacksNetwork` 内部 dispatch (`architecture_dims` / `fv_scale` 等) で引き続き使用。新マクロは tools 用に独立。
- fallback arm を caller 側に渡させる構造 `(net, |inner| body, _ => fallback)` にすることで、caller の `Result<T>` 戻り型・`anyhow::bail!` / `bail!` どちらにも適応。
- `update_accumulator` の `net_dims` / `stack_dims` 計算を cfg gate するのは、未使用変数を `_` prefix で誤魔化さず `#[allow(unused_variables)]` も使わない正攻法。

## 関連

- Closes #746
- Closes #747
- 前作業 PR #745 (LS FT generic 化、Issue #734): https://github.com/SH11235/rshogi/pull/745
- CLAUDE.md「警告抑止のために安易に `#[allow(...)]` 禁止」に準拠

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets --tests -- -D warnings` warning ゼロ
- [x] `cargo test --workspace` 全 pass
- [x] 主要 preset edition で `RUSTFLAGS='-D warnings' cargo check` 成功:
  - `edition-universal`
  - `edition-ls`
  - `edition-ls-halfka_hm_merged-1536x16x32-none`
  - `edition-ls-halfkp-1536x16x32-none`
  - `edition-halfkp-crelu`
- [x] tools default build (5 FT + 1 ls-size) と tools 9 features 全 enable build いずれも clippy warning ゼロ (fallback arm の cfg gate 動作確認)
- [x] `verify_nnue_accumulator --moves 50` を 10 .bin (5 FT × PSQT on/off) で実行 → 500/500 PASS
- [x] `bench_nnue_eval --mode layer-stack-eval` を 5 FT 代表モデルで実行 → 1.7M-2.8M evals/sec で正常動作
- [x] local Codex (`codex:codex-rescue`) review APPROVE
- [x] local independent Claude (`general-purpose`) review APPROVE