### PR TITLE
feat(nnue): Threat cross-side profile (id10) 追加 + arch_str dims 照合で load 堅牢化

### DIFF
--- a/.claude/skills/edition-build/SKILL.md
+++ b/.claude/skills/edition-build/SKILL.md
@@ -144,6 +144,11 @@ feature は 4 カテゴリの組み合わせ:
    / `layerstacks-768x16x32` / `layerstacks-512x16x32`。複数同時指定は cycles +5.5% 退行
 4. **拡張 / 最適化**: `nnue-psqt` / `nnue-threat` / `nnue-progress-diff` (L0=1536 限定、
    L0=768/512 では cache pressure 増加で cycles +2-6% 退行するため指定しない)
+5. **Threat profile** (Threat 使用時に任意で 1 つ): `threat-profile-same-class` (id1) /
+   `threat-profile-same-class-major-pawn` (id2) / `threat-profile-cross-side` (id10)。
+   除外 pair で次元を削減した変種で、未指定は full (id0)。edition grammar に profile 軸が
+   無いため preset は無く、`nnue-threat` に手動で 1 つ足す。engine と学習 net の profile は
+   一致必須 (不一致は EvalFile load 時に reject)。
 
 最新 feature 名は実コード確認:
 
@@ -162,6 +167,7 @@ Cargo.toml の `edition-*` feature 定義で確認する (meta.toml には featu
 | 同上 + PSQT | `ls-halfka_hm_merged-1536x16x32-psqt` | `layerstack-only,nnue-psqt,nnue-progress-diff` |
 | 同上 + Threat | `ls-halfka_hm_merged-1536x16x32-threat` | `layerstack-only,nnue-threat,nnue-progress-diff` |
 | 同上 + PSQT + Threat | `ls-halfka_hm_merged-1536x16x32-psqt_threat` | `layerstack-only,nnue-psqt,nnue-threat,nnue-progress-diff` |
+| 同上 + Threat (cross-side, id10) | (preset 無し、profile 軸は手動) | `layerstack-only,nnue-threat,threat-profile-cross-side,nnue-progress-diff` |
 | LayerStack 1536x32x32 (旧 L1=32) | `ls-halfka_hm_merged-1536x32x32-none` | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-1536x32x32,nnue-progress-diff` |
 | LayerStack 768x16x32 | `ls-halfka_hm_merged-768x16x32-none` | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-768x16x32` |
 | LayerStack 512x16x32 | `ls-halfka_hm_merged-512x16x32-none` | `--no-default-features --features search-no-pass-rules,layerstack-only,layerstacks-512x16x32` |

--- a/.claude/skills/verify-nnue/SKILL.md
+++ b/.claude/skills/verify-nnue/SKILL.md
@@ -21,6 +21,7 @@ user-invocable: true
 - **threat-profile**: Threat 次元削減プロファイル。bullet/rshogi 両方のビルドに同一 feature を指定する必要がある
   - `threat-profile-same-class` (profile 1): 同種ペア全除外 (192,640 dims)
   - `threat-profile-same-class-major-pawn` (profile 2): 同種 + 大駒→歩除外 (173,568 dims)
+  - `threat-profile-cross-side` (profile 10): 同 side / 同種除外、敵味方跨ぎ異種のみ (96,320 dims)
 
 ### デフォルト値（変更不要なら省略可）
 - **progress.bin**: `$SHOGI_DATA/progress/nodchip_progress_e1_f1_cuda.bin`
@@ -191,7 +192,7 @@ cargo build --release -p rshogi-usi --no-default-features \
 # 以降は Case B と同様に eval diag で比較
 ```
 
-**⚠️ 重要**: profile 2 (`threat-profile-same-class-major-pawn`) の場合は上記の `threat-profile-same-class` を `threat-profile-same-class-major-pawn` に全て置き換えること。
+**⚠️ 重要**: profile 2 (`threat-profile-same-class-major-pawn`) / profile 10 (`threat-profile-cross-side`) の場合は上記の `threat-profile-same-class` を該当 profile feature に全て置き換えること。
 
 ---
 

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -78,6 +78,7 @@ search-no-pass-rules = []
 # 詳細は crates/rshogi-core/src/nnue/threat_exclusion.rs の module doc 参照。
 threat-profile-same-class = []               # profile 1: 同種ペア全除外
 threat-profile-same-class-major-pawn = []   # profile 2: 同種 + 大駒→歩除外
+threat-profile-cross-side = []               # profile 10: 同 side / 同種を除外、敵味方跨ぎ異種のみ
 
 # === Edition 軸 atomic feature 群 ===
 # 設計は docs/decisions/2026-05-24-build-edition-flavor-design.md を参照。

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -295,10 +295,29 @@ impl<
         // Threat 読み込み（arch_str に "Threat=" があれば）
         #[cfg(feature = "ls-ext-threat")]
         {
-            let has_threat = arch_str.contains("Threat=");
-            if has_threat {
+            // arch_str の `Threat=<dims>` を構造化 parse し compiled THREAT_DIMENSIONS と
+            // 照合。tatara export は profile の dims を必ず書くため、不一致は engine と
+            // model の profile / feature set 不整合を意味する (旧 profile 0 net の
+            // Threat=216720 は engine profile 0 のとき通る)。
+            if arch_str.contains("Threat=") {
+                let model_dims = parse_threat_dims_from_arch(&arch_str).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("malformed Threat= token in arch string: {arch_str}"),
+                    )
+                })?;
+                let engine_dims = super::threat_features::THREAT_DIMENSIONS;
+                if model_dims != engine_dims {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "Threat dims mismatch: model={model_dims}, engine={engine_dims}. \
+                             Use a model trained with the matching threat profile / feature set."
+                        ),
+                    ));
+                }
                 // ThreatProfile= が arch_str にあれば profile id を読み込み検証
-                // なければ旧モデル (v91 以前): profile 0 と見なす
+                // なければ旧モデル (profile 0): profile id フィールド無し
                 let has_profile_field = arch_str.contains("ThreatProfile=");
                 if has_profile_field {
                     reader.read_exact(&mut buf4)?;
@@ -1681,6 +1700,16 @@ fn detect_layer_stacks_feature_set(arch_str: &str) -> super::spec::FeatureSet {
     super::spec::parse_feature_set_from_arch(arch_str).unwrap_or(Fs::LayerStacks)
 }
 
+/// arch_str の `Threat=<dims>` トークンから次元数を取り出す。
+/// `parse_fv_scale_from_arch` と同じ `,` split + strip_prefix 方式。
+#[cfg(feature = "ls-ext-threat")]
+fn parse_threat_dims_from_arch(arch_str: &str) -> Option<usize> {
+    arch_str
+        .split(',')
+        .find_map(|part| part.strip_prefix("Threat="))
+        .and_then(|v| v.parse::<usize>().ok())
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(all(feature = "ls-size-1536x16x32", feature = "ft-halfka_hm_merged"))]
@@ -1690,6 +1719,20 @@ mod tests {
     use crate::position::{Position, SFEN_HIRATE};
 
     const TEST_L1: usize = NNUE_PYTORCH_L1;
+
+    #[cfg(feature = "ls-ext-threat")]
+    #[test]
+    fn test_parse_threat_dims_from_arch() {
+        use super::parse_threat_dims_from_arch as parse;
+        assert_eq!(parse("FV_SCALE=16,Threat=216720,"), Some(216720));
+        assert_eq!(parse("Threat=96320,ThreatProfile=10,"), Some(96320));
+        // 末尾カンマ無し (旧 profile 0 形式)
+        assert_eq!(parse("Threat=216720"), Some(216720));
+        // Threat トークン無し
+        assert_eq!(parse("PSQT=1,"), None);
+        // 数値でない
+        assert_eq!(parse("Threat=abc,"), None);
+    }
 
     #[test]
     fn test_network_dimensions() {

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -1701,7 +1701,10 @@ fn detect_layer_stacks_feature_set(arch_str: &str) -> super::spec::FeatureSet {
 }
 
 /// arch_str の `Threat=<dims>` トークンから次元数を取り出す。
-/// `parse_fv_scale_from_arch` と同じ `,` split + strip_prefix 方式。
+/// `parse_fv_scale_from_arch` と同じトークン分割方針 (`,` split + `strip_prefix`)。
+///
+/// `strip_prefix("Threat=")` は `Threat=` で始まるトークンにのみ一致するため、
+/// 同居しうる `ThreatProfile=` トークン（7 文字目が `P` で `=` でない）には誤マッチしない。
 #[cfg(feature = "ls-ext-threat")]
 fn parse_threat_dims_from_arch(arch_str: &str) -> Option<usize> {
     arch_str
@@ -1726,6 +1729,10 @@ mod tests {
         use super::parse_threat_dims_from_arch as parse;
         assert_eq!(parse("FV_SCALE=16,Threat=216720,"), Some(216720));
         assert_eq!(parse("Threat=96320,ThreatProfile=10,"), Some(96320));
+        // ThreatProfile= が先行しても Threat= に誤マッチしない
+        assert_eq!(parse("ThreatProfile=10,Threat=96320,"), Some(96320));
+        // ThreatProfile= のみで Threat= が無い場合は None
+        assert_eq!(parse("ThreatProfile=10,"), None);
         // 末尾カンマ無し (旧 profile 0 形式)
         assert_eq!(parse("Threat=216720"), Some(216720));
         // Threat トークン無し

--- a/crates/rshogi-core/src/nnue/threat_exclusion.rs
+++ b/crates/rshogi-core/src/nnue/threat_exclusion.rs
@@ -20,6 +20,7 @@
 //! | 0  | (default) | なし (Baseline) | 216,720 |
 //! | 1  | `threat-profile-same-class` | 同種ペア全除外 (9 クラス × 4 side = 36 pair) | 192,640 |
 //! | 2  | `threat-profile-same-class-major-pawn` | profile 1 + 大駒 attacker → Pawn attacked (4 大駒 × 4 side = 16 pair 追加) | 173,568 |
+//! | 10 | `threat-profile-cross-side` | 同 side (`as==ds`) と同種 (`ac==dc`) を除外、敵味方跨ぎの異種 pair のみ残す | 96,320 |
 //!
 //! # 設計: pair_base の sentinel
 //!
@@ -75,7 +76,8 @@
 // 相互排他チェック: 複数 profile を同時選択すると compile error
 const _PROFILE_EXCLUSIVITY: () = {
     let count = cfg!(feature = "threat-profile-same-class") as usize
-        + cfg!(feature = "threat-profile-same-class-major-pawn") as usize;
+        + cfg!(feature = "threat-profile-same-class-major-pawn") as usize
+        + cfg!(feature = "threat-profile-cross-side") as usize;
     assert!(count <= 1, "Multiple threat profiles selected. Choose at most one.");
 };
 
@@ -84,7 +86,9 @@ const _PROFILE_EXCLUSIVITY: () = {
 /// quantised.bin に書き込まれる profile 識別子。
 /// engine と model の profile が一致しなければ読み込みエラー。
 pub const THREAT_PROFILE_ID: u32 = {
-    if cfg!(feature = "threat-profile-same-class-major-pawn") {
+    if cfg!(feature = "threat-profile-cross-side") {
+        10
+    } else if cfg!(feature = "threat-profile-same-class-major-pawn") {
         2
     } else if cfg!(feature = "threat-profile-same-class") {
         1
@@ -98,9 +102,9 @@ pub const THREAT_PROFILE_ID: u32 = {
 /// `build_pair_base` (const fn) から呼ばれるため、引数は usize。
 ///
 /// # 引数
-/// - `as_`: attacker side (0=friend, 1=enemy) — 現在未使用 (reserved)
+/// - `as_`: attacker side (0=friend, 1=enemy) — `threat-profile-cross-side` のみ使用
 /// - `ac`: attacker class index (0..8, ThreatClass の discriminant)
-/// - `ds`: attacked side (0=friend, 1=enemy) — 現在未使用 (reserved)
+/// - `ds`: attacked side (0=friend, 1=enemy) — `threat-profile-cross-side` のみ使用
 /// - `dc`: attacked class index (0..8)
 ///
 /// # ThreatClass index
@@ -122,6 +126,11 @@ pub const fn is_excluded(as_: usize, ac: usize, ds: usize, dc: usize) -> bool {
         return true;
     }
 
+    // 同 side ペアと同種ペアを除外し、敵味方跨ぎの異種 pair のみ残す (profile 10)
+    if cfg!(feature = "threat-profile-cross-side") && (as_ == ds || ac == dc) {
+        return true;
+    }
+
     false
 }
 
@@ -134,6 +143,7 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-cross-side",
         )))]
         assert_eq!(THREAT_PROFILE_ID, 0);
     }
@@ -143,6 +153,7 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-cross-side",
         )))]
         {
             assert!(!is_excluded(0, 0, 0, 0));
@@ -168,6 +179,19 @@ mod tests {
             assert!(is_excluded(0, 0, 0, 0)); // same-class
             assert!(is_excluded(0, 5, 0, 0)); // Bishop→Pawn
             assert!(!is_excluded(0, 3, 0, 0)); // Silver→Pawn (not major)
+        }
+    }
+
+    #[test]
+    fn test_block_cross_side() {
+        #[cfg(feature = "threat-profile-cross-side")]
+        {
+            assert_eq!(THREAT_PROFILE_ID, 10);
+            assert!(is_excluded(0, 3, 0, 5)); // 同 side (friend→friend) → 除外
+            assert!(is_excluded(1, 3, 1, 5)); // 同 side (enemy→enemy) → 除外
+            assert!(is_excluded(0, 4, 1, 4)); // 同種 (ac==dc) → 除外
+            assert!(!is_excluded(0, 3, 1, 5)); // cross-side 異種 (friend→enemy) → 残す
+            assert!(!is_excluded(1, 5, 0, 3)); // cross-side 異種 (enemy→friend) → 残す
         }
     }
 }

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -62,8 +62,8 @@
 //!     = 216,720
 //! ```
 //!
-//! Profile 1 (same-class) は 192,640、profile 2 (same-class-major-pawn) は 173,568。
-//! 詳細は [`super::threat_exclusion`] を参照。
+//! Profile 1 (same-class) は 192,640、profile 2 (same-class-major-pawn) は 173,568、
+//! profile 10 (cross-side) は 96,320。詳細は [`super::threat_exclusion`] を参照。
 //!
 //! # index 構造
 //!
@@ -398,6 +398,7 @@ fn pair_base(
     if cfg!(any(
         feature = "threat-profile-same-class",
         feature = "threat-profile-same-class-major-pawn",
+        feature = "threat-profile-cross-side",
     )) && base == EXCLUDED_PAIR_BASE
     {
         None
@@ -1449,6 +1450,7 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-cross-side",
         )))]
         assert_eq!(THREAT_DIMENSIONS, 216_720, "profile 0 (full)");
 
@@ -1457,6 +1459,9 @@ mod tests {
 
         #[cfg(feature = "threat-profile-same-class-major-pawn")]
         assert_eq!(THREAT_DIMENSIONS, 173_568, "profile 2 (same-class-major-pawn)");
+
+        #[cfg(feature = "threat-profile-cross-side")]
+        assert_eq!(THREAT_DIMENSIONS, 96_320, "profile 10 (cross-side)");
     }
 
     #[test]
@@ -1661,9 +1666,19 @@ mod tests {
         let mut indices_w = Vec::new();
         append_active_threat_indices(&pos, Color::White, king_sq_w, &mut indices_w);
 
-        // 初期局面では threat pair が最低限含まれることを確認
-        assert!(!indices_b.is_empty(), "Black perspective should have threats");
-        assert!(!indices_w.is_empty(), "White perspective should have threats");
+        // 初期局面は両軍が接触しておらず敵駒への利きが無い。cross-side (敵味方跨ぎの
+        // 異種のみ) では同 side の利きが全除外され threat が 0 になる。それ以外の profile は
+        // 同 side の利きが残るため最低限含まれる。
+        #[cfg(feature = "threat-profile-cross-side")]
+        {
+            assert!(indices_b.is_empty(), "cross-side startpos should have no threats");
+            assert!(indices_w.is_empty(), "cross-side startpos should have no threats");
+        }
+        #[cfg(not(feature = "threat-profile-cross-side"))]
+        {
+            assert!(!indices_b.is_empty(), "Black perspective should have threats");
+            assert!(!indices_w.is_empty(), "White perspective should have threats");
+        }
 
         // 全 index が範囲内
         for &idx in &indices_b {
@@ -1681,6 +1696,7 @@ mod tests {
     #[cfg(not(any(
         feature = "threat-profile-same-class",
         feature = "threat-profile-same-class-major-pawn",
+        feature = "threat-profile-cross-side",
     )))]
     fn test_canonical_startpos_threat_indices() {
         let mut pos = Position::new();

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -171,6 +171,7 @@ use std::sync::LazyLock;
 /// Profile 0 (full): 216,720
 /// Profile 1 (same-class): 192,640
 /// Profile 2 (same-class-major-pawn): 173,568
+/// Profile 10 (cross-side): 96,320
 #[cfg(feature = "ls-ext-threat")]
 pub const THREAT_DIMENSIONS: usize = PAIR_DATA.1;
 

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -39,6 +39,7 @@ diagnostics = ["rshogi-core/diagnostics"]
 # Threat exclusion profiles
 threat-profile-same-class = ["rshogi-core/threat-profile-same-class"]
 threat-profile-same-class-major-pawn = ["rshogi-core/threat-profile-same-class-major-pawn"]
+threat-profile-cross-side = ["rshogi-core/threat-profile-cross-side"]
 # NNUE progress8kpabs 差分更新最適化（L1=1536 で有効、L1=768 で退行）
 nnue-progress-diff = ["rshogi-core/nnue-progress-diff"]
 # 探索経路限定で pass_rights を無効化

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -21,6 +21,7 @@ diagnostics = ["rshogi-core/diagnostics"]
 # Threat exclusion profiles
 threat-profile-same-class = ["rshogi-core/threat-profile-same-class"]
 threat-profile-same-class-major-pawn = ["rshogi-core/threat-profile-same-class-major-pawn"]
+threat-profile-cross-side = ["rshogi-core/threat-profile-cross-side"]
 
 # === Edition 軸 atomic feature 群 (本 crate で必要なものだけ forward) ===
 # 設計は docs/decisions/2026-05-24-build-edition-flavor-design.md を参照。


### PR DESCRIPTION
## 概要

NNUE Threat 特徴量の **cross-side profile (id 10, dims 96,320)** を engine に追加し、EvalFile load 時の arch_str parse を堅牢化する。cross-side は 3080 Ti で素 fit する profile で、これにより cross-side net の engine eval が解禁される。profile は **compile-time 軸**（runtime dispatch は入れない方針）。

## 変更

### 1. arch_str parse 堅牢化 (`network_layer_stacks.rs`)
- `Threat=<dims>` を構造化 parse (`parse_threat_dims_from_arch`、`split(',')`+`strip_prefix` の既存 `parse_fv_scale_from_arch` 流儀) し、compiled `THREAT_DIMENSIONS` と照合。不一致・parse 不能は `InvalidData` で reject（silent desync 回避）。
- profile 0 net (`Threat=216720`、`ThreatProfile=` 無し) は profile-0 engine で従来どおり load（後方互換維持）。`ThreatProfile=` token は `Threat=` 部分文字列に誤マッチしない。

### 2. cross-side profile (id 10)
- `is_excluded`: `as_ == ds || ac == dc`（同 side / 同種を除外、敵味方跨ぎの異種 pair のみ残す）。dims = 16 × Σ ATTACKS_PER_COLOR = 16 × 6020 = **96,320**。
- `THREAT_PROFILE_ID` → 10、`_PROFILE_EXCLUSIVITY` に加算、`pair_base()` の除外 sentinel→None gate に cross-side を追加（漏れると除外 pair が `usize::MAX` base で index 破壊）。
- test: dims=96320 / exclusion / startpos（cross-side は両軍非接触で threat=0 を積極検証）/ 既存 profile-0 限定 gate に cross-side 追加。
- feature passthrough を `rshogi-core`（定義）/ `rshogi-usi` / `tools`（golden-forward 検証 `verify_nnue_accumulator` ビルドに必要）に追加。

### 3. doc (実験 ergonomics)
- `edition-build` skill: 手動 build feature 表 + Threat profile カテゴリに cross-side を追記（profile 軸は edition grammar 外なので preset でなく手動 feature で合成）。
- `verify-nnue` skill: profile catalog に profile 10 (96,320 dims) を追記、置換注記も更新。

## test / gate
- `cargo fmt` / `cargo clippy --all-targets`（default + cross-side feature、警告 0）/ `cargo test`（default workspace + cross-side feature）全 pass。
- cross-side build: `rshogi-core` / `rshogi-usi` / `tools` いずれも EXIT=0。
- 既知の無関係 flaky: `rshogi-csa-client` の `descendant_process_killed_via_killpg_on_drop`（killpg の process-group timing、isolation で 3/3 pass、本 PR と無関係）。

## review
- 独立 dual review（Codex + Claude）両者 APPROVE。dims 96,320 は両者が独立に検算、parse 後方互換・index sentinel・bin/tools passthrough も検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
