### PR TITLE
feat(csa-client): analyze_selfplay 互換 JSONL 出力を既定 ON にする

### DIFF
--- a/crates/rshogi-csa-client/examples/README.md
+++ b/crates/rshogi-csa-client/examples/README.md
@@ -88,11 +88,17 @@ cargo run -p rshogi-csa-client --release -- \
 Worker で動かしたい場合は TOML 直書きの host を `wss://<your-subdomain>/ws/lobby` に
 向ける必要があり、現状の `--lobby` モードは未対応 (`--target staging|production` 必須)。
 
-## JSONL 出力モード — `tools::analyze_selfplay` で集計
+## JSONL 出力 — `tools::analyze_selfplay` で集計
 
-`--jsonl-out <DIR>` を付けて起動すると、対局完了ごとに analyze_selfplay 互換の JSONL を
+対局完了ごとに analyze_selfplay 互換の JSONL を
 `<DIR>/<datetime>_<sente>_vs_<gote>.jsonl` として書き出す。サーバーへ送信するわけでは
-なく、完全にローカル CLI 解析専用の opt-in 機能 (既定 OFF)。
+なく、完全にローカル CLI 解析専用。既定 ON で `record.dir/jsonl/`
+(デフォルト `./records/jsonl/`) に保存され、`--jsonl-out <DIR>` または TOML の
+`record.jsonl_out` で出力先を上書きできる。止めたい場合は TOML で
+`record.save_jsonl = false`（または記録ごと止める `record.enabled = false`）。
+
+JSONL には CSA 棋譜 (`T<sec>` = 秒単位) から復元できない ms 単位の消費時間や
+`nodes` / `nps` / `seldepth` が含まれるため、既定 ON で取り損ねを防いでいる。
 
 スキーマは selfplay (`tools/src/bin/tournament.rs`) の出力と同じ `meta` / `move` /
 `result` の 3 種類で、`move.eval` は `score_cp` / `score_mate` / `depth` / `seldepth` /
@@ -101,8 +107,7 @@ Worker で動かしたい場合は TOML 直書きの host を `wss://<your-subdo
 そのまま流用できる。
 
 ```bash
-# 1. CSA 経由対局を JSONL 付きで実行（--target staging の例）
-mkdir -p runs/csa-jsonl
+# 1. CSA 経由対局を実行（--target staging の例。JSONL は既定 ON）
 cargo run -p rshogi-csa-client --release -- \
   --target staging \
   --room-id e2e-jsonl-1 \
@@ -111,23 +116,23 @@ cargo run -p rshogi-csa-client --release -- \
   --game-name byoyomi-msec-10-100 \
   --engine /path/to/your/rshogi-usi \
   --options "EvalFile=/path/to/your-nnue.bin,USI_Hash=256" \
-  --jsonl-out runs/csa-jsonl \
   --max-games 5
 
-# 2. selfplay と同じツールで集計
-cargo run -p tools --release --bin analyze_selfplay -- runs/csa-jsonl/*.jsonl
+# 2. selfplay と同じツールで集計（既定の出力先は ./records/jsonl/）
+cargo run -p tools --release --bin analyze_selfplay -- records/jsonl/*.jsonl
 
 # JSON で受け取りたい場合
-cargo run -p tools --release --bin analyze_selfplay -- --json runs/csa-jsonl/*.jsonl
+cargo run -p tools --release --bin analyze_selfplay -- --json records/jsonl/*.jsonl
 ```
 
-TOML 設定の `[record]` セクションでも指定可能:
+出力先・ON/OFF は TOML 設定の `[record]` セクションでも指定可能:
 
 ```toml
 [record]
 enabled = true
 dir = "./records"
-jsonl_out = "./runs/csa-jsonl"
+save_jsonl = true                  # false で JSONL のみ停止
+jsonl_out = "./runs/csa-jsonl"     # 省略時は dir/jsonl/
 ```
 
 注意点:

--- a/crates/rshogi-csa-client/examples/csa_client.toml.example
+++ b/crates/rshogi-csa-client/examples/csa_client.toml.example
@@ -69,6 +69,11 @@ dir = "./records"
 filename_template = "{datetime}_{sente}_vs_{gote}"
 save_csa = true
 save_sfen = true
+# analyze_selfplay 互換 JSONL（meta / move / result 行）。既定 ON で
+# `dir/jsonl/` に 1 局 1 ファイル保存される。出力先を変えるときだけ
+# jsonl_out を指定する。
+save_jsonl = true
+# jsonl_out = "./runs/csa-jsonl"
 
 [log]
 level = "info"

--- a/crates/rshogi-csa-client/src/config.rs
+++ b/crates/rshogi-csa-client/src/config.rs
@@ -164,9 +164,10 @@ pub struct RecordConfig {
     pub filename_template: String,
     pub save_csa: bool,
     pub save_sfen: bool,
-    /// JSONL 出力先ディレクトリ。`None` のとき JSONL は生成しない。
-    /// 指定すると `<datetime>_<sente>_vs_<gote>.jsonl` を出力し、
-    /// `tools::analyze_selfplay` で読み込めるスキーマで meta / move / result 行を書き込む。
+    /// `tools::analyze_selfplay` 互換 JSONL を保存するか。CSA 棋譜から復元できない
+    /// ms 単位の消費時間や nodes / nps / seldepth を含むため既定 ON。
+    pub save_jsonl: bool,
+    /// JSONL 出力先ディレクトリの上書き。`None` のとき `dir/jsonl/` に保存する。
     #[serde(default)]
     pub jsonl_out: Option<PathBuf>,
 }
@@ -179,8 +180,20 @@ impl Default for RecordConfig {
             filename_template: "{datetime}_{sente}_vs_{gote}".to_string(),
             save_csa: true,
             save_sfen: true,
+            save_jsonl: true,
             jsonl_out: None,
         }
+    }
+}
+
+impl RecordConfig {
+    /// JSONL の出力先を返す。記録自体が無効 (`enabled = false`) か
+    /// `save_jsonl = false` のときは `None`（= JSONL を出力しない）。
+    pub fn jsonl_dir(&self) -> Option<PathBuf> {
+        if !self.enabled || !self.save_jsonl {
+            return None;
+        }
+        Some(self.jsonl_out.clone().unwrap_or_else(|| self.dir.join("jsonl")))
     }
 }
 
@@ -224,5 +237,50 @@ impl CsaClientConfig {
             bail!("keepalive.ping_interval_sec must be >= 30 (CSA protocol requirement)");
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonl_dir_defaults_under_record_dir() {
+        let config = RecordConfig::default();
+        assert_eq!(config.jsonl_dir(), Some(PathBuf::from("./records/jsonl")));
+    }
+
+    #[test]
+    fn jsonl_dir_honors_explicit_override() {
+        let config = RecordConfig {
+            jsonl_out: Some(PathBuf::from("/tmp/csa-jsonl")),
+            ..RecordConfig::default()
+        };
+        assert_eq!(config.jsonl_dir(), Some(PathBuf::from("/tmp/csa-jsonl")));
+    }
+
+    #[test]
+    fn jsonl_dir_none_when_save_jsonl_off() {
+        let config = RecordConfig {
+            save_jsonl: false,
+            ..RecordConfig::default()
+        };
+        assert_eq!(config.jsonl_dir(), None);
+    }
+
+    #[test]
+    fn jsonl_dir_none_when_record_disabled() {
+        let config = RecordConfig {
+            enabled: false,
+            ..RecordConfig::default()
+        };
+        assert_eq!(config.jsonl_dir(), None);
+    }
+
+    #[test]
+    fn record_toml_without_save_jsonl_defaults_on() {
+        let config: CsaClientConfig = toml::from_str("[record]\nenabled = true\n").unwrap();
+        assert!(config.record.save_jsonl);
+        assert_eq!(config.record.jsonl_dir(), Some(PathBuf::from("./records/jsonl")));
     }
 }

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -160,9 +160,8 @@ struct Cli {
     #[arg(long)]
     record_dir: Option<PathBuf>,
 
-    /// JSONL 出力ディレクトリ。指定すると対局完了ごとに analyze_selfplay 互換の
-    /// JSONL ファイルを `<datetime>_<sente>_vs_<gote>.jsonl` として書き出す。
-    /// 未指定時は JSONL を出力しない（既定 OFF）。TOML の `record.jsonl_out` でも指定可。
+    /// analyze_selfplay 互換 JSONL の出力先上書き（未指定時は `record.dir/jsonl/`）。
+    /// 出力を止めるには TOML で `record.save_jsonl = false` を指定する。
     #[arg(long)]
     jsonl_out: Option<PathBuf>,
 
@@ -363,9 +362,9 @@ fn main() -> Result<()> {
                     log::error!("棋譜保存エラー: {e}");
                 }
 
-                // JSONL 出力（opt-in、--jsonl-out / record.jsonl_out 指定時のみ）
-                if let Some(ref jsonl_dir) = config.record.jsonl_out {
-                    match write_game_jsonl(jsonl_dir, &record, &config, &result) {
+                // analyze_selfplay 互換 JSONL（ON/OFF と出力先は RecordConfig::jsonl_dir）
+                if let Some(jsonl_dir) = config.record.jsonl_dir() {
+                    match write_game_jsonl(&jsonl_dir, &record, &config, &result) {
                         Ok(path) => log::info!("[REC] JSONL 保存: {}", path.display()),
                         Err(e) => log::error!("JSONL 保存エラー: {e}"),
                     }


### PR DESCRIPTION
## 概要

csa_client の analyze_selfplay 互換 JSONL 出力（従来は `--jsonl-out` / `record.jsonl_out` 指定時のみの opt-in）をデフォルト ON にする。

## 動機

JSONL には CSA 棋譜（`T<sec>` = 秒単位）から復元できない情報が含まれる:

- ms 単位の消費時間 (`elapsed_ms`) / 考慮上限 (`think_limit_ms`)
- `nodes` / `nps` / `seldepth`

これらは analyze_selfplay の per-engine timing・eval 統計の元データであり、`--jsonl-out` の指定忘れで長期間対局を回すとデータを恒久的に取り損ねる。CSA / SFEN 棋譜が `record.enabled = true` で default ON なのに JSONL だけ opt-in なのも非対称だった。

## 変更内容

- `RecordConfig` に `save_jsonl: bool`（default **true**）を追加し、`save_csa` / `save_sfen` と同パターンに揃える
- 出力先解決を `RecordConfig::jsonl_dir()` に集約。`jsonl_out` 未指定時は `record.dir/jsonl/`（デフォルト `./records/jsonl/`）
- `record.enabled = false` で CSA / SFEN と同様に JSONL も停止（挙動変更: 従来は `jsonl_out` 指定時 `enabled` と無関係に出力されていた）
- `--jsonl-out` CLI フラグは出力先上書きとして互換維持
- examples/README.md / csa_client.toml.example を新挙動に更新

## 後方互換性

- 既存 TOML（`save_jsonl` 未記載）: `#[serde(default)]` により true が適用され、JSONL が新たに `record.dir/jsonl/` へ出力されるようになる（意図した挙動変更）
- `jsonl_out` 指定済みの既存設定: 従来どおりその場所へ出力

## テスト

- `jsonl_dir()` の解決ロジック 4 ケース + 既存 TOML 後方互換の unit test を追加
- `cargo fmt` / `cargo clippy --tests`（警告ゼロ）/ `cargo test -p rshogi-csa-client`（全 pass）
- ローカル Codex review: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)