### PR TITLE
fix(csa-server): cold-start で早発火した turn alarm を force_time_up せず reschedule する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -509,6 +509,33 @@ impl DurableObject for GameRoom {
         }
 
         self.ensure_core_loaded().await?;
+
+        // hibernation evict を跨ぐと、最後の手で予約した絶対 deadline alarm が evict
+        // 中に到来して発火し得る。cold-start 復元では ensure_core_loaded が
+        // turn_started_at を now へ張り直すため、まだ残時間があれば「実際の時間切れ
+        // ではなく evict 滞留での早発火」とみなし、force_time_up せず残時間で alarm を
+        // 張り直す。warm な真の時間切れでは alarm は turn_budget + margin + safety 後に
+        // 発火し、残時間は 0 になるのでこの分岐を通らない。
+        let now_ms = self.now_ms();
+        let remaining_ms = {
+            let borrow = self.core.borrow();
+            let Some(core) = borrow.as_ref() else {
+                return Response::ok("no core");
+            };
+            core.current_turn_remaining_ms(now_ms)
+        };
+        if let Some(remaining) = remaining_ms.filter(|&r| r > 0) {
+            let margin_ms = self
+                .config
+                .borrow()
+                .as_ref()
+                .map(|c| c.time_margin_ms)
+                .unwrap_or(DEFAULT_TIME_MARGIN_MS);
+            let total = remaining.saturating_add(margin_ms).saturating_add(ALARM_SAFETY_MS);
+            self.state.storage().set_alarm(Duration::from_millis(total)).await?;
+            return Response::ok("turn_alarm rescheduled after cold restart");
+        }
+
         let outcome = {
             let mut borrow = self.core.borrow_mut();
             let Some(core) = borrow.as_mut() else {
@@ -2546,9 +2573,8 @@ impl GameRoom {
         // 短い byoyomi / msec 時計では復元 I/O だけで TimeUp になり得るため。
         // ここに到達した時点で core が Some なのは直前の replay が Restored だった
         // 場合のみ (warm path は早期 return 済み)。Playing 以外は setter 側で no-op。
-        // NOTE: 復元では turn alarm を再予約していないため、最後の手の時点で set_alarm
-        // した絶対 deadline が evict 中に発火し force_time_up する経路はこれだけでは
-        // 塞げない (別経路として要対処)。
+        // evict 中に予約済み絶対 deadline alarm が早発火するケースは `alarm` ハンドラ
+        // 側で `current_turn_remaining_ms` を再判定して reschedule することで救済する。
         let now_ms = self.now_ms();
         if let Some(core) = self.core.borrow_mut().as_mut() {
             core.reset_turn_started_at(now_ms);

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -328,6 +328,23 @@ impl GameRoom {
         }
     }
 
+    /// 現在手番が `now_ms` 時点で残している持ち時間 (ms)。`0` は時間切れ。
+    /// `Playing` 以外は `None`。
+    ///
+    /// turn alarm 発火時に「evict 滞留での早発火か、実際の時間切れか」を区別する
+    /// ために使う。`reset_turn_started_at` で cold-start 復元時に起点が `now` へ
+    /// 張り直されるため、evict 早発火では満額の残時間が返り、warm な真の時間切れ
+    /// （alarm は `turn_budget + margin + safety` 後に発火）では `0` が返る。
+    pub fn current_turn_remaining_ms(&self, now_ms: u64) -> Option<u64> {
+        if !matches!(self.status, GameStatus::Playing) {
+            return None;
+        }
+        let started = self.turn_started_at_ms.unwrap_or(now_ms);
+        let elapsed = now_ms.saturating_sub(started);
+        let budget = self.clock.turn_budget_ms(self.current_turn()).max(0) as u64;
+        Some(budget.saturating_sub(elapsed))
+    }
+
     /// 切断を検出したときに呼ぶ。再接続猶予 0 秒で即時 `#ABNORMAL` 確定。
     ///
     /// 勝者確定は「対局中の切断」に限り、それ以前
@@ -747,6 +764,27 @@ mod tests {
         agree_both(&mut room);
         room.reset_turn_started_at(67_890);
         assert_eq!(room.turn_started_at_ms, Some(67_890));
+    }
+
+    #[test]
+    fn current_turn_remaining_ms_is_none_before_start() {
+        let room = make_room();
+        assert_eq!(room.current_turn_remaining_ms(0), None);
+    }
+
+    #[test]
+    fn current_turn_remaining_ms_reflects_elapsed_and_zero_on_timeup() {
+        let mut room = make_room();
+        agree_both(&mut room); // now=0 で START → 現手番の計測起点も 0、満額 budget
+        let budget = room.clock_turn_budget_ms(room.current_turn()).max(0) as u64;
+        assert!(budget > 0);
+        // 経過 0 → 残 == budget（evict 早発火: 復元で起点が now に張り直された状況に相当）
+        assert_eq!(room.current_turn_remaining_ms(0), Some(budget));
+        // 経過 < budget → 残 = budget - elapsed
+        assert_eq!(room.current_turn_remaining_ms(budget / 2), Some(budget - budget / 2));
+        // budget 到達/超過 → 0（warm な真の時間切れ: alarm は budget+margin+safety 後に発火）
+        assert_eq!(room.current_turn_remaining_ms(budget), Some(0));
+        assert_eq!(room.current_turn_remaining_ms(budget + 5_000), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

GameRoom DO が WS Hibernation で evict された後、最後の手で予約済みの **turn alarm（絶対 deadline）が evict 中に発火し、実際には時間切れでない対局を誤って `TimeUp` 終局させる**経路を修正する。直前の cold-start 修正（#780）が「復元後の最初の**着手**」の誤 TimeUp を防いだのに対し、本 PR は「復元前後に**発火した alarm**」による誤終局を防ぐ。

## 原因

`reschedule_turn_alarm` は手番開始ごとに `turn_budget + margin + safety` 後の発火を `set_alarm` で予約する（DO はこれを絶対 deadline 化して保持）。DO が evict されると alarm は hibernation を跨いで残り、evict 中に到来して `alarm()` ハンドラが発火する。従来ハンドラは `force_time_up` を**無条件**に呼んでいたため、長考中の evict など「実時間ではまだ budget 内」の局面でも時間切れ負けになっていた。

## 修正

`alarm()` の TimeUp 経路で、`ensure_core_loaded`（cold-start 復元時に `turn_started_at` を `now` へ張り直す）の後に**現在手番の残時間を再判定**する。

- `CoreRoom::current_turn_remaining_ms(now)` を追加（`Playing` なら `turn_budget_ms(current_turn) − (now − turn_started_at)` の saturating、それ以外 `None`）。
- 残時間 > 0 → evict 滞留での早発火とみなし、`force_time_up` せず残時間（+ margin + safety）で alarm を張り直して return。
- 残時間 0 / `None` → 従来どおり `force_time_up`。

**切り分けの根拠**: warm な真の時間切れでは alarm は `budget + margin + safety` 後に発火し `elapsed ≥ budget` → 残 0 → `force_time_up`。cold 早発火では復元で `turn_started_at = now` のため残 ≈ 満額 → reschedule。残時間に margin を引かないため判定境界は真の clock 境界より早側＝**force_time_up 側に保守的**で、真の時間切れを取りこぼさない。

## 検証

- host `cargo test`: `rshogi-csa-server` 336 / `rshogi-csa-server-workers` 329 全 pass（`current_turn_remaining_ms` の host テスト2本を追加）。
- `cargo check --target wasm32-unknown-unknown` / `cargo fmt --check` / clippy（編集域 warning 0）。
- レビュー: local claude / codex 両エージェント APPROVE。
- 注: `alarm()` ハンドラ自体は `#[cfg(target_arch = "wasm32")]` で host 未テスト。判定の本質は host テスト済みの `current_turn_remaining_ms` に集約し、ハンドラは薄い配線のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
