### PR TITLE
feat(nnue-stats): add threat accumulator update counters (full/diff/multiply)

### DIFF
--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -17,6 +17,8 @@ use super::features::{Feature, FeatureSet};
 use super::leb128::read_compressed_tensor_i16_all;
 use super::ls_feature_spec::LsFeatureSpec;
 use super::piece_list::PieceNumber;
+#[cfg(feature = "nnue-threat")]
+use super::stats::count_threat_multiply;
 use super::stats::{count_refresh, count_update};
 #[cfg(feature = "nnue-threat")]
 use super::threat_features::{self, MAX_CHANGED_THREAT_FEATURES, THREAT_DIMENSIONS};
@@ -1248,6 +1250,7 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                 for perspective in [Color::Black, Color::White] {
                     let p = perspective as usize;
                     let king_sq = pos.king_square(perspective);
+                    count_threat_multiply!();
                     let threat_acc = stack.current_mut().accumulator.get_threat_mut(p);
                     threat_acc.fill(0);
                     threat_features::for_each_active_threat_index(

--- a/crates/rshogi-core/src/nnue/stats.rs
+++ b/crates/rshogi-core/src/nnue/stats.rs
@@ -36,7 +36,8 @@ pub struct NnueStats {
     pub refresh_diff_sum: AtomicU64,
     /// threat full 列挙 (`for_each_active_threat_index`) 呼び出し回数（perspective 単位）
     pub threat_full_count: AtomicU64,
-    /// threat 差分更新 (`append_changed_threat_indices`) 呼び出し回数（perspective 単位）
+    /// threat 差分更新 (`append_changed_threat_indices`) が実処理を行った回数
+    /// （`dirty_num == 0` の早期リターンは除く; perspective 単位）
     pub threat_diff_count: AtomicU64,
     /// うち multi-ply jump (`forward_update_incremental` path>=2) 起因の threat full 再列挙回数（perspective 単位）
     pub threat_multiply_count: AtomicU64,
@@ -321,16 +322,18 @@ impl NnueStatsSnapshot {
         let threat_total = self.threat_full_count + self.threat_diff_count;
         if threat_total > 0 {
             let full_pct = self.threat_full_count as f64 / threat_total as f64 * 100.0;
-            let mul_pct = self.threat_multiply_count as f64 / threat_total as f64 * 100.0;
+            let diff_pct = self.threat_diff_count as f64 / threat_total as f64 * 100.0;
+            // multiply は full enum の内訳なので、比率の分母は threat_total ではなく threat_full_count
+            let mul_pct = if self.threat_full_count > 0 {
+                self.threat_multiply_count as f64 / self.threat_full_count as f64 * 100.0
+            } else {
+                0.0
+            };
             eprintln!("threat updates:        {:>12}", threat_total);
             eprintln!("  full enum:           {:>12} ({:>5.1}%)", self.threat_full_count, full_pct);
+            eprintln!("  diff:                {:>12} ({:>5.1}%)", self.threat_diff_count, diff_pct);
             eprintln!(
-                "  diff:                {:>12} ({:>5.1}%)",
-                self.threat_diff_count,
-                100.0 - full_pct
-            );
-            eprintln!(
-                "  multiply full(#2):   {:>12} ({:>5.1}%)",
+                "  multiply(of full):   {:>12} ({:>5.1}%)",
                 self.threat_multiply_count, mul_pct
             );
         }

--- a/crates/rshogi-core/src/nnue/stats.rs
+++ b/crates/rshogi-core/src/nnue/stats.rs
@@ -34,6 +34,12 @@ pub struct NnueStats {
     pub refresh_diff_histogram: [AtomicU64; 8],
     /// refresh cache hit 時の差分駒数の累積合計（平均計算用）
     pub refresh_diff_sum: AtomicU64,
+    /// threat full 列挙 (`for_each_active_threat_index`) 呼び出し回数（perspective 単位）
+    pub threat_full_count: AtomicU64,
+    /// threat 差分更新 (`append_changed_threat_indices`) 呼び出し回数（perspective 単位）
+    pub threat_diff_count: AtomicU64,
+    /// うち multi-ply jump (`forward_update_incremental` path>=2) 起因の threat full 再列挙回数（perspective 単位）
+    pub threat_multiply_count: AtomicU64,
 }
 
 #[cfg(feature = "nnue-stats")]
@@ -59,6 +65,9 @@ impl NnueStats {
                 AtomicU64::new(0),
             ],
             refresh_diff_sum: AtomicU64::new(0),
+            threat_full_count: AtomicU64::new(0),
+            threat_diff_count: AtomicU64::new(0),
+            threat_multiply_count: AtomicU64::new(0),
         }
     }
 
@@ -75,6 +84,9 @@ impl NnueStats {
             bin.store(0, Ordering::Relaxed);
         }
         self.refresh_diff_sum.store(0, Ordering::Relaxed);
+        self.threat_full_count.store(0, Ordering::Relaxed);
+        self.threat_diff_count.store(0, Ordering::Relaxed);
+        self.threat_multiply_count.store(0, Ordering::Relaxed);
     }
 
     /// refresh_accumulator 呼び出しをカウント
@@ -136,6 +148,24 @@ impl NnueStats {
         self.refresh_diff_sum.fetch_add(diff as u64, Ordering::Relaxed);
     }
 
+    /// threat full 列挙をカウント
+    #[inline]
+    pub fn count_threat_full(&self) {
+        self.threat_full_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// threat 差分更新をカウント
+    #[inline]
+    pub fn count_threat_diff(&self) {
+        self.threat_diff_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// multi-ply jump 起因の threat full 再列挙をカウント
+    #[inline]
+    pub fn count_threat_multiply(&self) {
+        self.threat_multiply_count.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// 統計情報を取得
     pub fn snapshot(&self) -> NnueStatsSnapshot {
         let mut hist = [0u64; 8];
@@ -152,7 +182,17 @@ impl NnueStats {
             cache_miss_count: self.cache_miss_count.load(Ordering::Relaxed),
             refresh_diff_histogram: hist,
             refresh_diff_sum: self.refresh_diff_sum.load(Ordering::Relaxed),
+            threat_full_count: self.threat_full_count.load(Ordering::Relaxed),
+            threat_diff_count: self.threat_diff_count.load(Ordering::Relaxed),
+            threat_multiply_count: self.threat_multiply_count.load(Ordering::Relaxed),
         }
+    }
+}
+
+#[cfg(feature = "nnue-stats")]
+impl Default for NnueStats {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -168,6 +208,9 @@ pub struct NnueStatsSnapshot {
     pub cache_miss_count: u64,
     pub refresh_diff_histogram: [u64; 8],
     pub refresh_diff_sum: u64,
+    pub threat_full_count: u64,
+    pub threat_diff_count: u64,
+    pub threat_multiply_count: u64,
 }
 
 impl NnueStatsSnapshot {
@@ -274,6 +317,22 @@ impl NnueStatsSnapshot {
                 };
                 eprintln!("  diff {:>5}:  {:>12} ({:>5.1}%)", labels[i], cnt, pct);
             }
+        }
+        let threat_total = self.threat_full_count + self.threat_diff_count;
+        if threat_total > 0 {
+            let full_pct = self.threat_full_count as f64 / threat_total as f64 * 100.0;
+            let mul_pct = self.threat_multiply_count as f64 / threat_total as f64 * 100.0;
+            eprintln!("threat updates:        {:>12}", threat_total);
+            eprintln!("  full enum:           {:>12} ({:>5.1}%)", self.threat_full_count, full_pct);
+            eprintln!(
+                "  diff:                {:>12} ({:>5.1}%)",
+                self.threat_diff_count,
+                100.0 - full_pct
+            );
+            eprintln!(
+                "  multiply full(#2):   {:>12} ({:>5.1}%)",
+                self.threat_multiply_count, mul_pct
+            );
         }
         eprintln!("==============================");
     }
@@ -415,9 +474,51 @@ macro_rules! count_refresh_diff {
     };
 }
 
+/// threat full 列挙カウント（feature有効時のみ）
+#[cfg(feature = "nnue-stats")]
+macro_rules! count_threat_full {
+    () => {
+        $crate::nnue::stats::NNUE_STATS.count_threat_full()
+    };
+}
+/// threat full 列挙カウント（no-op）
+#[cfg(not(feature = "nnue-stats"))]
+macro_rules! count_threat_full {
+    () => {};
+}
+
+/// threat 差分カウント（feature有効時のみ）
+#[cfg(feature = "nnue-stats")]
+macro_rules! count_threat_diff {
+    () => {
+        $crate::nnue::stats::NNUE_STATS.count_threat_diff()
+    };
+}
+/// threat 差分カウント（no-op）
+#[cfg(not(feature = "nnue-stats"))]
+macro_rules! count_threat_diff {
+    () => {};
+}
+
+/// multi-ply threat full カウント（feature有効時のみ）
+#[cfg(feature = "nnue-stats")]
+macro_rules! count_threat_multiply {
+    () => {
+        $crate::nnue::stats::NNUE_STATS.count_threat_multiply()
+    };
+}
+/// multi-ply threat full カウント（no-op）
+#[cfg(not(feature = "nnue-stats"))]
+macro_rules! count_threat_multiply {
+    () => {};
+}
+
 pub(crate) use count_already_computed;
 pub(crate) use count_cache_hit;
 pub(crate) use count_cache_miss;
 pub(crate) use count_refresh;
 pub(crate) use count_refresh_diff;
+pub(crate) use count_threat_diff;
+pub(crate) use count_threat_full;
+pub(crate) use count_threat_multiply;
 pub(crate) use count_update;

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -158,6 +158,8 @@ use super::bona_piece::BonaPiece;
 use super::bona_piece_halfka_hm_merged::is_hm_mirror;
 use super::bona_piece_halfka_hm_merged::{E_KING, F_KING};
 #[cfg(feature = "nnue-threat")]
+use super::stats::{count_threat_diff, count_threat_full};
+#[cfg(feature = "nnue-threat")]
 use super::threat_exclusion;
 
 use std::sync::LazyLock;
@@ -795,6 +797,7 @@ pub fn for_each_active_threat_index<F: FnMut(usize)>(
     king_sq: Square,
     mut f: F,
 ) {
+    count_threat_full!();
     let hm = is_hm_mirror(king_sq, perspective);
     let occupied = pos.occupied();
     let from_offset_table = &*FROM_OFFSET_TABLE;
@@ -996,6 +999,7 @@ pub fn append_changed_threat_indices(
     if dirty_piece.dirty_num == 0 {
         return true;
     }
+    count_threat_diff!();
 
     let hm = is_hm_mirror(king_sq, perspective);
     let from_offset_table = &*FROM_OFFSET_TABLE;


### PR DESCRIPTION
## 概要

`nnue-stats` feature に threat accumulator の更新カウンタを 3 つ追加（diagnostic）:
- **threat_full**: `for_each_active_threat_index`（full 列挙）呼び出し回数
- **threat_diff**: `append_changed_threat_indices`（差分更新）呼び出し回数
- **threat_multiply**: `forward_update_incremental` path≥2 の threat full 再列挙回数（multi-ply jump）

## 目的

base FT には refresh/update/forward_update の統計があるが threat accumulator には無かった。本カウンタで
threat の更新パターン（full-enum vs diff の比率、multi-ply rebuild の頻度）を `print_nnue_stats` で可視化でき、
MAX_DEPTH や accumulator 戦略のチューニング・将来の threat-accumulator 最適化の対象量把握に使える。

## 実装

- `stats.rs`: `NnueStats` に 3 フィールド + count メソッド + snapshot + `print_report` の threat 節 + 3 マクロ
  （feature 有効=実体 / 無効=no-op）+ export。clippy 対応で `impl Default for NnueStats` 追加。
- `threat_features.rs`: `for_each_active_threat_index` / `append_changed_threat_indices` の入口で計上。
- `feature_transformer_layer_stacks.rs`: `forward_update_incremental` の path≥2 分岐で multiply を計上。

すべて `nnue-stats` feature 配下で、**無効時は no-op マクロに展開され挙動・性能不変**。

## 検証

- `cargo test -p rshogi-core`（nnue::threat_features、34 tests pass）
- `cargo fmt` / `cargo clippy`（threat edition、nnue-stats 有無の両方）warning 0
- `bash scripts/check-tracked-abs-paths.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
