### PR TITLE
feat(tools): PSV / tournament JSONL 共通の棋譜プレイヤー TUI (kifu_player)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +295,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +316,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -354,6 +389,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +432,40 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -672,6 +766,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -917,6 +1013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,9 +1059,31 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -983,6 +1107,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1056,6 +1189,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1080,6 +1219,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1181,6 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1359,6 +1508,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1598,6 +1753,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1854,6 +2030,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1861,7 +2050,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2100,6 +2289,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,11 +2373,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -2257,7 +2495,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2421,6 +2659,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-channel",
+ "crossterm",
  "ctrlc",
  "env_logger",
  "flate2",
@@ -2432,6 +2671,7 @@ dependencies = [
  "ort",
  "rand",
  "rand_chacha",
+ "ratatui",
  "rayon",
  "regex",
  "reqwest",
@@ -2591,10 +2831,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -3342,7 +3605,7 @@ dependencies = [
  "async-trait",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.27.2",
  "syn",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +132,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -145,10 +163,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "2.11.1"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -186,6 +225,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,12 +247,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -279,7 +324,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -296,9 +341,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -316,8 +361,17 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -353,6 +407,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -394,11 +454,29 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -424,13 +502,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -454,7 +542,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -465,7 +553,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -473,6 +561,40 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "difflib"
@@ -496,7 +618,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -510,7 +632,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -565,16 +696,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -654,7 +833,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -766,8 +945,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -777,6 +954,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -785,12 +964,23 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1059,7 +1249,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "unit-prefix",
  "web-time",
 ]
@@ -1083,7 +1273,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1110,9 +1300,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1144,7 +1334,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1158,6 +1348,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1188,6 +1395,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,11 +1450,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1234,6 +1462,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "matchers"
@@ -1267,6 +1505,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1544,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1307,10 +1560,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1366,14 +1625,37 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1404,6 +1686,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,7 +1744,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1468,6 +1776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1802,30 @@ name = "ort-sys"
 version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1510,16 +1851,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1538,7 +1968,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1570,6 +2000,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1614,7 +2050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1655,7 +2091,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1670,13 +2106,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1719,12 +2155,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1734,8 +2179,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1752,28 +2203,108 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
- "bitflags",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
  "compact_str",
- "crossterm",
+ "critical-section",
+ "hashbrown 0.17.0",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.0",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1782,7 +2313,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1817,7 +2348,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1911,7 +2442,7 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
  "log",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "rayon",
  "serde",
@@ -1937,14 +2468,14 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "nix",
+ "nix 0.31.2",
  "rshogi-core",
  "rshogi-csa",
  "rshogi-csa-server",
  "rustls",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tungstenite",
 ]
@@ -1954,14 +2485,14 @@ name = "rshogi-csa-server"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "rshogi-core",
  "rshogi-csa",
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
 ]
@@ -1976,12 +2507,12 @@ dependencies = [
  "futures-util",
  "metrics",
  "metrics-exporter-prometheus",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -2029,12 +2560,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2047,7 +2587,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2175,7 +2715,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2248,7 +2788,7 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2326,6 +2866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,15 +2919,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -2390,16 +2927,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.26.4"
+name = "strum"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -2411,7 +2944,19 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2419,6 +2964,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2448,7 +3004,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2471,7 +3027,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2500,10 +3056,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
 
 [[package]]
 name = "thiserror"
@@ -2511,7 +3152,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2522,7 +3174,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2533,6 +3185,27 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -2583,7 +3256,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2659,7 +3332,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-channel",
- "crossterm",
+ "crossterm 0.28.1",
  "ctrlc",
  "env_logger",
  "flate2",
@@ -2669,7 +3342,7 @@ dependencies = [
  "log",
  "ndarray 0.16.1",
  "ort",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "ratatui",
  "rayon",
@@ -2708,7 +3381,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -2751,7 +3424,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2809,11 +3482,11 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
  "webpki-roots 0.26.11",
 ]
@@ -2823,6 +3496,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -2838,20 +3517,14 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2914,6 +3587,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +3609,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -3019,7 +3713,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3073,7 +3767,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3115,6 +3809,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -3215,7 +3981,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3226,7 +3992,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3508,7 +4274,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3524,7 +4290,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3536,7 +4302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -3606,7 +4372,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.27.2",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
@@ -3661,7 +4427,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3682,7 +4448,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3702,7 +4468,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3742,7 +4508,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -58,6 +58,16 @@ aobazero-onnx = ["dep:ort", "dep:ndarray"]
 # 標準dlshogi ONNX直接推論（DL水匠等、ONNX Runtime + CUDA が必要）
 dlshogi-onnx = ["dep:ort", "dep:ndarray"]
 
+# 棋譜プレイヤー TUI（PSV / tournament JSONL 共通の対局再生ビューア）。
+# default に含めない: 学習パイプライン専用に checkout・ビルドする側へ
+# 対話的 TUI 依存 (ratatui/crossterm) を持ち込まないため。
+kifu-player = ["dep:ratatui", "dep:crossterm"]
+
+[[bin]]
+name = "kifu_player"
+path = "src/bin/kifu_player.rs"
+required-features = ["kifu-player"]
+
 [dependencies]
 # Workspace dependencies
 anyhow.workspace = true
@@ -95,3 +105,7 @@ sha2 = "0.10"
 # AobaZero ONNX direct inference (optional, behind "aobazero-onnx" feature)
 ort = { version = "2.0.0-rc.12", optional = true, default-features = false, features = ["load-dynamic", "api-24"] }
 ndarray = { version = "0.16", optional = true }
+
+# 棋譜プレイヤー TUI (optional, behind "kifu-player" feature)
+ratatui = { version = "0.29", optional = true }
+crossterm = { version = "0.28", optional = true }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -107,5 +107,5 @@ ort = { version = "2.0.0-rc.12", optional = true, default-features = false, feat
 ndarray = { version = "0.16", optional = true }
 
 # 棋譜プレイヤー TUI (optional, behind "kifu-player" feature)
-ratatui = { version = "0.29", optional = true }
+ratatui = { version = "0.30", optional = true }
 crossterm = { version = "0.28", optional = true }

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -13,6 +13,12 @@
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 
+### 棋譜閲覧
+
+| ツール | 説明 |
+|--------|------|
+| `kifu_player` | PSV / tournament JSONL を同じ TUI で再生・評価値グラフ付きで閲覧（`kifu-player` feature、[詳細](docs/kifu_player.md)） |
+
 ### 学習データ処理
 
 | ツール | 説明 |
@@ -74,6 +80,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 各ツールの詳細は `docs/` を参照：
 
 - [tournament](docs/tournament.md) - 並列トーナメント・SPRT 検定
+- [kifu_player](docs/kifu_player.md) - PSV / tournament JSONL 共通の棋譜プレイヤー TUI（評価値グラフ付き）
 - [gensfen](docs/gensfen.md) - 教師局面生成ツールの詳細
 - [benchmark](docs/benchmark.md) - ベンチマークツールの詳細
 - [pack_tools](docs/pack_tools.md) - 学習データ処理ツール群

--- a/crates/tools/docs/kifu_player.md
+++ b/crates/tools/docs/kifu_player.md
@@ -1,0 +1,75 @@
+# kifu_player — PSV / tournament JSONL 棋譜プレイヤー TUI
+
+PSV (PackedSfenValue) ファイルと `tournament` の出力 JSONL を、同じ TUI で
+1手ずつ再生・閲覧するツール。`tournament` の out-dir は数千局規模になりうるため、
+横断した対局リストをインクリメンタルにフィルタして特定の対局へすぐ辿り着けるように
+してある。
+
+読み取り専用のビューアであり、PSV のシャッフル・分割・統合や JSONL の編集は行わない。
+
+## ビルド
+
+`ratatui`/`crossterm` への依存を持つため、default feature には含まれていない
+（学習パイプライン専用の checkout・ビルドに対話的 TUI 依存を持ち込まないため）。
+
+```bash
+cargo build -p tools --release --features kifu-player --bin kifu_player
+```
+
+## 使い方
+
+### PSV を開く
+
+```bash
+cargo run -p tools --release --features kifu-player --bin kifu_player -- \
+  --psv runs/gensfen/20260701_120000/gensfen.psv
+```
+
+`--psv` には**連続した自己対局ストリーム**（`gensfen` の直接出力等）を渡す。
+`shuffle_psv`/`merge_psv` 等でレコード順序がシャッフルされたプールを渡すと、
+対局境界検出（`game_ply` のリセット検出）が機能せず、ほぼ全レコードが
+1レコードだけの対局として誤検出される。索引構築後に平均対局長が極端に短い
+場合は起動時に警告が出る。
+
+### tournament の out-dir を開く
+
+```bash
+cargo run -p tools --release --features kifu-player --bin kifu_player -- \
+  --tournament-dir runs/selfplay/20260701_120000-v1-vs-v2
+```
+
+out-dir 配下の `*-vs-*.jsonl`（`tournament` が出力するペアファイル）を横断して
+1つの対局リストにまとめる。`control_history.jsonl` 等、対局データを含まない
+付随ファイルは自動的に除外される。
+
+## 画面構成
+
+- 左: 対局一覧（`/` で検索・フィルタ。対局ラベル・`black_win`/`white_win`/`draw`/
+  `error`・`game_id`・`pair_index`/`pair_slot`/`startpos_idx` で絞り込める）
+- 中央: 盤面（先手の駒は黄、後手の駒は シアン で色分け）
+- 右: 指し手一覧（棋譜風ラベル。現在の手をハイライト）
+- 評価値グラフ: 先手から見た評価値（**プラス=先手優勢、マイナス=後手優勢**に
+  固定した POV）を、着手側の色（先手=黄、後手=シアン）で線分を塗り分けて表示する。
+  tournament 対局で先後に別エンジンが付いている場合、評価値はエンジンごとに
+  異なるスケールでありうる点に注意（グラフのギザギザを単純な形勢の振れと
+  読みすぎない）。PSV はレコードに残っている `game_ply` をそのまま X 軸に使うため、
+  `skip_initial_ply`/`skip_in_check` による欠番がある場合はそのまま見える。
+  評価値が無い手（JSONL でエンジンが返さなかった場合）は打点しない。
+- 下部: 現在手の注釈（深さ・ノード数・NPS・経過時間・エンジン名等、ある分だけ表示）
+
+## キーバインド
+
+| キー | 動作 |
+|------|------|
+| `h` / `←` | 1手戻す |
+| `l` / `→` | 1手進める |
+| `j` / `↓` | 次の対局（フィルタ後のリスト内） |
+| `k` / `↑` | 前の対局 |
+| `/` | 検索・フィルタ入力開始（`Enter`/`Esc` で終了、`Esc` はフィルタもクリア） |
+| `q` / `Esc` | 終了 |
+
+## スコープ外
+
+- 実行中の tournament の live-tail（オフライン解析専用）
+- セッションをまたいだ「最後に見ていた対局」の記憶
+- PSV の pack（書き込み）、KIF/CSA へのエクスポート（`jsonl_to_kif` 等の既存ツールで代替）

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -11,6 +11,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
+| `kifu_player` | PSV / tournament JSONL を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ付き。[詳細](kifu_player.md)） |
 
 ## ベンチマーク・評価
 

--- a/crates/tools/src/bin/kifu_player.rs
+++ b/crates/tools/src/bin/kifu_player.rs
@@ -1,0 +1,37 @@
+//! PSV / tournament JSONL 共通の棋譜プレイヤー TUI。
+//!
+//! 詳細は `crates/tools/docs/kifu_player.md` を参照。
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use clap::Parser;
+use tools::replay::{GameSource, JsonlSource, PsvSource, tui};
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "PSV / tournament JSONL の対局を TUI で再生する"
+)]
+struct Cli {
+    /// PSV (PackedSfenValue) ファイルを開く。連続した自己対局ストリームを想定する
+    /// （shuffle_psv/merge_psv 等でシャッフル済みのプールは対局境界検出が機能しない）。
+    #[arg(long, conflicts_with = "tournament_dir")]
+    psv: Option<PathBuf>,
+
+    /// tournament の out-dir を開く（配下の `*-vs-*.jsonl` を横断して索引する）。
+    #[arg(long, conflicts_with = "psv")]
+    tournament_dir: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let source: Box<dyn GameSource> = match (cli.psv, cli.tournament_dir) {
+        (Some(path), None) => Box::new(PsvSource::new(path)),
+        (None, Some(dir)) => Box::new(JsonlSource::new(dir)),
+        (None, None) => bail!("--psv か --tournament-dir のどちらか一方を指定してください"),
+        (Some(_), Some(_)) => unreachable!("clap の conflicts_with により同時指定は弾かれる"),
+    };
+    tui::run(source)
+}

--- a/crates/tools/src/kif.rs
+++ b/crates/tools/src/kif.rs
@@ -314,16 +314,19 @@ fn engine_names_for(meta: Option<&KifMeta>) -> (String, String) {
     (black_display, white_display)
 }
 
-fn format_move_kif(ply: u32, pos: &Position, mv: Move, elapsed_ms: u64, total_ms: u64) -> String {
+/// 指し手1つ分の棋譜風ラベル（消費時間を含まない）。
+///
+/// `crates/tools/src/replay/` の棋譜プレイヤー TUI から、PSV/JSONL 共通の
+/// 手の表示ラベルとして再利用する（PSV には消費時間情報が無いため、
+/// 時間表示を含む `format_move_kif` ではなくこちらを直接使う）。
+pub(crate) fn format_move_label(ply: u32, pos: &Position, mv: Move) -> String {
     let prefix = if pos.side_to_move() == Color::Black {
         "▲"
     } else {
         "△"
     };
     if mv.is_pass() {
-        let per_move = format_mm_ss(elapsed_ms);
-        let total = format_hh_mm_ss(total_ms);
-        return format!("{:>4} {}パス   ({:>5}/{})", ply, prefix, per_move, total);
+        return format!("{:>4} {}パス", ply, prefix);
     }
     let dest = square_label_kanji(mv.to());
     let (label, from_suffix) = if mv.is_drop() {
@@ -335,12 +338,14 @@ fn format_move_kif(ply: u32, pos: &Position, mv: Move, elapsed_ms: u64, total_ms
         let suffix = format!("({}{})", square_file_digit(from), square_rank_digit(from));
         (piece_label(piece.piece_type(), promoted).to_string(), suffix)
     };
+    format!("{:>4} {}{}{}{}", ply, prefix, dest, label, from_suffix)
+}
+
+fn format_move_kif(ply: u32, pos: &Position, mv: Move, elapsed_ms: u64, total_ms: u64) -> String {
+    let label = format_move_label(ply, pos, mv);
     let per_move = format_mm_ss(elapsed_ms);
     let total = format_hh_mm_ss(total_ms);
-    format!(
-        "{:>4} {}{}{}{}   ({:>5}/{})",
-        ply, prefix, dest, label, from_suffix, per_move, total
-    )
+    format!("{}   ({:>5}/{})", label, per_move, total)
 }
 
 fn square_label_kanji(sq: Square) -> String {
@@ -370,7 +375,8 @@ fn square_rank_digit(sq: Square) -> char {
     char::from_digit(idx as u32, 10).unwrap_or('1')
 }
 
-fn piece_label(piece_type: PieceType, promoted: bool) -> &'static str {
+/// `replay::tui` の盤面・持ち駒表示からも再利用する駒名ラベル。
+pub(crate) fn piece_label(piece_type: PieceType, promoted: bool) -> &'static str {
     match (piece_type, promoted) {
         (PieceType::Pawn, false) => "歩",
         (PieceType::Pawn, true) => "と",

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -52,6 +52,8 @@ pub mod onnx_value;
 pub mod packed_sfen;
 pub mod positions;
 pub mod qsearch_pv;
+#[cfg(feature = "kifu-player")]
+pub mod replay;
 pub mod report;
 pub mod runner;
 pub mod selfplay;

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -1,0 +1,503 @@
+//! tournament JSONL (`{label}-vs-{label}.jsonl`) を対象にした `GameSource` 実装。
+//!
+//! out-dir 配下の `*-vs-*.jsonl` を横断して、対局単位の索引を1つのリストに
+//! フラット化する。`game_id` はペアファイルごとのローカル連番（out-dir 全体での
+//! 一意性は無い）なので、一意キーは `(file_idx, game_id)` にする。
+
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use rshogi_core::position::Position;
+use rshogi_core::types::{Color, Move};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::kif::format_move_label;
+use crate::selfplay::EvalLog;
+
+use super::model::{
+    GameIndex, GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef,
+    MoveAnnotation, MoveView, PairFileMeta,
+};
+
+pub struct JsonlSource {
+    out_dir: PathBuf,
+}
+
+impl JsonlSource {
+    pub fn new(out_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            out_dir: out_dir.into(),
+        }
+    }
+}
+
+impl GameSource for JsonlSource {
+    fn build_index(&self) -> Result<GameIndex> {
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(&self.out_dir)
+            .with_context(|| format!("failed to read directory {}", self.out_dir.display()))?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| is_pair_jsonl_name(p))
+            .collect();
+        // file_idx を実行のたびに安定させるため、列挙順をファイル名でソートする。
+        paths.sort();
+
+        let mut entries = Vec::new();
+        let mut pair_files = Vec::new();
+        let mut warnings = Vec::new();
+
+        for path in &paths {
+            let file_idx = pair_files.len();
+            match index_one_file(path, file_idx, &mut entries, &mut warnings)? {
+                Some(meta) => pair_files.push(meta),
+                None => warnings.push(format!(
+                    "{}: 先頭行が type:\"meta\" ではないため対局ファイルとして扱わず読み飛ばしました",
+                    path.display()
+                )),
+            }
+        }
+
+        Ok(GameIndex {
+            entries,
+            pair_files,
+            warnings,
+        })
+    }
+
+    fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord> {
+        let GameSourceRef::Jsonl {
+            file_idx,
+            start_offset,
+            end_offset,
+            ..
+        } = entry.source
+        else {
+            bail!("JsonlSource::load_game received a non-JSONL GameIndexEntry");
+        };
+        let meta = index
+            .pair_file(file_idx)
+            .ok_or_else(|| anyhow!("file_idx {file_idx} not found in index"))?;
+
+        let mut file = File::open(&meta.path)
+            .with_context(|| format!("failed to open {}", meta.path.display()))?;
+        file.seek(SeekFrom::Start(start_offset))?;
+        let mut buf = vec![0u8; (end_offset - start_offset) as usize];
+        file.read_exact(&mut buf).context("failed to read JSONL game byte range")?;
+
+        let mut moves = Vec::new();
+        for line in buf.split(|&b| b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_slice(line)
+                .context("failed to parse JSONL line while loading game")?;
+            if value.get("type").and_then(Value::as_str) != Some("move") {
+                continue; // result 行はここでは不要
+            }
+            let move_line: MoveLine = serde_json::from_value(value)
+                .context("failed to parse move line while loading game")?;
+            moves.push(build_move_view(&move_line)?);
+        }
+
+        Ok(GameRecord { moves })
+    }
+}
+
+fn is_pair_jsonl_name(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.ends_with(".jsonl") && n.contains("-vs-"))
+}
+
+#[derive(Deserialize)]
+struct MetaLine {
+    engine_cmd: MetaEngineCmd,
+}
+
+#[derive(Deserialize)]
+struct MetaEngineCmd {
+    label_black: String,
+    label_white: String,
+}
+
+#[derive(Deserialize)]
+struct MoveLine {
+    ply: u32,
+    sfen_before: String,
+    move_usi: String,
+    #[serde(default)]
+    elapsed_ms: Option<u64>,
+    #[serde(default)]
+    think_limit_ms: Option<u64>,
+    #[serde(default)]
+    timed_out: Option<bool>,
+    #[serde(default)]
+    engine: Option<String>,
+    #[serde(default)]
+    eval: Option<EvalLog>,
+}
+
+#[derive(Deserialize)]
+struct ResultLine {
+    game_id: u32,
+    #[serde(default)]
+    outcome: String,
+    #[serde(default)]
+    plies: u32,
+    #[serde(default)]
+    error: bool,
+    #[serde(default)]
+    pair_index: Option<u32>,
+    #[serde(default)]
+    pair_slot: Option<u32>,
+    #[serde(default)]
+    startpos_idx: Option<u32>,
+}
+
+/// 1ペアファイルを索引する。先頭行が `type:"meta"` でなければ
+/// 「対局ファイルではない」とみなし `Ok(None)` を返す（エラーにしない）。
+/// `game_id` の行が result 行の後に再出現する等の契約違反は `Err` を返し、
+/// 呼び出し側 (`build_index`) の `?` で索引構築全体を中断させる。
+fn index_one_file(
+    path: &Path,
+    file_idx: usize,
+    entries: &mut Vec<GameIndexEntry>,
+    warnings: &mut Vec<String>,
+) -> Result<Option<PairFileMeta>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut offset: u64 = 0;
+    let mut line_buf = Vec::new();
+
+    let Some((_, meta_len)) = read_line(&mut reader, &mut offset, &mut line_buf)? else {
+        return Ok(None); // 空ファイル
+    };
+    let Ok(meta_value) = serde_json::from_slice::<Value>(&line_buf) else {
+        return Ok(None);
+    };
+    if meta_value.get("type").and_then(Value::as_str) != Some("meta") {
+        return Ok(None);
+    }
+    let meta_line: MetaLine = serde_json::from_value(meta_value)
+        .with_context(|| format!("{}: invalid meta line", path.display()))?;
+    let _ = meta_len;
+
+    let mut open: HashMap<u32, u64> = HashMap::new();
+    let mut closed: HashSet<u32> = HashSet::new();
+
+    while let Some((line_start, line_len)) = read_line(&mut reader, &mut offset, &mut line_buf)? {
+        let value: Value = serde_json::from_slice(&line_buf).with_context(|| {
+            format!("{}: invalid JSON line at offset {line_start}", path.display())
+        })?;
+        match value.get("type").and_then(Value::as_str) {
+            Some("move") => {
+                let game_id = value.get("game_id").and_then(Value::as_u64).ok_or_else(|| {
+                    anyhow!("{}: move line missing game_id at offset {line_start}", path.display())
+                })? as u32;
+                if closed.contains(&game_id) {
+                    bail!(
+                        "{}: game_id={game_id} の move 行が result 行の後に再出現しました（offset {line_start}）。\
+                         1局分の行は連続しているという前提が崩れているため索引構築を中断します。",
+                        path.display()
+                    );
+                }
+                open.entry(game_id).or_insert(line_start);
+            }
+            Some("result") => {
+                let result: ResultLine = serde_json::from_value(value).with_context(|| {
+                    format!("{}: invalid result line at offset {line_start}", path.display())
+                })?;
+                if closed.contains(&result.game_id) {
+                    bail!(
+                        "{}: game_id={} の result 行が複数回出現しました（offset {line_start}）",
+                        path.display(),
+                        result.game_id
+                    );
+                }
+                // move 行が1つも無い対局（エンジン起動失敗等のエラー対局）は
+                // result 行自身の offset を開始位置にする。
+                let start_offset = open.remove(&result.game_id).unwrap_or(line_start);
+                let end_offset = line_start + line_len;
+                entries.push(GameIndexEntry {
+                    source: GameSourceRef::Jsonl {
+                        file_idx,
+                        game_id: result.game_id,
+                        start_offset,
+                        end_offset,
+                    },
+                    outcome: parse_outcome(&result.outcome),
+                    error: result.error,
+                    ply_count: result.plies,
+                    pair_index: result.pair_index,
+                    pair_slot: result.pair_slot,
+                    startpos_idx: result.startpos_idx,
+                });
+                closed.insert(result.game_id);
+            }
+            Some("meta") => {
+                bail!(
+                    "{}: meta 行がファイル中盤に再出現しました（offset {line_start}）",
+                    path.display()
+                );
+            }
+            _ => {
+                // control_history 相当の type 等、対局データを含まない行は無視する。
+            }
+        }
+    }
+
+    if !open.is_empty() {
+        warnings.push(format!(
+            "{}: {} 局が result 行を伴わず終端しました（実行中・途中終了したファイルの可能性）。索引から除外します。",
+            path.display(),
+            open.len()
+        ));
+    }
+
+    Ok(Some(PairFileMeta {
+        path: path.to_path_buf(),
+        black_label: meta_line.engine_cmd.label_black,
+        white_label: meta_line.engine_cmd.label_white,
+    }))
+}
+
+fn parse_outcome(s: &str) -> Option<GameOutcomeView> {
+    match s {
+        "black_win" => Some(GameOutcomeView::Win(Color::Black)),
+        "white_win" => Some(GameOutcomeView::Win(Color::White)),
+        "draw" => Some(GameOutcomeView::Draw),
+        _ => None,
+    }
+}
+
+fn build_move_view(line: &MoveLine) -> Result<MoveView> {
+    let mut pos = Position::new();
+    pos.set_sfen(&line.sfen_before)
+        .map_err(|e| anyhow!("failed to parse sfen_before '{}': {e}", line.sfen_before))?;
+    let side = pos.side_to_move();
+
+    // resign/win/timeout/illegal 等の終局用の擬似指し手は Move::from_usi が None
+    // を返すため、実手と区別してそのまま文字列を表示する。
+    let (mv, kif_label) = match Move::from_usi(&line.move_usi) {
+        Some(mv) => (mv, format_move_label(line.ply, &pos, mv)),
+        None => (Move::NONE, format!("{:>4} {}", line.ply, line.move_usi)),
+    };
+
+    let annotation = MoveAnnotation {
+        score_cp: line.eval.as_ref().and_then(|e| e.score_cp),
+        score_mate: line.eval.as_ref().and_then(|e| e.score_mate),
+        depth: line.eval.as_ref().and_then(|e| e.depth),
+        seldepth: line.eval.as_ref().and_then(|e| e.seldepth),
+        nodes: line.eval.as_ref().and_then(|e| e.nodes),
+        nps: line.eval.as_ref().and_then(|e| e.nps),
+        elapsed_ms: line.elapsed_ms,
+        think_limit_ms: line.think_limit_ms,
+        timed_out: line.timed_out,
+        engine_label: line.engine.clone(),
+    };
+
+    Ok(MoveView {
+        ply: line.ply,
+        side,
+        sfen_before: line.sfen_before.clone(),
+        mv,
+        kif_label,
+        annotation,
+    })
+}
+
+/// `\n` 区切りで1行読み、`(行の開始バイトオフセット, 行のバイト長)` を返す。
+/// `offset` は呼び出し側で累積する。EOF (0バイト読めた) では `None`。
+fn read_line(
+    reader: &mut impl BufRead,
+    offset: &mut u64,
+    buf: &mut Vec<u8>,
+) -> io::Result<Option<(u64, u64)>> {
+    buf.clear();
+    let start = *offset;
+    let n = reader.read_until(b'\n', buf)?;
+    if n == 0 {
+        return Ok(None);
+    }
+    *offset += n as u64;
+    Ok(Some((start, n as u64)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    const STARTPOS: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+    fn write_file(dir: &Path, name: &str, lines: &[String]) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = File::create(&path).expect("create");
+        for line in lines {
+            writeln!(f, "{line}").expect("write line");
+        }
+        path
+    }
+
+    fn meta_line(black: &str, white: &str) -> String {
+        format!(
+            r#"{{"type":"meta","engine_cmd":{{"label_black":"{black}","label_white":"{white}"}}}}"#
+        )
+    }
+
+    fn move_line(game_id: u32, ply: u32, move_usi: &str) -> String {
+        format!(
+            r#"{{"type":"move","game_id":{game_id},"ply":{ply},"side_to_move":"b","sfen_before":"{STARTPOS}","move_usi":"{move_usi}","engine":"e","elapsed_ms":10,"think_limit_ms":100,"timed_out":false}}"#
+        )
+    }
+
+    fn result_line(game_id: u32, outcome: &str, plies: u32, error: bool) -> String {
+        format!(
+            r#"{{"type":"result","game_id":{game_id},"outcome":"{outcome}","reason":"r","plies":{plies},"error":{error}}}"#
+        )
+    }
+
+    #[test]
+    fn indexes_two_games_in_one_pair_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                result_line(1, "black_win", 1, false),
+                move_line(2, 1, "2g2f"),
+                result_line(2, "draw", 1, false),
+            ],
+        );
+
+        let source = JsonlSource::new(dir.path());
+        let index = source.build_index().expect("build_index");
+        assert_eq!(index.pair_files.len(), 1);
+        assert_eq!(index.entries.len(), 2);
+        assert_eq!(index.entries[0].outcome, Some(GameOutcomeView::Win(Color::Black)));
+        assert_eq!(index.entries[1].outcome, Some(GameOutcomeView::Draw));
+
+        let game = source.load_game(&index, &index.entries[0]).expect("load_game");
+        assert_eq!(game.moves.len(), 1);
+        assert!(game.moves[0].kif_label.contains('▲'));
+    }
+
+    #[test]
+    fn excludes_control_history_and_non_matching_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "control_history.jsonl",
+            &[r#"{"type":"control","target_games":10}"#.to_string()],
+        );
+        write_file(dir.path(), "a-vs-b.jsonl", &[meta_line("a", "b")]);
+        // meta.json はそもそも *.jsonl ではないため対象外（拡張子で除外される）。
+        std::fs::write(dir.path().join("meta.json"), "{}").expect("write meta.json");
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
+        assert_eq!(index.pair_files.len(), 1);
+        assert_eq!(index.pair_files[0].black_label, "a");
+    }
+
+    #[test]
+    fn tolerates_zero_game_pair_file_and_error_game() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(dir.path(), "empty-vs-pair.jsonl", &[meta_line("e1", "e2")]);
+        write_file(
+            dir.path(),
+            "x-vs-y.jsonl",
+            &[
+                meta_line("x", "y"),
+                result_line(1, "draw", 0, true), // move 行 0 件のエラー対局
+            ],
+        );
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
+        assert_eq!(index.pair_files.len(), 2);
+        assert_eq!(index.entries.len(), 1);
+        assert!(index.entries[0].error);
+        assert_eq!(index.entries[0].ply_count, 0);
+    }
+
+    #[test]
+    fn game_id_is_scoped_per_file_not_global() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                result_line(1, "draw", 1, false),
+            ],
+        );
+        write_file(
+            dir.path(),
+            "c-vs-d.jsonl",
+            &[
+                meta_line("c", "d"),
+                move_line(1, 1, "2g2f"),
+                result_line(1, "draw", 1, false),
+            ],
+        );
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 2);
+        let GameSourceRef::Jsonl {
+            file_idx: f0,
+            game_id: g0,
+            ..
+        } = index.entries[0].source
+        else {
+            panic!("expected Jsonl source");
+        };
+        let GameSourceRef::Jsonl {
+            file_idx: f1,
+            game_id: g1,
+            ..
+        } = index.entries[1].source
+        else {
+            panic!("expected Jsonl source");
+        };
+        assert_eq!((g0, g1), (1, 1), "game_id はペアローカルなので両方とも 1");
+        assert_ne!(f0, f1, "file_idx で区別できる");
+    }
+
+    #[test]
+    fn aborts_on_move_line_after_game_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                result_line(1, "draw", 1, false),
+                move_line(1, 2, "2g2f"), // 既に閉じた game_id=1 の move 行が再出現
+            ],
+        );
+
+        let err = JsonlSource::new(dir.path()).build_index().expect_err("must abort");
+        assert!(format!("{err}").contains("再出現"), "err: {err}");
+    }
+
+    #[test]
+    fn warns_and_drops_incomplete_trailing_game() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[meta_line("a", "b"), move_line(1, 1, "7g7f")], // result 行が無いまま終端
+        );
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 0);
+        assert!(!index.warnings.is_empty());
+    }
+}

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -188,7 +188,7 @@ fn index_one_file(
     let mut offset: u64 = 0;
     let mut line_buf = Vec::new();
 
-    let Some((_, meta_len)) = read_line(&mut reader, &mut offset, &mut line_buf)? else {
+    let Some(_) = read_line(&mut reader, &mut offset, &mut line_buf)? else {
         return Ok(None); // 空ファイル。対局ファイルとして不自然ではないので warning は出さない。
     };
     let Ok(meta_value) = serde_json::from_slice::<Value>(&line_buf) else {
@@ -216,7 +216,6 @@ fn index_one_file(
             return Ok(None);
         }
     };
-    let _ = meta_len;
 
     let mut open: HashMap<u32, u64> = HashMap::new();
     let mut closed: HashSet<u32> = HashSet::new();

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -52,12 +52,10 @@ impl GameSource for JsonlSource {
 
         for path in &paths {
             let file_idx = pair_files.len();
-            match index_one_file(path, file_idx, &mut entries, &mut warnings)? {
-                Some(meta) => pair_files.push(meta),
-                None => warnings.push(format!(
-                    "{}: 先頭行が type:\"meta\" ではないため対局ファイルとして扱わず読み飛ばしました",
-                    path.display()
-                )),
+            // スキップ理由ごとの warning は index_one_file 側で push 済みなので、
+            // ここでは Some/None の振り分けだけ行う（二重・不正確な warning を防ぐ）。
+            if let Some(meta) = index_one_file(path, file_idx, &mut entries, &mut warnings)? {
+                pair_files.push(meta);
             }
         }
 
@@ -71,9 +69,9 @@ impl GameSource for JsonlSource {
     fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord> {
         let GameSourceRef::Jsonl {
             file_idx,
+            game_id,
             start_offset,
             end_offset,
-            ..
         } = entry.source
         else {
             bail!("JsonlSource::load_game received a non-JSONL GameIndexEntry");
@@ -100,6 +98,18 @@ impl GameSource for JsonlSource {
             }
             let move_line: MoveLine = serde_json::from_value(value)
                 .context("failed to parse move line while loading game")?;
+            // インデックス時のバイト範囲が他 game の行を巻き込んでいないことの
+            // 防御的検証。現行の tournament.rs 書き込みモデルでは起こらない
+            // はずだが、将来の書き込みモデル変更や手作業で連結したファイル等で
+            // 不変条件が崩れた場合に、誤った対局として静かに表示しないため。
+            if move_line.game_id != game_id {
+                bail!(
+                    "{}: 範囲 [{start_offset}, {end_offset}) に game_id={} の move 行が \
+                     混入しています（期待値 game_id={game_id}）。索引が壊れている可能性があります。",
+                    meta.path.display(),
+                    move_line.game_id
+                );
+            }
             moves.push(build_move_view(&move_line)?);
         }
 
@@ -126,6 +136,7 @@ struct MetaEngineCmd {
 
 #[derive(Deserialize)]
 struct MoveLine {
+    game_id: u32,
     ply: u32,
     sfen_before: String,
     move_usi: String,
@@ -158,10 +169,14 @@ struct ResultLine {
     startpos_idx: Option<u32>,
 }
 
-/// 1ペアファイルを索引する。先頭行が `type:"meta"` でなければ
-/// 「対局ファイルではない」とみなし `Ok(None)` を返す（エラーにしない）。
-/// `game_id` の行が result 行の後に再出現する等の契約違反は `Err` を返し、
-/// 呼び出し側 (`build_index`) の `?` で索引構築全体を中断させる。
+/// 1ペアファイルを索引する。先頭行が `type:"meta"` として解釈できない
+/// （JSON として不正・type が違う・`engine_cmd` 等の必須フィールドが無い）場合は
+/// 「対局ファイルではない」とみなし、このファイルだけを warning 付きで読み飛ばす
+/// （`Ok(None)`、index 全体は中断しない）。一方、`game_id` の行が result 行の後に
+/// 再出現する等の**ファイル中盤での**契約違反は `Err` を返し、呼び出し側
+/// (`build_index`) の `?` で索引構築全体を中断させる（1ファイルの破損が
+/// 他の健全なファイルの可視性を奪わない先頭行と、対局単位の整合性を保証する
+/// 必要がある中盤以降とで、扱いを意図的に分けている）。
 fn index_one_file(
     path: &Path,
     file_idx: usize,
@@ -174,16 +189,33 @@ fn index_one_file(
     let mut line_buf = Vec::new();
 
     let Some((_, meta_len)) = read_line(&mut reader, &mut offset, &mut line_buf)? else {
-        return Ok(None); // 空ファイル
+        return Ok(None); // 空ファイル。対局ファイルとして不自然ではないので warning は出さない。
     };
     let Ok(meta_value) = serde_json::from_slice::<Value>(&line_buf) else {
+        warnings.push(format!(
+            "{}: 先頭行が JSON として解釈できないため対局ファイルとして扱わず読み飛ばしました",
+            path.display()
+        ));
         return Ok(None);
     };
     if meta_value.get("type").and_then(Value::as_str) != Some("meta") {
+        warnings.push(format!(
+            "{}: 先頭行が type:\"meta\" ではないため対局ファイルとして扱わず読み飛ばしました",
+            path.display()
+        ));
         return Ok(None);
     }
-    let meta_line: MetaLine = serde_json::from_value(meta_value)
-        .with_context(|| format!("{}: invalid meta line", path.display()))?;
+    // meta 行として認識はできたが構造が想定と異なる（`engine_cmd` 欠落等）場合は、
+    // 「対局ファイルではない」場合と同様に当該ファイルだけを読み飛ばす。
+    // ここで `?` により build_index 全体を中断させると、out-dir 中の1ファイルの
+    // schema 不整合で他の健全な数千局が一切見られなくなってしまう。
+    let meta_line: MetaLine = match serde_json::from_value(meta_value) {
+        Ok(m) => m,
+        Err(e) => {
+            warnings.push(format!("{}: invalid meta line ({e}), skipped", path.display()));
+            return Ok(None);
+        }
+    };
     let _ = meta_len;
 
     let mut open: HashMap<u32, u64> = HashMap::new();
@@ -499,5 +531,67 @@ mod tests {
         let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
         assert_eq!(index.entries.len(), 0);
         assert!(!index.warnings.is_empty());
+    }
+
+    #[test]
+    fn skips_file_with_malformed_meta_line_without_aborting_whole_build() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // type:"meta" だが engine_cmd が欠落している壊れたファイル。
+        write_file(dir.path(), "broken-vs-meta.jsonl", &[r#"{"type":"meta"}"#.to_string()]);
+        // 健全なファイルも同じ out-dir に置く。
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                result_line(1, "draw", 1, false),
+            ],
+        );
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index must not abort");
+        assert_eq!(index.pair_files.len(), 1, "壊れたファイルは除外され、健全な方だけ残る");
+        assert_eq!(index.entries.len(), 1);
+        assert!(index.warnings.iter().any(|w| w.contains("broken-vs-meta.jsonl")));
+    }
+
+    #[test]
+    fn load_game_rejects_byte_range_with_foreign_game_id() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(
+            dir.path(),
+            "a-vs-b.jsonl",
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                result_line(1, "draw", 1, false),
+                move_line(2, 1, "2g2f"),
+                result_line(2, "draw", 1, false),
+            ],
+        );
+        let source = JsonlSource::new(dir.path());
+        let index = source.build_index().expect("build_index");
+
+        // game_id=2 の実体を指すバイト範囲はそのままに、entry の game_id だけ
+        // 1 に書き換えて「索引が壊れている」状態を人為的に再現する。
+        let mut tampered = index.entries[1].clone();
+        let GameSourceRef::Jsonl {
+            file_idx,
+            start_offset,
+            end_offset,
+            ..
+        } = tampered.source
+        else {
+            panic!("expected Jsonl source");
+        };
+        tampered.source = GameSourceRef::Jsonl {
+            file_idx,
+            game_id: 1,
+            start_offset,
+            end_offset,
+        };
+
+        let err = source.load_game(&index, &tampered).expect_err("must reject mismatched game_id");
+        assert!(format!("{err}").contains("混入"), "err: {err}");
     }
 }

--- a/crates/tools/src/replay/mod.rs
+++ b/crates/tools/src/replay/mod.rs
@@ -1,0 +1,13 @@
+//! PSV / tournament JSONL 共通の棋譜プレイヤー（`kifu_player` バイナリの実体）。
+
+pub mod jsonl_source;
+pub mod model;
+pub mod psv_source;
+pub mod tui;
+
+pub use jsonl_source::JsonlSource;
+pub use model::{
+    GameIndex, GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef,
+    MoveAnnotation, MoveView, PairFileMeta, display_label,
+};
+pub use psv_source::PsvSource;

--- a/crates/tools/src/replay/model.rs
+++ b/crates/tools/src/replay/model.rs
@@ -1,0 +1,151 @@
+//! 棋譜プレイヤー TUI が PSV / tournament JSONL を共通に扱うためのデータモデル。
+//!
+//! 設計の背景は `rshogi-notes/rshogi/plans/20260701_kifu_player_tui_design.md`
+//! を参照（OSS repo には置かない private な設計メモ）。
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use rshogi_core::types::{Color, Move};
+
+/// 索引フェーズで構築する、対局1件分のメタ情報（局面・指し手は含まない）。
+///
+/// `build_index` はこれを対局数ぶんだけ保持する。手の内容は `load_game` を
+/// 呼ぶまで読み込まないため、ピークメモリは総対局数に比例し総手数には依存しない。
+#[derive(Debug, Clone)]
+pub struct GameIndexEntry {
+    pub source: GameSourceRef,
+    /// 対局の最終結果から導出済みの値（生のスコア符号は保持しない）。
+    pub outcome: Option<GameOutcomeView>,
+    /// JSONL の `result.error` を伝播。PSV は常に false。
+    pub error: bool,
+    pub ply_count: u32,
+    /// 検索 UI 用（JSONL のみ）。再現性ある対局指定に使う。
+    pub pair_index: Option<u32>,
+    pub pair_slot: Option<u32>,
+    pub startpos_idx: Option<u32>,
+}
+
+/// 対局の出典と、その対局を再生するために必要な位置情報。
+#[derive(Debug, Clone, Copy)]
+pub enum GameSourceRef {
+    /// PSV ストリーム中の `[start_record, end_record)` レコード範囲。
+    /// `ordinal` は表示用の通し番号（0-indexed）。
+    Psv {
+        start_record: u64,
+        end_record: u64,
+        ordinal: u32,
+    },
+    /// out-dir 横断インデックスの中での位置。
+    /// `start_offset`/`end_offset` はペアファイル内のバイト範囲 `[start, end)`
+    /// （`meta` 行を含まず、対象対局の `move`/`result` 行のみ）。
+    Jsonl {
+        file_idx: usize,
+        game_id: u32,
+        start_offset: u64,
+        end_offset: u64,
+    },
+}
+
+/// 対局の勝者（手番に依存しない固定 POV で表現する）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GameOutcomeView {
+    Win(Color),
+    Draw,
+}
+
+/// JSONL ペアファイル単位のメタ情報。対局ごとに複製しない
+/// （`GameIndexEntry::file_idx` からこちらを引く）。
+#[derive(Debug, Clone)]
+pub struct PairFileMeta {
+    pub path: PathBuf,
+    pub black_label: String,
+    pub white_label: String,
+}
+
+/// 索引全体。`entries` は出典を問わず1つの横断リストとしてフラット化されている。
+#[derive(Debug, Clone, Default)]
+pub struct GameIndex {
+    pub entries: Vec<GameIndexEntry>,
+    /// JSONL のみ使用。PSV ソースの場合は空。
+    pub pair_files: Vec<PairFileMeta>,
+    /// 致命的ではないが利用者に伝えるべき事項（シャッフル済み PSV の疑い、
+    /// 対局データを含まないため読み飛ばした JSONL ファイル等）。
+    pub warnings: Vec<String>,
+}
+
+impl GameIndex {
+    pub fn pair_file(&self, file_idx: usize) -> Option<&PairFileMeta> {
+        self.pair_files.get(file_idx)
+    }
+}
+
+impl GameIndexEntry {
+    /// `GameSourceRef::Jsonl` のときのみ `Some`。`GameIndex::pair_file` を引くキー。
+    pub fn file_idx(&self) -> Option<usize> {
+        match self.source {
+            GameSourceRef::Jsonl { file_idx, .. } => Some(file_idx),
+            GameSourceRef::Psv { .. } => None,
+        }
+    }
+}
+
+/// 1局を開いたときに遅延構築する、再生用の完全な手順。
+#[derive(Debug, Clone)]
+pub struct GameRecord {
+    pub moves: Vec<MoveView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MoveView {
+    /// 出典上の手数。PSV は `skip_initial_ply`/`skip_in_check` により欠番がありうる
+    /// ため、連番である保証はない（欠番はそのまま表示する）。
+    pub ply: u32,
+    pub side: Color,
+    pub sfen_before: String,
+    pub mv: Move,
+    /// `kif.rs::format_move_label` を再利用した、棋譜風の人間可読ラベル。
+    pub kif_label: String,
+    pub annotation: MoveAnnotation,
+}
+
+/// 手への注釈。全フィールド `Option`。PSV は `score_cp` のみ埋まり、
+/// JSONL（tournament 出力）は埋まる分だけ多くなる。
+#[derive(Debug, Clone, Default)]
+pub struct MoveAnnotation {
+    pub score_cp: Option<i32>,
+    pub score_mate: Option<i32>,
+    pub depth: Option<u32>,
+    pub seldepth: Option<u32>,
+    pub nodes: Option<u64>,
+    pub nps: Option<u64>,
+    pub elapsed_ms: Option<u64>,
+    pub think_limit_ms: Option<u64>,
+    pub timed_out: Option<bool>,
+    pub engine_label: Option<String>,
+}
+
+/// PSV / JSONL の違いを吸収する共通インターフェース。
+pub trait GameSource {
+    /// 全件を1パスでストリーミングし、対局単位のメタ情報だけを集めた索引を返す。
+    fn build_index(&self) -> Result<GameIndex>;
+
+    /// 索引のオフセットへ seek し、その対局の範囲だけを読んで再生用の手順を返す。
+    /// `index` は `file_idx` から `PairFileMeta`（出典パス）を引くために使う
+    /// （`GameIndexEntry` 自体にはパスを複製しない）。PSV ソースでは未使用。
+    fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord>;
+}
+
+/// 対局一覧に出す表示ラベルを、保持済みの文字列ではなくその場で組み立てる
+/// （`display_label: String` を `GameIndexEntry` ごとに複製しない設計上の選択）。
+pub fn display_label(index: &GameIndex, entry: &GameIndexEntry) -> String {
+    match entry.source {
+        GameSourceRef::Psv { ordinal, .. } => format!("psv #{:03}", ordinal + 1),
+        GameSourceRef::Jsonl {
+            file_idx, game_id, ..
+        } => match index.pair_file(file_idx) {
+            Some(meta) => format!("{}-vs-{} #{:03}", meta.black_label, meta.white_label, game_id),
+            None => format!("?-vs-? #{:03}", game_id),
+        },
+    }
+}

--- a/crates/tools/src/replay/model.rs
+++ b/crates/tools/src/replay/model.rs
@@ -1,7 +1,4 @@
 //! 棋譜プレイヤー TUI が PSV / tournament JSONL を共通に扱うためのデータモデル。
-//!
-//! 設計の背景は `rshogi-notes/rshogi/plans/20260701_kifu_player_tui_design.md`
-//! を参照（OSS repo には置かない private な設計メモ）。
 
 use std::path::PathBuf;
 

--- a/crates/tools/src/replay/psv_source.rs
+++ b/crates/tools/src/replay/psv_source.rs
@@ -1,0 +1,304 @@
+//! PSV (PackedSfenValue, 40B 固定長) を対象にした `GameSource` 実装。
+//!
+//! 各レコードは局面を丸ごと持つため、連続再生は「次レコードの sfen を
+//! decode して表示する」だけで成立する（直前レコードへの move 適用は不要）。
+//! 対局境界は `game_ply` のリセット（前レコード以下に戻る）で検出する。
+
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek, SeekFrom};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow, bail};
+use rshogi_core::position::Position;
+use rshogi_core::types::{Color, Move};
+
+use crate::kif::format_move_label;
+use crate::packed_sfen::{PackedSfenValue, move16_to_move, unpack_sfen};
+
+use super::model::{
+    GameIndex, GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef,
+    MoveAnnotation, MoveView,
+};
+
+/// 1対局あたりの平均レコード数がこれを下回ったら、連続した自己対局ストリーム
+/// ではない（shuffle_psv 等でシャッフル済みのプールである）可能性を警告する。
+/// `skip_in_check` で間引かれた通常の対局でもこの値を大きく下回ることは無い。
+const SHORT_GAME_WARNING_THRESHOLD: f64 = 5.0;
+
+pub struct PsvSource {
+    path: PathBuf,
+}
+
+impl PsvSource {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl GameSource for PsvSource {
+    fn build_index(&self) -> Result<GameIndex> {
+        let file = File::open(&self.path)
+            .with_context(|| format!("failed to open PSV file {}", self.path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut buf = [0u8; PackedSfenValue::SIZE];
+
+        let mut entries = Vec::new();
+        let mut prev_ply: Option<u16> = None;
+        let mut current_start: u64 = 0;
+        let mut record_idx: u64 = 0;
+        // 直近に読んだレコードの (game_result, side_to_move)。境界を検出した瞬間、
+        // これは「閉じる対局」の最終レコードの値になっている。
+        let mut last_result: Option<(i8, Color)> = None;
+
+        loop {
+            match reader.read_exact(&mut buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e).context("failed to read PSV record"),
+            }
+            let psv = PackedSfenValue::from_bytes(&buf)
+                .ok_or_else(|| anyhow!("corrupt PSV record at index {record_idx}"))?;
+
+            let is_boundary = matches!(prev_ply, Some(p) if psv.game_ply <= p);
+            if is_boundary {
+                entries.push(finish_entry(
+                    current_start,
+                    record_idx,
+                    last_result,
+                    entries.len() as u32,
+                ));
+                current_start = record_idx;
+            }
+            prev_ply = Some(psv.game_ply);
+            last_result = Some((psv.game_result, side_to_move_from_packed(&psv.sfen)));
+            record_idx += 1;
+        }
+
+        if record_idx > current_start {
+            entries.push(finish_entry(
+                current_start,
+                record_idx,
+                last_result,
+                entries.len() as u32,
+            ));
+        }
+
+        let mut warnings = Vec::new();
+        if entries.len() > 1 {
+            let avg = record_idx as f64 / entries.len() as f64;
+            if avg < SHORT_GAME_WARNING_THRESHOLD {
+                warnings.push(format!(
+                    "平均対局長が {avg:.1} レコード/対局と極端に短い対局が {} 件検出されました。\
+                     shuffle_psv/merge_psv 等でシャッフル済みのプールを指定していないか確認してください。",
+                    entries.len()
+                ));
+            }
+        }
+
+        Ok(GameIndex {
+            entries,
+            pair_files: Vec::new(),
+            warnings,
+        })
+    }
+
+    fn load_game(&self, _index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord> {
+        let GameSourceRef::Psv {
+            start_record,
+            end_record,
+            ..
+        } = entry.source
+        else {
+            bail!("PsvSource::load_game received a non-PSV GameIndexEntry");
+        };
+        let mut file = File::open(&self.path)
+            .with_context(|| format!("failed to open PSV file {}", self.path.display()))?;
+        file.seek(SeekFrom::Start(start_record * PackedSfenValue::SIZE as u64))?;
+
+        let count = (end_record - start_record) as usize;
+        let mut moves = Vec::with_capacity(count);
+        let mut buf = [0u8; PackedSfenValue::SIZE];
+        for _ in 0..count {
+            file.read_exact(&mut buf)
+                .context("failed to read PSV record while loading game")?;
+            let psv = PackedSfenValue::from_bytes(&buf)
+                .ok_or_else(|| anyhow!("corrupt PSV record while loading game"))?;
+
+            let sfen_before =
+                unpack_sfen(&psv.sfen).map_err(|e| anyhow!("failed to unpack PSV sfen: {e}"))?;
+            let mut pos = Position::new();
+            pos.set_sfen(&sfen_before)
+                .map_err(|e| anyhow!("failed to parse PSV sfen '{sfen_before}': {e}"))?;
+            let side = pos.side_to_move();
+
+            // move16 == 0 は「この局面からの指し手は記録されていない」
+            // （対局終了時点の最終レコード等）を意味し、Move::PASS とは別物。
+            // format_move_label に通常の指し手として渡すと無意味な座標を
+            // 表示してしまうため、専用ラベルにする。
+            let (mv, kif_label) = if psv.move16 == 0 {
+                (Move::NONE, format!("{:>4} (終局局面)", psv.game_ply))
+            } else {
+                let mv = move16_to_move(psv.move16);
+                let label = format_move_label(psv.game_ply as u32, &pos, mv);
+                (mv, label)
+            };
+
+            moves.push(MoveView {
+                ply: psv.game_ply as u32,
+                side,
+                sfen_before,
+                mv,
+                kif_label,
+                annotation: MoveAnnotation {
+                    score_cp: Some(psv.score as i32),
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(GameRecord { moves })
+    }
+}
+
+/// packed sfen の bit 0（手番）だけを読む。インデックス構築フェーズでは
+/// 盤面全体のハフマン復号は不要なため、`unpack_sfen` を呼ばずに済ませる。
+fn side_to_move_from_packed(sfen: &[u8; 32]) -> Color {
+    if sfen[0] & 1 == 0 {
+        Color::Black
+    } else {
+        Color::White
+    }
+}
+
+fn finish_entry(
+    start_record: u64,
+    end_record: u64,
+    last_result: Option<(i8, Color)>,
+    ordinal: u32,
+) -> GameIndexEntry {
+    let outcome = match last_result {
+        Some((1, side)) => Some(GameOutcomeView::Win(side)),
+        Some((-1, side)) => Some(GameOutcomeView::Win(!side)),
+        Some((0, _)) => Some(GameOutcomeView::Draw),
+        _ => None,
+    };
+    GameIndexEntry {
+        source: GameSourceRef::Psv {
+            start_record,
+            end_record,
+            ordinal,
+        },
+        outcome,
+        error: false,
+        ply_count: (end_record - start_record) as u32,
+        pair_index: None,
+        pair_slot: None,
+        startpos_idx: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    /// game_ply / score / move16 / game_result を指定してテスト用 PSV レコードを作る。
+    /// 盤面は平手初期局面の packed sfen を使い回し、bit 0 (手番) だけ書き換える
+    /// （全 0 埋めだと先手玉・後手玉が同一マス扱いになり `unpack_sfen` が失敗するため）。
+    fn record(side: Color, game_ply: u16, score: i16, move16: u16, game_result: i8) -> [u8; 40] {
+        let mut hirate = Position::new();
+        hirate
+            .set_sfen("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .unwrap();
+        let mut sfen = crate::packed_sfen::pack_position(&hirate);
+        if side == Color::White {
+            sfen[0] |= 1;
+        } else {
+            sfen[0] &= !1;
+        }
+        let psv = PackedSfenValue {
+            sfen,
+            score,
+            move16,
+            game_ply,
+            game_result,
+            padding: 0,
+        };
+        psv.to_bytes()
+    }
+
+    fn write_psv(records: &[[u8; 40]]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        for r in records {
+            f.write_all(r).expect("write record");
+        }
+        f.flush().expect("flush");
+        f
+    }
+
+    #[test]
+    fn build_index_splits_on_ply_reset() {
+        let records = [
+            record(Color::Black, 1, 0, 1, 0),
+            record(Color::White, 2, 0, 1, 0),
+            record(Color::Black, 3, 0, 0, 1), // 対局1終了（黒勝ち、手番=黒視点 +1）
+            record(Color::Black, 1, 0, 1, 0), // 対局2開始
+            record(Color::White, 2, 0, 0, -1), // 対局2終了（白勝ち：手番=白視点 -1）
+        ];
+        let f = write_psv(&records);
+        let source = PsvSource::new(f.path());
+        let index = source.build_index().expect("build_index");
+
+        assert_eq!(index.entries.len(), 2);
+        let g1 = &index.entries[0];
+        assert_eq!(g1.ply_count, 3);
+        assert_eq!(g1.outcome, Some(GameOutcomeView::Win(Color::Black)));
+        let g2 = &index.entries[1];
+        assert_eq!(g2.ply_count, 2);
+        // game_result=-1 はそのレコードの手番(白)から見て負け = 勝者は黒。
+        assert_eq!(g2.outcome, Some(GameOutcomeView::Win(Color::Black)));
+    }
+
+    #[test]
+    fn build_index_handles_draw() {
+        let records = [
+            record(Color::Black, 1, 0, 1, 0),
+            record(Color::White, 2, 0, 0, 0),
+        ];
+        let f = write_psv(&records);
+        let index = PsvSource::new(f.path()).build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 1);
+        assert_eq!(index.entries[0].outcome, Some(GameOutcomeView::Draw));
+    }
+
+    #[test]
+    fn load_game_reads_only_requested_range() {
+        let records = [
+            record(Color::Black, 1, 10, 1, 0),
+            record(Color::White, 2, -20, 0, 1),
+            record(Color::Black, 1, 30, 1, 0),
+        ];
+        let f = write_psv(&records);
+        let source = PsvSource::new(f.path());
+        let index = source.build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 2);
+
+        let game1 = source.load_game(&index, &index.entries[0]).expect("load_game");
+        assert_eq!(game1.moves.len(), 2);
+        assert_eq!(game1.moves[0].annotation.score_cp, Some(10));
+        assert_eq!(game1.moves[1].annotation.score_cp, Some(-20));
+
+        let game2 = source.load_game(&index, &index.entries[1]).expect("load_game");
+        assert_eq!(game2.moves.len(), 1);
+    }
+
+    #[test]
+    fn warns_on_implausibly_short_average_game_length() {
+        // 全レコードが ply=1 (常にリセット扱い) = 1局1レコードのシャッフル済みプール相当。
+        let records: Vec<[u8; 40]> = (0..20).map(|_| record(Color::Black, 1, 0, 1, 0)).collect();
+        let f = write_psv(&records);
+        let index = PsvSource::new(f.path()).build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 20);
+        assert!(!index.warnings.is_empty(), "shuffled pool であることが警告されるべき");
+    }
+}

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -36,6 +36,15 @@ pub fn run(source: Box<dyn GameSource>) -> Result<()> {
         anyhow::bail!("対局が1件も見つかりませんでした");
     }
 
+    // raw mode/alternate screen 中に panic すると端末が壊れたまま残るため、
+    // 復元してから元の panic hook に委譲する。
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(panic_info);
+    }));
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -331,12 +340,14 @@ fn black_pov_cp(mv: &MoveView) -> Option<f64> {
     Some(black_pov.clamp(-GRAPH_CP_CLAMP, GRAPH_CP_CLAMP))
 }
 
-/// `(ply, black_pov_cp, mover)` の点列。X 軸には実際の `ply` を使う
-/// （PSV の `skip_initial_ply`/`skip_in_check` による欠番がそのまま見えるように）。
-fn eval_points(game: &GameRecord) -> Vec<(f64, f64, Color)> {
+/// `game.moves` と同じ長さ・同じ並びの打点列（評価値が無い手は `None`）。
+/// 「手」のインデックスで隣接判定するために、評価値の有無でフィルタした
+/// flat なリストにはしない（フィルタ後に隣接させると、評価値が欠けた手を
+/// 挟んだ前後の手が直線で繋がってしまい、欠損が無かったように見えてしまう）。
+fn eval_points(game: &GameRecord) -> Vec<Option<(f64, f64, Color)>> {
     game.moves
         .iter()
-        .filter_map(|mv| black_pov_cp(mv).map(|cp| (mv.ply as f64, cp, mv.side)))
+        .map(|mv| black_pov_cp(mv).map(|cp| (mv.ply as f64, cp, mv.side)))
         .collect()
 }
 
@@ -348,14 +359,15 @@ fn draw_eval_graph(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout:
         frame.render_widget(Paragraph::new("(対局を選択してください)").block(block), area);
         return;
     };
-    let points = eval_points(game);
-    if points.len() < 2 {
+    let aligned = eval_points(game);
+    let plotted: Vec<(f64, f64, Color)> = aligned.iter().filter_map(|p| *p).collect();
+    if plotted.len() < 2 {
         frame.render_widget(Paragraph::new("(表示できる評価値がありません)").block(block), area);
         return;
     }
 
-    let min_ply = points.first().map(|p| p.0).unwrap_or(0.0);
-    let max_ply = points.last().map(|p| p.0).unwrap_or(1.0).max(min_ply + 1.0);
+    let min_ply = plotted.first().map(|p| p.0).unwrap_or(0.0);
+    let max_ply = plotted.last().map(|p| p.0).unwrap_or(1.0).max(min_ply + 1.0);
     let cursor_ply = current_move(app).map(|mv| mv.ply as f64);
 
     let canvas = Canvas::default()
@@ -372,9 +384,11 @@ fn draw_eval_graph(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout:
                 color: RColor::DarkGray,
             });
             // 着手側で色分けした線分（着手後の評価値を、その着手側の色で結ぶ）。
-            for pair in points.windows(2) {
-                let (x1, y1, _) = pair[0];
-                let (x2, y2, side2) = pair[1];
+            // 評価値の無い手を挟む区間は線を引かない（隣接する「手」同士のみ結ぶ）。
+            for pair in aligned.windows(2) {
+                let (Some((x1, y1, _)), Some((x2, y2, side2))) = (pair[0], pair[1]) else {
+                    continue;
+                };
                 let color = if side2 == Color::Black {
                     RColor::Yellow
                 } else {
@@ -583,5 +597,24 @@ mod tests {
     #[test]
     fn black_pov_cp_none_when_no_eval() {
         assert_eq!(black_pov_cp(&mv(Color::Black, None, None)), None);
+    }
+
+    #[test]
+    fn eval_points_preserves_gap_position_for_missing_eval() {
+        // 中央の手だけ評価値が無い対局。draw_eval_graph 側はこの None を
+        // 「前後の手を直線で繋がない」境界として使うため、None の位置が
+        // 元の手の並びと一致していることをここで固定する。
+        let game = GameRecord {
+            moves: vec![
+                mv(Color::Black, Some(10), None),
+                mv(Color::White, None, None),
+                mv(Color::Black, Some(-5), None),
+            ],
+        };
+        let points = eval_points(&game);
+        assert_eq!(points.len(), 3);
+        assert!(points[0].is_some());
+        assert!(points[1].is_none(), "評価値の無い手は None のまま保持される");
+        assert!(points[2].is_some());
     }
 }

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -1,0 +1,587 @@
+//! ratatui ベースの棋譜プレイヤー画面・イベントループ。
+
+use std::io::{self};
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color as RColor, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::canvas::{Canvas, Line as CanvasLine};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+use rshogi_core::position::Position;
+use rshogi_core::types::{Color, PieceType, Square};
+
+use crate::kif::piece_label;
+
+use super::model::{
+    GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef, MoveView,
+};
+use super::{GameIndex, display_label};
+
+/// 棋譜プレイヤー TUI を起動する。`Ctrl-C`／`q` で終了するまでブロックする。
+pub fn run(source: Box<dyn GameSource>) -> Result<()> {
+    let index = source.build_index()?;
+    for warning in &index.warnings {
+        eprintln!("warning: {warning}");
+    }
+    if index.entries.is_empty() {
+        anyhow::bail!("対局が1件も見つかりませんでした");
+    }
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(source, index);
+    let result = run_event_loop(&mut terminal, &mut app);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+enum Mode {
+    Browse,
+    Filter,
+}
+
+struct App {
+    source: Box<dyn GameSource>,
+    index: GameIndex,
+    /// `index.entries` のうち、現在のフィルタに一致するものの index 列。
+    filtered: Vec<usize>,
+    selected: usize,
+    mode: Mode,
+    filter_input: String,
+    current_game: Option<GameRecord>,
+    current_move: usize,
+    status: String,
+}
+
+impl App {
+    fn new(source: Box<dyn GameSource>, index: GameIndex) -> Self {
+        let filtered: Vec<usize> = (0..index.entries.len()).collect();
+        let mut app = Self {
+            source,
+            index,
+            filtered,
+            selected: 0,
+            mode: Mode::Browse,
+            filter_input: String::new(),
+            current_game: None,
+            current_move: 0,
+            status: String::new(),
+        };
+        app.load_selected();
+        app
+    }
+
+    fn selected_entry(&self) -> Option<&GameIndexEntry> {
+        self.filtered.get(self.selected).map(|&i| &self.index.entries[i])
+    }
+
+    fn load_selected(&mut self) {
+        self.current_move = 0;
+        self.current_game = None;
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        match self.source.load_game(&self.index, entry) {
+            Ok(game) => self.current_game = Some(game),
+            Err(e) => self.status = format!("対局の読み込みに失敗しました: {e}"),
+        }
+    }
+
+    fn apply_filter(&mut self) {
+        let query = self.filter_input.to_lowercase();
+        self.filtered = (0..self.index.entries.len())
+            .filter(|&i| entry_matches(&self.index, &self.index.entries[i], &query))
+            .collect();
+        self.selected = 0;
+        self.load_selected();
+    }
+
+    fn next_game(&mut self) {
+        if self.selected + 1 < self.filtered.len() {
+            self.selected += 1;
+            self.load_selected();
+        }
+    }
+
+    fn prev_game(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+            self.load_selected();
+        }
+    }
+
+    fn next_move(&mut self) {
+        if let Some(game) = &self.current_game
+            && self.current_move + 1 < game.moves.len()
+        {
+            self.current_move += 1;
+        }
+    }
+
+    fn prev_move(&mut self) {
+        if self.current_move > 0 {
+            self.current_move -= 1;
+        }
+    }
+
+    /// `false` を返したらイベントループを終了する。
+    fn handle_key(&mut self, code: KeyCode) -> bool {
+        match self.mode {
+            Mode::Filter => match code {
+                KeyCode::Esc => {
+                    self.filter_input.clear();
+                    self.apply_filter();
+                    self.mode = Mode::Browse;
+                }
+                KeyCode::Enter => self.mode = Mode::Browse,
+                KeyCode::Backspace => {
+                    self.filter_input.pop();
+                    self.apply_filter();
+                }
+                KeyCode::Char(c) => {
+                    self.filter_input.push(c);
+                    self.apply_filter();
+                }
+                _ => {}
+            },
+            Mode::Browse => match code {
+                KeyCode::Char('q') | KeyCode::Esc => return false,
+                KeyCode::Char('h') | KeyCode::Left => self.prev_move(),
+                KeyCode::Char('l') | KeyCode::Right => self.next_move(),
+                KeyCode::Char('j') | KeyCode::Down => self.next_game(),
+                KeyCode::Char('k') | KeyCode::Up => self.prev_game(),
+                KeyCode::Char('/') => self.mode = Mode::Filter,
+                _ => {}
+            },
+        }
+        true
+    }
+}
+
+fn outcome_keyword(entry: &GameIndexEntry) -> &'static str {
+    if entry.error {
+        return "error";
+    }
+    match entry.outcome {
+        Some(GameOutcomeView::Win(Color::Black)) => "black_win",
+        Some(GameOutcomeView::Win(Color::White)) => "white_win",
+        Some(GameOutcomeView::Draw) => "draw",
+        None => "unknown",
+    }
+}
+
+fn entry_matches(index: &GameIndex, entry: &GameIndexEntry, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    if display_label(index, entry).to_lowercase().contains(query) {
+        return true;
+    }
+    if outcome_keyword(entry).contains(query) {
+        return true;
+    }
+    if let GameSourceRef::Jsonl { game_id, .. } = entry.source
+        && game_id.to_string() == query
+    {
+        return true;
+    }
+    [entry.pair_index, entry.pair_slot, entry.startpos_idx]
+        .iter()
+        .flatten()
+        .any(|v| v.to_string() == query)
+}
+
+fn run_event_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> Result<()> {
+    loop {
+        terminal.draw(|frame| draw(frame, app))?;
+        if let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && !app.handle_key(key.code)
+        {
+            return Ok(());
+        }
+    }
+}
+
+fn draw(frame: &mut ratatui::Frame, app: &mut App) {
+    let root = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(10),
+            Constraint::Length(9),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(30),
+            Constraint::Percentage(40),
+            Constraint::Percentage(30),
+        ])
+        .split(root[0]);
+
+    draw_game_list(frame, app, main[0]);
+    draw_board(frame, app, main[1]);
+    draw_move_list(frame, app, main[2]);
+    draw_eval_graph(frame, app, root[1]);
+    draw_status_bar(frame, app, root[2]);
+}
+
+fn draw_game_list(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let items: Vec<ListItem> = app
+        .filtered
+        .iter()
+        .map(|&i| {
+            let entry = &app.index.entries[i];
+            let label = display_label(&app.index, entry);
+            let marker = if entry.error {
+                " [error]"
+            } else {
+                match entry.outcome {
+                    Some(GameOutcomeView::Win(Color::Black)) => " [b-win]",
+                    Some(GameOutcomeView::Win(Color::White)) => " [w-win]",
+                    Some(GameOutcomeView::Draw) => " [draw]",
+                    None => "",
+                }
+            };
+            ListItem::new(format!("{label}{marker}"))
+        })
+        .collect();
+
+    let title = format!("対局一覧 ({}/{})", app.filtered.len(), app.index.entries.len());
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+    let mut state = ListState::default();
+    if !app.filtered.is_empty() {
+        state.select(Some(app.selected));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_board(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let lines = match current_move(app) {
+        Some(mv) => render_board(&mv.sfen_before),
+        None => vec![Line::from("(対局を選択してください)")],
+    };
+    let para = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("盤面"));
+    frame.render_widget(para, area);
+}
+
+fn draw_move_list(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let items: Vec<ListItem> = match &app.current_game {
+        Some(game) => game.moves.iter().map(|mv| ListItem::new(mv.kif_label.clone())).collect(),
+        None => Vec::new(),
+    };
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("指し手"))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    let mut state = ListState::default();
+    if app.current_game.is_some() {
+        state.select(Some(app.current_move));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+/// 評価値グラフの Y 軸クランプ幅（cp 換算）。詰みはこの符号付き値に丸める。
+const GRAPH_CP_CLAMP: f64 = 3000.0;
+
+/// 手番相対の生スコアから、先手固定 POV の打点値を導出する。
+/// プラス = 先手優勢、マイナス = 後手優勢（design doc「評価値グラフ」節参照）。
+/// `score_cp`/`score_mate` が両方とも無い手は `None`（打点をスキップする）。
+fn black_pov_cp(mv: &MoveView) -> Option<f64> {
+    let a = &mv.annotation;
+    let stm_relative = if let Some(mate) = a.score_mate {
+        if mate >= 0 {
+            GRAPH_CP_CLAMP
+        } else {
+            -GRAPH_CP_CLAMP
+        }
+    } else {
+        a.score_cp? as f64
+    };
+    let black_pov = if mv.side == Color::Black {
+        stm_relative
+    } else {
+        -stm_relative
+    };
+    Some(black_pov.clamp(-GRAPH_CP_CLAMP, GRAPH_CP_CLAMP))
+}
+
+/// `(ply, black_pov_cp, mover)` の点列。X 軸には実際の `ply` を使う
+/// （PSV の `skip_initial_ply`/`skip_in_check` による欠番がそのまま見えるように）。
+fn eval_points(game: &GameRecord) -> Vec<(f64, f64, Color)> {
+    game.moves
+        .iter()
+        .filter_map(|mv| black_pov_cp(mv).map(|cp| (mv.ply as f64, cp, mv.side)))
+        .collect()
+}
+
+fn draw_eval_graph(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title("評価値グラフ（＋先手優勢／－後手優勢）");
+    let Some(game) = &app.current_game else {
+        frame.render_widget(Paragraph::new("(対局を選択してください)").block(block), area);
+        return;
+    };
+    let points = eval_points(game);
+    if points.len() < 2 {
+        frame.render_widget(Paragraph::new("(表示できる評価値がありません)").block(block), area);
+        return;
+    }
+
+    let min_ply = points.first().map(|p| p.0).unwrap_or(0.0);
+    let max_ply = points.last().map(|p| p.0).unwrap_or(1.0).max(min_ply + 1.0);
+    let cursor_ply = current_move(app).map(|mv| mv.ply as f64);
+
+    let canvas = Canvas::default()
+        .block(block)
+        .x_bounds([min_ply, max_ply])
+        .y_bounds([-GRAPH_CP_CLAMP * 1.1, GRAPH_CP_CLAMP * 1.1])
+        .paint(move |ctx| {
+            // 0 の水平基準線。
+            ctx.draw(&CanvasLine {
+                x1: min_ply,
+                y1: 0.0,
+                x2: max_ply,
+                y2: 0.0,
+                color: RColor::DarkGray,
+            });
+            // 着手側で色分けした線分（着手後の評価値を、その着手側の色で結ぶ）。
+            for pair in points.windows(2) {
+                let (x1, y1, _) = pair[0];
+                let (x2, y2, side2) = pair[1];
+                let color = if side2 == Color::Black {
+                    RColor::Yellow
+                } else {
+                    RColor::Cyan
+                };
+                ctx.draw(&CanvasLine {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    color,
+                });
+            }
+            if let Some(cursor) = cursor_ply {
+                ctx.draw(&CanvasLine {
+                    x1: cursor,
+                    y1: -GRAPH_CP_CLAMP * 1.1,
+                    x2: cursor,
+                    y2: GRAPH_CP_CLAMP * 1.1,
+                    color: RColor::White,
+                });
+            }
+        });
+    frame.render_widget(canvas, area);
+}
+
+fn draw_status_bar(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::Rect) {
+    let text = match &app.mode {
+        Mode::Filter => format!("検索: {}_", app.filter_input),
+        Mode::Browse => {
+            let annotation = current_move(app).map(annotation_line).unwrap_or_default();
+            let help = "h/l:手  j/k:対局  /:検索  q:終了";
+            if app.status.is_empty() {
+                format!("{annotation}   [{help}]")
+            } else {
+                format!("{}   [{help}]", app.status)
+            }
+        }
+    };
+    let para = Paragraph::new(text).block(Block::default().borders(Borders::ALL));
+    frame.render_widget(para, area);
+}
+
+fn current_move(app: &App) -> Option<&MoveView> {
+    app.current_game.as_ref().and_then(|g| g.moves.get(app.current_move))
+}
+
+fn annotation_line(mv: &MoveView) -> String {
+    let a = &mv.annotation;
+    let mut parts = Vec::new();
+    if let Some(v) = a.score_mate {
+        parts.push(format!("詰み{v:+}"));
+    } else if let Some(v) = a.score_cp {
+        parts.push(format!("評価値{v:+}"));
+    }
+    if let Some(v) = a.depth {
+        parts.push(format!("depth={v}"));
+    }
+    if let Some(v) = a.seldepth {
+        parts.push(format!("seldepth={v}"));
+    }
+    if let Some(v) = a.nodes {
+        parts.push(format!("nodes={v}"));
+    }
+    if let Some(v) = a.nps {
+        parts.push(format!("nps={v}"));
+    }
+    if let Some(v) = a.elapsed_ms {
+        parts.push(format!("経過={v}ms"));
+    }
+    if let Some(v) = a.think_limit_ms {
+        parts.push(format!("制限={v}ms"));
+    }
+    if a.timed_out == Some(true) {
+        parts.push("TIMEOUT".to_string());
+    }
+    if let Some(v) = &a.engine_label {
+        parts.push(format!("engine={v}"));
+    }
+    if parts.is_empty() {
+        "(注釈なし)".to_string()
+    } else {
+        parts.join("  ")
+    }
+}
+
+fn render_board(sfen: &str) -> Vec<Line<'static>> {
+    let mut pos = Position::new();
+    if pos.set_sfen(sfen).is_err() {
+        return vec![Line::from("(局面を表示できません)")];
+    }
+
+    let mut lines = Vec::new();
+    let turn = if pos.side_to_move() == Color::Black {
+        "先手番"
+    } else {
+        "後手番"
+    };
+    lines.push(Line::from(format!("手番: {turn}")));
+    lines.push(Line::from(format!("後手持駒: {}", hand_text(&pos, Color::White))));
+    lines.push(Line::from(""));
+
+    for rank in 0..9u8 {
+        let mut spans = Vec::new();
+        for file in (0..9u8).rev() {
+            let sq_idx = file * 9 + rank;
+            let Some(sq) = Square::from_u8(sq_idx) else {
+                continue;
+            };
+            let piece = pos.piece_on(sq);
+            if piece.is_none() {
+                spans.push(Span::raw(" ・"));
+                continue;
+            }
+            let label = piece_label(piece.piece_type(), piece.piece_type().is_promoted());
+            let style = if piece.color() == Color::Black {
+                Style::default().fg(RColor::Yellow)
+            } else {
+                Style::default().fg(RColor::Cyan)
+            };
+            spans.push(Span::styled(format!("{label:>2}"), style));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!("先手持駒: {}", hand_text(&pos, Color::Black))));
+    lines
+}
+
+fn hand_text(pos: &Position, color: Color) -> String {
+    const ORDER: [PieceType; 7] = [
+        PieceType::Rook,
+        PieceType::Bishop,
+        PieceType::Gold,
+        PieceType::Silver,
+        PieceType::Knight,
+        PieceType::Lance,
+        PieceType::Pawn,
+    ];
+    let hand = pos.hand(color);
+    let parts: Vec<String> = ORDER
+        .iter()
+        .filter_map(|&pt| {
+            let n = hand.count(pt);
+            if n == 0 {
+                None
+            } else if n > 1 {
+                Some(format!("{}{}", piece_label(pt, false), n))
+            } else {
+                Some(piece_label(pt, false).to_string())
+            }
+        })
+        .collect();
+    if parts.is_empty() {
+        "なし".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::MoveAnnotation;
+    use super::*;
+
+    fn mv(side: Color, score_cp: Option<i32>, score_mate: Option<i32>) -> MoveView {
+        MoveView {
+            ply: 1,
+            side,
+            sfen_before: String::new(),
+            mv: rshogi_core::types::Move::NONE,
+            kif_label: String::new(),
+            annotation: MoveAnnotation {
+                score_cp,
+                score_mate,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn black_pov_cp_keeps_sign_for_black_mover() {
+        // 先手が指した手で score_cp=+120（先手にとって +120）なら、
+        // グラフ用の先手 POV もそのまま +120（先手優勢）。
+        assert_eq!(black_pov_cp(&mv(Color::Black, Some(120), None)), Some(120.0));
+    }
+
+    #[test]
+    fn black_pov_cp_flips_sign_for_white_mover() {
+        // 後手が指した手で score_cp=+80（後手にとって +80 = 後手優勢）なら、
+        // 先手 POV では -80（後手優勢はマイナスで表す）。
+        assert_eq!(black_pov_cp(&mv(Color::White, Some(80), None)), Some(-80.0));
+    }
+
+    #[test]
+    fn black_pov_cp_clamps_and_keeps_sign_for_mate() {
+        // 後手が指した手で詰みあり（後手が詰ます = 後手にとって正の mate）なら、
+        // 先手 POV では負の sentinel（後手優勢）。
+        assert_eq!(black_pov_cp(&mv(Color::White, None, Some(3))), Some(-GRAPH_CP_CLAMP));
+        // 先手が指した手で詰みあり（先手が詰まされる = 負の mate）なら、
+        // 先手 POV でも負の sentinel（後手優勢）のまま。
+        assert_eq!(black_pov_cp(&mv(Color::Black, None, Some(-2))), Some(-GRAPH_CP_CLAMP));
+    }
+
+    #[test]
+    fn black_pov_cp_none_when_no_eval() {
+        assert_eq!(black_pov_cp(&mv(Color::Black, None, None)), None);
+    }
+}

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -108,7 +108,10 @@ impl App {
             return;
         };
         match self.source.load_game(&self.index, entry) {
-            Ok(game) => self.current_game = Some(game),
+            Ok(game) => {
+                self.status.clear();
+                self.current_game = Some(game);
+            }
             Err(e) => self.status = format!("対局の読み込みに失敗しました: {e}"),
         }
     }
@@ -366,8 +369,12 @@ fn draw_eval_graph(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout:
         return;
     }
 
-    let min_ply = plotted.first().map(|p| p.0).unwrap_or(0.0);
-    let max_ply = plotted.last().map(|p| p.0).unwrap_or(1.0).max(min_ply + 1.0);
+    // x_bounds は「評価値がある手」ではなく対局全体の ply 範囲に合わせる。
+    // plotted 基準にすると、先頭 N 手が eval=None の対局で current_move が
+    // その範囲にあるとき cursor_ply < min_ply になり、カーソル縦線が
+    // Canvas のクリップで描画されなくなる。
+    let min_ply = game.moves.first().map(|mv| mv.ply as f64).unwrap_or(0.0);
+    let max_ply = game.moves.last().map(|mv| mv.ply as f64).unwrap_or(1.0).max(min_ply + 1.0);
     let cursor_ply = current_move(app).map(|mv| mv.ply as f64);
 
     let canvas = Canvas::default()


### PR DESCRIPTION
## Summary

- PSV (PackedSfenValue) の連続レコードと `tournament` の出力 JSONL (out-dir 横断、数千局規模) を同じ TUI (`kifu_player`、`kifu-player` feature、default 無効) で再生・閲覧できるようにする。
- PSV は `game_ply` のリセットで対局境界を検出し、JSONL は `*-vs-*.jsonl` を横断して `(file_idx, game_id)` 単位で対局を索引する。両方とも索引フェーズは対局メタ情報のみを保持し、対局を開いたときだけその対局分を読む streaming 設計（数千局・数GB規模でもピークメモリが対局数に依存し総手数に依存しない）。
- 先手から見た評価値（プラス=先手優勢／マイナス=後手優勢）に固定した評価値グラフを、着手側で色分けして表示する（ramu-shogi の既存グラフ機能を参考に、`MoveAnnotation` 自体は USI 標準の手番相対のまま保持し、描画時にのみ符号反転する設計）。

## 設計判断

- `crates/tools` に新規バイナリとして配置（JSONL 構造体定義と PSV decode が既にこの crate にあるため）。`ratatui`/`crossterm` は新規 feature `kifu-player` の背後に置き、default ビルドには含めない。
- 対局単位の索引 (`GameIndexEntry`) と、対局を開いたときだけ構築する手順 (`GameRecord`) を分離し、`GameSource` トレイトで PSV/JSONL の差異を吸収。
- JSONL の `game_id` はペアファイルごとのローカル連番（out-dir 全体では一意ではない）であり完了順に採番されるため、一意キーは `(file_idx, game_id)` にし、再現性ある対局指定には `pair_index`/`pair_slot`/`startpos_idx` を検索対象にしている。

設計の背景調査（PSV/JSONL の実フォーマット確認、`game_result`/`score` の POV 確認等）は private な設計メモで行い、Claude/Codex 独立レビューを2巡（アーキテクチャ→評価値グラフ追加）通している。OSS repo の規約上、その設計メモへの参照は本 repo のコメントには残していない。

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p tools --no-default-features --features kifu-player --tests` — 新規コードに warning なし
- [x] `cargo clippy -p tools --tests`（default features、kifu-player 無効）— `required-features` で新規 bin が除外されることを確認
- [x] `cargo test -p tools --no-default-features --features kifu-player --lib` — 127 passed（対局境界検出・winner 導出・JSONL 索引のエッジケース・評価値グラフの符号反転を含む新規テスト）
- [x] `cargo test -p tools --lib kif::` — 4 passed（既存 `format_move_kif` の出力保持を確認）
- [x] `bash scripts/check-tracked-abs-paths.sh`
- [x] pty 経由での実バイナリ手動smoke test（盤面・指し手送り・対局切り替え・フィルタ入力・終了が正常動作、panic なし）
- [x] local reviewer #1 (Codex 系) APPROVE
- [x] local reviewer #2 (Claude 系) APPROVE