### PR TITLE
ci: GitHub Actions の未固定 action を commit SHA に固定 (dtolnay/taiki-e)

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -138,8 +138,10 @@ jobs:
           # 過去の deploy-trigger commit が見えず、新規 PR を merge しても
           # `DEPLOYED_SHA` が空文字で落ちるため full history を取る。
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: steps.check.outputs.can_deploy == 'true'
+        with:
+          toolchain: stable
       - name: Add wasm32 target to pinned toolchain
         if: steps.check.outputs.can_deploy == 'true'
         run: |
@@ -357,8 +359,10 @@ jobs:
             --max-wait-sec "$MAX_WAIT" \
             --poll-interval-sec 30 \
             --require-stable-zero 3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: steps.check.outputs.can_deploy == 'true'
+        with:
+          toolchain: stable
       - name: Add wasm32 target to pinned toolchain
         if: steps.check.outputs.can_deploy == 'true'
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -63,8 +63,9 @@ jobs:
     if: needs.changes.outputs.rust_code == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
+          toolchain: stable
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -82,8 +83,9 @@ jobs:
           sudo apt-get install -y mold clang
           mold --version || true
           clang --version || true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
+          toolchain: stable
           components: clippy
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -112,7 +114,9 @@ jobs:
           sudo apt-get install -y mold clang
           mold --version || true
           clang --version || true
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Enable sccache
@@ -133,8 +137,10 @@ jobs:
     if: needs.changes.outputs.rust_code == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-audit
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@b1366b959af4acf9da276c715d1f12893b19397d # cargo-audit
       - name: Run security audit
         run: cargo audit --deny warnings
 
@@ -174,10 +180,12 @@ jobs:
       RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Add wasm32 target to pinned toolchain
         # `rust-toolchain.toml` が channel を 1.93.1 に pin しているため、
-        # cargo は dtolnay/rust-toolchain@stable が install した stable (1.95.0) では
+        # cargo は dtolnay/rust-toolchain が install した stable では
         # なく rust-toolchain.toml の channel を使う（`rustup show active-toolchain` で
         # 確認できる）。dtolnay action の `targets:` パラメータは default toolchain
         # （= stable）にのみ wasm32 target を追加するため、cargo の実行時には反映
@@ -248,7 +256,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # mold linker は .cargo/config.toml で wired されていないため install しない
       # (rshogi-core のみのリンクで効果が無く runner setup 時間を浪費するだけ)。
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Setup Intel SDE
         uses: petarpetrovt/setup-sde@31aa4a8e85e109bef00f1d838613fcc6ec421271 # v5.0
         with:
@@ -298,7 +308,9 @@ jobs:
       CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Add wasm32-wasip1 target to pinned toolchain
         # rust-toolchain.toml が channel を pin しているため、その toolchain に
         # wasm32-wasip1 target を明示的に追加する（wasm-build job と同じ理由）。

--- a/.github/workflows/synthetic-csa-staging.yml
+++ b/.github/workflows/synthetic-csa-staging.yml
@@ -81,8 +81,10 @@ jobs:
           else
             echo "can_run=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: steps.check.outputs.can_run == 'true'
+        with:
+          toolchain: stable
       - name: Pin toolchain
         if: steps.check.outputs.can_run == 'true'
         run: |

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -50,7 +50,9 @@ jobs:
       RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - name: Add wasm32 target to pinned toolchain
         run: |
           CHANNEL=$(awk -F'"' '/^channel/{print $2}' rust-toolchain.toml)


### PR DESCRIPTION
## 概要
未固定だった GitHub Actions を commit SHA に固定する supply-chain hardening。PR #797 のレビュー（claude bot）で指摘された `dtolnay/rust-toolchain@stable` 未固定を、リポ全 job 横断で対応する別 PR。

## 変更内容
- `dtolnay/rust-toolchain@stable`（全 11 箇所）→ `@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master` + `with: toolchain: stable`
- `taiki-e/install-action@cargo-audit`（1 箇所, security job）→ `@b1366b959af4acf9da276c715d1f12893b19397d # cargo-audit`
- これで `.github/workflows/` 配下の **全 action が SHA 固定**に（未固定ゼロ）。

対象: rust-ci.yml(7) / workers-smoke.yml(1) / synthetic-csa-staging.yml(1) / deploy-workers.yml(2)。

## なぜ master SHA + `toolchain: stable` か
dtolnay/rust-toolchain は `@ref` 名から toolchain を推論する設計で、SHA 固定すると ref 名から toolchain を読めない。README の公式作法に従い、**master 履歴の commit に固定し `with: toolchain: stable` で toolchain を明示**する。`3c5f7ea` は master の tip。

## 動作不変
従来の `@stable` も stable channel を install していたため、`@<master-sha> + toolchain: stable` と等価。実際に使われる Rust channel は `rust-toolchain.toml` で pin される（本変更は影響なし）。production deploy（deploy-workers.yml）の挙動も等価。

## 検証
- 全 10 workflow の YAML 構文 OK
- 未固定 action 残ゼロ（`grep -rnE "uses: [^@]+@[^ ]+" .github/workflows/ | grep -vE "@[0-9a-f]{40}"` が空）
- dtolnay 11 + `toolchain: stable` 11 + taiki-e 1、既存 `components`(rustfmt/clippy) 保持、`if:` との共存 OK
- SHA は upstream で実在確認（`3c5f7ea`=dtolnay master tip、`b1366b9`=cargo-audit tag の commit）

## レビュー
ローカルで Codex + Claude の独立レビューを実施、両者 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
