### PR TITLE
nnue: threat profile step-attacker (slider attacker 除外, id3/33408) を engine に追加

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -78,6 +78,7 @@ search-no-pass-rules = []
 # 詳細は crates/rshogi-core/src/nnue/threat_exclusion.rs の module doc 参照。
 threat-profile-same-class = []               # profile 1: 同種ペア全除外
 threat-profile-same-class-major-pawn = []   # profile 2: 同種 + 大駒→歩除外
+threat-profile-step-attacker = []           # profile 3: occupancy 依存 slider (香角飛馬竜) を attacker 除外
 threat-profile-cross-side = []               # profile 10: 同 side / 同種を除外、敵味方跨ぎ異種のみ
 
 # === Edition 軸 atomic feature 群 ===
@@ -228,6 +229,10 @@ edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class = [
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class_major_pawn = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32", "nnue-threat",
   "threat-profile-same-class-major-pawn",
+]
+edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker = [
+  "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32", "nnue-threat",
+  "threat-profile-step-attacker",
 ]
 edition-layerstacks-halfka_hm_merged-768x16x32-none = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-768x16x32",

--- a/crates/rshogi-core/src/nnue/threat_exclusion.rs
+++ b/crates/rshogi-core/src/nnue/threat_exclusion.rs
@@ -20,6 +20,7 @@
 //! | 0  | (default) | なし (Baseline) | 216,720 |
 //! | 1  | `threat-profile-same-class` | 同種ペア全除外 (9 クラス × 4 side = 36 pair) | 192,640 |
 //! | 2  | `threat-profile-same-class-major-pawn` | profile 1 + 大駒 attacker → Pawn attacked (4 大駒 × 4 side = 16 pair 追加) | 173,568 |
+//! | 3  | `threat-profile-step-attacker` | occupancy 依存 slider (香角飛馬竜) を attacker から除外 (`ac==1 \|\| ac>=5`)、単発利き駒 (歩桂銀金) のみ attacker | 33,408 |
 //! | 10 | `threat-profile-cross-side` | 同 side (`as==ds`) と同種 (`ac==dc`) を除外、敵味方跨ぎの異種 pair のみ残す | 96,320 |
 //!
 //! # 設計: pair_base の sentinel
@@ -77,6 +78,7 @@
 const _PROFILE_EXCLUSIVITY: () = {
     let count = cfg!(feature = "threat-profile-same-class") as usize
         + cfg!(feature = "threat-profile-same-class-major-pawn") as usize
+        + cfg!(feature = "threat-profile-step-attacker") as usize
         + cfg!(feature = "threat-profile-cross-side") as usize;
     assert!(count <= 1, "Multiple threat profiles selected. Choose at most one.");
 };
@@ -88,6 +90,8 @@ const _PROFILE_EXCLUSIVITY: () = {
 pub const THREAT_PROFILE_ID: u32 = {
     if cfg!(feature = "threat-profile-cross-side") {
         10
+    } else if cfg!(feature = "threat-profile-step-attacker") {
+        3
     } else if cfg!(feature = "threat-profile-same-class-major-pawn") {
         2
     } else if cfg!(feature = "threat-profile-same-class") {
@@ -131,6 +135,12 @@ pub const fn is_excluded(as_: usize, ac: usize, ds: usize, dc: usize) -> bool {
         return true;
     }
 
+    // occupancy 依存 slider (Lance=1, Bishop=5, Rook=6, Horse=7, Dragon=8) を attacker
+    // から除外し、単発利き駒 (Pawn/Knight/Silver/GoldLike) のみ attacker に残す (profile 3)
+    if cfg!(feature = "threat-profile-step-attacker") && (ac == 1 || ac >= 5) {
+        return true;
+    }
+
     false
 }
 
@@ -143,6 +153,7 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-step-attacker",
             feature = "threat-profile-cross-side",
         )))]
         assert_eq!(THREAT_PROFILE_ID, 0);
@@ -153,12 +164,29 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-step-attacker",
             feature = "threat-profile-cross-side",
         )))]
         {
             assert!(!is_excluded(0, 0, 0, 0));
             assert!(!is_excluded(0, 8, 1, 8));
             assert!(!is_excluded(0, 5, 0, 0));
+        }
+    }
+
+    #[test]
+    fn test_block_step_attacker() {
+        #[cfg(feature = "threat-profile-step-attacker")]
+        {
+            assert_eq!(THREAT_PROFILE_ID, 3);
+            // slider attacker (Lance=1, Bishop=5..Dragon=8) は除外
+            assert!(is_excluded(0, 1, 0, 0)); // Lance attacker
+            assert!(is_excluded(0, 8, 1, 0)); // Dragon attacker
+            assert!(is_excluded(0, 6, 0, 3)); // Rook attacker
+            // 単発利き駒 (Pawn=0, Knight=2, Silver=3, GoldLike=4) は残す (attacked 非依存)
+            assert!(!is_excluded(0, 0, 0, 0)); // Pawn attacker
+            assert!(!is_excluded(0, 2, 0, 6)); // Knight attacker → Rook attacked
+            assert!(!is_excluded(0, 4, 1, 8)); // GoldLike attacker → Dragon attacked
         }
     }
 

--- a/crates/rshogi-core/src/nnue/threat_features.rs
+++ b/crates/rshogi-core/src/nnue/threat_features.rs
@@ -63,7 +63,8 @@
 //! ```
 //!
 //! Profile 1 (same-class) は 192,640、profile 2 (same-class-major-pawn) は 173,568、
-//! profile 10 (cross-side) は 96,320。詳細は [`super::threat_exclusion`] を参照。
+//! profile 3 (step-attacker) は 33,408 (= 36 × (72+112+328+416)、attacker が
+//! 歩桂銀金のみ)、profile 10 (cross-side) は 96,320。詳細は [`super::threat_exclusion`] を参照。
 //!
 //! # index 構造
 //!
@@ -401,6 +402,7 @@ fn pair_base(
     if cfg!(any(
         feature = "threat-profile-same-class",
         feature = "threat-profile-same-class-major-pawn",
+        feature = "threat-profile-step-attacker",
         feature = "threat-profile-cross-side",
     )) && base == EXCLUDED_PAIR_BASE
     {
@@ -1455,6 +1457,7 @@ mod tests {
         #[cfg(not(any(
             feature = "threat-profile-same-class",
             feature = "threat-profile-same-class-major-pawn",
+            feature = "threat-profile-step-attacker",
             feature = "threat-profile-cross-side",
         )))]
         assert_eq!(THREAT_DIMENSIONS, 216_720, "profile 0 (full)");
@@ -1464,6 +1467,9 @@ mod tests {
 
         #[cfg(feature = "threat-profile-same-class-major-pawn")]
         assert_eq!(THREAT_DIMENSIONS, 173_568, "profile 2 (same-class-major-pawn)");
+
+        #[cfg(feature = "threat-profile-step-attacker")]
+        assert_eq!(THREAT_DIMENSIONS, 33_408, "profile 3 (step-attacker)");
 
         #[cfg(feature = "threat-profile-cross-side")]
         assert_eq!(THREAT_DIMENSIONS, 96_320, "profile 10 (cross-side)");
@@ -1701,6 +1707,7 @@ mod tests {
     #[cfg(not(any(
         feature = "threat-profile-same-class",
         feature = "threat-profile-same-class-major-pawn",
+        feature = "threat-profile-step-attacker",
         feature = "threat-profile-cross-side",
     )))]
     fn test_canonical_startpos_threat_indices() {
@@ -1731,6 +1738,42 @@ mod tests {
 
         assert_eq!(indices_b, expected, "Black perspective canonical mismatch");
         assert_eq!(indices_w, expected, "White perspective canonical mismatch (symmetric pos)");
+    }
+
+    /// step-attacker (profile 3) の startpos canonical。tatara
+    /// (`shogi-features` `ThreatIndexer::new(ThreatProfile::StepAttacker)`) で生成した
+    /// 同 startpos の sorted index と一致することを固定し、tatara ↔ rshogi の index
+    /// layout 一致を機械的に保証する (bullet-shogi に step-attacker が無く bullet golden が
+    /// 取れないため)。slider attacker を除外するので full の 34 値から step 駒由来の 16 値に減る。
+    #[test]
+    #[cfg(feature = "threat-profile-step-attacker")]
+    fn test_canonical_startpos_threat_indices_step_attacker() {
+        let mut pos = Position::new();
+        pos.set_sfen("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("Failed to parse startpos");
+
+        let king_sq_b = pos.king_square(Color::Black);
+        let mut indices_b = Vec::new();
+        append_active_threat_indices(&pos, Color::Black, king_sq_b, &mut indices_b);
+        indices_b.sort();
+
+        let king_sq_w = pos.king_square(Color::White);
+        let mut indices_w = Vec::new();
+        append_active_threat_indices(&pos, Color::White, king_sq_w, &mut indices_w);
+        indices_w.sort();
+
+        // tatara `ThreatProfile::StepAttacker` で生成。両 repo 同時更新のこと。
+        #[rustfmt::skip]
+        let expected: &[usize] = &[
+            1315, 1316, 1399, 1400, 5215, 5381, 10643, 10746,
+            19015, 19016, 19099, 19100, 24672, 25162, 31045, 31148,
+        ];
+
+        assert_eq!(indices_b, expected, "Black perspective step-attacker canonical mismatch");
+        assert_eq!(
+            indices_w, expected,
+            "White perspective step-attacker canonical mismatch (symmetric pos)"
+        );
     }
 
     // =========================================================================

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -39,6 +39,7 @@ diagnostics = ["rshogi-core/diagnostics"]
 # Threat exclusion profiles
 threat-profile-same-class = ["rshogi-core/threat-profile-same-class"]
 threat-profile-same-class-major-pawn = ["rshogi-core/threat-profile-same-class-major-pawn"]
+threat-profile-step-attacker = ["rshogi-core/threat-profile-step-attacker"]
 threat-profile-cross-side = ["rshogi-core/threat-profile-cross-side"]
 # NNUE progress8kpabs 差分更新最適化（L1=1536 で有効、L1=768 で退行）
 nnue-progress-diff = ["rshogi-core/nnue-progress-diff"]
@@ -93,6 +94,7 @@ edition-layerstacks-halfka_hm_merged-1024x16x32-none        = ["rshogi-core/edit
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat      = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat"]
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class            = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class"]
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class_major_pawn = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class_major_pawn"]
+edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker"]
 edition-layerstacks-halfka_hm_merged-768x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x16x32-none"]
 edition-layerstacks-halfka_hm_merged-768x8x32-none          = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x8x32-none"]
 edition-layerstacks-halfka_hm_merged-512x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-512x16x32-none"]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -29,6 +29,7 @@ diagnostics = ["rshogi-core/diagnostics"]
 # Threat exclusion profiles
 threat-profile-same-class = ["rshogi-core/threat-profile-same-class"]
 threat-profile-same-class-major-pawn = ["rshogi-core/threat-profile-same-class-major-pawn"]
+threat-profile-step-attacker = ["rshogi-core/threat-profile-step-attacker"]
 threat-profile-cross-side = ["rshogi-core/threat-profile-cross-side"]
 
 # === Edition 軸 atomic feature 群 (本 crate で必要なものだけ forward) ===


### PR DESCRIPTION
## 目的

tatara (`feat/threat-profile-step-attacker`) で学習する **step-attacker** threat net —
occupancy 依存 slider (香角飛馬竜) を attacker から除外、profile **id 3 / dims 33,408** — を
rshogi engine が **load して正しく eval** できるようにする。D2a の depth 固定 selfplay eval
(vs threatfull / none-1024) の前提。

採用根拠: attacker-class 別の eval 寄与診断で slider 列は重み magnitude は大きいが代償可能で
marginal eval 寄与が低い (prunable)、step 駒は marginal 最大。slider attacker を engine で
early-prune できれば pair-class late filter では届かない active-edge 削減で threat NPS を削れる、
という eval/NPS トレード検証用 profile。

**本 PR は load/run correctness のみ**。NPS の early-prune (slider 列挙の事前枝刈り) は別 PR。

## 変更 (5 files, +80/-1)

- `rshogi-core/Cargo.toml`: feature `threat-profile-step-attacker` + 1024 edition preset。
- `rshogi-core/src/nnue/threat_exclusion.rs`: 排他 assert / `THREAT_PROFILE_ID=3` /
  `is_excluded` (`ac==1 || ac>=5`) / doc 表 / `test_block_step_attacker` + profile-0 test gate 更新。
- `rshogi-core/src/nnue/threat_features.rs`: **`pair_base()` の `cfg!(any(...))` gate に step-attacker
  を追加** (除外 slider pair が `None` を返すように — これが無いと通常局面で `usize::MAX` index →
  OOB) / dims doc / dims・canonical test gate / 新 `test_canonical_startpos_threat_indices_step_attacker`。
- `rshogi-usi/Cargo.toml`, `tools/Cargo.toml`: feature passthrough (+ usi edition mirror)。
- THREAT_DIMENSIONS は `build_pair_base` で auto-recompute (33,408)。loader / xtask はコード変更なし
  (profile_id / dims を generic 比較 / edition auto-detect)。

## cross-repo bit-exactness

bullet-shogi (donor) に step-attacker が無く bullet golden が取れないため、**tatara
`ThreatProfile::StepAttacker` で生成した startpos sorted index (16 値) を rshogi test に pin** し、
rshogi の `append_active_threat_indices` 再計算が一致することを検証 (tatara ↔ rshogi の index
layout 一致を機械的に保証)。両 repo は同一の is_excluded / ATTACKS_PER_COLOR / pair_index 順序 /
prefix-sum を使う。

## 検証

- `cargo fmt && cargo clippy --fix --allow-dirty --tests` (0 warn) / `cargo test` (profile-0 不変) /
  `cargo test -p rshogi-core --features threat-profile-step-attacker` (dims 33,408 / canonical /
  exclusion 全 green) / `cargo xtask build --edition …-1024x16x32-threat_step_attacker` /
  `check-tracked-abs-paths.sh`。
- 設計 + 実装を Codex + Claude で dual-review。設計 review で `pair_base()` accessor gate (起動即 OOB)・
  rshogi-usi/tools passthrough・test gate の見落としを検出し修正済。

## follow-up (本 PR 対象外)

- engine early-prune (slider 列挙の事前枝刈り) で threat NPS 回復 — 別 PR (rshogi-perf-loop)。
- eval-kick の resolve() に step-attacker label 追加 — rshogi-notes 側。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDjwgLe9NitFbiiq6xZHnb
