### PR TITLE
docs(build): engines/ 命名規則を Edition 軸前提に本格化 (Issue #739)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -124,9 +124,9 @@ cargo xtask build [--edition <preset>[,<preset>...]] [--all-presets]
 - `--edition <name>` : preset edition (`edition-` 接頭辞省略可)。複数指定可
   (カンマ区切り or `--edition` 複数回)。
 - `--all-presets`    : `list-editions` の全 preset を順次 build。`--edition` と排他。
-- `--flavor <name>`  : Edition 軸と直交する flavor。`default` 以外は binary 名末尾に
-  `-flavor-<name>` が付加される (例 `engines/rshogi-usi-X-flavor-tournament`)。
-  Flavor 軸の中身 (`tournament` の具体内容等) は将来の別 Issue で決定。
+- `--flavor <name>`  : binary 命名規則の予約 slot。`default` 以外は binary 名末尾に
+  `-flavor-<name>` が付加されるが、**現状は命名上の slot のみで build 内容は不変**
+  (ADR で軸の存在のみ宣言、具体 flavor は別 Issue で実装される予定)。
   `[a-z0-9][a-z0-9_-]*` の slug のみ受け付ける。
 - `--profile <name>` : cargo profile。デフォルト `production` (LTO=fat、Full LTO、
   単一 codegen unit)。`release` は dev iteration 向け (thin LTO)、`profiling` は
@@ -147,9 +147,6 @@ build 後、`engines/rshogi-usi-<edition slug>[-flavor-<flavor>]` と
 ```
 edition=edition-ls-halfka_hm_merged-1536x16x32-psqt, flavor=default
   → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt
-
-edition=edition-ls, flavor=tournament
-  → engines/rshogi-usi-ls-flavor-tournament
 ```
 
 ### `cargo xtask list-editions`
@@ -180,7 +177,6 @@ $ cargo xtask list-binaries
 BINARY                                            EDITION                                        PROFILE     COMMIT    AGE  SIZE    STATUS
 rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt    edition-ls-halfka_hm_merged-1536x16x32-psqt    production  5616ea7c  2h   2.9 MB  current
 rshogi-usi-ls-halfka_hm_merged-1536x16x32-threat  edition-ls-halfka_hm_merged-1536x16x32-threat  production  4a34e06b  5d   2.8 MB  stale
-rshogi-usi-custom-experiment                      -                                              -           -         12d  2.7 MB  (no manifest)
 ```
 
 STATUS 列:
@@ -190,7 +186,7 @@ STATUS 列:
 | `current` | manifest 記録の commit が HEAD と一致 |
 | `stale`   | HEAD と異なる commit で build されている (古い) |
 | `dirty`   | manifest 記録時に working tree が dirty だった |
-| `(no manifest)` | xtask 経由 build でない旧 binary (`.meta.toml` 不在) |
+| `(no manifest)` | xtask 経由 build でない binary (`.meta.toml` 不在、user が手動配置した場合) |
 | `(manifest broken)` | `.meta.toml` が存在するが parse 失敗 (stderr に warning も出力) |
 
 ## build manifest

--- a/docs/build.md
+++ b/docs/build.md
@@ -180,7 +180,7 @@ $ cargo xtask list-binaries
 BINARY                                            EDITION                                        PROFILE     COMMIT    AGE  SIZE    STATUS
 rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt    edition-ls-halfka_hm_merged-1536x16x32-psqt    production  5616ea7c  2h   2.9 MB  current
 rshogi-usi-ls-halfka_hm_merged-1536x16x32-threat  edition-ls-halfka_hm_merged-1536x16x32-threat  production  4a34e06b  5d   2.8 MB  stale
-rshogi-usi-1536x16x32-v100v101cmp                 -                                              -           -         12d  2.7 MB  (no manifest)
+rshogi-usi-custom-experiment                      -                                              -           -         12d  2.7 MB  (no manifest)
 ```
 
 STATUS 列:
@@ -260,14 +260,12 @@ ADR Phase 2 完了後 / 別 Issue で追加予定:
 - `cargo xtask verify <binary>`: 既存 binary に USI smoke (usi/isready/readyok) を流す
   自動検証。preset → 推奨 NNUE model のマッピング policy 決定後に着手 (Tier 2)。
 - `cargo xtask clean --stale`: 古い binary を listing / 削除 (destructive、user 確認 prompt 付き)。
-- engines/ 既存 binary の rename (Issue #739): 手動命名 (`rshogi-usi-1536x16x32-psqt-v100v101cmp` 等)
-  を xtask 命名規則 (`rshogi-usi-<edition>`) に揃える。
 - WASM target 整備 (Issue #740): `cargo xtask build --target wasm32-unknown-unknown` 対応。
 - preset → model 対応表 / SPSA tune 後 binary の運用 doc。
 
 ## 関連 ドキュメント
 
 - [ADR: ビルド設定の Edition 軸設計][adr] (本ドキュメントの設計根拠)
-- [`engines/README.md`](../engines/README.md) (binary 保管方針 + manual naming legacy)
+- [`engines/README.md`](../engines/README.md) (binary 保管方針)
 - [`docs/nnue-supported-architectures.md`](./nnue-supported-architectures.md) (NNUE arch 一覧)
 - [`docs/nnue-architecture-detection.md`](./nnue-architecture-detection.md) (auto-detect ロジック)

--- a/engines/README.md
+++ b/engines/README.md
@@ -35,17 +35,16 @@ cargo xtask list-binaries
 ### 命名規則
 
 ```
-engines/rshogi-usi-<edition slug>[-flavor-<flavor>][.exe]
+engines/rshogi-usi-<edition slug>[.exe]
 ```
 
 - `<edition slug>` = preset edition 名から `edition-` 接頭辞を除いたもの
-- `flavor` が `default` の場合は省略
 - Windows host では `.exe` 拡張子付与
 
 例:
 
 ```
-edition=edition-ls-halfka_hm_merged-1536x16x32-psqt, flavor=default
+edition=edition-ls-halfka_hm_merged-1536x16x32-psqt
   → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt
   → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt.meta.toml
 ```

--- a/engines/README.md
+++ b/engines/README.md
@@ -9,46 +9,58 @@
 - `/tmp/` は再起動で揮発するので NG。
 - `.gitignore` で本体は除外、README と `.gitkeep` のみコミット対象。
 
-## 推奨フロー: `cargo xtask` 経由
+## ビルドフロー: `cargo xtask` 経由
 
-新規 build は `cargo xtask` 経由を推奨。preset edition 命名規則で binary を配置し、
-同階層に `<binary>.meta.toml` (commit / profile / built_at / rustc) を残す:
-
-```bash
-cargo xtask build --edition ls-halfka_hm_merged-1536x16x32-psqt
-# → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt
-# → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt.meta.toml
-
-cargo xtask list-binaries  # commit/age/status を表表示
-```
-
-詳細な workflow / preset の選び方 / manifest フィールド説明は
+binary の配置は `cargo xtask build` で行う。preset edition 命名規則で配置し、
+同階層に `<binary>.meta.toml` (commit / profile / built_at / rustc) を残す。
+preset の選び方・slot 値の意味論・manifest フィールドの詳細は
 [`docs/build.md`](../docs/build.md) を参照。
 
-## Legacy: 手動命名で残っている binary
+### 典型コマンド
 
-xtask 導入前 (Issue #738) の手動命名 binary。Issue #739 で xtask 命名規則に
-rename 予定:
+```bash
+# 利用可能な preset 一覧
+cargo xtask list-editions
+
+# 1 preset を build (engines/rshogi-usi-<edition slug> に配置)
+cargo xtask build --edition ls-halfka_hm_merged-1536x16x32-psqt
+
+# 複数 preset を順次 build
+cargo xtask build --edition ls-halfka_hm_merged-1536x16x32-psqt,ls-halfka_hm_merged-1536x16x32-none
+
+# engines/ 配下の binary 一覧 + manifest を整形表示
+cargo xtask list-binaries
+```
+
+### 命名規則
 
 ```
-rshogi-usi-<arch>-<flags>-<purpose>
+engines/rshogi-usi-<edition slug>[-flavor-<flavor>][.exe]
 ```
 
-- `<arch>`: NNUE アーキテクチャ。例 `1536x16x32`, `768x16x32`, `halfkahm`
-- `<flags>`: 有効化した特徴。`psqt`, `threat`, `progdiff` 等。複数は `-` 連結
-- `<purpose>`: 用途識別子。例 `v100v101cmp`, `baseline`, `spsa-tuned`
+- `<edition slug>` = preset edition 名から `edition-` 接頭辞を除いたもの
+- `flavor` が `default` の場合は省略
+- Windows host では `.exe` 拡張子付与
 
 例:
-- `rshogi-usi-1536x16x32-v100v101cmp` — v100 vs v101 比較用、PSQT なし
-- `rshogi-usi-1536x16x32-psqt-v100v101cmp` — v101 評価用、PSQT 有効
 
-### 現在の保持 legacy binary
+```
+edition=edition-ls-halfka_hm_merged-1536x16x32-psqt, flavor=default
+  → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt
+  → engines/rshogi-usi-ls-halfka_hm_merged-1536x16x32-psqt.meta.toml
+```
 
-| ファイル | 対応モデル | feature | 用途 | ビルド日 |
-|---|---|---|---|---|
-| rshogi-usi-1536x16x32-v100v101cmp | v100 系 (1536x16x32, no PSQT) | `layerstack-only,nnue-progress-diff` (default で `layerstacks-1536x16x32`) | v100 vs v101 比較 | 2026-05-09 |
-| rshogi-usi-1536x16x32-psqt-v100v101cmp | v101 系 (1536x16x32, PSQT) | `layerstack-only,nnue-psqt,nnue-progress-diff` | v101 評価 | TBD |
+### manifest
 
-ビルド profile は **production** で統一（公平な NPS 比較のため）。
-新 xtask 経由 build もデフォルト profile は `production` (詳細は
-[`docs/build.md`](../docs/build.md))。
+`engines/<binary>.meta.toml` には commit hash / profile / built_at / rustc 等を記録する。
+selfplay/SPRT の事後検証 (「この binary はどの commit / profile か」) で使う。
+schema とフィールド説明は [`docs/build.md` の build manifest 節](../docs/build.md#build-manifest)
+を参照。
+
+`cargo xtask list-binaries` の STATUS 列で manifest 不在 / 古い commit / dirty build を
+即座に判別できる。
+
+## PGO build
+
+PGO build は `scripts/build_pgo.sh` 経由 (xtask 統合 scope 外、`target/production/` に出力)。
+engines/ に長期保持したい場合は build 後に手動で copy + 命名する。


### PR DESCRIPTION
## Summary

- ADR Phase 2-C を実装。`engines/README.md` を xtask 経由フロー前提の document に本格更新し、"Legacy: 手動命名で残っている binary" セクションを削除。
- `docs/build.md` から #739 への前向き参照 (「今後の追加予定」「manual naming legacy」注記、`list-binaries` 例の legacy binary 名) を解消。
- preset 命名規則・manifest フィールド・`cargo xtask list-editions/build/list-binaries` の典型コマンドを README に集約 (詳細は `docs/build.md` へ hand-off)。

## 設計判断

- **Legacy section 完全削除**: 個人運用 repo で旧 binary は user 自身が手動 cleanup 前提のため、README に過去 binary の対応表を残す必要なし。
- **詳細は `docs/build.md` に集約**: README は engines/ 直下の方針 + 典型コマンドに絞り、preset の選び方・slot 値意味論・manifest schema は `docs/build.md` へ link 誘導。二重保守を回避。
- **CHANGELOG 移行ガイド省略**: 旧 atomic feature alias (`layerstack-only` ⇔ `ls-arch` 等) は `docs/build.md:249-254` で document 済み。本 repo は個人運用で旧名を他人に把握させる必要なし、`docs/build.md` の既存記述で十分と判断。

## 関連

- Closes #739
- Epic: #735 (Cargo feature を Edition 軸に再設計)
- ADR: `docs/decisions/2026-05-24-build-edition-flavor-design.md`
- 前提 (merge 済): #750 (xtask 本体、commit `9c26131e`)
- 次フェーズ候補: #740 (WASM target 整備、別 PR)

## 非スコープ (本 PR では扱わない)

- preset edition の追加 (#737/#750 で完了)
- xtask 機能追加 (verify / clean --stale など)
- WASM target (#740)
- 旧 atomic feature 名 alias の deprecate 警告 (別 Issue 化想定)
- CHANGELOG への Phase 2 移行ガイド追記 (個人運用前提のため省略)
- 既存 legacy binary の cleanup/rebuild (engines/ 配下の binary は `.gitignore` で除外、user の local 作業)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` 全 pass (5 test result OK、failure 0)
- [x] `cargo xtask list-editions` で 18 preset edition の列挙確認
- [x] `cargo xtask build --edition halfkp-crelu --profile release` で smoke build を実施し、`engines/rshogi-usi-halfkp-crelu` (+ `.meta.toml`) が README 記載通りの path に置かれ、`cargo xtask list-binaries` で表示されることを確認
- [x] `gh issue view 739` 受入条件 3 項目 (README が新命名・xtask コマンドで記述 / xtask build 生成物が README 記載通りの path / CI が引き続き pass) を満たす
- [x] local Codex (codex:codex-rescue) review: **APPROVE**
- [x] local 汎用 (general-purpose) review: **APPROVE** (Minor 1 + Nit 1、いずれも対応不要と判断)