### PR TITLE
fix(csa-server): cold-start 復元後の最初の手が誤 TimeUp するのを修正

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -2506,15 +2506,7 @@ impl GameRoom {
             ReplaySummary::Restored { core } => {
                 // `core` は `Box<CoreRoom>` で返るためここで unbox する
                 // (`ReplaySummary` の variant 間サイズ差対策、persistence.rs 参照)。
-                let mut core = *core;
-                // replay 後の turn_started_at_ms は最後の手の歴史的時刻のまま。
-                // hibernation evict を跨いだ復元で最初の手が即 TimeUp になるのを
-                // 防ぐため、計測起点を現在時刻へ張り直す。
-                // NOTE: 復元では turn alarm を再予約していないため、最後の手の時点で
-                // set_alarm した絶対 deadline が evict 中に発火し force_time_up する
-                // 経路はこれだけでは塞げない (別経路として要対処)。
-                core.reset_turn_started_at(self.now_ms());
-                *self.core.borrow_mut() = Some(core);
+                *self.core.borrow_mut() = Some(*core);
                 *self.config.borrow_mut() = Some(cfg);
             }
             ReplaySummary::InvalidSfen { reason } => {
@@ -2546,6 +2538,21 @@ impl GameRoom {
         // live-games-index put が抜けたまま hibernation で isolate が落ちた
         // ケースを救済する (https://github.com/SH11235/rshogi/issues/549 §5)。
         self.retry_live_games_index_if_needed().await?;
+
+        // replay 後の turn_started_at_ms は最後の手の歴史的時刻のまま。hibernation
+        // evict を跨いだ復元で最初の手が即 TimeUp になるのを防ぐため、計測起点を
+        // 現在時刻へ張り直す。上の retry I/O より後に行うのは、cold start が対局者の
+        // 着手で起きた場合、retry の R2 待ち時間がそのまま次手の elapsed に課金され、
+        // 短い byoyomi / msec 時計では復元 I/O だけで TimeUp になり得るため。
+        // ここに到達した時点で core が Some なのは直前の replay が Restored だった
+        // 場合のみ (warm path は早期 return 済み)。Playing 以外は setter 側で no-op。
+        // NOTE: 復元では turn alarm を再予約していないため、最後の手の時点で set_alarm
+        // した絶対 deadline が evict 中に発火し force_time_up する経路はこれだけでは
+        // 塞げない (別経路として要対処)。
+        let now_ms = self.now_ms();
+        if let Some(core) = self.core.borrow_mut().as_mut() {
+            core.reset_turn_started_at(now_ms);
+        }
         Ok(())
     }
 

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -2506,7 +2506,15 @@ impl GameRoom {
             ReplaySummary::Restored { core } => {
                 // `core` は `Box<CoreRoom>` で返るためここで unbox する
                 // (`ReplaySummary` の variant 間サイズ差対策、persistence.rs 参照)。
-                *self.core.borrow_mut() = Some(*core);
+                let mut core = *core;
+                // replay 後の turn_started_at_ms は最後の手の歴史的時刻のまま。
+                // hibernation evict を跨いだ復元で最初の手が即 TimeUp になるのを
+                // 防ぐため、計測起点を現在時刻へ張り直す。
+                // NOTE: 復元では turn alarm を再予約していないため、最後の手の時点で
+                // set_alarm した絶対 deadline が evict 中に発火し force_time_up する
+                // 経路はこれだけでは塞げない (別経路として要対処)。
+                core.reset_turn_started_at(self.now_ms());
+                *self.core.borrow_mut() = Some(core);
                 *self.config.borrow_mut() = Some(cfg);
             }
             ReplaySummary::InvalidSfen { reason } => {

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -596,6 +596,58 @@ mod tests {
         }
     }
 
+    /// hibernation evict を跨いだ cold start で replay 直後の `turn_started_at_ms`
+    /// は最後の手の歴史的時刻のまま残る。張り直さずに次の手を指すと、復元時刻と
+    /// の差（evict 滞留ぶん = 数十分）がそのまま elapsed になり即 `TimeUp` する。
+    /// この対照テストはバグ条件が実際に成立することを固定する。
+    #[test]
+    fn cold_start_without_reset_spuriously_times_out() {
+        let mut cfg = baseline_config();
+        cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
+        let moves = vec![move_row(1, "black", "+7776FU,T3", 3_000)];
+        let ReplaySummary::Restored { mut core } = replay_core_room(&cfg, &moves) else {
+            panic!("expected Restored");
+        };
+        // 黒の手の 30 分後に白が指す（白番の長考中に DO が evict された状況）。
+        let resumed_at_ms = PLAY_STARTED_AT_MS + 30 * 60_000;
+        let result = core
+            .handle_line(Color::White, &CsaLine::new("-3334FU,T1"), resumed_at_ms + 1_000)
+            .expect("handle_line itself must succeed");
+        assert!(
+            matches!(
+                result.outcome,
+                HandleOutcome::GameEnded(GameResult::TimeUp {
+                    loser: Color::White
+                })
+            ),
+            "張り直し無しでは復元滞留ぶんで即 TimeUp するはず: {:?}",
+            result.outcome
+        );
+    }
+
+    /// `reset_turn_started_at(now)` を復元直後に呼べば、計測起点が現在時刻に
+    /// 張り直され、復元後の最初の手が evict 滞留ぶんで誤 `TimeUp` しない。
+    #[test]
+    fn cold_start_reset_turn_started_at_avoids_spurious_time_up() {
+        let mut cfg = baseline_config();
+        cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
+        let moves = vec![move_row(1, "black", "+7776FU,T3", 3_000)];
+        let ReplaySummary::Restored { mut core } = replay_core_room(&cfg, &moves) else {
+            panic!("expected Restored");
+        };
+        let resumed_at_ms = PLAY_STARTED_AT_MS + 30 * 60_000;
+        core.reset_turn_started_at(resumed_at_ms);
+        let result = core
+            .handle_line(Color::White, &CsaLine::new("-3334FU,T1"), resumed_at_ms + 1_000)
+            .expect("post-restore move must not spuriously time out");
+        match result.outcome {
+            HandleOutcome::MoveAccepted { next_turn, .. } => {
+                assert_eq!(next_turn, Color::Black);
+            }
+            other => panic!("expected MoveAccepted, got {other:?}"),
+        }
+    }
+
     /// `MoveRow::at_ms` が 0 未満や `play_started_at_ms` より小さい異常値でも、
     /// `replay_core_room` が `at_ms.max(0).max(play_started_at_ms)` で正規化する
     /// 結果として時計が巻き戻らないことを直接検証する。`directly_played` ヘルパに

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -316,6 +316,18 @@ impl GameRoom {
         self.finish(result)
     }
 
+    /// cold-start 復元直後に、現在手番の経過計測起点を現在時刻へ張り直す。
+    ///
+    /// replay は局面と時計消費を再現するが `turn_started_at_ms` には最後の手の
+    /// 歴史的時刻が残る。張り直さないと復元後の最初の手で `apply_move` の
+    /// `now_ms - turn_started_at_ms` が evict 滞留ぶん過大になり即 `TimeUp` する。
+    /// `Playing` 以外は起点を持たない（`AgreeWaiting` 復元では `None` のまま）ため no-op。
+    pub fn reset_turn_started_at(&mut self, now_ms: u64) {
+        if matches!(self.status, GameStatus::Playing) {
+            self.turn_started_at_ms = Some(now_ms);
+        }
+    }
+
     /// 切断を検出したときに呼ぶ。再接続猶予 0 秒で即時 `#ABNORMAL` 確定。
     ///
     /// 勝者確定は「対局中の切断」に限り、それ以前
@@ -721,6 +733,20 @@ mod tests {
         assert_eq!(r2.broadcasts[0].target, BroadcastTarget::Players);
         assert_eq!(r2.broadcasts[0].line.as_str(), "START:20140101120000");
         assert!(matches!(room.status(), GameStatus::Playing));
+    }
+
+    #[test]
+    fn reset_turn_started_at_sets_now_when_playing_and_noop_before_start() {
+        // START 前 (AgreeWaiting) は起点を作らない。
+        let mut room = make_room();
+        room.reset_turn_started_at(12_345);
+        assert!(matches!(room.status(), GameStatus::AgreeWaiting));
+        assert_eq!(room.turn_started_at_ms, None);
+
+        // START 後 (Playing) は計測起点を渡した now へ張り直す。
+        agree_both(&mut room);
+        room.reset_turn_started_at(67_890);
+        assert_eq!(room.turn_started_at_ms, Some(67_890));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

GameRoom DO が WS Hibernation で evict された後の **cold-start 復元で、再開後の最初の手が誤って `TimeUp` 終局する**不具合を修正する。秒読み帯の長考（WS 無通信）中に DO がアイドル evict され、復帰時に時計の計測起点が「最後の手の歴史的時刻」のままになることで、次の手の経過時間が evict 滞留ぶん（数十分）として計算され即時間切れになっていた。

## 原因

`replay_core_room`（`persistence.rs:216`）は各手を**保存済みの歴史的 `at_ms`** で `handle_line` 再生する。最後の手の再生で `turn_started_at_ms` がその歴史的時刻に設定される（`room.rs` `apply_move` 末尾）。`ensure_core_loaded` はこの core をそのまま採用するため、復帰後の最初の手で `apply_move`（`room.rs:470`）の `elapsed = now_ms - turn_started_at_ms` が evict 滞留ぶん過大になり、`clock.consume` が `TimeUp` を返して終局していた。replay 自体が再現する局面・時計消費・手番・手数は正しく、**ズレるのは現在手番の計測起点だけ**。

## 修正

- `GameRoom::reset_turn_started_at(&mut self, now_ms)` を追加（`crates/rshogi-csa-server/src/game/room.rs`）。`Playing` のときだけ計測起点を `now_ms` へ張り直す。`AgreeWaiting` 復元（`play_started_at_ms = None`）では `turn_started_at_ms` を `None` のまま保つため no-op。
- `ensure_core_loaded` の `Restored` アーム（`crates/rshogi-csa-server-workers/src/game_room.rs`）で、復元 core を採用する直前に `core.reset_turn_started_at(self.now_ms())` を呼ぶ。`now` は `Date::now()` 由来で replay の歴史的 `at_ms` とは別系統。
- 回帰テスト（`persistence.rs`）: 対照（張り直し無し → 30 分後の手で `TimeUp(White)`）と修正（張り直し → `MoveAccepted`）の2本、および `room.rs` に `reset_turn_started_at` の Playing/AgreeWaiting 両分岐テスト。

## scope 外（別途対処が必要）

最後の手の時点で `set_alarm` 済みの **turn alarm（絶対 deadline）が evict 中に発火し `force_time_up` する経路**は、alarm が `turn_started_at_ms` を読まないため本修正では塞げない。コードに NOTE を残した。復元時の alarm 再予約は別対応とする。

## 検証

- host `cargo test`: `rshogi-csa-server` 333 / `rshogi-csa-server-workers` 329 全 pass（新規3テスト含む）。
- `cargo check --target wasm32-unknown-unknown`: pass。`cargo clippy`（host + wasm32）: 変更ファイル由来の warning 0。`cargo fmt --check`: pass。
- レビュー: local claude / codex 両エージェントから APPROVE（指摘の no-op ガードテスト・alarm NOTE を反映済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
