### PR TITLE
perf(tools/rescore_psv): 入力 host バッファを CUDA pinned 化し H2D 律速を解消 (Issue #811)

### DIFF
--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -351,6 +351,13 @@ CPU 前処理を待ってアイドルする区間を潰し、GPU を連続的に
 決定性: PSV のデコードを直列段階に残してバッチ構成を不変に保つため、出力は逐次実装と
 bit 一致する。
 
+入力特徴の host バッファは、GPU 推論時（`--onnx-gpu-id >= 0`）は **CUDA pinned (page-locked)
+メモリ**で確保する。pageable メモリだと `cudaMemcpyAsync` が CUDA 内部で pageable→pinned
+ステージング（CPU 介在）を伴い実質同期化するが、pinned 化でこれが消えて真の async H2D に
+なる。pinned 確保に失敗した環境では通常の pageable バッファに自動フォールバックする
+（出力は pinned/pageable で bit 一致）。計測例: TensorRT FP16 / batch 1024 / RTX 5090(WSL2)
+で約 +26%、CUDA EP / 同条件で約 +21%（いずれも 2M records, min-of-3, 出力 byte 一致）。
+
 ### `--threads` について
 
 特徴量構築（CPU 処理）を rayon で並列化するスレッド数（0 で論理コア数）。前処理は
@@ -554,10 +561,14 @@ AobaZero ONNX model loaded. Batch size: 1024
   FP32 で推論する場合は `--onnx-tensorrt` を指定せず CUDA EP を使うこと
 - TensorRT は初回実行時にモデルを GPU 固有にコンパイルする（数十秒〜数分）。
   `--onnx-tensorrt-cache` でキャッシュを保存すると 2 回目以降は高速起動する
-- このツールのボトルネックは CPU→GPU のデータ転送（全処理時間の 96%、nsys 計測）であり、
-  FP16 による高速化は主に転送量の半減と Tensor Core 活用に起因する
-- `--threads` による特徴量構築の並列化は、ボトルネックが CPU→GPU 転送（96%）に
-  あるため原理的に全体時間への影響がない。計測でもいずれの構成 (CUDA FP32 / TensorRT FP16、
-  90k / 1.05M records) で有意な差は観測されなかった
+- 入力 host バッファが pageable だった旧実装では、CPU→GPU 転送（`cudaMemcpyAsync`）が
+  pageable→pinned ステージングで実質同期化し全処理時間の ~96%（nsys 計測）を占めていた。
+  現在は GPU 推論時に host バッファを CUDA pinned 化してこの staging を解消している
+  （「ONNX モードの供給パイプライン」参照）。pinned 化後は転送が真の async になり overlap
+  されるため、転送は支配項ではなくなり、入力 FP16 化による転送量半減の効果も小さい
+  （本番 batch では計測上ほぼ誤差内）
+- `--threads` による特徴量構築の並列化は GPU 推論とオーバーラップされる。供給（read+build）が
+  GPU 推論より速ければ全体時間への影響は小さい（軽量モデル・高速 GPU で前処理が供給律速に
+  なる場合のみ寄与する）
 - 参考: 同等の Python ツール [psv-utils](https://github.com/KazApps/psv-utils) と比較して、
   本ツールは CUDA EP / TensorRT EP どちらでも約 6〜9% 速い（1,051,780 records, 温度管理付き計測）

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -2947,6 +2947,89 @@ fn canonicalize_predicted_path(path: &std::path::Path) -> Result<PathBuf> {
     Ok(canonical_parent.join(file_name))
 }
 
+/// 入力特徴の host バッファ。CUDA pinned (page-locked) が使える環境では真の async H2D に
+/// なり、pageable→pinned ステージング (CPU 介在) が消える。pinned 割当に失敗する環境
+/// (CPU 推論など) では通常の `Vec` にフォールバックする。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+enum HostBuf {
+    Paged(Vec<f32>),
+    /// CUDA pinned 確保ブロックへの生ポインタ。free は `PinnedPool` が一括で行う。
+    Pinned(PinnedBuf),
+}
+
+/// CUDA pinned 確保ブロックを指す生ポインタ。確保・解放は [`PinnedPool`] が所有する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+struct PinnedBuf {
+    ptr: *mut f32,
+    len: usize,
+}
+
+// SAFETY: pinned host memory (cudaHostAlloc 由来) は任意の CPU スレッドからアクセス可能な
+// 通常のホストメモリである。スロット (= PinnedBuf を含む PreparedBatch) の所有権は mpsc
+// channel で move 移送され、同一バッファに同時アクセスするスレッドは高々 1 つに保たれる
+// (producer が書き込み → ready 送信 → consumer が読み取り → free 返却)。よって PinnedBuf を
+// スレッド間で送っても data race は発生しない。ort の `Allocator` 自体は Sync でないため、
+// スロットには Allocator ではなく生ポインタを載せて channel 越しに渡す。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+unsafe impl Send for PinnedBuf {}
+
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+impl HostBuf {
+    #[inline]
+    fn as_slice(&self) -> &[f32] {
+        match self {
+            HostBuf::Paged(v) => v.as_slice(),
+            // SAFETY: ptr/len は生存中の pinned 割当を指し、len 要素分が有効。排他アクセスは
+            // channel による所有権移送で保証される (上の unsafe impl Send 参照)。
+            HostBuf::Pinned(p) => unsafe { std::slice::from_raw_parts(p.ptr, p.len) },
+        }
+    }
+
+    #[inline]
+    fn as_mut_slice(&mut self) -> &mut [f32] {
+        match self {
+            HostBuf::Paged(v) => v.as_mut_slice(),
+            // SAFETY: 上と同じ不変条件。`&mut self` 経由なので Rust の借用規則でも排他。
+            HostBuf::Pinned(p) => unsafe { std::slice::from_raw_parts_mut(p.ptr, p.len) },
+        }
+    }
+}
+
+/// pinned 割当の所有者。ort `Allocator` と確保済み生ポインタ群を保持し、drop 時にまとめて
+/// free する。`Allocator` は Sync でないため、確保したメモリはスロットへ生ポインタで渡し、
+/// 解放だけをこの型に集約する。`PinnedPool` は thread::scope より長生きさせること
+/// (スコープ内で全スロットが drop された後に free する)。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+struct PinnedPool {
+    allocator: ort::memory::Allocator,
+    ptrs: Vec<*mut f32>,
+}
+
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+impl PinnedPool {
+    /// `len` 要素 (f32) 分の pinned バッファを確保しゼロ初期化して返す。
+    fn alloc_zeroed(&mut self, len: usize) -> Result<PinnedBuf> {
+        let mut block = self.allocator.alloc::<f32>(len).map_err(onnx_ort_err)?;
+        let ptr = block.as_mut_ptr().cast::<f32>();
+        // SAFETY: alloc が len*size_of::<f32>() バイトを確保済み。pinned は CPU からアクセス可。
+        unsafe { std::ptr::write_bytes(ptr, 0, len) };
+        let ptr = block.into_raw().cast::<f32>();
+        self.ptrs.push(ptr);
+        Ok(PinnedBuf { ptr, len })
+    }
+}
+
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+impl Drop for PinnedPool {
+    fn drop(&mut self) {
+        for &ptr in &self.ptrs {
+            // SAFETY: ptr は self.allocator.alloc → into_raw で得たもの。確保した allocator で
+            // ちょうど 1 回だけ free する (ptrs に重複登録しない)。
+            unsafe { self.allocator.free(ptr) };
+        }
+    }
+}
+
 /// ストリーミング読み込み + rayon 並列特徴量構築 + ゼロコピー GPU 推論
 ///
 /// AobaZero / 標準 dlshogi の両方で共通のパイプライン処理。
@@ -3244,6 +3327,26 @@ where
         MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
             .map_err(onnx_ort_err)?;
 
+    // 入力特徴 host バッファを CUDA pinned (page-locked) 化するための allocator。
+    // pinned 化で pageable→pinned ステージング (CPU 介在) が消え、真の async H2D になる。
+    // GPU 推論 (gpu_id >= 0) のときのみ確保を試み、失敗したら pageable Vec にフォールバック。
+    let mut pinned_pool = if gpu_id >= 0 {
+        MemoryInfo::new(
+            AllocationDevice::CUDA_PINNED,
+            gpu_id,
+            AllocatorType::Device,
+            MemoryType::CPUInput,
+        )
+        .and_then(|info| ort::memory::Allocator::new(&session, info))
+        .map(|allocator| PinnedPool {
+            allocator,
+            ptrs: Vec::new(),
+        })
+        .ok()
+    } else {
+        None
+    };
+
     // フェーズ別 wall time 計測（RESCORE_PHASE_TIMING=1 のとき末尾で出力）。read/build は
     // producer、run/write は consumer の別スレッドで計測するため、オーバーラップ分は
     // 各フェーズの合算が wall を超える。供給コストと GPU コストの絶対値切り分けに使う。
@@ -3254,8 +3357,8 @@ where
     // producer が埋め、consumer（主スレッド）が GPU 推論・書き出しに使う。f1/f2 等は
     // slot プールで再利用し、ピークメモリは入力件数に非依存（PIPELINE_SLOTS 個ぶん）。
     struct PreparedBatch {
-        f1: Vec<f32>,
-        f2: Vec<f32>,
+        f1: HostBuf,
+        f2: HostBuf,
         records: Vec<(PackedSfenValue, String)>,
         stm_flags: Vec<bool>,
         in_checks: Vec<bool>,
@@ -3274,14 +3377,58 @@ where
     // 前の直列ループ実装と bit 一致。slot は free/ready の 2 本のチャネルで循環し、同時生存は
     // PIPELINE_SLOTS 個。
     const PIPELINE_SLOTS: usize = 2;
+
+    // 入力特徴バッファ (f1/f2) を PIPELINE_SLOTS 個ぶん確保。pinned_pool があれば pinned で
+    // 全スロットを一括確保し、1 件でも失敗したら pool を捨てて全スロットを pageable Vec で
+    // 作り直す (all-or-nothing。pinned/pageable 混在を避ける)。pinned_pool への &mut 借用は
+    // ここで完結させ、thread::scope には確保済みバッファ (HostBuf) のみ move する
+    // (pinned_pool は scope 後の drop で free)。
+    let mut slot_bufs: Vec<(HostBuf, HostBuf)> = Vec::with_capacity(PIPELINE_SLOTS);
+    let pinned_ok = if let Some(pool) = pinned_pool.as_mut() {
+        let mut ok = true;
+        for _ in 0..PIPELINE_SLOTS {
+            // 個別に評価してから match (同一 pool への &mut 借用を逐次化する)。
+            let f1 = pool.alloc_zeroed(batch_size * f1_size);
+            let f2 = pool.alloc_zeroed(batch_size * f2_size);
+            match (f1, f2) {
+                (Ok(f1), Ok(f2)) => slot_bufs.push((HostBuf::Pinned(f1), HostBuf::Pinned(f2))),
+                _ => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        ok
+    } else {
+        false
+    };
+    if !pinned_ok {
+        if gpu_id >= 0 {
+            eprintln!(
+                "Warning: CUDA pinned host buffer の確保に失敗。pageable Vec にフォールバックします"
+            );
+        }
+        // ここまでに確保した pinned (slot_bufs 内 + pool.ptrs に登録済) を解放する。
+        // PinnedBuf 自体は Drop を持たず、free は pinned_pool の drop に集約しているため、
+        // 先に slot_bufs を空にしてから pinned_pool を drop する (登録 ptr を 1 回ずつ free)。
+        slot_bufs.clear();
+        drop(pinned_pool.take());
+        for _ in 0..PIPELINE_SLOTS {
+            slot_bufs.push((
+                HostBuf::Paged(vec![0.0f32; batch_size * f1_size]),
+                HostBuf::Paged(vec![0.0f32; batch_size * f2_size]),
+            ));
+        }
+    }
+
     let (t_read, t_build) = thread::scope(|scope| -> Result<(u128, u128)> {
         let (free_tx, free_rx) = mpsc::channel::<PreparedBatch>();
         let (ready_tx, ready_rx) = mpsc::channel::<PreparedBatch>();
-        for _ in 0..PIPELINE_SLOTS {
+        for (f1, f2) in slot_bufs {
             free_tx
                 .send(PreparedBatch {
-                    f1: vec![0.0f32; batch_size * f1_size],
-                    f2: vec![0.0f32; batch_size * f2_size],
+                    f1,
+                    f2,
                     records: Vec::with_capacity(batch_size),
                     stm_flags: vec![false; batch_size],
                     in_checks: vec![false; batch_size],
@@ -3370,6 +3517,8 @@ where
                         leaf_sfens,
                         ..
                     } = &mut slot;
+                    let f1 = f1.as_mut_slice();
+                    let f2 = f2.as_mut_slice();
                     f1[..actual_batch * f1_size].fill(0.0);
                     f2[..actual_batch * f2_size].fill(0.0);
                     let f1_slices: Vec<&mut [f32]> =
@@ -3493,19 +3642,21 @@ where
                 //   毎回新規作成の方が速い。
                 // - output_policy のバインド省略も逆効果（10% 悪化）。
                 //   ORT が未バインド出力の処理にオーバーヘッドを生じる。
-                // - ボトルネックは cudaMemcpyAsync（CPU→GPU 転送）で全体の 96.1%（nsys 計測）。
-                //   転送量削減（FP16 化等）以外での大幅改善は困難。
+                // - 旧実装は pageable な Vec から H2D していたため cudaMemcpyAsync が実質同期
+                //   (CPU staging 介在) となり全体の ~96% を占めていた (nsys)。入力 host バッファを
+                //   pinned (page-locked) 化することでこの staging を消し、真の async H2D にしている
+                //   (HostBuf / PinnedPool 参照)。
                 let shape1: [usize; 4] = [actual_batch, input1_channels, 9, 9];
                 let input1 = TensorRef::<f32>::from_array_view((
                     shape1,
-                    &batch.f1[..actual_batch * f1_size],
+                    &batch.f1.as_slice()[..actual_batch * f1_size],
                 ))
                 .map_err(onnx_ort_err)?;
 
                 let shape2: [usize; 4] = [actual_batch, input2_channels, 9, 9];
                 let input2 = TensorRef::<f32>::from_array_view((
                     shape2,
-                    &batch.f2[..actual_batch * f2_size],
+                    &batch.f2.as_slice()[..actual_batch * f2_size],
                 ))
                 .map_err(onnx_ort_err)?;
 

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -3010,9 +3010,16 @@ impl PinnedPool {
     /// `len` 要素 (f32) 分の pinned バッファを確保しゼロ初期化して返す。
     fn alloc_zeroed(&mut self, len: usize) -> Result<PinnedBuf> {
         let mut block = self.allocator.alloc::<f32>(len).map_err(onnx_ort_err)?;
-        let ptr = block.as_mut_ptr().cast::<f32>();
-        // SAFETY: alloc が len*size_of::<f32>() バイトを確保済み。pinned は CPU からアクセス可。
-        unsafe { std::ptr::write_bytes(ptr, 0, len) };
+        // ゼロ初期化用に block を借用して書き込む（所有権はまだ block 側）。
+        {
+            let zero_ptr = block.as_mut_ptr().cast::<f32>();
+            // SAFETY: alloc が len*size_of::<f32>() バイトを確保済み（pinned は CPU アクセス可）。
+            // write_bytes::<f32>(_, 0, len) は len*size_of::<f32>() = len*4 バイトをゼロ化し、
+            // 確保サイズと一致する。
+            unsafe { std::ptr::write_bytes(zero_ptr, 0, len) };
+        }
+        // 所有権を block から取り出す（以後の free は PinnedPool::drop が担う）。zero_ptr と
+        // 同一アドレスだが、こちらは「移動した所有ポインタ」を表す。
         let ptr = block.into_raw().cast::<f32>();
         self.ptrs.push(ptr);
         Ok(PinnedBuf { ptr, len })
@@ -3387,7 +3394,9 @@ where
     let pinned_ok = if let Some(pool) = pinned_pool.as_mut() {
         let mut ok = true;
         for _ in 0..PIPELINE_SLOTS {
-            // 個別に評価してから match (同一 pool への &mut 借用を逐次化する)。
+            // 個別に評価してから match (同一 pool への &mut 借用を逐次化する)。f1 が Err でも
+            // f2 の確保は走るが、その PinnedBuf は `_` アームで即 drop される。ptr は確保成功時に
+            // pool.ptrs へ登録済みなので PinnedPool::drop で漏れなく free される (リークなし)。
             let f1 = pool.alloc_zeroed(batch_size * f1_size);
             let f2 = pool.alloc_zeroed(batch_size * f2_size);
             match (f1, f2) {


### PR DESCRIPTION
## Summary

- rescore_psv の ONNX 直推論パイプラインの入力特徴 host バッファ (f1/f2) を、GPU 推論時に **CUDA pinned (page-locked) メモリ**で確保する。
- pageable バッファでは `cudaMemcpyAsync` が pageable→pinned ステージング (CPU 介在) で実質同期化し、nsys 計測で H2D が全処理の ~96% を占めていた。pinned 化でこの staging が消え**真の async H2D** になる。
- 出力は pageable と **byte 一致**（メモリ配置のみの変更）。pinned 確保失敗時 / CPU 推論時は pageable に自動フォールバック。

## 計測 (2M records, batch 1024, RTX 5090/WSL2, min-of-3, 出力 byte 一致)

| EP / 精度 | host buffer | pos/s |
|---|---|---|
| CUDA EP (FP32) | pageable (現行) | 44.8k |
| CUDA EP (FP32) | **pinned** | **54.1k (+21%)** |
| TensorRT (FP16) | pageable (現行) | 132k |
| TensorRT (FP16) | **pinned** | **167k (+26%)** |

nsys (CUDA API): `cudaMemcpyAsync` 時間割合 pageable **35.7%** (avg 780µs/call=実質同期) → pinned **9.2%** (avg 191µs/call=真 async)。

## 実装

- `HostBuf{Paged(Vec<f32>)|Pinned(PinnedBuf)}` / `PinnedBuf{ptr,len}` / `PinnedPool{allocator, ptrs}` を追加。
- ort の `Allocator` は `Send` だが `Sync` でない（CUDA allocator はマルチスレッドで crash しうると ort 側に明記）。`AllocatedBlock<'a>` は `&Allocator` を持ち channel 越えに `Send` 不可なため、pinned block を `into_raw()` で生ポインタ化し `unsafe impl Send for PinnedBuf` でスロットへ載せ、producer→consumer に mpsc channel で move 移送する。解放は `PinnedPool::drop` に一元化（登録 ptr を 1 回ずつ free）。
- pinned 確保は all-or-nothing。1 件でも失敗したら pool を drop し全スロットを pageable で再構築（pinned/pageable 混在を回避）。

## FP16 入力について（本 PR では見送り）

入力 FP16 化（H2D バイト半減）も実装・実測したが、**pinned 適用後は H2D が支配項でなくなる**ため本番 batch では +1-2%（誤差内、大 batch でも ~8%）に留まり、TensorRT FP16 engine で f32-input と出力が bit 一致せず default 化に追加検証が要る。利得が小さく複雑性が高いため本 PR には含めない。詳細は #811 のコメント参照。

## 関連

- Refs #811

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p tools --features dlshogi-onnx --bin rescore_psv --tests` warning 0
- [x] `cargo test -p tools --features dlshogi-onnx` 全 pass
- [x] `scripts/check-tracked-abs-paths.sh` OK
- [x] 出力が pageable 実装と byte 一致（cmp 一致, TRT/CUDA EP 両方）
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)