### PR TITLE
feat(tools): yardstick_label に --spsa-params を追加（SPSA 探索params適用）

### DIFF
--- a/crates/tools/docs/yardstick_label.md
+++ b/crates/tools/docs/yardstick_label.md
@@ -86,6 +86,7 @@ depth を物差しの変数にするときは `--nodes 0` で depth を binding 
 | `--depth <i32>` | 12 | 探索深さ上限（0 以下=無制限）。`--nodes` と両方 0 は不可 |
 | `--nodes <u64>` | 0 | 探索ノード数上限（0=無制限）。depth を変数にするなら 0 |
 | `--hash-mb <usize>` | 128 | worker ごとの置換表サイズ（MB）。局面ごとに作り直すため過大にしない |
+| `--spsa-params <FILE>` | — | SPSA 探索パラメータ `.params`（USI `SPSAParamsFile` と同形式 CSV）を各局面の探索へ setoption 相当で適用（NNUE 探索モードのみ。`--onnx-model` では無視）。未指定は engine 既定値 |
 | `--threads <usize>` | 0 | worker スレッド数（0=全コア）。出力は thread 数非依存に bit 一致 |
 | `--source <STR>` | — | 出力に付与する source ラベル（hcpe はソースを持たないので任意。例 `floodgate`） |
 | `--limit <usize>` | 0 | 先頭から処理する最大レコード数（0=全件）。smoke 用 |

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -276,6 +276,10 @@ fn run_nnue_mode(cli: &Cli, total: u64, progress: &ProgressBar) -> Result<RunSta
     for out in &outputs {
         validate_paths(&cli.input, out)?;
     }
+    // `--spsa-params` は collector が truncate する出力先と衝突すると破壊されるので弾く。
+    if let Some(spsa) = &cli.spsa_params {
+        validate_side_input_not_clobbered(spsa, &outputs)?;
+    }
     if effective_depth <= 0 && cli.nodes == 0 {
         bail!("--depth and --nodes are both unlimited; specify at least one to bound the search");
     }
@@ -487,7 +491,7 @@ fn run_pipeline(
             warn_unapplied_tune_params(&parsed);
             Arc::from(parsed)
         }
-        None => Arc::from(Vec::new()),
+        None => Arc::from([]),
     };
 
     let mut workers = Vec::with_capacity(num_threads);
@@ -895,6 +899,36 @@ fn validate_paths(input: &Path, output: &Path) -> Result<()> {
     Ok(())
 }
 
+/// `--spsa-params` のような read-only な side input が、collector が `create` で truncate する
+/// 出力先と同一ファイルを指していないか検証する（衝突すると side input を破壊してしまう）。
+/// `validate_paths` の入出力チェックと同じく、canonical path と（hardlink 対策の）dev/ino の
+/// 両方で同一性を弾く。
+fn validate_side_input_not_clobbered(side_input: &Path, outputs: &[PathBuf]) -> Result<()> {
+    for out in outputs {
+        let same = side_input == out
+            || matches!(
+                (fs::canonicalize(side_input), fs::canonicalize(out)),
+                (Ok(a), Ok(b)) if a == b
+            );
+        #[cfg(unix)]
+        let same = same || {
+            use std::os::unix::fs::MetadataExt;
+            matches!(
+                (fs::metadata(side_input), fs::metadata(out)),
+                (Ok(sm), Ok(om)) if sm.dev() == om.dev() && sm.ino() == om.ino()
+            )
+        };
+        if same {
+            bail!(
+                "--spsa-params {} and output {} are the same file (output would be truncated)",
+                side_input.display(),
+                out.display()
+            );
+        }
+    }
+    Ok(())
+}
+
 /// 進捗バーの分母用に hcpe レコード数を数える（ファイルサイズ / 38）。
 fn count_records(path: &Path) -> Result<u64> {
     let len = fs::metadata(path)
@@ -956,7 +990,10 @@ fn parse_spsa_params_content(content: &str) -> Vec<(String, i32)> {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        let val_part = trimmed.split("//").next().unwrap_or(trimmed).replace("[[NOT USED]]", "");
+        let val_part = trimmed
+            .split_once("//")
+            .map_or(trimmed, |(before, _)| before)
+            .replace("[[NOT USED]]", "");
         let cols: Vec<&str> = val_part.split(',').map(str::trim).collect();
         if cols.len() < 3 {
             continue;
@@ -1079,6 +1116,21 @@ BAD_VALUE,int,xyz,0,8\n";
             ]
         );
         assert!(parse_spsa_params_content("# only a comment\n").is_empty());
+    }
+
+    #[test]
+    fn validate_side_input_rejects_output_collision() {
+        let outputs = vec![
+            PathBuf::from("runs/none1536_d9.jsonl"),
+            PathBuf::from("runs/none1536_d15.jsonl"),
+        ];
+        // spsa params が出力先と同一パス → 拒否（出力 truncate で破壊されるため）。
+        assert!(
+            validate_side_input_not_clobbered(Path::new("runs/none1536_d15.jsonl"), &outputs)
+                .is_err()
+        );
+        // 別パスなら OK。
+        assert!(validate_side_input_not_clobbered(Path::new("spsa/v99.params"), &outputs).is_ok());
     }
 
     #[test]

--- a/crates/tools/src/bin/yardstick_label.rs
+++ b/crates/tools/src/bin/yardstick_label.rs
@@ -24,6 +24,7 @@
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 
@@ -101,6 +102,12 @@ struct Cli {
     /// worker ごとの置換表サイズ（MB）。局面ごとに作り直すため過大にしない。
     #[arg(long, default_value_t = 128)]
     hash_mb: usize,
+
+    /// SPSA 探索パラメータ `.params` ファイル（USI `SPSAParamsFile` と同形式 CSV:
+    /// `name,type,value,...`）。指定すると各局面の探索へ setoption 相当（`set_search_tune_option`）
+    /// で適用する（NNUE 探索モードのみ。`--onnx-model` では無視）。未指定は engine 既定値。
+    #[arg(long)]
+    spsa_params: Option<PathBuf>,
 
     /// worker スレッド数（0=利用可能 CPU 数）。出力は thread 数非依存に bit 一致。
     #[arg(long, default_value_t = 0)]
@@ -220,6 +227,11 @@ fn run(cli: &Cli) -> Result<()> {
     );
 
     let stats = if cli.onnx_model.is_some() {
+        if cli.spsa_params.is_some() {
+            eprintln!(
+                "warning: --spsa-params is ignored with --onnx-model (static eval has no search)"
+            );
+        }
         run_onnx_mode(cli, &progress)?
     } else {
         run_nnue_mode(cli, total, &progress)?
@@ -468,6 +480,15 @@ fn run_pipeline(
     let hash_mb = cli.hash_mb;
     let source = cli.source.clone();
     let targets_owned: Option<Vec<i32>> = targets.map(<[i32]>::to_vec);
+    // SPSA 探索パラメータは worker 間で共有し、各局面の Search へ適用する（空なら engine 既定値）。
+    let tune_params: Arc<[(String, i32)]> = match &cli.spsa_params {
+        Some(path) => {
+            let parsed = parse_spsa_params(path)?;
+            warn_unapplied_tune_params(&parsed);
+            Arc::from(parsed)
+        }
+        None => Arc::from(Vec::new()),
+    };
 
     let mut workers = Vec::with_capacity(num_threads);
     for worker_idx in 0..num_threads {
@@ -475,6 +496,7 @@ fn run_pipeline(
         let res_tx = res_tx.clone();
         let source = source.clone();
         let targets = targets_owned.clone();
+        let tune_params = Arc::clone(&tune_params);
         let handle = thread::Builder::new()
             .name(format!("yardstick-worker-{worker_idx}"))
             .stack_size(SEARCH_STACK_SIZE)
@@ -490,6 +512,7 @@ fn run_pipeline(
                         nodes,
                         source.as_deref(),
                         targets.as_deref(),
+                        &tune_params,
                     );
                     if res_tx.send((seq, outcome)).is_err() {
                         break;
@@ -678,6 +701,7 @@ fn process_record(
     nodes: u64,
     source: Option<&str>,
     targets: Option<&[i32]>,
+    tune_params: &[(String, i32)],
 ) -> Outcome {
     let (mut pos, meta) = match parse_hcpe_record(bytes) {
         ParseHcpe::Ok(parsed) => *parsed,
@@ -687,6 +711,10 @@ fn process_record(
 
     let mut search = Search::new(hash_mb);
     search.set_num_threads(1);
+    // SPSA 探索パラメータを setoption 相当で適用（未指定なら空 = engine 既定値）。
+    for (name, value) in tune_params {
+        search.set_search_tune_option(name, *value);
+    }
     let mut limits = LimitsType::default();
     limits.depth = depth;
     if nodes > 0 {
@@ -905,6 +933,77 @@ fn parse_capture_depths(s: &str) -> Result<Vec<i32>> {
     Ok(depths)
 }
 
+/// SPSA `.params`（USI `SPSAParamsFile` と同形式）を `(USI 名, 値)` の列に読み込む。
+/// 行形式: `name,type,value[,min,max,c_end,r_end] [// comment] [[[NOT USED]]]`。空行・`#`
+/// コメント・列不足・値パース不能の行は読み飛ばす（USI 側ローダと同方針）。適用は探索ごとに
+/// `set_search_tune_option` で行うため、未知名は適用時に無視され、範囲外は clamp される。
+fn parse_spsa_params(path: &Path) -> Result<Vec<(String, i32)>> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read --spsa-params {}", path.display()))?;
+    let params = parse_spsa_params_content(&content);
+    if params.is_empty() {
+        bail!("--spsa-params {} contained no applicable rows", path.display());
+    }
+    eprintln!("Loaded {} SPSA param(s) from {}", params.len(), path.display());
+    Ok(params)
+}
+
+/// `.params` の本文を `(USI 名, 値)` の列にパースする（IO なし。`parse_spsa_params` の本体）。
+fn parse_spsa_params_content(content: &str) -> Vec<(String, i32)> {
+    let mut params = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let val_part = trimmed.split("//").next().unwrap_or(trimmed).replace("[[NOT USED]]", "");
+        let cols: Vec<&str> = val_part.split(',').map(str::trim).collect();
+        if cols.len() < 3 {
+            continue;
+        }
+        let (name, type_name, value_str) = (cols[0], cols[1], cols[2]);
+        let parsed = if type_name.eq_ignore_ascii_case("int") {
+            match value_str.parse::<f64>() {
+                Ok(v) => v.round() as i32,
+                Err(_) => continue,
+            }
+        } else {
+            match value_str.parse::<i32>() {
+                Ok(v) => v,
+                Err(_) => continue,
+            }
+        };
+        params.push((name.to_string(), parsed));
+    }
+    params
+}
+
+/// ロード時に 1 度だけ使い捨ての `Search` へ全 params を適用し、実際に適用される件数・clamp 件数・
+/// 未知名を warn する。`.params` の名前 typo（例: net-mismatch なファイルの取り違え）を黙殺せず早期に
+/// 気付けるようにするためで、USI ローダ（`maybe_load_spsa_params` の applied/clamped ログ）と挙動を揃える。
+/// 実探索は局面ごとに同じ (name,value) を決定的に適用するので、この検証は決定性に影響しない。
+fn warn_unapplied_tune_params(params: &[(String, i32)]) {
+    let mut probe = Search::new(1);
+    let mut applied = 0usize;
+    let mut clamped = 0usize;
+    let mut unknown: Vec<&str> = Vec::new();
+    for (name, value) in params {
+        match probe.set_search_tune_option(name, *value) {
+            Some(result) => {
+                applied += 1;
+                if result.clamped {
+                    clamped += 1;
+                }
+            }
+            None => unknown.push(name),
+        }
+    }
+    eprintln!("SPSA params applied: {applied} (clamped {clamped}, unknown {})", unknown.len());
+    if !unknown.is_empty() {
+        eprintln!("  warning: unknown SPSA param name(s) ignored: {}", unknown.join(", "));
+    }
+}
+
 /// `--out base.jsonl` と depth 列から、depth ごとの出力パス `base_d<depth>.jsonl` を作る。
 /// 拡張子が無ければ末尾に `_d<depth>` を付ける。
 fn capture_output_paths(base: &Path, depths: &[i32]) -> Vec<PathBuf> {
@@ -953,6 +1052,33 @@ mod tests {
         assert_eq!(eval_band(29_999), "1501+");
         assert_eq!(eval_band(30_000), "mate");
         assert_eq!(eval_band(-32_767), "mate");
+    }
+
+    #[test]
+    fn parse_spsa_params_content_parses_rounds_and_skips() {
+        // int は f64 として読んで round、空行/コメント/列不足/値不正は読み飛ばす。
+        let content = "\
+# comment\n\
+\n\
+SPSA_IIR_SHALLOW,int,1,0,8,1,0.4\n\
+SPSA_LMR_DELTA_SCALE,int,933.7,0,4096,20,204.8 // trailing comment\n\
+SPSA_DRAW_JITTER_OFFSET,int,-1,-16,16 [[NOT USED]]\n\
+NON_INT_SPIN,spin,7,0,100\n\
+NON_INT_FRACTION,spin,3.5,0,100\n\
+TOO_FEW,int\n\
+BAD_VALUE,int,xyz,0,8\n";
+        let params = parse_spsa_params_content(content);
+        assert_eq!(
+            params,
+            vec![
+                ("SPSA_IIR_SHALLOW".to_string(), 1),
+                ("SPSA_LMR_DELTA_SCALE".to_string(), 934),
+                ("SPSA_DRAW_JITTER_OFFSET".to_string(), -1),
+                // 非 int 型は i32 直読み（round しない）。小数は parse 失敗で読み飛ばす。
+                ("NON_INT_SPIN".to_string(), 7),
+            ]
+        );
+        assert!(parse_spsa_params_content("# only a comment\n").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`yardstick_label` の NNUE 探索 labeler モードに `--spsa-params <FILE>` を追加。各局面の探索へ SPSA 探索パラメータ `.params` を setoption 相当（`set_search_tune_option`）で適用する。USI の `SPSAParamsFile`（`maybe_load_spsa_params`）と同形式 CSV を読み、行解釈（`//` コメント・`[[NOT USED]]`・`#`・列不足・int の f64 round・parse 失敗 skip）も USI ローダと一致させた。

## 動機

`label_quality_yardstick` の **Phase 0a**（labeler config を default vs SPSA で横並び計測し production config を確定する）に必要。従来 yardstick_label には探索 params を渡す入口が無く、SPSA 版が測れなかった。

## 設計・不変条件

- params は全 worker に `Arc<[(String,i32)]>` で共有し、各局面で fresh な `Search` へ**ファイル順で決定的に適用**する。HashMap 反復順などの非決定は混入しないため、本ツールの不変条件「出力は `--threads` 非依存に bit 一致」は保たれる。
- 未指定時は空 `Arc` で no-op（= engine 既定値）。
- ロード時に使い捨て `Search` で全 params を 1 度適用し、**適用/clamp/未知名の件数を warn**（`.params` の取り違え・名前 typo を黙殺しない。USI ローダの applied/clamped ログと挙動を揃える）。
- ONNX モードは探索が無いため `--spsa-params` は無視（warning）。

## テスト

- `cargo fmt` / `cargo clippy`（クリーン）/ `cargo test -p tools --bin yardstick_label`（6 pass）/ `scripts/check-tracked-abs-paths.sh` 通過。
- unit test に非 int 型分岐・コメント・空行・列不足・値不正の網羅を追加。
- 実データ smoke: 163 params ロード→全適用（unknown 0）、わざと未知名/範囲外を足すと `applied/clamped/unknown` 件数と未知名 warning が出ることを確認。

## 計測結果（参考）

同一 Floodgate held-out（49410, hash 32MB, capture 9/12/15）で default vs SPSA:

| depth | logloss default→SPSA | Δ改善 | sign default→SPSA |
|---|---|---|---|
| d15 | 0.4105 → 0.4075 | +0.0030 | 0.7848 → 0.7876 |

（default は既存 findings を本環境ビルドで完全再現）

🤖 Generated with [Claude Code](https://claude.com/claude-code)