### PR TITLE
test(threat): incremental==refresh coverage over all legal moves

### DIFF
--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -1888,13 +1888,19 @@ mod tests {
     }
 
     /// 複数局面の全合法手で差分更新(append_changed)を full refresh と照合する網羅テスト。
-    /// slider の blocker 変化(取り/成り/打ち)を広くカバーするため、成駒・手駒・開き線を含む
-    /// 中盤局面を入れる。
+    /// slider の blocker 変化(取り/成り/開き線/大駒打ち)を広くカバーするため、成駒・手駒(大駒含む)・
+    /// 密集局面を入れる。
     #[test]
     fn test_changed_indices_all_legal_moves() {
         let sfens = [
+            // 平手初形
             "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+            // 成駒(+B)・開き線のある中盤
             "+Bn1g2s1l/2skg2r1/ppppp1n1p/5bpp1/5p1P1/2P6/PP1PP1P1P/1SK2S1R1/LN1G1G1NL w Lp 24",
+            // 両者が角を手駒に持つ複雑な中盤(大駒打ちが blocker 変化を生む)
+            "l4S2l/4g1gs1/5p1p1/pr2N1pkp/4Gn3/PP3PPPP/2GPP4/1K7/L3r+s2L w BS2N5Pb 1",
+            // 飛を手駒に持つ密集局面(飛打ち + 取り/成りが多い)
+            "l6nl/5+P1gk/2np1S3/p1p4Pp/3P2Sp1/1PPb2P1P/P5GS1/R8/LN4bKL w RGgsn5p 1",
         ];
         for sfen in sfens {
             let mut pos = Position::new();
@@ -1903,6 +1909,7 @@ mod tests {
             generate_legal(&pos, &mut list);
             assert!(!list.is_empty(), "no legal moves for {sfen}");
             for &m in &list {
+                // verify_incremental は内部で undo_move するため pos は不変。各手を独立検証。
                 verify_incremental(&mut pos, m);
             }
         }

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -1064,16 +1064,12 @@ pub fn append_changed_threat_indices(
     // Step 2: Source squares 収集
     // ---------------------------------------------------------------
 
-    // before_occ & after_occ は両 occ より blocker が少なく slider 利きが広がるので、その
-    // attackers は before/after 双方の attackers を包含する superset になる。source_bb は
-    // superset であれば足りる(余分な source は Step 3 の再列挙で同一 edge を生み diff で相殺)。
-    // よって 1 回の attackers_to_occ で両 occ 分を集められる。
-    let lenient_occ = before_occ & after_occ;
     let mut source_bb = changed_bb;
     let mut ch_iter = changed_bb;
     while !ch_iter.is_empty() {
         let sq = ch_iter.pop();
-        source_bb |= pos.attackers_to_occ(sq, lenient_occ);
+        source_bb |= pos.attackers_to_occ(sq, before_occ);
+        source_bb |= pos.attackers_to_occ(sq, after_occ);
     }
 
     // ---------------------------------------------------------------
@@ -1891,9 +1887,9 @@ mod tests {
         }
     }
 
-    /// 複数局面の全合法手で差分更新を full refresh と照合する網羅テスト。
-    /// source 収集を lenient occ 1 回に畳んでも slider の blocker 変化(取り/成り/打ち)で
-    /// removed/added が不変であることを担保する。中盤局面(成駒・手駒・開き線)を含める。
+    /// 複数局面の全合法手で差分更新(append_changed)を full refresh と照合する網羅テスト。
+    /// slider の blocker 変化(取り/成り/打ち)を広くカバーするため、成駒・手駒・開き線を含む
+    /// 中盤局面を入れる。
     #[test]
     fn test_changed_indices_all_legal_moves() {
         let sfens = [

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -1064,12 +1064,16 @@ pub fn append_changed_threat_indices(
     // Step 2: Source squares 収集
     // ---------------------------------------------------------------
 
+    // before_occ & after_occ は両 occ より blocker が少なく slider 利きが広がるので、その
+    // attackers は before/after 双方の attackers を包含する superset になる。source_bb は
+    // superset であれば足りる(余分な source は Step 3 の再列挙で同一 edge を生み diff で相殺)。
+    // よって 1 回の attackers_to_occ で両 occ 分を集められる。
+    let lenient_occ = before_occ & after_occ;
     let mut source_bb = changed_bb;
     let mut ch_iter = changed_bb;
     while !ch_iter.is_empty() {
         let sq = ch_iter.pop();
-        source_bb |= pos.attackers_to_occ(sq, before_occ);
-        source_bb |= pos.attackers_to_occ(sq, after_occ);
+        source_bb |= pos.attackers_to_occ(sq, lenient_occ);
     }
 
     // ---------------------------------------------------------------
@@ -1734,6 +1738,7 @@ mod tests {
     // =========================================================================
 
     use super::super::accumulator::IndexList;
+    use crate::movegen::{MoveList, generate_legal};
     use crate::types::Move;
 
     /// 差分更新の結果が full refresh と一致することを検証するヘルパー。
@@ -1883,6 +1888,27 @@ mod tests {
             verify_incremental(&mut pos, m);
             let gc = pos.gives_check(m);
             pos.do_move(m, gc);
+        }
+    }
+
+    /// 複数局面の全合法手で差分更新を full refresh と照合する網羅テスト。
+    /// source 収集を lenient occ 1 回に畳んでも slider の blocker 変化(取り/成り/打ち)で
+    /// removed/added が不変であることを担保する。中盤局面(成駒・手駒・開き線)を含める。
+    #[test]
+    fn test_changed_indices_all_legal_moves() {
+        let sfens = [
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1",
+            "+Bn1g2s1l/2skg2r1/ppppp1n1p/5bpp1/5p1P1/2P6/PP1PP1P1P/1SK2S1R1/LN1G1G1NL w Lp 24",
+        ];
+        for sfen in sfens {
+            let mut pos = Position::new();
+            pos.set_sfen(sfen).expect("valid sfen");
+            let mut list = MoveList::new();
+            generate_legal(&pos, &mut list);
+            assert!(!list.is_empty(), "no legal moves for {sfen}");
+            for &m in &list {
+                verify_incremental(&mut pos, m);
+            }
         }
     }
 


### PR DESCRIPTION
## 概要

threat 差分更新 `append_changed_threat_indices` の **incremental == full-refresh** 整合を、複数局面の
**全合法手**で検証する `test_changed_indices_all_legal_moves` を追加します。既存の差分テストは特定手
中心だったため、slider の blocker 変化(取り/成り/打ち)を広くカバーするテスト資産を増やします。
**net 差分はテスト追加のみ**です。

## この PR の 2 commit について

1. `perf(threat): collapse Step2 attackers_to_occ ...`
   Step2 の source 収集を 2× `attackers_to_occ(before_occ, after_occ)` → 1×
   `attackers_to_occ(before_occ & after_occ)` に畳む最適化の試行。lenient occ は両 occ の attackers を
   包含する superset（blocker が減り slider 利きが単調拡大）で、余分な source は Step3 の再列挙で同一
   edge を生み diff で相殺 → bit-identical。
2. `revert(threat): drop the attackers_to_occ collapse ...`
   `search_only_ab` の A/B（production + `target-cpu=native`、abba / rounds 3、c=1 pin、movetime 6s、
   4 局面）で **instructions/node −1.88% だが cycles/node +0.33% / nps −0.30%**。命令は減るが cycle に
   効かない（この経路は memory-latency-bound）ため最適化は revert。

最適化の試行は履歴に残し、再挑戦時の出発点とします。

## 検証

- `cargo test -p rshogi-core --lib nnue::threat_features` → 34 tests pass（追加テスト含む）
- `cargo fmt` / `cargo clippy -p rshogi-core --lib --tests` → warning 0
- `bash scripts/check-tracked-abs-paths.sh` → OK
- bit-identity: 追加テスト + 既存 `verify_incremental` 系で removed/added 不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)
