### PR TITLE
chore(release): rshogi v1.0.0 (rshogi-core 0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,115 +1,233 @@
 # Changelog
 
-破壊的変更と移行手順をまとめる。詳細は各 PR / runbook を参照。
+リリースごとの主要変更点と移行手順をまとめる。詳細は各 PR / runbook を参照。
 
-## Unreleased — 2026-05 SPSA v4 (fishtest 整合)
+GitHub Release tag は engine 全体 (USI engine + CSA server + tools + spsa) の release
+marker として `vX.Y.Z` を打つ。crates.io 上の `rshogi-core` は別系列 (0.x semver) で
+運用しており、library API の互換性は core のバージョンで判断する
+(`crates/rshogi-core/Cargo.toml`)。
 
-fishtest 主リファレンス (`server/fishtest/spsa_handler.py` /
-`worker/games.py`) と整合させる v4 改修。「パラメータは動くが棋力が下がる」
-報告に対する根本対応として、SPSA アルゴリズムの 4 つの中核バグを修正する。
+## v1.0.0 — 2026-05-24
 
-### Breaking changes (CLI)
+GitHub 上初の正式リリース。USI engine としての対局動作 (floodgate / WCSC 系運用) が
+安定稼働に到達した時点のスナップショット。同時に crates.io `rshogi-core` を
+0.2.4 → 0.3.0 (semver minor bump、後述 API 変更を反映) として publish。
 
-- **`--total-pairs N` (新, 必須)**: SPSA 全体の game pair 数 (= fishtest
-  `num_iter`)。`total_games = 2 × N`。
-- **`--batch-pairs B` (新, 既定 8)**: 1 batch あたりの game pair 数。1 batch
-  内で同 flip ベクトルで `2B` 局を消化し、batch 末で θ を 1 回更新する
-  (k は `+= B`、fishtest worker の `iter += game_pairs` と等価)。
-- **`--iterations` / `--games-per-iteration` (deprecated)**: 併用すると
-  warning + 自動換算 (`total_pairs = gpi × iters / 2`,
-  `batch_pairs = gpi / 2`) で 1 リリース猶予。
+### 対応 NNUE アーキテクチャ
+
+LayerStacks (LS, tatara 学習形式) と HalfKX (Simple-arch, suisho5 互換) の 2 系統に対応。
+
+**LayerStacks 系**
+
+- Feature Transformer 5 種類:
+  - HalfKP
+  - HalfKaSplit / HalfKaMerged
+  - HalfKaHmSplit / HalfKaHmMerged
+- L1 サイズ 4 構成:
+  - 1536×16×32 / 1536×32×32 / 768×16×32 / 512×16×32
+- 活性化: CReLU / SCReLU / Pairwise
+- 拡張: PSQT (Piece-Square Table accumulator) / Threat (HandThreat 特徴量)
+- バケット選択: `progress8kpabs` mode (YaneuraOu 互換 `progress.bin` で 8 buckets を選択。
+  LS 自体は 9-bucket バンク構造で、bucket8 は現状 mode で未使用)
+- preset edition feature でビルド構成を切替 (`edition-universal` / `edition-ls` /
+  `edition-ls-{ft}-{L1}-{ext}` 等)
+
+**HalfKX 系 (Simple-arch)**
+
+- 5 種類の feature set: HalfKP / HalfKaSplit / HalfKaMerged / HalfKaHmSplit /
+  HalfKaHmMerged
+- 活性化: CReLU / SCReLU / Pairwise
+- 主な L1 サイズ: 256 / 512 / 1024 / 1536
+- AVX-512BW SIMD パス対応 (FT 差分更新)
+
+**運用機能**
+
+- プロセス間 NNUE 重み共有メモリ: 多プロセス対局時の PSS メモリを 8 プロセスで
+  3780 → 2276 MB に削減
+- USI オプション `EvalFile` / `FV_SCALE` / `NNUE_ARCHITECTURE` 等で実行時に切替
+
+### 主要 engine 機能
+
+- **探索**: Stockfish 13 系統のアルゴリズム移植 (PVS, LMR, LMP, null-move, ProbCut,
+  IID, SE, history heuristics, multi-cut, futility, razoring 等)
+- **TT (transposition table)**: 16-bit key、cluster-based、generation-aware
+  (YaneuraOu 一致)
+- **mate_1ply**: 1 手詰めの高速判定
+- TT cutoff quiet bonus / small ProbCut beta が SPSA でチューニング可能
+- **NNUE 評価**: 上記 NNUE アーキテクチャによる局面評価
+- **incremental update + Finny Tables**: 差分更新 + KP-abs cache + PSQT cache
+- **時間管理**: byoyomi / inc / time control 各種、ponder 対応 (`PonderhitHandle`)
+- **WASM/WASI ターゲット対応**: SIMD128 SCReLU 実装
+
+### CSA Server (rshogi-csa-server / rshogi-csa-server-tcp / rshogi-csa-server-workers)
+
+- floodgate 互換 CSA protocol 実装
+- 平手 / 駒落ち (初期局面パターン) / Buoy 対局 / 観戦
+- 重複ログイン制御 / LOGIN handle whitelist (security hardening 済)
+- x1 拡張コマンド: VERSION / HELP / WHO / LIST / SHOW
+- 2 deployment target: TCP daemon / Cloudflare Workers (WASM, Durable Objects)
+- Workers 側は Pulumi で IaC 化 (Cloudflare 側設定、cron 監視 Worker)
+
+### Tools (crates/tools)
+
+- **tournament**: USI engine 同士の対局、複数 engine 同時比較
+- **analyze_selfplay**: tournament 結果から SPRT 含む post-hoc 解析
+- **spsa**: SPSA 自動チューニング (本リリース内で fishtest 整合 v4 改修済)
+- **bench_nnue_eval**: NNUE 推論の throughput bench
+- **verify_nnue_accumulator**: refresh vs differential update 一致テスト
+- **dump_psqt_stats**: quantised.bin の PSQT 統計ダンプ
+- **eval_sfens**: SFEN テキストから LayerStacks NNUE で局面評価
+- **gensfen / pack_to_psv / psv_to_jsonl / rescore_psv 系**: 教師局面生成と
+  packed SFEN フォーマット I/O
+
+### rshogi-core 0.3.0 (crates.io)
+
+0.2.4 以降の public API 変更を集約。0.x 系列の minor bump として breaking change を
+含む (crates.io 上の外部 user 想定はゼロのため安全に minor bump で処理)。
+
+#### Breaking changes (API)
+
+- **PascalCase 命名統一** (#729 / #730 / #731 / #732):
+  FeatureSet enum / 関連型 alias / 構造体名 / ファイル名 / ディレクトリ名を PascalCase
+  に統一。旧 alias (`parse_feature_set_from_arch` 経由) は受理可能で arch 文字列レベル
+  の後方互換は維持。
+- **Atomic feature の Edition 軸再編** (#736 / #741):
+  旧 `feature-*` 系 atomic feature を Edition 軸 ADR
+  (`docs/decisions/2026-05-24-build-edition-flavor-design.md`) に沿って再編。
+  `edition-universal` / `edition-ls` / `edition-ls-{ft}-{L1}-{ext}` / `edition-halfkp-crelu`
+  などの preset を使う運用に変更。`ls-arch` の意味論も再定義。
+- **LayerStack network の FT generic 化** (#745):
+  `NetworkLayerStacks` に FT type parameter を追加し、`LsNetByFt<FT>` で L1 軸 dispatch
+  する 2-tier enum に再構成。
+- **AccumulatorStackVariant の cfg gate** (#744):
+  HalfKX specific preset の workaround を撤去し、active feature で variant を制御。
+- **LS dispatch macro 共通化** (#749):
+  `rshogi_core::nnue::ls_dispatch_ft_size!` を `#[macro_export]` で公開。tools 3 binary
+  の dispatch macro を統合し、5 FT × 4 L1 の更新ポイントを 1 箇所に集約。
+  同時に `#[allow(unreachable_patterns)]` 5 箇所を cfg-gated fallback に置換 (#747)。
+
+#### 機能追加 (API)
+
+- HalfKaMerged / HalfKaHmSplit feature set を engine に追加 (#719)
+- Simple-arch 5 feature set に SCReLU / Pairwise 活性化を追加 (#721)
+- arch 文字列を構造マーカで bucket-less / LayerStacks / 活性化検出 (#717)
+- NNUE 重みのプロセス間共有メモリを実装 (#714)
+- Finny Tables (AccCacheEntry) に PSQT accumulator を追加 (#705)
+- `dump_psqt_stats` ツール (#696)
+- `add/sub_psqt_weights` を SIMD 化 (NPS +3.0%) (#687)
+- Threat / HandThreat 特徴量と LayerStacks 周辺改修 (#466)
+- `NNUE_ARCHITECTURE` USI オプション (#437)
+- PSQT ショートカット推論対応 (#436)
+- `PonderhitHandle`: clone-able な ponderhit signal API (#589)
+
+#### バグ修正
+
+- Simple-arch SCReLU 推論の 2 バグを修正 (#723)
+- `l1_sqr_clipped_relu_activation` の AVX2 i32 乗算オーバーフロー修正 (#416)
+  — NNUE 評価値が崩れる重大バグ
+- A-15 King 開き王手でクラッシュするバグ修正 (#432)
+
+#### Performance
+
+- Simple-arch FT 差分更新の sub+add 融合 fast path (#725)
+- Simple-arch FT に AVX-512BW SIMD パスを追加 (#726)
+- LS dispatch 経路の dead-code 検出最適化
+
+---
+
+### spsa CLI (v3 → v4, fishtest 整合)
+
+fishtest 主リファレンス (`server/fishtest/spsa_handler.py` / `worker/games.py`) と
+整合させる v4 改修。「パラメータは動くが棋力が下がる」報告の根本対応として SPSA
+アルゴリズムの 4 つの中核バグを修正。
+
+#### Breaking changes (CLI)
+
+- **`--total-pairs N` (新, 必須)**: SPSA 全体の game pair 数 (= fishtest `num_iter`)。
+  `total_games = 2 × N`。
+- **`--batch-pairs B` (新, 既定 8)**: 1 batch あたりの game pair 数。1 batch 内で同 flip
+  ベクトルで `2B` 局を消化し、batch 末で θ を 1 回更新する (k は `+= B`、fishtest
+  worker の `iter += game_pairs` と等価)。
+- **`--iterations` / `--games-per-iteration` (deprecated)**: 併用すると warning + 自動
+  換算 (`total_pairs = gpi × iters / 2`, `batch_pairs = gpi / 2`) で 1 リリース猶予。
 - **`--seeds` (削除)** / **`--parallel-seeds` (削除)**: hard error で停止する。
-  multi-seed の探索は **`--seed` を変えた独立 run dir** を並列実行する運用に
-  置き換え。
-- **`--stats-aggregate-csv` / `--no-stats-aggregate-csv` (削除)**: clap で
-  unknown argument エラー。複数 run の比較は外部スクリプト (pandas/awk で
+  multi-seed の探索は **`--seed` を変えた独立 run dir** を並列実行する運用に置き換え。
+- **`--stats-aggregate-csv` / `--no-stats-aggregate-csv` (削除)**: clap で unknown
+  argument エラー。複数 run の比較は外部スクリプト (pandas/awk で
   `runs/spsa_seed*/stats.csv` を concat) で行う。
-- **`--seed S` (維持)**: 単一 base_seed の挙動は同じ。SPSA の RNG stream は
-  seed と batch index から決定論的に生成。
+- **`--seed S` (維持)**: 単一 base_seed の挙動は同じ。SPSA の RNG stream は seed と
+  batch index から決定論的に生成。
 
-### Breaking changes (format / CSV)
+#### Breaking changes (format / CSV)
 
-- **`meta.json` `format_version` v3 → v4**: 新フィールド `total_pairs` /
-  `batch_pairs` / `completed_pairs` を追加。
-- **v3 silent migration**: `format_version=3` の meta は warning を出して
-  自動 migrate する (`completed_iterations × batch_pairs` で `completed_pairs`
-  を再構築)。multi-seed run / 奇数 `games_per_iteration` の v3 meta は
-  schema 上自動検出できないため、最終値を新 run の canonical として再投入する
-  (`crates/tools/docs/spsa_runbook.md` §10.7 参照)。
+- **`meta.json` `format_version` v3 → v4**: 新フィールド `total_pairs` / `batch_pairs`
+  / `completed_pairs` を追加。
+- **v3 silent migration**: `format_version=3` の meta は warning を出して自動 migrate
+  する (`completed_iterations × batch_pairs` で `completed_pairs` を再構築)。multi-seed
+  run / 奇数 `games_per_iteration` の v3 meta は schema 上自動検出できないため、最終値
+  を新 run の canonical として再投入する (`crates/tools/docs/spsa_runbook.md` §10.7 参照)。
 - **`stats.csv` 列変更**:
   - 撤去: `seed`
   - rename: `games` → `batch_pairs` (値の意味も「game 数」から「game pair 数」)
   - 1 batch = 1 行 (v3 までは 1 iter あたり seed 数の行が出ていた)
 - **`stats_aggregate.csv` (撤去)**: 自動生成されない。
 - **`state.params` / `final.params` / `values.csv` の int 値**: `42` 形式から
-  `42.000000` 形式に変更。θ 内部状態を f64 のまま保持するため (v3 までの
-  resume 経由で小数部が消える退行を解消)。parser は f64 なので互換あり。
+  `42.000000` 形式に変更。θ 内部状態を f64 のまま保持するため (v3 までの resume 経由で
+  小数部が消える退行を解消)。parser は f64 なので互換あり。
 
-### 主要バグ修正
+#### 主要バグ修正 (SPSA)
 
-- **B-1 paired antithetic** (#TBD): pair 内 2 局で同じ start_pos を共有し、
-  `plus_is_black` のみ反転。v3 では pair 内で別 start_pos を抽選していたため
-  開局選択ノイズが完全には相殺されていなかった。
-- **B-2 1 batch = 1 update**: 1 batch で同 flip ベクトル + 同 plus/minus 値を
-  使い、batch 末で θ を 1 回更新。schedule の k 軸を「累積 game pair 数」に
-  再定義。
-- **B-3 stochastic rounding + RNG stream 分離**: is_int 型 SPSA param の θ
-  内部状態を f64 のまま保持し、engine 送信時のみ `floor(v + U(0,1))` で
-  確率的丸め。clamp → round → 再 clamp で範囲外滑り込みを吸収。RNG stream を
-  flip / rounding / startpos 用に salt XOR で分離。**棋力低下の主因への
-  根本対応**。
+- **B-1 paired antithetic**: pair 内 2 局で同じ start_pos を共有し、`plus_is_black` のみ
+  反転。v3 では pair 内で別 start_pos を抽選していたため開局選択ノイズが完全には相殺
+  されていなかった。
+- **B-2 1 batch = 1 update**: 1 batch で同 flip ベクトル + 同 plus/minus 値を使い、
+  batch 末で θ を 1 回更新。schedule の k 軸を「累積 game pair 数」に再定義。
+- **B-3 stochastic rounding + RNG stream 分離**: is_int 型 SPSA param の θ 内部状態を
+  f64 のまま保持し、engine 送信時のみ `floor(v + U(0,1))` で確率的丸め。clamp → round
+  → 再 clamp で範囲外滑り込みを吸収。RNG stream を flip / rounding / startpos 用に
+  salt XOR で分離。**棋力低下の主因への根本対応**。
 - **B-4 ponder=off / NetworkDelay=0 強制**: 既存実装で固定済み (確認のみ)。
 - **B-5 multi-seed 機能の全廃**: `SeedRunContext` / `SeedGameStats` /
   `AggregateIterationStats` / `stats_aggregate.csv` / `resolve_seeds` /
   `mean_and_variance` / `panic_payload_to_string` を削除。
 
-### 移行チェックリスト
+#### 関連 PR (spsa v4)
 
-既存運用スクリプトをこのリポジトリ外で持っているなら、以下のパターンを grep:
+- `feat(spsa)!: fishtest 整合の v4 改修 (paired antithetic / stochastic rounding / multi-seed 撤去)` (#604)
 
-```bash
-rg '\-\-seeds\b|\-\-parallel\-seeds|\-\-games\-per\-iteration|\-\-iterations \
-   |stats_aggregate\.csv|stats-aggregate-csv'
-```
+### tournament CLI / spsa CLI (2026-04 系)
 
-### 関連 PR
+#### tournament
 
-- `feat(spsa)!: fishtest 整合の v4 改修 (paired antithetic / stochastic rounding / multi-seed 撤去)`
-
-## Unreleased — 2026-04 SPSA 系破壊的変更
-
-### tournament CLI
-
-- `--engine-usi-option` はデフォルトで共通 `--usi-option` にマージし、同じキーは
-  engine 個別指定が上書きするように変更。旧挙動の完全置換が必要な場合は
+- `--engine-usi-option` はデフォルトで共通 `--usi-option` にマージし、同じキーは engine
+  個別指定が上書きするように変更。旧挙動の完全置換が必要な場合は
   `--strict-engine-usi-option` を指定する。
-- engine read timeout 時に、EvalFile 未指定・NNUE 読み込み遅延・isready 中の
-  panic を疑うヒントと、取得できた engine stderr の直近行を出すようにした。
+- engine read timeout 時に、EvalFile 未指定・NNUE 読み込み遅延・isready 中の panic を
+  疑うヒントと、取得できた engine stderr の直近行を出すようにした。
 
-### spsa CLI
+#### spsa (safety / observability series)
 
 - `--params <path>` を完全削除 (deprecation alias なし)。代替は `--run-dir <dir>`。
   run-dir 配下に固定レイアウトで派生ファイルを配置する (#579)
-- `--init-from` の暗黙スキップを禁止。既存 state がある状態で `--init-from`
-  を指定すると `--resume` または `--force-init` が必須 (#576)
+- `--init-from` の暗黙スキップを禁止。既存 state がある状態で `--init-from` を指定すると
+  `--resume` または `--force-init` が必須 (#576)
 - `meta.json` format_version を 3 に bump。旧形式の meta は再開不可 (#576)
-- 起動時に `=== SPSA Startup Summary ===` を stderr に出力 (init mode と
-  active params 上位 5 件を確認できる) (#577)
+- 起動時に `=== SPSA Startup Summary ===` を stderr に出力 (init mode と active params
+  上位 5 件を確認できる) (#577)
 - `iter 0 snapshot` を `values.csv` に記録するように変更 (#577)
-- `rshogi_to_yo_params`: rshogi default 値の混入を 95% 一致閾値で検知し
-  warn/error。`--allow-rshogi-defaults` / `--strict-rshogi-defaults` を新設 (#578)
-- `<run-dir>/.lock` で同 run-dir の二重起動を排他制御。残留 lock は
-  `--force-unlock` で削除 (#580)
-- 既存 state.params + フラグなし起動を bail に変更。canonical なしで
-  既存 state を起点にしたい場合は `--use-existing-state-as-init` を明示指定
-  (silent fresh start は事故の温床だったため) (#580)
-- `meta.json` format_version 3 → 4。`current_params_sha256` を追加し、resume
-  時に on-disk state.params の hash と meta が一致しなければ bail (write_params
-  → save_meta の transactional 復旧検証) (#580)
-- SPSA 正常完了時に `<run-dir>/final.params` を atomic に書き出し。
-  `tune.py apply` には `state.params` ではなく `final.params` を渡すこと (#580)
+- `rshogi_to_yo_params`: rshogi default 値の混入を 95% 一致閾値で検知し warn/error。
+  `--allow-rshogi-defaults` / `--strict-rshogi-defaults` を新設 (#578)
+- `<run-dir>/.lock` で同 run-dir の二重起動を排他制御。残留 lock は `--force-unlock` で
+  削除 (#580)
+- 既存 state.params + フラグなし起動を bail に変更。canonical なしで既存 state を起点
+  にしたい場合は `--use-existing-state-as-init` を明示指定 (silent fresh start は事故の
+  温床だったため) (#580)
+- `meta.json` format_version 3 → 4。`current_params_sha256` を追加し、resume 時に
+  on-disk state.params の hash と meta が一致しなければ bail (#580)
+- SPSA 正常完了時に `<run-dir>/final.params` を atomic に書き出し。`tune.py apply` には
+  `state.params` ではなく `final.params` を渡すこと (#580)
 
-### ファイル名 / パスの移行表
+#### ファイル名 / パスの移行表
 
 | 旧 | 新 (run-dir 直下) |
 |---|---|
@@ -119,7 +237,7 @@ rg '\-\-seeds\b|\-\-parallel\-seeds|\-\-games\-per\-iteration|\-\-iterations \
 | `<run>/tuned.params.stats.csv` | `<run>/stats.csv` |
 | `<run>/tuned.params.stats_aggregate.csv` | `<run>/stats_aggregate.csv` |
 
-### CLI 移行表
+#### CLI 移行表
 
 | 旧 | 新 |
 |---|---|
@@ -127,7 +245,7 @@ rg '\-\-seeds\b|\-\-parallel\-seeds|\-\-games\-per\-iteration|\-\-iterations \
 | (resume) `spsa --params RUN/tuned.params --resume ...` | `spsa --run-dir RUN --resume ...` |
 | (やり直し) `rm -rf RUN && spsa --params ... --init-from ...` | `spsa --run-dir RUN --init-from CANON --force-init ...` |
 
-### 移行チェックリスト
+#### 移行チェックリスト
 
 既存運用スクリプトをこのリポジトリ外で持っているなら、以下のパターンを grep:
 
@@ -135,11 +253,14 @@ rg '\-\-seeds\b|\-\-parallel\-seeds|\-\-games\-per\-iteration|\-\-iterations \
 rg 'tuned\.params|--params |\.values\.csv|\.stats\.csv|\.stats_aggregate\.csv|\.meta\.json'
 ```
 
-旧 run dir からの継続は不可 (`tuned.params` は新 run の `--init-from` に渡し
-fresh start で seed として再利用する。詳細は `crates/tools/docs/spsa_runbook.md`
-§10.7 参照)。
+```bash
+rg '\-\-seeds\b|\-\-parallel\-seeds|\-\-games\-per\-iteration|\-\-iterations |stats_aggregate\.csv|stats-aggregate-csv'
+```
 
-### 関連 PR
+旧 run dir からの継続は不可 (`tuned.params` は新 run の `--init-from` に渡し fresh
+start で seed として再利用する。詳細は `crates/tools/docs/spsa_runbook.md` §10.7 参照)。
+
+#### 関連 PR (spsa safety / observability)
 
 - #576 — safety core (state machine, force-init, meta v3, atomic I/O)
 - #577 — observability (iter 0, startup summary, stderr 統一)
@@ -147,3 +268,10 @@ fresh start で seed として再利用する。詳細は `crates/tools/docs/sps
 - #579 — `--params` 廃止 + `--run-dir` 採用 + ドキュメント整理
 - #580 — checkpoint safety (lock + state hash + use-existing 明示化 + final.params)
 - #581 — runbook §10.7 命名整理 + run-dir integration test (fake USI engine)
+
+---
+
+### Archive tag (release ではない)
+
+- `archive/nnue-unadopted-features-20260415` — 採用しなかった NNUE 実験を保管する archive。
+  release tag ではない。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "rshogi-core"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ NNUE 学習には [bullet-shogi](https://github.com/SH11235/bullet-shogi/tree/sh
 
 ```toml
 [dependencies]
-rshogi-core = "0.2"
+rshogi-core = "0.3"
 ```
 
 ## ビルド

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rshogi-core"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 authors = ["SH11235"]
 description = "A high-performance shogi engine core library with NNUE evaluation"

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -23,7 +23,7 @@ env_logger.workspace = true
 # Local dependencies
 # rshogi-core の default features は本 crate の default で明示的に再構築する
 # (preset edition specific build 時に複数 edition が unify されるのを防ぐため)。
-rshogi-core = { version = "0.2", path = "../rshogi-core", default-features = false }
+rshogi-core = { version = "0.3", path = "../rshogi-core", default-features = false }
 
 [features]
 # default は rshogi-core 側 default (search-no-pass-rules + edition-universal) と一致させる。


### PR DESCRIPTION
## Summary

GitHub 上初の正式リリース準備。USI engine としての対局動作 (floodgate / WCSC 系運用) が安定稼働に到達した時点のスナップショットとして v1.0.0 を打つ。同時に crates.io `rshogi-core` を **0.2.4 → 0.3.0** (semver minor bump、API rename / preset edition 再編 / FT generic 化を反映) へ publish 予定。

## 運用方針 (合意済)

- **GitHub tag**: engine 全体 (USI engine + CSA server + tools + spsa) の release marker (`vX.Y.Z`)
- **crates.io `rshogi-core`**: 別系列の semver。0.x のまま運用継続、API rename が落ち着いたタイミングで別途 1.0 化を判断
- 両者の Version 番号は独立、対応関係は CHANGELOG で明示

## 変更内容

- `crates/rshogi-core/Cargo.toml`: version 0.2.4 → 0.3.0
- `crates/rshogi-usi/Cargo.toml`: `rshogi-core` 依存 pin `"0.2"` → `"0.3"`
- `Cargo.lock`: 上記 bump の反映
- `README.md`: インストール例 `rshogi-core = "0.2"` → `"0.3"`
- `CHANGELOG.md`:
  - 既存 `Unreleased — 2026-05 SPSA v4` / `Unreleased — 2026-04 SPSA` を `## v1.0.0 — 2026-05-24` 配下に統合
  - 「対応 NNUE アーキテクチャ」「主要 engine 機能」「CSA Server」「Tools」「rshogi-core 0.3.0 (Breaking changes / 機能追加 / バグ修正 / Performance)」「spsa v3→v4」「tournament/spsa 2026-04 系」のサブセクションを構成
  - 冒頭に GitHub tag と crates.io `rshogi-core` の独立 semver 運用方針を記載

## Post-merge 手順

1. `git tag v1.0.0` を merge commit に打ち、`git push origin v1.0.0`
2. `cargo publish -p rshogi-core` で 0.3.0 を crates.io へ
3. `gh release create v1.0.0` で GitHub Release を作成

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets --tests -- -D warnings` warning ゼロ
- [x] `cargo test --workspace` 全 pass (1500+ tests)
- [x] `cargo publish -p rshogi-core --dry-run --allow-dirty` 成功 (150 files, 2.8 MiB packaged, 認証 OK)
- [x] local Codex (`codex:codex-rescue`) review APPROVE (修正 4 件反映後)
- [x] local independent Claude (`general-purpose`) review APPROVE (修正 2 件反映後)