### PR TITLE
perf(tools): rescore_psv の出力 host バッファを CUDA pinned 化

### DIFF
--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -365,6 +365,23 @@ bit 一致する。
 （出力は pinned/pageable で bit 一致）。計測例: TensorRT FP16 / batch 1024 / RTX 5090(WSL2)
 で約 +26%、CUDA EP / 同条件で約 +21%（いずれも 2M records, min-of-3, 出力 byte 一致）。
 
+出力（推論結果）の host バッファも同様に、入力 pinned が確保できた GPU 経路では
+**CUDA pinned (page-locked) メモリ**にバインドする（`IoBinding` の出力先を
+`AllocationDevice::CUDA_PINNED` に設定）。pageable 出力だと `run_binding` 内の D2H が
+pageable staging を伴い実質同期化するが、pinned 化で真の async D2H になり `run` フェーズ
+内部の GPU アイドルが縮む。pinned 不使用時（CPU 推論 / pinned 確保失敗）は従来どおり CPU
+pageable に保ち、出力は pinned/pageable で bit 一致する（メモリ場所のみの変更で数値不変）。
+計測例: TensorRT FP16 / batch 1024 / RTX 5090(WSL2) / 10M records で wall 63.2s→57–58s
+（throughput +8〜11%、GPU util 約 73–76%→80–84%、出力 byte 一致）。なお本構成では
+これにより GPU 推論（`run`）の所要が供給（`read`+`build`）を下回り、以降は特徴量供給が
+新たな上限になる。
+
+> CUDA Graph について: TensorRT EP は `trt_cuda_graph_enable` を備えるが、本パイプラインの
+> 出力取得経路（`bind_output_to_device` + `run_binding`）は ort 2.0-rc.12 では CUDA Graph 有効時に
+> 出力 OrtValue の型情報取得で panic し利用不可。加えて CUDA Graph は入出力アドレス固定・
+> 形状固定が前提で、本実装の slot 二重化（入力アドレスが毎回変わる）・端数バッチ（形状が変わる）
+> とも非互換のため、現状は非採用。
+
 ### `--threads` について
 
 特徴量構築（CPU 処理）を rayon で並列化するスレッド数（0 で論理コア数）。前処理は

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -358,29 +358,12 @@ CPU 前処理を待ってアイドルする区間を潰し、GPU を連続的に
 決定性: PSV のデコードを直列段階に残してバッチ構成を不変に保つため、出力は逐次実装と
 bit 一致する。
 
-入力特徴の host バッファは、GPU 推論時（`--onnx-gpu-id >= 0`）は **CUDA pinned (page-locked)
-メモリ**で確保する。pageable メモリだと `cudaMemcpyAsync` が CUDA 内部で pageable→pinned
-ステージング（CPU 介在）を伴い実質同期化するが、pinned 化でこれが消えて真の async H2D に
-なる。pinned 確保に失敗した環境では通常の pageable バッファに自動フォールバックする
-（出力は pinned/pageable で bit 一致）。計測例: TensorRT FP16 / batch 1024 / RTX 5090(WSL2)
-で約 +26%、CUDA EP / 同条件で約 +21%（いずれも 2M records, min-of-3, 出力 byte 一致）。
-
-出力（推論結果）の host バッファも同様に、入力 pinned が確保できた GPU 経路では
-**CUDA pinned (page-locked) メモリ**にバインドする（`IoBinding` の出力先を
-`AllocationDevice::CUDA_PINNED` に設定）。pageable 出力だと `run_binding` 内の D2H が
-pageable staging を伴い実質同期化するが、pinned 化で真の async D2H になり `run` フェーズ
-内部の GPU アイドルが縮む。pinned 不使用時（CPU 推論 / pinned 確保失敗）は従来どおり CPU
-pageable に保ち、出力は pinned/pageable で bit 一致する（メモリ場所のみの変更で数値不変）。
-計測例: TensorRT FP16 / batch 1024 / RTX 5090(WSL2) / 10M records で wall 63.2s→57–58s
-（throughput +8〜11%、GPU util 約 73–76%→80–84%、出力 byte 一致）。なお本構成では
-これにより GPU 推論（`run`）の所要が供給（`read`+`build`）を下回り、以降は特徴量供給が
-新たな上限になる。
-
-> CUDA Graph について: TensorRT EP は `trt_cuda_graph_enable` を備えるが、本パイプラインの
-> 出力取得経路（`bind_output_to_device` + `run_binding`）は ort 2.0-rc.12 では CUDA Graph 有効時に
-> 出力 OrtValue の型情報取得で panic し利用不可。加えて CUDA Graph は入出力アドレス固定・
-> 形状固定が前提で、本実装の slot 二重化（入力アドレスが毎回変わる）・端数バッチ（形状が変わる）
-> とも非互換のため、現状は非採用。
+入力特徴と出力（推論結果）の host バッファは、GPU 推論時（`--onnx-gpu-id >= 0`）に確保できれば
+**CUDA pinned (page-locked) メモリ**を使う（`IoBinding` の入出力先を `AllocationDevice::CUDA_PINNED`
+に設定）。pageable だと H2D（`cudaMemcpyAsync`）や `run_binding` 内の D2H が pageable→pinned
+ステージング（CPU 介在）を伴い実質同期化するが、pinned 化でこれが消えて真の async 転送になる。
+pinned を確保できない環境（CPU 推論 / 確保失敗）では通常の pageable バッファに自動フォール
+バックする。pinned 化はメモリ場所のみの差で、出力は pinned/pageable で bit 一致する（数値不変）。
 
 ### `--threads` について
 
@@ -394,22 +377,6 @@ GPU 推論とオーバーラップされるので、GPU が前処理より遅い
 1 回の `session.run` あたりの局面数。大きくすると GPU 呼び出し回数と per-call
 オーバーヘッドが減り GPU 利用率が上がる。VRAM に余裕がある場合は拡大を検討する
 （特徴量バッファは batch_size に比例し、slot プール枚数ぶん確保される）。
-
-### 計測例（DL_suisho15b.onnx, BS=1024, RTX 3080 Ti, 500k records）
-
-供給と GPU 推論のオーバーラップ有無の比較（同一入力で出力は bit 一致）:
-
-| 構成 | wall | GPU util | SM clock |
-|---|---|---|---|
-| オーバーラップなし | 60.6 s | 91.9% | 1695 MHz |
-| パイプライン | 52.2 s | 97.3% | 1929 MHz |
-
-GPU を連続供給するとアイドル区間が消えるだけでなく、boost clock を維持できるため
-推論自体も速くなり、合計 -14%（約 +16% pos/s）。供給律速がより顕著な高速 GPU では
-効果はさらに大きい。
-
-> 注: GPU のサーマルスロットリングが計測に大きく影響するため、
-> 連続計測時は GPU 温度を冷却（目安 60℃ 以下）してから実行すること。
 
 ## 進捗表示（進捗率・残り時間・完了予定時刻）
 
@@ -544,7 +511,7 @@ rescore_psv --input "expanded1/*.bin" --output-dir rescored_expanded1/ \
 - 入力ディレクトリ（例 `expanded1/`）と新しい `--expand-output-dir`（例
   `expanded2/`）も **別ディレクトリ**を指定
 - 旧段の expand 出力が次段の入力と同じファイル実体になる誤設定は起動時に検出
-  してエラー（安全装置、PR #463 で追加）
+  してエラー（安全装置）
 
 ## 動作確認
 
@@ -596,14 +563,12 @@ AobaZero ONNX model loaded. Batch size: 1024
   FP32 で推論する場合は `--onnx-tensorrt` を指定せず CUDA EP を使うこと
 - TensorRT は初回実行時にモデルを GPU 固有にコンパイルする（数十秒〜数分）。
   `--onnx-tensorrt-cache` でキャッシュを保存すると 2 回目以降は高速起動する
-- 入力 host バッファが pageable だった旧実装では、CPU→GPU 転送（`cudaMemcpyAsync`）が
-  pageable→pinned ステージングで実質同期化し全処理時間の ~96%（nsys 計測）を占めていた。
-  現在は GPU 推論時に host バッファを CUDA pinned 化してこの staging を解消している
-  （「ONNX モードの供給パイプライン」参照）。pinned 化後は転送が真の async になり overlap
-  されるため、転送は支配項ではなくなり、入力 FP16 化による転送量半減の効果も小さい
-  （本番 batch では計測上ほぼ誤差内）
+- GPU 推論時は host バッファを CUDA pinned 化し、CPU↔GPU 転送（`cudaMemcpyAsync` / D2H）の
+  pageable→pinned ステージング（CPU 介在で実質同期化）を解消する（「ONNX モードの供給
+  パイプライン」参照）。pinned 化で転送は真の async になり推論と overlap されるため、転送は
+  支配項ではなく、入力 FP16 化による転送量半減の効果も小さい
 - `--threads` による特徴量構築の並列化は GPU 推論とオーバーラップされる。供給（read+build）が
   GPU 推論より速ければ全体時間への影響は小さい（軽量モデル・高速 GPU で前処理が供給律速に
   なる場合のみ寄与する）
-- 参考: 同等の Python ツール [psv-utils](https://github.com/KazApps/psv-utils) と比較して、
-  本ツールは CUDA EP / TensorRT EP どちらでも約 6〜9% 速い（1,051,780 records, 温度管理付き計測）
+- 参考: 同等機能の Python ツール [psv-utils](https://github.com/KazApps/psv-utils) がある
+  （本ツールは Rust 実装）

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -3428,11 +3428,11 @@ where
         }
     }
 
-    // 出力 host バッファのメモリ種別。MemoryInfo はバッチサイズに依存しないのでループ外で
-    // 1 回だけ作成する。入力を pinned 化できた GPU 経路では出力も CUDA pinned (page-locked)
-    // にして run_binding 内の D2H を pageable staging 無しの真の async D2H にする
-    // (入力 pinned の出力版)。pinned 不使用時 (CPU 推論 / pinned 確保失敗) は従来どおり CPU
-    // pageable に保つ。pinned はメモリ場所のみの変更で数値は不変 (出力 bit 一致)。
+    // 出力 host バッファのメモリ種別 (バッチサイズ非依存なのでループ外で 1 回だけ作成)。
+    // pinned 化の可否は入力 pinned (pinned_ok) に従う: 入力を pinned 化できた GPU 経路では出力も
+    // CUDA pinned (page-locked) にして run_binding 内の D2H を真の async D2H にする。それ以外
+    // (CPU 推論 / 入力 pinned 確保失敗) は CPU pageable。pinned 化はメモリ場所のみの差で出力は
+    // bit 一致。出力 pinned の実確保は run_binding 内で行われ、失敗時は fallback せずエラーになる。
     let output_mem = if pinned_ok {
         MemoryInfo::new(
             AllocationDevice::CUDA_PINNED,

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -3332,11 +3332,6 @@ where
     let mut logits_buf: Vec<f32> = Vec::with_capacity(600);
     let mut probs_buf: Vec<f32> = Vec::with_capacity(600);
 
-    // MemoryInfo はバッチサイズに依存しないのでループ外で1回だけ作成
-    let output_mem =
-        MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
-            .map_err(onnx_ort_err)?;
-
     // 入力特徴 host バッファを CUDA pinned (page-locked) 化するための allocator。
     // pinned 化で pageable→pinned ステージング (CPU 介在) が消え、真の async H2D になる。
     // GPU 推論 (gpu_id >= 0) のときのみ確保を試み、失敗したら pageable Vec にフォールバック。
@@ -3432,6 +3427,23 @@ where
             ));
         }
     }
+
+    // 出力 host バッファのメモリ種別。MemoryInfo はバッチサイズに依存しないのでループ外で
+    // 1 回だけ作成する。入力を pinned 化できた GPU 経路では出力も CUDA pinned (page-locked)
+    // にして run_binding 内の D2H を pageable staging 無しの真の async D2H にする
+    // (入力 pinned の出力版)。pinned 不使用時 (CPU 推論 / pinned 確保失敗) は従来どおり CPU
+    // pageable に保つ。pinned はメモリ場所のみの変更で数値は不変 (出力 bit 一致)。
+    let output_mem = if pinned_ok {
+        MemoryInfo::new(
+            AllocationDevice::CUDA_PINNED,
+            gpu_id,
+            AllocatorType::Device,
+            MemoryType::CPUOutput,
+        )
+    } else {
+        MemoryInfo::new(AllocationDevice::CPU, 0, AllocatorType::Device, MemoryType::CPUOutput)
+    }
+    .map_err(onnx_ort_err)?;
 
     let (t_read, t_build) = thread::scope(|scope| -> Result<(u128, u128)> {
         let (free_tx, free_rx) = mpsc::channel::<PreparedBatch>();


### PR DESCRIPTION
## 概要

ONNX/TensorRT-fp16 リスコア (`rescore_psv` の `process_file_with_onnx_pipeline`) の GPU util 天井対策。入力 host バッファの CUDA pinned 化に続き、**出力（推論結果）の IoBinding 先も CUDA pinned (page-locked) 化**して `run_binding` 内の D2H から pageable staging を排し、真の async D2H にする。

- `output_mem` を `pinned_ok` 時のみ `AllocationDevice::CUDA_PINNED` で確保。pinned 不使用時（CPU 推論 / 入力 pinned 確保失敗）は従来の CPU pageable に維持。**メモリ場所のみの変更で数値不変（出力 bit 一致）**。
- 出力 pinned の実確保失敗時は fallback せずエラー（入力 pinned 成功済みなら蓋然性低・コメントに明記）。

## 計測（RTX 5090 / WSL2 / TRT fp16 / batch1024 / 10M records）

| | before(HEAD) | ② pinned |
|---|---|---|
| wall | 63.2s | 57–58s |
| throughput | 158k | **172–175k pos/s（+8〜11%）** |
| GPU util | ~73–76% | **80–84%** |

出力 byte 一致を確認。phase timing 上、②で `run` が縮み供給（read+build）律速へ移る（詳細な phase split / 律速分析は private notes 管理）。

## レビュー（ローカル dual review・`@codex` bot 不使用）

- **Claude**: APPROVE / **Codex**: APPROVE
- 指摘反映（doc/コメントのみ・ロジック不変）: 出力 pinned の fallback 挙動明記、「同 allocator」断定撤回（入力 CPUInput / 出力 CPUOutput で別）。

## OSS doc 整理

`crates/tools/docs/rescore_psv.md` から作業ログ・開発意思決定・ベンチ provenance を除去し、ユーザー向け機能説明に限定（pinned 挙動・フォールバック・bit 一致のみ）。CUDA Graph 非採用の経緯・phase timing 分析・GPU 別計測例・PR 番号参照・nsys/records 等の provenance は OSS doc から削除（開発記録は private notes へ）。

## テスト

- `cargo fmt -- --check` ✓ / `cargo clippy -p tools --tests` ✓（警告0）/ `cargo test -p tools` ✓（132 passed）/ `bash scripts/check-tracked-abs-paths.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
