### PR TITLE
build: edition-layerstacks-halfka_hm_merged-1024x16x32-threat を追加

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -215,6 +215,9 @@ edition-layerstacks-halfka_hm_merged-1536x32x32-none = [
 edition-layerstacks-halfka_hm_merged-1024x16x32-none = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32",
 ]
+edition-layerstacks-halfka_hm_merged-1024x16x32-threat = [
+  "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32", "nnue-threat",
+]
 edition-layerstacks-halfka_hm_merged-768x16x32-none = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-768x16x32",
 ]

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -90,6 +90,7 @@ edition-layerstacks-halfka_hm_merged-1536x16x32-threat      = ["rshogi-core/edit
 edition-layerstacks-halfka_hm_merged-1536x16x32-psqt_threat = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1536x16x32-psqt_threat"]
 edition-layerstacks-halfka_hm_merged-1536x32x32-none        = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1536x32x32-none"]
 edition-layerstacks-halfka_hm_merged-1024x16x32-none        = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-none"]
+edition-layerstacks-halfka_hm_merged-1024x16x32-threat      = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat"]
 edition-layerstacks-halfka_hm_merged-768x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x16x32-none"]
 edition-layerstacks-halfka_hm_merged-768x8x32-none          = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x8x32-none"]
 edition-layerstacks-halfka_hm_merged-512x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-512x16x32-none"]

--- a/docs/build.md
+++ b/docs/build.md
@@ -63,7 +63,7 @@ cargo xtask build --edition layerstacks-halfka_hm_merged-1536x16x32-psqt
 cargo xtask build --edition layerstacks-halfka_hm_merged-1536x16x32-psqt,layerstacks-halfka_hm_merged-1536x16x32-threat
 cargo xtask build --edition X --edition Y
 
-# 全 preset を build (現状 20 件)
+# 全 preset を build (現状 21 件)
 cargo xtask build --all-presets
 
 # engines/ 配下の binary 一覧 + manifest を表表示
@@ -159,7 +159,7 @@ edition-layerstacks
 edition-layerstacks-any-any-any
 edition-layerstacks-halfka_hm_merged-1536x16x32-none
 edition-layerstacks-halfka_hm_merged-1536x16x32-psqt
-... (現状 20 件)
+... (現状 21 件)
 edition-universal
 ```
 


### PR DESCRIPTION
## 目的

LayerStack ft-out **1024** + halfka_hm_merged + Threat (ThreatProfile=full) の NNUE net を
load できる USI engine を build するための preset edition を追加する。これまで threat は
`1536x16x32` 系にしか bundle されておらず、1024 幅 + threat の edition が無かったため、
学習側 (tatara) が出した threat@1024 net を engine 化できなかった。

## 変更

- `crates/rshogi-core/Cargo.toml`: edition `edition-layerstacks-halfka_hm_merged-1024x16x32-threat`
  を追加。既存 `-1024x16x32-none` の feature 構成 + `nnue-threat`。L0≠1536 のため
  progress-diff は付けない (Cargo.toml コメント / build.rs の L0=1536 限定チェックに準拠)。
- `crates/rshogi-usi/Cargo.toml`: xtask build は `rshogi-usi` package を build し edition
  feature を core へ forward するため、対応する mirror entry を追加 (無いと
  "package 'rshogi-usi' does not contain this feature" で build 失敗)。
- `docs/build.md`: 列挙している preset 件数を更新。

Rust 側の変更は不要 (`LsNetByFt::L1024x16x32` は FT 型に generic で `nnue-threat` 拡張を受理)。

## 検証

- `cargo xtask build --edition layerstacks-halfka_hm_merged-1024x16x32-threat --profile production`
  成功 → `engines/rshogi-usi-layerstacks-halfka_hm_merged-1024x16x32-threat`。
- USI handshake (`usi`→`usiok`)、実 threat@1024 net (FT threat 221,921,280 = 216720×1024)
  の load + `go depth 10` bestmove を確認。
- `cargo xtask list-editions` に新 edition が表示される。
- CI: `cargo fmt` clean / `cargo clippy` warning なし。`cargo test` は
  `rshogi-csa-server-tcp::transport::tests::send_line_appends_crlf` が fail するが、
  本変更と無関係の既存 failure (clean HEAD でも同様に fail することを確認済、本 PR は
  Cargo.toml / docs のみの変更)。