### PR TITLE
feat(tools): ラベル品質「物差し」ハーネス yardstick_label / yardstick_score

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -37,6 +37,7 @@
 | `extract_bench_positions` | floodgate CSA / selfplay JSONL から教師ラベル品質測定用のベンチ局面を抽出 |
 | `label_bench_positions` | ベンチ局面 jsonl を深い探索でラベル付けし `eval_deep` を追記（ground truth） |
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) で静的評価し `eval_dl` を追記（`dlshogi-onnx` feature、default 有効） |
+| `yardstick_label` / `yardstick_score` | ラベル品質「物差し」。held-out hcpe を labeler でラベル付け（stage 1）→ engine ごとに勝率較正して per-class WDL logloss / 参照天井 / リファレンス一致を採点（stage 2） |
 
 ### NNUE 学習
 
@@ -77,6 +78,8 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [extract_bench_positions](docs/extract_bench_positions.md) - 教師ラベル品質測定用ベンチ局面の抽出
 - [label_bench_positions](docs/label_bench_positions.md) - ベンチ局面の深い探索ラベリング（ground truth）
 - [label_bench_dl](docs/label_bench_dl.md) - label_bench jsonl への DL水匠 (dlshogi ONNX) 評価値追記
+- [yardstick_label](docs/yardstick_label.md) - held-out hcpe を labeler の固定 depth 探索でラベル付け（物差し stage 1）
+- [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の ONNX 再スコアリング（qsearch-leaf ラベル / dual-output 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み）
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -26,6 +26,8 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `extract_bench_positions` | floodgate CSA / selfplay JSONL から教師ラベル品質測定用のベンチ局面を抽出（層化サンプル + 入玉オーバーサンプル + 互角局面） |
 | `label_bench_positions` | ベンチ局面 jsonl を深い探索（depth / nodes 指定）でラベル付けし `eval_deep` 等を追記（ground truth、局面ごと隔離で `--threads` 非依存に bit 一致） |
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) value head で静的評価し `eval_dl`（先手視点 cp）を追記（`dlshogi-onnx` feature、default 有効） |
+| `yardstick_label` | ラベル品質「物差し」ステージ 1。held-out hcpe を labeler（NNUE + 固定 depth）の決定的探索でラベル付けし採点用 jsonl（手番側視点 `wdl`/`eval_ref`/`eval_label` + class）を出す |
+| `yardstick_score` | ラベル品質「物差し」ステージ 2。`yardstick_label` 出力を engine ごとに勝率スケール較正し per-class の WDL logloss / 参照天井（符号一致）/ リファレンス一致（win-prob MAE・Spearman）を出す |
 
 ## NNUE 学習
 

--- a/crates/tools/docs/yardstick_label.md
+++ b/crates/tools/docs/yardstick_label.md
@@ -59,6 +59,26 @@ depth を物差しの変数にするときは `--nodes 0` で depth を binding 
 | `--threads <usize>` | 0 | worker スレッド数（0=全コア）。出力は thread 数非依存に bit 一致 |
 | `--source <STR>` | — | 出力に付与する source ラベル（hcpe はソースを持たないので任意。例 `floodgate`） |
 | `--limit <usize>` | 0 | 先頭から処理する最大レコード数（0=全件）。smoke 用 |
+| `--capture-depths <CSV>` | — | 反復深化の中間 depth を 1 回の探索で捕捉し depth ごとに別ファイルへ（L0 用）。例 `9,12,15` |
+
+## depth sweep を 1 回の探索で（`--capture-depths`）
+
+depth 選定（L0）で複数 depth を比べるとき、`--depth 9` / `12` / `15` を別々に 3 回探索する代わりに
+`--capture-depths 9,12,15` を使うと、**1 回の depth-15 探索の反復深化の副産物**として各 depth のスコアを
+捕捉し、`<out>_d9.jsonl` / `_d12.jsonl` / `_d15.jsonl` の 3 ファイルに書き分けます（探索 1 回ぶんの
+コストで N depth＝約 1/N の時間）。
+
+```bash
+target/release/yardstick_label \
+  --in floodgate_2025_val_r3000.hcpe --out runs/threat1024_floodgate.jsonl \
+  --nnue threat-full-1024-400.bin --fv-scale 28 --ls-progress-coeff progress_hao_full_cuda.e1.bin \
+  --capture-depths 9,12,15 --nodes 0 --threads 0 --source floodgate
+# → runs/threat1024_floodgate_{d9,d12,d15}.jsonl
+```
+
+`--nodes 0`（depth 固定）では、捕捉した中間 depth のスコアは**単独固定 depth 探索と bit 一致**します
+（反復深化の depth d までの挙動は最終 depth に依存しないため）。`--nodes` でノード制限する
+場合は共有ノード予算により単独探索とズレうるので、その用途では `--depth` 個別実行を使ってください。
 
 ## 出力フィールド（手番側視点）
 

--- a/crates/tools/docs/yardstick_label.md
+++ b/crates/tools/docs/yardstick_label.md
@@ -27,6 +27,36 @@ cargo build -p tools --bin yardstick_label --release \
 LS サイズ slot（`layerstacks-1536x16x32` など）は同時に 1 つだけ有効にします。default feature は
 1536 を含むため、別サイズ（1024 等）のモデルを使う時は `--no-default-features` で切り替えます。
 
+ONNX labeler モード（`--onnx-model`）は `dlshogi-onnx` feature（default 有効）でビルドすれば動きます
+（NNUE arch には依存しないので default build で可）。
+
+## DL value head で静的評価する（`--onnx-model`、engine 軸比較用）
+
+`--onnx-model` を指定すると、NNUE 探索の代わりに **DL（標準 dlshogi ONNX, DL水匠 等）の value head を
+1 forward pass** で回し、その静的評価を `eval_label` にします。NNUE labeler と**同じ採点用 jsonl**を出すので、
+ステージ 2 で「NNUE@depth-d vs DL水匠-static」を同一 held-out・同一実結果で apples-to-apples に比較できます
+（例: Floodgate 局面集を DL水匠 で rescore し、NNUE 探索ラベルと WDL 予測精度を並べる）。
+
+ONNX 推論には GPU 版 ONNX Runtime（+ CUDA/cuDNN、TensorRT 使用時は TensorRT）が要り、`ORT_DYLIB_PATH`
+/ `LD_LIBRARY_PATH` で明示します（`label_bench_dl` と同じ）。`ort` は 1.24 系想定。
+
+```bash
+export ORT_DYLIB_PATH=/path/to/onnxruntime-linux-x64-gpu-1.24.x/lib/libonnxruntime.so
+export LD_LIBRARY_PATH=/path/to/onnxruntime/lib:/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+target/release/yardstick_label \
+  --in floodgate_2025_val_r3000.hcpe --out runs/dlsuisho_floodgate.jsonl \
+  --onnx-model /path/to/DL_suisho.onnx --onnx-gpu-id 0 --onnx-batch-size 1024 --onnx-eval-scale 600 \
+  --source floodgate
+```
+
+ONNX モードは静的（探索深さなし）なので `--capture-depths` 不可・`--nnue`/`--depth`/`--threads` は不要、
+出力は単一ファイル。GPU バッチ推論なので NNUE 探索（CPU）の数十分に対し数分で終わります。
+
+決定性: 出力は入力順（バッチ streaming で順序保存）。CUDA EP（FP32）は **同一 ORT/driver/model なら実行間で
+bit 一致**しますが、ORT/driver/cuBLAS のバージョンが変わると微小に変わりえます。TensorRT EP（FP16, `--onnx-tensorrt`）
+は **bit 一致を保証しません**（FP32 とも微小に異なる）。labeler 間を比較する時は **推論 mode/ORT/driver/model を固定**
+してください。なお NNUE 探索モードの「`--threads` 非依存に bit 一致」は ONNX モードには当てはまりません（別経路）。
+
 ## 使い方
 
 ```bash
@@ -49,7 +79,7 @@ depth を物差しの変数にするときは `--nodes 0` で depth を binding 
 |---|---|---|
 | `--in <FILE>` | （必須） | 入力 hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード） |
 | `--out <FILE>` | （必須） | 出力 jsonl（採点用フィールドのみ、入力順） |
-| `--nnue <FILE>` | （必須） | labeler の NNUE モデル |
+| `--nnue <FILE>` | — | labeler の NNUE モデル。**NNUE 探索モードでは必須**（`--onnx-model` 指定時は不要・無視） |
 | `--fv-scale <i32>` | 0 | FV_SCALE オーバーライド（0=ヘッダ自動判定）。評価器に合わせ明示（threat/none 系=28） |
 | `--ls-bucket-mode <STR>` | — | LayerStacks bucket mode。LS ビルド既定は `progress8kpabs` なので通常不要 |
 | `--ls-progress-coeff <FILE>` | — | progress8kpabs 用の進行度係数。LS モデル + progress8kpabs のとき必須 |
@@ -60,6 +90,12 @@ depth を物差しの変数にするときは `--nodes 0` で depth を binding 
 | `--source <STR>` | — | 出力に付与する source ラベル（hcpe はソースを持たないので任意。例 `floodgate`） |
 | `--limit <usize>` | 0 | 先頭から処理する最大レコード数（0=全件）。smoke 用 |
 | `--capture-depths <CSV>` | — | 反復深化の中間 depth を 1 回の探索で捕捉し depth ごとに別ファイルへ（L0 用）。例 `9,12,15` |
+| `--onnx-model <PATH>` | — | DL ONNX value head で静的評価する ONNX labeler モード（`dlshogi-onnx` feature 要、下記） |
+| `--onnx-tensorrt` | false | ONNX: TensorRT EP (FP16)。未指定は CUDA EP (FP32) |
+| `--onnx-tensorrt-cache <PATH>` | — | ONNX: TensorRT エンジンキャッシュ保存先 |
+| `--onnx-batch-size <usize>` | 1024 | ONNX: 1 推論あたりの最大局面数 |
+| `--onnx-gpu-id <i32>` | 0 | ONNX: CUDA device id（負値で CPU） |
+| `--onnx-eval-scale <f32>` | 600 | ONNX: winrate→cp 変換スケール |
 
 ## depth sweep を 1 回の探索で（`--capture-depths`）
 

--- a/crates/tools/docs/yardstick_label.md
+++ b/crates/tools/docs/yardstick_label.md
@@ -1,0 +1,103 @@
+# yardstick_label
+
+`yardstick_label` は、ラベル品質「物差し」のステージ 1 です。固定 held-out（棋譜由来の
+hcpe。各局面に保存 eval＝教師ラベルと gameResult＝実対局結果を持つ）の各局面を、与えた
+labeler（NNUE 評価器 + 固定 depth）の**決定的探索**で評価し、採点に必要な値だけを 1 行 1
+局面の jsonl に書き出します。ステージ 2 (`yardstick_score`) がこの出力を読み、engine ごとに
+勝率スケールを較正して per-class の WDL logloss / 参照天井 / リファレンス一致を算出します。
+
+「engine + USI param + 固定 depth」を labeler とみなし、深さ軸（depth 選定）・param 軸
+（labeler config 最適化）・engine 軸（教師比較: Threat / 非 Threat / DL水匠 / 将来の DL net）を
+同一の物差しで回すための共通核です。
+
+## ビルド（重要: モデルの architecture と一致させる）
+
+評価器の architecture を含む edition でビルドしてください。`label_bench_positions` と同じ制約です。
+
+```bash
+# 1536 HalfKaHmMerged none（既定 feature でビルド可）
+cargo build -p tools --bin yardstick_label --release
+
+# Threat モデル（例: 1024x16x32 / 1536x16x32 の Threat）は nnue-threat と LS サイズを明示
+cargo build -p tools --bin yardstick_label --release \
+  --no-default-features \
+  --features layerstacks-1536x16x32,nnue-threat,ft-halfka_hm_merged
+```
+
+LS サイズ slot（`layerstacks-1536x16x32` など）は同時に 1 つだけ有効にします。default feature は
+1536 を含むため、別サイズ（1024 等）のモデルを使う時は `--no-default-features` で切り替えます。
+
+## 使い方
+
+```bash
+target/release/yardstick_label \
+  --in  /path/to/floodgate_2025_val_r3000.hcpe \
+  --out runs/yardstick/threat1536_d12.jsonl \
+  --nnue   /path/to/threat-full-1536.bin \
+  --fv-scale 28 \
+  --ls-progress-coeff /path/to/progress_hao_full_cuda.e1.bin \
+  --depth 12 --nodes 0 \
+  --threads 0 \
+  --source floodgate
+```
+
+depth を物差しの変数にするときは `--nodes 0` で depth を binding にします（固定 depth 探索）。
+
+## オプション
+
+| フラグ | 既定 | 説明 |
+|---|---|---|
+| `--in <FILE>` | （必須） | 入力 hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード） |
+| `--out <FILE>` | （必須） | 出力 jsonl（採点用フィールドのみ、入力順） |
+| `--nnue <FILE>` | （必須） | labeler の NNUE モデル |
+| `--fv-scale <i32>` | 0 | FV_SCALE オーバーライド（0=ヘッダ自動判定）。評価器に合わせ明示（threat/none 系=28） |
+| `--ls-bucket-mode <STR>` | — | LayerStacks bucket mode。LS ビルド既定は `progress8kpabs` なので通常不要 |
+| `--ls-progress-coeff <FILE>` | — | progress8kpabs 用の進行度係数。LS モデル + progress8kpabs のとき必須 |
+| `--depth <i32>` | 12 | 探索深さ上限（0 以下=無制限）。`--nodes` と両方 0 は不可 |
+| `--nodes <u64>` | 0 | 探索ノード数上限（0=無制限）。depth を変数にするなら 0 |
+| `--hash-mb <usize>` | 128 | worker ごとの置換表サイズ（MB）。局面ごとに作り直すため過大にしない |
+| `--threads <usize>` | 0 | worker スレッド数（0=全コア）。出力は thread 数非依存に bit 一致 |
+| `--source <STR>` | — | 出力に付与する source ラベル（hcpe はソースを持たないので任意。例 `floodgate`） |
+| `--limit <usize>` | 0 | 先頭から処理する最大レコード数（0=全件）。smoke 用 |
+
+## 出力フィールド（手番側視点）
+
+評価値・勝敗の符号規約はすべて**手番側視点（side-to-move view）**です。hcpe の保存 eval は手番側
+視点 cp（PSV `score` と同じ）、dlshogi DataLoader の value 目標も手番側視点なので、先手視点へ変換
+せず素通しします（ステージ 2 もこの規約で採点）。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `stm` | char | 手番（`b`/`w`） |
+| `wdl` | float | 実対局結果（手番側視点の勝率: 勝 1.0 / 負 0.0 / 引分 0.5） |
+| `eval_ref` | int | held-out 保存 eval（手番側視点 cp、教師＝リファレンスラベル） |
+| `eval_label` | int | labeler の探索値（手番側視点 cp） |
+| `eval_band` | string | `eval_ref` の \|cp\| 帯（`0-150`/`151-600`/`601-1500`/`1501+`/`mate`）。class は labeler 非依存に固定するため `eval_ref` で決める |
+| `nyugyoku` | string | 入玉 class（`none`/`black_entered`/`white_entered`/`both_entered`） |
+| `in_check` | bool | 王手局面か |
+| `mate_ref` | bool | `eval_ref` が飽和域（\|cp\| >= 30000）か |
+| `mate_label` | bool | labeler が詰みスコアを返したか |
+| `source` | string | `--source` 指定時のみ |
+
+gameResult（0=DRAW / 1=BLACK_WIN / 2=WHITE_WIN, 絶対視点）は手番側視点の勝率へ変換します。0/1/2
+以外のレコードは採点対象外として skip します（stderr に件数）。
+
+## 決定性と隔離
+
+- 局面ごとに新規 `Search` を作り、1 スレッド固定（`set_num_threads(1)`）で探索します。各局面の評価は
+  他局面・処理順・`--threads` から独立し、同一入力なら出力は bit 一致します（`--threads 1` と
+  `--threads 0` の出力一致を確認できます）。
+- 決定的 CPU ラベリングなので `--threads 0`（全コア）が既定。出力は thread 数非依存に bit 一致するため
+  絞る理由はありません。
+
+## メモリ
+
+入力件数に対してピークメモリが線形に増えないよう streaming で処理します。producer がトークン制で
+in-flight 件数を一定上限に抑え、collector が入力順へ並べ替えて逐次書き出すため、reorder buffer も
+in-flight 上限でバウンドします。
+
+## コンタミ（教師/検証/対局の非交差）
+
+held-out（特に floodgate slice）を labeler の教師にも対局の互角局面にも混ぜないでください。混ぜると
+WDL 指標が train-on-test で汚染され「accuracy は上がるが強くない」状態になります。floodgate を教師に
+含む labeler を採点する場合は、教師に対し dedup した clean held-out を使ってください。

--- a/crates/tools/docs/yardstick_score.md
+++ b/crates/tools/docs/yardstick_score.md
@@ -35,7 +35,7 @@ target/release/yardstick_score \
 
 符号規約はすべて手番側視点。詰み（labeler が詰みスコアを返した `mate_label`、または保存 eval が
 飽和域 \|eval_ref\| >= 30000、加えて防御的に \|eval_label\| >= 30000）は較正・logloss・一致から除外
-します（飽和域は勝率較正を歪めるため）。`spearman` は単一値 group（分散 0）で `null`（NaN）になります。
+します（飽和域は勝率較正を歪めるため）。`spearman` は n<2・分散 0 の group で未定義になり、表では `—`、`--out` JSON では `null` です。
 
 - **主指標: WDL logloss** = mean[ CE(sigmoid(eval/a), wdl) ]。`a` は labeler ごとに WDL logloss
   最小化で較正したスケール（1 engine につき 1 つの global scale。class ごとには較正しない＝scale を

--- a/crates/tools/docs/yardstick_score.md
+++ b/crates/tools/docs/yardstick_score.md
@@ -29,7 +29,7 @@ target/release/yardstick_score \
 | フラグ | 既定 | 説明 |
 |---|---|---|
 | `<labeled>...` | （必須） | 採点する jsonl（`yardstick_label` 出力）。複数指定可 |
-| `--out <FILE>` | — | 結果 JSON の出力先（per-file/per-group の数値を機械可読で残す） |
+| `--out <FILE>` | — | 結果 JSON の出力先（per-file/per-group の数値を機械可読で残す）。入力ラベル jsonl と同一パス/inode は拒否（高価なラベルの上書き防止） |
 
 ## 指標
 

--- a/crates/tools/docs/yardstick_score.md
+++ b/crates/tools/docs/yardstick_score.md
@@ -1,0 +1,84 @@
+# yardstick_score
+
+`yardstick_score` は、ラベル品質「物差し」のステージ 2 です。`yardstick_label` が出した採点用
+jsonl（手番側視点で `wdl`＝実対局結果・`eval_ref`＝保存教師 eval・`eval_label`＝labeler の探索値）を
+読み、engine ごとに勝率スケールを較正してから class 別に指標を出します。
+
+複数ファイルを渡すと labeler/depth を並べて比較できます（depth sweep・config sweep・教師比較）。
+
+## ビルド
+
+```bash
+cargo build -p tools --bin yardstick_score --release
+```
+
+採点は純粋な算術のみで NNUE 推論を含まないため、architecture feature は不要（既定ビルドで動作）です。
+
+## 使い方
+
+```bash
+target/release/yardstick_score \
+  runs/yardstick/threat1536_d9.jsonl \
+  runs/yardstick/threat1536_d12.jsonl \
+  runs/yardstick/threat1536_d15.jsonl \
+  --out runs/yardstick/results.json
+```
+
+## オプション
+
+| フラグ | 既定 | 説明 |
+|---|---|---|
+| `<labeled>...` | （必須） | 採点する jsonl（`yardstick_label` 出力）。複数指定可 |
+| `--out <FILE>` | — | 結果 JSON の出力先（per-file/per-group の数値を機械可読で残す） |
+
+## 指標
+
+符号規約はすべて手番側視点。詰み（labeler が詰みスコアを返した `mate_label`、または保存 eval が
+飽和域 \|eval_ref\| >= 30000、加えて防御的に \|eval_label\| >= 30000）は較正・logloss・一致から除外
+します（飽和域は勝率較正を歪めるため）。`spearman` は単一値 group（分散 0）で `null`（NaN）になります。
+
+- **主指標: WDL logloss** = mean[ CE(sigmoid(eval/a), wdl) ]。`a` は labeler ごとに WDL logloss
+  最小化で較正したスケール（1 engine につき 1 つの global scale。class ごとには較正しない＝scale を
+  class に過適合させない）。NNUE の FV_SCALE と DL の winrate を混ぜても scale 差を精度と誤認しない
+  ように、各 engine を win-prob 軸に合わせてから logloss を取ります。WDL logloss は NNUE 学習の
+  eval+WDL 目標と同じ ground truth（探索深さと独立）を、proper scoring rule で測ったものです。
+- **参照天井（ceiling）**: 保存 eval（教師）の符号一致率。labeler が超えるべき model 非依存の上限
+  （datagap の `diag_strict.py` の `evalvs_result` と同義。Floodgate ≈ 0.797 / DL水匠val ≈ 0.787）。
+  `ref_ceiling_all` は全レコード（詰み含む）、各 group の `ref_sgn` は採点対象（詰み除外）で算出します。
+- **副指標: リファレンス一致**: 較正後 win-prob 空間で labeler と保存 eval の MAE（`wp_mae`）、および
+  eval_label vs eval_ref の Spearman 順位相関（`spearman`）。深いリファレンス eval への収束効率を見ます。
+
+## 出力
+
+ファイルごとに、ヘッダ（`n_total` / `n_scored`(非詰み) / `a_label` / `a_ref` / `ref_ceiling(all)`）に続けて
+group 別の表を stdout に出します。group は `overall` / `eval_band=*` / `nyugyoku=*` / `in_check=*` /
+（source ラベルが 2 種以上あれば）`source=*`。
+
+class は各次元の**周辺スライス（marginal）**で出します（`eval_band×nyugyoku×in_check×source` の直積
+セルは出しません）。bias の所在は周辺スライスで特定でき、直積は入玉局面のほぼ無い held-out で空セルが
+多発して可読性・統計的安定性を損なうためです（T0 `compare_t03.py` の各 key 別集計と同じ方針）。
+
+```
+group                        n   lbl_loss   ref_loss   lbl_sgn   ref_sgn    wp_mae  spearman
+overall                  44215     0.5XXX     0.5XXX    0.6XXX    0.7XXX    0.0XXX    0.8XXX
+eval_band=0-150          ...
+nyugyoku=black_entered   ...
+```
+
+`--out` を付けると同じ数値を JSON で書き出します（per-file の配列、各 file に groups 配列）。
+
+## 較正の仕組み
+
+`win_prob = sigmoid(eval / a)`。WDL logloss（NLL）は `k = 1/a` について凸なので、`k` を黄金分割探索で
+最小化します（決定的・乱数なし）。`a` の探索域は 10〜20000cp。draw（wdl=0.5）は soft target として
+そのまま CE に入ります。
+
+この sigmoid 写像は nnue_train の WRM loss（`loss_kind=wrm`、target は
+`sigmoid((cp − offset)/scaling)`）の logistic family と同種で、scale を engine ごとに較正する点が要点
+です。WRM の offset/scaling や pow_exp を厳密に踏襲するのではなく、proper scoring rule（logloss）で
+較正済み sigmoid を測ることで、labeler 間を apples-to-apples に比較します。
+
+## メモリ
+
+held-out は設計上 5〜20 万局面で bounded なので、採点は全件を読み込んでから行います（億規模の教師
+プールを load-all する系ツールとは別物。入力は held-out サイズで頭打ち）。

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -6,6 +6,10 @@
 //! この出力を読み、engine ごとに勝率スケールを較正して per-class の WDL logloss /
 //! 参照天井 / リファレンス一致を算出する。
 //!
+//! labeler は 2 種: NNUE 評価器 + 固定 depth 探索（既定）と、`--onnx-model` 指定時の DL（dlshogi
+//! ONNX, DL水匠 等）value head の静的 1 forward。後者で「NNUE@depth-d vs DL水匠-static」を同一
+//! held-out で比較できる。
+//!
 //! 設計上の不変条件（`label_bench_positions` と同じ）:
 //! - 局面ごとに `Search` を作り直し 1 スレッド固定（`set_num_threads(1)`）で探索する。
 //!   これにより 1 局面の評価は他局面・処理順・`--threads` から独立し、同一入力なら
@@ -55,7 +59,7 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 #[command(
     name = "yardstick_label",
     version,
-    about = "held-out hcpe を NNUE labeler の固定 depth 探索でラベル付けし採点用 jsonl を出す"
+    about = "held-out hcpe を labeler (NNUE 固定 depth 探索 / DL ONNX 静的) でラベル付けし採点用 jsonl を出す"
 )]
 struct Cli {
     /// 入力 hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード）。
@@ -66,9 +70,9 @@ struct Cli {
     #[arg(long = "out")]
     output: PathBuf,
 
-    /// labeler の NNUE モデルファイル。
+    /// labeler の NNUE モデルファイル（NNUE 探索モード。`--onnx-model` 指定時は不要）。
     #[arg(long)]
-    nnue: PathBuf,
+    nnue: Option<PathBuf>,
 
     /// FV_SCALE オーバーライド（0=ヘッダ自動判定、1 以上=指定値）。評価器の native 値に
     /// 合わせて明示すること（threat/none LayerStacks 系は 28）。
@@ -119,6 +123,32 @@ struct Cli {
     /// `--nodes` でノード制限すると共有ノード予算により単独探索とズレうる。
     #[arg(long)]
     capture_depths: Option<String>,
+
+    /// DL（標準 dlshogi ONNX, DL水匠 等）value head で静的評価する ONNX labeler モード。
+    /// 指定すると NNUE 探索の代わりに 1 forward pass で `eval_label` を付ける（`--nnue`/`--depth`/
+    /// `--capture-depths` は無視/不可、出力は単一ファイル）。`dlshogi-onnx` feature が要る。
+    #[arg(long)]
+    onnx_model: Option<PathBuf>,
+
+    /// ONNX: TensorRT EP (FP16) を使う。未指定は CUDA EP (FP32)。
+    #[arg(long)]
+    onnx_tensorrt: bool,
+
+    /// ONNX: TensorRT エンジンキャッシュの保存先（`--onnx-tensorrt` 時のみ）。
+    #[arg(long)]
+    onnx_tensorrt_cache: Option<PathBuf>,
+
+    /// ONNX: 1 回の推論あたりの最大局面数。
+    #[arg(long, default_value_t = 1024)]
+    onnx_batch_size: usize,
+
+    /// ONNX: CUDA device id（負値で CPU 推論）。
+    #[arg(long, default_value_t = 0)]
+    onnx_gpu_id: i32,
+
+    /// ONNX: winrate→cp 変換スケール。
+    #[arg(long, default_value_t = 600.0)]
+    onnx_eval_scale: f32,
 }
 
 /// ステージ 2 が読む採点用レコード。符号規約はすべて手番側視点。
@@ -172,6 +202,52 @@ fn install_fatal_panic_hook() {
 }
 
 fn run(cli: &Cli) -> Result<()> {
+    ctrlc::set_handler(|| INTERRUPTED.store(true, Ordering::SeqCst))
+        .context("Failed to set Ctrl-C handler")?;
+
+    let total_records = count_records(&cli.input)?;
+    let total = if cli.limit > 0 {
+        total_records.min(cli.limit as u64)
+    } else {
+        total_records
+    };
+
+    let progress = ProgressBar::new(total);
+    progress.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({per_sec}) {msg}")
+            .expect("valid template"),
+    );
+
+    let stats = if cli.onnx_model.is_some() {
+        run_onnx_mode(cli, &progress)?
+    } else {
+        run_nnue_mode(cli, total, &progress)?
+    };
+
+    progress.finish_with_message("Done");
+    eprintln!("Wrote {} labeled records", stats.written);
+    if stats.skipped > 0 {
+        eprintln!("Skipped {} records (invalid wdl/board)", stats.skipped);
+    }
+    if stats.errors > 0 {
+        eprintln!("Skipped {} records due to errors", stats.errors);
+    }
+    if INTERRUPTED.load(Ordering::SeqCst) {
+        bail!(
+            "interrupted: output truncated to the in-order prefix ({} records written)",
+            stats.written
+        );
+    }
+    Ok(())
+}
+
+/// NNUE 探索 labeler モード（固定 depth / capture-depths）。
+fn run_nnue_mode(cli: &Cli, total: u64, progress: &ProgressBar) -> Result<RunStats> {
+    let nnue = cli.nnue.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("--nnue is required for NNUE search mode (or use --onnx-model)")
+    })?;
+
     // capture-depths 指定時は depth ごとの N 出力、未指定時は --out 単一。探索深さは capture の
     // 最大 depth（中間 depth は反復深化の副産物として 1 回の探索で捕捉する）。
     let targets: Option<Vec<i32>> =
@@ -192,19 +268,12 @@ fn run(cli: &Cli) -> Result<()> {
         bail!("--depth and --nodes are both unlimited; specify at least one to bound the search");
     }
 
-    configure_eval(cli)?;
+    configure_eval(cli, nnue)?;
 
     let num_threads = if cli.threads > 0 {
         cli.threads
     } else {
         std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
-    };
-
-    let total_records = count_records(&cli.input)?;
-    let total = if cli.limit > 0 {
-        total_records.min(cli.limit as u64)
-    } else {
-        total_records
     };
 
     eprintln!(
@@ -221,34 +290,152 @@ fn run(cli: &Cli) -> Result<()> {
         eprintln!("  out: {}", out.display());
     }
 
-    ctrlc::set_handler(|| INTERRUPTED.store(true, Ordering::SeqCst))
-        .context("Failed to set Ctrl-C handler")?;
+    run_pipeline(cli, &outputs, targets.as_deref(), effective_depth, num_threads, progress)
+}
 
-    let progress = ProgressBar::new(total);
-    progress.set_style(
-        ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({per_sec}) {msg}")
-            .expect("valid template"),
-    );
+/// ONNX (DL value head) 静的 labeler モード。build に `dlshogi-onnx` feature が無いと使えない。
+#[cfg(not(feature = "dlshogi-onnx"))]
+fn run_onnx_mode(_cli: &Cli, _progress: &ProgressBar) -> Result<RunStats> {
+    bail!(
+        "--onnx-model requires the 'dlshogi-onnx' feature (on by default; this build disabled it). \
+         Rebuild without --no-default-features, or add --features dlshogi-onnx."
+    )
+}
 
-    let stats =
-        run_pipeline(cli, &outputs, targets.as_deref(), effective_depth, num_threads, &progress)?;
+#[cfg(feature = "dlshogi-onnx")]
+fn run_onnx_mode(cli: &Cli, progress: &ProgressBar) -> Result<RunStats> {
+    use tools::onnx_value::{OnnxValueConfig, OnnxValueEvaluator};
 
-    progress.finish_with_message("Done");
-    eprintln!("Wrote {} labeled records", stats.written);
-    if stats.skipped > 0 {
-        eprintln!("Skipped {} records (invalid wdl/board)", stats.skipped);
-    }
-    if stats.errors > 0 {
-        eprintln!("Skipped {} records due to errors", stats.errors);
-    }
-    if INTERRUPTED.load(Ordering::SeqCst) {
+    let model = cli.onnx_model.as_ref().expect("onnx mode requires --onnx-model");
+    if cli.capture_depths.is_some() {
         bail!(
-            "interrupted: output truncated to the in-order prefix ({} records written)",
-            stats.written
+            "--capture-depths is not supported with --onnx-model (static eval has no search depth)"
         );
     }
-    Ok(())
+    if cli.onnx_batch_size == 0 {
+        bail!("--onnx-batch-size must be > 0");
+    }
+    if cli.onnx_tensorrt && cli.onnx_gpu_id < 0 {
+        bail!("--onnx-tensorrt requires a GPU (--onnx-gpu-id >= 0)");
+    }
+    if !cli.onnx_eval_scale.is_finite() || cli.onnx_eval_scale <= 0.0 {
+        bail!("--onnx-eval-scale must be a positive finite value, got {}", cli.onnx_eval_scale);
+    }
+    if cli.onnx_tensorrt_cache.is_some() && !cli.onnx_tensorrt {
+        eprintln!("warning: --onnx-tensorrt-cache is ignored without --onnx-tensorrt");
+    }
+    validate_paths(&cli.input, &cli.output)?;
+
+    let cfg = OnnxValueConfig {
+        model_path: model.clone(),
+        gpu_id: cli.onnx_gpu_id,
+        use_tensorrt: cli.onnx_tensorrt,
+        tensorrt_cache: cli.onnx_tensorrt_cache.clone(),
+        eval_scale: cli.onnx_eval_scale,
+        batch_size: cli.onnx_batch_size,
+    };
+    let mut evaluator = OnnxValueEvaluator::new(&cfg)?;
+    eprintln!(
+        "ONNX value model loaded: {} -> {} (batch={}, gpu={}, tensorrt={})",
+        model.display(),
+        cli.output.display(),
+        cli.onnx_batch_size,
+        cli.onnx_gpu_id,
+        cli.onnx_tensorrt,
+    );
+
+    let file = File::open(&cli.input)
+        .with_context(|| format!("Failed to open {}", cli.input.display()))?;
+    let mut reader = BufReader::new(file);
+    let out = File::create(&cli.output)
+        .with_context(|| format!("Failed to create {}", cli.output.display()))?;
+    let mut writer = BufWriter::new(out);
+
+    let source = cli.source.as_deref();
+    let mut positions: Vec<Position> = Vec::with_capacity(cli.onnx_batch_size);
+    let mut metas: Vec<RecMeta> = Vec::with_capacity(cli.onnx_batch_size);
+    let mut written = 0u64;
+    let mut skipped = 0u64;
+    let mut errors = 0u64;
+    let mut seq = 0usize;
+    let mut buf = [0u8; HCPE_RECORD_SIZE];
+
+    // バッチ単位の static 推論。eval_label = DL value head の手番側視点 cp。DL value head は
+    // 静的勝率を返すだけで詰みスコアを返さないので mate_label は常に false。
+    let flush = |positions: &mut Vec<Position>,
+                 metas: &mut Vec<RecMeta>,
+                 evaluator: &mut OnnxValueEvaluator,
+                 writer: &mut BufWriter<File>,
+                 written: &mut u64|
+     -> Result<()> {
+        if positions.is_empty() {
+            return Ok(());
+        }
+        let cps = evaluator.evaluate(positions.as_slice())?;
+        // 推論出力数が入力局面数と完全一致しないと zip が末尾を無言で落とす。実行時に弾く
+        // （positions と metas は同じ ParseHcpe::Ok 分岐で 1:1 に push するので常に同数）。
+        anyhow::ensure!(
+            cps.len() == positions.len() && metas.len() == positions.len(),
+            "ONNX returned {} evals for {} positions (metas={})",
+            cps.len(),
+            positions.len(),
+            metas.len(),
+        );
+        for (meta, &cp) in metas.iter().zip(&cps) {
+            let line = score_line(meta, source, cp, false).map_err(|e| anyhow::anyhow!(e))?;
+            writeln!(writer, "{line}")?;
+            *written += 1;
+        }
+        positions.clear();
+        metas.clear();
+        Ok(())
+    };
+
+    loop {
+        if cli.limit > 0 && seq >= cli.limit {
+            break;
+        }
+        if INTERRUPTED.load(Ordering::SeqCst) {
+            break;
+        }
+        match reader.read_exact(&mut buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e).context("Failed to read hcpe record"),
+        }
+        seq += 1;
+        match parse_hcpe_record(&buf) {
+            ParseHcpe::Ok(parsed) => {
+                let (pos, meta) = *parsed;
+                positions.push(pos);
+                metas.push(meta);
+            }
+            ParseHcpe::Skip => {
+                skipped += 1;
+                progress.inc(1);
+            }
+            ParseHcpe::Error(msg) => {
+                errors += 1;
+                eprintln!("skip record {}: {msg}", seq - 1);
+                progress.inc(1);
+            }
+        }
+        if positions.len() >= cli.onnx_batch_size {
+            let n = positions.len() as u64;
+            flush(&mut positions, &mut metas, &mut evaluator, &mut writer, &mut written)?;
+            progress.inc(n);
+        }
+    }
+    let n = positions.len() as u64;
+    flush(&mut positions, &mut metas, &mut evaluator, &mut writer, &mut written)?;
+    progress.inc(n);
+    writer.flush()?;
+
+    Ok(RunStats {
+        written,
+        skipped,
+        errors,
+    })
 }
 
 struct RunStats {
@@ -406,6 +593,78 @@ fn run_pipeline(
     })
 }
 
+/// labeler 非依存の共有フィールド（eval_label/mate_label 以外）。NNUE 探索・ONNX 双方で使う。
+struct RecMeta {
+    stm: Color,
+    wdl: f64,
+    eval_ref: i32,
+    nyugyoku: &'static str,
+    in_check: bool,
+}
+
+enum ParseHcpe {
+    // Position が大きいので Box 化（variant 間サイズ差を抑える）。
+    Ok(Box<(Position, RecMeta)>),
+    Skip,
+    Error(String),
+}
+
+/// hcpe 1 レコードを Position + 共有フィールドへ展開する（labeler 共通の前段）。
+fn parse_hcpe_record(bytes: &[u8; HCPE_RECORD_SIZE]) -> ParseHcpe {
+    let eval_ref = i16::from_le_bytes([bytes[32], bytes[33]]) as i32;
+    let game_result = bytes[36];
+
+    let mut hcp = [0u8; 32];
+    hcp.copy_from_slice(&bytes[0..32]);
+    let sfen = match unpack_hcp(&hcp) {
+        Ok(s) => s,
+        Err(e) => return ParseHcpe::Error(format!("unpack_hcp failed: {e}")),
+    };
+    let mut pos = Position::new();
+    if let Err(e) = pos.set_sfen(&sfen) {
+        return ParseHcpe::Error(format!("set_sfen failed: {e:?}: {sfen}"));
+    }
+    let stm = pos.side_to_move();
+    let Some(wdl) = wdl_stm(game_result, stm) else {
+        // gameResult が不正（0/1/2 以外）なレコードは採点対象外。
+        return ParseHcpe::Skip;
+    };
+    let nyugyoku = nyugyoku_label(&pos);
+    let in_check = pos.in_check();
+    ParseHcpe::Ok(Box::new((
+        pos,
+        RecMeta {
+            stm,
+            wdl,
+            eval_ref,
+            nyugyoku,
+            in_check,
+        },
+    )))
+}
+
+/// 共有フィールド + labeler 値から採点用 jsonl 1 行を組み立てる。
+fn score_line(
+    meta: &RecMeta,
+    source: Option<&str>,
+    eval_label: i32,
+    mate_label: bool,
+) -> Result<String, String> {
+    let record = ScoreRecord {
+        stm: if meta.stm == Color::Black { 'b' } else { 'w' },
+        wdl: meta.wdl,
+        eval_ref: meta.eval_ref,
+        eval_label,
+        eval_band: eval_band(meta.eval_ref),
+        nyugyoku: meta.nyugyoku,
+        in_check: meta.in_check,
+        mate_ref: meta.eval_ref.abs() >= MATE_ABS,
+        mate_label,
+        source: source.map(str::to_string),
+    };
+    serde_json::to_string(&record).map_err(|e| format!("serialize error: {e}"))
+}
+
 /// hcpe 1 レコードを labeler でラベル付けし採点用 jsonl 行にする。
 /// `targets` 指定時は 1 回の探索で各 depth の中間スコアを捕捉し depth 数だけの行を返す。
 fn process_record(
@@ -416,29 +675,11 @@ fn process_record(
     source: Option<&str>,
     targets: Option<&[i32]>,
 ) -> Outcome {
-    let eval_ref = i16::from_le_bytes([bytes[32], bytes[33]]) as i32;
-    let game_result = bytes[36];
-
-    let mut hcp = [0u8; 32];
-    hcp.copy_from_slice(&bytes[0..32]);
-    let sfen = match unpack_hcp(&hcp) {
-        Ok(s) => s,
-        Err(e) => return Outcome::Error(format!("unpack_hcp failed: {e}")),
+    let (mut pos, meta) = match parse_hcpe_record(bytes) {
+        ParseHcpe::Ok(parsed) => *parsed,
+        ParseHcpe::Skip => return Outcome::Skip,
+        ParseHcpe::Error(e) => return Outcome::Error(e),
     };
-
-    let mut pos = Position::new();
-    if let Err(e) = pos.set_sfen(&sfen) {
-        return Outcome::Error(format!("set_sfen failed: {e:?}: {sfen}"));
-    }
-    let stm = pos.side_to_move();
-
-    let Some(wdl) = wdl_stm(game_result, stm) else {
-        // gameResult が不正（0/1/2 以外）なレコードは採点対象外。
-        return Outcome::Skip;
-    };
-
-    let nyugyoku = nyugyoku_label(&pos);
-    let in_check = pos.in_check();
 
     let mut search = Search::new(hash_mb);
     search.set_num_threads(1);
@@ -449,23 +690,8 @@ fn process_record(
     }
     limits.set_start_time();
 
-    // 出力 1 行を組み立てる（eval_label / mate_label 以外は depth 間で共有）。
-    let stm_char = if stm == Color::Black { 'b' } else { 'w' };
-    let make_line = |eval_label: i32, mate_label: bool| -> Result<String, String> {
-        let record = ScoreRecord {
-            stm: stm_char,
-            wdl,
-            eval_ref,
-            eval_label,
-            eval_band: eval_band(eval_ref),
-            nyugyoku,
-            in_check,
-            mate_ref: eval_ref.abs() >= MATE_ABS,
-            mate_label,
-            source: source.map(str::to_string),
-        };
-        serde_json::to_string(&record).map_err(|e| format!("serialize error: {e}"))
-    };
+    let make_line =
+        |eval_label: i32, mate_label: bool| score_line(&meta, source, eval_label, mate_label);
 
     let lines: Result<Vec<String>, String> = match targets {
         // capture mode: 1 回の探索で各 target depth の反復深化中間スコアを捕捉する。
@@ -549,9 +775,9 @@ fn eval_band(eval: i32) -> &'static str {
 
 /// 評価器（NNUE + LayerStacks bucket 設定）を USI エンジンと同じ手順で構成する。
 /// `label_bench_positions::configure_eval` と同じく progress8kpabs で係数未指定なら弾く。
-fn configure_eval(cli: &Cli) -> Result<()> {
-    if !cli.nnue.exists() {
-        bail!("NNUE model file not found: {}", cli.nnue.display());
+fn configure_eval(cli: &Cli, nnue: &Path) -> Result<()> {
+    if !nnue.exists() {
+        bail!("NNUE model file not found: {}", nnue.display());
     }
     if cli.fv_scale != 0 {
         set_fv_scale_override(cli.fv_scale);
@@ -573,8 +799,8 @@ fn configure_eval(cli: &Cli) -> Result<()> {
         coeff_loaded = true;
         eprintln!("LS_PROGRESS_COEFF: {}", path.display());
     }
-    init_nnue(&cli.nnue).context("Failed to load NNUE model")?;
-    eprintln!("NNUE model loaded: {}", cli.nnue.display());
+    init_nnue(nnue).context("Failed to load NNUE model")?;
+    eprintln!("NNUE model loaded: {}", nnue.display());
     if is_layer_stacks_loaded()
         && get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
         && !coeff_loaded

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -110,6 +110,15 @@ struct Cli {
     /// 先頭から処理する最大レコード数（0=全件）。smoke 用。
     #[arg(long, default_value_t = 0)]
     limit: usize,
+
+    /// 反復深化の中間 depth を 1 回の探索で捕捉し depth ごとに別ファイルへ出す（L0 用）。
+    /// 例 `--capture-depths 9,12,15`。指定時 `--out PATH.jsonl` は `PATH_d9.jsonl` 等の N
+    /// ファイルになり、`--depth` は最大 capture depth へ上書きされる。`--nodes 0`（depth 固定）
+    /// では捕捉した中間 depth のスコアは単独固定 depth 探索と bit 一致する（反復深化の depth d
+    /// までの挙動は最終 depth に依存しないため）→ N depth を探索 1 回ぶんのコストで採れる。
+    /// `--nodes` でノード制限すると共有ノード予算により単独探索とズレうる。
+    #[arg(long)]
+    capture_depths: Option<String>,
 }
 
 /// ステージ 2 が読む採点用レコード。符号規約はすべて手番側視点。
@@ -139,8 +148,9 @@ struct ScoreRecord {
 }
 
 /// 1 局面の処理結果。`Error` でも seq スロットを消費するので順序は崩れない。
+/// `Ok` は出力ファイルごとの 1 行（capture-depths 時は depth 数、通常は 1）。
 enum Outcome {
-    Ok(String),
+    Ok(Vec<String>),
     Skip,
     Error(String),
 }
@@ -162,8 +172,23 @@ fn install_fatal_panic_hook() {
 }
 
 fn run(cli: &Cli) -> Result<()> {
-    validate_paths(&cli.input, &cli.output)?;
-    if cli.depth <= 0 && cli.nodes == 0 {
+    // capture-depths 指定時は depth ごとの N 出力、未指定時は --out 単一。探索深さは capture の
+    // 最大 depth（中間 depth は反復深化の副産物として 1 回の探索で捕捉する）。
+    let targets: Option<Vec<i32>> =
+        cli.capture_depths.as_deref().map(parse_capture_depths).transpose()?;
+    let outputs: Vec<PathBuf> = match &targets {
+        Some(ds) => capture_output_paths(&cli.output, ds),
+        None => vec![cli.output.clone()],
+    };
+    let effective_depth = match &targets {
+        // parse_capture_depths が昇順を保証するので最大 depth = 末尾。
+        Some(ds) => *ds.last().expect("non-empty capture depths"),
+        None => cli.depth,
+    };
+    for out in &outputs {
+        validate_paths(&cli.input, out)?;
+    }
+    if effective_depth <= 0 && cli.nodes == 0 {
         bail!("--depth and --nodes are both unlimited; specify at least one to bound the search");
     }
 
@@ -183,15 +208,18 @@ fn run(cli: &Cli) -> Result<()> {
     };
 
     eprintln!(
-        "Labeling {} ({} records) -> {} (depth={}, nodes={}, hash={}MB/worker, threads={})",
+        "Labeling {} ({} records) -> {} file(s) (depth={}, nodes={}, hash={}MB/worker, threads={})",
         cli.input.display(),
         total,
-        cli.output.display(),
-        cli.depth,
+        outputs.len(),
+        effective_depth,
         cli.nodes,
         cli.hash_mb,
         num_threads,
     );
+    for out in &outputs {
+        eprintln!("  out: {}", out.display());
+    }
 
     ctrlc::set_handler(|| INTERRUPTED.store(true, Ordering::SeqCst))
         .context("Failed to set Ctrl-C handler")?;
@@ -203,7 +231,8 @@ fn run(cli: &Cli) -> Result<()> {
             .expect("valid template"),
     );
 
-    let stats = run_pipeline(cli, num_threads, &progress)?;
+    let stats =
+        run_pipeline(cli, &outputs, targets.as_deref(), effective_depth, num_threads, &progress)?;
 
     progress.finish_with_message("Done");
     eprintln!("Wrote {} labeled records", stats.written);
@@ -229,7 +258,16 @@ struct RunStats {
 }
 
 /// producer + worker + collector のストリーミングパイプライン本体。
-fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result<RunStats> {
+/// `outputs` は出力ファイル（capture-depths 時は depth 数、通常は 1）、`targets` は capture
+/// する depth 列（昇順）、`depth` は実探索深さ（= capture の最大 depth）。
+fn run_pipeline(
+    cli: &Cli,
+    outputs: &[PathBuf],
+    targets: Option<&[i32]>,
+    depth: i32,
+    num_threads: usize,
+    progress: &ProgressBar,
+) -> Result<RunStats> {
     let inflight_cap = (num_threads * 4).max(num_threads + 1);
 
     let (token_tx, token_rx) = bounded::<()>(inflight_cap);
@@ -239,16 +277,17 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
     let (work_tx, work_rx) = unbounded::<(usize, [u8; HCPE_RECORD_SIZE])>();
     let (res_tx, res_rx) = unbounded::<(usize, Outcome)>();
 
-    let depth = cli.depth;
     let nodes = cli.nodes;
     let hash_mb = cli.hash_mb;
     let source = cli.source.clone();
+    let targets_owned: Option<Vec<i32>> = targets.map(<[i32]>::to_vec);
 
     let mut workers = Vec::with_capacity(num_threads);
     for worker_idx in 0..num_threads {
         let work_rx = work_rx.clone();
         let res_tx = res_tx.clone();
         let source = source.clone();
+        let targets = targets_owned.clone();
         let handle = thread::Builder::new()
             .name(format!("yardstick-worker-{worker_idx}"))
             .stack_size(SEARCH_STACK_SIZE)
@@ -257,7 +296,14 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
                     if INTERRUPTED.load(Ordering::SeqCst) {
                         break;
                     }
-                    let outcome = process_record(&bytes, hash_mb, depth, nodes, source.as_deref());
+                    let outcome = process_record(
+                        &bytes,
+                        hash_mb,
+                        depth,
+                        nodes,
+                        source.as_deref(),
+                        targets.as_deref(),
+                    );
                     if res_tx.send((seq, outcome)).is_err() {
                         break;
                     }
@@ -302,10 +348,15 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
         Ok(())
     });
 
-    // collector: seq 順に並べ替えて逐次書き出す。
-    let out_file = File::create(&cli.output)
-        .with_context(|| format!("Failed to create {}", cli.output.display()))?;
-    let mut writer = BufWriter::new(out_file);
+    // collector: seq 順に並べ替えて逐次書き出す。出力は depth ごとに分かれた N 個の writer。
+    let mut writers: Vec<BufWriter<File>> = outputs
+        .iter()
+        .map(|p| {
+            File::create(p)
+                .with_context(|| format!("Failed to create {}", p.display()))
+                .map(BufWriter::new)
+        })
+        .collect::<Result<_>>()?;
     let mut next = 0usize;
     let mut buf: std::collections::BTreeMap<usize, Outcome> = std::collections::BTreeMap::new();
     let mut written = 0u64;
@@ -316,9 +367,15 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
         buf.insert(seq, outcome);
         while let Some(outcome) = buf.remove(&next) {
             match outcome {
-                Outcome::Ok(line) => {
-                    writer.write_all(line.as_bytes())?;
-                    writer.write_all(b"\n")?;
+                // lines[i] は writers[i]（= depth i）へ。process_record が outputs と同数の
+                // 行を返す不変条件なので zip で 1 対 1 に書き出す（崩れると silent な行ズレに
+                // なるため debug ビルドで検出する）。
+                Outcome::Ok(lines) => {
+                    debug_assert_eq!(lines.len(), writers.len());
+                    for (writer, line) in writers.iter_mut().zip(&lines) {
+                        writer.write_all(line.as_bytes())?;
+                        writer.write_all(b"\n")?;
+                    }
                     written += 1;
                 }
                 Outcome::Skip => skipped += 1,
@@ -332,7 +389,9 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
             let _ = token_tx.send(());
         }
     }
-    writer.flush()?;
+    for writer in &mut writers {
+        writer.flush()?;
+    }
 
     drop(token_tx);
     producer.join().map_err(|_| anyhow::anyhow!("producer thread panicked"))??;
@@ -348,12 +407,14 @@ fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result
 }
 
 /// hcpe 1 レコードを labeler でラベル付けし採点用 jsonl 行にする。
+/// `targets` 指定時は 1 回の探索で各 depth の中間スコアを捕捉し depth 数だけの行を返す。
 fn process_record(
     bytes: &[u8; HCPE_RECORD_SIZE],
     hash_mb: usize,
     depth: i32,
     nodes: u64,
     source: Option<&str>,
+    targets: Option<&[i32]>,
 ) -> Outcome {
     let eval_ref = i16::from_le_bytes([bytes[32], bytes[33]]) as i32;
     let game_result = bytes[36];
@@ -387,24 +448,62 @@ fn process_record(
         limits.nodes = nodes;
     }
     limits.set_start_time();
-    let result = search.go(&mut pos, limits, None::<fn(&SearchInfo)>);
-    let score = result.score;
 
-    let record = ScoreRecord {
-        stm: if stm == Color::Black { 'b' } else { 'w' },
-        wdl,
-        eval_ref,
-        eval_label: score.to_cp(),
-        eval_band: eval_band(eval_ref),
-        nyugyoku,
-        in_check,
-        mate_ref: eval_ref.abs() >= MATE_ABS,
-        mate_label: score.is_mate_score(),
-        source: source.map(str::to_string),
+    // 出力 1 行を組み立てる（eval_label / mate_label 以外は depth 間で共有）。
+    let stm_char = if stm == Color::Black { 'b' } else { 'w' };
+    let make_line = |eval_label: i32, mate_label: bool| -> Result<String, String> {
+        let record = ScoreRecord {
+            stm: stm_char,
+            wdl,
+            eval_ref,
+            eval_label,
+            eval_band: eval_band(eval_ref),
+            nyugyoku,
+            in_check,
+            mate_ref: eval_ref.abs() >= MATE_ABS,
+            mate_label,
+            source: source.map(str::to_string),
+        };
+        serde_json::to_string(&record).map_err(|e| format!("serialize error: {e}"))
     };
-    match serde_json::to_string(&record) {
-        Ok(s) => Outcome::Ok(s),
-        Err(e) => Outcome::Error(format!("serialize error: {e}")),
+
+    let lines: Result<Vec<String>, String> = match targets {
+        // capture mode: 1 回の探索で各 target depth の反復深化中間スコアを捕捉する。
+        // 反復深化は depth 1,2,… と単調増加するので、各 target に「target 以下で最後に完了した
+        // depth」のスコアが残る（target に到達すれば exact、早期終了（詰み等）なら最深 depth）。
+        Some(targets) => {
+            let mut captured: Vec<Option<(i32, bool)>> = vec![None; targets.len()];
+            let result = {
+                let cap = &mut captured;
+                let on_info = |info: &SearchInfo| {
+                    if info.multi_pv != 1 {
+                        return;
+                    }
+                    for (slot, &td) in cap.iter_mut().zip(targets) {
+                        if info.depth <= td {
+                            *slot = Some((info.score.to_cp(), info.score.is_mate_score()));
+                        }
+                    }
+                };
+                search.go(&mut pos, limits, Some(on_info))
+            };
+            let fallback = (result.score.to_cp(), result.score.is_mate_score());
+            captured
+                .into_iter()
+                .map(|c| {
+                    let (eval, mate) = c.unwrap_or(fallback);
+                    make_line(eval, mate)
+                })
+                .collect()
+        }
+        None => {
+            let result = search.go(&mut pos, limits, None::<fn(&SearchInfo)>);
+            make_line(result.score.to_cp(), result.score.is_mate_score()).map(|s| vec![s])
+        }
+    };
+    match lines {
+        Ok(lines) => Outcome::Ok(lines),
+        Err(e) => Outcome::Error(e),
     }
 }
 
@@ -553,6 +652,50 @@ fn count_records(path: &Path) -> Result<u64> {
     Ok(len / HCPE_RECORD_SIZE as u64)
 }
 
+/// `--capture-depths` の "9,12,15" を昇順・重複排除した正の depth 列に。
+fn parse_capture_depths(s: &str) -> Result<Vec<i32>> {
+    let mut depths: Vec<i32> = Vec::new();
+    for tok in s.split(',') {
+        let tok = tok.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        let d: i32 =
+            tok.parse().with_context(|| format!("invalid --capture-depths entry '{tok}'"))?;
+        if d <= 0 {
+            bail!("--capture-depths entries must be > 0 (got {d})");
+        }
+        depths.push(d);
+    }
+    if depths.is_empty() {
+        bail!("--capture-depths is empty");
+    }
+    depths.sort_unstable();
+    depths.dedup();
+    Ok(depths)
+}
+
+/// `--out base.jsonl` と depth 列から、depth ごとの出力パス `base_d<depth>.jsonl` を作る。
+/// 拡張子が無ければ末尾に `_d<depth>` を付ける。
+fn capture_output_paths(base: &Path, depths: &[i32]) -> Vec<PathBuf> {
+    let parent = base.parent();
+    let stem = base.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+    let ext = base.extension().map(|e| e.to_string_lossy().into_owned());
+    depths
+        .iter()
+        .map(|d| {
+            let name = match &ext {
+                Some(ext) => format!("{stem}_d{d}.{ext}"),
+                None => format!("{stem}_d{d}"),
+            };
+            match parent {
+                Some(p) if !p.as_os_str().is_empty() => p.join(name),
+                _ => PathBuf::from(name),
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -580,6 +723,29 @@ mod tests {
         assert_eq!(eval_band(29_999), "1501+");
         assert_eq!(eval_band(30_000), "mate");
         assert_eq!(eval_band(-32_767), "mate");
+    }
+
+    #[test]
+    fn parse_capture_depths_sorts_dedups_validates() {
+        assert_eq!(parse_capture_depths("15,9,12,9").unwrap(), vec![9, 12, 15]);
+        assert_eq!(parse_capture_depths(" 9 , 12 ").unwrap(), vec![9, 12]);
+        assert!(parse_capture_depths("").is_err());
+        assert!(parse_capture_depths("9,0").is_err());
+        assert!(parse_capture_depths("9,x").is_err());
+    }
+
+    #[test]
+    fn capture_output_paths_inserts_depth_suffix() {
+        let p = capture_output_paths(Path::new("runs/threat.jsonl"), &[9, 12]);
+        assert_eq!(
+            p,
+            vec![
+                PathBuf::from("runs/threat_d9.jsonl"),
+                PathBuf::from("runs/threat_d12.jsonl")
+            ]
+        );
+        let p2 = capture_output_paths(Path::new("threat"), &[15]);
+        assert_eq!(p2, vec![PathBuf::from("threat_d15")]);
     }
 
     /// 玉位置と入玉 class（初期局面はどちらも自陣なので none）。

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -1,0 +1,593 @@
+//! ラベル品質「物差し」ステージ 1: held-out hcpe を labeler でラベル付けする。
+//!
+//! 固定 held-out（棋譜由来の hcpe。各局面に保存 eval=教師ラベルと gameResult=実対局結果
+//! を持つ）の各局面を、与えた labeler（NNUE 評価器 + 固定 depth）の決定的探索で評価し、
+//! 採点に必要な値だけを 1 行 1 局面の jsonl に書き出す。ステージ 2 (`yardstick_score`) が
+//! この出力を読み、engine ごとに勝率スケールを較正して per-class の WDL logloss /
+//! 参照天井 / リファレンス一致を算出する。
+//!
+//! 設計上の不変条件（`label_bench_positions` と同じ）:
+//! - 局面ごとに `Search` を作り直し 1 スレッド固定（`set_num_threads(1)`）で探索する。
+//!   これにより 1 局面の評価は他局面・処理順・`--threads` から独立し、同一入力なら
+//!   出力は bit 一致する。
+//! - 入力件数に対してピークメモリが線形に増えないよう streaming で処理する。producer が
+//!   トークン制で in-flight 件数を一定上限に抑え、collector が入力順へ並べ替えて逐次書き出す。
+//!
+//! 評価値・勝敗の符号規約は **手番側視点（side-to-move view）**で統一する。hcpe の保存 eval は
+//! 手番側視点 cp（PSV `score` と同じ）であり、dlshogi DataLoader の value 目標もそうなので、
+//! ここでは先手視点へ変換せず手番側視点のまま素通しする（ステージ 2 もこの規約で採点する）。
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use crossbeam_channel::{bounded, unbounded};
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::Serialize;
+
+use rshogi_core::bitboard::{Bitboard, RANK_BB};
+use rshogi_core::nnue::{
+    LayerStackBucketMode, SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, get_layer_stack_bucket_mode,
+    init_nnue, is_layer_stacks_loaded, parse_layer_stack_bucket_mode, set_fv_scale_override,
+    set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
+};
+use rshogi_core::position::Position;
+use rshogi_core::search::{LimitsType, Search, SearchInfo};
+use rshogi_core::types::Color;
+use tools::packed_sfen::unpack_hcp;
+
+/// 探索用スタックサイズ（64MB）。深い探索で再帰スタックを使うため main 同等を確保する。
+const SEARCH_STACK_SIZE: usize = 64 * 1024 * 1024;
+
+/// hcpe（cshogi HuffmanCodedPosAndEval）1 レコードのバイト長。
+const HCPE_RECORD_SIZE: usize = 38;
+
+/// 詰みとみなす絶対 cp 閾値。保存 eval の符号飽和域は較正・logloss から除外する。
+const MATE_ABS: i32 = 30000;
+
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "yardstick_label",
+    version,
+    about = "held-out hcpe を NNUE labeler の固定 depth 探索でラベル付けし採点用 jsonl を出す"
+)]
+struct Cli {
+    /// 入力 hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード）。
+    #[arg(long = "in")]
+    input: PathBuf,
+
+    /// 出力 jsonl（採点用フィールドのみ、入力順）。
+    #[arg(long = "out")]
+    output: PathBuf,
+
+    /// labeler の NNUE モデルファイル。
+    #[arg(long)]
+    nnue: PathBuf,
+
+    /// FV_SCALE オーバーライド（0=ヘッダ自動判定、1 以上=指定値）。評価器の native 値に
+    /// 合わせて明示すること（threat/none LayerStacks 系は 28）。
+    #[arg(long, default_value_t = 0)]
+    fv_scale: i32,
+
+    /// LayerStacks の bucket mode（例: `progress8kpabs`）。LS ビルドでは既定が
+    /// progress8kpabs なので通常は指定不要。
+    #[arg(long)]
+    ls_bucket_mode: Option<String>,
+
+    /// progress8kpabs 用の進行度係数ファイル（USI `LS_PROGRESS_COEFF` と同じ）。
+    /// LayerStacks モデルで bucket mode が progress8kpabs のとき必須。
+    #[arg(long)]
+    ls_progress_coeff: Option<PathBuf>,
+
+    /// 探索深さ上限（0 以下=無制限）。depth を物差しの変数にする時は `--nodes 0` で
+    /// depth を binding にする。`--nodes` と両方とも無制限は不可。
+    #[arg(long, default_value_t = 12)]
+    depth: i32,
+
+    /// 探索ノード数上限（0=無制限）。深さと併用し先に到達した方で停止。
+    #[arg(long, default_value_t = 0)]
+    nodes: u64,
+
+    /// worker ごとの置換表サイズ（MB）。局面ごとに作り直すため過大にしない。
+    #[arg(long, default_value_t = 128)]
+    hash_mb: usize,
+
+    /// worker スレッド数（0=利用可能 CPU 数）。出力は thread 数非依存に bit 一致。
+    #[arg(long, default_value_t = 0)]
+    threads: usize,
+
+    /// 出力レコードに付与する source ラベル（hcpe はソースを持たないので任意指定）。
+    /// 例: `floodgate` / `dlsuisho_val`。
+    #[arg(long)]
+    source: Option<String>,
+
+    /// 先頭から処理する最大レコード数（0=全件）。smoke 用。
+    #[arg(long, default_value_t = 0)]
+    limit: usize,
+}
+
+/// ステージ 2 が読む採点用レコード。符号規約はすべて手番側視点。
+#[derive(Serialize)]
+struct ScoreRecord {
+    /// 手番（`b`/`w`）。
+    stm: char,
+    /// 実対局結果（手番側視点の勝率: 勝 1.0 / 負 0.0 / 引分 0.5）。
+    wdl: f64,
+    /// held-out 保存 eval（手番側視点 cp、教師=リファレンスラベル）。
+    eval_ref: i32,
+    /// labeler の探索値（手番側視点 cp）。
+    eval_label: i32,
+    /// 保存 eval から決めた class（labeler 非依存に固定するため eval_ref を使う）。
+    eval_band: &'static str,
+    /// 入玉 class（`none`/`black_entered`/`white_entered`/`both_entered`）。
+    nyugyoku: &'static str,
+    /// 王手局面か。
+    in_check: bool,
+    /// 保存 eval が飽和域（|eval_ref| >= MATE_ABS）か。
+    mate_ref: bool,
+    /// labeler が詰みスコアを返したか。
+    mate_label: bool,
+    /// source ラベル（`--source` 指定時のみ）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+}
+
+/// 1 局面の処理結果。`Error` でも seq スロットを消費するので順序は崩れない。
+enum Outcome {
+    Ok(String),
+    Skip,
+    Error(String),
+}
+
+fn main() -> Result<()> {
+    install_fatal_panic_hook();
+    let cli = Cli::parse();
+    run(&cli)
+}
+
+/// worker スレッドの探索パニックでプロセス全体を loud に終了させる（致命バグを黙って
+/// 部分出力に残さない）。`label_bench_positions` と同方針。
+fn install_fatal_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+        std::process::exit(101);
+    }));
+}
+
+fn run(cli: &Cli) -> Result<()> {
+    validate_paths(&cli.input, &cli.output)?;
+    if cli.depth <= 0 && cli.nodes == 0 {
+        bail!("--depth and --nodes are both unlimited; specify at least one to bound the search");
+    }
+
+    configure_eval(cli)?;
+
+    let num_threads = if cli.threads > 0 {
+        cli.threads
+    } else {
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+    };
+
+    let total_records = count_records(&cli.input)?;
+    let total = if cli.limit > 0 {
+        total_records.min(cli.limit as u64)
+    } else {
+        total_records
+    };
+
+    eprintln!(
+        "Labeling {} ({} records) -> {} (depth={}, nodes={}, hash={}MB/worker, threads={})",
+        cli.input.display(),
+        total,
+        cli.output.display(),
+        cli.depth,
+        cli.nodes,
+        cli.hash_mb,
+        num_threads,
+    );
+
+    ctrlc::set_handler(|| INTERRUPTED.store(true, Ordering::SeqCst))
+        .context("Failed to set Ctrl-C handler")?;
+
+    let progress = ProgressBar::new(total);
+    progress.set_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({per_sec}) {msg}")
+            .expect("valid template"),
+    );
+
+    let stats = run_pipeline(cli, num_threads, &progress)?;
+
+    progress.finish_with_message("Done");
+    eprintln!("Wrote {} labeled records", stats.written);
+    if stats.skipped > 0 {
+        eprintln!("Skipped {} records (invalid wdl/board)", stats.skipped);
+    }
+    if stats.errors > 0 {
+        eprintln!("Skipped {} records due to errors", stats.errors);
+    }
+    if INTERRUPTED.load(Ordering::SeqCst) {
+        bail!(
+            "interrupted: output truncated to the in-order prefix ({} records written)",
+            stats.written
+        );
+    }
+    Ok(())
+}
+
+struct RunStats {
+    written: u64,
+    skipped: u64,
+    errors: u64,
+}
+
+/// producer + worker + collector のストリーミングパイプライン本体。
+fn run_pipeline(cli: &Cli, num_threads: usize, progress: &ProgressBar) -> Result<RunStats> {
+    let inflight_cap = (num_threads * 4).max(num_threads + 1);
+
+    let (token_tx, token_rx) = bounded::<()>(inflight_cap);
+    for _ in 0..inflight_cap {
+        token_tx.send(()).expect("prime tokens");
+    }
+    let (work_tx, work_rx) = unbounded::<(usize, [u8; HCPE_RECORD_SIZE])>();
+    let (res_tx, res_rx) = unbounded::<(usize, Outcome)>();
+
+    let depth = cli.depth;
+    let nodes = cli.nodes;
+    let hash_mb = cli.hash_mb;
+    let source = cli.source.clone();
+
+    let mut workers = Vec::with_capacity(num_threads);
+    for worker_idx in 0..num_threads {
+        let work_rx = work_rx.clone();
+        let res_tx = res_tx.clone();
+        let source = source.clone();
+        let handle = thread::Builder::new()
+            .name(format!("yardstick-worker-{worker_idx}"))
+            .stack_size(SEARCH_STACK_SIZE)
+            .spawn(move || {
+                while let Ok((seq, bytes)) = work_rx.recv() {
+                    if INTERRUPTED.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let outcome = process_record(&bytes, hash_mb, depth, nodes, source.as_deref());
+                    if res_tx.send((seq, outcome)).is_err() {
+                        break;
+                    }
+                }
+            })
+            .context("Failed to spawn worker thread")?;
+        workers.push(handle);
+    }
+    drop(work_rx);
+    drop(res_tx);
+
+    let input_path = cli.input.clone();
+    let limit = cli.limit;
+    let producer = thread::spawn(move || -> Result<()> {
+        let file = File::open(&input_path)
+            .with_context(|| format!("Failed to open {}", input_path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut seq = 0usize;
+        let mut buf = [0u8; HCPE_RECORD_SIZE];
+        loop {
+            if limit > 0 && seq >= limit {
+                break;
+            }
+            if INTERRUPTED.load(Ordering::SeqCst) {
+                break;
+            }
+            match reader.read_exact(&mut buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e).context("Failed to read hcpe record"),
+            }
+            // in-flight 上限まで投入したら token を待つ（collector が 1 件書き出すと返る）。
+            if token_rx.recv().is_err() {
+                break;
+            }
+            if work_tx.send((seq, buf)).is_err() {
+                break;
+            }
+            seq += 1;
+        }
+        drop(work_tx);
+        Ok(())
+    });
+
+    // collector: seq 順に並べ替えて逐次書き出す。
+    let out_file = File::create(&cli.output)
+        .with_context(|| format!("Failed to create {}", cli.output.display()))?;
+    let mut writer = BufWriter::new(out_file);
+    let mut next = 0usize;
+    let mut buf: std::collections::BTreeMap<usize, Outcome> = std::collections::BTreeMap::new();
+    let mut written = 0u64;
+    let mut skipped = 0u64;
+    let mut errors = 0u64;
+
+    while let Ok((seq, outcome)) = res_rx.recv() {
+        buf.insert(seq, outcome);
+        while let Some(outcome) = buf.remove(&next) {
+            match outcome {
+                Outcome::Ok(line) => {
+                    writer.write_all(line.as_bytes())?;
+                    writer.write_all(b"\n")?;
+                    written += 1;
+                }
+                Outcome::Skip => skipped += 1,
+                Outcome::Error(msg) => {
+                    errors += 1;
+                    eprintln!("skip record {next}: {msg}");
+                }
+            }
+            next += 1;
+            progress.inc(1);
+            let _ = token_tx.send(());
+        }
+    }
+    writer.flush()?;
+
+    drop(token_tx);
+    producer.join().map_err(|_| anyhow::anyhow!("producer thread panicked"))??;
+    for handle in workers {
+        let _ = handle.join();
+    }
+
+    Ok(RunStats {
+        written,
+        skipped,
+        errors,
+    })
+}
+
+/// hcpe 1 レコードを labeler でラベル付けし採点用 jsonl 行にする。
+fn process_record(
+    bytes: &[u8; HCPE_RECORD_SIZE],
+    hash_mb: usize,
+    depth: i32,
+    nodes: u64,
+    source: Option<&str>,
+) -> Outcome {
+    let eval_ref = i16::from_le_bytes([bytes[32], bytes[33]]) as i32;
+    let game_result = bytes[36];
+
+    let mut hcp = [0u8; 32];
+    hcp.copy_from_slice(&bytes[0..32]);
+    let sfen = match unpack_hcp(&hcp) {
+        Ok(s) => s,
+        Err(e) => return Outcome::Error(format!("unpack_hcp failed: {e}")),
+    };
+
+    let mut pos = Position::new();
+    if let Err(e) = pos.set_sfen(&sfen) {
+        return Outcome::Error(format!("set_sfen failed: {e:?}: {sfen}"));
+    }
+    let stm = pos.side_to_move();
+
+    let Some(wdl) = wdl_stm(game_result, stm) else {
+        // gameResult が不正（0/1/2 以外）なレコードは採点対象外。
+        return Outcome::Skip;
+    };
+
+    let nyugyoku = nyugyoku_label(&pos);
+    let in_check = pos.in_check();
+
+    let mut search = Search::new(hash_mb);
+    search.set_num_threads(1);
+    let mut limits = LimitsType::default();
+    limits.depth = depth;
+    if nodes > 0 {
+        limits.nodes = nodes;
+    }
+    limits.set_start_time();
+    let result = search.go(&mut pos, limits, None::<fn(&SearchInfo)>);
+    let score = result.score;
+
+    let record = ScoreRecord {
+        stm: if stm == Color::Black { 'b' } else { 'w' },
+        wdl,
+        eval_ref,
+        eval_label: score.to_cp(),
+        eval_band: eval_band(eval_ref),
+        nyugyoku,
+        in_check,
+        mate_ref: eval_ref.abs() >= MATE_ABS,
+        mate_label: score.is_mate_score(),
+        source: source.map(str::to_string),
+    };
+    match serde_json::to_string(&record) {
+        Ok(s) => Outcome::Ok(s),
+        Err(e) => Outcome::Error(format!("serialize error: {e}")),
+    }
+}
+
+/// gameResult（0=DRAW / 1=BLACK_WIN / 2=WHITE_WIN, 絶対視点）を手番側視点の勝率へ。
+fn wdl_stm(game_result: u8, stm: Color) -> Option<f64> {
+    match game_result {
+        0 => Some(0.5),
+        1 => Some(if stm == Color::Black { 1.0 } else { 0.0 }),
+        2 => Some(if stm == Color::White { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+/// 入玉 class。敵陣 3 段目以内に玉がいるかで分類（`extract_bench_positions` と同義）。
+fn nyugyoku_label(pos: &Position) -> &'static str {
+    let black = enemy_field_ranks(Color::Black).contains(pos.king_square(Color::Black));
+    let white = enemy_field_ranks(Color::White).contains(pos.king_square(Color::White));
+    match (black, white) {
+        (true, true) => "both_entered",
+        (true, false) => "black_entered",
+        (false, true) => "white_entered",
+        (false, false) => "none",
+    }
+}
+
+fn enemy_field_ranks(color: Color) -> Bitboard {
+    match color {
+        Color::Black => RANK_BB[0] | RANK_BB[1] | RANK_BB[2],
+        Color::White => RANK_BB[6] | RANK_BB[7] | RANK_BB[8],
+    }
+}
+
+/// |eval| の帯（`extract_bench_positions` と同義）。手番側視点でも絶対値分類なので不変。
+fn eval_band(eval: i32) -> &'static str {
+    match eval.abs() {
+        0..=150 => "0-150",
+        151..=600 => "151-600",
+        601..=1500 => "601-1500",
+        1501..=29_999 => "1501+",
+        _ => "mate",
+    }
+}
+
+/// 評価器（NNUE + LayerStacks bucket 設定）を USI エンジンと同じ手順で構成する。
+/// `label_bench_positions::configure_eval` と同じく progress8kpabs で係数未指定なら弾く。
+fn configure_eval(cli: &Cli) -> Result<()> {
+    if !cli.nnue.exists() {
+        bail!("NNUE model file not found: {}", cli.nnue.display());
+    }
+    if cli.fv_scale != 0 {
+        set_fv_scale_override(cli.fv_scale);
+        eprintln!("FV_SCALE: {}", cli.fv_scale);
+    } else {
+        eprintln!("FV_SCALE: auto-detect (header)");
+    }
+    if let Some(mode_str) = &cli.ls_bucket_mode {
+        let mode = parse_layer_stack_bucket_mode(mode_str)
+            .with_context(|| format!("invalid --ls-bucket-mode '{mode_str}'"))?;
+        set_layer_stack_bucket_mode(mode);
+        eprintln!("LS_BUCKET_MODE: {}", mode.as_str());
+    }
+    let mut coeff_loaded = false;
+    if let Some(path) = &cli.ls_progress_coeff {
+        let weights = load_progress_coeff_kpabs(path)?;
+        set_layer_stack_progress_kpabs_weights(weights)
+            .map_err(|e| anyhow::anyhow!("failed to set progress coeff weights: {e}"))?;
+        coeff_loaded = true;
+        eprintln!("LS_PROGRESS_COEFF: {}", path.display());
+    }
+    init_nnue(&cli.nnue).context("Failed to load NNUE model")?;
+    eprintln!("NNUE model loaded: {}", cli.nnue.display());
+    if is_layer_stacks_loaded()
+        && get_layer_stack_bucket_mode() == LayerStackBucketMode::Progress8KPAbs
+        && !coeff_loaded
+    {
+        bail!(
+            "LS_BUCKET_MODE=progress8kpabs requires --ls-progress-coeff. \
+             Without it the progress bucket selection diverges from training and labels are wrong."
+        );
+    }
+    Ok(())
+}
+
+/// progress8kpabs 用の進行度係数ファイル（f64 配列）を読み f32 重みへ変換する。
+fn load_progress_coeff_kpabs(path: &Path) -> Result<Box<[f32]>> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read --ls-progress-coeff {}", path.display()))?;
+    let expected = SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS * std::mem::size_of::<f64>();
+    if bytes.len() != expected {
+        bail!("progress coeff size mismatch: got {} bytes, expected {}", bytes.len(), expected);
+    }
+    let weights: Vec<f32> = bytes
+        .chunks_exact(std::mem::size_of::<f64>())
+        .map(|chunk| f64::from_le_bytes(chunk.try_into().expect("chunk size is checked")) as f32)
+        .collect();
+    Ok(weights.into_boxed_slice())
+}
+
+fn validate_paths(input: &Path, output: &Path) -> Result<()> {
+    if input == output {
+        bail!("--in and --out must differ");
+    }
+    if let (Ok(a), Ok(b)) = (fs::canonicalize(input), fs::canonicalize(output))
+        && a == b
+    {
+        bail!("--in and --out resolve to the same file");
+    }
+    // canonicalize は hardlink（別 path・同一 inode）を検出できない。collector が出力を
+    // create で truncate するため、dev/ino でも同一性を弾いて入力破壊を防ぐ。
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let (Ok(im), Ok(om)) = (fs::metadata(input), fs::metadata(output))
+            && im.dev() == om.dev()
+            && im.ino() == om.ino()
+        {
+            bail!("--in and --out are the same file (same dev/ino)");
+        }
+    }
+    if let Ok(meta) = fs::symlink_metadata(output)
+        && meta.file_type().is_symlink()
+    {
+        bail!("refusing to write through a symlink: {}", output.display());
+    }
+    if let Some(parent) = output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create output dir {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+/// 進捗バーの分母用に hcpe レコード数を数える（ファイルサイズ / 38）。
+fn count_records(path: &Path) -> Result<u64> {
+    let len = fs::metadata(path)
+        .with_context(|| format!("Failed to stat {}", path.display()))?
+        .len();
+    if len % HCPE_RECORD_SIZE as u64 != 0 {
+        bail!(
+            "hcpe file size {} is not a multiple of {} (corrupt or wrong format)",
+            len,
+            HCPE_RECORD_SIZE
+        );
+    }
+    Ok(len / HCPE_RECORD_SIZE as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wdl_stm_maps_absolute_result_to_side_to_move() {
+        assert_eq!(wdl_stm(1, Color::Black), Some(1.0));
+        assert_eq!(wdl_stm(1, Color::White), Some(0.0));
+        assert_eq!(wdl_stm(2, Color::Black), Some(0.0));
+        assert_eq!(wdl_stm(2, Color::White), Some(1.0));
+        assert_eq!(wdl_stm(0, Color::Black), Some(0.5));
+        assert_eq!(wdl_stm(0, Color::White), Some(0.5));
+        assert_eq!(wdl_stm(3, Color::Black), None);
+    }
+
+    #[test]
+    fn eval_band_boundaries() {
+        assert_eq!(eval_band(0), "0-150");
+        assert_eq!(eval_band(150), "0-150");
+        assert_eq!(eval_band(-151), "151-600");
+        assert_eq!(eval_band(600), "151-600");
+        assert_eq!(eval_band(601), "601-1500");
+        assert_eq!(eval_band(1500), "601-1500");
+        assert_eq!(eval_band(1501), "1501+");
+        assert_eq!(eval_band(29_999), "1501+");
+        assert_eq!(eval_band(30_000), "mate");
+        assert_eq!(eval_band(-32_767), "mate");
+    }
+
+    /// 玉位置と入玉 class（初期局面はどちらも自陣なので none）。
+    #[test]
+    fn nyugyoku_initial_position_is_none() {
+        let mut pos = Position::new();
+        pos.set_sfen("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("startpos");
+        assert_eq!(nyugyoku_label(&pos), "none");
+    }
+}

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -583,7 +583,11 @@ fn run_pipeline(
     drop(token_tx);
     producer.join().map_err(|_| anyhow::anyhow!("producer thread panicked"))??;
     for handle in workers {
-        let _ = handle.join();
+        if let Err(e) = handle.join() {
+            // 探索パニックは fatal hook が exit(101) するのでここには通常来ない。巻き戻し中の
+            // drop パニック等で join が Err になる稀なケースは握りつぶさず記録する。
+            eprintln!("worker thread panicked: {e:?}");
+        }
     }
 
     Ok(RunStats {

--- a/crates/tools/src/bin/yardstick_score.rs
+++ b/crates/tools/src/bin/yardstick_score.rs
@@ -1,0 +1,463 @@
+//! ラベル品質「物差し」ステージ 2: labeler のラベルを WDL ground truth で採点する。
+//!
+//! `yardstick_label` が出した採点用 jsonl（手番側視点で `wdl`=実対局結果・`eval_ref`=保存
+//! 教師 eval・`eval_label`=labeler の探索値を持つ）を読み、engine ごとに勝率スケールを較正
+//! してから class 別に以下を出す:
+//!
+//! - **主指標: WDL logloss** = mean[ CE(sigmoid(eval/a), wdl) ]。a は labeler ごとに logloss
+//!   最小化で較正（NNUE の FV_SCALE と DL の winrate を混ぜても scale 差を精度と誤認しない）。
+//! - **参照天井**: 保存 eval（教師）の符号一致率。labeler が超えるべき model 非依存の上限
+//!   （datagap の `diag_strict.py` の `evalvs_result` と同義）。
+//! - **副指標: リファレンス一致**: 較正後 win-prob 空間で labeler と保存 eval の MAE、および
+//!   eval の Spearman 順位相関。
+//!
+//! 符号規約はすべて手番側視点（`yardstick_label` と同じ）。詰み（|eval| >= 30000）は較正・
+//! logloss・一致から除外する（飽和域は勝率較正を歪めるため）。
+//!
+//! held-out は設計上 5〜20 万局面で bounded なので全件を読み込んでから採点する
+//! （億規模の教師プールを load-all する系ツールとは別）。
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+/// 詰みとみなす絶対 cp 閾値（`yardstick_label` と一致させる）。
+const MATE_ABS: i32 = 30000;
+
+/// logloss の確率クランプ（log(0) 回避）。
+const PROB_EPS: f64 = 1e-7;
+
+/// eval_band を |cp| 昇順で表示するための固定順（mate は採点対象外なので含めない）。
+const EVAL_BAND_ORDER: [&str; 4] = ["0-150", "151-600", "601-1500", "1501+"];
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "yardstick_score",
+    version,
+    about = "labeler の jsonl を WDL で採点し per-class の logloss/参照天井/一致を出す"
+)]
+struct Cli {
+    /// 採点する jsonl（`yardstick_label` 出力）。複数指定で labeler/depth を並べて比較。
+    #[arg(required = true)]
+    labeled: Vec<PathBuf>,
+
+    /// 結果 JSON の出力先（任意）。指定すると per-file/per-group の数値を機械可読で残す。
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+/// `yardstick_label` の 1 行レコード。
+#[derive(Deserialize)]
+struct ScoreRecord {
+    wdl: f64,
+    eval_ref: i32,
+    eval_label: i32,
+    eval_band: String,
+    nyugyoku: String,
+    in_check: bool,
+    mate_ref: bool,
+    mate_label: bool,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+/// 1 グループの集計結果。
+#[derive(Serialize, Clone)]
+struct GroupMetrics {
+    group: String,
+    /// 採点対象（詰み除外）の局面数。
+    n: usize,
+    /// labeler の WDL logloss（較正後）。
+    label_logloss: f64,
+    /// 保存 eval（教師）の WDL logloss（較正後）。
+    ref_logloss: f64,
+    /// labeler の符号一致率。
+    label_sign_acc: f64,
+    /// 保存 eval の符号一致率（= 参照天井）。
+    ref_sign_acc: f64,
+    /// 較正後 win-prob 空間での labeler vs 保存 eval の MAE。
+    winprob_mae: f64,
+    /// eval_label vs eval_ref の Spearman 順位相関。
+    spearman: f64,
+}
+
+/// 1 ファイル（= 1 labeler config）の採点結果。
+#[derive(Serialize)]
+struct FileReport {
+    file: String,
+    n_total: usize,
+    n_scored: usize,
+    /// labeler eval の較正スケール（cp、win-prob = sigmoid(eval/a_label)）。
+    a_label: f64,
+    /// 保存 eval の較正スケール。
+    a_ref: f64,
+    /// 全レコード（詰み含む）での参照天井符号一致率（datagap の diag_strict と比較可能）。
+    ref_ceiling_all: f64,
+    groups: Vec<GroupMetrics>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let mut reports = Vec::new();
+    for path in &cli.labeled {
+        let report = score_file(path)?;
+        print_report(&report);
+        reports.push(report);
+    }
+    if let Some(out) = &cli.out {
+        let f = File::create(out).with_context(|| format!("Failed to create {}", out.display()))?;
+        let mut w = BufWriter::new(f);
+        serde_json::to_writer_pretty(&mut w, &reports)?;
+        w.write_all(b"\n")?;
+        w.flush()?;
+        eprintln!("wrote results json: {}", out.display());
+    }
+    Ok(())
+}
+
+fn score_file(path: &Path) -> Result<FileReport> {
+    let records = load_records(path)?;
+    if records.is_empty() {
+        bail!("no records in {}", path.display());
+    }
+    let n_total = records.len();
+
+    // 参照天井（全レコード、詰み含む）= 保存 eval 符号 vs 実結果。draw は wdl>=0.5 を
+    // 「手番側勝ち」として扱う（diag_strict の value>=0.5 規約に合わせる）。
+    let ref_ceiling_all = sign_acc(records.iter().map(|r| (r.eval_ref, r.wdl)));
+
+    // 採点対象 = labeler・保存 eval どちらも非詰みの共通集合（飽和域は較正を歪めるため除外）。
+    // `to_cp()` が詰みフラグ無しで飽和 cp を返す経路もあるので、フラグと |cp| 閾値の両方で弾く。
+    let scored: Vec<&ScoreRecord> = records
+        .iter()
+        .filter(|r| {
+            !r.mate_ref
+                && !r.mate_label
+                && r.eval_ref.abs() < MATE_ABS
+                && r.eval_label.abs() < MATE_ABS
+        })
+        .collect();
+    let n_scored = scored.len();
+    if n_scored == 0 {
+        bail!("no non-mate records to score in {}", path.display());
+    }
+
+    // engine ごとに 1 つの global scale を較正（class ごとには較正しない＝scale を class に
+    // 過適合させない）。較正後の固定 scale で per-class の logloss を出す。
+    let a_label = calibrate(scored.iter().map(|r| (r.eval_label as f64, r.wdl)));
+    let a_ref = calibrate(scored.iter().map(|r| (r.eval_ref as f64, r.wdl)));
+
+    // class は各次元の周辺スライス（marginal）で出す。eval_band×nyugyoku×in_check×source の
+    // 直積セルは出さない。理由: bias の所在は周辺スライスで特定でき（「互角帯に集中」「入玉
+    // class に集中」）、直積は Floodgate のように入玉局面がほぼ無い held-out で空セルが多発し
+    // 可読性・統計的安定性を損なうため。直積が要るようになってから追加する（現状は不要）。
+    let mut groups = Vec::new();
+    groups.push(group_metrics("overall", &scored, a_label, a_ref));
+
+    // eval_band 別（保存 eval 由来なので labeler 非依存に固定）。表示は |cp| 昇順に並べる
+    // （lexicographic だと `1501+` が `151-600` より前に来て直感に反するため）。
+    for band in EVAL_BAND_ORDER {
+        let g: Vec<&ScoreRecord> = scored.iter().filter(|r| r.eval_band == band).copied().collect();
+        if !g.is_empty() {
+            groups.push(group_metrics(&format!("eval_band={band}"), &g, a_label, a_ref));
+        }
+    }
+    // 入玉別。
+    for ny in distinct(scored.iter().map(|r| r.nyugyoku.as_str())) {
+        let g: Vec<&ScoreRecord> = scored.iter().filter(|r| r.nyugyoku == ny).copied().collect();
+        groups.push(group_metrics(&format!("nyugyoku={ny}"), &g, a_label, a_ref));
+    }
+    // 王手別。
+    for chk in [false, true] {
+        let g: Vec<&ScoreRecord> = scored.iter().filter(|r| r.in_check == chk).copied().collect();
+        if !g.is_empty() {
+            groups.push(group_metrics(&format!("in_check={chk}"), &g, a_label, a_ref));
+        }
+    }
+    // source 別（指定があれば）。
+    let sources = distinct(scored.iter().filter_map(|r| r.source.as_deref()));
+    if sources.len() > 1 {
+        for src in sources {
+            let g: Vec<&ScoreRecord> =
+                scored.iter().filter(|r| r.source.as_deref() == Some(src)).copied().collect();
+            groups.push(group_metrics(&format!("source={src}"), &g, a_label, a_ref));
+        }
+    }
+
+    Ok(FileReport {
+        file: path.display().to_string(),
+        n_total,
+        n_scored,
+        a_label,
+        a_ref,
+        ref_ceiling_all,
+        groups,
+    })
+}
+
+fn load_records(path: &Path) -> Result<Vec<ScoreRecord>> {
+    let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for (i, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let rec: ScoreRecord = serde_json::from_str(&line)
+            .with_context(|| format!("{}:{}: json parse error", path.display(), i + 1))?;
+        out.push(rec);
+    }
+    Ok(out)
+}
+
+/// 較正済みスケール `a` で 1 グループの指標を計算する。
+fn group_metrics(name: &str, group: &[&ScoreRecord], a_label: f64, a_ref: f64) -> GroupMetrics {
+    let n = group.len();
+    let label_logloss = mean_logloss(group.iter().map(|r| (r.eval_label as f64, r.wdl)), a_label);
+    let ref_logloss = mean_logloss(group.iter().map(|r| (r.eval_ref as f64, r.wdl)), a_ref);
+    let label_sign_acc = sign_acc(group.iter().map(|r| (r.eval_label, r.wdl)));
+    let ref_sign_acc = sign_acc(group.iter().map(|r| (r.eval_ref, r.wdl)));
+    let winprob_mae = if n == 0 {
+        0.0
+    } else {
+        group
+            .iter()
+            .map(|r| {
+                (sigmoid(r.eval_label as f64 / a_label) - sigmoid(r.eval_ref as f64 / a_ref)).abs()
+            })
+            .sum::<f64>()
+            / n as f64
+    };
+    let spearman = spearman_corr(
+        &group.iter().map(|r| r.eval_label as f64).collect::<Vec<_>>(),
+        &group.iter().map(|r| r.eval_ref as f64).collect::<Vec<_>>(),
+    );
+    GroupMetrics {
+        group: name.to_string(),
+        n,
+        label_logloss,
+        ref_logloss,
+        label_sign_acc,
+        ref_sign_acc,
+        winprob_mae,
+        spearman,
+    }
+}
+
+fn sigmoid(x: f64) -> f64 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// 数値安定な softplus = ln(1 + e^x)。
+fn softplus(x: f64) -> f64 {
+    x.max(0.0) + (1.0 + (-x.abs()).exp()).ln()
+}
+
+/// 平均 logloss（cross-entropy）。target は wdl∈[0,1]（draw=0.5）、予測は sigmoid(eval/a)。
+fn mean_logloss(samples: impl Iterator<Item = (f64, f64)>, a: f64) -> f64 {
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    for (eval, wdl) in samples {
+        let p = sigmoid(eval / a).clamp(PROB_EPS, 1.0 - PROB_EPS);
+        sum += -(wdl * p.ln() + (1.0 - wdl) * (1.0 - p).ln());
+        n += 1;
+    }
+    if n == 0 { 0.0 } else { sum / n as f64 }
+}
+
+/// 符号一致率。pred = (eval >= 0)、target = (wdl >= 0.5)（draw は手番側勝ち扱い）。
+fn sign_acc(samples: impl Iterator<Item = (i32, f64)>) -> f64 {
+    let mut agree = 0usize;
+    let mut n = 0usize;
+    for (eval, wdl) in samples {
+        if (eval >= 0) == (wdl >= 0.5) {
+            agree += 1;
+        }
+        n += 1;
+    }
+    if n == 0 { 0.0 } else { agree as f64 / n as f64 }
+}
+
+/// labeler ごとに 1 つの勝率スケール `a` を WDL logloss 最小化で較正する。
+///
+/// `win_prob = sigmoid(eval / a)`。NLL は k=1/a について凸なので、k を黄金分割探索で
+/// 最小化する（決定的・乱数なし）。a の探索域は 10〜20000cp（k = 5e-5〜0.1）。
+fn calibrate(samples: impl Iterator<Item = (f64, f64)>) -> f64 {
+    let data: Vec<(f64, f64)> = samples.collect();
+    // NLL(k) = Σ [ w·softplus(-k·e) + (1-w)·softplus(k·e) ]。
+    let nll = |k: f64| -> f64 {
+        data.iter()
+            .map(|&(e, w)| {
+                let z = k * e;
+                w * softplus(-z) + (1.0 - w) * softplus(z)
+            })
+            .sum::<f64>()
+    };
+    // 黄金分割で凸 1 変数最小化（k ∈ [k_lo, k_hi]）。
+    let (mut lo, mut hi) = (5e-5_f64, 0.1_f64);
+    let inv_phi = (5.0_f64.sqrt() - 1.0) / 2.0;
+    let mut c = hi - (hi - lo) * inv_phi;
+    let mut d = lo + (hi - lo) * inv_phi;
+    let mut fc = nll(c);
+    let mut fd = nll(d);
+    for _ in 0..200 {
+        if fc < fd {
+            hi = d;
+            d = c;
+            fd = fc;
+            c = hi - (hi - lo) * inv_phi;
+            fc = nll(c);
+        } else {
+            lo = c;
+            c = d;
+            fc = fd;
+            d = lo + (hi - lo) * inv_phi;
+            fd = nll(d);
+        }
+        if (hi - lo).abs() < 1e-9 {
+            break;
+        }
+    }
+    let k = 0.5 * (lo + hi);
+    1.0 / k
+}
+
+/// Spearman 順位相関（同順位は平均順位）。スケール不変なので生 eval で取れる。
+fn spearman_corr(xs: &[f64], ys: &[f64]) -> f64 {
+    if xs.len() < 2 {
+        return f64::NAN;
+    }
+    let rx = average_ranks(xs);
+    let ry = average_ranks(ys);
+    pearson(&rx, &ry)
+}
+
+/// 同順位を平均順位にした順位ベクトルを返す。
+fn average_ranks(v: &[f64]) -> Vec<f64> {
+    let n = v.len();
+    let mut idx: Vec<usize> = (0..n).collect();
+    idx.sort_by(|&a, &b| v[a].partial_cmp(&v[b]).unwrap_or(std::cmp::Ordering::Equal));
+    let mut ranks = vec![0.0; n];
+    let mut i = 0;
+    while i < n {
+        let mut j = i + 1;
+        while j < n && v[idx[j]] == v[idx[i]] {
+            j += 1;
+        }
+        // [i, j) が同値 → 平均順位 (1-based の平均)。
+        let avg = ((i + 1 + j) as f64) / 2.0;
+        for &k in &idx[i..j] {
+            ranks[k] = avg;
+        }
+        i = j;
+    }
+    ranks
+}
+
+fn pearson(xs: &[f64], ys: &[f64]) -> f64 {
+    let n = xs.len() as f64;
+    let mx = xs.iter().sum::<f64>() / n;
+    let my = ys.iter().sum::<f64>() / n;
+    let mut sxy = 0.0;
+    let mut sxx = 0.0;
+    let mut syy = 0.0;
+    for (&x, &y) in xs.iter().zip(ys) {
+        sxy += (x - mx) * (y - my);
+        sxx += (x - mx) * (x - mx);
+        syy += (y - my) * (y - my);
+    }
+    if sxx <= 0.0 || syy <= 0.0 {
+        return f64::NAN;
+    }
+    sxy / (sxx.sqrt() * syy.sqrt())
+}
+
+/// 出現順を安定させた distinct（BTreeMap で key ソート、決定的）。
+fn distinct<'a>(it: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
+    let mut m: BTreeMap<&'a str, ()> = BTreeMap::new();
+    for x in it {
+        m.insert(x, ());
+    }
+    m.into_keys().collect()
+}
+
+fn print_report(r: &FileReport) {
+    println!("\n=== {} ===", r.file);
+    println!(
+        "n_total={}  n_scored(non-mate)={}  a_label={:.1}cp  a_ref={:.1}cp  ref_ceiling(all,sign)={:.4}",
+        r.n_total, r.n_scored, r.a_label, r.a_ref, r.ref_ceiling_all
+    );
+    println!(
+        "{:<22} {:>7} {:>10} {:>10} {:>9} {:>9} {:>9} {:>9}",
+        "group", "n", "lbl_loss", "ref_loss", "lbl_sgn", "ref_sgn", "wp_mae", "spearman"
+    );
+    for g in &r.groups {
+        println!(
+            "{:<22} {:>7} {:>10.4} {:>10.4} {:>9.4} {:>9.4} {:>9.4} {:>9.4}",
+            g.group,
+            g.n,
+            g.label_logloss,
+            g.ref_logloss,
+            g.label_sign_acc,
+            g.ref_sign_acc,
+            g.winprob_mae,
+            g.spearman
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigmoid_and_softplus_basic() {
+        assert!((sigmoid(0.0) - 0.5).abs() < 1e-12);
+        assert!((softplus(0.0) - 2.0_f64.ln()).abs() < 1e-12);
+        // softplus(x) - softplus(-x) == x
+        for x in [-5.0, -1.0, 0.0, 1.0, 5.0] {
+            assert!((softplus(x) - softplus(-x) - x).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn sign_acc_counts_agreement() {
+        // eval>=0 ↔ wdl>=0.5 が一致する割合。
+        let s = vec![(100, 1.0), (-100, 0.0), (50, 0.0), (-50, 1.0)];
+        assert!((sign_acc(s.into_iter()) - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn calibrate_recovers_known_scale() {
+        // win_prob = sigmoid(eval/a_true) で生成した soft target を入れ、a_true を復元できるか。
+        let a_true = 300.0;
+        let samples: Vec<(f64, f64)> = (-2000..=2000)
+            .step_by(10)
+            .map(|e| (e as f64, sigmoid(e as f64 / a_true)))
+            .collect();
+        let a = calibrate(samples.into_iter());
+        assert!((a - a_true).abs() < 5.0, "recovered a={a}, expected {a_true}");
+    }
+
+    #[test]
+    fn spearman_monotone_is_one() {
+        let xs = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let ys = vec![10.0, 20.0, 30.0, 40.0, 50.0];
+        assert!((spearman_corr(&xs, &ys) - 1.0).abs() < 1e-9);
+        let yr = vec![50.0, 40.0, 30.0, 20.0, 10.0];
+        assert!((spearman_corr(&xs, &yr) + 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn average_ranks_handles_ties() {
+        // 同値は平均順位。
+        let r = average_ranks(&[10.0, 10.0, 20.0]);
+        assert_eq!(r, vec![1.5, 1.5, 3.0]);
+    }
+}

--- a/crates/tools/src/bin/yardstick_score.rs
+++ b/crates/tools/src/bin/yardstick_score.rs
@@ -82,8 +82,8 @@ struct GroupMetrics {
     ref_sign_acc: f64,
     /// 較正後 win-prob 空間での labeler vs 保存 eval の MAE。
     winprob_mae: f64,
-    /// eval_label vs eval_ref の Spearman 順位相関。
-    spearman: f64,
+    /// eval_label vs eval_ref の Spearman 順位相関（n<2・分散 0 等で未定義なら null）。
+    spearman: Option<f64>,
 }
 
 /// 1 ファイル（= 1 labeler config）の採点結果。
@@ -103,6 +103,11 @@ struct FileReport {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    if let Some(out) = &cli.out {
+        // 採点を全部終えてから create するため、--out が入力ラベル jsonl と同一だと高価な
+        // ラベルを結果 JSON で上書きしてしまう。同一パス/同一 inode を事前に弾く。
+        validate_out_not_input(out, &cli.labeled)?;
+    }
     let mut reports = Vec::new();
     for path in &cli.labeled {
         let report = score_file(path)?;
@@ -116,6 +121,37 @@ fn main() -> Result<()> {
         w.write_all(b"\n")?;
         w.flush()?;
         eprintln!("wrote results json: {}", out.display());
+    }
+    Ok(())
+}
+
+/// `--out`（結果 JSON）が入力ラベル jsonl のどれかと同一パス/同一 inode なら弾く。
+fn validate_out_not_input(out: &Path, inputs: &[PathBuf]) -> Result<()> {
+    let out_canon = std::fs::canonicalize(out).ok();
+    #[cfg(unix)]
+    let out_devino = {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(out).ok().map(|m| (m.dev(), m.ino()))
+    };
+    for input in inputs {
+        if input == out {
+            bail!("--out must differ from every input ({})", out.display());
+        }
+        if let (Some(oc), Some(ic)) = (&out_canon, std::fs::canonicalize(input).ok())
+            && *oc == ic
+        {
+            bail!("--out resolves to input {}", input.display());
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if let (Some((od, oi)), Some(im)) = (out_devino, std::fs::metadata(input).ok())
+                && od == im.dev()
+                && oi == im.ino()
+            {
+                bail!("--out is the same file as input {} (same dev/ino)", input.display());
+            }
+        }
     }
     Ok(())
 }
@@ -234,10 +270,12 @@ fn group_metrics(name: &str, group: &[&ScoreRecord], a_label: f64, a_ref: f64) -
             .sum::<f64>()
             / n as f64
     };
-    let spearman = spearman_corr(
+    let spearman_raw = spearman_corr(
         &group.iter().map(|r| r.eval_label as f64).collect::<Vec<_>>(),
         &group.iter().map(|r| r.eval_ref as f64).collect::<Vec<_>>(),
     );
+    // NaN（n<2・分散 0）は null として持つ（JSON で明示 null、表では "—"）。
+    let spearman = spearman_raw.is_finite().then_some(spearman_raw);
     GroupMetrics {
         group: name.to_string(),
         n,
@@ -378,7 +416,7 @@ fn pearson(xs: &[f64], ys: &[f64]) -> f64 {
     sxy / (sxx.sqrt() * syy.sqrt())
 }
 
-/// 出現順を安定させた distinct（BTreeMap で key ソート、決定的）。
+/// 出現した値を辞書順（BTreeMap の key 順）で重複排除して返す（決定的）。
 fn distinct<'a>(it: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
     let mut m: BTreeMap<&'a str, ()> = BTreeMap::new();
     for x in it {
@@ -398,8 +436,9 @@ fn print_report(r: &FileReport) {
         "group", "n", "lbl_loss", "ref_loss", "lbl_sgn", "ref_sgn", "wp_mae", "spearman"
     );
     for g in &r.groups {
+        let spearman = g.spearman.map_or_else(|| "—".to_string(), |v| format!("{v:.4}"));
         println!(
-            "{:<22} {:>7} {:>10.4} {:>10.4} {:>9.4} {:>9.4} {:>9.4} {:>9.4}",
+            "{:<22} {:>7} {:>10.4} {:>10.4} {:>9.4} {:>9.4} {:>9.4} {:>9}",
             g.group,
             g.n,
             g.label_logloss,
@@ -407,7 +446,7 @@ fn print_report(r: &FileReport) {
             g.label_sign_acc,
             g.ref_sign_acc,
             g.winprob_mae,
-            g.spearman
+            spearman
         );
     }
 }


### PR DESCRIPTION
## 概要

labeler（engine + USI param + 固定 depth）が付けた eval ラベルの品質を、固定 held-out 上で独立な ground truth（棋譜由来の WDL=実対局結果）に対して採点する再利用ツールを追加します。depth 選定・labeler config 最適化・教師比較（Threat / 非 Threat / DL net）の共通核です。

2 段構成（高価なラベリングと安価な採点を分離）:

- **`yardstick_label`** (stage 1): held-out hcpe（cshogi HuffmanCodedPosAndEval, 38B）を labeler でラベル付けし、採点用 jsonl（手番側視点の `wdl` / `eval_ref`(保存教師 eval) / `eval_label` + class）を出す。
- **`yardstick_score`** (stage 2): engine ごとに勝率スケールを較正し、per-class で **WDL logloss**（主）/ **参照天井（符号一致）** / **リファレンス一致（win-prob MAE・Spearman）**（副）を出す。

## labeler 2 種

- **NNUE 探索**: 局面ごと fresh `Search` + 1 スレッド固定で `--threads` 非依存に **bit 一致**（決定的 CPU ラベリング）。`--capture-depths 9,12,15` で 1 回の反復深化探索から複数 depth を捕捉し depth ごとに別ファイルへ（`--nodes 0` では単独固定 depth 探索と bit 一致）。
- **DL ONNX 静的** (`--onnx-model`): NNUE 探索の代わりに DL（標準 dlshogi ONNX）value head を 1 forward pass で回し `eval_label` に。NNUE labeler と同じ口で stage 2 に通せるので「NNUE@depth-d vs DL static」を同一 held-out で apples-to-apples 比較できる。`dlshogi-onnx` feature（default 有効）。

## 設計

- 符号規約はすべて手番側視点（hcpe 保存 eval / WDL / labeler eval）。詰みは較正・logloss・一致から除外。
- 較正は `sigmoid(eval/a)` の WDL logloss を黄金分割で最小化（engine ごとに 1 つの global scale。NNUE の FV_SCALE と DL の winrate を混ぜても scale 差を精度と誤認しない）。
- class は周辺スライス（eval_band × nyugyoku × in_check × source、各次元別）。
- held-out は設計上 5〜20 万局面で bounded。stage 1 は streaming でピークメモリを入力件数に非依存に保つ。

## コミット

1. ハーネス本体（`yardstick_label` / `yardstick_score` + docs）
2. `--capture-depths`（反復深化で 1 探索 N depth）
3. ONNX labeler モード（DL value head 静的評価）

## チェック

- `cargo fmt` / `cargo clippy --tests`（警告 0、`#[allow]`/`unsafe` 無し）/ `cargo test`（unit tests pass）
- default edition + Threat edition（`--no-default-features --features layerstacks-…,nnue-threat,ft-…`）両方ビルド確認
- 決定性（`--threads 1` == `--threads 0` bit 一致）・ONNX 推論のスモーク確認済
- `crates/tools/docs/{yardstick_label,yardstick_score}.md` + 索引（tools-reference.md / README.md）更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)