### PR TITLE
test(nnue): network AffineTransform 重みレイアウト往復テスト + wasm CI 拡張

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -332,11 +332,11 @@ jobs:
           # host / wasm32-unknown キャッシュと混在させないため専用 namespace を確保する。
           shared-key: wasm32-wasip1
       - name: Run NNUE layout tests on wasm (SIMD128 path)
-        run: cargo test -p rshogi-core nnue::layers --target wasm32-wasip1
+        run: cargo test -p rshogi-core affine_reference --target wasm32-wasip1
         env:
           RUSTFLAGS: "-C target-feature=+simd128"
       - name: Run NNUE layout tests on wasm (scalar fallback)
-        run: cargo test -p rshogi-core nnue::layers --target wasm32-wasip1
+        run: cargo test -p rshogi-core affine_reference --target wasm32-wasip1
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_merged.rs
@@ -1880,6 +1880,71 @@ pub type HalfKaHmMerged768Pairwise = NetworkHalfKaHmMerged<768, 1536, 768, 16, 6
 mod tests {
     use super::*;
 
+    /// read→propagate を、SIMD レイアウト（スクランブル形式
+    /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で
+    /// 照合し、重み格納レイアウトと読み出しのドリフトを検出する。OUTPUT=8/4 は
+    /// スクランブル経路（AVX2 は %8、SSSE3 は %4）、OUTPUT=1 は行優先（出力層）、
+    /// INPUT が 32 の非倍数は PADDED に padding 列が生じる境界を踏む。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = crate::nnue::layers::padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding 列（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransformHalfKaHmMerged::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..])
+                        .unwrap();
+
+                let mut input = crate::nnue::accumulator::Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_halfka_hm_merged_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_halfka_hm_merged_512x4, 512, 4);
+    affine_reference_test!(test_affine_reference_halfka_hm_merged_512x1, 512, 1);
+    affine_reference_test!(test_affine_reference_halfka_hm_merged_760x8, 760, 8);
+
     #[test]
     fn test_accumulator_halfka_256() {
         let mut acc = AccumulatorHalfKaHmMerged::<256>::new();

--- a/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_hm_split.rs
@@ -1881,6 +1881,71 @@ pub type HalfKaHmSplit768Pairwise = NetworkHalfKaHmSplit<768, 1536, 768, 16, 64,
 mod tests {
     use super::*;
 
+    /// read→propagate を、SIMD レイアウト（スクランブル形式
+    /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で
+    /// 照合し、重み格納レイアウトと読み出しのドリフトを検出する。OUTPUT=8/4 は
+    /// スクランブル経路（AVX2 は %8、SSSE3 は %4）、OUTPUT=1 は行優先（出力層）、
+    /// INPUT が 32 の非倍数は PADDED に padding 列が生じる境界を踏む。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = crate::nnue::layers::padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding 列（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransformHalfKaHmSplit::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..])
+                        .unwrap();
+
+                let mut input = crate::nnue::accumulator::Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_halfka_hm_split_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_halfka_hm_split_512x4, 512, 4);
+    affine_reference_test!(test_affine_reference_halfka_hm_split_512x1, 512, 1);
+    affine_reference_test!(test_affine_reference_halfka_hm_split_760x8, 760, 8);
+
     #[test]
     fn test_accumulator_halfka_256() {
         let mut acc = AccumulatorHalfKaHmSplit::<256>::new();

--- a/crates/rshogi-core/src/nnue/network_halfka_merged.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_merged.rs
@@ -1882,6 +1882,71 @@ pub type HalfKaMerged768Pairwise = NetworkHalfKaMerged<768, 1536, 768, 16, 64, P
 mod tests {
     use super::*;
 
+    /// read→propagate を、SIMD レイアウト（スクランブル形式
+    /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で
+    /// 照合し、重み格納レイアウトと読み出しのドリフトを検出する。OUTPUT=8/4 は
+    /// スクランブル経路（AVX2 は %8、SSSE3 は %4）、OUTPUT=1 は行優先（出力層）、
+    /// INPUT が 32 の非倍数は PADDED に padding 列が生じる境界を踏む。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = crate::nnue::layers::padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding 列（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransformHalfKaMerged::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..])
+                        .unwrap();
+
+                let mut input = crate::nnue::accumulator::Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_halfka_merged_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_halfka_merged_512x4, 512, 4);
+    affine_reference_test!(test_affine_reference_halfka_merged_512x1, 512, 1);
+    affine_reference_test!(test_affine_reference_halfka_merged_760x8, 760, 8);
+
     #[test]
     fn test_accumulator_halfka_256() {
         let mut acc = AccumulatorHalfKaMerged::<256>::new();

--- a/crates/rshogi-core/src/nnue/network_halfka_split.rs
+++ b/crates/rshogi-core/src/nnue/network_halfka_split.rs
@@ -1878,6 +1878,71 @@ pub type HalfKaSplit768Pairwise = NetworkHalfKaSplit<768, 1536, 768, 16, 64, Pai
 mod tests {
     use super::*;
 
+    /// read→propagate を、SIMD レイアウト（スクランブル形式
+    /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で
+    /// 照合し、重み格納レイアウトと読み出しのドリフトを検出する。OUTPUT=8/4 は
+    /// スクランブル経路（AVX2 は %8、SSSE3 は %4）、OUTPUT=1 は行優先（出力層）、
+    /// INPUT が 32 の非倍数は PADDED に padding 列が生じる境界を踏む。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = crate::nnue::layers::padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding 列（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransformHalfKaSplit::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..])
+                        .unwrap();
+
+                let mut input = crate::nnue::accumulator::Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_halfka_split_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_halfka_split_512x4, 512, 4);
+    affine_reference_test!(test_affine_reference_halfka_split_512x1, 512, 1);
+    affine_reference_test!(test_affine_reference_halfka_split_760x8, 760, 8);
+
     #[test]
     fn test_accumulator_halfka_256() {
         let mut acc = AccumulatorHalfKaSplit::<256>::new();

--- a/crates/rshogi-core/src/nnue/network_halfkp.rs
+++ b/crates/rshogi-core/src/nnue/network_halfkp.rs
@@ -1940,6 +1940,70 @@ pub type HalfKP768Pairwise = NetworkHalfKP<768, 1536, 768, 16, 64, PairwiseCReLU
 mod tests {
     use super::*;
 
+    /// read→propagate を、SIMD レイアウト（スクランブル形式
+    /// `weights[input_chunk][output][4]`）に依存しない行優先スカラー参照と bit 一致で
+    /// 照合し、重み格納レイアウトと読み出しのドリフトを検出する。OUTPUT=8/4 は
+    /// スクランブル経路（AVX2 は %8、SSSE3 は %4）、OUTPUT=1 は行優先（出力層）、
+    /// INPUT が 32 の非倍数は PADDED に padding 列が生じる境界を踏む。
+    macro_rules! affine_reference_test {
+        ($name:ident, $in:literal, $out:literal) => {
+            #[test]
+            fn $name() {
+                const INPUT_DIM: usize = $in;
+                const OUTPUT_DIM: usize = $out;
+                const PADDED: usize = crate::nnue::layers::padded_input(INPUT_DIM);
+
+                let mut biases = [0i32; OUTPUT_DIM];
+                let mut logical = vec![0i8; OUTPUT_DIM * PADDED];
+                let mut bytes: Vec<u8> = Vec::new();
+                for o in 0..OUTPUT_DIM {
+                    let b = (o as i32) * 1000 - 3000;
+                    biases[o] = b;
+                    bytes.extend_from_slice(&b.to_le_bytes());
+                }
+                for o in 0..OUTPUT_DIM {
+                    for inp in 0..PADDED {
+                        // padding 列（inp >= INPUT_DIM）は 0、実重みは ±25 程度に散らす
+                        let w = if inp < INPUT_DIM {
+                            (((o * 31 + inp * 7) % 51) as i32 - 25) as i8
+                        } else {
+                            0
+                        };
+                        logical[o * PADDED + inp] = w;
+                        bytes.push(w as u8);
+                    }
+                }
+
+                let transform =
+                    AffineTransformHalfKP::<INPUT_DIM, OUTPUT_DIM>::read(&mut &bytes[..]).unwrap();
+
+                let mut input = crate::nnue::accumulator::Aligned([0u8; PADDED]);
+                for inp in 0..INPUT_DIM {
+                    input.0[inp] = ((inp * 13 + 5) % 128) as u8;
+                }
+
+                let mut expected = [0i32; OUTPUT_DIM];
+                for o in 0..OUTPUT_DIM {
+                    let mut acc = biases[o];
+                    for inp in 0..INPUT_DIM {
+                        acc += logical[o * PADDED + inp] as i32 * input.0[inp] as i32;
+                    }
+                    expected[o] = acc;
+                }
+
+                let mut output = [0i32; OUTPUT_DIM];
+                transform.propagate(&input.0, &mut output);
+
+                assert_eq!(output, expected);
+            }
+        };
+    }
+
+    affine_reference_test!(test_affine_reference_halfkp_256x8, 256, 8);
+    affine_reference_test!(test_affine_reference_halfkp_512x4, 512, 4);
+    affine_reference_test!(test_affine_reference_halfkp_512x1, 512, 1);
+    affine_reference_test!(test_affine_reference_halfkp_760x8, 760, 8);
+
     #[test]
     fn test_accumulator_halfkp_256() {
         let mut acc = AccumulatorHalfKP::<256>::new();


### PR DESCRIPTION
## 概要

PR #797 (AffineTransform 重みレイアウト判定の単一真実化) の follow-up。network 系 AffineTransform 構造体に「重みレイアウト往復テスト」を追加し、既存カバレッジ gap を埋める。

## 変更内容

- **往復テスト追加** (5 network ファイル): `AffineTransformHalfKP` / `HalfKaMerged` / `HalfKaSplit` / `HalfKaHmMerged` / `HalfKaHmSplit` に、`layers.rs` の `affine_reference_test!` と同趣旨の往復テストを追加。
  - 行優先で直列化した重み + bias を `read()` で読み込み（target ごとのレイアウトで格納される: x86 AVX2 = スクランブル `weights[input_chunk][output][4]` / SSSE3 = %4 スクランブル / wasm SIMD・スカラー = 行優先）
  - 独立な行優先スカラー参照と `propagate()` 出力を bit 一致照合 → read↔propagate のレイアウトドリフトを回帰検知
  - dims: `256x8` (AVX2 %8 scrambled) / `512x4` (SSSE3 %4 scrambled) / `512x1` (出力層 = 行優先) / `760x8` (PADDED に padding 列が生じる境界)
  - テスト名は全て `affine_reference` を含む → `cargo test -p rshogi-core affine_reference` で layers + network 全往復テストが一括マッチ
- **CI 拡張** (`.github/workflows/rust-ci.yml`): `nnue-wasm-runtime` job のフィルタを `nnue::layers` → `affine_reference` に拡張し、network 系往復テストも wasm32-wasip1 + wasmtime (simd128 / scalar) で実行する。SDE `simd-runtime` job は `--lib` で全 lib テストを拾うため変更不要。

## 検証

- `cargo test -p rshogi-core affine_reference`: 24 件 (layers 4 + network 20) 全 pass (native avx2)
- downlevel: `RUSTFLAGS="-C target-feature=+ssse3"` / sse2 baseline 全 pass
- wasm: wasm32-wasip1 + wasmtime で `+simd128` / scalar 全 pass
- `cargo clippy -p rshogi-core --all-targets -- -D warnings` clean / `cargo fmt --check` clean / `bash scripts/check-tracked-abs-paths.sh` OK
- dual review (Codex + Claude) ともに APPROVE

## 備考

- テスト + CI 追加のみ。プロダクションの `read()` / `propagate()` レイアウトロジックは不変更。
- #797 の NPS 影響を A/B 実測 (main vs main+#797, production build, `search_only_ab` abba): per-position で instructions/node がフラット (≤0.09%) → ホットパス生成コードは実質同一で、NPS 退行なしを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
