### PR TITLE
feat(tools): rescore_psv に --qsearch-leaf-label モードを追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -76,6 +76,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [extract_bench_positions](docs/extract_bench_positions.md) - 教師ラベル品質測定用ベンチ局面の抽出
 - [label_bench_positions](docs/label_bench_positions.md) - ベンチ局面の深い探索ラベリング（ground truth）
 - [label_bench_dl](docs/label_bench_dl.md) - label_bench jsonl への DL水匠 (dlshogi ONNX) 評価値追記
+- [rescore_psv](docs/rescore_psv.md) - PSV 評価値の ONNX 再スコアリング（qsearch-leaf ラベル / dual-output 対応）
 
 各ツールのオプション一覧は `--help` で確認できます。
 

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -306,7 +306,9 @@ fingerprint に含まれる項目:
 - replacement 有効時: `--qsearch-leaf-replacement-output` の canonicalize 済みパス
   （`replacement` フラグ + `replacement_output_path` + `replacement_output_size`）
 
-> 旧 marker（`--qsearch-leaf-label` / `replacement` キーを持たない）は欠落時 `false` 扱いで後方互換。
+> 後方互換: 旧 marker の `--qsearch-leaf-label` / `replacement` キー欠落は `false` 扱い。
+> `--qsearch-leaf-label=true` だが葉探索 NNUE キーを持たない旧 leaf-label marker は、NNUE メタを
+> `None` として読み（parse error にしない）、現設定（NNUE あり）と fingerprint 不一致になって再生成される。
 
 `Ctrl-C` で中断した場合は marker を書き出さない（中途半端に処理したファイルを
 完了扱いにしない）。プロセス kill / panic には atomic rename + `sync_all()` で

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -163,6 +163,7 @@ cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
 | `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール（有限値・正値必須） |
 | `--skip-in-check` | false | 王手親局面の rescore 出力を抑制（後述） |
 | `--qsearch-leaf-label` | false | root 局面を保持し、ラベルだけを qsearch 葉の評価にする（後述）。`--nnue`（葉探索用）併用必須 |
+| `--qsearch-leaf-replacement-output` | — | `--qsearch-leaf-label` と併用し、同一 1 パスで葉局面に置換したレコードを別ディレクトリにも書き出す（後述）。`--qsearch-leaf-label` 必須・`--output-dir` と別ディレクトリ必須 |
 | `--max-ply` | 16 | qsearch の最大深さ（`--qsearch-leaf-label` の葉探索でも使用） |
 | `--threads` | 1 | 処理スレッド数（rayon による特徴量構築の並列化） |
 
@@ -225,6 +226,49 @@ rescore_psv --input "data/*.bin" --output-dir rescored_leaflabel/ \
 > `--apply-qsearch-leaf`（局面を葉に置換）→ ONNX で rescore → 元 root と merge、の 3 工程と
 > 同じ結果を 1 パスで得られる。中間 leaf ファイルを作らないため大規模教師でのディスク・I/O を節約できる。
 
+### `--qsearch-leaf-replacement-output`（葉局面置換 arm を同時生成）
+
+`--qsearch-leaf-label` と併用すると、**同一 1 パスで** 2 つの教師データを生成できる:
+
+- **leaf-LABEL arm**（`--output-dir`）: root 局面 + 葉ラベル（既存の `--qsearch-leaf-label` 出力）
+- **leaf-REPLACEMENT arm**（`--qsearch-leaf-replacement-output`）: **葉局面に置換**したレコード
+
+```bash
+rescore_psv --input "data/*.bin" \
+  --output-dir rescored_leaflabel/ \
+  --qsearch-leaf-replacement-output rescored_leafrepl/ \
+  --dlshogi-onnx-model model.onnx \
+  --nnue suisho5.bin \
+  --qsearch-leaf-label \
+  --onnx-tensorrt --onnx-tensorrt-cache /tmp/trt_cache
+```
+
+「葉の qsearch + DL 評価」を 1 回だけ実行して 2 arm を同時に得るため、大規模教師での
+再計算を半減できる（`--apply-qsearch-leaf` → DL rescore の 2 工程を別々に走らせる必要がない）。
+
+leaf-REPLACEMENT レコードの仕様（`--apply-qsearch-leaf` → DL rescore の 2 工程と bit 一致）:
+
+- `sfen` = **葉局面の packed sfen**（局面を葉に置換）
+- `score` = 葉の DL 評価（**符号反転しない＝葉手番視点**）。`--score-clip` 適用
+- `move16` = 0
+- `game_ply` = root の `game_ply`
+- `game_result` = 葉で STM 反転時のみ `-game_result`、反転なしなら `game_result`
+- `padding` = 0
+
+leaf-LABEL arm（`--output-dir` 側）は現状の `--qsearch-leaf-label` 出力のまま
+（root sfen + root 手番視点へ符号反転した score + root の `game_result`）。
+
+両 arm は同一ループで 1:1 lockstep に書き出すためレコード数が一致する。
+`--skip-in-check` で王手 root を落とす場合は両 arm から同様に除外される。
+
+前提・制約:
+
+- `--qsearch-leaf-label` 必須（葉局面はそのモードの qsearch 結果を再利用する）。
+- したがって dlshogi モデル専用。
+- `--output-dir` と `--qsearch-leaf-replacement-output` は別ディレクトリ必須
+  （同一指定は起動時エラー）。
+- 出力ファイル名は入力ファイル名と同じ。
+
 ### ポリシー展開（`--expand-output-dir`）について
 
 `--expand-output-dir` を指定すると、同じ ONNX 推論の policy 出力を使って
@@ -243,10 +287,10 @@ ONNX モードでは、各入力ファイルの処理完了時に rescore 出力
 次回同じ入力に対して実行すると:
 
 - **marker の設定 fingerprint が現在の CLI と完全一致 + 出力サイズが記録と一致** → ファイル skip
-- **fingerprint 不一致（モデル差し替え・`--onnx-eval-scale` 変更・expand 設定変更など）** →
-  rescore/expand 両出力を truncate して再生成
-- **marker が無い（従来互換）+ expand 無効** → 既存のレコード数ベース resume にフォールバック
-- **marker が無い + expand 有効** → 両出力を truncate して最初から処理
+- **fingerprint 不一致（モデル差し替え・`--onnx-eval-scale` 変更・expand / replacement 設定変更など）** →
+  rescore / expand / replacement 全出力を truncate して再生成
+- **marker が無い（従来互換）+ expand / replacement いずれも無効** → 既存のレコード数ベース resume にフォールバック
+- **marker が無い + expand または replacement 有効** → 全出力を truncate して最初から処理
 
 fingerprint に含まれる項目:
 
@@ -258,8 +302,10 @@ fingerprint に含まれる項目:
 - `--qsearch-leaf-label`、および有効時のみ `--max-ply`（葉ラベルモードは出力内容を変えるため）
 - expand 有効時: `--expand-threshold`（to_bits hex）、`--expand-skip-parent-in-check`、
   `--expand-skip-child-in-check`、`--expand-output-dir` の canonicalize 済みパス
+- replacement 有効時: `--qsearch-leaf-replacement-output` の canonicalize 済みパス
+  （`replacement` フラグ + `replacement_output_path` + `replacement_output_size`）
 
-> 旧 marker（`--qsearch-leaf-label` キーを持たない）は欠落時 `false` 扱いで後方互換。
+> 旧 marker（`--qsearch-leaf-label` / `replacement` キーを持たない）は欠落時 `false` 扱いで後方互換。
 
 `Ctrl-C` で中断した場合は marker を書き出さない（中途半端に処理したファイルを
 完了扱いにしない）。プロセス kill / panic には atomic rename + `sync_all()` で
@@ -282,12 +328,14 @@ fingerprint に含まれる項目:
 
 ONNX モードでは以下を起動時 / ファイルごとに検証し、データ破壊を防止する:
 
-- `--output-dir` と `--expand-output-dir` が同一ディレクトリ → エラー
+- `--output-dir` と `--expand-output-dir` / `--qsearch-leaf-replacement-output` が
+  同一ディレクトリ → エラー
 - 入力ファイル = 予定出力パス（未作成でも parent canonicalize で検出）→ エラー
-- 既存出力が symlink → エラー（symlink 越しの truncate で入力を破壊しないため）
+- 既存出力（rescore / expand / replacement）が symlink → エラー
+  （symlink 越しの truncate で入力を破壊しないため）
 - Unix のみ: 既存出力が入力と同じ inode（hardlink）→ エラー
-- marker 不一致で旧 expand artifact を削除する前に、旧 artifact が現在の入力と
-  同一実体でないことを検証 → 同一なら削除せずエラー（段階的パイプライン対策）
+- marker 不一致で旧 expand / replacement artifact を削除する前に、旧 artifact が現在の
+  入力と同一実体でないことを検証 → 同一なら削除せずエラー（段階的パイプライン対策）
 
 ### `--threads` について
 
@@ -420,6 +468,8 @@ AobaZero ONNX model loaded. Batch size: 1024
 | `--expand-threshold must be a finite value in (0.0, 100.0]` | 範囲外 / NaN / inf | 有限値かつ `0 < v <= 100` を指定 |
 | `--onnx-eval-scale must be a positive finite value` | 0 以下 / NaN / inf | 正の有限値（通常 600.0）を指定 |
 | `--output-dir and --expand-output-dir must point to different directories` | 同一ディレクトリ指定 | 別ディレクトリを指定 |
+| `--qsearch-leaf-replacement-output requires --qsearch-leaf-label` | replacement のみ指定 | `--qsearch-leaf-label` を併用 |
+| `--output-dir and --qsearch-leaf-replacement-output must point to different directories` | 同一ディレクトリ指定 | 別ディレクトリを指定 |
 | `Output path is a symlink (refusing to truncate a symlink)` | 出力予定パスが symlink | symlink を削除するか別ディレクトリを使う |
 | `Output path is a hardlink to the input file` | 出力予定が入力の hardlink（Unix） | 別ディレクトリを指定 |
 | `Stale expand artifact ... resolves to the current input file` | 旧 expand 出力と現在 input が同一（段階的パイプライン） | 入力を移動するか `--expand-output-dir` を変更 |

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -162,6 +162,8 @@ cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
 | `--onnx-tensorrt-cache` | — | TensorRT エンジンキャッシュの保存先 |
 | `--onnx-eval-scale` | 600.0 | 勝率→cp 変換スケール（有限値・正値必須） |
 | `--skip-in-check` | false | 王手親局面の rescore 出力を抑制（後述） |
+| `--qsearch-leaf-label` | false | root 局面を保持し、ラベルだけを qsearch 葉の評価にする（後述）。`--nnue`（葉探索用）併用必須 |
+| `--max-ply` | 16 | qsearch の最大深さ（`--qsearch-leaf-label` の葉探索でも使用） |
 | `--threads` | 1 | 処理スレッド数（rayon による特徴量構築の並列化） |
 
 ### ポリシー展開オプション（`--expand-output-dir` 指定時）
@@ -188,6 +190,39 @@ cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
 （教師データ中の王手局面は通常 1 桁 %）。
 `--expand-skip-parent-in-check` と `--expand-skip-child-in-check` で expand 側の
 王手フィルタを独立に制御できる。
+
+### `--qsearch-leaf-label`（root 局面据え置き・ラベルのみ葉評価）
+
+DL 系 ONNX モードで、**局面は root のまま保持し、ラベル（score）だけを qsearch 葉の
+評価にする**モード。NNUE 系のように探索でラベル付けする運用では探索部が qsearch を含む
+ため葉解決は不要だが、DL 系の静的評価でラベル付けする場合は葉の評価を root 局面に
+付与したいことがある（PV 末端の静かな局面の評価を教師ラベルにする）。
+
+```bash
+rescore_psv --input "data/*.bin" --output-dir rescored_leaflabel/ \
+  --dlshogi-onnx-model model.onnx \
+  --nnue suisho5.bin \
+  --qsearch-leaf-label \
+  --onnx-tensorrt --onnx-tensorrt-cache /tmp/trt_cache
+```
+
+挙動:
+
+- 各局面で `--nnue` の NNUE による qsearch を走らせ、PV 末端（葉）まで進めてから
+  **葉局面を ONNX で評価**する。**出力 sfen は常に root（局面は置換しない）**。
+- 葉で手番が反転（PV 長が奇数）した場合、葉の評価を root 手番視点へ符号反転して score にする。
+- 王手 root は葉探索せず原局面のまま評価する（`--apply-qsearch-leaf` と同じ扱い）。
+  `--skip-in-check` 併用で王手 root を出力から除外することも可能。
+
+前提・制約:
+
+- `--nnue`（葉探索用）と ONNX ラベラー（`--dlshogi-onnx-model` / `--onnx-model`）の
+  両方が必須。
+- `--apply-qsearch-leaf`（局面置換）とは併用不可（前者は据え置き・ラベルのみ、後者は置換）。
+- `--expand-output-dir` とは併用不可（policy 出力が葉局面に対応し root 局面と不整合になるため）。
+
+> `--apply-qsearch-leaf`（局面を葉に置換）→ ONNX で rescore → 元 root と merge、の 3 工程と
+> 同じ結果を 1 パスで得られる。中間 leaf ファイルを作らないため大規模教師でのディスク・I/O を節約できる。
 
 ### ポリシー展開（`--expand-output-dir`）について
 
@@ -219,8 +254,11 @@ fingerprint に含まれる項目:
 - `process_count`（`--limit` 適用後）
 - `--skip-in-check`、`--score-clip`、`--onnx-eval-scale`（`f32::to_bits()` の hex で保存）
 - AobaZero モデル時のみ `--onnx-draw-ply`
+- `--qsearch-leaf-label`、および有効時のみ `--max-ply`（葉ラベルモードは出力内容を変えるため）
 - expand 有効時: `--expand-threshold`（to_bits hex）、`--expand-skip-parent-in-check`、
   `--expand-skip-child-in-check`、`--expand-output-dir` の canonicalize 済みパス
+
+> 旧 marker（`--qsearch-leaf-label` キーを持たない）は欠落時 `false` 扱いで後方互換。
 
 `Ctrl-C` で中断した場合は marker を書き出さない（中途半端に処理したファイルを
 完了扱いにしない）。プロセス kill / panic には atomic rename + `sync_all()` で

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -216,8 +216,9 @@ rescore_psv --input "data/*.bin" --output-dir rescored_leaflabel/ \
 
 前提・制約:
 
-- `--nnue`（葉探索用）と ONNX ラベラー（`--dlshogi-onnx-model` / `--onnx-model`）の
-  両方が必須。
+- `--nnue`（葉探索用）と `--dlshogi-onnx-model`（葉ラベル用）の両方が必須。
+- **dlshogi モデル専用**（`--onnx-model` の AobaZero は非対応）。AobaZero 特徴量は手数
+  （game_ply）を含み、葉へ進めても root の game_ply が渡って葉特徴量に混入するため。
 - `--apply-qsearch-leaf`（局面置換）とは併用不可（前者は据え置き・ラベルのみ、後者は置換）。
 - `--expand-output-dir` とは併用不可（policy 出力が葉局面に対応し root 局面と不整合になるため）。
 

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -287,10 +287,10 @@ ONNX モードでは、各入力ファイルの処理完了時に rescore 出力
 次回同じ入力に対して実行すると:
 
 - **marker の設定 fingerprint が現在の CLI と完全一致 + 出力サイズが記録と一致** → ファイル skip
-- **fingerprint 不一致（モデル差し替え・`--onnx-eval-scale` 変更・expand / replacement 設定変更など）** →
+- **fingerprint 不一致（ONNX モデル差し替え・`--onnx-eval-scale` 変更・葉ラベル時の `--nnue` 差し替え・expand / replacement 設定変更など）** →
   rescore / expand / replacement 全出力を truncate して再生成
-- **marker が無い（従来互換）+ expand / replacement いずれも無効** → 既存のレコード数ベース resume にフォールバック
-- **marker が無い + expand または replacement 有効** → 全出力を truncate して最初から処理
+- **marker が無い（従来互換）+ expand / replacement / `--qsearch-leaf-label` いずれも無効** → 既存のレコード数ベース resume にフォールバック
+- **marker が無い + expand / replacement / `--qsearch-leaf-label` のいずれか有効** → 全出力を truncate して最初から処理（レコード数ベース resume は使わない）
 
 fingerprint に含まれる項目:
 
@@ -299,7 +299,8 @@ fingerprint に含まれる項目:
 - `process_count`（`--limit` 適用後）
 - `--skip-in-check`、`--score-clip`、`--onnx-eval-scale`（`f32::to_bits()` の hex で保存）
 - AobaZero モデル時のみ `--onnx-draw-ply`
-- `--qsearch-leaf-label`、および有効時のみ `--max-ply`（葉ラベルモードは出力内容を変えるため）
+- `--qsearch-leaf-label`、および有効時のみ `--max-ply` と葉探索用 `--nnue` のパス（canonicalize 済み）・
+  サイズ・mtime（ns）。葉ラベルは葉局面＝出力が `--nnue` に依存するため、NNUE 差し替えも fingerprint で検知する
 - expand 有効時: `--expand-threshold`（to_bits hex）、`--expand-skip-parent-in-check`、
   `--expand-skip-child-in-check`、`--expand-output-dir` の canonicalize 済みパス
 - replacement 有効時: `--qsearch-leaf-replacement-output` の canonicalize 済みパス

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -41,7 +41,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `shuffle_psv` | PSV ファイル内のレコード（40バイト単位）をシャッフル |
 | `split_psv` | PSV ファイルを局面数または容量で複数ファイルへ分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
-| `rescore_psv` | PSV ファイルの評価値を NNUE または外部エンジンで再計算 |
+| `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero) で再計算。qsearch-leaf ラベル付け（root 局面 + 葉評価）と置換/ラベルの dual-output に対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |
 | `fix_scores` | preprocess で上書きされたスコアを元ファイルから復元 |

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -2381,21 +2381,18 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         } else {
             None
         },
-        qsearch_nnue_path: if qsearch_leaf_label {
-            Some(PathBuf::from(get("qsearch_nnue_path")?))
-        } else {
-            None
-        },
-        qsearch_nnue_size: if qsearch_leaf_label {
-            Some(get("qsearch_nnue_size")?.parse().context("invalid qsearch_nnue_size")?)
-        } else {
-            None
-        },
-        qsearch_nnue_mtime_ns: if qsearch_leaf_label {
-            Some(get("qsearch_nnue_mtime_ns")?.parse().context("invalid qsearch_nnue_mtime_ns")?)
-        } else {
-            None
-        },
+        // 葉探索 NNUE のメタは leaf-label モードより後に追加したキーのため、leaf_label=true でも
+        // キー欠落（葉探索 NNUE 未追跡の旧 leaf-label marker）を None として許容する。現 fingerprint は
+        // Some(nnue) になるので不一致 → marker 不一致経路で再生成され、hard parse error にはしない。
+        qsearch_nnue_path: map.get("qsearch_nnue_path").map(PathBuf::from),
+        qsearch_nnue_size: map
+            .get("qsearch_nnue_size")
+            .map(|v| v.parse().context("invalid qsearch_nnue_size"))
+            .transpose()?,
+        qsearch_nnue_mtime_ns: map
+            .get("qsearch_nnue_mtime_ns")
+            .map(|v| v.parse().context("invalid qsearch_nnue_mtime_ns"))
+            .transpose()?,
         expand,
         expand_threshold_bits: if expand {
             Some(parse_hex_u32(get("expand_threshold_bits")?)?)
@@ -3521,6 +3518,18 @@ mod marker_tests {
         assert!(!m.fingerprint.qsearch_leaf_label);
         assert_eq!(m.fingerprint.qsearch_max_ply, None);
         assert_eq!(m.fingerprint.qsearch_nnue_path, None);
+    }
+
+    #[test]
+    fn old_leaf_label_marker_without_nnue_keys_parses_as_none() {
+        // 葉探索 NNUE キーを持たない旧 leaf-label marker は parse error にせず None として読む。
+        // 現 fingerprint は Some(nnue) のため不一致になり、marker 不一致経路で再生成される。
+        let m = parse_text(&base_marker("qsearch_leaf_label=true\nqsearch_max_ply=20\n"));
+        assert!(m.fingerprint.qsearch_leaf_label);
+        assert_eq!(m.fingerprint.qsearch_max_ply, Some(20));
+        assert_eq!(m.fingerprint.qsearch_nnue_path, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_size, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_mtime_ns, None);
     }
 
     #[test]

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -62,7 +62,7 @@ use rshogi_core::nnue::init_nnue;
 use rshogi_core::position::Position;
 use rshogi_core::search::{LimitsType, Search};
 use tools::packed_sfen::{PackedSfenValue, pack_position, unpack_sfen};
-use tools::qsearch_pv::{NnueStacks, qsearch_with_pv_nnue};
+use tools::qsearch_pv::{NnueStacks, apply_pv, qsearch_with_pv_nnue};
 
 /// 探索用スタックサイズ（64MB）
 const SEARCH_STACK_SIZE: usize = 64 * 1024 * 1024;
@@ -115,6 +115,13 @@ struct Cli {
     /// qsearch leaf置換も同時に適用
     #[arg(long)]
     apply_qsearch_leaf: bool,
+
+    /// root 局面を保持したまま、ラベルだけを qsearch 葉の評価にする（局面は置換しない）。
+    /// `--nnue`（葉探索用）＋ `--dlshogi-onnx-model`/`--onnx-model`（葉ラベル用）と併用する。
+    /// DL 系の静的評価でラベル付けする教師生成で、葉の評価を root 局面に付与する用途。
+    /// `--apply-qsearch-leaf`（局面置換）とは併用不可。
+    #[arg(long)]
+    qsearch_leaf_label: bool,
 
     /// qsearchの最大深さ
     #[arg(long, default_value_t = 16)]
@@ -393,6 +400,8 @@ fn onnx_marker_decide(
         input2_channels: 0,
         profile_path: None,
         expand: expand_cfg,
+        qsearch_leaf_label: cli.qsearch_leaf_label,
+        qsearch_max_ply: cli.max_ply,
     };
     let current = build_run_fingerprint(&cfg)?;
 
@@ -559,6 +568,33 @@ fn main() -> Result<()> {
         );
     }
 
+    // --qsearch-leaf-label の前提チェック
+    // root 局面を保持しつつラベルだけ葉評価にするには、葉を求める NNUE と
+    // 葉を評価する ONNX ラベラーの両方が要る。
+    if cli.qsearch_leaf_label {
+        if cli.nnue.is_none() {
+            anyhow::bail!("--qsearch-leaf-label requires --nnue (qsearch で葉局面を求めるため)");
+        }
+        if !(use_onnx || use_dlshogi_onnx) {
+            anyhow::bail!(
+                "--qsearch-leaf-label requires an ONNX labeling model \
+                 (--dlshogi-onnx-model or --onnx-model)"
+            );
+        }
+        if cli.apply_qsearch_leaf {
+            anyhow::bail!(
+                "--qsearch-leaf-label and --apply-qsearch-leaf are mutually exclusive \
+                 (前者は局面据え置き・ラベルのみ、後者は局面置換)"
+            );
+        }
+        if cli.expand_output_dir.is_some() {
+            anyhow::bail!(
+                "--qsearch-leaf-label is mutually exclusive with --expand-output-dir \
+                 (policy 出力は葉局面に対応し root 局面と不整合になるため)"
+            );
+        }
+    }
+
     // --expand-output-dir は ONNX モード必須
     if cli.expand_output_dir.is_some() && !(use_onnx || use_dlshogi_onnx) {
         anyhow::bail!(
@@ -638,8 +674,9 @@ fn main() -> Result<()> {
         anyhow::bail!("--output-dir and --expand-output-dir must point to different directories");
     }
 
-    // NNUEモデルのロード（NNUE内部評価モードのみ）
-    if !use_engine && !use_onnx && !use_dlshogi_onnx {
+    // NNUEモデルのロード（NNUE内部評価モード、または ONNX ラベラー併用の
+    // --qsearch-leaf-label で葉探索に NNUE を使う場合）
+    if (!use_engine && !use_onnx && !use_dlshogi_onnx) || cli.qsearch_leaf_label {
         let nnue = cli.nnue.as_ref().unwrap();
         if !nnue.exists() {
             anyhow::bail!("NNUE model file not found: {}", nnue.display());
@@ -1160,9 +1197,6 @@ fn process_record(
         return ProcessResult::Skip;
     }
 
-    // 元の手番を記録
-    let original_stm = pos.side_to_move();
-
     // qsearch leaf置換を適用する場合
     let (final_sfen, stm_changed) = if apply_leaf && !pos.in_check() {
         let result = qsearch_with_pv_nnue(
@@ -1174,13 +1208,8 @@ fn process_record(
             max_ply,
         );
 
-        // PVに沿って局面を進める
-        for mv in &result.pv {
-            let gives_check = pos.gives_check(*mv);
-            let _ = pos.do_move(*mv, gives_check);
-        }
-
-        let stm_changed = pos.side_to_move() != original_stm;
+        // PV に沿って葉局面まで進める。STM 反転有無も同時に得る。
+        let stm_changed = apply_pv(&mut pos, &result.pv);
         let new_sfen = pack_position(&pos);
         (new_sfen, stm_changed)
     } else {
@@ -1969,6 +1998,12 @@ struct OnnxPipelineConfig<'a> {
     input2_channels: usize,
     profile_path: Option<&'a std::path::Path>,
     expand: Option<ExpandConfig<'a>>,
+    /// root 局面据え置き・ラベルのみ葉評価モード（`--qsearch-leaf-label`）。
+    /// 真のとき各局面を NNUE qsearch で葉まで進めてから特徴量を構築し、
+    /// 出力 sfen は root のまま・STM 変化時はスコアを符号反転する。
+    qsearch_leaf_label: bool,
+    /// qsearch の最大深さ（`qsearch_leaf_label` 時のみ使用）
+    qsearch_max_ply: i32,
 }
 
 /// ポリシー展開機能の設定（`OnnxPipelineConfig::expand` が `Some` のときのみ動作）
@@ -2007,6 +2042,11 @@ struct RunFingerprint {
     score_clip: i16,
     eval_scale_bits: u32,
     onnx_draw_ply: i32,
+    // 出力内容を変える要素: root 据え置き・葉ラベルモードと葉探索深さ。
+    // モード差で resume / marker が誤って一致しないよう fingerprint に含める。
+    // max_ply は葉ラベル時のみ意味を持つので Option（expand_* と同じ扱い）。
+    qsearch_leaf_label: bool,
+    qsearch_max_ply: Option<i32>,
     expand: bool,
     expand_threshold_bits: Option<u32>,
     expand_skip_parent_in_check: Option<bool>,
@@ -2071,6 +2111,14 @@ fn serialize_marker(marker: &DoneMarker) -> String {
     let _ = writeln!(out, "score_clip={}", f.score_clip);
     let _ = writeln!(out, "eval_scale_bits=0x{:08x}", f.eval_scale_bits);
     let _ = writeln!(out, "onnx_draw_ply={}", f.onnx_draw_ply);
+    let _ = writeln!(out, "qsearch_leaf_label={}", f.qsearch_leaf_label);
+    if f.qsearch_leaf_label {
+        let _ = writeln!(
+            out,
+            "qsearch_max_ply={}",
+            f.qsearch_max_ply.expect("qsearch_leaf_label=true requires max_ply")
+        );
+    }
     let _ = writeln!(out, "expand={}", f.expand);
     if f.expand {
         let _ = writeln!(
@@ -2146,6 +2194,11 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         anyhow::bail!("Unsupported marker version: {version} (expected {MARKER_VERSION})");
     }
     let expand = parse_bool(get("expand")?)?;
+    // 後方互換: 旧 marker には無いキー。欠落時は false（葉ラベル未使用）扱い。
+    let qsearch_leaf_label = match map.get("qsearch_leaf_label") {
+        Some(v) => parse_bool(v)?,
+        None => false,
+    };
     let fingerprint = RunFingerprint {
         version,
         mode: get("mode")?.clone(),
@@ -2161,6 +2214,12 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         score_clip: get("score_clip")?.parse().context("invalid score_clip")?,
         eval_scale_bits: parse_hex_u32(get("eval_scale_bits")?)?,
         onnx_draw_ply: get("onnx_draw_ply")?.parse().context("invalid onnx_draw_ply")?,
+        qsearch_leaf_label,
+        qsearch_max_ply: if qsearch_leaf_label {
+            Some(get("qsearch_max_ply")?.parse().context("invalid qsearch_max_ply")?)
+        } else {
+            None
+        },
         expand,
         expand_threshold_bits: if expand {
             Some(parse_hex_u32(get("expand_threshold_bits")?)?)
@@ -2320,6 +2379,8 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         score_clip: config.score_clip,
         eval_scale_bits: config.eval_scale.to_bits(),
         onnx_draw_ply: config.onnx_draw_ply,
+        qsearch_leaf_label: config.qsearch_leaf_label,
+        qsearch_max_ply: config.qsearch_leaf_label.then_some(config.qsearch_max_ply),
         expand: config.expand.is_some(),
         expand_threshold_bits: config.expand.map(|e| e.threshold.to_bits()),
         expand_skip_parent_in_check: config.expand.map(|e| e.skip_parent_in_check),
@@ -2377,6 +2438,8 @@ where
         input2_channels,
         profile_path,
         expand,
+        qsearch_leaf_label,
+        qsearch_max_ply,
     } = *config;
     use ort::ep::ExecutionProvider;
     use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
@@ -2690,16 +2753,43 @@ where
         let f2_slices: Vec<&mut [f32]> =
             f2_buf[..actual_batch * f2_size].chunks_mut(f2_size).collect();
 
-        f1_slices.into_par_iter().zip(f2_slices).zip(batch_records.par_iter()).for_each(
-            |((f1, f2), (psv, sfen, _in_check))| {
+        // qsearch-leaf-label モードでは局面ごとに「葉で STM が反転したか」を記録し、
+        // 出力時に葉の評価を root 手番視点へ符号調整する。非モード時は全 false。
+        let mut stm_flags = vec![false; actual_batch];
+
+        f1_slices
+            .into_par_iter()
+            .zip(f2_slices)
+            .zip(batch_records.par_iter())
+            .zip(stm_flags.par_iter_mut())
+            .for_each(|(((f1, f2), (psv, sfen, _in_check)), stm_flag)| {
                 let mut pos = Position::new();
                 if pos.set_sfen(sfen).is_err() {
                     batch_errors.fetch_add(1, Ordering::Relaxed);
                     return;
                 }
+                // root 局面据え置き・ラベルのみ葉評価: NNUE qsearch で葉まで進めてから
+                // 特徴量を構築する（DL は葉局面を評価）。王手 root は葉探索せず原局面のまま。
+                if qsearch_leaf_label && !pos.in_check() {
+                    thread_local! {
+                        static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
+                    }
+                    NNUE_STACKS.with(|stacks| {
+                        let mut stacks = stacks.borrow_mut();
+                        stacks.reset();
+                        let result = qsearch_with_pv_nnue(
+                            &mut pos,
+                            &mut stacks,
+                            QSEARCH_ALPHA_INIT,
+                            QSEARCH_BETA_INIT,
+                            0,
+                            qsearch_max_ply,
+                        );
+                        *stm_flag = apply_pv(&mut pos, &result.pv);
+                    });
+                }
                 build_features(&pos, f1, f2, psv);
-            },
-        );
+            });
 
         error_count += batch_errors.load(Ordering::Relaxed);
 
@@ -2749,12 +2839,21 @@ where
             let winrate = values[i];
             let clamped = winrate.clamp(0.001, 0.999);
             let logit = (clamped / (1.0 - clamped)).ln();
-            let raw_score = (logit * eval_scale) as i32;
+            // qsearch-leaf-label モードで葉の STM が root と異なる場合、推論値は葉の
+            // 手番視点なので root 視点へ符号反転する。
+            let leaf_score = logit * eval_scale;
+            let signed_score = if stm_flags[i] {
+                -leaf_score
+            } else {
+                leaf_score
+            };
+            let raw_score = signed_score as i32;
             let clipped = raw_score.abs() > score_clip as i32;
             let new_score = raw_score.clamp(-(score_clip as i32), score_clip as i32) as i16;
             if clipped {
                 clipped_count += 1;
             }
+            // 出力 sfen は常に root の `psv.sfen`（局面は置換しない）。葉評価はラベルのみに反映。
             let new_psv = PackedSfenValue {
                 sfen: psv.sfen,
                 score: new_score,
@@ -2965,6 +3064,8 @@ fn process_file_with_onnx(
         input2_channels: INPUT2_CHANNELS,
         profile_path: cli.ort_profile.as_deref(),
         expand,
+        qsearch_leaf_label: cli.qsearch_leaf_label,
+        qsearch_max_ply: cli.max_ply,
     };
     process_file_with_onnx_pipeline(&config, move |pos, f1, f2, psv| {
         make_input_features(pos, f1, f2, psv.game_ply as i32, draw_ply);
@@ -3016,6 +3117,8 @@ fn process_file_with_dlshogi_onnx(
         input2_channels: INPUT2_CHANNELS,
         profile_path: cli.ort_profile.as_deref(),
         expand,
+        qsearch_leaf_label: cli.qsearch_leaf_label,
+        qsearch_max_ply: cli.max_ply,
     };
     process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
         make_input_features(pos, f1, f2);

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -412,6 +412,7 @@ fn onnx_marker_decide(
         expand: expand_cfg,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
+        qsearch_nnue_path: cli.nnue.as_deref(),
         replacement_output,
     };
     let current = build_run_fingerprint(&cfg)?;
@@ -535,8 +536,10 @@ fn onnx_marker_decide(
     }
 
     // marker 不存在
-    if expand_output_path.is_some() || replacement_output.is_some() {
-        // expand / replacement 有効時は marker 必須。truncate して最初から
+    // leaf-label は marker 必須にする。record 数ベースの legacy resume では、旧通常 rescore の
+    // marker 無し出力（レコード数だけ一致）を完了扱いし、葉ラベルを生成せず stale 出力を温存する。
+    if expand_output_path.is_some() || replacement_output.is_some() || cli.qsearch_leaf_label {
+        // expand / replacement / leaf-label 有効時は marker 必須。truncate して最初から
         if rescore_output_path.exists() {
             File::options().write(true).open(rescore_output_path)?.set_len(0)?;
         }
@@ -2099,6 +2102,10 @@ struct OnnxPipelineConfig<'a> {
     qsearch_leaf_label: bool,
     /// qsearch の最大深さ（`qsearch_leaf_label` 時のみ使用）
     qsearch_max_ply: i32,
+    /// 葉探索用 NNUE モデルのパス（`qsearch_leaf_label` 時のみ Some）。
+    /// 葉 PV ＝ ONNX が評価する葉局面が NNUE に依存するため、NNUE 差し替えを
+    /// marker で検知できるよう fingerprint に path/size/mtime を含める。
+    qsearch_nnue_path: Option<&'a std::path::Path>,
     /// leaf-REPLACEMENT arm の出力パス（`--qsearch-leaf-replacement-output`）。
     /// `qsearch_leaf_label` 併用時のみ Some。葉局面に置換したレコード
     /// （葉 sfen + 葉評価・符号反転なし）をこのパスに書き出す。leaf-LABEL arm
@@ -2147,6 +2154,11 @@ struct RunFingerprint {
     // max_ply は葉ラベル時のみ意味を持つので Option（expand_* と同じ扱い）。
     qsearch_leaf_label: bool,
     qsearch_max_ply: Option<i32>,
+    // 葉探索用 NNUE（`--nnue`）。葉ラベルモードでは葉局面＝出力が NNUE に依存するため、
+    // path/size/mtime を fingerprint に含める。qsearch_max_ply と同じく leaf_label 時のみ Some。
+    qsearch_nnue_path: Option<PathBuf>,
+    qsearch_nnue_size: Option<u64>,
+    qsearch_nnue_mtime_ns: Option<u128>,
     expand: bool,
     expand_threshold_bits: Option<u32>,
     expand_skip_parent_in_check: Option<bool>,
@@ -2222,6 +2234,24 @@ fn serialize_marker(marker: &DoneMarker) -> String {
             out,
             "qsearch_max_ply={}",
             f.qsearch_max_ply.expect("qsearch_leaf_label=true requires max_ply")
+        );
+        let _ = writeln!(
+            out,
+            "qsearch_nnue_path={}",
+            f.qsearch_nnue_path
+                .as_ref()
+                .expect("qsearch_leaf_label=true requires nnue path")
+                .display()
+        );
+        let _ = writeln!(
+            out,
+            "qsearch_nnue_size={}",
+            f.qsearch_nnue_size.expect("qsearch_leaf_label=true requires nnue size")
+        );
+        let _ = writeln!(
+            out,
+            "qsearch_nnue_mtime_ns={}",
+            f.qsearch_nnue_mtime_ns.expect("qsearch_leaf_label=true requires nnue mtime")
         );
     }
     let _ = writeln!(out, "expand={}", f.expand);
@@ -2348,6 +2378,21 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         qsearch_leaf_label,
         qsearch_max_ply: if qsearch_leaf_label {
             Some(get("qsearch_max_ply")?.parse().context("invalid qsearch_max_ply")?)
+        } else {
+            None
+        },
+        qsearch_nnue_path: if qsearch_leaf_label {
+            Some(PathBuf::from(get("qsearch_nnue_path")?))
+        } else {
+            None
+        },
+        qsearch_nnue_size: if qsearch_leaf_label {
+            Some(get("qsearch_nnue_size")?.parse().context("invalid qsearch_nnue_size")?)
+        } else {
+            None
+        },
+        qsearch_nnue_mtime_ns: if qsearch_leaf_label {
+            Some(get("qsearch_nnue_mtime_ns")?.parse().context("invalid qsearch_nnue_mtime_ns")?)
         } else {
             None
         },
@@ -2518,6 +2563,22 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         }
         None => None,
     };
+    // 葉探索用 NNUE のメタを fingerprint へ（葉ラベル時のみ）。NNUE を差し替えると葉局面＝
+    // 出力が変わるのに、含めないと marker が一致して stale な葉ラベルを再利用してしまう。
+    let (qsearch_nnue_path, qsearch_nnue_size, qsearch_nnue_mtime_ns) = if config.qsearch_leaf_label
+    {
+        let p = config
+            .qsearch_nnue_path
+            .context("--qsearch-leaf-label requires --nnue path for fingerprint")?;
+        let cp = p
+            .canonicalize()
+            .with_context(|| format!("Failed to canonicalize --nnue {}", p.display()))?;
+        ensure_marker_safe_path("--nnue (qsearch leaf)", &cp)?;
+        let (size, mtime) = file_size_mtime_ns(&cp)?;
+        (Some(cp), Some(size), Some(mtime))
+    } else {
+        (None, None, None)
+    };
     Ok(RunFingerprint {
         version: MARKER_VERSION,
         mode: "onnx".to_string(),
@@ -2535,6 +2596,9 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         onnx_draw_ply: config.onnx_draw_ply,
         qsearch_leaf_label: config.qsearch_leaf_label,
         qsearch_max_ply: config.qsearch_leaf_label.then_some(config.qsearch_max_ply),
+        qsearch_nnue_path,
+        qsearch_nnue_size,
+        qsearch_nnue_mtime_ns,
         expand: config.expand.is_some(),
         expand_threshold_bits: config.expand.map(|e| e.threshold.to_bits()),
         expand_skip_parent_in_check: config.expand.map(|e| e.skip_parent_in_check),
@@ -2596,6 +2660,8 @@ where
         expand,
         qsearch_leaf_label,
         qsearch_max_ply,
+        // fingerprint 用。pipeline 本体では使わず build_run_fingerprint(config) で参照する。
+        qsearch_nnue_path: _,
         replacement_output,
     } = *config;
     use ort::ep::ExecutionProvider;
@@ -3318,7 +3384,8 @@ fn process_file_with_onnx(
         expand,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
-        // leaf-label は dlshogi 限定のため AobaZero では replacement arm を持たない。
+        // leaf-label は dlshogi 限定のため AobaZero では葉探索 NNUE / replacement arm を持たない。
+        qsearch_nnue_path: None,
         replacement_output: None,
     };
     process_file_with_onnx_pipeline(&config, move |pos, f1, f2, psv| {
@@ -3374,6 +3441,7 @@ fn process_file_with_dlshogi_onnx(
         expand,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
+        qsearch_nnue_path: cli.nnue.as_deref(),
         replacement_output: replacement_output_path,
     };
     process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
@@ -3416,20 +3484,34 @@ mod marker_tests {
         parse_marker(&path).unwrap()
     }
 
+    /// leaf-label=true の marker に必要な qsearch 系キー（max_ply + 葉探索 NNUE のメタ）。
+    const LEAF_LABEL_KEYS: &str = "qsearch_leaf_label=true\n\
+         qsearch_max_ply=20\n\
+         qsearch_nnue_path=/tmp/nn.bin\n\
+         qsearch_nnue_size=42\n\
+         qsearch_nnue_mtime_ns=789\n";
+
     #[test]
     fn old_marker_without_qsearch_keys_defaults_to_false() {
         // 旧 marker（qsearch_leaf_label 行なし）は false / None 扱いで後方互換
         let m = parse_text(&base_marker(""));
         assert!(!m.fingerprint.qsearch_leaf_label);
         assert_eq!(m.fingerprint.qsearch_max_ply, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_path, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_size, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_mtime_ns, None);
     }
 
     #[test]
     fn new_marker_leaf_label_true_roundtrips() {
-        let m = parse_text(&base_marker("qsearch_leaf_label=true\nqsearch_max_ply=20\n"));
+        let m = parse_text(&base_marker(LEAF_LABEL_KEYS));
         assert!(m.fingerprint.qsearch_leaf_label);
         assert_eq!(m.fingerprint.qsearch_max_ply, Some(20));
-        // serialize → parse で一致（max_ply 行は leaf_label=true 時のみ出力）
+        // 葉探索 NNUE のメタも fingerprint に取り込まれる（差し替え検知用）。
+        assert_eq!(m.fingerprint.qsearch_nnue_path, Some(PathBuf::from("/tmp/nn.bin")));
+        assert_eq!(m.fingerprint.qsearch_nnue_size, Some(42));
+        assert_eq!(m.fingerprint.qsearch_nnue_mtime_ns, Some(789));
+        // serialize → parse で一致（max_ply / nnue 行は leaf_label=true 時のみ出力）
         assert_eq!(m, parse_text(&serialize_marker(&m)));
     }
 
@@ -3438,6 +3520,7 @@ mod marker_tests {
         let m = parse_text(&base_marker("qsearch_leaf_label=false\n"));
         assert!(!m.fingerprint.qsearch_leaf_label);
         assert_eq!(m.fingerprint.qsearch_max_ply, None);
+        assert_eq!(m.fingerprint.qsearch_nnue_path, None);
     }
 
     #[test]
@@ -3461,6 +3544,9 @@ mod marker_tests {
     fn replacement_true_roundtrips() {
         let m = parse_text(&base_marker(
             "qsearch_leaf_label=true\nqsearch_max_ply=16\n\
+             qsearch_nnue_path=/tmp/nn.bin\n\
+             qsearch_nnue_size=42\n\
+             qsearch_nnue_mtime_ns=789\n\
              replacement=true\n\
              replacement_output_path=/tmp/repl/in.psv\n\
              replacement_output_size=320\n",

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -570,15 +570,16 @@ fn main() -> Result<()> {
 
     // --qsearch-leaf-label の前提チェック
     // root 局面を保持しつつラベルだけ葉評価にするには、葉を求める NNUE と
-    // 葉を評価する ONNX ラベラーの両方が要る。
+    // 葉を評価する ONNX ラベラーの両方が要る。AobaZero 特徴量は手数 (game_ply) を
+    // 含み、葉へ進めても root の game_ply が渡って葉特徴量に混入するため dlshogi 限定。
     if cli.qsearch_leaf_label {
         if cli.nnue.is_none() {
             anyhow::bail!("--qsearch-leaf-label requires --nnue (qsearch で葉局面を求めるため)");
         }
-        if !(use_onnx || use_dlshogi_onnx) {
+        if !use_dlshogi_onnx {
             anyhow::bail!(
-                "--qsearch-leaf-label requires an ONNX labeling model \
-                 (--dlshogi-onnx-model or --onnx-model)"
+                "--qsearch-leaf-label requires --dlshogi-onnx-model \
+                 (AobaZero 特徴量は game_ply を含み葉局面と不整合のため非対応)"
             );
         }
         if cli.apply_qsearch_leaf {
@@ -2676,6 +2677,9 @@ where
 
     let mut f1_buf = vec![0.0f32; batch_size * f1_size];
     let mut f2_buf = vec![0.0f32; batch_size * f2_size];
+    // qsearch-leaf-label モードで「葉で STM が反転したか」を局面ごとに記録するバッファ。
+    // f1/f2 と同様ループ外で 1 回確保し、各バッチ先頭で reset して再利用する。
+    let mut stm_flags = vec![false; batch_size];
     let mut buffer = [0u8; PackedSfenValue::SIZE];
     let mut skipped_count: u64 = 0;
     let mut error_count: u64 = 0;
@@ -2753,9 +2757,9 @@ where
         let f2_slices: Vec<&mut [f32]> =
             f2_buf[..actual_batch * f2_size].chunks_mut(f2_size).collect();
 
-        // qsearch-leaf-label モードでは局面ごとに「葉で STM が反転したか」を記録し、
-        // 出力時に葉の評価を root 手番視点へ符号調整する。非モード時は全 false。
-        let mut stm_flags = vec![false; actual_batch];
+        // 葉で STM が反転したかの記録領域を当バッチ分だけ reset（非モード時は全 false）。
+        let stm_flags = &mut stm_flags[..actual_batch];
+        stm_flags.fill(false);
 
         f1_slices
             .into_par_iter()
@@ -3123,4 +3127,64 @@ fn process_file_with_dlshogi_onnx(
     process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
         make_input_features(pos, f1, f2);
     })
+}
+
+#[cfg(all(test, any(feature = "aobazero-onnx", feature = "dlshogi-onnx")))]
+mod marker_tests {
+    use super::*;
+    use std::io::Write;
+
+    /// 必須キーを満たす最小 marker テキスト（expand=false）。`extra` に qsearch 系の追加行を差し込む。
+    fn base_marker(extra: &str) -> String {
+        format!(
+            "version={MARKER_VERSION}\n\
+             mode=onnx\n\
+             model_kind=dlshogi\n\
+             model_path=/tmp/model.onnx\n\
+             model_size=100\n\
+             model_mtime_ns=123\n\
+             input_path=/tmp/in.psv\n\
+             input_size=200\n\
+             input_mtime_ns=456\n\
+             process_count=10\n\
+             skip_in_check=false\n\
+             score_clip=10000\n\
+             eval_scale_bits=0x44160000\n\
+             onnx_draw_ply=0\n\
+             {extra}\
+             expand=false\n\
+             rescore_output_size=400\n"
+        )
+    }
+
+    fn parse_text(text: &str) -> DoneMarker {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("m.done");
+        std::fs::File::create(&path).unwrap().write_all(text.as_bytes()).unwrap();
+        parse_marker(&path).unwrap()
+    }
+
+    #[test]
+    fn old_marker_without_qsearch_keys_defaults_to_false() {
+        // 旧 marker（qsearch_leaf_label 行なし）は false / None 扱いで後方互換
+        let m = parse_text(&base_marker(""));
+        assert!(!m.fingerprint.qsearch_leaf_label);
+        assert_eq!(m.fingerprint.qsearch_max_ply, None);
+    }
+
+    #[test]
+    fn new_marker_leaf_label_true_roundtrips() {
+        let m = parse_text(&base_marker("qsearch_leaf_label=true\nqsearch_max_ply=20\n"));
+        assert!(m.fingerprint.qsearch_leaf_label);
+        assert_eq!(m.fingerprint.qsearch_max_ply, Some(20));
+        // serialize → parse で一致（max_ply 行は leaf_label=true 時のみ出力）
+        assert_eq!(m, parse_text(&serialize_marker(&m)));
+    }
+
+    #[test]
+    fn leaf_label_false_has_no_max_ply() {
+        let m = parse_text(&base_marker("qsearch_leaf_label=false\n"));
+        assert!(!m.fingerprint.qsearch_leaf_label);
+        assert_eq!(m.fingerprint.qsearch_max_ply, None);
+    }
 }

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -123,6 +123,15 @@ struct Cli {
     #[arg(long)]
     qsearch_leaf_label: bool,
 
+    /// `--qsearch-leaf-label` と併用し、同一 1 パスで葉局面に置換したレコードを
+    /// 別ディレクトリにも書き出す（leaf-REPLACEMENT arm）。
+    /// `--output-dir` 側は root 局面 + 葉ラベル（leaf-LABEL arm）のまま。
+    /// このディレクトリには葉局面 + 葉評価（符号反転なし）を書き出す。
+    /// `--apply-qsearch-leaf` → DL rescore の 2 工程と bit 一致する。
+    /// `--output-dir` とは別ディレクトリ必須。
+    #[arg(long)]
+    qsearch_leaf_replacement_output: Option<PathBuf>,
+
     /// qsearchの最大深さ
     #[arg(long, default_value_t = 16)]
     max_ply: i32,
@@ -361,6 +370,7 @@ fn onnx_marker_decide(
     input_path: &std::path::Path,
     rescore_output_path: &std::path::Path,
     expand_output_path: Option<&std::path::Path>,
+    replacement_output: Option<&std::path::Path>,
     process_count: u64,
 ) -> Result<OnnxMarkerDecision> {
     // 現在 run の OnnxPipelineConfig を組み立てて fingerprint を作る
@@ -402,6 +412,7 @@ fn onnx_marker_decide(
         expand: expand_cfg,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
+        replacement_output,
     };
     let current = build_run_fingerprint(&cfg)?;
 
@@ -409,6 +420,9 @@ fn onnx_marker_decide(
     let canonical_input = current.input_path.clone();
     ensure_safe_output_path(rescore_output_path, &canonical_input)?;
     if let Some(p) = expand_output_path {
+        ensure_safe_output_path(p, &canonical_input)?;
+    }
+    if let Some(p) = replacement_output {
         ensure_safe_output_path(p, &canonical_input)?;
     }
 
@@ -427,6 +441,17 @@ fn onnx_marker_decide(
                 }
                 (false, None, None) => true,
                 _ => false,
+            }
+            && match (
+                marker.fingerprint.replacement,
+                marker.output_sizes.replacement_output_size,
+                marker.fingerprint.replacement_output_path.as_ref(),
+            ) {
+                (true, Some(size), Some(path)) => {
+                    path.exists() && fs::metadata(path)?.len() == size
+                }
+                (false, None, None) => true,
+                _ => false,
             };
 
         if marker.fingerprint == current && bodies_match {
@@ -436,9 +461,11 @@ fn onnx_marker_decide(
         // 不一致時の再生成手順。
         // 破壊操作の順序は意図的:
         //   1. 旧 expand artifact 削除（失敗しうる、入力衝突も事前検証）
-        //   2. 現 rescore 出力 truncate
-        //   3. 現 expand 出力 truncate
-        //   4. marker 削除（最後）
+        //   2. 旧 replacement artifact 削除（同上）
+        //   3. 現 rescore 出力 truncate
+        //   4. 現 expand 出力 truncate
+        //   5. 現 replacement 出力 truncate
+        //   6. marker 削除（最後）
         // この順なら、どの段階で失敗しても次回実行時に marker 不一致判定が
         // 働き、続きからやり直せる。"truncate してから remove_file" の順だと、
         // 後段失敗時に truncate 済み出力 + 古い marker が残ってデータ損失に
@@ -466,29 +493,59 @@ fn onnx_marker_decide(
             }
         }
 
-        // 2. 現 rescore 出力 truncate
+        // 2. 旧 replacement artifact 削除
+        if let Some(old) = &marker.fingerprint.replacement_output_path {
+            if is_same_file(old, &canonical_input) {
+                anyhow::bail!(
+                    "Stale leaf-replacement artifact {} resolves to the current input file {}. \
+                     Refusing to delete to prevent input data loss. \
+                     Move the input or change --qsearch-leaf-replacement-output.",
+                    old.display(),
+                    canonical_input.display()
+                );
+            }
+            let same_as_current = replacement_output.is_some_and(|p| is_same_file(p, old));
+            if !same_as_current && old.exists() {
+                fs::remove_file(old).with_context(|| {
+                    format!("Failed to remove stale leaf-replacement artifact {}", old.display())
+                })?;
+            }
+        }
+
+        // 3. 現 rescore 出力 truncate
         if rescore_output_path.exists() {
             File::options().write(true).open(rescore_output_path)?.set_len(0)?;
         }
-        // 3. 現 expand 出力 truncate
+        // 4. 現 expand 出力 truncate
         if let Some(p) = expand_output_path
             && p.exists()
         {
             File::options().write(true).open(p)?.set_len(0)?;
         }
-        // 4. marker 削除（最後）
+        // 5. 現 replacement 出力 truncate
+        if let Some(p) = replacement_output
+            && p.exists()
+        {
+            File::options().write(true).open(p)?.set_len(0)?;
+        }
+        // 6. marker 削除（最後）
         fs::remove_file(&marker_path)
             .with_context(|| format!("Failed to remove stale marker {}", marker_path.display()))?;
         return Ok(OnnxMarkerDecision::TruncateAndProcess);
     }
 
     // marker 不存在
-    if expand_output_path.is_some() {
-        // expand 有効時は marker 必須。truncate して最初から
+    if expand_output_path.is_some() || replacement_output.is_some() {
+        // expand / replacement 有効時は marker 必須。truncate して最初から
         if rescore_output_path.exists() {
             File::options().write(true).open(rescore_output_path)?.set_len(0)?;
         }
         if let Some(p) = expand_output_path
+            && p.exists()
+        {
+            File::options().write(true).open(p)?.set_len(0)?;
+        }
+        if let Some(p) = replacement_output
             && p.exists()
         {
             File::options().write(true).open(p)?.set_len(0)?;
@@ -596,6 +653,15 @@ fn main() -> Result<()> {
         }
     }
 
+    // --qsearch-leaf-replacement-output は --qsearch-leaf-label 前提。
+    // leaf-label の qsearch 葉を再利用して、葉局面置換 arm を同時生成する。
+    if cli.qsearch_leaf_replacement_output.is_some() && !cli.qsearch_leaf_label {
+        anyhow::bail!(
+            "--qsearch-leaf-replacement-output requires --qsearch-leaf-label \
+             (葉局面は leaf-label の qsearch 結果を再利用するため)"
+        );
+    }
+
     // --expand-output-dir は ONNX モード必須
     if cli.expand_output_dir.is_some() && !(use_onnx || use_dlshogi_onnx) {
         anyhow::bail!(
@@ -659,7 +725,15 @@ fn main() -> Result<()> {
             format!("Failed to create expand output directory: {}", d.display())
         })?;
     }
-    // 両 dir を canonicalize して衝突を検出
+    // leaf-replacement 出力ディレクトリの作成
+    if let Some(d) = &cli.qsearch_leaf_replacement_output
+        && !d.exists()
+    {
+        fs::create_dir_all(d).with_context(|| {
+            format!("Failed to create leaf-replacement output directory: {}", d.display())
+        })?;
+    }
+    // 各 dir を canonicalize して衝突を検出
     let canonical_rescore_dir = cli.output_dir.canonicalize().with_context(|| {
         format!("Failed to canonicalize --output-dir {}", cli.output_dir.display())
     })?;
@@ -673,6 +747,19 @@ fn main() -> Result<()> {
         && &canonical_rescore_dir == ed
     {
         anyhow::bail!("--output-dir and --expand-output-dir must point to different directories");
+    }
+    let canonical_replacement_dir = match &cli.qsearch_leaf_replacement_output {
+        Some(d) => Some(d.canonicalize().with_context(|| {
+            format!("Failed to canonicalize --qsearch-leaf-replacement-output {}", d.display())
+        })?),
+        None => None,
+    };
+    if let Some(rd) = &canonical_replacement_dir
+        && &canonical_rescore_dir == rd
+    {
+        anyhow::bail!(
+            "--output-dir and --qsearch-leaf-replacement-output must point to different directories"
+        );
     }
 
     // NNUEモデルのロード（NNUE内部評価モード、または ONNX ラベラー併用の
@@ -784,6 +871,9 @@ fn main() -> Result<()> {
             cli.expand_skip_child_in_check,
         );
     }
+    if let Some(d) = &cli.qsearch_leaf_replacement_output {
+        eprintln!("Leaf-replacement output directory: {}", d.display());
+    }
     if cli.delete_input {
         eprintln!("Delete input after processing: yes");
     }
@@ -804,6 +894,8 @@ fn main() -> Result<()> {
         let output_path = cli.output_dir.join(file_name);
         #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
         let expand_output_path = canonical_expand_dir.as_ref().map(|d| d.join(file_name));
+        #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+        let replacement_output_path = canonical_replacement_dir.as_ref().map(|d| d.join(file_name));
 
         // 入力ファイルサイズと process_count を最初に確定（marker 判定の前提）
         let input_file_size = fs::metadata(input_path)?.len();
@@ -833,6 +925,7 @@ fn main() -> Result<()> {
                 input_path,
                 &output_path,
                 expand_output_path.as_deref(),
+                replacement_output_path.as_deref(),
                 process_count,
             )?;
             match decision {
@@ -942,6 +1035,7 @@ fn main() -> Result<()> {
                 input_path,
                 &output_path,
                 expand_output_path.as_deref(),
+                replacement_output_path.as_deref(),
                 process_count,
             )?;
         }
@@ -2005,6 +2099,11 @@ struct OnnxPipelineConfig<'a> {
     qsearch_leaf_label: bool,
     /// qsearch の最大深さ（`qsearch_leaf_label` 時のみ使用）
     qsearch_max_ply: i32,
+    /// leaf-REPLACEMENT arm の出力パス（`--qsearch-leaf-replacement-output`）。
+    /// `qsearch_leaf_label` 併用時のみ Some。葉局面に置換したレコード
+    /// （葉 sfen + 葉評価・符号反転なし）をこのパスに書き出す。leaf-LABEL arm
+    /// （`output_path`）とは 1:1 lockstep で同数のレコードを書く。
+    replacement_output: Option<&'a std::path::Path>,
 }
 
 /// ポリシー展開機能の設定（`OnnxPipelineConfig::expand` が `Some` のときのみ動作）
@@ -2053,6 +2152,10 @@ struct RunFingerprint {
     expand_skip_parent_in_check: Option<bool>,
     expand_skip_child_in_check: Option<bool>,
     expand_output_path: Option<PathBuf>,
+    // leaf-REPLACEMENT arm（`--qsearch-leaf-replacement-output`）。expand_* と同じ
+    // Option パターン。出力内容を変えるため fingerprint に含める。
+    replacement: bool,
+    replacement_output_path: Option<PathBuf>,
 }
 
 /// 完了マーカーの出力サイズ情報（fingerprint とは分離）
@@ -2061,6 +2164,7 @@ struct RunFingerprint {
 struct OutputSizes {
     rescore_output_size: u64,
     expand_output_size: Option<u64>,
+    replacement_output_size: Option<u64>,
 }
 
 /// 完了マーカー全体（fingerprint + output sizes）
@@ -2143,6 +2247,17 @@ fn serialize_marker(marker: &DoneMarker) -> String {
             f.expand_output_path.as_ref().expect("expand=true requires path").display()
         );
     }
+    let _ = writeln!(out, "replacement={}", f.replacement);
+    if f.replacement {
+        let _ = writeln!(
+            out,
+            "replacement_output_path={}",
+            f.replacement_output_path
+                .as_ref()
+                .expect("replacement=true requires path")
+                .display()
+        );
+    }
     let _ = writeln!(out, "rescore_output_size={}", marker.output_sizes.rescore_output_size);
     if f.expand {
         let _ = writeln!(
@@ -2152,6 +2267,16 @@ fn serialize_marker(marker: &DoneMarker) -> String {
                 .output_sizes
                 .expand_output_size
                 .expect("expand=true requires expand_output_size")
+        );
+    }
+    if f.replacement {
+        let _ = writeln!(
+            out,
+            "replacement_output_size={}",
+            marker
+                .output_sizes
+                .replacement_output_size
+                .expect("replacement=true requires replacement_output_size")
         );
     }
     out
@@ -2200,6 +2325,11 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         Some(v) => parse_bool(v)?,
         None => false,
     };
+    // 後方互換: 旧 marker には無いキー。欠落時は false（replacement arm 未使用）扱い。
+    let replacement = match map.get("replacement") {
+        Some(v) => parse_bool(v)?,
+        None => false,
+    };
     let fingerprint = RunFingerprint {
         version,
         mode: get("mode")?.clone(),
@@ -2242,6 +2372,12 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         } else {
             None
         },
+        replacement,
+        replacement_output_path: if replacement {
+            Some(PathBuf::from(get("replacement_output_path")?))
+        } else {
+            None
+        },
     };
     let output_sizes = OutputSizes {
         rescore_output_size: get("rescore_output_size")?
@@ -2249,6 +2385,15 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
             .context("invalid rescore_output_size")?,
         expand_output_size: if expand {
             Some(get("expand_output_size")?.parse().context("invalid expand_output_size")?)
+        } else {
+            None
+        },
+        replacement_output_size: if replacement {
+            Some(
+                get("replacement_output_size")?
+                    .parse()
+                    .context("invalid replacement_output_size")?,
+            )
         } else {
             None
         },
@@ -2365,6 +2510,14 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         }
         None => None,
     };
+    let replacement_output_path = match config.replacement_output {
+        Some(rp) => {
+            let p = canonicalize_predicted_path(rp)?;
+            ensure_marker_safe_path("--qsearch-leaf-replacement-output (entry)", &p)?;
+            Some(p)
+        }
+        None => None,
+    };
     Ok(RunFingerprint {
         version: MARKER_VERSION,
         mode: "onnx".to_string(),
@@ -2387,6 +2540,8 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         expand_skip_parent_in_check: config.expand.map(|e| e.skip_parent_in_check),
         expand_skip_child_in_check: config.expand.map(|e| e.skip_child_in_check),
         expand_output_path,
+        replacement: config.replacement_output.is_some(),
+        replacement_output_path,
     })
 }
 
@@ -2441,6 +2596,7 @@ where
         expand,
         qsearch_leaf_label,
         qsearch_max_ply,
+        replacement_output,
     } = *config;
     use ort::ep::ExecutionProvider;
     use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
@@ -2660,6 +2816,19 @@ where
         None
     };
 
+    // leaf-REPLACEMENT 出力 writer（replacement 有効時のみ）。expand と同様 main 側で
+    // truncate(0) 済みなので append open で常に先頭から書く。leaf-LABEL 出力（writer）と
+    // 同一ループで 1:1 lockstep に書くため、レコード数は両者で一致する。
+    let mut replacement_writer: Option<BufWriter<File>> = if let Some(rp) = replacement_output {
+        let f =
+            File::options().create(true).append(true).open(rp).with_context(|| {
+                format!("Failed to open leaf-replacement output {}", rp.display())
+            })?;
+        Some(BufWriter::new(f))
+    } else {
+        None
+    };
+
     // 既存レコード分の入力をスキップ（expand 無効 + marker 不存在の legacy
     // resume パス。main 側で truncate(0) 済みなら resume_count == 0 になり no-op）
     let mut remaining = process_count;
@@ -2680,6 +2849,13 @@ where
     // qsearch-leaf-label モードで「葉で STM が反転したか」を局面ごとに記録するバッファ。
     // f1/f2 と同様ループ外で 1 回確保し、各バッチ先頭で reset して再利用する。
     let mut stm_flags = vec![false; batch_size];
+    // leaf-REPLACEMENT 有効時、葉局面の packed sfen を局面ごとに記録するバッファ。
+    // f1/f2 と同様ループ外で 1 回確保し再利用する。非有効時は pack を行わず空のまま。
+    let mut leaf_sfens: Vec<[u8; 32]> = if replacement_output.is_some() {
+        vec![[0u8; 32]; batch_size]
+    } else {
+        Vec::new()
+    };
     let mut buffer = [0u8; PackedSfenValue::SIZE];
     let mut skipped_count: u64 = 0;
     let mut error_count: u64 = 0;
@@ -2760,40 +2936,73 @@ where
         // 葉で STM が反転したかの記録領域を当バッチ分だけ reset（非モード時は全 false）。
         let stm_flags = &mut stm_flags[..actual_batch];
         stm_flags.fill(false);
+        // leaf-REPLACEMENT 有効時のみ葉局面の packed sfen を書き込む領域を当バッチ分に絞る。
+        // 非有効時は空スライス（pack を行わないため zip しない）。
+        let leaf_sfens_slice: &mut [[u8; 32]] = if replacement_output.is_some() {
+            &mut leaf_sfens[..actual_batch]
+        } else {
+            &mut []
+        };
 
-        f1_slices
-            .into_par_iter()
-            .zip(f2_slices)
-            .zip(batch_records.par_iter())
-            .zip(stm_flags.par_iter_mut())
-            .for_each(|(((f1, f2), (psv, sfen, _in_check)), stm_flag)| {
-                let mut pos = Position::new();
-                if pos.set_sfen(sfen).is_err() {
-                    batch_errors.fetch_add(1, Ordering::Relaxed);
-                    return;
+        // 1 局面分の特徴量構築（必要なら葉まで進めて葉 sfen を packed_leaf に書く）。
+        let build_one = |f1: &mut [f32],
+                         f2: &mut [f32],
+                         psv: &PackedSfenValue,
+                         sfen: &str,
+                         stm_flag: &mut bool,
+                         packed_leaf: Option<&mut [u8; 32]>| {
+            let mut pos = Position::new();
+            if pos.set_sfen(sfen).is_err() {
+                batch_errors.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+            // root 局面据え置き・ラベルのみ葉評価: NNUE qsearch で葉まで進めてから
+            // 特徴量を構築する（DL は葉局面を評価）。王手 root は葉探索せず原局面のまま。
+            if qsearch_leaf_label && !pos.in_check() {
+                thread_local! {
+                    static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
                 }
-                // root 局面据え置き・ラベルのみ葉評価: NNUE qsearch で葉まで進めてから
-                // 特徴量を構築する（DL は葉局面を評価）。王手 root は葉探索せず原局面のまま。
-                if qsearch_leaf_label && !pos.in_check() {
-                    thread_local! {
-                        static NNUE_STACKS: RefCell<NnueStacks> = RefCell::new(NnueStacks::new());
-                    }
-                    NNUE_STACKS.with(|stacks| {
-                        let mut stacks = stacks.borrow_mut();
-                        stacks.reset();
-                        let result = qsearch_with_pv_nnue(
-                            &mut pos,
-                            &mut stacks,
-                            QSEARCH_ALPHA_INIT,
-                            QSEARCH_BETA_INIT,
-                            0,
-                            qsearch_max_ply,
-                        );
-                        *stm_flag = apply_pv(&mut pos, &result.pv);
-                    });
-                }
-                build_features(&pos, f1, f2, psv);
-            });
+                NNUE_STACKS.with(|stacks| {
+                    let mut stacks = stacks.borrow_mut();
+                    stacks.reset();
+                    let result = qsearch_with_pv_nnue(
+                        &mut pos,
+                        &mut stacks,
+                        QSEARCH_ALPHA_INIT,
+                        QSEARCH_BETA_INIT,
+                        0,
+                        qsearch_max_ply,
+                    );
+                    *stm_flag = apply_pv(&mut pos, &result.pv);
+                });
+            }
+            // 葉まで進めた pos を pack（王手 root は原局面のまま）。replacement arm 用。
+            if let Some(slot) = packed_leaf {
+                *slot = pack_position(&pos);
+            }
+            build_features(&pos, f1, f2, psv);
+        };
+
+        if replacement_output.is_some() {
+            f1_slices
+                .into_par_iter()
+                .zip(f2_slices)
+                .zip(batch_records.par_iter())
+                .zip(stm_flags.par_iter_mut())
+                .zip(leaf_sfens_slice.par_iter_mut())
+                .for_each(|((((f1, f2), (psv, sfen, _in_check)), stm_flag), leaf)| {
+                    build_one(f1, f2, psv, sfen, stm_flag, Some(leaf));
+                });
+        } else {
+            f1_slices
+                .into_par_iter()
+                .zip(f2_slices)
+                .zip(batch_records.par_iter())
+                .zip(stm_flags.par_iter_mut())
+                .for_each(|(((f1, f2), (psv, sfen, _in_check)), stm_flag)| {
+                    build_one(f1, f2, psv, sfen, stm_flag, None);
+                });
+        }
 
         error_count += batch_errors.load(Ordering::Relaxed);
 
@@ -2857,7 +3066,8 @@ where
             if clipped {
                 clipped_count += 1;
             }
-            // 出力 sfen は常に root の `psv.sfen`（局面は置換しない）。葉評価はラベルのみに反映。
+            // leaf-LABEL arm: 出力 sfen は常に root の `psv.sfen`（局面は置換しない）。
+            // 葉評価はラベルのみに反映（符号反転は signed_score に適用済み）。
             let new_psv = PackedSfenValue {
                 sfen: psv.sfen,
                 score: new_score,
@@ -2867,6 +3077,31 @@ where
                 padding: 0,
             };
             writer.write_all(&new_psv.to_bytes())?;
+
+            // leaf-REPLACEMENT arm（有効時のみ、leaf-LABEL と 1:1 lockstep）。
+            // `--apply-qsearch-leaf` → DL rescore の 2 工程と bit 一致させる:
+            // - sfen は葉局面の packed sfen
+            // - score は葉評価（符号反転なし＝葉手番視点）に clip 適用
+            // - game_result は STM 反転時のみ符号反転
+            if let Some(rw) = replacement_writer.as_mut() {
+                let leaf_raw = leaf_score as i32;
+                let leaf_clipped_score =
+                    leaf_raw.clamp(-(score_clip as i32), score_clip as i32) as i16;
+                let leaf_game_result = if stm_flags[i] {
+                    -psv.game_result
+                } else {
+                    psv.game_result
+                };
+                let replacement_psv = PackedSfenValue {
+                    sfen: leaf_sfens[i],
+                    score: leaf_clipped_score,
+                    move16: 0,
+                    game_ply: psv.game_ply,
+                    game_result: leaf_game_result,
+                    padding: 0,
+                };
+                rw.write_all(&replacement_psv.to_bytes())?;
+            }
         }
 
         // expand 機能（policy ベースの子局面生成）
@@ -2966,6 +3201,14 @@ where
         inner.sync_all()?;
     }
 
+    if let Some(mut rw) = replacement_writer.take() {
+        rw.flush()?;
+        let inner = rw
+            .into_inner()
+            .map_err(|e| anyhow::anyhow!("replacement writer into_inner error: {}", e.error()))?;
+        inner.sync_all()?;
+    }
+
     progress.finish_with_message("Done");
 
     // 統計情報
@@ -3010,11 +3253,16 @@ where
             Some(e) => Some(fs::metadata(e.output_path)?.len()),
             None => None,
         };
+        let replacement_size = match replacement_output {
+            Some(rp) => Some(fs::metadata(rp)?.len()),
+            None => None,
+        };
         let marker = DoneMarker {
             fingerprint,
             output_sizes: OutputSizes {
                 rescore_output_size: rescore_size,
                 expand_output_size: expand_size,
+                replacement_output_size: replacement_size,
             },
         };
         write_marker_atomic(output_path, &marker)?;
@@ -3070,6 +3318,8 @@ fn process_file_with_onnx(
         expand,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
+        // leaf-label は dlshogi 限定のため AobaZero では replacement arm を持たない。
+        replacement_output: None,
     };
     process_file_with_onnx_pipeline(&config, move |pos, f1, f2, psv| {
         make_input_features(pos, f1, f2, psv.game_ply as i32, draw_ply);
@@ -3086,6 +3336,7 @@ fn process_file_with_dlshogi_onnx(
     input_path: &std::path::Path,
     output_path: &std::path::Path,
     expand_output_path: Option<&std::path::Path>,
+    replacement_output_path: Option<&std::path::Path>,
     process_count: u64,
 ) -> Result<()> {
     use tools::dlshogi_features::{
@@ -3123,6 +3374,7 @@ fn process_file_with_dlshogi_onnx(
         expand,
         qsearch_leaf_label: cli.qsearch_leaf_label,
         qsearch_max_ply: cli.max_ply,
+        replacement_output: replacement_output_path,
     };
     process_file_with_onnx_pipeline(&config, |pos, f1, f2, _psv| {
         make_input_features(pos, f1, f2);
@@ -3186,5 +3438,37 @@ mod marker_tests {
         let m = parse_text(&base_marker("qsearch_leaf_label=false\n"));
         assert!(!m.fingerprint.qsearch_leaf_label);
         assert_eq!(m.fingerprint.qsearch_max_ply, None);
+    }
+
+    #[test]
+    fn old_marker_without_replacement_key_defaults_to_false() {
+        // 旧 marker（replacement 行なし）は false / None 扱いで後方互換
+        let m = parse_text(&base_marker(""));
+        assert!(!m.fingerprint.replacement);
+        assert_eq!(m.fingerprint.replacement_output_path, None);
+        assert_eq!(m.output_sizes.replacement_output_size, None);
+    }
+
+    #[test]
+    fn replacement_false_has_no_path_or_size() {
+        let m = parse_text(&base_marker("replacement=false\n"));
+        assert!(!m.fingerprint.replacement);
+        assert_eq!(m.fingerprint.replacement_output_path, None);
+        assert_eq!(m.output_sizes.replacement_output_size, None);
+    }
+
+    #[test]
+    fn replacement_true_roundtrips() {
+        let m = parse_text(&base_marker(
+            "qsearch_leaf_label=true\nqsearch_max_ply=16\n\
+             replacement=true\n\
+             replacement_output_path=/tmp/repl/in.psv\n\
+             replacement_output_size=320\n",
+        ));
+        assert!(m.fingerprint.replacement);
+        assert_eq!(m.fingerprint.replacement_output_path, Some(PathBuf::from("/tmp/repl/in.psv")));
+        assert_eq!(m.output_sizes.replacement_output_size, Some(320));
+        // serialize → parse で一致（replacement_* 行は replacement=true 時のみ出力）
+        assert_eq!(m, parse_text(&serialize_marker(&m)));
     }
 }

--- a/crates/tools/src/qsearch_pv.rs
+++ b/crates/tools/src/qsearch_pv.rs
@@ -338,6 +338,20 @@ pub fn qsearch_with_pv_nnue(
     }
 }
 
+/// PV を辿って局面を葉まで進め、進めた後の手番が始点と変わったか（= PV 長が奇数か）を返す。
+///
+/// qsearch-leaf ラベル付け（root 局面据え置き・ラベルのみ葉評価）で、葉の評価値を root の
+/// 手番視点に揃えるための符号反転要否を判定する。将棋は全ての手で手番が入れ替わるため、
+/// 結果は PV 長の偶奇と一致する。`pos` は葉局面まで進んだ状態で返る。
+pub fn apply_pv(pos: &mut Position, pv: &[Move]) -> bool {
+    let start_stm = pos.side_to_move();
+    for mv in pv {
+        let gives_check = pos.gives_check(*mv);
+        let _ = pos.do_move(*mv, gives_check);
+    }
+    pos.side_to_move() != start_stm
+}
+
 /// 軽量版 qsearch with PV
 ///
 /// # 引数
@@ -517,5 +531,29 @@ mod tests {
         let result = qsearch_with_pv(&mut pos, &evaluator, -30000, 30000, 0, 0);
 
         assert!(result.pv.is_empty(), "PV should be empty when max_ply = 0");
+    }
+
+    #[test]
+    fn test_apply_pv_stm_matches_parity() {
+        let ev = MaterialEvaluator;
+
+        // 平手は駒取りなし → PV 空 → STM 不変・葉=root
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let r = qsearch_with_pv(&mut pos, &ev, -30000, 30000, 0, 32);
+        let mut leaf = Position::new();
+        leaf.set_hirate();
+        assert!(!apply_pv(&mut leaf, &r.pv));
+        assert_eq!(leaf.side_to_move(), pos.side_to_move());
+
+        // 駒取りがある局面 → 葉まで辿った後の STM 反転は PV 長の偶奇と一致
+        let sfen = "4k4/9/9/9/4p4/4P4/9/9/4K4 b - 1";
+        let mut p2 = Position::new();
+        p2.set_sfen(sfen).unwrap();
+        let r2 = qsearch_with_pv(&mut p2, &ev, -30000, 30000, 0, 32);
+        let mut leaf2 = Position::new();
+        leaf2.set_sfen(sfen).unwrap();
+        let changed = apply_pv(&mut leaf2, &r2.pv);
+        assert_eq!(changed, r2.pv.len() % 2 == 1);
     }
 }


### PR DESCRIPTION
## 概要

`rescore_psv` に `--qsearch-leaf-label` を追加。DL 系 ONNX ラベラーで **root 局面を保持したまま、ラベル（score）だけを qsearch 葉の評価にする** 1-pass モード。

これまで「root 局面 + 葉ラベル」教師は `--apply-qsearch-leaf`（局面を葉に置換）→ ONNX rescore → 元 root と merge の **3 工程**で作っていた。本モードは同結果を **1 パス**で得る。

## 動機

- **中間 leaf ファイルを作らない** → 大規模教師（数十〜数百 GB）の disk / I/O を節約。
- student-proxy 実験で「葉ラベルは student を強くする（HalfKP +12 / LayerStack 768x8x32 +111、いずれも accept_h1）」一方「**局面置換**は分布シフトで弱くする（−22 / −114）」と判明。production 教師を「root 局面 + 葉ラベル」でリスコアする運用にこのモードが要る。

## 実装

- 各局面を `--nnue` の NNUE qsearch で葉まで進めてから **葉局面を ONNX 評価**。出力 sfen は常に root（局面は置換しない）。葉で手番が反転（PV 長が奇数）した場合のみ score を root 手番視点へ符号反転。
- 王手 root は葉探索せず原局面のまま評価（`--apply-qsearch-leaf` と同じ）。`--skip-in-check` とは独立。
- `--nnue` + `--dlshogi-onnx-model` 必須。`--apply-qsearch-leaf` / `--expand-output-dir` と排他。**dlshogi 専用**（AobaZero 特徴量は game_ply を含み葉局面と不整合のため非対応）。
- `apply_pv` ヘルパーを `qsearch_pv` に抽出（`process_record` も統一）+ 単体テスト。
- marker fingerprint に `qsearch_leaf_label` / `qsearch_max_ply` を追加（出力内容を変えるため）。旧 marker は欠落キー→`false` で後方互換。後方互換 unit test 追加。

## 検証

- tiny PSV 1024 件で、本 1-pass 出力が**既知良の 2-pass（`--apply-qsearch-leaf`→ONNX rescore）+ merge 出力と全フィールド bit 完全一致**を確認（DL-rescore 済み root で merge した場合）。入力ファイルは非破壊（サイズ・mtime 不変）。
- `cargo fmt` / `cargo clippy`（default + `--features dlshogi-onnx`、`--tests` 含む）warning 0 / `cargo test`（`qsearch_pv` + `marker_tests`）green。

## レビュー

ローカルで Codex + Claude の 2 reviewer がいずれも Approve。Minor 指摘（dlshogi 限定化 / `stm_flags` のループ外確保 / marker 後方互換テスト）は本 PR で反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)