### PR TITLE
fix(deps): quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1538,7 +1538,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- CI の Security Audit (`cargo audit --deny warnings`) が検出した **RUSTSEC-2026-0185**（`quinn-proto` の out-of-order stream reassembly によるリモートメモリ枯渇、severity 7.5）を解消。
- `cargo update -p quinn-proto` で **0.11.14 → 0.11.15**（advisory 推奨の修正版 `>=0.11.15`、semver 互換 patch bump）。`reqwest → quinn → quinn-proto` の transitive 依存で、**Cargo.lock のみ**変更（Cargo.toml 不変）。
- 追随で quinn-proto の依存エッジ `windows-sys 0.52.0 → 0.60.2`（lock に既存・他 crate でも使用、新規追加/削除なし）。

## Test plan

- [x] `cargo audit` exit 0（RUSTSEC-2026-0185 解消を確認）
- [x] `cargo build --workspace` exit 0
- [x] local reviewer (Codex) APPROVE

## 関連

- これにより main / 各 PR の Security Audit ジョブが緑に戻る（feature PR #817 の唯一の赤もこれ起因）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)