### PR TITLE
fix(nnue): HalfKp LayerStack の玉 BonaPiece OOR panic を修正

### DIFF
--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -1088,6 +1088,9 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
         } else {
             piece_list_owned = {
                 let mut pl = *raw_piece_list;
+                // piece_list の玉スロット 2 つ (PieceNumber::KING=先手玉, KING+1=後手玉)
+                // を ZERO 化。slot 38/39 が両玉に予約されているのは piece_list.rs の
+                // PIECE_NUMBER_BASE で確定。
                 pl[PieceNumber::KING as usize] = BonaPiece::ZERO;
                 pl[(PieceNumber::KING + 1) as usize] = BonaPiece::ZERO;
                 pl

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -1433,6 +1433,10 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
         // ここで検出して slow path (`append_changed_indices` 経由、玉 BP を除外する)
         // にフォールバックする。INCLUDE_KING_IN_PIECE_LIST は const なので HalfKa*
         // 系では分岐ごと dead-code eliminate される。
+        //
+        // `dirty_num == 0` (パス手・盤面変化なし) の場合は `dn == 0` で本ループは
+        // no-op、続く `match dirty_piece.dirty_num` の `_ => false` で fallback する
+        // ため、guard 自体の早期 return は不要。
         if !FT::INCLUDE_KING_IN_PIECE_LIST {
             use super::bona_piece::FE_END;
             let dn = dirty_piece.dirty_num as usize;
@@ -2315,18 +2319,8 @@ mod tests {
         smoke_refresh_for_spec::<HalfKpSpec>();
     }
 
-    /// HalfKp + cache 経由 refresh: 玉成り/捕獲含む複雑な ply32 局面で
-    /// `refresh_or_cache` 内の `idx_fn(king_BP)` OOR を踏まないことを保証する。
-    /// 修正前は `feature_transformer_layer_stacks.rs:31` の
-    /// `feature_index_out_of_range` で panic していた。
-    ///
-    /// 期待動作:
-    /// 1. 初回 refresh (cache miss): piece_list 40 slot 走査時に玉スロットを
-    ///    BonaPiece::ZERO でマスクして idx_fn を呼ばないこと
-    /// 2. 同局面でもう一度 refresh (cache hit, piece_list 不変): 差分 0 で
-    ///    cache の accumulation をそのまま返すこと
-    /// 3. 相手玉が異なる位置の派生局面 (cache hit, 玉 slot 差分のみ): 玉 slot
-    ///    マスクにより差分 0 と認識し、再び idx_fn を呼ばないこと
+    /// HalfKp + cache 経由 refresh で玉 BonaPiece (`>= FE_END`) を `idx_fn` に渡さない
+    /// ことを ply32 局面 (駒成り + 駒台手駒あり) と相手玉位置違い派生局面で保証する。
     #[test]
     fn refresh_with_cache_halfkp_complex_position() {
         let weights = AlignedBox::<i16>::new_zeroed(HalfKpSpec::DIMENSIONS * TEST_L1);
@@ -2355,21 +2349,17 @@ mod tests {
         let mut acc = AccumulatorLayerStacks::<TEST_L1>::new();
         let mut cache = AccumulatorCacheLayerStacks::<TEST_L1>::new();
 
-        // 1) cache miss: 玉スロットを ZERO でマスクして full refresh
         ft.refresh_accumulator_with_cache(&pos, &mut acc, &mut cache);
         assert!(acc.computed_accumulation);
         for v in acc.get(0).iter().chain(acc.get(1).iter()) {
             assert_eq!(*v, 0, "zero-weights refresh should keep accumulation at 0");
         }
 
-        // 2) cache hit (piece_list 不変): 差分 0
         ft.refresh_accumulator_with_cache(&pos, &mut acc, &mut cache);
         for v in acc.get(0).iter().chain(acc.get(1).iter()) {
             assert_eq!(*v, 0);
         }
 
-        // 3) 相手玉が異なる位置の派生局面: 玉 slot 差分を idx_fn 経由で
-        //    `halfkp_index(king, F_KING+sq)` させない (=玉マスクで早期スキップ)
         let mut pos2 = Position::new();
         pos2.set_sfen(
             "+B1sg1gsnl/2+N4b1/pP2ppk1p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
@@ -2381,26 +2371,12 @@ mod tests {
         }
     }
 
-    /// HalfKp + 非ゼロ weights/biases で `refresh_accumulator` (slow path、
-    /// `append_active_indices` 経由) と `refresh_accumulator_with_cache`
-    /// (fast cache path、玉スロット ZERO マスク経由) の結果が **bit 一致** する
-    /// ことを保証する数値正確性テスト。
-    ///
-    /// crash-free regression (`refresh_with_cache_halfkp_complex_position`) は
-    /// panic しないことだけ検証するが、本テストは fix が **計算的にも正しい**
-    /// ことを担保する。
-    ///
-    /// シナリオ:
-    /// 1. 初期局面 (ply32 SFEN) で slow と cache が一致
-    /// 2. 相手玉が異なる位置の派生局面でも slow と cache が一致
-    ///    (cache hit-with-diff path の正しさを保証)
-    ///
-    /// PR #757 review #3 への対応 (HalfKp 限定 1 件、5 FT 全体への展開は別 Issue)。
+    /// HalfKp で `refresh_accumulator` (slow path) と `refresh_accumulator_with_cache`
+    /// (fast cache path、玉スロット ZERO マスク経由) の accumulation が
+    /// 非ゼロ weights 下で bit 一致することを保証する。
     #[test]
     fn refresh_with_cache_halfkp_matches_slow_path() {
-        // 非ゼロ deterministic weights/biases で FT 構築 (seed 固定)
         let mut weights = AlignedBox::<i16>::new_zeroed(HalfKpSpec::DIMENSIONS * TEST_L1);
-        // 簡易擬似乱数: i に対し i16 範囲で安定なパターン
         for (i, slot) in weights.iter_mut().enumerate() {
             *slot = (((i as u32).wrapping_mul(2_654_435_761) >> 16) as i16) % 127 - 63;
         }
@@ -2428,9 +2404,7 @@ mod tests {
         let ft_cache = make_ft();
 
         let sfens = [
-            // 1) 駒成り + 駒台手駒ありの典型 ply32 局面
             "+B1sg1gsnl/2+N2k1b1/pP2pp2p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
-            // 2) 相手玉位置が異なる派生局面 (cache hit-with-diff path を踏ませる)
             "+B1sg1gsnl/2+N4b1/pP2ppk1p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
         ];
 
@@ -2440,11 +2414,9 @@ mod tests {
             let mut pos = Position::new();
             pos.set_sfen(sfen).unwrap();
 
-            // slow path: append_active_indices 経由で full refresh (玉 BP は除外)
             let mut acc_slow = AccumulatorLayerStacks::<TEST_L1>::new();
             ft_slow.refresh_accumulator(&pos, &mut acc_slow);
 
-            // fast cache path: 玉スロットを ZERO マスクして cache に渡す
             let mut acc_cache = AccumulatorLayerStacks::<TEST_L1>::new();
             ft_cache.refresh_accumulator_with_cache(&pos, &mut acc_cache, &mut cache);
 
@@ -2456,5 +2428,67 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// HalfKp の `try_apply_dirty_piece_fast` が玉 BonaPiece (`>= FE_END`) を含む
+    /// `DirtyPiece` を受け取ったとき `false` を返して slow path にフォールバック
+    /// することを直接検証する。
+    #[test]
+    fn try_apply_dirty_piece_fast_halfkp_rejects_king_bp() {
+        let weights = AlignedBox::<i16>::new_zeroed(HalfKpSpec::DIMENSIONS * TEST_L1);
+        let ft = FeatureTransformerLayerStacks::<TEST_L1, HalfKpSpec> {
+            biases: Aligned([0; TEST_L1]),
+            weights,
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_biases: [0; NUM_LAYER_STACK_BUCKETS],
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-psqt")]
+            has_psqt: false,
+            #[cfg(feature = "ls-ext-threat")]
+            threat_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-threat")]
+            has_threat: false,
+            _ft: PhantomData,
+        };
+
+        let king_sq = Square::new(File::File5, Rank::Rank9);
+        let mut acc = Aligned([0i16; TEST_L1]);
+
+        let mut dp_king_move = DirtyPiece::new();
+        dp_king_move.dirty_num = 1;
+        dp_king_move.piece_no[0] = PieceNumber(PieceNumber::KING + 1);
+        dp_king_move.changed_piece[0] = ChangedBonaPiece {
+            old_piece: ExtBonaPiece::from_board(
+                Piece::W_KING,
+                Square::new(File::File5, Rank::Rank1),
+            ),
+            new_piece: ExtBonaPiece::from_board(
+                Piece::W_KING,
+                Square::new(File::File4, Rank::Rank1),
+            ),
+        };
+        assert!(
+            !ft.try_apply_dirty_piece_fast(&mut acc.0, &dp_king_move, Color::Black, king_sq),
+            "HalfKp fast path must reject king BonaPiece move"
+        );
+
+        let mut dp_pawn = DirtyPiece::new();
+        dp_pawn.dirty_num = 1;
+        dp_pawn.piece_no[0] = PieceNumber(0);
+        dp_pawn.changed_piece[0] = ChangedBonaPiece {
+            old_piece: ExtBonaPiece::from_board(
+                Piece::B_PAWN,
+                Square::new(File::File7, Rank::Rank7),
+            ),
+            new_piece: ExtBonaPiece::from_board(
+                Piece::B_PAWN,
+                Square::new(File::File7, Rank::Rank6),
+            ),
+        };
+        assert!(
+            ft.try_apply_dirty_piece_fast(&mut acc.0, &dp_pawn, Color::Black, king_sq),
+            "HalfKp fast path must accept non-king BonaPiece move"
+        );
     }
 }

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -1074,23 +1074,16 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             pos.piece_list().piece_list_fw()
         };
 
-        // HalfKP (= !INCLUDE_KING_IN_PIECE_LIST) は玉 BonaPiece を特徴量に含めないため
-        // piece_list の玉スロット (PieceNumber::KING / KING+1) を BonaPiece::ZERO で
-        // マスクしてから cache に渡す。これで `refresh_or_cache` 内の
-        // `if bp != ZERO { idx_fn(bp) }` 判定で玉 BP が自動的にスキップされ、
-        // `halfkp_index(king, F_KING+sq)` の OOR を避ける。cache.piece_list との
-        // 比較も両側 ZERO で一貫し、相手玉移動時に no-op となる。
-        // INCLUDE_KING_IN_PIECE_LIST は const なので HalfKa* 系では本ブロックは
-        // dead-code eliminated される (`piece_list_owned` は原本のコピー)。
+        // HalfKp は玉 BonaPiece を特徴量に含めないため、`refresh_or_cache` の
+        // `if bp != ZERO` で skip されるよう玉スロット (KING / KING+1) を ZERO に
+        // マスクして cache に渡す。`INCLUDE_KING_IN_PIECE_LIST = const` なので
+        // HalfKa* 系では本分岐ごと DCE される。
         let piece_list_owned;
         let piece_list: &[BonaPiece; PieceNumber::NB] = if FT::INCLUDE_KING_IN_PIECE_LIST {
             raw_piece_list
         } else {
             piece_list_owned = {
                 let mut pl = *raw_piece_list;
-                // piece_list の玉スロット 2 つ (PieceNumber::KING=先手玉, KING+1=後手玉)
-                // を ZERO 化。slot 38/39 が両玉に予約されているのは piece_list.rs の
-                // PIECE_NUMBER_BASE で確定。
                 pl[PieceNumber::KING as usize] = BonaPiece::ZERO;
                 pl[(PieceNumber::KING + 1) as usize] = BonaPiece::ZERO;
                 pl
@@ -1426,17 +1419,9 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             (old_bp, new_bp)
         };
 
-        // HalfKP (= !INCLUDE_KING_IN_PIECE_LIST) は玉の BonaPiece を特徴量に含めない。
-        // 自玉移動は `needs_refresh` (FriendKingMoved) で full refresh が走るが、
-        // 相手玉移動は refresh が走らずこの fast path に dirty_piece が流れてくる。
-        // 玉 BP (>= FE_END) を `FT::feature_index` に渡すと OOR で panic するため、
-        // ここで検出して slow path (`append_changed_indices` 経由、玉 BP を除外する)
-        // にフォールバックする。INCLUDE_KING_IN_PIECE_LIST は const なので HalfKa*
-        // 系では分岐ごと dead-code eliminate される。
-        //
-        // `dirty_num == 0` (パス手・盤面変化なし) の場合は `dn == 0` で本ループは
-        // no-op、続く `match dirty_piece.dirty_num` の `_ => false` で fallback する
-        // ため、guard 自体の早期 return は不要。
+        // HalfKp で相手玉移動は `needs_refresh` で拾えず fast path に流れる。
+        // 玉 BonaPiece (`>= FE_END`) を `FT::feature_index` に渡すと OOR になるため
+        // slow path (`append_changed_indices` が玉 BP を除外) にフォールバックする。
         if !FT::INCLUDE_KING_IN_PIECE_LIST {
             use super::bona_piece::FE_END;
             let dn = dirty_piece.dirty_num as usize;

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -16,6 +16,7 @@ use super::constants::NUM_LAYER_STACK_BUCKETS;
 use super::features::{Feature, FeatureSet};
 use super::leb128::read_compressed_tensor_i16_all;
 use super::ls_feature_spec::LsFeatureSpec;
+use super::piece_list::PieceNumber;
 use super::stats::{count_refresh, count_update};
 #[cfg(feature = "ls-ext-threat")]
 use super::threat_features::{self, MAX_CHANGED_THREAT_FEATURES, THREAT_DIMENSIONS};
@@ -1067,10 +1068,31 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
     ) {
         let king_sq = pos.king_square(perspective);
 
-        let piece_list = if perspective == Color::Black {
+        let raw_piece_list = if perspective == Color::Black {
             pos.piece_list().piece_list_fb()
         } else {
             pos.piece_list().piece_list_fw()
+        };
+
+        // HalfKP (= !INCLUDE_KING_IN_PIECE_LIST) は玉 BonaPiece を特徴量に含めないため
+        // piece_list の玉スロット (PieceNumber::KING / KING+1) を BonaPiece::ZERO で
+        // マスクしてから cache に渡す。これで `refresh_or_cache` 内の
+        // `if bp != ZERO { idx_fn(bp) }` 判定で玉 BP が自動的にスキップされ、
+        // `halfkp_index(king, F_KING+sq)` の OOR を避ける。cache.piece_list との
+        // 比較も両側 ZERO で一貫し、相手玉移動時に no-op となる。
+        // INCLUDE_KING_IN_PIECE_LIST は const なので HalfKa* 系では本ブロックは
+        // dead-code eliminated される (`piece_list_owned` は原本のコピー)。
+        let piece_list_owned;
+        let piece_list: &[BonaPiece; PieceNumber::NB] = if FT::INCLUDE_KING_IN_PIECE_LIST {
+            raw_piece_list
+        } else {
+            piece_list_owned = {
+                let mut pl = *raw_piece_list;
+                pl[PieceNumber::KING as usize] = BonaPiece::ZERO;
+                pl[(PieceNumber::KING + 1) as usize] = BonaPiece::ZERO;
+                pl
+            };
+            &piece_list_owned
         };
 
         let idx_fn = move |bp: BonaPiece| FT::feature_index(bp, perspective, king_sq);
@@ -1400,6 +1422,28 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             };
             (old_bp, new_bp)
         };
+
+        // HalfKP (= !INCLUDE_KING_IN_PIECE_LIST) は玉の BonaPiece を特徴量に含めない。
+        // 自玉移動は `needs_refresh` (FriendKingMoved) で full refresh が走るが、
+        // 相手玉移動は refresh が走らずこの fast path に dirty_piece が流れてくる。
+        // 玉 BP (>= FE_END) を `FT::feature_index` に渡すと OOR で panic するため、
+        // ここで検出して slow path (`append_changed_indices` 経由、玉 BP を除外する)
+        // にフォールバックする。INCLUDE_KING_IN_PIECE_LIST は const なので HalfKa*
+        // 系では分岐ごと dead-code eliminate される。
+        if !FT::INCLUDE_KING_IN_PIECE_LIST {
+            use super::bona_piece::FE_END;
+            let dn = dirty_piece.dirty_num as usize;
+            for entry in changed.iter().take(dn) {
+                let (old_bp, new_bp) = if perspective == Color::Black {
+                    (entry.old_piece.fb, entry.new_piece.fb)
+                } else {
+                    (entry.old_piece.fw, entry.new_piece.fw)
+                };
+                if (old_bp.value() as usize) >= FE_END || (new_bp.value() as usize) >= FE_END {
+                    return false;
+                }
+            }
+        }
 
         // dirty_num==1: 駒の移動（非捕獲）。打ち駒は old_bp==ZERO のためフォールバック。
         // dirty_num==2: 駒を取る指し手のみ。全 BonaPiece は非 ZERO のはずだが、
@@ -2266,5 +2310,71 @@ mod tests {
     #[test]
     fn smoke_refresh_halfkp() {
         smoke_refresh_for_spec::<HalfKpSpec>();
+    }
+
+    /// HalfKp + cache 経由 refresh: 玉成り/捕獲含む複雑な ply32 局面で
+    /// `refresh_or_cache` 内の `idx_fn(king_BP)` OOR を踏まないことを保証する。
+    /// 修正前は `feature_transformer_layer_stacks.rs:31` の
+    /// `feature_index_out_of_range` で panic していた。
+    ///
+    /// 期待動作:
+    /// 1. 初回 refresh (cache miss): piece_list 40 slot 走査時に玉スロットを
+    ///    BonaPiece::ZERO でマスクして idx_fn を呼ばないこと
+    /// 2. 同局面でもう一度 refresh (cache hit, piece_list 不変): 差分 0 で
+    ///    cache の accumulation をそのまま返すこと
+    /// 3. 相手玉が異なる位置の派生局面 (cache hit, 玉 slot 差分のみ): 玉 slot
+    ///    マスクにより差分 0 と認識し、再び idx_fn を呼ばないこと
+    #[test]
+    fn refresh_with_cache_halfkp_complex_position() {
+        let weights = AlignedBox::<i16>::new_zeroed(HalfKpSpec::DIMENSIONS * TEST_L1);
+        let ft = FeatureTransformerLayerStacks::<TEST_L1, HalfKpSpec> {
+            biases: Aligned([0; TEST_L1]),
+            weights,
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_biases: [0; NUM_LAYER_STACK_BUCKETS],
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-psqt")]
+            has_psqt: false,
+            #[cfg(feature = "ls-ext-threat")]
+            threat_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-threat")]
+            has_threat: false,
+            _ft: PhantomData,
+        };
+
+        let mut pos = Position::new();
+        pos.set_sfen(
+            "+B1sg1gsnl/2+N2k1b1/pP2pp2p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
+        )
+        .unwrap();
+
+        let mut acc = AccumulatorLayerStacks::<TEST_L1>::new();
+        let mut cache = AccumulatorCacheLayerStacks::<TEST_L1>::new();
+
+        // 1) cache miss: 玉スロットを ZERO でマスクして full refresh
+        ft.refresh_accumulator_with_cache(&pos, &mut acc, &mut cache);
+        assert!(acc.computed_accumulation);
+        for v in acc.get(0).iter().chain(acc.get(1).iter()) {
+            assert_eq!(*v, 0, "zero-weights refresh should keep accumulation at 0");
+        }
+
+        // 2) cache hit (piece_list 不変): 差分 0
+        ft.refresh_accumulator_with_cache(&pos, &mut acc, &mut cache);
+        for v in acc.get(0).iter().chain(acc.get(1).iter()) {
+            assert_eq!(*v, 0);
+        }
+
+        // 3) 相手玉が異なる位置の派生局面: 玉 slot 差分を idx_fn 経由で
+        //    `halfkp_index(king, F_KING+sq)` させない (=玉マスクで早期スキップ)
+        let mut pos2 = Position::new();
+        pos2.set_sfen(
+            "+B1sg1gsnl/2+N4b1/pP2ppk1p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
+        )
+        .unwrap();
+        ft.refresh_accumulator_with_cache(&pos2, &mut acc, &mut cache);
+        for v in acc.get(0).iter().chain(acc.get(1).iter()) {
+            assert_eq!(*v, 0);
+        }
     }
 }

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -2380,4 +2380,81 @@ mod tests {
             assert_eq!(*v, 0);
         }
     }
+
+    /// HalfKp + 非ゼロ weights/biases で `refresh_accumulator` (slow path、
+    /// `append_active_indices` 経由) と `refresh_accumulator_with_cache`
+    /// (fast cache path、玉スロット ZERO マスク経由) の結果が **bit 一致** する
+    /// ことを保証する数値正確性テスト。
+    ///
+    /// crash-free regression (`refresh_with_cache_halfkp_complex_position`) は
+    /// panic しないことだけ検証するが、本テストは fix が **計算的にも正しい**
+    /// ことを担保する。
+    ///
+    /// シナリオ:
+    /// 1. 初期局面 (ply32 SFEN) で slow と cache が一致
+    /// 2. 相手玉が異なる位置の派生局面でも slow と cache が一致
+    ///    (cache hit-with-diff path の正しさを保証)
+    ///
+    /// PR #757 review #3 への対応 (HalfKp 限定 1 件、5 FT 全体への展開は別 Issue)。
+    #[test]
+    fn refresh_with_cache_halfkp_matches_slow_path() {
+        // 非ゼロ deterministic weights/biases で FT 構築 (seed 固定)
+        let mut weights = AlignedBox::<i16>::new_zeroed(HalfKpSpec::DIMENSIONS * TEST_L1);
+        // 簡易擬似乱数: i に対し i16 範囲で安定なパターン
+        for (i, slot) in weights.iter_mut().enumerate() {
+            *slot = (((i as u32).wrapping_mul(2_654_435_761) >> 16) as i16) % 127 - 63;
+        }
+        let mut biases = Aligned([0i16; TEST_L1]);
+        for (i, b) in biases.0.iter_mut().enumerate() {
+            *b = ((i as i16) % 17) - 8;
+        }
+
+        let make_ft = || FeatureTransformerLayerStacks::<TEST_L1, HalfKpSpec> {
+            biases,
+            weights: weights.clone(),
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_biases: [0; NUM_LAYER_STACK_BUCKETS],
+            #[cfg(feature = "ls-ext-psqt")]
+            psqt_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-psqt")]
+            has_psqt: false,
+            #[cfg(feature = "ls-ext-threat")]
+            threat_weights: AlignedBox::new_zeroed(0),
+            #[cfg(feature = "ls-ext-threat")]
+            has_threat: false,
+            _ft: PhantomData,
+        };
+        let ft_slow = make_ft();
+        let ft_cache = make_ft();
+
+        let sfens = [
+            // 1) 駒成り + 駒台手駒ありの典型 ply32 局面
+            "+B1sg1gsnl/2+N2k1b1/pP2pp2p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
+            // 2) 相手玉位置が異なる派生局面 (cache hit-with-diff path を踏ませる)
+            "+B1sg1gsnl/2+N4b1/pP2ppk1p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
+        ];
+
+        let mut cache = AccumulatorCacheLayerStacks::<TEST_L1>::new();
+
+        for (idx, sfen) in sfens.iter().enumerate() {
+            let mut pos = Position::new();
+            pos.set_sfen(sfen).unwrap();
+
+            // slow path: append_active_indices 経由で full refresh (玉 BP は除外)
+            let mut acc_slow = AccumulatorLayerStacks::<TEST_L1>::new();
+            ft_slow.refresh_accumulator(&pos, &mut acc_slow);
+
+            // fast cache path: 玉スロットを ZERO マスクして cache に渡す
+            let mut acc_cache = AccumulatorLayerStacks::<TEST_L1>::new();
+            ft_cache.refresh_accumulator_with_cache(&pos, &mut acc_cache, &mut cache);
+
+            for p in 0..2 {
+                let slow = acc_slow.get(p);
+                let fast = acc_cache.get(p);
+                for (j, (s, f)) in slow.iter().zip(fast.iter()).enumerate() {
+                    assert_eq!(s, f, "sfen #{idx} perspective {p} slot {j}: slow={s} cache={f}");
+                }
+            }
+        }
+    }
 }

--- a/crates/rshogi-core/src/nnue/features/half_kp.rs
+++ b/crates/rshogi-core/src/nnue/features/half_kp.rs
@@ -428,4 +428,36 @@ mod tests {
         assert!(max_b <= max_valid, "Black max index out of range");
         assert!(max_w <= max_valid, "White max index out of range");
     }
+
+    /// 駒成り (+B, +N) + 駒台手駒ありの ply32 局面で `append_active_indices`
+    /// が玉スロット (`[..PieceNumber::KING]`) を正しく除外し続けることを保証する
+    /// regression test。`feature_transformer_layer_stacks` 側 (cache refresh /
+    /// fast diff) で同等の OOR バグ修正に対応する pair test
+    /// (`refresh_with_cache_halfkp_complex_position`) もそちらに置いてある。
+    #[test]
+    fn test_halfkp_active_indices_in_range_with_promoted_and_hand() {
+        use crate::nnue::accumulator::{IndexList, MAX_ACTIVE_FEATURES};
+
+        let mut pos = Position::new();
+        pos.set_sfen(
+            "+B1sg1gsnl/2+N2k1b1/pP2pp2p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32",
+        )
+        .unwrap();
+
+        let max_valid = 81 * FE_END - 1;
+        for perspective in [Color::Black, Color::White] {
+            let mut active: IndexList<MAX_ACTIVE_FEATURES> = IndexList::new();
+            HalfKP::append_active_indices(&pos, perspective, &mut active);
+            for (i, idx) in active.iter().enumerate() {
+                assert!(
+                    idx <= max_valid,
+                    "{:?} slot {} idx {} > {}",
+                    perspective,
+                    i,
+                    idx,
+                    max_valid
+                );
+            }
+        }
+    }
 }

--- a/crates/rshogi-core/src/nnue/features/half_kp.rs
+++ b/crates/rshogi-core/src/nnue/features/half_kp.rs
@@ -429,11 +429,8 @@ mod tests {
         assert!(max_w <= max_valid, "White max index out of range");
     }
 
-    /// 駒成り (+B, +N) + 駒台手駒ありの ply32 局面で `append_active_indices`
-    /// が玉スロット (`[..PieceNumber::KING]`) を正しく除外し続けることを保証する
-    /// regression test。`feature_transformer_layer_stacks` 側 (cache refresh /
-    /// fast diff) で同等の OOR バグ修正に対応する pair test
-    /// (`refresh_with_cache_halfkp_complex_position`) もそちらに置いてある。
+    /// 駒成り + 駒台手駒ありの ply32 局面でも `append_active_indices` が玉スロット
+    /// (`[..PieceNumber::KING]`) を除外し、全 index が `81 * FE_END` 範囲内であることを保証する。
     #[test]
     fn test_halfkp_active_indices_in_range_with_promoted_and_hand() {
         use crate::nnue::accumulator::{IndexList, MAX_ACTIVE_FEATURES};


### PR DESCRIPTION
## Summary

- `engines/rshogi-usi-ls-halfkp-1536x16x32-none` で `position sfen <ply32+>` + 探索中に `Feature index out of range` で panic していた件を修正
- 玉 BonaPiece (>= FE_END = 1548) を非特徴量として扱う HalfKp 仕様に **cache refresh path** と **fast diff path** の 2 つの LayerStack 経路を合わせる
- 修正前: 5-feature-set RR tournament で halfkp が 4 ペア 1600 局すべて forfeit → 修正後: 通常の対局成立 (現在 ~40% 勝率で実走中)

## Root cause

PR #745 で LS FT generic 化された際、HalfKp / HalfKa* を統一的に扱う 2 つの高速経路で玉 BonaPiece の除外漏れ。

1. **`try_apply_dirty_piece_fast`**: dirty_piece の old/new BonaPiece を `FT::feature_index` (= `halfkp_index`) に直接渡す。`needs_refresh` は自玉移動時のみ true となるため、相手玉移動の dirty_piece は fast diff に流れ、`halfkp_index(king, F_KING+sq)` で OOR (index 125468〜125523, max 125388)
2. **`refresh_perspective_with_cache`**: piece_list 40 slot 全部 (含む玉 slot 38/39) を cache iteration に渡す。cache miss 時は `idx_fn(king_BP)`、cache hit 時は玉 slot 差分でも同様に OOR

`features/half_kp.rs::append_active_indices` / `append_changed_indices` は元から玉除外 (`[..PieceNumber::KING]` および `value() < FE_END`) なので slow path は安全。**fast/cached path が slow path と一致していなかった**形。

## Fix

1. `try_apply_dirty_piece_fast` 冒頭で `!FT::INCLUDE_KING_IN_PIECE_LIST` (HalfKp のみ true) 時に dirty pieces を走査、`>= FE_END` の BonaPiece があれば `false` を返して slow path にフォールバック
2. `refresh_perspective_with_cache` で raw piece_list の玉スロット (`PieceNumber::KING` / `KING+1`) を `BonaPiece::ZERO` でマスクしたローカルコピーを cache に渡す。`refresh_or_cache` 側の `if bp != ZERO` で自然にスキップされ、`entry.piece_list` にも ZERO 化版が保存されるため相手玉移動の cache hit diff も「両側 ZERO で差分 0」と認識される

両ガードとも `INCLUDE_KING_IN_PIECE_LIST` が `const bool` なので HalfKa* 系 (HalfKaHmMerged 等、4 variants) では分岐ごと dead-code eliminated される。zero overhead を維持。

## Reproducer

```
SFEN: +B1sg1gsnl/2+N2k1b1/pP2pp2p/2p3p2/9/2PpP4/P1+p2PP1P/7R1/LN1GKGSNL w RLs3p 32
位置: 駒成り (+B, +N) + 駒台手駒あり + 玉位置中盤の典型 ply32 局面
```

修正前: 上記 SFEN + `go byoyomi 2000` → depth 11 付近で OOR panic (cache miss 時の `refresh_or_cache` ループから発火)

修正後: 同じ条件で depth 17+ まで cleanly 探索完走、NPS ~640K で他 FT と同水準

## Test plan

- [x] `nnue::feature_transformer_layer_stacks::tests::refresh_with_cache_halfkp_complex_position` 新規追加: ply32 SFEN で cache miss → 同局面 hit → 相手玉違い派生局面 hit の 3 path を exercise。修正前は cache miss 分岐で `idx_fn(king_BP)` が `weight_row` OOR panic していたため bug path を確実に踏み抜く regression test として成立
- [x] `nnue::features::half_kp::tests::test_halfkp_active_indices_in_range_with_promoted_and_hand` 追加 (記録用): `append_active_indices` 経路で玉 BP が漏れないことを同じ fixture SFEN で確認
- [x] `cargo fmt`
- [x] `cargo clippy --tests --workspace -- -D warnings` ゼロ警告
- [x] `cargo test --release -p rshogi-core --lib nnue::` 全 nnue test pass
  - pre-existing 2 failure (`network::tests::test_evaluate_fallback` / `test_accumulator_stack_variant_fallback`) は main HEAD でも fail する test isolation 問題、本修正と無関係
- [x] **実機検証**: 修正後 engine で 5-feature-set RR tournament (200/dir = 400/pair) の halfkp 4 ペアを再走 → 20 局時点で halfkp 勝率 ~40% で通常対局成立 (1600 局完走待ち)
- [x] **Codex local review**: APPROVE (cache refresh path / fast diff path / API 互換 / 副作用 / CLAUDE.md 規約 全観点 OK)

## Related

- 混入元: SH11235/rshogi#745 (LS FT 5 variant 対応、PR merge 後の HalfKp で発覚)
- HalfKa* 系 (`-none` / `-psqt` / `-threat` / `-psqt_threat`) には影響なし (`INCLUDE_KING_IN_PIECE_LIST = true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)