### PR TITLE
perf(threat): gate accumulator MAX_DEPTH by nnue-threat (1 for threat, 4 otherwise)

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -523,23 +523,19 @@ impl<const L1: usize> AccumulatorStackLayerStacks<L1> {
     ///
     /// アキュムレータの差分更新における祖先探索には複数のアプローチがある:
     ///
-    /// - **YaneuraOu方式**: 1手前のみをチェック（シンプルだが差分更新の機会を逃す）
-    /// - **Stockfish方式**: スタック全体を探索し、各ステップで玉移動をチェック
+    /// - **YaneuraOu方式**: 1手前のみをチェック（`max_depth=1`。シンプルだが差分更新機会を逃す）
+    /// - **Stockfish方式**: スタックを遡って計算済み祖先を探し、各ステップで玉移動をチェック
     ///
-    /// このプロジェクトでは、HalfKP側（accumulator.rs）と同じロジックを採用している。
-    /// 最大8手前まで探索し、各ステップで玉移動があれば即座に打ち切る方式である。
-    /// この方式により、1手前限定より多くの差分更新機会を得つつ、玉移動時の
-    /// 無駄な探索を早期に打ち切ることでNPS向上が観測されている。
+    /// 本実装は Stockfish 方式。遡及上限 `max_depth` は呼び出し側が **runtime のモデル種別**
+    /// (`has_threat`) で渡す（threat モデル=1 / それ以外=4。理由は呼び出し側コメント参照）。
+    /// edition-universal など threat 非対応モデルも同一バイナリで動く構成があるため、
+    /// compile-time feature でなく runtime で分ける。各ステップで玉移動があれば即座に打ち切る。
     ///
     /// ## 戻り値
     ///
     /// `Some((計算済みエントリのインデックス, 経由する局面数))` - 玉移動がない範囲で
     /// 計算済み祖先が見つかった場合。`None` - 使用可能な祖先が見つからない場合。
-    pub fn find_usable_accumulator(&self) -> Option<(usize, usize)> {
-        // representative 4局面 x 2 rounds の search-only A/B では
-        // MAX_DEPTH=4 が MAX_DEPTH=1 比で +2.15% だったため維持する。
-        const MAX_DEPTH: usize = 4;
-
+    pub fn find_usable_accumulator(&self, max_depth: usize) -> Option<(usize, usize)> {
         debug_assert!(self.current < self.entries.len());
         // SAFETY: current は do_move/undo_move の対称呼び出しで常に範囲内。
         let current = unsafe { self.entries.get_unchecked(self.current) };
@@ -564,7 +560,7 @@ impl<const L1: usize> AccumulatorStackLayerStacks<L1> {
             }
 
             // 探索上限に達した
-            if depth >= MAX_DEPTH {
+            if depth >= max_depth {
                 return None;
             }
 

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -1144,7 +1144,18 @@ impl<FT: LsFeatureSpec + 'static> LsNetByFt<FT> {
                 }
 
                 if !updated {
-                    if let Some((source_idx, _depth)) = $stack.find_usable_accumulator() {
+                    // 遡及上限は runtime のモデル種別で決める。non-threat は forward-chain の
+                    // piece/PSQT 差分が玉移動 refresh より安く深さ 4 が速いが、threat モデルは
+                    // path>=2 の forward update が threat accumulator を full 再列挙する(Finny 非対象)
+                    // ため refresh(piece は Finny)に落ちる深さ 1 が速い(1 は YaneuraOu 方式相当)。
+                    // edition-universal は threat 非対応モデルも同一バイナリで動くので runtime 判定。
+                    #[cfg(feature = "nnue-threat")]
+                    let max_depth = if $net.feature_transformer.has_threat { 1 } else { 4 };
+                    #[cfg(not(feature = "nnue-threat"))]
+                    let max_depth = 4;
+                    if let Some((source_idx, _depth)) =
+                        $stack.find_usable_accumulator(max_depth)
+                    {
                         updated = $net.forward_update_incremental(pos, $stack, source_idx);
                     }
                 }


### PR DESCRIPTION
## 概要

`find_usable_accumulator` の `MAX_DEPTH`（multi-ply accumulator 遡及深さ）を `nnue-threat` feature で分岐
（threat 有効=1 / 非有効=4）。従来は固定 4。

## 背景・計測

MAX_DEPTH は model により最適が逆になる:
- **non-threat**: forward-chain の piece/PSQT 差分が玉移動 refresh より安く、MAX_DEPTH=4 が速い。
- **threat 有効時**: path≥2 の forward update が threat accumulator を **full 再列挙**（threat は Finny cache
  非対象）するため、refresh（piece は Finny cache で安い）に落ちる MAX_DEPTH=1 の方が速い。

`search_only_ab`（production + `target-cpu=native`、c=1 pin、sentinel 4 局面）。MAX_DEPTH=1 vs =4 の
cycles-per-node 差（n=16/局面、SEM 付き）:

| 局面 | Δ(MD1−MD4) | \|Δ\|/SEM | jump率(参考) |
|--|--|--|--|
| complex-middle | **−1.75%** | 3.1σ | 9.2% |
| tactical | **−1.18%** | 2.2σ | 12.6% |
| movegen-heavy | **−0.82%** | 2.0σ | 13.0% |
| hirate（序盤） | +0.51% | 0.9σ（非有意） | 3.6% |

→ **threat: MAX_DEPTH=1 が pooled で cycles-per-node −0.8%（≈ NPS +0.8%）。jump 率の高い midgame/tactical
3 局面で 2〜3σ 有意に速い**（効果が threat full-rebuild 頻度=jump 率と相関）。序盤のみ MD4 微優位だが非有意。
- none-1024: 別 A/B で **MAX_DEPTH=4 が MD1 比 NPS +1.0%**（4/4 局面で速い、旧 +2.15% と整合）。

両立のため feature で分岐。

## bit-identity

MAX_DEPTH は accumulator の計算経路（forward replay か refresh か）のみ変え、生成される accumulator 値は
同一。`go depth 20` で MAX_DEPTH=1 / =4 が **nodes / pv / score 完全一致**を確認。探索結果不変の純粋 perf 変更。

## 検証

- `cargo test -p rshogi-core`（accumulator）
- `cargo fmt` / `cargo clippy`（threat・none 両 edition）warning 0
- `bash scripts/check-tracked-abs-paths.sh`

ついでに `find_usable_accumulator` の docstring（「最大8手前」= `MAX_PATH_LENGTH` との混同による既存の
誤り）を実態（feature 依存 1/4）に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
