### PR TITLE
ci(tools): ONNX 無効フォールバック経路を CI clippy 対象化 + fallback main 統一

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -96,6 +96,11 @@ jobs:
           cache-on-failure: true
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # workspace clippy は default features (dlshogi-onnx 有効) で走るため、tools の
+      # #[cfg(not(feature = "dlshogi-onnx"))] フォールバック経路を踏まない。ONNX 依存を
+      # 外した構成でも lint し、その分岐の warning を検出する。
+      - name: Run Clippy (tools, ONNX 依存無効)
+        run: cargo clippy -p tools --no-default-features --features nnue-arch --all-targets -- -D warnings
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -8,17 +8,21 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/SH11235/rshogi"
 
 [features]
-default = [
+# default は解析対象 NNUE アーキテクチャ集合 (nnue-arch) と DL 教師リスコア用 ONNX
+# (dlshogi-onnx) から成る。ort は load-dynamic なので dlshogi-onnx を default にしても
+# build 時に libonnxruntime は不要 (実行時 dlopen)。両者を分離しておくことで ONNX 依存
+# だけを外したビルド (`--no-default-features --features nnue-arch`) を表現でき、CI も
+# その構成 (ONNX 無効フォールバック経路) を lint できる。
+default = ["nnue-arch", "dlshogi-onnx"]
+
+# 解析対象 NNUE アーキテクチャ (LayerStack L1 サイズ + FT variant 5 種) の既定集合。
+nnue-arch = [
     "layerstacks-1536x16x32",
     "ft-halfkp",
     "ft-halfka_split",
     "ft-halfka_merged",
     "ft-halfka_hm_split",
     "ft-halfka_hm_merged",
-    # DL 教師リスコア (rescore_psv --dlshogi-onnx-model 等) を追加フラグ無しの
-    # default build で使えるようにする。ort は load-dynamic なので build 時に
-    # libonnxruntime は不要 (ONNX Runtime は実行時に dlopen)。
-    "dlshogi-onnx",
 ]
 # 診断ログ（EvalHashヒット率など）
 diagnostics = ["rshogi-core/diagnostics"]

--- a/crates/tools/docs/label_bench_dl.md
+++ b/crates/tools/docs/label_bench_dl.md
@@ -6,7 +6,7 @@
 
 ## ビルド
 
-ONNX 推論に使う `dlshogi-onnx` は default feature なので、追加フラグ無しの default build でそのまま動きます（`ort` は load-dynamic のため build 時に libonnxruntime は不要、ONNX Runtime は実行時に dlopen）。`dlshogi-onnx` を外したビルド（`--no-default-features` で default 一式を外す等）ではコンパイルは通りますが、実行すると再ビルド手順を案内して終了します。
+ONNX 推論に使う `dlshogi-onnx` は default feature なので、追加フラグ無しの default build でそのまま動きます（`ort` は load-dynamic のため build 時に libonnxruntime は不要、ONNX Runtime は実行時に dlopen）。`dlshogi-onnx` を外したビルド（ONNX 依存だけ外すなら `--no-default-features --features nnue-arch`）ではコンパイルは通りますが、実行すると再ビルド手順を案内して終了します。
 
 ```bash
 cargo build --release -p tools --bin label_bench_dl

--- a/crates/tools/src/bin/label_bench_dl.rs
+++ b/crates/tools/src/bin/label_bench_dl.rs
@@ -5,8 +5,8 @@
 //! 後段で ground truth の `eval_deep` とクラス別に比較するための入力を作る。
 //!
 //! `dlshogi-onnx` は default feature なので、追加フラグ無しの default build で推論が動く。
-//! `dlshogi-onnx` を外したビルド (`--no-default-features` 等) でもコンパイルは通り、実行時に
-//! 再ビルド手順を案内して終了する。
+//! `dlshogi-onnx` を外したビルド (ONNX 依存だけなら `--no-default-features --features nnue-arch`)
+//! でもコンパイルは通り、実行時に再ビルド手順を案内して終了する。
 
 use clap::Parser;
 #[cfg(any(feature = "dlshogi-onnx", test))]
@@ -75,12 +75,11 @@ fn insert_field(mut obj: Map<String, Value>, field: &str, value: i32) -> Map<Str
 }
 
 #[cfg(not(feature = "dlshogi-onnx"))]
-fn main() {
-    eprintln!(
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!(
         "label_bench_dl requires the 'dlshogi-onnx' feature (on by default; this build disabled it).\n\
          Rebuild with default features: cargo build --release -p tools --bin label_bench_dl"
-    );
-    std::process::exit(1);
+    )
 }
 
 #[cfg(feature = "dlshogi-onnx")]


### PR DESCRIPTION
## Summary

PR #824（`tools` の `dlshogi-onnx` を default feature 化）の follow-up 2 点。

- **(A) CI カバレッジ・ギャップ**: CI の `clippy --workspace --all-targets` は default features（`dlshogi-onnx` 有効）のみで走るため、`tools` の `#[cfg(not(feature = "dlshogi-onnx"))]` フォールバック経路（ONNX 無効時の案内 error）が一度も lint されていなかった。
- **(B) フォールバック機構の不統一**: `label_bench_dl.rs` の ONNX 無効 main は `eprintln!`+`std::process::exit(1)`、`rescore_psv.rs` / `expand_psv_from_policy.rs` は `anyhow::bail!`。

## 変更

| 項目 | 内容 |
|---|---|
| `crates/tools/Cargo.toml` | 既定 arch feature 6 個（`layerstacks-1536x16x32` + `ft-*` 5 種）を `nnue-arch` bundle に括り、`default = ["nnue-arch", "dlshogi-onnx"]` に再構成。**feature 解決は不変**（default build は従来と同一集合）。 |
| `.github/workflows/rust-ci.yml` | `lint` job に `cargo clippy -p tools --no-default-features --features nnue-arch --all-targets -- -D warnings` を追加。フォールバック経路を lint する。この構成は `ort`/`ndarray` を一切 compile しないため ORT 無し runner で安全。 |
| `crates/tools/src/bin/label_bench_dl.rs` | ONNX 無効 main を `eprintln!`+`exit(1)` → `-> anyhow::Result<()>` + `anyhow::bail!` に変更。`rescore_psv` / `expand` と機構統一。**出力先（stderr）と exit code（1）は不変**。anyhow `Termination` によりメッセージ先頭に `Error: ` が付く形式となり、3 binary で揃う（両 main の signature も一致）。 |
| `crates/tools/docs/label_bench_dl.md` | opt-out 記述を `--no-default-features --features nnue-arch` に精緻化。 |

`nnue-arch` が必要な理由: `tools` を zero-features（`--no-default-features` のみ）で lint すると arch 系コードが dead-code となり 27 warnings で `-D warnings` に通らない。default の arch 集合を bundle として表現することで ONNX-off lint と opt-out の双方を簡潔に書ける。

## Test plan

- [x] `cargo build`/`tree` で default が従来と同一 feature 集合に解決されることを確認
- [x] `cargo clippy --workspace --all-targets -- -D warnings`（default, ONNX path）exit 0
- [x] `cargo clippy -p tools --no-default-features --features nnue-arch --all-targets -- -D warnings`（**新 CI step**、clean rebuild から）exit 0 → CI の Clippy Lint job でも green
- [x] フォールバック `label_bench_dl` 実行: exit code 1 + stderr 出力（`Error: ` プレフィックス付き、anyhow `Termination`）
- [x] `cargo test -p tools` / `cargo fmt --all -- --check` / `check-tracked-abs-paths.sh` / YAML 構文
- [x] local reviewer #1（Codex）APPROVE
- [x] local reviewer #2（汎用）APPROVE — 新 step に lint を注入して「default では素通り・新 step で検出（exit 101）」を実証

## 既知の follow-up（本 PR 非スコープ）

CI の正方向 feature 分岐（`feature = "aobazero-onnx"` の ONNX 推論コード）や `diagnostics` / `nnue-threat` 等の cfg 分岐は依然 default clippy の対象外。本 PR は `dlshogi-onnx` フォールバックのギャップ解消に限定。完全な feature-matrix lint は別途検討。