### PR TITLE
perf(tools/rescore_psv): 内部NNUE評価をparts直接構築にし約3.3x高速化

### DIFF
--- a/crates/rshogi-core/src/position/sfen.rs
+++ b/crates/rshogi-core/src/position/sfen.rs
@@ -822,7 +822,7 @@ mod tests {
 
             any_in_check |= from_sfen.in_check();
         }
-        // in_check() == true の局面を最低 1 件は通し、王手計算の parity を実際に検証する。
-        assert!(any_in_check, "王手局面が含まれていない（テストの意味が薄れる）");
+        // 王手計算の parity を実際に検証するため、in_check() == true の局面を最低 1 件通す。
+        assert!(any_in_check, "王手局面を最低 1 件含むこと");
     }
 }

--- a/crates/rshogi-core/src/position/sfen.rs
+++ b/crates/rshogi-core/src/position/sfen.rs
@@ -3,7 +3,7 @@
 use crate::eval::material::compute_material_value;
 use crate::nnue::piece_list::piece_number_base;
 use crate::nnue::{ExtBonaPiece, PieceNumber};
-use crate::types::{Color, File, Piece, PieceType, Rank, Square};
+use crate::types::{Color, File, Hand, Piece, PieceType, Rank, Square};
 
 use super::pos::{Position, is_minor_piece};
 use super::zobrist::{zobrist_hand, zobrist_no_pawns, zobrist_psq, zobrist_side};
@@ -78,6 +78,48 @@ impl Position {
             self.game_ply = 1;
         }
 
+        self.finalize_after_population()
+    }
+
+    /// SFEN 文字列を経ずに、盤面・手駒・手番から局面を構築する。
+    ///
+    /// `set_sfen` の文字列パース（`generate_sfen` 由来の `String` 生成や `split` の `Vec` 確保）
+    /// を避けたいホットパス（PSV → 局面の大量変換など）向け。`board` はマス index（0..81、
+    /// `Square` の index と同順）で空マスは `Piece::NONE`、`hand` は `[先手, 後手]`。手数は 1
+    /// に設定する（PSV 変換用途では手数は評価に影響しない）。`set_sfen` と同じ後処理
+    /// （PieceList / ハッシュ / 利き / pin / 王手 / material の再計算と在庫検証）を通すため、
+    /// 得られる局面は同一盤面を `set_sfen` で構築したものと一致する。
+    pub fn set_from_parts(
+        &mut self,
+        board: &[Piece; Square::NUM],
+        hand: &[Hand; Color::NUM],
+        side_to_move: Color,
+    ) -> Result<(), SfenError> {
+        *self = Position::new();
+
+        for (sq_idx, &pc) in board.iter().enumerate() {
+            if pc.is_none() {
+                continue;
+            }
+            // sq_idx は 0..Square::NUM(81) なので from_u8 は必ず Some。
+            let sq = Square::from_u8(sq_idx as u8)
+                .ok_or_else(|| SfenError::Board(format!("Invalid square index: {sq_idx}")))?;
+            self.put_piece(pc, sq);
+            if pc.piece_type() == PieceType::King {
+                self.king_square[pc.color().index()] = sq;
+            }
+        }
+
+        self.hand = *hand;
+        self.side_to_move = side_to_move;
+        self.game_ply = 1;
+
+        self.finalize_after_population()
+    }
+
+    /// 盤面・手駒・手番を投入済みの状態から、PieceList・ハッシュ・利き・pin・王手・material を
+    /// 再計算し、駒在庫を検証して局面を確定する（`set_sfen` / `set_from_parts` 共通の後処理）。
+    fn finalize_after_population(&mut self) -> Result<(), SfenError> {
         self.validate_piece_inventory()?;
 
         // PieceList の初期化
@@ -737,5 +779,40 @@ mod tests {
         assert_eq!(piece_to_sfen(Piece::W_PAWN), "p");
         assert_eq!(piece_to_sfen(Piece::B_PRO_PAWN), "+P");
         assert_eq!(piece_to_sfen(Piece::W_HORSE), "+b");
+    }
+
+    #[test]
+    fn test_set_from_parts_matches_set_sfen() {
+        // set_from_parts（String を経由しない構築）が、同一盤面を set_sfen で構築した
+        // 局面と一致することを保証する。手駒・成り駒・駒落ち・後手番を網羅。
+        // 手数は set_from_parts が 1 固定のため、SFEN 側も手数 1 で揃える。
+        let sfens = [
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPP1P/1B5R1/LNSGKGSNL b P 1",
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1+B5R1/LNSGKGSNL w - 1",
+            "lnsgkgsn1/1r5b1/ppppppppp/9/9/9/1PPPPPPPP/1B5R1/LNSGKGSN1 b - 1",
+            "9/9/9/9/4k4/9/9/9/4K4 w 2G2g 1",
+        ];
+        for sfen in sfens {
+            let mut from_sfen = Position::new();
+            from_sfen.set_sfen(sfen).expect("set_sfen should succeed");
+
+            // 構築済み局面から素の要素を取り出す
+            let mut board = [Piece::NONE; Square::NUM];
+            for (i, cell) in board.iter_mut().enumerate() {
+                let sq = Square::from_u8(i as u8).expect("valid square index");
+                *cell = from_sfen.piece_on(sq);
+            }
+            let hand = [from_sfen.hand(Color::Black), from_sfen.hand(Color::White)];
+
+            let mut from_parts = Position::new();
+            from_parts
+                .set_from_parts(&board, &hand, from_sfen.side_to_move())
+                .expect("set_from_parts should succeed");
+
+            assert_eq!(from_parts.to_sfen(), from_sfen.to_sfen(), "sfen mismatch for {sfen}");
+            assert_eq!(from_parts.key(), from_sfen.key(), "key mismatch for {sfen}");
+            assert_eq!(from_parts.in_check(), from_sfen.in_check(), "in_check mismatch for {sfen}");
+        }
     }
 }

--- a/crates/rshogi-core/src/position/sfen.rs
+++ b/crates/rshogi-core/src/position/sfen.rs
@@ -101,11 +101,13 @@ impl Position {
             if pc.is_none() {
                 continue;
             }
-            // sq_idx は 0..Square::NUM(81) なので from_u8 は必ず Some。
+            // sq_idx は board.iter() の添字で 0..Square::NUM(81) の範囲内。範囲外になるのは
+            // 入力エラーではなく内部不変条件の破壊（ロジックバグ）なので panic させる。
             let sq = Square::from_u8(sq_idx as u8)
-                .ok_or_else(|| SfenError::Board(format!("Invalid square index: {sq_idx}")))?;
+                .expect("sq_idx は 0..Square::NUM の範囲内であり from_u8 は必ず Some");
             self.put_piece(pc, sq);
             if pc.piece_type() == PieceType::King {
+                // put_piece は king_square を更新しないため、parse_board と同様に明示的にセットする。
                 self.king_square[pc.color().index()] = sq;
             }
         }
@@ -792,7 +794,11 @@ mod tests {
             "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1+B5R1/LNSGKGSNL w - 1",
             "lnsgkgsn1/1r5b1/ppppppppp/9/9/9/1PPPPPPPP/1B5R1/LNSGKGSN1 b - 1",
             "9/9/9/9/4k4/9/9/9/4K4 w 2G2g 1",
+            // 手番側（先手）が王手を受けている局面。先手玉 5e を後手飛車 5a が同一筋で王手。
+            // finalize_after_population の王手計算が set_from_parts でも働くことを確認する。
+            "4r4/9/9/9/4K4/9/9/9/4k4 b - 1",
         ];
+        let mut any_in_check = false;
         for sfen in sfens {
             let mut from_sfen = Position::new();
             from_sfen.set_sfen(sfen).expect("set_sfen should succeed");
@@ -813,6 +819,10 @@ mod tests {
             assert_eq!(from_parts.to_sfen(), from_sfen.to_sfen(), "sfen mismatch for {sfen}");
             assert_eq!(from_parts.key(), from_sfen.key(), "key mismatch for {sfen}");
             assert_eq!(from_parts.in_check(), from_sfen.in_check(), "in_check mismatch for {sfen}");
+
+            any_in_check |= from_sfen.in_check();
         }
+        // in_check() == true の局面を最低 1 件は通し、王手計算の parity を実際に検証する。
+        assert!(any_in_check, "王手局面が含まれていない（テストの意味が薄れる）");
     }
 }

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -167,6 +167,12 @@ cargo run --release -p tools --features dlshogi-onnx --bin rescore_psv -- \
 | `--max-ply` | 16 | qsearch の最大深さ（`--qsearch-leaf-label` の葉探索でも使用） |
 | `--threads` | 1 | 処理スレッド数（rayon による特徴量構築の並列化） |
 
+> **性能メモ（内部 NNUE 評価モード）**: PSV → 局面の復元は SFEN 文字列・`Position::set_sfen`
+> を経由せず `unpack_sfen_to_parts` → `Position::set_from_parts` で直接構築する（per-record の
+> `String`/`Vec` 確保を排除）。これにより多スレッド時の malloc 競合（kernel 時間）が解消され、
+> 静的 NNUE 評価で 1M 件 4.99s→1.51s（約 3.3x、system time 63.5s→0.6s、出力 bit 一致）を確認。
+> 外部 USI エンジン / ONNX モードは SFEN 文字列が必要なため従来経路のまま（GPU 律速で影響は軽微）。
+
 ### ポリシー展開オプション（`--expand-output-dir` 指定時）
 
 | オプション | デフォルト | 説明 |

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -63,7 +63,7 @@ use std::time::{Duration, Instant};
 use rshogi_core::nnue::init_nnue;
 use rshogi_core::position::Position;
 use rshogi_core::search::{LimitsType, Search};
-use tools::packed_sfen::{PackedSfenValue, pack_position, unpack_sfen};
+use tools::packed_sfen::{PackedSfenValue, pack_position, unpack_sfen, unpack_sfen_to_parts};
 use tools::qsearch_pv::{NnueStacks, apply_pv, qsearch_with_pv_nnue};
 
 /// 探索用スタックサイズ（64MB）
@@ -1624,15 +1624,15 @@ fn process_record(
         None => return ProcessResult::Error(anyhow::anyhow!("Failed to parse PackedSfenValue")),
     };
 
-    // PackedSfen → SFEN → Position
-    let sfen = match unpack_sfen(&psv.sfen) {
-        Ok(s) => s,
+    // PackedSfen → 局面（String/Position 経由の往復を避け、parts から直接構築）
+    let parts = match unpack_sfen_to_parts(&psv.sfen) {
+        Ok(p) => p,
         Err(e) => return ProcessResult::Error(anyhow::anyhow!("Failed to unpack SFEN: {e}")),
     };
 
     let mut pos = Position::new();
-    if let Err(e) = pos.set_sfen(&sfen) {
-        return ProcessResult::Error(anyhow::anyhow!("Failed to set SFEN: {e:?}"));
+    if let Err(e) = pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move) {
+        return ProcessResult::Error(anyhow::anyhow!("Failed to set position: {e:?}"));
     }
 
     // 王手局面をスキップ
@@ -1946,15 +1946,15 @@ fn process_record_with_search(
         None => return ProcessResult::Error(anyhow::anyhow!("Failed to parse PackedSfenValue")),
     };
 
-    // PackedSfen → SFEN → Position
-    let sfen = match unpack_sfen(&psv.sfen) {
-        Ok(s) => s,
+    // PackedSfen → 局面（String/Position 経由の往復を避け、parts から直接構築）
+    let parts = match unpack_sfen_to_parts(&psv.sfen) {
+        Ok(p) => p,
         Err(e) => return ProcessResult::Error(anyhow::anyhow!("Failed to unpack SFEN: {e}")),
     };
 
     let mut pos = Position::new();
-    if let Err(e) = pos.set_sfen(&sfen) {
-        return ProcessResult::Error(anyhow::anyhow!("Failed to set SFEN: {e:?}"));
+    if let Err(e) = pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move) {
+        return ProcessResult::Error(anyhow::anyhow!("Failed to set position: {e:?}"));
     }
 
     // 王手局面をスキップ


### PR DESCRIPTION
## 概要
`rescore_psv` の**内部 NNUE 評価モード**の PSV→局面復元を、`unpack_sfen`→`String`→`Position::set_sfen` の往復から `unpack_sfen_to_parts`→`Position::set_from_parts` の直接構築に置換し、per-record の `String`/`Vec` 確保を排除する。165億局面の静的 NNUE スコアリングを見据えた CPU 経路の高速化。

## 動機（実測）
静的 NNUE eval は CPU 律速で、per-record のヒープ確保（`unpack_sfen` の `String` + `set_sfen` の `split` `Vec`）が多スレッド時に malloc 競合を起こし、**system time がボトルネック**だった。

| metric (32コア機, 静的NNUE eval, 1M件) | BEFORE | AFTER |
|---|---|---|
| Elapsed | 4.99s | **1.51s（約3.3x）** |
| System time | 63.5s | **0.61s** |
| throughput | ~200k rec/s | **~662k rec/s** |
| 出力 sha256 | `0317ca3c…` | 同一（**bit一致**） |

→ 16.5B 静的スコアリングの試算が ~23h → ~7h。

## 変更点
### rshogi-core `Position`
- `set_sfen` の後処理（`validate_piece_inventory` / `init_piece_list` / `compute_hash` / `update_blockers_and_pinners` / `update_check_squares` / `recompute_board_effects` / checkers / material）を `finalize_after_population()` に抽出。**`set_sfen` は挙動不変**（パース後に finalize を呼ぶだけ）。
- `set_from_parts(board: &[Piece; 81], hand: &[Hand; 2], side_to_move)` を追加。SFEN 文字列を経ず `put_piece` で盤面を構築し、手数=1 にして同じ `finalize_after_population` を通す。同一盤面を `set_sfen` で構築した局面と一致。
- parity テスト `test_set_from_parts_matches_set_sfen`（`to_sfen`/`key`/`in_check` 一致、手駒・成り・駒落ち・後手番を網羅）を追加。

### rescore_psv
- 内部 NNUE 評価の 2 つの call site を直接構築へ置換。
- **外部 USI エンジン / ONNX バッチモードは SFEN 文字列が必要なため従来経路を維持**（GPU/外部プロセス律速で per-record malloc は支配的でない）。

### doc
- `rescore_psv.md` に性能メモを追記（内部実装の高速化で CLI/出力/セマンティクスは不変）。

## 後方互換
`set_sfen` のリファクタは純粋な抽出で順序・副作用とも不変。`game_ply=1` 固定は、旧経路も `unpack_sfen`→`generate_sfen` が手数を `1` でハードコードしていたため search 経路含め回帰なし（PSV は手数を持たない）。

## テスト / gate
- `cargo fmt --check` clean、`cargo clippy --workspace --all-targets -- -D warnings` 警告0、`cargo test -p rshogi-core -p tools` 1317 passed 0 failed（parity 含む）。
- bit一致: 静的 NNUE eval 1M件の出力が変更前と sha256 完全一致。

> 注: ローカル workspace 全テストで `rshogi-csa-server-tcp::transport::tests::send_line_appends_crlf` が落ちるが、これは **origin/main(c58c59b5) でも同様に落ちる pre-existing な環境依存（WSL2 loopback の短 read）**で本変更と無関係。CI の Test job では green。

## レビュー
ローカルで独立 2 reviewer（Codex + Claude）の APPROVE 取得済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)