### PR TITLE
fix(nnue): AVX-512 ビルドで OUTPUT_DIM=8 の AffineTransform が誤 eval を返すのを修正 (#789)

### DIFF
--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -14,14 +14,10 @@ pub(crate) const fn padded_input(input_dim: usize) -> usize {
 }
 
 /// AVX2での水平加算（i32×8 → i32）
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    not(all(
-        target_feature = "avx512f",
-        any(target_feature = "avx512vnni", target_feature = "avx512bw")
-    ))
-))]
+///
+/// AVX-512 ビルドでも propagate の AVX2 フォールスルー経路から参照されるため
+/// compile-in する（_mm256 命令のみで avx512 ビルドでも利用可能）。
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
 unsafe fn hsum_i32_avx2(v: std::arch::x86_64::__m256i) -> i32 {
     // SAFETY: 呼び出し側が avx2 フィーチャを保証する
@@ -92,14 +88,9 @@ unsafe fn m512_add_dpbusd_epi32(
 /// AVX2用 DPBUSD エミュレーション（u8×i8→i32積和演算）
 ///
 /// VNNI非対応CPU向け。`maddubs` + `madd` の2命令で積和演算を実行。
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    not(all(
-        target_feature = "avx512f",
-        any(target_feature = "avx512vnni", target_feature = "avx512bw")
-    ))
-))]
+/// AVX-512 ビルドでも propagate の AVX2 フォールスルー経路から参照されるため
+/// compile-in する。
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 #[inline]
 unsafe fn m256_add_dpbusd_epi32(
     acc: &mut std::arch::x86_64::__m256i,
@@ -573,14 +564,11 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
         }
 
         // AVX2: 256bit = 32 x u8/i8
-        #[cfg(all(
-            target_arch = "x86_64",
-            target_feature = "avx2",
-            not(all(
-                target_feature = "avx512f",
-                any(target_feature = "avx512vnni", target_feature = "avx512bw")
-            ))
-        ))]
+        // AVX-512 ビルドでも compile-in する。AVX-512 経路は OUTPUT_DIM % 16 == 0 のみ
+        // 処理して return するため、それ以外（例 OUTPUT_DIM=8）はここへフォールスルーする。
+        // これを not(avx512) で除外するとフォールスルー先が消え、スクランブル重みを
+        // 行優先で誤読する scalar fallback に落ちて誤った積和になる。
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
         {
             // SAFETY:
             // - input.len() >= PADDED_INPUT (debug_assert で検証済み)
@@ -1233,4 +1221,71 @@ mod tests {
             assert_eq!(val, 10 + (i + 1) as i32, "mismatch at index {i}");
         }
     }
+
+    /// propagate の出力を、SIMD レイアウト（スクランブル形式）に依存しない
+    /// 行優先スカラー参照と bit 一致で照合する。
+    ///
+    /// OUTPUT_DIM が 16 の倍数でない L1（例 768x8）は AVX-512 経路では
+    /// %16==0 分岐に入れず AVX2 経路へフォールスルーする。AVX-512 ビルドで
+    /// その AVX2 経路が compile-out されるとスクランブル重みを行優先で誤読する
+    /// スカラーに落ちるため、その境界を固定する。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransform::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..]).unwrap();
+
+                let mut input = Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_768x8, 768, 8);
+    affine_reference_test!(test_affine_reference_1536x16, 1536, 16);
+    // INPUT_DIM が 32 の倍数でなく PADDED に padding 列が生じる境界も照合する
+    affine_reference_test!(test_affine_reference_760x8, 760, 8);
 }


### PR DESCRIPTION
## Summary

- AVX-512 ビルドで `OUTPUT_DIM=8` の `AffineTransform`（LayerStack L1、例 `ls-halfka_hm_merged-768x8x32`）の static eval が AVX2 ビルドと一致せず誤値を返すバグ (#789) を修正。
- `AffineTransform::propagate` の AVX-512 経路は `OUTPUT_DIM % 16 == 0` のみ処理して `return` し、それ以外は AVX2 経路へフォールスルーする設計だが、AVX2 ブロックと依存ヘルパー `hsum_i32_avx2` / `m256_add_dpbusd_epi32` の cfg が `not(avx512f && (vnni||bw))` で **AVX-512 ビルドでは compile-out** され、フォールスルー先が消失していた。結果 `OUTPUT_DIM=8` はスクランブル重みを行優先で誤読する scalar fallback に落ちていた。
- cfg を `all(x86_64, avx2)` に変更してフォールスルー先を compile-in。`%16==0` は AVX-512 経路が先に `return` するため挙動・性能は不変。L1=16 / HalfKP は元々無傷。

## 検証（実機 Ryzen 9 9950X3D / Zen5 / native AVX-512）

| | 256x8 | 768x8 | 760x8 | 1536x16 |
|---|---|---|---|---|
| 修正前 | ❌ FAIL | ❌ FAIL | — | ✅ PASS |
| 修正後 | ✅ PASS | ✅ PASS | ✅ PASS | ✅ PASS |

Issue 報告の表（L1=8 のみ壊れ・L1=16 無傷）と一致。スクランブルレイアウト非依存のスカラー参照と bit 一致を照合する回帰テストを追加（`760x8` は INPUT_DIM が 32 の倍数でない padding 列発生ケース）。

## 関連

- Closes #789

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p rshogi-core --all-targets -- -D warnings` clean（通常 avx2 / 強制 avx512 両構成）
- [x] `cargo test -p rshogi-core --lib` 938 passed / 0 failed（追加テスト含め green）
- [x] 実機 Zen5 native AVX-512 で before/after 実証（修正前 256x8/768x8 FAIL → 修正後全 PASS）
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude 汎用) APPROVE