### PR TITLE
chore(comments): rshogi-csa-server-tcp の冗長コメント / local-context 依存ワード除去

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/auth.rs
+++ b/crates/rshogi-csa-server-tcp/src/auth.rs
@@ -80,9 +80,9 @@ impl PlainPasswordHasher {
 impl PasswordHasher for PlainPasswordHasher {
     fn verify(&self, candidate: &Secret, stored_hash: &str) -> bool {
         // 注意: 平文比較かつ長さ不一致で即 return するため、処理時間からパスワード長を
-        // 推定する攻撃に対して定数時間ではない。本実装は shogi-server 互換
-        // players.yaml の平文保存に合わせた暫定経路であり、ハッシュ方式への移行時は
-        // 長さ分岐ごと `subtle::ConstantTimeEq` 等の完全定数時間比較に置き換える。
+        // 推定する攻撃に対して定数時間ではない。shogi-server 互換 players.yaml の
+        // 平文保存に合わせた暫定経路で、ハッシュ方式への移行時は長さ分岐ごと
+        // `subtle::ConstantTimeEq` 等の完全定数時間比較に置き換える。
         let a = candidate.expose().as_bytes();
         let b = stored_hash.as_bytes();
         if a.len() != b.len() {

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -739,7 +739,7 @@ mod tests {
 
     /// `ALLOW_FLOODGATE_FEATURES_FLAG` 定数と clap が生成する CLI フラグ名が
     /// 一致することを固定する。`Cli::allow_floodgate_features` のフィールド名を
-    /// リネームしたら本テストが落ち、エラーメッセージ生成側との同期忘れを検知する。
+    /// リネームすると test が落ち、エラーメッセージ生成側との同期忘れを検知する。
     #[test]
     fn allow_floodgate_features_flag_matches_clap_long() {
         let cmd = Cli::command();

--- a/crates/rshogi-csa-server-tcp/src/broadcaster.rs
+++ b/crates/rshogi-csa-server-tcp/src/broadcaster.rs
@@ -110,7 +110,7 @@ impl Broadcaster for InMemoryBroadcaster {
         line: &CsaLine,
     ) -> Result<(), TransportError> {
         if !matches!(tag, BroadcastTag::Spectator) {
-            // Admin/Player タグは本実装では使われない。未対応経路が来たら黙って no-op。
+            // Admin/Player タグは未対応経路。来たら黙って no-op。
             return Ok(());
         }
         let mut guard = self.inner.lock().await;
@@ -156,7 +156,7 @@ mod tests {
             .broadcast_tag(&RoomId::new("g1"), BroadcastTag::Player, &CsaLine::new("X"))
             .await
             .unwrap();
-        // Player タグは本実装では無視される。
+        // Player タグは無視される。
         assert!(rx.try_recv().is_err());
     }
 

--- a/crates/rshogi-csa-server-tcp/src/metrics.rs
+++ b/crates/rshogi-csa-server-tcp/src/metrics.rs
@@ -173,7 +173,7 @@ mod tests {
 
     /// メトリクス名は外部から観測される運用契約。意図せぬ rename を CI で止める
     /// ため、定数の文字列値を完全一致で固定する。新しい系列を追加する場合は
-    /// 本テストも更新する（exporter のラベル付与方式と Prometheus 命名規約に
+    /// この test も更新する（exporter のラベル付与方式と Prometheus 命名規約に
     /// 準拠していることを併せて確認する）。
     #[test]
     fn metric_names_are_byte_stable() {
@@ -190,9 +190,9 @@ mod tests {
     /// `csa_games_finished_total{result_code}` ラベルに乗る値は外部 (Prometheus
     /// dashboards / alert rules) から観測される運用契約のため、`primary_result_code`
     /// が返し得る値と合成 `#ABORTED` の合算が **既知 allowlist に閉じている**こと
-    /// を CI で固定する。新しい `GameResult` variant を `core` に追加する PR は
-    /// `primary_result_code` の更新を強制され、その時点で本テストが落ちて漏れに
-    /// 気付ける。
+    /// を CI で固定する。新しい `GameResult` variant が追加されると
+    /// `primary_result_code` の更新が強制され、その時点でこの test が落ちて
+    /// 漏れに気付ける。
     #[test]
     fn result_code_label_values_are_in_known_allowlist() {
         use rshogi_csa_server::game::result::{GameResult, IllegalReason};

--- a/crates/rshogi-csa-server-tcp/src/scheduler.rs
+++ b/crates/rshogi-csa-server-tcp/src/scheduler.rs
@@ -611,7 +611,7 @@ mod tests {
     use super::*;
 
     /// `build_strategy` が `"direct"` / `"least_diff"` を受理し、その他は
-    /// エラーにする契約を固定。新しい戦略を追加するときに本テストを更新する。
+    /// エラーにする契約を固定。新しい戦略を追加するときはこの test も更新する。
     #[test]
     fn build_strategy_accepts_known_strategies_and_rejects_unknown() {
         // `dyn PairingLogic` は Debug 非実装なので `unwrap` ベースのアサートは

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -4303,8 +4303,8 @@ mod tests {
 
     /// release ビルドでは `run_connection_isolated` 経路の `catch_unwind` が
     /// `panic!` を tracing event に変換してタスクを正常終了させる。
-    /// `handle_connection` を叩かずに同経路の async catch_unwind を直接呼び、
-    /// debug build と release build の挙動契約が分岐していることを確認する。
+    /// このテストは `handle_connection` を叩かずに同経路の async catch_unwind を
+    /// 直接呼び、debug build と release build の挙動契約が分岐していることを確認する。
     ///
     /// 注: テスト名に "isolates" を含むが、これは `run_connection_isolated`
     /// そのものの connection レベル隔離ではなく、同関数が依拠する

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -3035,7 +3035,7 @@ where
 ///   切断方針 (debug 用 trace のみ) と同質性は保ちつつ、ハンドシェイク
 ///   コストだけ削れる。https://github.com/SH11235/rshogi/issues/582 の TCP フロー §1 step 5 にある「LOGOUT
 ///   応答は保証しない」という記述は「LOGOUT の応答行を返さない」意図であり、
-///   本実装でも応答行は送らない (単に loop 脱出のみ)。応答可否ではなく
+///   ここでも応答行は送らない (単に loop 脱出のみ)。応答可否ではなく
 ///   ループ離脱の trigger としての扱いの差異である。
 async fn run_challenge_issuer<R, K, P, H>(
     state: Rc<SharedState<R, K, P, H>>,
@@ -4302,7 +4302,7 @@ mod tests {
     }
 
     /// release ビルドでは `run_connection_isolated` 経路の `catch_unwind` が
-    /// `panic!` を tracing event に変換してタスクを正常終了させる。本テストは
+    /// `panic!` を tracing event に変換してタスクを正常終了させる。
     /// `handle_connection` を叩かずに同経路の async catch_unwind を直接呼び、
     /// debug build と release build の挙動契約が分岐していることを確認する。
     ///

--- a/crates/rshogi-csa-server-tcp/tests/floodgate_acceptance.rs
+++ b/crates/rshogi-csa-server-tcp/tests/floodgate_acceptance.rs
@@ -1,9 +1,9 @@
 //! Floodgate 運用機能の受入シナリオ統合テスト。
 //!
-//! 本テストは TCP listener や fake client を立てる「フル E2E」ではなく、
 //! `ServerConfig` を Floodgate 全機能 ON で組み立てたときの起動経路と
-//! intent 算出の **横断的整合性** を固定する smoke 統合テスト。各機能の
-//! 個別テストはそれぞれの crate / モジュールに網羅されている:
+//! intent 算出の **横断的整合性** を固定する smoke 統合テスト (TCP listener や
+//! fake client を立てる「フル E2E」ではない)。各機能の個別テストはそれぞれの
+//! crate / モジュールに網羅されている:
 //!
 //! - Players レート永続化: `rshogi_csa_server::storage::players_yaml::tests`
 //! - スケジューラ: `rshogi_csa_server::scheduler::tests` +
@@ -12,7 +12,7 @@
 //! - LeastDiff ペアリング: `rshogi_csa_server::matching::pairing::tests`
 //! - 駒落ち / 重複ログイン: `rshogi_csa_server_tcp::server::tests`
 //!
-//! 本受入は「全部入りで起動できるか」を上から見て確認する位置付けで、
+//! 「全部入りで起動できるか」を上から見て確認する位置付けで、
 //! 実 TCP / 実エンジン接続を伴う E2E は負荷試験ハーネス側で扱う。
 
 use std::collections::HashMap;

--- a/crates/rshogi-csa-server-tcp/tests/metrics_exporter.rs
+++ b/crates/rshogi-csa-server-tcp/tests/metrics_exporter.rs
@@ -70,8 +70,8 @@ async fn fetch_metrics(addr: SocketAddr) -> String {
 /// - ラベル無しの値が初期 `0` で出る（Prometheus の `rate(...)` / `absent(...)`
 ///   クエリが起動直後でも展開できる）
 ///
-/// histogram (`csa_move_latency_seconds`) は意図的に事前 record しないため、
-/// 値発火前は出力に出ない（観測値の汚染を避ける契約）。本テストでは含めない。
+/// histogram (`csa_move_latency_seconds`) は意図的に事前 record せず、
+/// 値発火前は出力に出ない（観測値の汚染を避ける契約）。
 #[tokio::test(flavor = "current_thread")]
 async fn exporter_serves_help_type_and_zero_init_for_main_series() {
     let addr = ephemeral_loopback_addr();

--- a/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
+++ b/crates/rshogi-csa-server-tcp/tests/tcp_session.rs
@@ -626,8 +626,8 @@ fn kifu_and_zerozero_list_match_format_contract() {
         let _ = read_until(&mut rb, "#LOSE").await;
 
         // 棋譜の場所は YYYY/MM/DD/<game_id>.csa（game_id は YYYYMMDDHHMMSS+連番）。
-        // 本テストは「format contract」として日付ディレクトリ配置も検証対象に含める
-        // ため、再帰探索ではなく game_id から組み立てた具体パスをポーリングする。
+        // 「format contract」として日付ディレクトリ配置も検証対象に含めるため、
+        // 再帰探索ではなく game_id から組み立てた具体パスをポーリングする。
         // `relative_kifu_path` が壊れて別ディレクトリへ書き出すような回帰は、ここで
         // タイムアウト → panic で検知される。
         let yyyy = &game_id[0..4];
@@ -1188,10 +1188,10 @@ fn monitor2_subscribes_and_receives_moves_and_chat() {
         // (subscriber は drop されて prune される)。厳密な「届かない」検証は
         // タイミング依存なので、後続手を送って observer の recv_line が短時間
         // (100ms) 以内に何も届かない (あるいは subscriber が落ちて何か別行が
-        // 届く) ことで妥協する。本テストでは購読解除 reply の最終行まで
-        // 完了した時点を off 済みとみなし、以降は検証しない (スケジューラ
-        // タイミングで broadcaster の retain (prune) が未実行のまま 1 通だけ
-        // 取りこぼす可能性がある)。
+        // 届く) ことで妥協する。購読解除 reply の最終行まで完了した時点を
+        // off 済みとみなし、以降は検証しない (スケジューラタイミングで
+        // broadcaster の retain (prune) が未実行のまま 1 通だけ取りこぼす
+        // 可能性がある)。
 
         // 対局を投了で畳んでテスト clean-up する。
         send_line(&mut wb, "%TORYO").await;
@@ -1482,7 +1482,7 @@ fn fork_creates_single_use_buoy_from_existing_game() {
 
         // 固定 sleep だと並行実行下で persist_kifu 完了前に %%FORK が走り、
         // kifu_storage.load が NotFound を返して `##[FORK] NOT_FOUND` に落ちる
-        // race が出る (PR #497 と同種)。CSA ファイル書き込みを polling で待つ。
+        // race が出る。CSA ファイル書き込みを polling で待つ。
         let _ = wait_for_csa_text(&topdir, &source_game_id).await;
 
         let (mut ra, mut wa) = connect(addr).await;
@@ -1586,8 +1586,8 @@ fn fork_gracefully_errors_and_keeps_connection_alive() {
         let _ = read_until(&mut rw, "#LOSE").await;
 
         // 固定 sleep だと並行実行下で persist_kifu 完了前に %%FORK が走り、
-        // 期待する `##[FORK] ERROR` ではなく `NOT_FOUND` に落ちる race が出る
-        // (PR #497 と同種)。CSA ファイル書き込みを polling で待つ。
+        // 期待する `##[FORK] ERROR` ではなく `NOT_FOUND` に落ちる race が出る。
+        // CSA ファイル書き込みを polling で待つ。
         let _ = wait_for_csa_text(&topdir, &source_game_id).await;
 
         // nth_move=999 は範囲外。切断せず ERROR + END を返す。
@@ -2692,7 +2692,7 @@ fn private_match_issue_succeeds_with_valid_inputs() {
             "token must be lowercase hex: {resp:?}",
         );
         // ttl: spawn_server に渡した ServerConfig::challenge_ttl を動的に取り出して比較。
-        // sensible_defaults() の値が変わっても本テストの期待値は config から導出される。
+        // sensible_defaults() の値が変わっても期待値は config から導出されるため壊れない。
         let expected_ttl = rshogi_csa_server_tcp::server::ServerConfig::sensible_defaults()
             .challenge_ttl
             .as_secs();
@@ -3013,7 +3013,7 @@ fn private_match_ttl_expiry_disconnects_pending_session() {
             // `##[ERROR] ...` を送って transport を drop する。並行負荷下では
             // FIN が先に届いて `read_line_raw` が `Ok(0) → None` を返すケースが
             // 観測されるため、line と EOF の両方を許容する形で期限切れの観測を
-            // 確定する (= 「サーバ側 close まで来たか」が本テストの目的、
+            // 確定する (= 「サーバ側 close まで来たか」を確認するのが目的、
             // wire 上の 1 行は best-effort)。
             let line = read_line_raw(&mut ra).await;
             match line {
@@ -3092,8 +3092,8 @@ fn private_match_consumed_token_cannot_be_reused() {
 ///    `unregister` する経路が想定どおり動けば「`already_logged_in` で弾かれない」。
 ///
 /// 注: 現状の `run_private_match_waiter` の `tokio::select!` 経路に `recv_line`
-/// 監視が無い場合は本テストは failure する。failure 時は実装側 (production code)
-/// に切断検知経路の追加が要るシグナルになる。
+/// 監視が無い場合は test が failure する。failure 時は production code に
+/// 切断検知経路の追加が要るシグナルになる。
 #[test]
 fn private_match_pending_session_unregister_avoids_stale_race() {
     run_local(|| async {


### PR DESCRIPTION
## Summary

- 「コメント規約」(`~/.claude/CLAUDE.md`) + `code-comment-hygiene` SKILL に基づき、`crates/rshogi-csa-server-tcp/` 配下のコメントから local-context 依存ワード (本テスト / 本実装 / PR # 等) を機械的に除去
- ロジック変更ゼロ、+32 -32 (9 ファイル)
- 全 sweep を進める前段の **area 単位 PR の 1 本目**。先行検証として csa-server-tcp に絞った

## Scope (除去対象)

| Pattern | Hit | Action |
|---|---:|---|
| 「本テスト / 本実装 / 本受入」等の自己言及表現 | 16 | 同等意味の非自己言及表現に置換 or 文意を保ったまま削除 |
| `(PR #497 と同種)` 形式 | 2 | 削除 (race 機構の説明文は残置) |

判断分かれそうな箇所:
- `auth.rs:83`「本実装は shogi-server 互換」→「shogi-server 互換 players.yaml の平文保存に合わせた暫定経路」
- `broadcaster.rs:113`「本実装では使われない」→「未対応経路」
- test 契約 docstring (`metrics.rs` / `scheduler.rs` / `bin/main.rs`): 能動→受動の言い換えで「将来 X 追加時の同期忘れ検知」契約は維持

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests -p rshogi-csa-server-tcp -- -D warnings` clean
- [x] `cargo test --release -p rshogi-csa-server-tcp` 全 54 pass
- [x] SKILL grep (`本 ?PR|本テスト|本修正|本フィックス|本対応|本実装|今回の対応|今回の修正|今回追加|修正前は|修正後は`) tcp 配下で違反 0
- [x] Local Codex review: APPROVE (Major/Minor 0)
- [x] Local Claude review: APPROVE (Major/Minor 0)

## Out of scope (後続 sweep PR で対応)

- `crates/rshogi-csa-server-workers/` 配下 (~50 候補)
- `crates/rshogi-csa-server/` 配下 (1 候補)
- URL 形式の Issue 参照 (例 `https://github.com/SH11235/rshogi/issues/582`) は SKILL grep の D パターン対象外、別途判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)