### PR TITLE
fix(deps): anyhow を 1.0.103 に更新して RUSTSEC-2026-0190 を解消

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"


### PR DESCRIPTION
## Summary
- Security Audit CI (`cargo audit --deny warnings`) が anyhow 1.0.102 の `Error::downcast_mut()` unsoundness (RUSTSEC-2026-0190) で failing していたため、patched バージョン (>= 1.0.103) へ `Cargo.lock` を更新
- Ref: https://github.com/SH11235/rshogi/actions/runs/28494397697/job/84457591158

## Test plan
- [x] `cargo audit --deny warnings` が通ることを確認
- [x] `cargo check --workspace` でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzwEGixMq6DkfR9FWeyKXT