### PR TITLE
refactor(nnue): AffineTransform 重みレイアウト判定を単一の真実に集約 + wasm runtime CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -276,6 +276,58 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
+  nnue-wasm-runtime:
+    # rshogi-core の NNUE AffineTransform は重み格納レイアウトを target ごとに
+    # 切り替える（x86 AVX2/SSSE3 はスクランブル形式、wasm SIMD / スカラーは行優先）。
+    # host job (`test`) と simd-runtime job は x86 経路しか実行しないため、wasm SIMD128
+    # 経路と wasm スカラー fallback の数値正当性は CI で検証されない。affine_reference
+    # テストは格納→読み出しを行優先参照と bit 一致で照合する target 非依存テストなので、
+    # wasm32-wasip1 + wasmtime で実行して wasm 経路のレイアウト整合を回帰検知する。
+    # +simd128（SIMD128 経路）と simd128 無し（スカラー fallback）の両方を走らせる。
+    name: NNUE wasm32 Runtime Test
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust_code == 'true'
+    timeout-minutes: 20
+    env:
+      # wasm32 では host 用 baseline (`-C target-cpu=x86-64-v2`) が無効なので空で上書きする。
+      # simd128 を有効化する step は個別に RUSTFLAGS を指定する。
+      RUSTFLAGS: ""
+      # wasm32-wasip1 のテストバイナリは wasmtime 経由で実行する。
+      CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Add wasm32-wasip1 target to pinned toolchain
+        # rust-toolchain.toml が channel を pin しているため、その toolchain に
+        # wasm32-wasip1 target を明示的に追加する（wasm-build job と同じ理由）。
+        run: |
+          CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)
+          echo "Adding wasm32-wasip1 to toolchain $CHANNEL"
+          rustup target add --toolchain "$CHANNEL" wasm32-wasip1
+      - name: Install wasmtime
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasmtime
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Enable sccache
+        run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-on-failure: true
+          # host / wasm32-unknown キャッシュと混在させないため専用 namespace を確保する。
+          shared-key: wasm32-wasip1
+      - name: Run NNUE layout tests on wasm (SIMD128 path)
+        run: cargo test -p rshogi-core nnue::layers --target wasm32-wasip1
+        env:
+          RUSTFLAGS: "-C target-feature=+simd128"
+      - name: Run NNUE layout tests on wasm (scalar fallback)
+        run: cargo test -p rshogi-core nnue::layers --target wasm32-wasip1
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
   abs-paths:
     # tracked file に machine 依存の絶対パスが混入していないか検査する
     # (検出対象の具体は scripts/check-tracked-abs-paths.sh を参照)。docs / skills を

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -306,7 +306,7 @@ jobs:
           echo "Adding wasm32-wasip1 to toolchain $CHANNEL"
           rustup target add --toolchain "$CHANNEL" wasm32-wasip1
       - name: Install wasmtime
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
         with:
           tool: wasmtime
       - name: Setup sccache

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -292,6 +292,9 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
     /// スクランブル後のインデックスを返す
     #[inline]
     const fn get_weight_index_scrambled(i: usize) -> usize {
+        // i = output * PADDED_INPUT + input
+        // output = i / PADDED_INPUT, input = i % PADDED_INPUT
+        // input_chunk = input / CHUNK_SIZE, byte_in_chunk = input % CHUNK_SIZE
         // 変換後: input_chunk * OUTPUT_DIM * CHUNK_SIZE + output * CHUNK_SIZE + byte_in_chunk
         (i / Self::CHUNK_SIZE) % Self::NUM_INPUT_CHUNKS * OUTPUT_DIM * Self::CHUNK_SIZE
             + i / Self::PADDED_INPUT * Self::CHUNK_SIZE

--- a/crates/rshogi-core/src/nnue/layers.rs
+++ b/crates/rshogi-core/src/nnue/layers.rs
@@ -241,7 +241,7 @@ pub(crate) unsafe fn haddx4(
 pub struct AffineTransform<const INPUT_DIM: usize, const OUTPUT_DIM: usize> {
     /// バイアス
     pub biases: [i32; OUTPUT_DIM],
-    /// 重み（転置形式で保持、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -258,43 +258,27 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
 
     /// チャンクサイズ（u8×4 = i32として読む単位）
     /// スクランブル形式重みとループ逆転最適化用
-    #[cfg(any(
-        all(target_arch = "x86_64", target_feature = "avx2"),
-        all(
-            target_arch = "x86_64",
-            target_feature = "ssse3",
-            not(target_feature = "avx2")
-        )
-    ))]
     const CHUNK_SIZE: usize = 4;
 
     /// 入力チャンク数（ループ逆転最適化用）
-    #[cfg(any(
-        all(target_arch = "x86_64", target_feature = "avx2"),
-        all(
-            target_arch = "x86_64",
-            target_feature = "ssse3",
-            not(target_feature = "avx2")
-        )
-    ))]
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    /// スクランブル形式のウェイトを使用するかどうか
-    /// AVX2: OUTPUT_DIM % 8 == 0、SSSE3: OUTPUT_DIM % 4 == 0 の場合に使用
-    #[cfg(any(
-        all(target_arch = "x86_64", target_feature = "avx2"),
-        all(
-            target_arch = "x86_64",
-            target_feature = "ssse3",
-            not(target_feature = "avx2")
-        )
-    ))]
+    /// 重み格納レイアウトの単一判定。`read`/`read_leb128`/`propagate` が
+    /// すべてこれを参照し、格納時と読み出し時のレイアウト不一致を防ぐ。
+    /// true のとき重みはスクランブル形式（input_chunk-major）で格納・参照される。
+    /// スクランブル経路を持たない target（wasm SIMD / SSE2 / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
             OUTPUT_DIM.is_multiple_of(8) && OUTPUT_DIM > 0
-        } else {
+        } else if cfg!(all(
+            target_arch = "x86_64",
+            target_feature = "ssse3",
+            not(target_feature = "avx2")
+        )) {
             OUTPUT_DIM.is_multiple_of(4) && OUTPUT_DIM > 0
+        } else {
+            false
         }
     }
 
@@ -306,26 +290,10 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
     ///
     /// i = output * PADDED_INPUT + input の元インデックスに対して
     /// スクランブル後のインデックスを返す
-    #[cfg(any(
-        all(target_arch = "x86_64", target_feature = "avx2"),
-        all(
-            target_arch = "x86_64",
-            target_feature = "ssse3",
-            not(target_feature = "avx2")
-        )
-    ))]
     #[inline]
     const fn get_weight_index_scrambled(i: usize) -> usize {
-        // i = output * PADDED_INPUT + input
-        // output = i / PADDED_INPUT
-        // input = i % PADDED_INPUT
-        // input_chunk = input / CHUNK_SIZE
-        // byte_in_chunk = input % CHUNK_SIZE
-        //
         // 変換後: input_chunk * OUTPUT_DIM * CHUNK_SIZE + output * CHUNK_SIZE + byte_in_chunk
-        (i / Self::CHUNK_SIZE) % (Self::PADDED_INPUT / Self::CHUNK_SIZE)
-            * OUTPUT_DIM
-            * Self::CHUNK_SIZE
+        (i / Self::CHUNK_SIZE) % Self::NUM_INPUT_CHUNKS * OUTPUT_DIM * Self::CHUNK_SIZE
             + i / Self::PADDED_INPUT * Self::CHUNK_SIZE
             + i % Self::CHUNK_SIZE
     }
@@ -349,45 +317,19 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
         }
 
         // 重みを読み込み（64バイトアラインで確保）
+        // 格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT_DIM * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
         let mut buf1 = [0u8; 1];
 
-        // AVX2: OUTPUT_DIM % 8 == 0、SSSE3: OUTPUT_DIM % 4 == 0 の場合はスクランブル形式で格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // 非AVX2/非SSSE3環境: 元の順序で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                weights[i] = buf1[0] as i8;
-            }
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -405,44 +347,18 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
         }
 
         // 重みを読み込み（64バイトアラインで確保）
+        // 格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT_DIM * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // AVX2/SSSE3: スクランブル形式で格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            for i in 0..weight_size {
-                let val = read_signed_leb128(reader)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = val as i8;
-            }
-        }
-
-        // 非AVX2/非SSSE3環境: 元の順序で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            for i in 0..weight_size {
-                let val = read_signed_leb128(reader)?;
-                weights[i] = val as i8;
-            }
+        for i in 0..weight_size {
+            let val = read_signed_leb128(reader)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = val as i8;
         }
 
         Ok(Self { biases, weights })
@@ -512,10 +428,12 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             unsafe {
                 use std::arch::x86_64::*;
 
-                // OUTPUT_DIM % 16 == 0 の場合: ループ逆転最適化版（AVX-512）
-                // 入力をブロードキャストして全出力に同時適用
+                // スクランブル格納かつ OUTPUT_DIM % 16 == 0 の場合のみループ逆転最適化版（AVX-512）。
+                // should_use_scrambled_weights() を && 条件にすることで、行優先格納時に
+                // スクランブル前提の本経路へ落ちないことを単一判定で保証する（%16 ⊂ %8 なので
+                // スクランブル成立時は本条件 == %16）。
                 #[allow(clippy::needless_range_loop)]
-                if OUTPUT_DIM.is_multiple_of(16) && OUTPUT_DIM > 0 {
+                if Self::should_use_scrambled_weights() && OUTPUT_DIM.is_multiple_of(16) {
                     // 出力レジスタ数（16出力/レジスタ）
                     const MAX_REGS: usize = 64; // 最大1024出力まで対応
                     let num_regs = OUTPUT_DIM / 16;
@@ -580,13 +498,13 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             unsafe {
                 use std::arch::x86_64::*;
 
-                // OUTPUT_DIM % 8 == 0 の場合: ループ逆転最適化版
-                // 入力をブロードキャストして全出力に同時適用
+                // スクランブル格納時（AVX2 では OUTPUT_DIM % 8 == 0）: ループ逆転最適化版。
+                // それ以外（行優先格納）はフォールスルーして下の行優先ループで処理する。
                 //
                 // 疎入力処理は密度40%では効果なし（find_nnzオーバーヘッドが利点を上回る）
                 // 計測結果: 疎入力版 634K NPS vs 密版 655K NPS
                 #[allow(clippy::needless_range_loop)]
-                if OUTPUT_DIM.is_multiple_of(8) && OUTPUT_DIM > 0 {
+                if Self::should_use_scrambled_weights() {
                     // 出力レジスタ数（8出力/レジスタ）
                     const MAX_REGS: usize = 128; // 最大1024出力まで対応
                     let num_regs = OUTPUT_DIM / 8;
@@ -674,10 +592,10 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             unsafe {
                 use std::arch::x86_64::*;
 
-                // OUTPUT_DIM % 4 == 0 の場合: ループ逆転最適化版
-                // 入力をブロードキャストして全出力に同時適用
+                // スクランブル格納時（SSSE3 では OUTPUT_DIM % 4 == 0）: ループ逆転最適化版。
+                // それ以外（行優先格納）はフォールスルーして下の行優先ループで処理する。
                 #[allow(clippy::needless_range_loop)]
-                if OUTPUT_DIM.is_multiple_of(4) && OUTPUT_DIM > 0 {
+                if Self::should_use_scrambled_weights() {
                     // 出力レジスタ数（4出力/レジスタ）
                     const MAX_REGS: usize = 256; // 最大1024出力まで対応
                     let num_regs = OUTPUT_DIM / 4;
@@ -752,6 +670,8 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             not(target_feature = "ssse3")
         ))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - input.len() >= PADDED_INPUT (debug_assert で検証済み)
             // - weights.len() >= OUTPUT_DIM * PADDED_INPUT (構造上保証)
@@ -814,6 +734,8 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
         // WASM SIMD128
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - input.len() >= PADDED_INPUT (debug_assert で検証済み)
             // - weights.len() >= OUTPUT_DIM * PADDED_INPUT (構造上保証)
@@ -894,6 +816,8 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
         }
 
         // スカラーフォールバック
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する（x86 では本経路は到達不能）。
         #[allow(unreachable_code)]
         {
             // バイアスで初期化
@@ -903,7 +827,12 @@ impl<const INPUT_DIM: usize, const OUTPUT_DIM: usize> AffineTransform<INPUT_DIM,
             for (i, &in_byte) in input.iter().enumerate().take(INPUT_DIM) {
                 let in_val = in_byte as i32;
                 for (j, out) in output.iter_mut().enumerate() {
-                    let weight_idx = j * Self::PADDED_INPUT + i;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
                     *out += self.weights[weight_idx] as i32 * in_val;
                 }
             }
@@ -1177,28 +1106,11 @@ mod tests {
         // スクランブル形式が有効な場合は変換して設定
         for i in 0..32 {
             let raw_idx = i * 512 + i; // 元のインデックス: weights[output][input]
-            #[cfg(any(
-                all(target_arch = "x86_64", target_feature = "avx2"),
-                all(
-                    target_arch = "x86_64",
-                    target_feature = "ssse3",
-                    not(target_feature = "avx2")
-                )
-            ))]
             let idx = if AffineTransform::<512, 32>::should_use_scrambled_weights() {
                 AffineTransform::<512, 32>::get_weight_index_scrambled(raw_idx)
             } else {
                 raw_idx
             };
-            #[cfg(not(any(
-                all(target_arch = "x86_64", target_feature = "avx2"),
-                all(
-                    target_arch = "x86_64",
-                    target_feature = "ssse3",
-                    not(target_feature = "avx2")
-                )
-            )))]
-            let idx = raw_idx;
             weights[idx] = 1;
         }
 

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
@@ -1064,15 +1064,18 @@ impl<const L1: usize> FeatureTransformerHalfKaHmMerged<L1> {
 // AffineTransformHalfKaHmMerged - const generics 版アフィン変換（ループ逆転最適化版）
 // =============================================================================
 
-/// アフィン変換層（ループ逆転最適化 + スクランブル重み形式）
+/// アフィン変換層（ループ逆転最適化対応）
 ///
 /// YaneuraOu/Stockfish スタイルの SIMD 最適化を実装。
-/// 重みはスクランブル形式 `weights[input_chunk][output][4]` で保持し、
-/// ループ逆転により入力をブロードキャストして全出力に同時適用する。
+/// 重みの格納レイアウトは `should_use_scrambled_weights()` で決まる:
+/// x86 AVX2 かつ OUTPUT が 8 の倍数、または x86 SSSE3 かつ OUTPUT が 4 の倍数では
+/// スクランブル形式 `weights[input_chunk][output][4]`、それ以外では行優先
+/// `weights[output][input]`。
+/// スクランブル形式ではループ逆転で入力をブロードキャストして全出力に同時適用する。
 pub struct AffineTransformHalfKaHmMerged<const INPUT: usize, const OUTPUT: usize> {
     /// バイアス [OUTPUT]
     pub biases: [i32; OUTPUT],
-    /// 重み（スクランブル形式、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -1080,34 +1083,31 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
     /// パディング済み入力次元（32の倍数）
     const PADDED_INPUT: usize = INPUT.div_ceil(32) * 32;
 
-    // SIMD最適化用の定数・メソッド（AVX2/SSSE3環境でのみコンパイル）
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// チャンクサイズ（u8×4 = i32として読む単位）
     const CHUNK_SIZE: usize = 4;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 入力チャンク数
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
-    /// スクランブル形式を使用するかどうか
-    /// AVX2: OUTPUT % 8 == 0、SSSE3: OUTPUT % 4 == 0
+    /// 重み格納レイアウトの単一判定。read()/propagate() がすべてこれを参照し、
+    /// 格納時と読み出し時のレイアウト不一致を防ぐ。true のとき重みはスクランブル形式
+    /// （input_chunk-major）で格納・参照される。スクランブル経路を持たない target
+    /// （wasm SIMD / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-            OUTPUT.is_multiple_of(8)
+            OUTPUT.is_multiple_of(8) && OUTPUT > 0
         } else if cfg!(all(
             target_arch = "x86_64",
             target_feature = "ssse3",
             not(target_feature = "avx2")
         )) {
-            OUTPUT.is_multiple_of(4)
+            OUTPUT.is_multiple_of(4) && OUTPUT > 0
         } else {
             false
         }
     }
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 重みインデックスのスクランブル変換
     ///
     /// 元のレイアウト: weights[output][input]
@@ -1130,49 +1130,19 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
             *bias = i32::from_le_bytes(buf4);
         }
 
-        // 重みを読み込み（スクランブル形式で格納）
+        // 重みを読み込み。格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // スクランブル形式の場合は変換しながら格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            let mut buf1 = [0u8; 1];
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // スカラー環境: 標準形式で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            let mut row_buf = vec![0u8; Self::PADDED_INPUT];
-            for o in 0..OUTPUT {
-                reader.read_exact(&mut row_buf)?;
-                for i in 0..Self::PADDED_INPUT {
-                    weights[o * Self::PADDED_INPUT + i] = row_buf[i] as i8;
-                }
-            }
+        let mut buf1 = [0u8; 1];
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -1203,6 +1173,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         // WASM SIMD128: 標準形式の重みで内積
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - WASM SIMD128 はアライメント不要（v128_load/v128_store は任意アドレスで動作。
             //   biases は [i32; OUTPUT] でアライメント4バイトだが WASM では制約なし）
@@ -1303,6 +1275,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         }
 
         // スカラー fallback（avx2 は ssse3 を暗黙に含むが、意図を明示するため列挙）
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する。
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "avx2"),
             all(target_arch = "x86_64", target_feature = "ssse3"),
@@ -1311,9 +1285,14 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         {
             output.copy_from_slice(&self.biases);
             for (j, out) in output.iter_mut().enumerate() {
-                let weight_offset = j * Self::PADDED_INPUT;
                 for (i, &in_val) in input.iter().enumerate().take(INPUT) {
-                    *out += self.weights[weight_offset + i] as i32 * in_val as i32;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
+                    *out += self.weights[weight_idx] as i32 * in_val as i32;
                 }
             }
         }
@@ -1331,8 +1310,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT % 8 == 0 の場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(8) {
+            // スクランブル格納時（AVX2 では OUTPUT % 8 == 0）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 128; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 8;
                 debug_assert!(num_regs <= MAX_REGS);
@@ -1409,8 +1388,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmMerged<INPU
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT が 4 の倍数 ∧ 非ゼロの場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(4) && OUTPUT > 0 {
+            // スクランブル格納時（SSSE3 では OUTPUT % 4 == 0 ∧ 非ゼロ）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 256; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 4;
                 debug_assert!(num_regs <= MAX_REGS);

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -1066,15 +1066,18 @@ impl<const L1: usize> FeatureTransformerHalfKaHmSplit<L1> {
 // AffineTransformHalfKaHmSplit - const generics 版アフィン変換（ループ逆転最適化版）
 // =============================================================================
 
-/// アフィン変換層（ループ逆転最適化 + スクランブル重み形式）
+/// アフィン変換層（ループ逆転最適化対応）
 ///
 /// YaneuraOu/Stockfish スタイルの SIMD 最適化を実装。
-/// 重みはスクランブル形式 `weights[input_chunk][output][4]` で保持し、
-/// ループ逆転により入力をブロードキャストして全出力に同時適用する。
+/// 重みの格納レイアウトは `should_use_scrambled_weights()` で決まる:
+/// x86 AVX2 かつ OUTPUT が 8 の倍数、または x86 SSSE3 かつ OUTPUT が 4 の倍数では
+/// スクランブル形式 `weights[input_chunk][output][4]`、それ以外では行優先
+/// `weights[output][input]`。
+/// スクランブル形式ではループ逆転で入力をブロードキャストして全出力に同時適用する。
 pub struct AffineTransformHalfKaHmSplit<const INPUT: usize, const OUTPUT: usize> {
     /// バイアス [OUTPUT]
     pub biases: [i32; OUTPUT],
-    /// 重み（スクランブル形式、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -1082,34 +1085,31 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
     /// パディング済み入力次元（32の倍数）
     const PADDED_INPUT: usize = INPUT.div_ceil(32) * 32;
 
-    // SIMD最適化用の定数・メソッド（AVX2/SSSE3環境でのみコンパイル）
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// チャンクサイズ（u8×4 = i32として読む単位）
     const CHUNK_SIZE: usize = 4;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 入力チャンク数
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
-    /// スクランブル形式を使用するかどうか
-    /// AVX2: OUTPUT % 8 == 0、SSSE3: OUTPUT % 4 == 0
+    /// 重み格納レイアウトの単一判定。read()/propagate() がすべてこれを参照し、
+    /// 格納時と読み出し時のレイアウト不一致を防ぐ。true のとき重みはスクランブル形式
+    /// （input_chunk-major）で格納・参照される。スクランブル経路を持たない target
+    /// （wasm SIMD / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-            OUTPUT.is_multiple_of(8)
+            OUTPUT.is_multiple_of(8) && OUTPUT > 0
         } else if cfg!(all(
             target_arch = "x86_64",
             target_feature = "ssse3",
             not(target_feature = "avx2")
         )) {
-            OUTPUT.is_multiple_of(4)
+            OUTPUT.is_multiple_of(4) && OUTPUT > 0
         } else {
             false
         }
     }
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 重みインデックスのスクランブル変換
     ///
     /// 元のレイアウト: weights[output][input]
@@ -1132,49 +1132,19 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
             *bias = i32::from_le_bytes(buf4);
         }
 
-        // 重みを読み込み（スクランブル形式で格納）
+        // 重みを読み込み。格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // スクランブル形式の場合は変換しながら格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            let mut buf1 = [0u8; 1];
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // スカラー環境: 標準形式で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            let mut row_buf = vec![0u8; Self::PADDED_INPUT];
-            for o in 0..OUTPUT {
-                reader.read_exact(&mut row_buf)?;
-                for i in 0..Self::PADDED_INPUT {
-                    weights[o * Self::PADDED_INPUT + i] = row_buf[i] as i8;
-                }
-            }
+        let mut buf1 = [0u8; 1];
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -1205,6 +1175,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         // WASM SIMD128: 標準形式の重みで内積
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - WASM SIMD128 はアライメント不要（v128_load/v128_store は任意アドレスで動作。
             //   biases は [i32; OUTPUT] でアライメント4バイトだが WASM では制約なし）
@@ -1305,6 +1277,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         }
 
         // スカラー fallback（avx2 は ssse3 を暗黙に含むが、意図を明示するため列挙）
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する。
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "avx2"),
             all(target_arch = "x86_64", target_feature = "ssse3"),
@@ -1313,9 +1287,14 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         {
             output.copy_from_slice(&self.biases);
             for (j, out) in output.iter_mut().enumerate() {
-                let weight_offset = j * Self::PADDED_INPUT;
                 for (i, &in_val) in input.iter().enumerate().take(INPUT) {
-                    *out += self.weights[weight_offset + i] as i32 * in_val as i32;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
+                    *out += self.weights[weight_idx] as i32 * in_val as i32;
                 }
             }
         }
@@ -1333,8 +1312,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT % 8 == 0 の場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(8) {
+            // スクランブル格納時（AVX2 では OUTPUT % 8 == 0）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 128; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 8;
                 debug_assert!(num_regs <= MAX_REGS);
@@ -1411,8 +1390,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaHmSplit<INPUT
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT が 4 の倍数 ∧ 非ゼロの場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(4) && OUTPUT > 0 {
+            // スクランブル格納時（SSSE3 では OUTPUT % 4 == 0 ∧ 非ゼロ）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 256; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 4;
                 debug_assert!(num_regs <= MAX_REGS);

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -1066,15 +1066,18 @@ impl<const L1: usize> FeatureTransformerHalfKaMerged<L1> {
 // AffineTransformHalfKaMerged - const generics 版アフィン変換（ループ逆転最適化版）
 // =============================================================================
 
-/// アフィン変換層（ループ逆転最適化 + スクランブル重み形式）
+/// アフィン変換層（ループ逆転最適化対応）
 ///
 /// YaneuraOu/Stockfish スタイルの SIMD 最適化を実装。
-/// 重みはスクランブル形式 `weights[input_chunk][output][4]` で保持し、
-/// ループ逆転により入力をブロードキャストして全出力に同時適用する。
+/// 重みの格納レイアウトは `should_use_scrambled_weights()` で決まる:
+/// x86 AVX2 かつ OUTPUT が 8 の倍数、または x86 SSSE3 かつ OUTPUT が 4 の倍数では
+/// スクランブル形式 `weights[input_chunk][output][4]`、それ以外では行優先
+/// `weights[output][input]`。
+/// スクランブル形式ではループ逆転で入力をブロードキャストして全出力に同時適用する。
 pub struct AffineTransformHalfKaMerged<const INPUT: usize, const OUTPUT: usize> {
     /// バイアス [OUTPUT]
     pub biases: [i32; OUTPUT],
-    /// 重み（スクランブル形式、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -1082,34 +1085,31 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
     /// パディング済み入力次元（32の倍数）
     const PADDED_INPUT: usize = INPUT.div_ceil(32) * 32;
 
-    // SIMD最適化用の定数・メソッド（AVX2/SSSE3環境でのみコンパイル）
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// チャンクサイズ（u8×4 = i32として読む単位）
     const CHUNK_SIZE: usize = 4;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 入力チャンク数
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
-    /// スクランブル形式を使用するかどうか
-    /// AVX2: OUTPUT % 8 == 0、SSSE3: OUTPUT % 4 == 0
+    /// 重み格納レイアウトの単一判定。read()/propagate() がすべてこれを参照し、
+    /// 格納時と読み出し時のレイアウト不一致を防ぐ。true のとき重みはスクランブル形式
+    /// （input_chunk-major）で格納・参照される。スクランブル経路を持たない target
+    /// （wasm SIMD / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-            OUTPUT.is_multiple_of(8)
+            OUTPUT.is_multiple_of(8) && OUTPUT > 0
         } else if cfg!(all(
             target_arch = "x86_64",
             target_feature = "ssse3",
             not(target_feature = "avx2")
         )) {
-            OUTPUT.is_multiple_of(4)
+            OUTPUT.is_multiple_of(4) && OUTPUT > 0
         } else {
             false
         }
     }
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 重みインデックスのスクランブル変換
     ///
     /// 元のレイアウト: weights[output][input]
@@ -1132,49 +1132,19 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
             *bias = i32::from_le_bytes(buf4);
         }
 
-        // 重みを読み込み（スクランブル形式で格納）
+        // 重みを読み込み。格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // スクランブル形式の場合は変換しながら格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            let mut buf1 = [0u8; 1];
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // スカラー環境: 標準形式で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            let mut row_buf = vec![0u8; Self::PADDED_INPUT];
-            for o in 0..OUTPUT {
-                reader.read_exact(&mut row_buf)?;
-                for i in 0..Self::PADDED_INPUT {
-                    weights[o * Self::PADDED_INPUT + i] = row_buf[i] as i8;
-                }
-            }
+        let mut buf1 = [0u8; 1];
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -1205,6 +1175,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         // WASM SIMD128: 標準形式の重みで内積
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - WASM SIMD128 はアライメント不要（v128_load/v128_store は任意アドレスで動作。
             //   biases は [i32; OUTPUT] でアライメント4バイトだが WASM では制約なし）
@@ -1307,6 +1279,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         }
 
         // スカラー fallback（avx2 は ssse3 を暗黙に含むが、意図を明示するため列挙）
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する。
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "avx2"),
             all(target_arch = "x86_64", target_feature = "ssse3"),
@@ -1315,9 +1289,14 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         {
             output.copy_from_slice(&self.biases);
             for (j, out) in output.iter_mut().enumerate() {
-                let weight_offset = j * Self::PADDED_INPUT;
                 for (i, &in_val) in input.iter().enumerate().take(INPUT) {
-                    *out += self.weights[weight_offset + i] as i32 * in_val as i32;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
+                    *out += self.weights[weight_idx] as i32 * in_val as i32;
                 }
             }
         }
@@ -1335,8 +1314,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT % 8 == 0 の場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(8) {
+            // スクランブル格納時（AVX2 では OUTPUT % 8 == 0）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 128; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 8;
                 debug_assert!(num_regs <= MAX_REGS);
@@ -1413,8 +1392,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaMerged<INPUT,
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT が 4 の倍数 ∧ 非ゼロの場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(4) && OUTPUT > 0 {
+            // スクランブル格納時（SSSE3 では OUTPUT % 4 == 0 ∧ 非ゼロ）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 256; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 4;
                 debug_assert!(num_regs <= MAX_REGS);

--- a/crates/rshogi-core/src/nnue/network_halfka_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_split.rs
@@ -1064,15 +1064,18 @@ impl<const L1: usize> FeatureTransformerHalfKaSplit<L1> {
 // AffineTransformHalfKaSplit - const generics 版アフィン変換（ループ逆転最適化版）
 // =============================================================================
 
-/// アフィン変換層（ループ逆転最適化 + スクランブル重み形式）
+/// アフィン変換層（ループ逆転最適化対応）
 ///
 /// YaneuraOu/Stockfish スタイルの SIMD 最適化を実装。
-/// 重みはスクランブル形式 `weights[input_chunk][output][4]` で保持し、
-/// ループ逆転により入力をブロードキャストして全出力に同時適用する。
+/// 重みの格納レイアウトは `should_use_scrambled_weights()` で決まる:
+/// x86 AVX2 かつ OUTPUT が 8 の倍数、または x86 SSSE3 かつ OUTPUT が 4 の倍数では
+/// スクランブル形式 `weights[input_chunk][output][4]`、それ以外では行優先
+/// `weights[output][input]`。
+/// スクランブル形式ではループ逆転で入力をブロードキャストして全出力に同時適用する。
 pub struct AffineTransformHalfKaSplit<const INPUT: usize, const OUTPUT: usize> {
     /// バイアス [OUTPUT]
     pub biases: [i32; OUTPUT],
-    /// 重み（スクランブル形式、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -1080,34 +1083,31 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
     /// パディング済み入力次元（32の倍数）
     const PADDED_INPUT: usize = INPUT.div_ceil(32) * 32;
 
-    // SIMD最適化用の定数・メソッド（AVX2/SSSE3環境でのみコンパイル）
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// チャンクサイズ（u8×4 = i32として読む単位）
     const CHUNK_SIZE: usize = 4;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 入力チャンク数
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
-    /// スクランブル形式を使用するかどうか
-    /// AVX2: OUTPUT % 8 == 0、SSSE3: OUTPUT % 4 == 0
+    /// 重み格納レイアウトの単一判定。read()/propagate() がすべてこれを参照し、
+    /// 格納時と読み出し時のレイアウト不一致を防ぐ。true のとき重みはスクランブル形式
+    /// （input_chunk-major）で格納・参照される。スクランブル経路を持たない target
+    /// （wasm SIMD / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-            OUTPUT.is_multiple_of(8)
+            OUTPUT.is_multiple_of(8) && OUTPUT > 0
         } else if cfg!(all(
             target_arch = "x86_64",
             target_feature = "ssse3",
             not(target_feature = "avx2")
         )) {
-            OUTPUT.is_multiple_of(4)
+            OUTPUT.is_multiple_of(4) && OUTPUT > 0
         } else {
             false
         }
     }
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 重みインデックスのスクランブル変換
     ///
     /// 元のレイアウト: weights[output][input]
@@ -1130,49 +1130,19 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
             *bias = i32::from_le_bytes(buf4);
         }
 
-        // 重みを読み込み（スクランブル形式で格納）
+        // 重みを読み込み。格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // スクランブル形式の場合は変換しながら格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            let mut buf1 = [0u8; 1];
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // スカラー環境: 標準形式で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            let mut row_buf = vec![0u8; Self::PADDED_INPUT];
-            for o in 0..OUTPUT {
-                reader.read_exact(&mut row_buf)?;
-                for i in 0..Self::PADDED_INPUT {
-                    weights[o * Self::PADDED_INPUT + i] = row_buf[i] as i8;
-                }
-            }
+        let mut buf1 = [0u8; 1];
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -1203,6 +1173,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         // WASM SIMD128: 標準形式の重みで内積
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - WASM SIMD128 はアライメント不要（v128_load/v128_store は任意アドレスで動作。
             //   biases は [i32; OUTPUT] でアライメント4バイトだが WASM では制約なし）
@@ -1305,6 +1277,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         }
 
         // スカラー fallback（avx2 は ssse3 を暗黙に含むが、意図を明示するため列挙）
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する。
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "avx2"),
             all(target_arch = "x86_64", target_feature = "ssse3"),
@@ -1313,9 +1287,14 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         {
             output.copy_from_slice(&self.biases);
             for (j, out) in output.iter_mut().enumerate() {
-                let weight_offset = j * Self::PADDED_INPUT;
                 for (i, &in_val) in input.iter().enumerate().take(INPUT) {
-                    *out += self.weights[weight_offset + i] as i32 * in_val as i32;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
+                    *out += self.weights[weight_idx] as i32 * in_val as i32;
                 }
             }
         }
@@ -1333,8 +1312,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT % 8 == 0 の場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(8) {
+            // スクランブル格納時（AVX2 では OUTPUT % 8 == 0）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 128; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 8;
                 debug_assert!(num_regs <= MAX_REGS);
@@ -1411,8 +1390,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKaSplit<INPUT, 
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT が 4 の倍数 ∧ 非ゼロの場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(4) && OUTPUT > 0 {
+            // スクランブル格納時（SSSE3 では OUTPUT % 4 == 0 ∧ 非ゼロ）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 256; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 4;
                 debug_assert!(num_regs <= MAX_REGS);

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -1171,15 +1171,18 @@ impl<const L1: usize> FeatureTransformerHalfKP<L1> {
 // AffineTransformHalfKP - const generics 版アフィン変換（ループ逆転最適化版）
 // =============================================================================
 
-/// アフィン変換層（ループ逆転最適化 + スクランブル重み形式）
+/// アフィン変換層（ループ逆転最適化対応）
 ///
 /// YaneuraOu/Stockfish スタイルの SIMD 最適化を実装。
-/// 重みはスクランブル形式 `weights[input_chunk][output][4]` で保持し、
-/// ループ逆転により入力をブロードキャストして全出力に同時適用する。
+/// 重みの格納レイアウトは `should_use_scrambled_weights()` で決まる:
+/// x86 AVX2 かつ OUTPUT が 8 の倍数、または x86 SSSE3 かつ OUTPUT が 4 の倍数では
+/// スクランブル形式 `weights[input_chunk][output][4]`、それ以外では行優先
+/// `weights[output][input]`。
+/// スクランブル形式ではループ逆転で入力をブロードキャストして全出力に同時適用する。
 pub struct AffineTransformHalfKP<const INPUT: usize, const OUTPUT: usize> {
     /// バイアス [OUTPUT]
     pub biases: [i32; OUTPUT],
-    /// 重み（スクランブル形式、64バイトアライン）
+    /// 重み（格納レイアウトは should_use_scrambled_weights() に従う、64バイトアライン）
     pub weights: AlignedBox<i8>,
 }
 
@@ -1187,34 +1190,31 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
     /// パディング済み入力次元（32の倍数）
     const PADDED_INPUT: usize = INPUT.div_ceil(32) * 32;
 
-    // SIMD最適化用の定数・メソッド（AVX2/SSSE3環境でのみコンパイル）
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// チャンクサイズ（u8×4 = i32として読む単位）
     const CHUNK_SIZE: usize = 4;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 入力チャンク数
     const NUM_INPUT_CHUNKS: usize = Self::PADDED_INPUT / Self::CHUNK_SIZE;
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
-    /// スクランブル形式を使用するかどうか
-    /// AVX2: OUTPUT % 8 == 0、SSSE3: OUTPUT % 4 == 0
+    /// 重み格納レイアウトの単一判定。read()/propagate() がすべてこれを参照し、
+    /// 格納時と読み出し時のレイアウト不一致を防ぐ。true のとき重みはスクランブル形式
+    /// （input_chunk-major）で格納・参照される。スクランブル経路を持たない target
+    /// （wasm SIMD / スカラー）では常に false。
     #[inline]
     const fn should_use_scrambled_weights() -> bool {
         if cfg!(all(target_arch = "x86_64", target_feature = "avx2")) {
-            OUTPUT.is_multiple_of(8)
+            OUTPUT.is_multiple_of(8) && OUTPUT > 0
         } else if cfg!(all(
             target_arch = "x86_64",
             target_feature = "ssse3",
             not(target_feature = "avx2")
         )) {
-            OUTPUT.is_multiple_of(4)
+            OUTPUT.is_multiple_of(4) && OUTPUT > 0
         } else {
             false
         }
     }
 
-    #[cfg(any(target_feature = "avx2", target_feature = "ssse3"))]
     /// 重みインデックスのスクランブル変換
     ///
     /// 元のレイアウト: weights[output][input]
@@ -1237,49 +1237,19 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
             *bias = i32::from_le_bytes(buf4);
         }
 
-        // 重みを読み込み（スクランブル形式で格納）
+        // 重みを読み込み。格納レイアウトは should_use_scrambled_weights() の単一判定に従う。
         let weight_size = OUTPUT * Self::PADDED_INPUT;
         let mut weights = AlignedBox::new_zeroed(weight_size);
 
-        // スクランブル形式の場合は変換しながら格納
-        #[cfg(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        ))]
-        {
-            let mut buf1 = [0u8; 1];
-            for i in 0..weight_size {
-                reader.read_exact(&mut buf1)?;
-                let idx = if Self::should_use_scrambled_weights() {
-                    Self::get_weight_index_scrambled(i)
-                } else {
-                    i
-                };
-                weights[idx] = buf1[0] as i8;
-            }
-        }
-
-        // スカラー環境: 標準形式で格納
-        #[cfg(not(any(
-            all(target_arch = "x86_64", target_feature = "avx2"),
-            all(
-                target_arch = "x86_64",
-                target_feature = "ssse3",
-                not(target_feature = "avx2")
-            )
-        )))]
-        {
-            let mut row_buf = vec![0u8; Self::PADDED_INPUT];
-            for o in 0..OUTPUT {
-                reader.read_exact(&mut row_buf)?;
-                for i in 0..Self::PADDED_INPUT {
-                    weights[o * Self::PADDED_INPUT + i] = row_buf[i] as i8;
-                }
-            }
+        let mut buf1 = [0u8; 1];
+        for i in 0..weight_size {
+            reader.read_exact(&mut buf1)?;
+            let idx = if Self::should_use_scrambled_weights() {
+                Self::get_weight_index_scrambled(i)
+            } else {
+                i
+            };
+            weights[idx] = buf1[0] as i8;
         }
 
         Ok(Self { biases, weights })
@@ -1310,6 +1280,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         // WASM SIMD128: 標準形式の重みで内積
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
         {
+            // 本経路は重みを行優先で読む。スクランブル格納と共存しないことを単一判定で保証する。
+            const { assert!(!Self::should_use_scrambled_weights()) };
             // SAFETY:
             // - WASM SIMD128 はアライメント不要（v128_load/v128_store は任意アドレスで動作。
             //   biases は [i32; OUTPUT] でアライメント4バイトだが WASM では制約なし）
@@ -1410,6 +1382,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         }
 
         // スカラー fallback（avx2 は ssse3 を暗黙に含むが、意図を明示するため列挙）
+        // スクランブル / 行優先のどちらの格納でも正しく読めるよう、weight index は
+        // should_use_scrambled_weights() の単一判定で解決する。
         #[cfg(not(any(
             all(target_arch = "x86_64", target_feature = "avx2"),
             all(target_arch = "x86_64", target_feature = "ssse3"),
@@ -1418,9 +1392,14 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         {
             output.copy_from_slice(&self.biases);
             for (j, out) in output.iter_mut().enumerate() {
-                let weight_offset = j * Self::PADDED_INPUT;
                 for (i, &in_val) in input.iter().enumerate().take(INPUT) {
-                    *out += self.weights[weight_offset + i] as i32 * in_val as i32;
+                    let logical = j * Self::PADDED_INPUT + i;
+                    let weight_idx = if Self::should_use_scrambled_weights() {
+                        Self::get_weight_index_scrambled(logical)
+                    } else {
+                        logical
+                    };
+                    *out += self.weights[weight_idx] as i32 * in_val as i32;
                 }
             }
         }
@@ -1438,8 +1417,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT % 8 == 0 の場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(8) {
+            // スクランブル格納時（AVX2 では OUTPUT % 8 == 0）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 128; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 8;
                 debug_assert!(num_regs <= MAX_REGS);
@@ -1516,8 +1495,8 @@ impl<const INPUT: usize, const OUTPUT: usize> AffineTransformHalfKP<INPUT, OUTPU
         unsafe {
             use std::arch::x86_64::*;
 
-            // OUTPUT が 4 の倍数 ∧ 非ゼロの場合のみループ逆転を使用
-            if OUTPUT.is_multiple_of(4) && OUTPUT > 0 {
+            // スクランブル格納時（SSSE3 では OUTPUT % 4 == 0 ∧ 非ゼロ）のみループ逆転を使用
+            if Self::should_use_scrambled_weights() {
                 const MAX_REGS: usize = 256; // 最大 1024 出力まで対応
                 let num_regs = OUTPUT / 4;
                 debug_assert!(num_regs <= MAX_REGS);


### PR DESCRIPTION
## 概要

NNUE `AffineTransform` の重み格納レイアウト判定（スクランブル形式 vs 行優先）を、`read` / `read_leb128` / `propagate` で **単一の真実**（`should_use_scrambled_weights()` + コンパイル時 `const assert`）に集約する不変リファクタ。あわせて wasm 経路の数値正当性を CI で回帰検知する job を追加する。

## 動機

重み格納は target により異なる:
- x86 AVX2（OUTPUT が 8 の倍数）/ SSSE3（OUTPUT が 4 の倍数）: スクランブル形式 `weights[input_chunk][output][4]`
- それ以外（wasm SIMD / SSE2 / スカラー）: 行優先 `weights[output][input]`

従来は格納側（`read`/`read_leb128`）と読み出し側（`propagate` の各 SIMD 経路）が**別々の cfg・マジック条件で独立に**レイアウトを決めており、両者がズレても crash せず静かに誤 eval になる暗黙結合だった。直近の AVX-512 OUTPUT=8 修正 (#792) はまさにこの結合を踏んだもの。

## 変更内容

### A. レイアウト判定の単一の真実化（nnue 6ファイル）
`layers.rs`（`AffineTransform`）と `network_{halfkp,halfka_merged,halfka_split,halfka_hm_merged,halfka_hm_split}.rs` に共通適用:

- `should_use_scrambled_weights()` / `get_weight_index_scrambled()` / `CHUNK_SIZE` / `NUM_INPUT_CHUNKS` を全 target で利用可能に un-gate（単一の真実）
- `read` / `read_leb128` を cfg 分岐廃止 → 単一 runtime-if に統一
- `propagate` のスクランブル経路選択を `is_multiple_of(8/4)` → `should_use_scrambled_weights()` に置換（AVX-512 は `&& %16`）
- scalar fallback を **layout-agnostic 化**（述語 + scramble index でどの格納でも正しく読む）
- 行優先専用 SIMD 経路（全ファイルの wasm、`layers.rs` の SSE2）に `const { assert!(!should_use_scrambled_weights()) }` を追加し、スクランブル格納との共存をコンパイル時に禁止

**評価値は bit-identical**（コンパイル時に畳まれる不変リファクタ、ホットループの生成コードは不変）。

### B. wasm 経路の runtime 回帰テスト（`rust-ci.yml`）
host `test` job と `simd-runtime` job は x86 経路しか実行せず、wasm SIMD128 経路と wasm スカラー fallback の数値正当性が CI 未検証だった。target 非依存の `affine_reference` テストを **wasm32-wasip1 + wasmtime** で +simd128 / scalar の両方実行する `nnue-wasm-runtime` job を追加。

## 検証

| 経路 | 方法 | 結果 |
|---|---|---|
| native (avx2) | `cargo test -p rshogi-core` | 全 pass |
| SSSE3 / SSE2 | RUSTFLAGS 指定で実行 | `nnue::layers` 全 pass |
| AVX-512 | avx512f 実機で実行 | `affine_reference` 全 pass |
| wasm SIMD128 | wasm32-wasip1 + wasmtime | `affine_reference` 全 pass |
| wasm scalar | wasm32-wasip1 + wasmtime（simd128 無効） | `affine_reference` 全 pass |

`cargo fmt --check` / `cargo clippy -D warnings` / `check-tracked-abs-paths.sh` clean。

`affine_reference_test`（256x8 / 768x8 / 1536x16 / 760x8）は read→propagate を行優先スカラー参照と bit 一致照合する target 非依存テストで、本変更により全 x86 SIMD 経路 + wasm runtime で実行される。

## レビュー
ローカルで独立 reviewer 2 系統（Codex + Claude）のフル差分レビューを実施し、両者 APPROVE 取得済み。

## 補足 / follow-up 候補
- AVX-512 を有効化しつつ AVX2 を外す pathological build 構成では、従来 read が行優先・propagate がスクランブル読みで誤 eval になり得たが、本変更の `should_use_scrambled_weights() && %16` で行優先側に正しく degrade するよう副次的に解消。
- network 系 `AffineTransformHalfKP` 等の wasm round-trip テストは未整備（既存 gap、本変更で悪化せず）。同述語・同 const assert を共有するため述語ロジックは推移的に検証されるが、専用テスト追加は別 PR 候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
