### PR TITLE
chore(comments): rshogi-csa-server* family の冗長コメント / local-context 依存ワード除去

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -15,11 +15,11 @@
 //! `run_live_orphan_sweep` は cron 30s 制限の安全側 (`SWEEP_DEADLINE_MS`) 内で
 //! 複数 page を処理し、超過分は次回 cron に持ち越す (cursor は再開しない =
 //! 先頭から再走査するが、live key は新しい対局順なので大きな問題にならない)。
-//! 本実装範囲では admin invoke endpoint や 1 万件超の bulk 並列化は Non-goals
+//! admin invoke endpoint や 1 万件超の bulk 並列化はスコープ外
 //! (設計 v3 §10)。
 //!
 //! 進捗ログは [`structured_log!`](crate::structured_log) で JSON 化して
-//! Cloudflare Workers の Logs / tail へ流す ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A)。
+//! Cloudflare Workers の Logs / tail へ流す (Cloudflare Workers Logs Phase A)。
 //! いかなる失敗 (R2 binding 解決失敗 / list 失敗 / get 失敗 / put 失敗 /
 //! parse 失敗) も `Err` を返さず ログのみ残して `Ok` で抜ける契約。
 //! `scheduled` handler が次回 cron 起動を妨げないようにするため、伝播禁止。
@@ -34,7 +34,7 @@
 use serde::Deserialize;
 
 /// `kifu-by-id/` prefix。`<id>.csa` と `<id>.meta.json` が同居するため、
-/// `.meta.json` で suffix 判定する側で本 prefix を再利用する。
+/// `.meta.json` で suffix 判定する側でこの prefix を再利用する。
 pub(crate) const KIFU_BY_ID_PREFIX: &str = "kifu-by-id/";
 
 /// `kifu-by-id/<id>.meta.json` の suffix。list 結果から meta だけを抽出する。

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -70,7 +70,7 @@ impl ConfigKeys {
     /// Rate limit (issue [#622](https://github.com/SH11235/rshogi/issues/622)
     /// PR3a) — `/ws/<room_id>` (player route) upgrade の 1 IP あたり 1 分間の
     /// 最大回数。新規 GameRoom DO 起動の代理指標として使う (room 起動を厳密に
-    /// 数えるには DO 内 state を追う必要があり、本 PR では player route upgrade
+    /// 数えるには DO 内 state を追う必要があるため、player route upgrade
     /// 回数で近似する)。設定不正値は既定 (20) にフォールバック。
     pub const ROOM_CREATE_RATE_PER_IP_PER_MIN: &'static str = "ROOM_CREATE_RATE_PER_IP_PER_MIN";
     /// Rate limit (issue [#622](https://github.com/SH11235/rshogi/issues/622)
@@ -276,11 +276,11 @@ impl ConfigKeys {
         Self::LOBBY_QUEUE_ENTRY_TTL_SEC,
         Self::CHALLENGE_TTL_SEC,
         Self::PRIVATE_CHALLENGE_ENABLED,
-        // Rate limit thresholds (issue #622 PR3a) — 6 keys。各値の根拠は
-        // `docs/csa-server/rate_limit_design.md` §3 Q3 表と本ファイル冒頭の
+        // Rate limit thresholds — 6 keys。各値の根拠は
+        // `docs/csa-server/rate_limit_design.md` §3 Q3 表とこのファイル冒頭の
         // 各定数 docstring を参照。閾値を deploy なしで上書きしたい場合は
         // `wrangler secret put <KEY>` ではなく `wrangler.<env>.toml` の `[vars]`
-        // 編集 + redeploy で反映する (本配列に含まれる = 平文管理 OK 値)。
+        // 編集 + redeploy で反映する (この配列に含まれる = 平文管理 OK 値)。
         Self::LOBBY_LOGIN_RATE_PER_IP_PER_MIN,
         Self::LOBBY_LOGIN_RATE_PER_HANDLE_PER_MIN,
         Self::LOBBY_CHALLENGE_RATE_PER_IP_PER_MIN,

--- a/crates/rshogi-csa-server-workers/src/export_retry.rs
+++ b/crates/rshogi-csa-server-workers/src/export_retry.rs
@@ -1,14 +1,14 @@
-//! 終局時 R2 export PUT 失敗時の retry policy (Issue #623)。
+//! 終局時 R2 export PUT 失敗時の retry policy。
 //!
 //! 終局時に CSA 本文 / by-id / meta / games-index の 4 オブジェクトを R2 に
 //! 書き出すが、Cloudflare の transient 失敗で 1 つでも PUT に失敗すると以前は
-//! 棋譜が恒久欠損していた。本モジュールは:
+//! 棋譜が恒久欠損していた。このモジュールは:
 //!
 //! - DO storage に [`ExportPendingState`](crate::persistence::ExportPendingState)
 //!   を残して再 PUT に必要な body / key を保持する
 //! - [`PendingAlarmKind::ExportRetry`](crate::reconnect::PendingAlarmKind::ExportRetry)
 //!   タグで `state.alarm()` 経路を分岐する (`KEY_FINISHED` ガードよりも前で受ける)
-//! - 本モジュール内の純粋ロジック ([`next_retry_delay_ms`] / [`is_exhausted`])
+//! - このモジュール内の純粋ロジック ([`next_retry_delay_ms`] / [`is_exhausted`])
 //!   で次回 alarm 遅延と打ち切り判定を一元化する
 //!
 //! 純粋ロジックのみ置く方針なので I/O (DO storage / R2 binding) は呼び出し側

--- a/crates/rshogi-csa-server-workers/src/floodgate_history.rs
+++ b/crates/rshogi-csa-server-workers/src/floodgate_history.rs
@@ -470,7 +470,7 @@ mod tests {
     /// instance を同じ backing storage で構築して `list_recent` が永続化された
     /// entry を返すことを確認する。`InMemoryFloodgateHistoryStorage` は R2 アダプタ
     /// と同じ trait を実装し、同じ key 生成ロジック (`entry_key`) を共有するため、
-    /// 本テストの pass は trait の cold-start 契約を host target 上で固定する。
+    /// このテストの pass は trait の cold-start 契約を host target 上で固定する。
     #[tokio::test(flavor = "current_thread")]
     async fn cold_start_then_list_recent_returns_persisted_entry() {
         let backing = Arc::new(Mutex::new(BTreeMap::new()));
@@ -507,7 +507,7 @@ mod tests {
     /// sort することで、複数日にまたがる append でも `list_recent` が正しく
     /// 新しい順を返す。R2 アダプタの day-walking ループ自体は wrangler dev で
     /// 検証するが、キー設計（end_time の年月日要素を埋める）が day 境界を
-    /// またいで sortable である事実は本テストで固定する。
+    /// またいで sortable である事実をここで固定する。
     #[tokio::test(flavor = "current_thread")]
     async fn list_recent_orders_entries_across_day_boundaries() {
         let backing = Arc::new(Mutex::new(BTreeMap::new()));
@@ -534,7 +534,7 @@ mod tests {
     /// 固定する。R2 の page-boundary を超えるシナリオは wrangler dev で実 R2 を
     /// 使って検証するが、キー設計自体が page 境界をまたいでも単調順序を持つ
     /// （= `Vec::extend` で全ページ収集 → `into_iter().rev()` で正しく新しい順を
-    /// 取り出せる）事実は本テストで固定する。
+    /// 取り出せる）事実をここで固定する。
     #[test]
     fn entry_key_sorts_lexicographically_with_end_time() {
         let early = entry("g1", "2026-04-26T08:30:15+00:00");

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -159,15 +159,15 @@ const KEY_GRACE_REGISTRY: &str = "grace_registry";
 /// `GraceExpired` を書き込む。
 const KEY_PENDING_ALARM_KIND: &str = "pending_alarm_kind";
 /// 終局時に R2 export PUT が一部または全部失敗したときに、再 PUT に必要な
-/// CSA 本文 / meta JSON / 失敗 key 一覧を保持する DO storage key (Issue #623)。
+/// CSA 本文 / meta JSON / 失敗 key 一覧を保持する DO storage key (R2 export retry)。
 /// `KEY_PENDING_ALARM_KIND = ExportRetry` とペアでセットされ、`alarm()` 経路で
 /// `handle_export_retry_alarm` が読み取る。retry 全消費後は alarm のみ停止し
-/// 本 key は残置する (運用観測用)。
+/// この key は残置する (運用観測用)。
 const KEY_EXPORT_PENDING: &str = "export_pending";
 
-/// 終局時 R2 export 試行の結果分類 (Issue #623)。
+/// 終局時 R2 export 試行の結果分類 (R2 export retry)。
 ///
-/// `export_kifu_to_r2` は本 enum を返し、呼び出し側 (`finalize_if_ended`) が
+/// `export_kifu_to_r2` はこの enum を返し、呼び出し側 (`finalize_if_ended`) が
 /// `Complete` / `Pending` / `Skipped` に応じて pending 永続化 + retry alarm
 /// 予約 / 何もしない を分岐する。
 #[derive(Debug)]
@@ -175,14 +175,14 @@ enum ExportAttempt {
     /// 4 オブジェクト (csa 本文 / by-id / meta / games-index) すべて PUT 成功
     /// (`exported_at_ms = Some` を埋められる)。
     Complete,
-    /// 1 つ以上 PUT 失敗で retry 必要。本 variant が持つ
+    /// 1 つ以上 PUT 失敗で retry 必要。この variant が持つ
     /// [`ExportPendingState`] を `KEY_EXPORT_PENDING` に永続化する。
     Pending(Box<ExportPendingState>),
     /// retry しても解決しない致命的失敗 (bucket binding 不在 / load_moves 失敗 /
     /// SFEN 不正 / serialize 失敗 / games_index_key 生成失敗等)。
     /// `exported_at_ms = None` のままで観測上は欠損として残るが、それ以外の処理
     /// は通常通り進める。retry できるはずの CSA PUT 失敗が混在している場合は
-    /// `Pending` に倒し、CSA 部分だけ retry する (Codex code review #2 反映)。
+    /// `Pending` に倒し、CSA 部分だけ retry する。
     Skipped,
 }
 
@@ -211,8 +211,8 @@ impl ExportAttempt {
     }
 
     /// 4 オブジェクト中いずれかを **PUT 試行できなかった** 経路から呼ぶ
-    /// コンストラクタ (Codex code review #2 反映)。serialize 失敗 /
-    /// games_index_key 生成失敗で meta or index PUT が抜けたケースなど。
+    /// コンストラクタ。serialize 失敗 / games_index_key 生成失敗で
+    /// meta or index PUT が抜けたケースなど。
     ///
     /// retry 可能な CSA PUT 失敗が `failed_keys` にあれば `Pending` に倒し、
     /// CSA 部分だけ再試行する (`exported_at_ms` は引き続き `None`)。
@@ -484,7 +484,7 @@ impl DurableObject for GameRoom {
         // alarm 種別タグを読み、各経路を分岐する。
         // 既定値 (タグ未設定 / `TimeUp`) は時間切れ駆動とみなす。
         //
-        // ⚠ Issue #623: `ExportRetry` は `KEY_FINISHED` 確定**後**に発火する
+        // ⚠ `ExportRetry` は `KEY_FINISHED` 確定**後**に発火する
         // 特殊な alarm なので、`load_finished` ガードよりも**前**に分岐する必要
         // がある。それ以外 (`GraceExpired` / `AgreeTimeout` / `TimeUp`) は終局前
         // 経路なので従来どおり `load_finished` ガードを先に通す。
@@ -572,7 +572,7 @@ impl GameRoom {
             return Ok(());
         };
 
-        // `WORKERS_HANDLE_AUTH` whitelist (issue #664): registry に登録された
+        // `WORKERS_HANDLE_AUTH` whitelist: registry に登録された
         // handle に限り SHA256(password) を要求する。reconnect 経路の前に挟む
         // (= reconnect token を持っていても、whitelist 対象 handle で password
         // 検証に落ちる session は reconnect 経路にも入らない)。fail-closed:
@@ -907,9 +907,9 @@ impl GameRoom {
         //
         // - 両者 AGREE で `HandleOutcome::GameStarted` が観測されたら、
         //   `reschedule_turn_alarm` が turn budget で alarm 本体を上書きした **後**
-        //   に `clear_agree_timeout_tag` で kind タグを削除する (順序の意図は
-        //   Issue #597: タグ削除を後置することで「kind=None かつ alarm=AgreeTimeout
-        //   当時の発火時刻」の中間状態をコード上に作らない)。
+        //   に `clear_agree_timeout_tag` で kind タグを削除する (タグ削除を後置
+        //   することで「kind=None かつ alarm=AgreeTimeout 当時の発火時刻」の
+        //   中間状態をコード上に作らない)。
         //   タグが無くなった後は alarm が時間切れ駆動 (TimeUp) として扱われる。
         // - alarm が `AgreeTimeout` のまま発火したら `handle_agree_timeout_alarm` で
         //   部屋を解放する (`abort_pending_match_with_error` 相当 + `KEY_FINISHED`
@@ -993,7 +993,7 @@ impl GameRoom {
             }
         };
 
-        // outcome 別の永続化 + alarm + broadcast 順序 (Issue #597)。
+        // outcome 別の永続化 + alarm + broadcast 順序 (AgreeTimeout タグ管理)。
         //
         // - `GameStarted` / `MoveAccepted`: 新 turn alarm の予約と
         //   `clear_agree_timeout_tag` を **broadcast より前** に行う。broadcast 失敗で
@@ -1651,7 +1651,7 @@ impl GameRoom {
 
     /// 終局したなら R2 に棋譜を書き出し、finished フラグを立てて両 ws を close する。
     ///
-    /// R2 export PUT が一部または全部失敗した場合 (Issue #623):
+    /// R2 export PUT が一部または全部失敗した場合 (R2 export retry):
     /// 1. CSA 本文 / meta JSON / 失敗 key 一覧を [`ExportPendingState`] として
     ///    `KEY_EXPORT_PENDING` に保存する
     /// 2. `KEY_PENDING_ALARM_KIND = ExportRetry` をセット
@@ -1704,7 +1704,7 @@ impl GameRoom {
 
         // export 一部失敗なら pending 永続化 + retry alarm を貼る。pending put /
         // alarm 書き込みは best-effort で失敗ログのみ残し、`finalize_if_ended` の
-        // 残り処理 (live-games-index 削除 / WS close) を必ず進める (Issue #623 主契約)。
+        // 残り処理 (live-games-index 削除 / WS close) を必ず進める (R2 export retry 主契約)。
         if let Some(pending) = attempt.into_pending() {
             self.schedule_export_retry(pending).await;
         }
@@ -1741,7 +1741,7 @@ impl GameRoom {
         Ok(())
     }
 
-    /// 終局時 export PUT 失敗の retry を予約する (Issue #623)。
+    /// 終局時 export PUT 失敗の retry を予約する。
     ///
     /// `KEY_EXPORT_PENDING` (本文 + 失敗 key 一覧) と `KEY_PENDING_ALARM_KIND =
     /// ExportRetry` を put し、`RETRY_DELAYS_SEC[0]` 後に `state.alarm()` を貼る。
@@ -1803,7 +1803,7 @@ impl GameRoom {
         }
     }
 
-    /// `PendingAlarmKind::ExportRetry` で alarm が発火したときの再 PUT 経路 (Issue #623)。
+    /// `PendingAlarmKind::ExportRetry` で alarm が発火したときの再 PUT 経路。
     ///
     /// `KEY_EXPORT_PENDING` から保存済の本文 + 失敗 key 一覧を読み、各 key に
     /// 対して再 PUT を試みる。全成功で `exported_at_ms` を埋めて pending を消し、
@@ -1836,8 +1836,8 @@ impl GameRoom {
                     err: format!("{e:?}"),
                 );
                 // bucket binding 不在 = config 不正。retry を進めても解決しない
-                // ので alarm を停止し pending は残置 (deploy 修正で再開する想定
-                // だが、本 PR の scope ではここまで)。
+                // ので alarm を停止し pending は残置 (deploy 修正で再開する想定、
+                // 自動回復経路は持たない)。
                 let _ = self.state.storage().delete(KEY_PENDING_ALARM_KIND).await;
                 let _ = self.state.storage().delete_alarm().await;
                 return Ok(());
@@ -2006,13 +2006,13 @@ impl GameRoom {
     /// 構造なので、外部のレート集計や HTML レンダリングなどの後段処理は R2 を
     /// mount するだけで TCP 版と同じパスで読める。
     ///
-    /// 戻り値 [`ExportAttempt`] (Issue #623):
+    /// 戻り値 [`ExportAttempt`] (R2 export retry):
     /// - `Complete`: 4 オブジェクト (csa 本文 / by-id / meta / games-index) すべて
     ///   PUT 成功 (= retry 不要)。
     /// - `Pending(state)`: 1 つ以上 PUT 失敗で retry 用の本文 + 失敗 key 一覧を
-    ///   保持。`finalize_if_ended` は本値を `KEY_EXPORT_PENDING` に永続化する。
+    ///   保持。`finalize_if_ended` がこの値を `KEY_EXPORT_PENDING` に永続化する。
     /// - `Skipped`: bucket binding 不在 / `load_moves` 失敗 / SFEN 不正 / serialize
-    ///   失敗等の「retry しても解決しない致命的失敗」。本関数内で
+    ///   失敗等の「retry しても解決しない致命的失敗」。この関数内で
     ///   [`structured_log!`](crate::structured_log) で吸収済みなので呼び出し側は
     ///   何もしない (`exported_at_ms = None` だけ残る)。
     ///
@@ -2134,7 +2134,7 @@ impl GameRoom {
 
         // 4 つの PUT を集約する。各 PUT は独立して試行し、失敗した key だけを
         // `failed_keys` に積む。CSA 本文 PUT が失敗しても meta / index PUT は試す
-        // (Issue #623: best-effort 全 put → retry で残りを順送り)。
+        // (best-effort 全 put → retry で残りを順送り)。
         let mut failed_keys: Vec<FailedExportObject> = Vec::with_capacity(4);
         let csa_bytes = text.as_bytes().to_vec();
         for (key, label) in [
@@ -2203,9 +2203,9 @@ impl GameRoom {
                     err: format!("{e:?}"),
                 );
                 // CSA 本文 PUT は試行済 (failed_keys に積まれているかも) だが、
-                // meta/index は serialize 失敗で本経路で PUT 試行できていない。
+                // meta/index は serialize 失敗でこの経路で PUT 試行できていない。
                 // 4 PUT 全成功にはなり得ないので `from_partial_attempt` で
-                // `Complete` を絶対返さない経路に倒す (Codex code review #2)。
+                // `Complete` を絶対返さない経路に倒す。
                 return ExportAttempt::from_partial_attempt(
                     cfg.game_id.clone(),
                     ended_at_ms,
@@ -2243,7 +2243,7 @@ impl GameRoom {
                 );
                 // games-index key 生成失敗は retry 不可。pending には CSA / meta
                 // のみ残す。index PUT が抜けるため `from_partial_attempt` で
-                // `Complete` 経路を塞ぐ (Codex code review #2)。
+                // `Complete` 経路を塞ぐ。
                 return ExportAttempt::from_partial_attempt(
                     cfg.game_id.clone(),
                     ended_at_ms,
@@ -2392,10 +2392,10 @@ impl GameRoom {
             if snapshot_in_progress {
                 // https://github.com/SH11235/rshogi/issues/627: queue を push する前に上限を判定する。
                 // - 行数 > `MAX_SPECTATOR_QUEUE_ITEMS`
-                // - bytes (各 line の `len()` 総和 + 今回追加分) > `MAX_SPECTATOR_QUEUE_BYTES`
+                // - bytes (各 line の `len()` 総和 + 新規 line 分) > `MAX_SPECTATOR_QUEUE_BYTES`
                 // のいずれか満たす場合は、attachment を上書きせずに観戦者を切断する。
                 // serialize_attachment をスキップすることで、close 後の hibernation
-                // 復帰時にも肥大化した queue が残らないことを保証する (Codex review)。
+                // 復帰時にも肥大化した queue が残らないことを保証する。
                 let next_items = pending_queue.len().saturating_add(1);
                 let current_bytes: usize = pending_queue.iter().map(|(s, _)| s.len()).sum();
                 let next_bytes = current_bytes.saturating_add(line.len());
@@ -2864,8 +2864,8 @@ impl GameRoom {
         let (alarm_kind, should_set_grace) =
             classify_alarm_after_enter_grace(existing_alarm, grace_deadline_ms);
 
-        // `KEY_PENDING_ALARM_KIND` → `KEY_GRACE_REGISTRY` の順で put する
-        // (Issue #597 隣接懸念 2)。`put_multiple` を使うとローカル struct の
+        // `KEY_PENDING_ALARM_KIND` → `KEY_GRACE_REGISTRY` の順で put する。
+        // `put_multiple` を使うとローカル struct の
         // `#[serde(rename = "...")]` が各定数と一致する暗黙契約になり、定数を
         // rename した際に silent failure となるリスクがあるため、定数を直接
         // `put` に渡す形に分解する。
@@ -2996,7 +2996,7 @@ impl GameRoom {
         if let Some(result) = result_opt {
             self.dispatch_broadcasts(&result.broadcasts).await?;
             // `finalize_if_ended` は内部で `delete_grace_alarm_state` を呼んだ後に
-            // ExportRetry alarm を貼り直す可能性がある (Issue #623)。ここで重ねて
+            // ExportRetry alarm を貼り直す可能性がある (R2 export retry)。ここで重ねて
             // `delete_grace_alarm_state` を呼ぶと `KEY_PENDING_ALARM_KIND=ExportRetry`
             // を巻き込んで削除してしまい、retry alarm が発火しても kind が `None`
             // で `KEY_FINISHED` ガードに弾かれる。`finalize_if_ended` の責務に任せ
@@ -3246,7 +3246,7 @@ impl GameRoom {
     }
 }
 
-/// LOGIN handle 自称防止 (issue #664)。`WORKERS_HANDLE_AUTH` whitelist の
+/// LOGIN handle 自称防止。`WORKERS_HANDLE_AUTH` whitelist の
 /// 1 LOGIN あたり 1 回 fetch + parse して、登録 handle に限り SHA256(password)
 /// を要求する。
 ///

--- a/crates/rshogi-csa-server-workers/src/games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_index.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn games_index_key_inv_ms_zero_pads_for_recent_timestamp() {
-        // 2026-04-29 頃の epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
+        // epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
         let ended = 1_777_392_877_244_u64;
         let key = games_index_key(ended, "lobby-cross-fischer-1777391025209").unwrap();
         // INV_BASE - 1_777_392_877_244 = 98_222_607_122_755 (14 桁)

--- a/crates/rshogi-csa-server-workers/src/handle_auth.rs
+++ b/crates/rshogi-csa-server-workers/src/handle_auth.rs
@@ -21,9 +21,9 @@
 //!   通る経路を絶つ。env が空 (`None` / `""` / `"[]"`) のみが「whitelist 未宣言」
 //!   として self-claim 既定挙動を維持する。
 //! - **private 経路にも適用**: `LOGIN_LOBBY <handle>+private-<token>+free` も
-//!   whitelist 対象 (PR #708 codex-connector P1 review 由来)。`CHALLENGE_LOBBY`
-//!   の `opponent=<handle>` は発行者の自己申告のため、任意 handle を仕込んだ
-//!   token を握って private LOGIN_LOBBY 経由で名乗る経路が成立してしまう。
+//!   whitelist 対象。`CHALLENGE_LOBBY` の `opponent=<handle>` は発行者の
+//!   自己申告のため、任意 handle を仕込んだ token を握って
+//!   private LOGIN_LOBBY 経由で名乗る経路が成立してしまう。
 //!   handle_auth を token validation より先に評価し reason を
 //!   `handle_auth_failed` に uniform 化することで、`not_invited` /
 //!   `challenge_expired` の差分から whitelist 対象 handle を推測される情報

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -44,9 +44,9 @@ pub mod export_retry;
 pub mod floodgate_history;
 pub mod games_index;
 // `handle_auth` は `WORKERS_HANDLE_AUTH` whitelist の parse + password SHA256
-// 比較 (issue #664) を担う。`HandleAuthRegistry` + `verify` は I/O 非依存の
+// 比較を担う。`HandleAuthRegistry` + `verify` は I/O 非依存の
 // pure helper でホスト target からテストできるよう `pub mod` で公開する。
-// wasm32 限定の `load_handle_auth_registry` (env 読み出し配線) は本 module 内で
+// wasm32 限定の `load_handle_auth_registry` (env 読み出し配線) はこの module 内で
 // `#[cfg(target_arch = "wasm32")]` 化する。
 pub mod handle_auth;
 pub mod live_games_index;
@@ -55,8 +55,7 @@ pub mod origin;
 // `rate_limit` は host テスト可能な pure helper (TokenBucketState, threshold
 // resolution, Retry-After 算出) と wasm32-only な `RateLimiter` Durable Object を
 // 同居させる。DO 部分は `#[cfg(target_arch = "wasm32")]` で gate しているので、
-// ホスト target からも `cargo test` で pure logic を直接走らせられる
-// (issue #622 PR3a)。
+// ホスト target からも `cargo test` で pure logic を直接走らせられる。
 pub mod rate_limit;
 // `persistence` は DO ランタイム (`game_room`) からのみ消費される I/O 非依存の
 // 純粋ロジックを置く。ホスト target の通常ビルドでは消費者が存在しないので

--- a/crates/rshogi-csa-server-workers/src/live_games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/live_games_index.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn live_games_index_key_inv_ms_zero_pads_for_recent_timestamp() {
-        // 2026-04-29 頃の epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
+        // epoch ms (13 桁) でも inv は 14 桁ゼロパディングで揃う。
         let started = 1_777_391_025_209_u64;
         let key = live_games_index_key(started, "lobby-cross-fischer-1777391025209").unwrap();
         // INV_BASE - 1_777_391_025_209 = 98_222_608_974_790 (14 桁)

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -16,11 +16,11 @@
 //!
 //! 認証は self-claim (`<password>` 値検証なし)、本家 Floodgate と同じ扱い。
 //!
-//! # 私的対局 (https://github.com/SH11235/rshogi/issues/582) — 本 PR スコープ
+//! # 私的対局 (https://github.com/SH11235/rshogi/issues/582)
 //!
-//! 本 PR では以下のみ実装する。両者揃った後の対局起動経路 (consume → GameRoom
-//! DO 起動 + clock_spec / initial_sfen バトンパス) は https://github.com/SH11235/rshogi/issues/582 follow-up
-//! integration の後半スコープに分割する。
+//! ここでは以下のみ実装する。両者揃った後の対局起動経路 (consume → GameRoom
+//! DO 起動 + clock_spec / initial_sfen バトンパス) は別モジュール (follow-up
+//! integration の後半スコープ) に分割されている。
 //!
 //! - `CHALLENGE_LOBBY <inviter> <opponent> <color> <clock_preset> [<sfen>]` 受理
 //!   と token 発行 (`CHALLENGE_LOBBY:OK <token> <ttl_sec>` 応答)
@@ -181,10 +181,10 @@ impl DurableObject for Lobby {
         let server = pair.server;
         self.state.accept_web_socket(&server);
 
-        // Rate limit (issue #622 PR3a) のため、`router::forward_ws_to_lobby` が
+        // Rate limit のため、`router::forward_ws_to_lobby` が
         // 転送した `CF-Connecting-IP` を attachment に保存する。
         // `accept_web_socket` 後の `websocket_message` ハンドラは Worker fetch
-        // context を持たないため、本フィールド経由でしか per-IP rate limit を
+        // context を持たないため、このフィールド経由でしか per-IP rate limit を
         // 適用できない。ヘッダ欠落 / 空文字は `None` として扱い、後段の
         // LOGIN_LOBBY / CHALLENGE_LOBBY ハンドラ側で fail-closed する。
         let client_ip = crate::rate_limit::extract_client_ip(&req);
@@ -514,22 +514,22 @@ impl Lobby {
             Err(e) => return self.send_login_error(ws, e).await,
         };
 
-        // Rate limit (issue #622 PR3a): per-IP + per-handle の二段チェック。
+        // Rate limit: per-IP + per-handle の二段チェック。
         // **parse 通過後** に走らせることで、`bad_format` 等の構文不正は
         // counter を増やさずに既存経路で reject する (構文不正 flood は別軸の
-        // `MAX_WS_LINE_BYTES` + connection-level 削減で対処、本 limiter の対象外)。
+        // `MAX_WS_LINE_BYTES` + connection-level 削減で対処、この limiter の対象外)。
         // **fail-closed 順序**:
         // 1. CF-Connecting-IP 欠落 → `rate_limited` で reject (per-IP / per-handle
         //    どちらも IP を一次キーに使うため、IP 不在は両方とも適用不能)
         // 2. per-IP 拒否 → reject
         // 3. per-handle 拒否 → reject
         // いずれの順で reject されても WS は close せず、client が retry できる
-        // 経路を保つ (`Q4-A` design: csa-client は retry_after honoring、PR #683)。
+        // 経路を保つ (`Q4-A` design: csa-client は retry_after honoring)。
         if let Some(decision) = self.check_login_lobby_rate_limit(client_ip, &req.handle).await? {
             return self.send_rate_limited_login_lobby(ws, decision).await;
         }
 
-        // `WORKERS_HANDLE_AUTH` whitelist (issue #664): registry に登録された
+        // `WORKERS_HANDLE_AUTH` whitelist: registry に登録された
         // handle に限り SHA256(password) を要求する。rate_limit の後 / queue
         // enqueue の前に挟むのは、`bad_format` 等の構文不正は counter を
         // 増やさない既存契約に揃え、かつ password 検証失敗の度に queue 操作の
@@ -733,10 +733,10 @@ impl Lobby {
     /// - `Ok(Some(decision))` → どこかの bucket が deny、caller は
     ///   `send_rate_limited_login_lobby(decision)` で client に応答する
     /// - `Err(_)` → DO RPC 自体が失敗 (transient)。caller は `?` で伝播し、
-    ///   Worker 全体としては 500 系に倒れる (= fail-closed、本リクエストは reject
+    ///   Worker 全体としては 500 系に倒れる (= fail-closed、当該リクエストは reject
     ///   される)
     ///
-    /// **fail-closed 順序** (issue #622 PR3a 設計): CF-Connecting-IP 欠落 →
+    /// **fail-closed 順序**: CF-Connecting-IP 欠落 →
     /// per-IP → per-handle。先に拒否された方の `decision` を返す。
     async fn check_login_lobby_rate_limit(
         &self,
@@ -855,8 +855,8 @@ impl Lobby {
 
     /// rate limit 拒否時の LOGIN_LOBBY 応答。design doc Q4-A の wire format
     /// (`LOGIN_LOBBY:incorrect rate_limited retry_after=<sec>`) を採用する。
-    /// **WS は close しない**: csa-client 側 (PR #683) で `retry_after` を
-    /// honoring しつつ retry する経路を踏むため、close すると client が
+    /// **WS は close しない**: csa-client 側で `retry_after` を honoring
+    /// しつつ retry する経路を踏むため、close すると client が
     /// 即座に再 upgrade する fast-loop を作ってしまい cap が効かなくなる。
     async fn send_rate_limited_login_lobby(
         &self,
@@ -882,10 +882,10 @@ impl Lobby {
     /// `ChallengeRegistry::issue` で token を発行して
     /// `CHALLENGE_LOBBY:OK <token> <ttl_sec>` を返す。
     ///
-    /// **本 PR スコープ補足**: `unknown_opponent_handle` の検証は Workers では
+    /// **スコープ補足**: `unknown_opponent_handle` の検証は Workers では
     /// 実装しない (self-claim モデル、`PasswordStore` 等の認証層がないため)。
-    /// 両者揃った時点での GameRoom DO 起動経路は次 PR に分割するため、本関数
-    /// は token を登録するだけで対局起動の trigger を発火させない。
+    /// 両者揃った時点での GameRoom DO 起動経路は別モジュールに分割されており、
+    /// この関数は token を登録するだけで対局起動の trigger を発火させない。
     async fn handle_challenge_lobby(
         &self,
         ws: &WebSocket,
@@ -906,7 +906,7 @@ impl Lobby {
             }
         };
 
-        // Rate limit (issue #622 PR3a): per-IP + per-inviter handle の二段チェック。
+        // Rate limit: per-IP + per-inviter handle の二段チェック。
         // **parse 通過後** に走らせ、構文不正は counter を増やさない。fail-closed
         // 順序は LOGIN_LOBBY と対称 (1. CF-Connecting-IP 欠落 → reject、
         // 2. per-IP、3. per-inviter handle)。`req.inviter` を per-handle 判定の
@@ -1011,11 +1011,11 @@ impl Lobby {
     /// 5. 通過 → `mark_ws_logged_in` で attachment id を登録し、
     ///    `LOGIN_LOBBY:<handle> OK pending_match_dispatch_pending` 暫定応答を返す。
     ///
-    /// **本 PR スコープ補足**: 両者揃った時点で `consume(token)` → GameRoom DO
+    /// **スコープ補足**: 両者揃った時点で `consume(token)` → GameRoom DO
     /// 起動 + clock_spec / initial_sfen バトンパスする経路は https://github.com/SH11235/rshogi/issues/582
-    /// follow-up integration の後半スコープに分割する。本 PR では LOGIN_LOBBY
+    /// follow-up integration の後半スコープに分割されている。ここでは LOGIN_LOBBY
     /// を受理して attachment を `PrivatePending` で登録するだけで、対局起動
-    /// trigger を発火させない (WS は接続維持され、次 PR の dispatch 経路で
+    /// trigger を発火させない (WS は接続維持され、別モジュールの dispatch 経路で
     /// 起動する)。
     async fn handle_login_lobby_private(
         &self,
@@ -1033,7 +1033,7 @@ impl Lobby {
             password,
         } = req;
 
-        // Rate limit (issue #622 PR3a): 私的 LOGIN_LOBBY も公開 LOGIN_LOBBY と
+        // Rate limit: 私的 LOGIN_LOBBY も公開 LOGIN_LOBBY と
         // 同じ IP / handle カウンタを共有する (どちらも `LOGIN_LOBBY` 系コマンドで、
         // 同 IP / handle からの flood 攻撃面が同等)。
         // private LOGIN_LOBBY ではエラー応答に `1003 close` が伴うのが既存仕様だが、
@@ -1043,8 +1043,8 @@ impl Lobby {
             return self.send_rate_limited_login_lobby(ws, decision).await;
         }
 
-        // `WORKERS_HANDLE_AUTH` whitelist (issue #664) — private 経路 follow-up
-        // (codex-connector P1 review 由来)。`CHALLENGE_LOBBY` の `opponent` が
+        // `WORKERS_HANDLE_AUTH` whitelist — private 経路でも適用する。
+        // `CHALLENGE_LOBBY` の `opponent` が
         // 発行者の自己申告のため、攻撃者が `opponent=alice` で token を発行 →
         // `LOGIN_LOBBY alice+private-<token>+free wrong-password` で whitelist
         // 対象 handle を無認証で名乗れる経路を塞ぐ。rate_limit の後・challenge
@@ -1124,10 +1124,10 @@ impl Lobby {
         send_line(ws, &format!("LOGIN_LOBBY:{handle} OK pending_match_dispatch_pending"))?;
         // 私的対局 token は診断用途で平文ログに残す (旧 console_log! と同等の挙動を
         // 保つ移行)。CHALLENGE_LOBBY 発行時の TTL (`CHALLENGE_TTL_SEC`、既定
-        // 3600 秒) で自動失効するため、Tail Workers / R2 archive (#625 Phase B)
-        // 経由で漏えいしてもリプレイ攻撃ウィンドウは限定的。token を無害化したい
-        // 場合は本フィールドを `token_prefix: token.as_str().chars().take(8).collect::<String>()`
-        // 等に差し替える (本 PR スコープでは保留)。
+        // 3600 秒) で自動失効するため、Tail Workers / R2 archive 経由で
+        // 漏えいしてもリプレイ攻撃ウィンドウは限定的。token を無害化したい
+        // 場合はこのフィールドを `token_prefix: token.as_str().chars().take(8).collect::<String>()`
+        // 等に差し替える (現状は保留)。
         crate::structured_log!(
             event: "login_lobby_private",
             component: "lobby",
@@ -1161,8 +1161,8 @@ impl Lobby {
         Ok(())
     }
 
-    /// 私的対局 attachment 状態で受信した line。本 PR スコープでは対局起動が
-    /// 動かないため、`LOGOUT_LOBBY` を受理して切断する以外は ignore する。
+    /// 私的対局 attachment 状態で受信した line。対局起動経路はこのモジュール
+    /// では発火しないため、`LOGOUT_LOBBY` を受理して切断する以外は ignore する。
     /// `LOBBY_PONG` は keep-alive として silent に受理する。
     async fn handle_private_pending_line(
         &self,
@@ -1346,15 +1346,15 @@ fn evict_old_websockets_with_handle(state: &State, current_ws: &WebSocket, handl
     }
 }
 
-/// LOGIN handle 自称防止 (issue #664) の lobby 経路版。
+/// LOGIN handle 自称防止の lobby 経路版。
 /// `WORKERS_HANDLE_AUTH` whitelist 設定を 1 LOGIN_LOBBY あたり 1 回 fetch + parse
 /// し、登録 handle に限り SHA256(password) を要求する。
 ///
 /// 公開経路 ([`Lobby::handle_login_lobby`]) と private 経路
-/// ([`Lobby::handle_login_lobby_private`]) の双方から呼ばれる (codex-connector
-/// PR #708 P1 review 由来 — `CHALLENGE_LOBBY` の `opponent` 自己申告で whitelist
-/// 対象 handle を private 経由で名乗れる経路を塞ぐため、private 経路でも
-/// 同じ enforcement を走らせる)。private 経路では token validation **より先** に
+/// ([`Lobby::handle_login_lobby_private`]) の双方から呼ばれる。
+/// `CHALLENGE_LOBBY` の `opponent` 自己申告で whitelist 対象 handle を private
+/// 経由で名乗れる経路を塞ぐため、private 経路でも同じ enforcement を走らせる。
+/// private 経路では token validation **より先** に
 /// 評価することで reason を `handle_auth_failed` に uniform 化し、
 /// `not_invited` / `challenge_expired` との差分から whitelist 対象 handle が
 /// 推測される情報 leak も同時に塞ぐ。

--- a/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby_protocol.rs
@@ -9,9 +9,9 @@
 //! - in-memory queue ([`LobbyQueue`]) と直接マッチング (`DirectMatchStrategy` 再利用)。
 //! - 出力 line のシリアライズ (`LOGIN_LOBBY:<handle> OK` / `MATCHED <room_id> <color>` 等)。
 //! - 私的対局 (`CHALLENGE_LOBBY` / `LOGIN_LOBBY <handle>+private-<token>+free`)
-//!   の入口パース。https://github.com/SH11235/rshogi/issues/582 の Workers 側受け入れ基準のうち本 PR スコープ
-//!   (token 発行 + LOGIN 認識 + 永続化 + Alarm purge) で参照される。両者揃った
-//!   後の対局起動経路は次 PR に分割するため、本モジュールは対局室 (GameRoom DO)
+//!   の入口パース。https://github.com/SH11235/rshogi/issues/582 の Workers 側受け入れ基準のうち
+//!   token 発行 + LOGIN 認識 + 永続化 + Alarm purge で参照される。対局起動経路は
+//!   別モジュール側に分離されており、ここは対局室 (GameRoom DO)
 //!   起動側の知識を持たない。
 
 use rshogi_csa_server::matching::challenge::ChallengeToken;
@@ -105,7 +105,7 @@ pub fn parse_login_lobby(line: &str) -> Result<LoginLobbyRequest, LoginLobbyErro
     let rest = line.strip_prefix("LOGIN_LOBBY ").ok_or(LoginLobbyError::NotLoginCommand)?;
     let mut parts = rest.split_whitespace();
     let id = parts.next().ok_or(LoginLobbyError::BadFormat)?;
-    // password は LOGIN_LOBBY の必須トークン。issue #664 で `WORKERS_HANDLE_AUTH`
+    // password は LOGIN_LOBBY の必須トークン。`WORKERS_HANDLE_AUTH`
     // whitelist 経路に渡せるよう、parser でも保持する (whitelist 未宣言モードで
     // 当該 handle が登録されていない場合は呼び出し側 `handle_login_lobby` で
     // 値を捨てる)。
@@ -541,7 +541,7 @@ pub fn parse_login_lobby_with_free(
         .ok_or(LoginLobbyPrivateError::NotLoginCommand)?;
     let mut parts = rest.split_whitespace();
     let id = parts.next().ok_or(LoginLobbyPrivateError::BadFormat)?;
-    // password は issue #664 follow-up (codex-connector P1) で必須化:
+    // password は private 経路でも必須:
     // `WORKERS_HANDLE_AUTH` whitelist 対象 handle が private 経路で無認証で
     // 名乗れる経路を塞ぐため、parser で保持して呼び出し側 verify に渡す。
     let password = parts.next().ok_or(LoginLobbyPrivateError::BadFormat)?;
@@ -588,14 +588,13 @@ mod tests {
         assert_eq!(req.handle, "alice");
         assert_eq!(req.game_name, "game-eval");
         assert_eq!(req.color, Color::Black);
-        // password token は parser に保持される (issue #664 で
-        // WORKERS_HANDLE_AUTH 経路に渡せるようにするため)。
+        // password token は parser に保持される (WORKERS_HANDLE_AUTH 経路に渡せるようにするため)。
         assert_eq!(req.password, "anything");
     }
 
-    /// `LoginLobbyRequest::Debug` は password を `"***"` でマスクする (issue
-    /// #664 PR #708 codex Minor review 由来)。`Debug` 派生を再導入すると平文が
-    /// panic message 経路に流れるため、本不変条件をテストで gate する。
+    /// `LoginLobbyRequest::Debug` は password を `"***"` でマスクする。
+    /// `Debug` 派生を再導入すると平文が panic message 経路に流れるため、
+    /// この不変条件をテストで gate する。
     #[test]
     fn login_lobby_request_debug_masks_password() {
         let req = parse_login_lobby("LOGIN_LOBBY alice+game-eval+black secret-password").unwrap();
@@ -638,7 +637,7 @@ mod tests {
 
     /// 既存 `parse_login_lobby` は私的対局の `+free` を `BadColor` として
     /// 拒否し続ける (`dispatch_pending_line` 側で `is_private_login_handle` 経由
-    /// で先に分岐させる契約)。本テストは「私的対局専用 parser 追加で公開
+    /// で先に分岐させる契約)。このテストは「私的対局専用 parser 追加で公開
     /// マッチング parser が `+free` を黙って通すようになっていない」ことを
     /// 固定する後方互換 regression。
     #[test]
@@ -966,8 +965,8 @@ mod tests {
         .unwrap();
         assert_eq!(req.handle, "alice");
         assert_eq!(req.token.as_str(), "0123456789abcdef0123abcd");
-        // password token は private 経路でも parser に保持される (issue #664
-        // follow-up で `WORKERS_HANDLE_AUTH` 経路に渡せるようにするため)。
+        // password token は private 経路でも parser に保持される
+        // (`WORKERS_HANDLE_AUTH` 経路に渡せるようにするため)。
         assert_eq!(req.password, "pw");
     }
 

--- a/crates/rshogi-csa-server-workers/src/observability.rs
+++ b/crates/rshogi-csa-server-workers/src/observability.rs
@@ -2,7 +2,8 @@
 //!
 //! Cloudflare Workers Logs / Tail Workers / dashboard から JSON フィールドで
 //! aggregate / grep できるよう、全 log を 1 行 JSON で出力する。
-//! ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A)
+//! (Cloudflare Workers Logs Phase A,
+//! <https://github.com/SH11235/rshogi/issues/625>)
 //!
 //! # 必須キー
 //!
@@ -50,11 +51,11 @@
 //!
 //! # ホスト target
 //!
-//! 本 macro は [`worker::Date::now`] と [`worker::console_log!`] を経由する
+//! このマクロは [`worker::Date::now`] と [`worker::console_log!`] を経由する
 //! ため、wasm32 でのみ展開される ([`worker`] crate がホスト target で参照
 //! 不可)。ホスト test 経路では呼び出さない契約。
 
-/// 構造化ログ ([Issue #625](https://github.com/SH11235/rshogi/issues/625) Phase A) の唯一の出力経路。
+/// 構造化ログ (Cloudflare Workers Logs Phase A) の唯一の出力経路。
 ///
 /// 詳細は [`crate::observability`] module の doc を参照。
 #[macro_export]

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -72,9 +72,9 @@ pub struct PersistedConfig {
 /// 終局フラグ。一度 `Some` になったらその DO は同じ対局を二度開始しない。
 ///
 /// `exported_at_ms` は R2 棋譜エクスポートが全 PUT 完了した時刻 (UNIX epoch ms)。
-/// `None` のあいだは終局はしているが R2 への書き出しが未完了で、Issue #623 の
+/// `None` のあいだは終局はしているが R2 への書き出しが未完了で、R2 export retry の
 /// `KEY_EXPORT_PENDING` + `PendingAlarmKind::ExportRetry` 経路で再試行されている
-/// ことを示す。`#[serde(default)]` で旧 schema (本フィールド導入前の cold start
+/// ことを示す。`#[serde(default)]` で旧 schema (このフィールド導入前の cold start
 /// snapshot) との互換を保つ。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinishedState {
@@ -87,7 +87,7 @@ pub struct FinishedState {
     pub(crate) exported_at_ms: Option<u64>,
 }
 
-/// 終局時の R2 export PUT のうち失敗した key を表すエントリ (Issue #623)。
+/// 終局時の R2 export PUT のうち失敗した key を表すエントリ (R2 export retry)。
 ///
 /// `body_kind` で再 PUT 時に乗せる本文 (`csa` = CSA 本文 / `meta` = JSON meta) を
 /// 区別する。`key` 文字列の prefix 推測ではなく明示分類にするのは、key 形式の
@@ -114,7 +114,7 @@ pub enum ExportBodyKind {
 }
 
 /// 終局時に R2 export の一部または全部が失敗したときに DO storage へ残す
-/// retry payload (Issue #623)。
+/// retry payload。
 ///
 /// CSA 本文 / meta JSON は finalize 時点で計算済のものをそのまま保存する
 /// (cold start 後でも `load_moves` を呼び直さず再 PUT できる)。`failed_keys`
@@ -692,9 +692,9 @@ mod tests {
         assert_eq!(restored.exported_at_ms, original.exported_at_ms);
     }
 
-    /// 旧 schema (本 `exported_at_ms` フィールド導入前) で書かれた DO storage
+    /// 旧 schema (`exported_at_ms` フィールド導入前) で書かれた DO storage
     /// 値が `#[serde(default)]` 経由で `None` として deserialize できることを
-    /// 固定する (Issue #623)。本契約が壊れると cold start 後の DO で
+    /// 固定する。この契約が壊れると cold start 後の DO で
     /// `load_finished` が失敗し、終局済 DO が新規 LOGIN を受け付ける退行になる。
     #[test]
     fn finished_state_deserializes_when_exported_at_ms_absent() {
@@ -708,9 +708,9 @@ mod tests {
         assert_eq!(restored.exported_at_ms, None);
     }
 
-    /// `ExportPendingState` の round-trip 固定 (Issue #623)。`failed_keys` の
-    /// `body_kind` が `csa` / `meta` の lower snake で wire される (rename_all)
-    /// ことも本テストで実装契約として固定する。
+    /// `ExportPendingState` の round-trip 固定 (R2 export retry の永続化契約)。
+    /// `failed_keys` の `body_kind` が `csa` / `meta` の lower snake で
+    /// wire される (rename_all) ことも実装契約として固定する。
     #[test]
     fn export_pending_state_round_trips_through_serde_json() {
         let original = ExportPendingState {

--- a/crates/rshogi-csa-server-workers/src/rate_limit.rs
+++ b/crates/rshogi-csa-server-workers/src/rate_limit.rs
@@ -1,11 +1,11 @@
-//! Rate limit / abuse protection (issue #622 PR3a)。
+//! Rate limit / abuse protection。
 //!
 //! Floodgate 相当 production 昇格 blocker。`/ws/lobby` への LOGIN_LOBBY /
 //! CHALLENGE_LOBBY flood、`/ws/<room_id>` upgrade flood、room 起動 flood を
 //! Worker code 側の **atomic token bucket** で抑制する。Cloudflare Workers
 //! Rate Limiting binding は本アカウントで利用不可確認のため、専用 Durable
 //! Object (`RateLimiterDO`) を per-key sharding で実装する (Q2-B 採択、
-//! 2026-05-10 user 確認、`docs/csa-server/rate_limit_design.md` §3 Q2)。
+//! `docs/csa-server/rate_limit_design.md` §3 Q2)。
 //!
 //! # 設計の前提
 //!
@@ -85,7 +85,7 @@ pub struct RateLimitThresholds {
 }
 
 impl RateLimitThresholds {
-    /// 設計 doc §3 Q3 表の推奨初期値 (2026-05-10 user 確定)。env 未設定 / 不正値の
+    /// 設計 doc §3 Q3 表の推奨初期値。env 未設定 / 不正値の
     /// fallback として参照する。
     pub const DEFAULTS: Self = Self {
         lobby_login_per_ip: 10,
@@ -113,10 +113,10 @@ impl RateLimitThresholds {
 /// 空文字 / `0` / 非数値 / 範囲外は `fallback` を返す。
 ///
 /// `0` を fallback に倒すのは「env 設定で 0 を入れて運用を無効化する」と
-/// 「typo / 範囲外で 0 になる」の区別が付かないため。本 PR では「rate limit
-/// は常に有効」を staging / production 共通の不変条件として固定し、
-/// env 経由で無効化する経路を提供しない (運用で外したくなった場合は
-/// 巨大な値を入れて事実上無効化する設計に倒す)。
+/// 「typo / 範囲外で 0 になる」の区別が付かないため。「rate limit は常に
+/// 有効」を staging / production 共通の不変条件として固定し、env 経由で
+/// 無効化する経路を提供しない (運用で外したくなった場合は巨大な値を
+/// 入れて事実上無効化する設計に倒す)。
 pub fn resolve_positive_u32_threshold(raw: Option<&str>, fallback: u32) -> u32 {
     let trimmed = raw.unwrap_or("").trim();
     if trimmed.is_empty() {
@@ -536,13 +536,13 @@ mod tests {
 
     use super::*;
 
-    /// 60_000 ms = 1 minute は capacity 全量を refill する根拠時間。本テストで
-    /// 1 minute スパンの境界挙動を全部回す。
+    /// 60_000 ms = 1 minute は capacity 全量を refill する根拠時間。
+    /// 1 minute スパンの境界挙動をまとめて検証する。
     const ONE_MINUTE_MS: u64 = 60_000;
 
     #[test]
     fn defaults_match_design_doc_q3_table() {
-        // 設計 doc §3 Q3 表の 6 推奨値 (2026-05-10 user 確定)。
+        // 設計 doc §3 Q3 表の 6 推奨値。
         let d = RateLimitThresholds::DEFAULTS;
         assert_eq!(d.lobby_login_per_ip, 10);
         assert_eq!(d.lobby_login_per_handle, 5);

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -186,9 +186,9 @@ pub enum PendingAlarmKind {
     /// 未 put) のため、`force_abnormal` ではなく `abort_pending_match_with_error`
     /// + `KEY_FINISHED` セット相当の経路で部屋を解放する (https://github.com/SH11235/rshogi/issues/600)。
     AgreeTimeout,
-    /// R2 棋譜 export PUT 失敗の retry (Issue #623)。`KEY_FINISHED` 確定後の
+    /// R2 棋譜 export PUT 失敗の retry。`KEY_FINISHED` 確定後の
     /// alarm 経路。終局時に PUT 失敗したオブジェクトキーを `KEY_EXPORT_PENDING`
-    /// に保存しておき、本タグで `handle_export_retry_alarm` を駆動して再 PUT する。
+    /// に保存しておき、このタグで `handle_export_retry_alarm` を駆動して再 PUT する。
     /// 終局後発火の特殊性から `alarm()` 入口で `KEY_FINISHED` ガード**より前**に
     /// 分岐させる必要がある (他種別と異なり「終局済 DO」での発火が正常経路)。
     ExportRetry,
@@ -416,7 +416,7 @@ mod tests {
         let restored: PendingAlarmKind =
             serde_json::from_str(&s).expect("deserialize GraceExpired");
         assert_eq!(restored, PendingAlarmKind::GraceExpired);
-        // Issue #623: ExportRetry も同形式で wire 互換であること。
+        // ExportRetry も同形式で wire 互換であること。
         let s =
             serde_json::to_string(&PendingAlarmKind::ExportRetry).expect("serialize ExportRetry");
         let restored: PendingAlarmKind = serde_json::from_str(&s).expect("deserialize ExportRetry");

--- a/crates/rshogi-csa-server-workers/src/router.rs
+++ b/crates/rshogi-csa-server-workers/src/router.rs
@@ -87,11 +87,11 @@ async fn forward_ws_to_lobby(req: Request, env: Env) -> Result<Response> {
         "sec-websocket-version",
         "sec-websocket-protocol",
         "sec-websocket-extensions",
-        // Rate limit (issue #622 PR3a): LobbyDO 側で LOGIN_LOBBY / CHALLENGE_LOBBY
+        // Rate limit: LobbyDO 側で LOGIN_LOBBY / CHALLENGE_LOBBY
         // 受信時に per-IP 限流するため、CF-Connecting-IP を DO に渡す。
-        // `accept_web_socket` は Worker fetch context を keep しないので、本ヘッダ
+        // `accept_web_socket` は Worker fetch context を keep しないので、このヘッダ
         // を attachment に保存して `websocket_message` から参照する設計。
-        // 本リストに名前を載せていない他ヘッダは意図的に削ぎ落とすコントラクト
+        // このリストに名前を載せていない他ヘッダは意図的に削ぎ落とすコントラクト
         // (DO 側で信頼できるのは `Upgrade` / `Sec-WebSocket-*` / `CF-Connecting-IP`
         // のみ) を維持する。
         "cf-connecting-ip",
@@ -151,13 +151,13 @@ async fn forward_ws_to_room(
         return Response::error("Upgrade required", 426);
     }
 
-    // Rate limit (issue #622 PR3a): WS upgrade flood / GameRoom DO 起動 flood の
+    // Rate limit: WS upgrade flood / GameRoom DO 起動 flood の
     // 抑制。`parse_ws_route` 通過後 + Origin / Upgrade 検査済み + DO `id_from_name`
     // 解決前にチェックする (`docs/csa-server/rate_limit_design.md` §4.4 hook 順序)。
     //
-    // `parse_ws_route` で reject される `%%room_id` 不正値は本パスに到達しない
-    // ため、bucket への counter 増加経路を踏まない (= claude review #1 の
-    // 「不正値で counter 増加してはいけない」契約を満たす)。
+    // `parse_ws_route` で reject される `%%room_id` 不正値はこのパスに到達しない
+    // ため、bucket への counter 増加経路を踏まない (= 「不正値で counter 増加
+    // してはいけない」契約を満たす)。
     //
     // 二段階チェック:
     // 1. `WsRoomUpgradePerIp` (looser cap, 既定 60/分) — player + spectator 共有

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -51,18 +51,18 @@
 //!   により毎回 worker に再検証を投げるため、kill-switch / allowlist 変更は即時に
 //!   ブラウザにも反映される)。
 //!
-//! ## Cache-Control directive 設計 (Issue #653 P2)
+//! ## Cache-Control directive 設計
 //!
-//! Issue #648 の初期実装では `public, max-age=<TTL>` を採用していたが、これだと
+//! 初期実装では `public, max-age=<TTL>` を採用していたが、これだと
 //! `caches.default` だけでなくブラウザ・共有 HTTP cache にも `max-age` が効いて
 //! しまう。`WS_ALLOWED_ORIGINS` から Origin を除外したり `ALLOW_VIEWER_API` を
 //! 落としても、すでに 200 を取得済みのブラウザは worker に再到達せず TTL 満了まで
 //! cache を返し続ける (`check_origin` / kill-switch は worker 到達時にしか効かない)。
 //!
-//! 現行設計 (#653): `public, s-maxage=<TTL>, max-age=0, must-revalidate`
+//! 現行設計: `public, s-maxage=<TTL>, max-age=0, must-revalidate`
 //! - `s-maxage=<TTL>`: shared cache (Cloudflare edge `caches.default` を含む) は
 //!   TTL 秒保存する。worker `Cache` API も `cache-control` の `max-age` か
-//!   `s-maxage` のいずれかが必要 (worker 0.8 cache.rs L65-66 の契約) で、
+//!   `s-maxage` のいずれかが必要 (worker 0.8 の `Cache::put` 契約) で、
 //!   `s-maxage` 単独でも `cache.put` は受理される。
 //! - `max-age=0, must-revalidate`: ブラウザ・private HTTP cache は毎リクエスト
 //!   worker に再検証を要求する (origin = worker)。これにより allowlist / kill-switch
@@ -262,9 +262,8 @@ impl CacheableKind {
     /// `s-maxage` は Cloudflare edge (`caches.default`) を含む shared cache で
     /// TTL 秒保存させる。`max-age=0, must-revalidate` でブラウザ・private cache は
     /// 毎回 worker に再検証要求を投げ、`check_origin` / `ALLOW_VIEWER_API` の
-    /// 変更を即時に反映できる (Issue #653 P2)。worker 0.8 `Cache` API は
-    /// `max-age` か `s-maxage` のいずれかがあれば `cache.put` を受理する
-    /// (worker 0.8 cache.rs L65-66)。
+    /// 変更を即時に反映できる。worker 0.8 `Cache` API は
+    /// `max-age` か `s-maxage` のいずれかがあれば `cache.put` を受理する。
     pub(crate) fn cache_control_header(self) -> &'static str {
         match self {
             CacheableKind::List => "public, s-maxage=60, max-age=0, must-revalidate",
@@ -743,7 +742,7 @@ fn set_cache_control(resp: &mut Response, value: &str) -> Result<()> {
 /// `cache.get` が `Err` を返した場合 (Cache API 自体の障害) は `None` を返して
 /// miss と同じくフォールバック (R2 から再 fetch) させる。ただし運用上の観測性が
 /// 必要なため、`event` (`<root>_cache_get`) と `client_kind` 付きの logfmt を
-/// `log_viewer_api_failed` で残す (Issue #653)。サイレント抑制すると staging /
+/// `log_viewer_api_failed` で残す。サイレント抑制すると staging /
 /// 本番で Cache API が一切機能していない事象に気付けない。
 async fn cache_get_origin_neutral(
     cache_key: &str,
@@ -808,7 +807,7 @@ mod tests {
 
     #[test]
     fn cache_control_header_for_list_kind() {
-        // Issue #653 P2: edge は s-maxage で TTL 秒保存し、ブラウザ・private cache は
+        // edge は s-maxage で TTL 秒保存し、ブラウザ・private cache は
         // max-age=0 + must-revalidate で毎回 worker に再検証要求を投げる。
         assert_eq!(
             CacheableKind::List.cache_control_header(),

--- a/crates/rshogi-csa-server-workers/src/x1_paths.rs
+++ b/crates/rshogi-csa-server-workers/src/x1_paths.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn buoy_object_key_always_starts_with_prefix() {
-        // `delete_buoy` の runtime ガードで使う前提条件 (Issue #624 隣接懸念):
+        // `delete_buoy` の runtime ガードで使う前提条件 (バックアップ経路の隣接懸念):
         // 任意入力に対して `buoy_object_key` の戻り値は `BUOY_KEY_PREFIX` で
         // 始まる。`encode_component` のエスケープ規則と相俟って、buoy 命名の
         // 不正値が `buoys/` の外に逃げ出さないことを固定する。

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -6,9 +6,9 @@
 //! した定数（[`ConfigKeys::SHARED_PUBLIC_VARS_KEYS`]）が過不足なく宣言されている
 //! ことを各環境ファイルについて検証する。
 //!
-//! **本ファイルが各環境で扱わない値**（[`ConfigKeys::LOCAL_DEV_ONLY_VARS_KEYS`]、
+//! **このファイルで各環境向けに扱わない値**（[`ConfigKeys::LOCAL_DEV_ONLY_VARS_KEYS`]、
 //! 例: `ADMIN_API_TOKEN`）は production / staging いずれも `wrangler secret put`
-//! 経由で設定する仕様。本テストでは各環境 toml の `[vars]` に **これらの値が
+//! 経由で設定する仕様。ここでは各環境 toml の `[vars]` に **これらの値が
 //! 含まれていないこと** も検証する。
 //!
 //! `wrangler.toml.example` (local dev template) は別テスト

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -7,11 +7,11 @@
 //! `ConfigKeys` への追加を忘れたケースもコード側で参照されない dead binding を
 //! 抱え込む原因になる。
 //!
-//! 過去事例: PR #500 で `R2FloodgateHistoryStorage` を新設し
+//! 過去事例: `R2FloodgateHistoryStorage` 新設で
 //! `ConfigKeys::FLOODGATE_HISTORY_BUCKET_BINDING` を追加したが、対応する
-//! `[[r2_buckets]]` エントリの template への追加が漏れていた（PR #505 で修正）。
+//! `[[r2_buckets]]` エントリの template への追加が漏れた回帰がある。
 //!
-//! 本テストは `wrangler.toml.example` を TOML として parse し、`ConfigKeys` の
+//! ここでは `wrangler.toml.example` を TOML として parse し、`ConfigKeys` の
 //! 網羅配列 (`ALL_R2_BINDINGS` / `ALL_DO_BINDINGS` /
 //! `SHARED_PUBLIC_VARS_KEYS` ∪ `LOCAL_DEV_ONLY_VARS_KEYS`) と template の宣言が
 //! **双方向に一致** することを assert する。
@@ -150,7 +150,7 @@ fn wrangler_template_do_bindings_match_config_keys() {
 /// 単独と整合することを検証する。
 ///
 /// `[vars]` 値は運用側で書き換える前提なので空文字や placeholder で構わない。
-/// 本テストは「キーの集合が一致すること」のみを検証し、値の内容には関与しない。
+/// ここでは「キーの集合が一致すること」のみを検証し、値の内容には関与しない。
 #[test]
 fn wrangler_template_vars_keys_match_config_keys() {
     let expected: Vec<&'static str> = ConfigKeys::SHARED_PUBLIC_VARS_KEYS

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -142,7 +142,7 @@ impl ClockSpec {
 ///
 /// - `total_time_seconds`: 持ち時間本体（秒）。使い切ると秒読みへ移行。
 /// - `byoyomi_seconds`: 1 手あたりの秒読み時間（秒）。使い切ると時間切れ。
-/// - `least_time_per_move`: CSA 2014 改訂では `0`。本実装も `0` 固定。
+/// - `least_time_per_move`: CSA 2014 改訂では `0`。ここでも `0` 固定。
 /// - 経過時間は整数秒に切り捨て（`elapsed_sec = elapsed_ms / 1000`）。
 #[derive(Debug, Clone)]
 pub struct SecondsCountdownClock {

--- a/crates/rshogi-csa-server/src/game/validator.rs
+++ b/crates/rshogi-csa-server/src/game/validator.rs
@@ -681,7 +681,7 @@ mod tests {
         // 5 二に既に先手歩が居る局面で、敵玉頭でもある同筋（file 5）に歩打を試みる。
         // 検証順は「在庫 → 二歩 → 合法手探索 → 打ち歩詰判定」なので、
         // 二歩が先に検出され Violation::DoublePawn が返るはず。
-        // 本テストの主目的は Uchifuzume に誤分類しないことの確認。
+        // ここでは Uchifuzume に誤分類しないことを確認する。
         let v = Validator::new(EnteringKingRule::Point24);
         let pos = pos_from_sfen("4k4/4P4/9/9/9/9/9/9/4K4 b P 1");
         let err = v.validate_move(&pos, &token("+0052FU")).unwrap_err();

--- a/crates/rshogi-csa-server/src/matching/challenge.rs
+++ b/crates/rshogi-csa-server/src/matching/challenge.rs
@@ -313,10 +313,9 @@ impl ChallengeRegistry {
         self.entries.values().map(|e| e.expires_at_ms).min()
     }
 
-    /// 登録件数 (テスト専用 accessor)。本 PR スコープ内では production 経路で
-    /// 件数を観測する用途が無いため `#[cfg(test)]` で閉じる。Workers の Alarm
-    /// reset 判定で使うなら `earliest_expiry_ms().is_some()` で代替できるため、
-    /// 件数公開は YAGNI。
+    /// 登録件数 (テスト専用 accessor)。production 経路で件数を観測する用途が
+    /// 無いため `#[cfg(test)]` で閉じる。Workers の Alarm reset 判定で使うなら
+    /// `earliest_expiry_ms().is_some()` で代替できるため、件数公開は YAGNI。
     #[cfg(test)]
     pub fn len(&self) -> usize {
         self.entries.len()

--- a/crates/rshogi-csa-server/src/protocol/summary.rs
+++ b/crates/rshogi-csa-server/src/protocol/summary.rs
@@ -78,7 +78,8 @@ impl GameSummaryBuilder {
         if !self.position_section.ends_with('\n') {
             out.push('\n');
         }
-        // 観戦者向け拡張行: 残時間 (ms 粒度)。reconnect.rs:148-149 と同形式。
+        // 観戦者向け拡張行: 残時間 (ms 粒度)。Workers reconnect 経路の
+        // `Black/White_Time_Remaining_Ms:` 行と同形式。
         let _ = writeln!(out, "Black_Time_Remaining_Ms:{black_remaining_ms}");
         let _ = writeln!(out, "White_Time_Remaining_Ms:{white_remaining_ms}");
         out.push_str("END Game_Summary\n");
@@ -377,7 +378,7 @@ mod tests {
     fn position_section_from_sfen_equals_standard_block_for_hirate() {
         // 平手 SFEN で `position_section_from_sfen` を呼んだ結果は、既存の
         // `standard_initial_position_block()` とほぼ一致するはず (差は無い想定)。
-        // 完全一致は駒並びや手番・持ち駒なしの表現次第だが、本実装では両者とも
+        // 完全一致は駒並びや手番・持ち駒なしの表現次第だが、ここでは両者とも
         // `PI` 行を使わず P1-P9 + 手番のみなので全行一致する。
         let hirate = rshogi_core::position::SFEN_HIRATE;
         let block = position_section_from_sfen(hirate).unwrap();

--- a/crates/rshogi-csa-server/src/record/kifu.rs
+++ b/crates/rshogi-csa-server/src/record/kifu.rs
@@ -498,7 +498,7 @@ PI
         let end = "2026-04-17T12:10:00Z";
 
         // (variant, expected_result_code) を網羅する。新しい variant が `GameResult` に
-        // 増えた場合、本テストの match と list 両方を更新する必要がある (single source
+        // 増えた場合、このテストの match と list 両方を更新する必要がある (single source
         // of truth として `primary_result_code` も同時に更新する契約)。
         // `winner` / `loser` は `primary_result_code` が無視するため片側のみ網羅する。
         let cases: Vec<(GameResult, &str)> = vec![

--- a/crates/rshogi-csa-server/src/storage/file.rs
+++ b/crates/rshogi-csa-server/src/storage/file.rs
@@ -251,7 +251,7 @@ mod tests {
         // Multi-thread runtime + JoinSet で 50 件並列 append を発火する。
         // OS の write(2) アトミック性に依存しなくても 50 行が壊れず保存されることを
         // 確認する「スモークテスト」。`append_lock` が無くても OS の write 追記が
-        // 単一 syscall で完了するサイズなら通ってしまうため、本テストはロック欠落の
+        // 単一 syscall で完了するサイズなら通ってしまうため、ロック欠落の
         // 回帰検出までは保証しない。ロック欠落を決定的に検出したい場合は
         // [`append_lock_serializes_critical_section`] を参照。
         let dir = unique_topdir("append_smoke");

--- a/crates/rshogi-csa-server/src/storage/floodgate_history/jsonl.rs
+++ b/crates/rshogi-csa-server/src/storage/floodgate_history/jsonl.rs
@@ -14,7 +14,7 @@
 //! - **クロスプロセス並行 append は非対応**: 単一プロセス前提。複数プロセスが
 //!   同ファイルを書く運用は想定しない（YAGNI）
 //! - **ローテーションは外部任せ**: ファイルサイズ管理は logrotate 等の外部
-//!   ツールに任せ、本実装は append のみ責任を持つ
+//!   ツールに任せ、append のみ責任を持つ
 
 use std::path::PathBuf;
 
@@ -34,7 +34,7 @@ use super::types::FloodgateHistoryEntry;
 /// 開いて 1 entry を書く。POSIX 上の `O_APPEND` 書き込みは「現在のファイル末尾
 /// にカーソルを移動 → write」を 1 syscall で行うため、同一プロセス内の追記は
 /// 上述 Mutex で直列化、他プロセスからの追記は OS 任せ（PIPE_BUF 以下なら atomic、
-/// 超える場合は interleave 可能だが本実装は単一プロセス前提）。
+/// 超える場合は interleave 可能だが単一プロセス前提）。
 #[derive(Debug)]
 pub struct JsonlFloodgateHistoryStorage {
     path: PathBuf,

--- a/crates/rshogi-csa-server/src/storage/players_yaml.rs
+++ b/crates/rshogi-csa-server/src/storage/players_yaml.rs
@@ -6,7 +6,7 @@
 //! Ruby `YAML.dump` で書き出される `players.yaml` 形式（[design.md] 1110 行）に
 //! 合わせ、トップレベルはプレイヤ名（String）→ レコード（Ruby Symbol キー）の
 //! マップで構成する。Ruby の `Symbol` は YAML 上で `":name"` のようにコロン接頭辞
-//! つき文字列で表現されるため、本実装でも `:name`/`:rate`/`:win`/`:loss`/
+//! つき文字列で表現されるため、ここでも `:name`/`:rate`/`:win`/`:loss`/
 //! `:last_game_id`/`:last_modified` をキーとして読み書きする:
 //!
 //! ```yaml
@@ -473,7 +473,7 @@ mod tests {
         records.insert("bob".to_owned(), rec("bob", 2400, 80, 60));
 
         let yaml = render_document(&records).unwrap();
-        // Ruby `YAML.dump` のキー順は内部 Hash 挿入順だが、本実装では BTreeMap で
+        // Ruby `YAML.dump` のキー順は内部 Hash 挿入順だが、ここでは BTreeMap で
         // 名前昇順に正規化する。アルファベット順で alice → bob が確定。
         // `:name`/`:rate`/`:win`/`:loss`/`:last_game_id`/`:last_modified` の
         // Ruby Symbol キーが quote 無しで出力されることを byte 比較で固定する。

--- a/crates/rshogi-csa-server/tests/license_integrity.rs
+++ b/crates/rshogi-csa-server/tests/license_integrity.rs
@@ -6,9 +6,9 @@
 //! を引き継がせる必要がある。各 `Cargo.toml` の `license` フィールドが手作業で
 //! 書き換わって不揃いになる事故を、ビルド時 / cargo test 時に確実に止める。
 //!
-//! 本テストは workspace ルートの `Cargo.toml` の `members` を動的に走査するため、
-//! 将来 `crates/rshogi-csa-server-*` という名前で新クレートが追加された場合も
-//! 自動で検査対象になる（追加 PR が license を忘れるとここで落ちる）。
+//! workspace ルートの `Cargo.toml` の `members` を動的に走査するため、将来
+//! `crates/rshogi-csa-server-*` という名前で新クレートが追加された場合も
+//! 自動で検査対象になる（追加時に license を忘れるとここで落ちる）。
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 /// csa-server 系クレートのライセンスとして許可される唯一の値。
 const REQUIRED_LICENSE: &str = "GPL-3.0-only";
 
-/// workspace 内クレートのうち、本テストが整合性を要求する名前接頭辞。
+/// workspace 内クレートのうち、整合性を要求する名前接頭辞。
 const SCOPED_PREFIX: &str = "rshogi-csa-server";
 
 /// `CARGO_MANIFEST_DIR` から workspace ルート（= `Cargo.toml` に


### PR DESCRIPTION
## Summary

- 「コメント規約」(`~/.claude/CLAUDE.md`) + `code-comment-hygiene` SKILL に基づき、`crates/rshogi-csa-server-workers/` + `crates/rshogi-csa-server/` のコメントから OSS で問題となる local-context 依存ワードを除去
- ロジック変更ゼロ、+167 -169 (29 ファイル)
- 前回 PR (#760) の csa-server-tcp sweep に続く sweep の **2 本目**。csa-server* family を完了

## Scope (除去対象)

| Pattern | Hit | Action |
|---|---:|---|
| **A**: 自己言及表現 (本 PR / 本テスト / 本実装 / 本受入 等) | 33 | 「ここでは / この test / 概念名」等の非自己言及表現に置換 or 削除 |
| **B**: 他ファイル `<filename>.rs:<line>` + 外部 repo `cache.rs L65-66` | 3 | 関数名 / 概念名で参照 |
| **D**: PR # / Issue # / review # / Codex code review # | 23 | WHY 1-2 単語で本文化 (例: `Issue #623` → `R2 export retry`、`Issue #625` → `Cloudflare Workers Logs Phase A`) or 単純削除 |

## KEEP (絶対 trim しない)

- URL 形式 `https://github.com/SH11235/rshogi/issues/...` (SKILL grep の D pattern 対象外)
- numerical fixture/example の日付:
  - `datetime.rs:45/67/69/75` (タイムスタンプ変換の具体例 4 件)
  - `lib.rs:255` (`base = 2026-01-01T00:00:00Z = 1_767_225_600_000 ms`)
- `本モジュール / 本関数 / 本ヘルパ / 本配列` 等は SKILL pattern 対象外として温存

## 判断分かれた箇所

- `game_room.rs:484, 911` の `⚠ Issue #623` 警告マーカー → Issue # のみ削除、`⚠` は維持
- `observability.rs:5, 57` markdown link `[Issue #625](URL)` → 「Cloudflare Workers Logs Phase A」に本文化、URL は別行で保持
- 「本 PR スコープ」表現の完全削除 → merge 後に意味失う historical のため削除、scope 境界の宣言は「ここでは ... のみ実装」「別モジュール ... に分割」等で表現

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests -p rshogi-csa-server -p rshogi-csa-server-workers -- -D warnings` clean
- [x] `cargo test --release -p rshogi-csa-server -p rshogi-csa-server-workers` 全 697 件 pass (core 334 + workers 327 + integration 13/17/5/1)
- [x] SKILL grep A/B/D 全 0 hit (KEEP リスト除く)
- [x] Local Codex review: APPROVE (Major/Minor 0)
- [x] Local Claude review: APPROVE (Major/Minor 0)

## Related

- 先行: SH11235/rshogi#760 (csa-server-tcp sweep)
- これで `crates/rshogi-csa-server*` family は完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)