### PR TITLE
fix(csa-server): viewer 配信 API の cache hit で immutable ヘッダ書込により 500 になるのを修正

### DIFF
--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -737,13 +737,16 @@ fn set_cache_control(resp: &mut Response, value: &str) -> Result<()> {
 /// `caches.default` から URL key で hit を取り出す。miss は `None`。
 ///
 /// 取り出した Response は origin-neutral なので、呼び出し側で `with_cors` を
-/// 被せて返却する契約。
+/// 被せて返却する契約。`Cache::get` が返す Response はヘッダ guard が immutable で
+/// `with_cors` の `headers.set` が必ず失敗する (= hit のたび 500) ため、ここで
+/// mutable な Response に作り直してから返す。
 ///
-/// `cache.get` が `Err` を返した場合 (Cache API 自体の障害) は `None` を返して
-/// miss と同じくフォールバック (R2 から再 fetch) させる。ただし運用上の観測性が
-/// 必要なため、`event` (`<root>_cache_get`) と `client_kind` 付きの logfmt を
-/// `log_viewer_api_failed` で残す。サイレント抑制すると staging /
-/// 本番で Cache API が一切機能していない事象に気付けない。
+/// `cache.get` が `Err` を返した場合 (Cache API 自体の障害)、または mutable 化の
+/// body 読み出しに失敗した場合は `None` を返して miss と同じくフォールバック
+/// (R2 から再 fetch) させる。ただし運用上の観測性が必要なため、`event`
+/// (`<root>_cache_get`) と `client_kind` 付きの logfmt を `log_viewer_api_failed`
+/// で残す。サイレント抑制すると staging / 本番で Cache API が一切機能していない
+/// 事象に気付けない。
 async fn cache_get_origin_neutral(
     cache_key: &str,
     event: &str,
@@ -751,13 +754,30 @@ async fn cache_get_origin_neutral(
 ) -> Option<Response> {
     let cache = worker::Cache::default();
     match cache.get(cache_key.to_string(), true).await {
-        Ok(Some(resp)) => Some(resp),
+        Ok(Some(resp)) => match into_mutable_response(resp).await {
+            Ok(resp) => Some(resp),
+            Err(e) => {
+                log_viewer_api_failed(event, client_kind, &e.to_string());
+                None
+            }
+        },
         Ok(None) => None,
         Err(e) => {
             log_viewer_api_failed(event, client_kind, &e.to_string());
             None
         }
     }
+}
+
+/// `Cache::get` が返す Response はヘッダ guard が immutable で、後段 `with_cors` の
+/// `headers.set` が `Err` になる。body / status / headers を複製した mutable な
+/// Response に作り直す。`Headers::clone` は `new Headers(...)` で guard=none の
+/// 複製を作るため、複製後のヘッダは書き換え可能になる。
+async fn into_mutable_response(mut resp: Response) -> Result<Response> {
+    let status = resp.status_code();
+    let headers = resp.headers().clone();
+    let bytes = resp.bytes().await?;
+    Ok(Response::from_bytes(bytes)?.with_status(status).with_headers(headers))
 }
 
 /// origin-neutral な Response を `caches.default` に put する。


### PR DESCRIPTION
## 概要

viewer 配信 API `/api/v1/games*`（一覧・単局）が **cache hit のたびに 500 `INTERNAL SERVER ERROR`** を返していた不具合を修正する。実測では「cold isolate の初回（cache miss）のみ 200、2 回目以降（cache hit）は 500、cache TTL 切れで一旦復活」という挙動で、viewer のゲーム読込がほぼ常に失敗していた（prod / staging 双方）。

## 原因

`caches.default` から `Cache::get` で取り出した `Response` はヘッダ guard が **immutable**。cache hit 経路（`serve_cached_list` / `handle_get`）はその Response を `with_cors` に渡し、`with_cors` は `headers.set("Access-Control-Allow-Origin"/"Vary", …)` で **in-place 書き込み**する。immutable guard では `Headers::set` が `Err` を返す（worker 0.8 `headers.rs` のドキュメントが明記）ため、cache hit のたびに失敗して 500 になっていた。cache miss 経路は自前構築の mutable Response なので 200 を返せていた。

## 修正

cache hit の Response を **body / status / headers を複製した mutable な Response に作り直してから** `with_cors` に渡す。`Headers::clone` は `new Headers(...)` で guard=none（書き換え可能）の複製を生成するため、以降の `headers.set` が通る。

- `cache_get_origin_neutral` の hit 分岐で `into_mutable_response` を経由。body 読み出しに失敗した場合は `None` を返し、既存の「`Err → None → R2 再構築」フォールバックと同じ挙動にする（観測用 log も従来どおり残す）。
- 影響範囲は get 経路のみ。cache PUT 側・`no_store_error`・OPTIONS には波及しない。

## 検証

- `cargo build`/`cargo clippy`（`--target wasm32-unknown-unknown`）/ `cargo fmt`: pass（viewer_api.rs 由来の warning 0）。
- **staging に deploy して実環境検証**: `/api/v1/games` 5 連打 = 200×5、cache hit 応答（`cf-cache-status: HIT`）に `Access-Control-Allow-Origin` + `Vary` が付与。実在ゲームの単局経路も 200×4。修正前は 200→500→500。
- レビュー: local claude / codex 両エージェントから APPROVE。

## 残課題（非 blocker）

`viewer_api` は `#[cfg(target_arch = "wasm32")]` gate のため host `cargo test` では未コンパイルで、この cache-hit バグを host 単体テストで再現できない。回帰テストは miniflare smoke harness（R2 fixture + 同一エンドポイント 2 連打で両方 200）が必要で、別途追加が望ましい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
