### PR TITLE
ci: Dependabot で Actions SHA pin を自動更新 + コメント rot 修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # GitHub Actions は commit SHA で pin 運用しているため、pin の陳腐化
+  # （action 側のセキュリティ修正の取りこぼし）を防ぐべく Dependabot で
+  # SHA 更新を週次で自動提案する。全 action の更新は 1 件にまとめる。
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -184,7 +184,7 @@ jobs:
         with:
           toolchain: stable
       - name: Add wasm32 target to pinned toolchain
-        # `rust-toolchain.toml` が channel を 1.93.1 に pin しているため、
+        # `rust-toolchain.toml` が channel を pin しているため、
         # cargo は dtolnay/rust-toolchain が install した stable では
         # なく rust-toolchain.toml の channel を使う（`rustup show active-toolchain` で
         # 確認できる）。dtolnay action の `targets:` パラメータは default toolchain


### PR DESCRIPTION
## 概要
直前の PR #800 で `.github/workflows/` 配下の全 GitHub Actions を commit SHA に固定したことに伴う CI 衛生の後続対応。

## 変更内容
1. **`.github/dependabot.yml`（新規）**: SHA 固定した action が陳腐化（action 側のセキュリティ修正の取りこぼし）しないよう、Dependabot で `github-actions` ecosystem を**週次監視**し SHA 更新を自動提案する。全 action の更新は 1 件にグループ化、commit prefix は `ci`。
2. **`rust-ci.yml`**: wasm-build job のコメント中で rot していた channel 版番号（`1.93.1`、実際は `rust-toolchain.toml` = `1.95.0`）を除去し version 非依存表現にする。

## 背景
SHA 固定は供給網安全性を上げる一方、自動更新機構が無いと pin が古いまま放置される。Dependabot の `# master` / `# vX` 等の trailer コメント形式とも互換で、branch ref 固定（dtolnay の `# master`）も branch tip へ追従して更新される。

## 検証
- `dependabot.yml` / `rust-ci.yml` とも YAML 構文 OK、Dependabot v2 スキーマ準拠（package-ecosystem / directory / schedule.interval / groups / commit-message.prefix）
- 他 workflow のコメントに残存 rot 無し（`# vX.Y.Z` の SHA trailer は注釈でありスコープ外）

## レビュー
ローカルで Codex + Claude の独立レビューを実施、両者 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
