### PR TITLE
fix(tools): floodgate の URL/index 形式 rot に追従し fetch-ratings/download を復旧

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定 |
 | `gensfen` | NNUE 学習用 PSV/pack 教師局面の生成（USI engine vs engine／NativeBackend） |
-| `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換 |
+| `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 
 ### 学習データ処理
 

--- a/crates/tools/docs/floodgate_pipeline.md
+++ b/crates/tools/docs/floodgate_pipeline.md
@@ -1,0 +1,79 @@
+# floodgate_pipeline
+
+Floodgate（`wdoor.c.u-tokyo.ac.jp`）の公開棋譜を取得し、NNUE 学習向けに
+CSA → SFEN へ変換するパイプライン。サブコマンドは `fetch-ratings` /
+`fetch-index` / `download` / `extract` の 4 つ。
+
+通信は `reqwest`（rustls）で行う。Floodgate は http アクセスを https へ 301
+誘導するため、既定 root は https を直接指す（`--root` に http を渡しても
+サーバ側リダイレクトで動作する）。
+
+## サブコマンド
+
+### `fetch-ratings`
+
+レーティングページから高レートプレイヤー名を取得し、`download` の事前フィルタ
+（`--player-file`）に使うリストを出力する。
+
+```bash
+cargo run -p tools --bin floodgate_pipeline -- fetch-ratings --min-rating 3900 --out high_rated.txt
+```
+
+- `--url <URL>`: レーティングページ URL。**未指定なら直近の日付のページを自動取得**する。
+  ページは日次生成の日付スタンプ付き（`.../shogi/x/rating/players-floodgate-YYYYMMDD.html`）で、
+  サーバ（JST）基準の当日から最大 7 日遡って最初に取得できたものを採用する。
+- `--min-rating <N>`: この値以上のプレイヤーを出力（既定 3900）。
+- `--out <PATH>`: 出力先。1 行 1 プレイヤーで `名前<TAB>レート` 形式。
+
+### `fetch-index`
+
+棋譜インデックス `00LIST.floodgate` をダウンロードする。
+
+```bash
+cargo run -p tools --bin floodgate_pipeline -- fetch-index --out 00LIST.floodgate
+```
+
+- `--root <URL>`: Floodgate root（既定は https）。
+- `--out <PATH>`: 出力先。
+
+### `download`
+
+インデックスに記載された CSA ファイルを並列ダウンロードする。インデックス内の
+絶対パスは末尾の `/x/` 以降を相対パスとして `--out-dir` 配下へ配置する。
+
+```bash
+cargo run -p tools --bin floodgate_pipeline -- download \
+  --index 00LIST.floodgate --date-from 2026-03-10 --player-file high_rated.txt --concurrency 16
+```
+
+- `--index <PATH>` / `--root <URL>` / `--out-dir <DIR>`。
+- `--limit <N>`: ダウンロード数の上限（テスト用）。
+- `--date-from` / `--date-to <YYYY-MM-DD>`: 日付フィルタ。
+- `--player-file <PATH>`: いずれかの対局者が含まれる対局のみ取得（`fetch-ratings` の出力を渡す）。
+- `--concurrency <N>`: 並列数（既定 8、`0` で CPU コア数）。
+
+### `extract`
+
+ローカルの CSA から学習用 SFEN を抽出する。
+
+```bash
+cargo run -p tools --bin floodgate_pipeline -- extract --min-rating 3900 --max-ply 32
+```
+
+- `--root <DIR>` / `--out <PATH>`（`-` で標準出力、`.gz` 対応）。
+- `--mode <initial|all|nth>`、`--nth <手数,...>`、`--min-ply` / `--max-ply`。
+- `--mirror-dedup`（水平ミラー正規化で重複排除）/ `--emit-mirror`。
+- `--per-game-cap <N>`（1 棋譜あたりの最大抽出数）/ `--min-rating <N>`。
+
+## 典型的な流れ
+
+```bash
+# 1. 高レートプレイヤーリスト
+cargo run -p tools --bin floodgate_pipeline -- fetch-ratings --min-rating 3900 --out high_rated.txt
+# 2. インデックス取得
+cargo run -p tools --bin floodgate_pipeline -- fetch-index --out 00LIST.floodgate
+# 3. CSA ダウンロード（日付・プレイヤーでフィルタ）
+cargo run -p tools --bin floodgate_pipeline -- download --date-from 2026-03-10 --player-file high_rated.txt --concurrency 16
+# 4. SFEN 抽出
+cargo run -p tools --bin floodgate_pipeline -- extract --min-rating 3900 --max-ply 32
+```

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -73,7 +73,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 
 | ツール | 説明 |
 |--------|------|
-| `floodgate_pipeline` | Floodgate 棋譜の取得・変換パイプライン（CSA → SFEN → mirror → dedup） |
+| `floodgate_pipeline` | Floodgate 棋譜の取得・変換パイプライン（CSA → SFEN → mirror → dedup）。[詳細](floodgate_pipeline.md) |
 | `shogitest_sprt_log_to_csv` | shogitest SPRT ログを Elo・LLR・対局結果の CSV に変換 |
 
 ## パイプライン例

--- a/crates/tools/src/bin/floodgate_pipeline.rs
+++ b/crates/tools/src/bin/floodgate_pipeline.rs
@@ -45,9 +45,9 @@ struct Cli {
 enum Cmd {
     /// Floodgateレーティングページから高レートプレイヤー名を取得
     FetchRatings {
-        /// レーティングページ URL
-        #[arg(long, default_value = fg::RATING_PAGE_URL)]
-        url: String,
+        /// レーティングページ URL（未指定なら直近の日付のページを自動取得）
+        #[arg(long)]
+        url: Option<String>,
         /// レーティング閾値（この値以上のプレイヤーを出力）
         #[arg(long, default_value_t = 3900)]
         min_rating: u32,
@@ -57,7 +57,7 @@ enum Cmd {
     },
     /// 00LIST.floodgateインデックスをダウンロード
     FetchIndex {
-        /// Root URL (HTTP only)
+        /// Root URL（既定は HTTPS。http 指定時もサーバ側 301 で https へ誘導）
         #[arg(long, default_value = fg::DEFAULT_ROOT)]
         root: String,
         /// 出力ファイルパス
@@ -69,7 +69,7 @@ enum Cmd {
         /// 00LIST.floodgateのパス
         #[arg(long, default_value = "00LIST.floodgate")]
         index: String,
-        /// Root URL (HTTP only)
+        /// Root URL（既定は HTTPS。http 指定時もサーバ側 301 で https へ誘導）
         #[arg(long, default_value = fg::DEFAULT_ROOT)]
         root: String,
         /// 出力ディレクトリ
@@ -156,7 +156,7 @@ fn main() -> Result<()> {
             url,
             min_rating,
             out,
-        } => run_fetch_ratings(&url, min_rating, &out),
+        } => run_fetch_ratings(url.as_deref(), min_rating, &out),
         Cmd::FetchIndex { root, out } => run_fetch_index(&root, &out),
         Cmd::Download {
             index,
@@ -204,10 +204,19 @@ fn main() -> Result<()> {
     }
 }
 
-fn run_fetch_ratings(url: &str, min_rating: u32, out: &str) -> Result<()> {
-    eprintln!("Fetching rating page from: {url}");
+fn run_fetch_ratings(url: Option<&str>, min_rating: u32, out: &str) -> Result<()> {
     let client = Client::builder().build()?;
-    let html = fg::http_get_text(&client, url)?;
+    let html = match url {
+        Some(u) => {
+            eprintln!("Fetching rating page from: {u}");
+            fg::http_get_text(&client, u)?
+        }
+        None => {
+            let (u, html) = fg::fetch_latest_rating_page(&client)?;
+            eprintln!("Fetched latest rating page: {u}");
+            html
+        }
+    };
     let all = fg::parse_rating_page(&html);
     eprintln!("Found {} players on rating page", all.len());
     let filtered: Vec<_> = all.iter().filter(|(_, r)| *r >= min_rating as f64).collect();

--- a/crates/tools/src/common/floodgate.rs
+++ b/crates/tools/src/common/floodgate.rs
@@ -84,7 +84,8 @@ fn extract_csa_rel_path(line: &str) -> Option<String> {
             // 絶対パスは末尾の "/x/" 以降を相対パスとして返す。floodgate サーバの
             // www root は変わりうる (例: /home/shogi-server/www/x/ →
             // /home/shogi/work/x/) ため prefix をハードコードせず "/x/" を anchor に
-            // して吸収する。"/x/" が無ければ既に YYYY/MM/DD/... 相対形式とみなす。
+            // して吸収する。rfind で末尾側の "/x/" を採るので、先行パスに偶発的な
+            // "/x/" があっても影響されない。"/x/" が無ければ既に相対形式とみなす。
             if let Some(pos) = path.rfind("/x/") {
                 return Some(path[pos + "/x/".len()..].to_string());
             }
@@ -117,7 +118,11 @@ pub fn rating_page_url(root: &str, date_yyyymmdd: &str) -> Result<String> {
 /// 今日から数日遡って最初に取得できたページを採用する。
 pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String)> {
     const LOOKBACK_DAYS: i64 = 7;
-    let today = chrono::Local::now().date_naive();
+    // ファイル名は floodgate サーバ (JST/+0900) 基準の日付なので、ホスト TZ に依存せず
+    // JST で当日を求める。UTC など JST より遅れた TZ のホストでは現地 today が当日分を
+    // 取りこぼしうるため。
+    let jst = chrono::FixedOffset::east_opt(9 * 3600).expect("JST は有効なオフセット");
+    let today = chrono::Utc::now().with_timezone(&jst).date_naive();
     let mut last_err: Option<anyhow::Error> = None;
     for back in 0..=LOOKBACK_DAYS {
         let date = today - chrono::Duration::days(back);
@@ -127,11 +132,10 @@ pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String)> {
             Err(e) => last_err = Some(e),
         }
     }
-    Err(last_err
-        .unwrap_or_else(|| anyhow::anyhow!("no candidate dates"))
-        .context(format!(
-            "直近 {LOOKBACK_DAYS} 日分の Floodgate レーティングページを取得できませんでした"
-        )))
+    // ここに到達するのは全試行が Err だった時のみで、その場合 last_err は必ず Some。
+    Err(last_err.expect("全失敗時のみ到達するため last_err は Some").context(format!(
+        "直近 {LOOKBACK_DAYS} 日分の Floodgate レーティングページを取得できませんでした"
+    )))
 }
 
 /// Floodgate レーティングページ HTML から (プレイヤー名, レーティング) のリストを抽出。

--- a/crates/tools/src/common/floodgate.rs
+++ b/crates/tools/src/common/floodgate.rs
@@ -8,12 +8,13 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use url::Url;
 
-/// Floodgate root (HTTP only)
-pub const DEFAULT_ROOT: &str = "http://wdoor.c.u-tokyo.ac.jp/shogi/x/";
+/// Floodgate root。サイトは http アクセスを 301 で https へ誘導するため、
+/// リダイレクトを避けて https を直接指す。
+pub const DEFAULT_ROOT: &str = "https://wdoor.c.u-tokyo.ac.jp/shogi/x/";
 
-/// Floodgate レーティングページ URL
-pub const RATING_PAGE_URL: &str =
-    "http://wdoor.c.u-tokyo.ac.jp/shogi/LATEST/players-floodgate.html";
+/// レーティングページの相対パス接頭辞。実体は日次生成の日付スタンプ付き
+/// `rating/players-floodgate-YYYYMMDD.html`。
+const RATING_PAGE_REL_PREFIX: &str = "rating/players-floodgate-";
 
 /// Download text from a URL (HTTP).
 pub fn http_get_text(client: &Client, url: &str) -> Result<String> {
@@ -80,21 +81,13 @@ fn extract_csa_rel_path(line: &str) -> Option<String> {
         }
         if let Some(idx) = tok.find(".csa") {
             let path = &tok[..idx + 4];
-            // 正規化: /home/shogi-server/www/x/ 以降を相対パスとして返却
-            const ABS_PREFIX: &str = "/home/shogi-server/www/x/";
-            if let Some(rest) = path.strip_prefix(ABS_PREFIX) {
-                return Some(rest.to_string());
+            // 絶対パスは末尾の "/x/" 以降を相対パスとして返す。floodgate サーバの
+            // www root は変わりうる (例: /home/shogi-server/www/x/ →
+            // /home/shogi/work/x/) ため prefix をハードコードせず "/x/" を anchor に
+            // して吸収する。"/x/" が無ければ既に YYYY/MM/DD/... 相対形式とみなす。
+            if let Some(pos) = path.rfind("/x/") {
+                return Some(path[pos + "/x/".len()..].to_string());
             }
-            // /shogi/x/ を含む場合はその直後を相対とみなす
-            if let Some(pos) = path.find("/shogi/x/") {
-                let rel = &path[pos + "/shogi/x/".len()..];
-                return Some(rel.to_string());
-            }
-            // 既に YYYY/MM/DD/... 形式
-            if path.starts_with('2') && path.contains('/') {
-                return Some(path.to_string());
-            }
-            // それ以外はパスのまま返す（join_url で失敗する可能性あり）
             return Some(path.to_string());
         }
     }
@@ -113,37 +106,54 @@ pub fn local_path_for(root_dir: &Path, rel: &str) -> PathBuf {
     root_dir.join(rel)
 }
 
+/// 指定日 (YYYYMMDD) の Floodgate レーティングページ URL を root から構築する。
+pub fn rating_page_url(root: &str, date_yyyymmdd: &str) -> Result<String> {
+    join_url(root, &format!("{RATING_PAGE_REL_PREFIX}{date_yyyymmdd}.html"))
+}
+
+/// 直近のレーティングページを取得し (URL, HTML) を返す。
+///
+/// ページは日次生成の日付スタンプ付きで当日分が未生成のこともあるため、
+/// 今日から数日遡って最初に取得できたページを採用する。
+pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String)> {
+    const LOOKBACK_DAYS: i64 = 7;
+    let today = chrono::Local::now().date_naive();
+    let mut last_err: Option<anyhow::Error> = None;
+    for back in 0..=LOOKBACK_DAYS {
+        let date = today - chrono::Duration::days(back);
+        let url = rating_page_url(DEFAULT_ROOT, &date.format("%Y%m%d").to_string())?;
+        match http_get_text(client, &url) {
+            Ok(html) => return Ok((url, html)),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err
+        .unwrap_or_else(|| anyhow::anyhow!("no candidate dates"))
+        .context(format!(
+            "直近 {LOOKBACK_DAYS} 日分の Floodgate レーティングページを取得できませんでした"
+        )))
+}
+
 /// Floodgate レーティングページ HTML から (プレイヤー名, レーティング) のリストを抽出。
 ///
-/// HTML のパターン:
+/// ページはプレイヤー 1 人につき以下のテーブル行を持つ:
 /// ```html
-/// <a id="popup1" href="...">PlayerName</a>
-/// ...
-/// <span id="popup2"> 4550</span>
+/// <td class="name"><a href="...">PlayerName</a></td>
+/// <td class="rate">4550</td>
 /// ```
-/// 名前 (popup奇数) とレーティング (popup偶数) が交互に出現する。
+/// 表示名 (`<td class="name">` 内アンカーのテキスト) と直後に現れる
+/// `<td class="rate">` の数値をペアにする。
 pub fn parse_rating_page(html: &str) -> Vec<(String, f64)> {
     let mut results = Vec::new();
     let mut pending_name: Option<String> = None;
     for line in html.lines() {
         let s = line.trim();
-        // <a id="popupN" href="...">NAME</a>
-        if s.starts_with("<a id=\"popup")
-            && s.ends_with("</a>")
-            && let Some(gt_pos) = s.rfind("\">")
-        {
-            let name = &s[gt_pos + 2..s.len() - 4];
-            if !name.is_empty() {
-                pending_name = Some(name.to_string());
-            }
-        }
-        // <span id="popupN"> RATING</span>
-        if s.starts_with("<span id=\"popup")
-            && s.ends_with("</span>")
-            && let Some(gt_pos) = s.find("\">")
-        {
-            let val_str = &s[gt_pos + 2..s.len() - 7];
-            if let Ok(rating) = val_str.trim().parse::<f64>()
+        if let Some(rest) = s.strip_prefix("<td class=\"name\">") {
+            pending_name = anchor_text(rest);
+        } else if let Some(rest) = s.strip_prefix("<td class=\"rate\">") {
+            // セル先頭から最初の '<' (</td>) 直前までを数値とみなす。負レートも取りこぼさない。
+            let val = rest.split('<').next().unwrap_or("").trim();
+            if let Ok(rating) = val.parse::<f64>()
                 && let Some(name) = pending_name.take()
             {
                 results.push((name, rating));
@@ -151,6 +161,14 @@ pub fn parse_rating_page(html: &str) -> Vec<(String, f64)> {
         }
     }
     results
+}
+
+/// `<a href="...">TEXT</a>...` から TEXT を抽出する。
+fn anchor_text(s: &str) -> Option<String> {
+    let open_end = s.find('>')? + 1;
+    let close = s[open_end..].find("</a>")? + open_end;
+    let text = s[open_end..close].trim();
+    (!text.is_empty()).then(|| text.to_string())
 }
 
 /// CSA ファイルの相対パスからプレイヤー名を抽出。
@@ -193,34 +211,56 @@ mod tests {
     use super::*;
     #[test]
     fn test_parse_index_lines() {
-        let sample = b"2010/01/01\t...\t/home/shogi-server/www/x/2010/01/01/wdoor+floodgate-900-0+Bonanza+gps_l+20100101000000.csa\t115\n# comment\nfoo.txt\n2025/01/floodgate-3600-20250101-0001.csa\n";
+        let sample = b"2010/01/01\t...\t/home/shogi-server/www/x/2010/01/01/wdoor+floodgate-900-0+Bonanza+gps_l+20100101000000.csa\t115\n2026/04/13\t...\t/home/shogi/work/x/2026/04/13/wdoor+floodgate-300-10F+910+foo_human+20260413203001.csa\t70\n# comment\nfoo.txt\n2025/01/floodgate-3600-20250101-0001.csa\n";
         let v = parse_index_lines(&sample[..]).unwrap();
-        assert_eq!(v.len(), 2);
+        assert_eq!(v.len(), 3);
         assert!(v[0].starts_with("2010/01/01/") && v[0].ends_with(".csa"));
-        assert!(v[1].contains("2025/01/"));
+        // www root が変わった新形式 (/home/shogi/work/x/) も "/x/" anchor で吸収
+        assert!(v[1].starts_with("2026/04/13/") && v[1].ends_with(".csa"));
+        assert!(v[2].contains("2025/01/"));
     }
     #[test]
     fn test_join_url() {
         let u = join_url(DEFAULT_ROOT, "2025/01/a.csa").unwrap();
-        assert!(u.starts_with("http://"));
+        assert!(u.starts_with("https://"));
         assert!(u.contains("/shogi/x/2025/01/a.csa"));
+    }
+    #[test]
+    fn test_rating_page_url() {
+        let u = rating_page_url(DEFAULT_ROOT, "20260620").unwrap();
+        assert_eq!(
+            u,
+            "https://wdoor.c.u-tokyo.ac.jp/shogi/x/rating/players-floodgate-20260620.html"
+        );
     }
     #[test]
     fn test_parse_rating_page() {
         let html = r#"
-        <a id="popup1" href="/shogi/view/show-player.cgi?user=Frieren%2Bhash">Frieren</a>
-        <script>...</script>
-        <span id="popup2"> 4550</span>
-        <a id="popup3" href="/shogi/view/show-player.cgi?user=Reze%2Bhash">Reze</a>
-        <script>...</script>
-        <span id="popup4"> 4474</span>
+        <tr>
+          <td class="name"><a href="/shogi/x/2026/player/Frieren+abc1234.html">Frieren</a></td>
+          <td class="rate">4550</td>
+          <td class="last_modified">2026-06-19 03:00:00</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="/shogi/x/2026/player/Reze+def5678.html">Reze</a></td>
+          <td class="rate">4474</td>
+          <td class="last_modified">2026-06-18 03:00:00</td>
+        </tr>
+        <tr>
+          <td class="name"><a href="/shogi/x/2026/player/BCT+aaa9999.html">BCT</a></td>
+          <td class="rate">-1769</td>
+          <td class="last_modified">2026-06-17 03:00:00</td>
+        </tr>
         "#;
         let result = parse_rating_page(html);
-        assert_eq!(result.len(), 2);
+        assert_eq!(result.len(), 3);
         assert_eq!(result[0].0, "Frieren");
         assert!((result[0].1 - 4550.0).abs() < 0.01);
         assert_eq!(result[1].0, "Reze");
         assert!((result[1].1 - 4474.0).abs() < 0.01);
+        // 負レートも取りこぼさない
+        assert_eq!(result[2].0, "BCT");
+        assert!((result[2].1 + 1769.0).abs() < 0.01);
     }
     #[test]
     fn test_players_from_path() {


### PR DESCRIPTION
## Summary

floodgate (wdoor.c.u-tokyo.ac.jp) のサーバ再編により `floodgate_pipeline` が壊れていたのを実測ベースで復旧する。`fetch-ratings` は完全に動作不能（404 + パーサ不一致）、`download` も index の絶対パス prefix 変更で全件失敗していた。

## 実測した rot（再編内容）

| 経路 | 旧 | 現在 |
|---|---|---|
| レーティング URL | `http://.../shogi/LATEST/players-floodgate.html` | 301→https→**404**。日次生成の `https://.../shogi/x/rating/players-floodgate-YYYYMMDD.html` へ移転 |
| レーティング HTML | `<a id="popup1">名前</a>` / `<span id="popup2">レート</span>` | `<td class="name"><a>名前</a></td>` + `<td class="rate">数値</td>` テーブル |
| サイト全体 | http | http→https を **301 強制**（`/shogi/x/`・`00LIST` とも） |
| `00LIST.floodgate` 絶対パス prefix | `/home/shogi-server/www/x/` | `/home/shogi/work/x/`（21,799 行すべて） |

## 変更

- **fetch-ratings URL rot**: 死んだ `RATING_PAGE_URL` 定数を撤去し、`rating_page_url(root, "YYYYMMDD")` ビルダ + `fetch_latest_rating_page(client)`（今日から最大 7 日遡って最初に取得できたページを採用）を追加。`--url` を `Option<String>` 化し、未指定で自動探索。
- **parse_rating_page 書き換え**: 新テーブル構造（`<td class="name">` / `<td class="rate">`）を行単位でパース。rate は `</td>` 直前までを取り `f64` 化（負レートも取りこぼさない）。`anchor_text` ヘルパ追加。
- **download index prefix rot**: `extract_csa_rel_path` の prefix ハードコードを廃し、末尾 `/x/` を anchor にした相対化へ一般化（旧 `/home/shogi-server/www/x/`・新 `/home/shogi/work/x/`・`/shogi/x/` を統一処理）。
- **DEFAULT_ROOT を https 化**: `(HTTP only)` コメント/doc を是正し、download/fetch-index の 301 往復を除去（result-preserving）。
- テスト更新: `test_join_url`(https) / `test_rating_page_url`(新規) / `test_parse_rating_page`(新構造 + 負レート) / `test_parse_index_lines`(新 prefix)。

### スコープ補足
当初の「fetch-ratings URL rot」に対し、同一サーバ再編が原因の `download` index prefix rot と http→https 移行も同 PR にまとめた（fetch-ratings だけ直しても pipeline が半壊のままになるため）。

## Test plan

- [x] `cargo build -p tools`（default / dlshogi-onnx / aobazero-onnx）
- [x] `cargo clippy -p tools --tests -- -D warnings` 警告ゼロ
- [x] `cargo test -p tools` 全 pass / `cargo fmt --all -- --check` clean / `scripts/check-tracked-abs-paths.sh` OK
- [x] 実 floodgate E2E: `fetch-ratings`（自動探索で当日ページ取得・124 名抽出）/ `fetch-index`（https 21,799 行）/ `download --limit 2`（`YYYY/MM/DD/*.csa` に正しく相対化して取得）
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude) APPROVE