### PR TITLE
fix(search): SE 探索爆発で fixed-depth 探索が非終了になる問題を修正 (#816)

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2698,6 +2698,14 @@ impl SearchWorker {
                         + (singular_value < singular_beta - Value::new(double_margin)) as i32
                         + (singular_value < singular_beta - Value::new(triple_margin)) as i32;
 
+                    // engine 自身に打ち切り予算（時間・ノード・infinite）が無い深さ固定探索では、
+                    // double/triple 延長が child の探索深さを親より深くし続け、置換表飽和下で
+                    // 延長が連鎖して探索木が爆発し `go depth N` が事実上終了しなくなる。止める
+                    // 手段が無いため、この場合のみ単延長に制限して net の深さ成長を抑え終了を保証する。
+                    if !limits.has_interrupt_budget() {
+                        extension = extension.min(1);
+                    }
+
                     // singular確定時にdepthを+1
                     depth += 1;
                 } else if singular_value >= beta && !singular_value.is_mate_score() {

--- a/crates/rshogi-core/src/search/limits.rs
+++ b/crates/rshogi-core/src/search/limits.rs
@@ -170,16 +170,18 @@ impl LimitsType {
     /// 「実際に enforce される停止条件」のみを予算とみなす:
     /// - `use_time_management()`: 純粋な時間管理が有効で時間で停止する（`go depth N btime T` の
     ///   ように depth 併用だと時間管理は無効化されるため `true` にならず、この場合は cap 対象）。
-    /// - movetime / rtime: 固定思考時間で停止（depth 併用でも enforce される）。
+    ///   `rtime` は `time_manager.init` でこの判定が真のときだけ反映されるため（depth 併用時は
+    ///   `!use_time_management()` の早期 return より後で処理され enforce されない）、ここでは
+    ///   独立項を持たず `use_time_management()` に内包する。
+    /// - movetime: 固定思考時間。`time_manager.init` の最初に処理され depth 併用でも enforce される。
     /// - nodes: ノード数で停止。
     /// - infinite: `stop` で打ち切り可能。
+    ///
+    /// なお `go perft N` は `use_time_management()` が `false` になり「予算なし」扱いだが、
+    /// perft は alpha-beta を通らず SE に到達しないため cap は発火しない（実害なし）。
     #[inline]
     pub fn has_interrupt_budget(&self) -> bool {
-        self.use_time_management()
-            || self.movetime != 0
-            || self.rtime != 0
-            || self.nodes != 0
-            || self.infinite
+        self.use_time_management() || self.movetime != 0 || self.nodes != 0 || self.infinite
     }
 }
 
@@ -271,21 +273,21 @@ mod tests {
         l.mate = 5;
         assert!(!l.has_interrupt_budget());
 
-        // 純粋な時間管理（depth 併用なし）は予算あり。increment のみ（go binc）も時間管理が有効。
+        // 純粋な時間管理（depth 併用なし）は予算あり。increment のみ（go binc）・rtime 単独も時間管理が有効。
         for set in [
             |l: &mut LimitsType| l.time[Color::Black.index()] = 60000,
             |l: &mut LimitsType| l.byoyomi[Color::Black.index()] = 30000,
             |l: &mut LimitsType| l.inc[Color::Black.index()] = 1000,
+            |l: &mut LimitsType| l.rtime = 1000,
         ] {
             let mut l = LimitsType::new();
             set(&mut l);
             assert!(l.has_interrupt_budget());
         }
 
-        // movetime / rtime / nodes / infinite は depth 併用でも enforce されるため予算あり
+        // movetime / nodes / infinite は depth 併用でも enforce されるため予算あり
         for set in [
             |l: &mut LimitsType| l.movetime = 1000,
-            |l: &mut LimitsType| l.rtime = 1000,
             |l: &mut LimitsType| l.nodes = 100000,
             |l: &mut LimitsType| l.infinite = true,
         ] {
@@ -294,6 +296,13 @@ mod tests {
             set(&mut l);
             assert!(l.has_interrupt_budget());
         }
+
+        // depth + rtime は time_manager.init で rtime 処理前に !use_time_management() で早期 return
+        // され rtime が enforce されない → 予算なし扱い（cap 対象）
+        let mut l = LimitsType::new();
+        l.depth = 15;
+        l.rtime = 1000;
+        assert!(!l.has_interrupt_budget());
 
         // depth と残り時間/秒読みの併用は時間管理が無効化される（time MAX/2 で実 enforce されない）
         // ため予算なし扱い → cap 対象とし、この組合せでもハングしないようにする

--- a/crates/rshogi-core/src/search/limits.rs
+++ b/crates/rshogi-core/src/search/limits.rs
@@ -159,6 +159,28 @@ impl LimitsType {
     pub fn has_movetime(&self) -> bool {
         self.movetime > 0
     }
+
+    /// 暴走探索を engine 自身が打ち切れる予算（時間・ノード・infinite）を持つか。
+    ///
+    /// `false`（深さ／詰み目標の完了のみで停止し、時間もノードも `stop` も効かない探索）の場合、
+    /// Singular Extension の double/triple 延長が置換表飽和下で連鎖して探索木が
+    /// 深さ方向に成長し続けても止める手段が無く、`go depth N` が事実上終了しなくなる。
+    /// この判定が `false` のときだけ SE 延長を単延長に制限して終了を保証する。
+    ///
+    /// 「実際に enforce される停止条件」のみを予算とみなす:
+    /// - `use_time_management()`: 純粋な時間管理が有効で時間で停止する（`go depth N btime T` の
+    ///   ように depth 併用だと時間管理は無効化されるため `true` にならず、この場合は cap 対象）。
+    /// - movetime / rtime: 固定思考時間で停止（depth 併用でも enforce される）。
+    /// - nodes: ノード数で停止。
+    /// - infinite: `stop` で打ち切り可能。
+    #[inline]
+    pub fn has_interrupt_budget(&self) -> bool {
+        self.use_time_management()
+            || self.movetime != 0
+            || self.rtime != 0
+            || self.nodes != 0
+            || self.infinite
+    }
 }
 
 // =============================================================================
@@ -237,6 +259,52 @@ mod tests {
         let elapsed = limits.elapsed();
         assert!(elapsed >= 10);
         assert!(elapsed < 1000); // 1秒以内
+    }
+
+    #[test]
+    fn test_has_interrupt_budget() {
+        // 純粋な depth 固定（go depth N）・詰み探索は engine 自身の打ち切り予算なし → cap 対象
+        let mut l = LimitsType::new();
+        l.depth = 15;
+        assert!(!l.has_interrupt_budget());
+        let mut l = LimitsType::new();
+        l.mate = 5;
+        assert!(!l.has_interrupt_budget());
+
+        // 純粋な時間管理（depth 併用なし）は予算あり。increment のみ（go binc）も時間管理が有効。
+        for set in [
+            |l: &mut LimitsType| l.time[Color::Black.index()] = 60000,
+            |l: &mut LimitsType| l.byoyomi[Color::Black.index()] = 30000,
+            |l: &mut LimitsType| l.inc[Color::Black.index()] = 1000,
+        ] {
+            let mut l = LimitsType::new();
+            set(&mut l);
+            assert!(l.has_interrupt_budget());
+        }
+
+        // movetime / rtime / nodes / infinite は depth 併用でも enforce されるため予算あり
+        for set in [
+            |l: &mut LimitsType| l.movetime = 1000,
+            |l: &mut LimitsType| l.rtime = 1000,
+            |l: &mut LimitsType| l.nodes = 100000,
+            |l: &mut LimitsType| l.infinite = true,
+        ] {
+            let mut l = LimitsType::new();
+            l.depth = 15;
+            set(&mut l);
+            assert!(l.has_interrupt_budget());
+        }
+
+        // depth と残り時間/秒読みの併用は時間管理が無効化される（time MAX/2 で実 enforce されない）
+        // ため予算なし扱い → cap 対象とし、この組合せでもハングしないようにする
+        let mut l = LimitsType::new();
+        l.depth = 15;
+        l.time[Color::Black.index()] = 60000;
+        assert!(!l.has_interrupt_budget());
+        let mut l = LimitsType::new();
+        l.depth = 15;
+        l.byoyomi[Color::Black.index()] = 30000;
+        assert!(!l.has_interrupt_budget());
     }
 
     #[test]


### PR DESCRIPTION
## 問題 (#816)
置換表が蓄積した状態 (engine プロセス再利用) の fixed-depth selfplay (`go depth N`) で、特定局面の探索が目標深さに達せず事実上ハングする。tournament 実バイナリで再現し、engine 側の本物バグ。fresh engine (空 TT) では同一局面が正常終了する。

## 根因 (計測で確定)
- **非 cyclic**: deep node 8000 サンプルで現局面 board_key が探索 path 祖先と **99.8% 不一致・真の千日手 0** → cuckoo / `upcoming_repetition` は発火せず非対象。
- **Singular Extension の double/triple 延長**が主駆動: child の `new_depth` を親 depth より深くし (ext=3 で +2)、置換表飽和下で SE 入口条件 (`tt_data.depth >= depth - margin`) が広く通る feedback で延長が連鎖、探索木が指数的に成長 (有限だが巨大、fixed-depth では実質ハング)。SE 確定 16000 件中 double 92.7%/triple 46.5% 発火、non-capture ttMove の 85% が triple。
- rshogi SE は YaneuraOu と byte 一致。時間/ノード制限が無い fixed-depth でのみ露出する **inherent な lineage 問題** (YO/SF も同条件なら爆発しうる。YO の `upcoming_repetition` は `#if STOCKFISH` で通常無効)。

## 修正
engine 自身に打ち切り予算 (実 enforce される時間管理 / movetime / rtime / nodes / infinite) が無い探索でのみ、SE を単延長に制限 (`extension.min(1)`) して net の深さ成長を抑え終了を保証する。

- **timed / nodes / infinite 探索は条件分岐が false で探索 bit-identical** → 通常対局の棋力は不変。`go nodes 2000000` を hang 局面に投げ baseline と `BEST/DEPTH/NODES/PV` 完全一致を確認。
- `depth + btime` 併用は時間管理が無効化され実 enforce されないため cap 対象に含める (レビュー指摘反映)。
- 純 fixed-depth (唯一の hang ケース) でのみ単延長に制限。eval ワークフロー (fixed-depth selfplay) は決定的に終了する。

## 検証
- fixed-depth hang3 局面: **完走** (baseline はハングし 1 局のみ)
- `go nodes 2000000`: baseline と **bit-identical**
- ply100 深局面 20 局: ハングなし、手数正常 (一部 512 手 max-moves 引き分け)
- `cargo test -p rshogi-core`: 961+31 passed、fmt/clippy 警告 0、abs-paths OK
- local 2 reviewer (Codex + Claude) **Approve**

計測の詳細・instrumentation コード・候補 sweep: private notes `rshogi/20260623-hang816-rootcause/se_explosion_noncyclic_measured.md`

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
