### PR TITLE
refactor(nnue): LayerStack enum 宣言を L0 降順に整理

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -630,14 +630,14 @@ pub enum LayerStacksAccStack {
     L1536x16x32(AccumulatorStackLayerStacks<1536>),
     #[cfg(feature = "layerstacks-1536x32x32")]
     L1536x32x32(AccumulatorStackLayerStacks<1536>),
+    #[cfg(feature = "layerstacks-1024x16x32")]
+    L1024x16x32(AccumulatorStackLayerStacks<1024>),
     #[cfg(feature = "layerstacks-768x16x32")]
     L768x16x32(AccumulatorStackLayerStacks<768>),
     #[cfg(feature = "layerstacks-768x8x32")]
     L768x8x32(AccumulatorStackLayerStacks<768>),
     #[cfg(feature = "layerstacks-512x16x32")]
     L512x16x32(AccumulatorStackLayerStacks<512>),
-    #[cfg(feature = "layerstacks-1024x16x32")]
-    L1024x16x32(AccumulatorStackLayerStacks<1024>),
 }
 
 /// LayerStacks dispatch match の網羅性を確保するマクロ
@@ -763,14 +763,14 @@ pub enum LayerStacksAccCache {
     L1536x16x32(AccumulatorCacheLayerStacks<1536>),
     #[cfg(feature = "layerstacks-1536x32x32")]
     L1536x32x32(AccumulatorCacheLayerStacks<1536>),
+    #[cfg(feature = "layerstacks-1024x16x32")]
+    L1024x16x32(AccumulatorCacheLayerStacks<1024>),
     #[cfg(feature = "layerstacks-768x16x32")]
     L768x16x32(AccumulatorCacheLayerStacks<768>),
     #[cfg(feature = "layerstacks-768x8x32")]
     L768x8x32(AccumulatorCacheLayerStacks<768>),
     #[cfg(feature = "layerstacks-512x16x32")]
     L512x16x32(AccumulatorCacheLayerStacks<512>),
-    #[cfg(feature = "layerstacks-1024x16x32")]
-    L1024x16x32(AccumulatorCacheLayerStacks<1024>),
 }
 
 impl LayerStacksAccCache {

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -773,6 +773,10 @@ pub enum LsNetByFt<FT: LsFeatureSpec + 'static> {
     L1536x32x32(
         Box<NetworkLayerStacks<1536, LAYER_STACK_32X32_L1_OUT, LAYER_STACK_32X32_L2_IN, 64, FT>>,
     ),
+    #[cfg(feature = "layerstacks-1024x16x32")]
+    L1024x16x32(
+        Box<NetworkLayerStacks<1024, LAYER_STACK_16X32_L1_OUT, LAYER_STACK_16X32_L2_IN, 32, FT>>,
+    ),
     #[cfg(feature = "layerstacks-768x16x32")]
     L768x16x32(
         Box<NetworkLayerStacks<768, LAYER_STACK_16X32_L1_OUT, LAYER_STACK_16X32_L2_IN, 32, FT>>,
@@ -784,10 +788,6 @@ pub enum LsNetByFt<FT: LsFeatureSpec + 'static> {
     #[cfg(feature = "layerstacks-512x16x32")]
     L512x16x32(
         Box<NetworkLayerStacks<512, LAYER_STACK_16X32_L1_OUT, LAYER_STACK_16X32_L2_IN, 32, FT>>,
-    ),
-    #[cfg(feature = "layerstacks-1024x16x32")]
-    L1024x16x32(
-        Box<NetworkLayerStacks<1024, LAYER_STACK_16X32_L1_OUT, LAYER_STACK_16X32_L2_IN, 32, FT>>,
     ),
     #[cfg(not(any(
         feature = "layerstacks-1536x16x32",


### PR DESCRIPTION
## Summary

LayerStack の variant enum 宣言で、PR #805 で末尾 append された `L1024x16x32` を L0 降順位置 (`L1536x32x32` 直後) へ移動し、宣言順を `1536x16x32 → 1536x32x32 → 1024x16x32 → 768x16x32 → 768x8x32 → 512x16x32` に整理する。GitHub bot レビューと可読性向上の要望に対応。

対象 enum: `LayerStacksAccStack` / `LayerStacksAccCache` / `LsNetByFt`。

## 挙動への影響

なし。variant は名前 keyed の match arm で dispatch され、宣言順に依存しない (`#[repr]` / 明示 discriminant / `mem::discriminant` 依存なし)。差分は純粋な並べ替え (追加行集合 == 削除行集合、内容変更ゼロを機械検証)。dispatch の match arm は順序非依存のため据え置き、mod.rs re-export は元々昇順で 1024 は正しい位置。

## Test plan

- [x] 差分が純粋並べ替え (追加/削除行集合一致) を機械検証
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` 全 pass
- [x] `edition-layerstacks-halfka_hm_merged-1024x16x32-none` build OK
- [x] local reviewer (Codex) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)