### PR TITLE
feat(book): 定跡機構 Phase 1 — YANEURAOU-DB2016 定跡DBリーダ + FlippedBook + probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rshogi-book"
+version = "0.1.0"
+dependencies = [
+ "rshogi-core",
+]
+
+[[package]]
 name = "rshogi-core"
 version = "0.4.0"
 dependencies = [
@@ -2547,6 +2554,7 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
+ "rshogi-book",
  "rshogi-core",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/rshogi-book",
     "crates/rshogi-core",
     "crates/rshogi-csa",
     "crates/rshogi-csa-client",

--- a/crates/rshogi-book/Cargo.toml
+++ b/crates/rshogi-book/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rshogi-book"
+version = "0.1.0"
+edition = "2024"
+authors = ["SH11235"]
+description = "Opening book (YANEURAOU-DB2016 .db) reader and probe for rshogi"
+license = "GPL-3.0-or-later"
+repository = "https://github.com/sh11235/rshogi"
+keywords = ["shogi", "usi", "opening-book", "japanese-chess", "engine"]
+categories = ["games", "game-engines"]
+
+[dependencies]
+# rshogi-core は Position / Move / Color のみ利用する。edition(NNUE)軸には触れないため
+# default-features=false とし、standalone ビルド用の既定 edition のみ本 crate の default で足す。
+# rshogi-usi は本 crate を default-features=false で依存し、preset edition specific build 時に
+# edition-universal が unify されるのを防ぐ(rshogi-usi/Cargo.toml と同じ方針)。
+rshogi-core = { version = "0.4", path = "../rshogi-core", default-features = false }
+
+[features]
+# standalone(`cargo test -p rshogi-book`)時に rshogi-core を既定 edition で解決するための default。
+# rshogi-usi 経由の依存では default-features=false で無効化され、core の edition は usi 側が決める。
+default = ["rshogi-core/edition-universal", "rshogi-core/search-no-pass-rules"]

--- a/crates/rshogi-book/src/flip.rs
+++ b/crates/rshogi-book/src/flip.rs
@@ -1,0 +1,249 @@
+//! FlippedBook 用の局面 / 指し手反転。
+//!
+//! 「盤 180 度回転 + 先後入替 + 持ち駒入替 + 手番反転」を実装する。片側の手番の局面
+//! しか収録しない定跡(片側正規化済み定跡)では、この反転検索が前提となる。
+//!
+//! **注意**: tools の `mirror_horizontal` / `canonicalize_4t_with_mirror` は左右鏡像であり、
+//! ここで実装する 180 度回転(先後反転)とは別物。
+//!
+//! - 局面: 元局面の SFEN を反転した「生 SFEN」を作り、`Position` で再パース → `to_sfen()` で
+//!   rshogi 正準形に直したものを検索キーとする(持ち駒の並び順など正準化を保証するため)。
+//! - 指し手: USI 文字列のマスを 180 度回転させる。ply は不変。
+
+use rshogi_core::position::Position;
+
+/// 英大文字 ⇔ 英小文字を入れ替える(先後の入替)。それ以外の文字はそのまま。
+fn swap_case(c: char) -> char {
+    if c.is_ascii_uppercase() {
+        c.to_ascii_lowercase()
+    } else if c.is_ascii_lowercase() {
+        c.to_ascii_uppercase()
+    } else {
+        c
+    }
+}
+
+/// SFEN 盤面部を 180 度回転 + 先後入替する。
+///
+/// 段の順序を反転し、各段内の駒トークン列も反転して、駒文字の大小を入れ替える。
+/// `+P` のような成り駒は `+` を保ったまま駒文字だけ入替。空マス数字はそのまま。
+fn flip_board(board: &str) -> Option<String> {
+    let ranks: Vec<&str> = board.split('/').collect();
+    if ranks.len() != 9 {
+        return None;
+    }
+
+    let mut out_ranks: Vec<String> = Vec::with_capacity(9);
+    for rank in ranks.iter().rev() {
+        // 段をトークン(数字 / 駒 / 成り駒)に分解する。
+        let mut units: Vec<String> = Vec::new();
+        let mut chars = rank.chars();
+        while let Some(c) = chars.next() {
+            if c == '+' {
+                let p = chars.next()?; // 成りマーカーの直後は必ず駒文字
+                if !p.is_ascii_alphabetic() {
+                    return None;
+                }
+                units.push(format!("+{}", swap_case(p)));
+            } else if c.is_ascii_digit() {
+                units.push(c.to_string());
+            } else if c.is_ascii_alphabetic() {
+                units.push(swap_case(c).to_string());
+            } else {
+                return None;
+            }
+        }
+        units.reverse();
+        out_ranks.push(units.concat());
+    }
+    Some(out_ranks.join("/"))
+}
+
+/// SFEN 持ち駒部を先後入替する(駒文字の大小入替。順序は問わない)。
+fn flip_hands(hands: &str) -> String {
+    if hands == "-" {
+        return "-".to_string();
+    }
+    hands
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphabetic() {
+                swap_case(c)
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// SFEN 文字列を反転した「生 SFEN 文字列」に変換する(正準化前)。
+/// ply(末尾手数)は不変。手番 `b`⇔`w` を入替。
+fn flip_sfen_raw(sfen: &str) -> Option<String> {
+    let mut parts = sfen.split_whitespace();
+    let board = parts.next()?;
+    let turn = parts.next()?;
+    let hands = parts.next()?;
+    let ply = parts.next();
+
+    let flipped_board = flip_board(board)?;
+    let flipped_turn = match turn {
+        "b" => "w",
+        "w" => "b",
+        _ => return None,
+    };
+    let flipped_hands = flip_hands(hands);
+
+    let mut out = format!("{flipped_board} {flipped_turn} {flipped_hands}");
+    if let Some(p) = ply {
+        out.push(' ');
+        out.push_str(p);
+    }
+    Some(out)
+}
+
+/// SFEN を反転した rshogi 正準形の検索キーを返す。
+///
+/// 生反転 SFEN を `Position::set_sfen` で再パースし `to_sfen()` で正準化することで、
+/// 持ち駒の並び順まで含めて元定跡ファイルのキー空間と一致させる。
+pub(crate) fn flipped_key(sfen: &str) -> Option<String> {
+    let raw = flip_sfen_raw(sfen)?;
+    let mut pos = Position::new();
+    pos.set_sfen(&raw).ok()?;
+    Some(pos.to_sfen())
+}
+
+/// USI マス文字列(`"7g"` 等)を 180 度回転する。file: `10-f`、rank: `10-(letter)`。
+fn flip_square(sq: &str) -> Option<String> {
+    let bytes = sq.as_bytes();
+    if bytes.len() != 2 {
+        return None;
+    }
+    let file = bytes[0];
+    let rank = bytes[1];
+    if !(b'1'..=b'9').contains(&file) || !(b'a'..=b'i').contains(&rank) {
+        return None;
+    }
+    let new_file = b'1' + (b'9' - file); // 10 - file
+    let new_rank = b'a' + (b'i' - rank); // 10 - rank
+    Some(format!("{}{}", new_file as char, new_rank as char))
+}
+
+/// USI 指し手文字列を 180 度回転する。
+///
+/// - 駒打ち `P*5e`: 駒種はそのまま、打つマスを回転。
+/// - 通常手 `7g7f` / 成り `7g7f+`: from/to を回転、成りフラグは保持。
+///
+/// パースできない入力は `None`。
+pub(crate) fn flip_usi_move(usi: &str) -> Option<String> {
+    if let Some((piece, dst)) = usi.split_once('*') {
+        // 駒打ち。
+        if piece.len() != 1 {
+            return None;
+        }
+        let flipped_dst = flip_square(dst)?;
+        return Some(format!("{piece}*{flipped_dst}"));
+    }
+
+    let bytes = usi.as_bytes();
+    if bytes.len() < 4 {
+        return None;
+    }
+    let from = flip_square(&usi[0..2])?;
+    let to = flip_square(&usi[2..4])?;
+    let promote = if bytes.len() == 5 && bytes[4] == b'+' {
+        "+"
+    } else if bytes.len() == 4 {
+        ""
+    } else {
+        return None;
+    };
+    Some(format!("{from}{to}{promote}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rshogi_core::position::Position;
+
+    /// SFEN を rshogi 正準形に直す(比較用)。
+    fn canonical(sfen: &str) -> String {
+        let mut pos = Position::new();
+        pos.set_sfen(sfen).unwrap();
+        pos.to_sfen()
+    }
+
+    #[test]
+    fn flip_square_rotates_180() {
+        assert_eq!(flip_square("7g").as_deref(), Some("3c"));
+        assert_eq!(flip_square("5e").as_deref(), Some("5e")); // 中央は不動
+        assert_eq!(flip_square("1a").as_deref(), Some("9i"));
+        assert_eq!(flip_square("9i").as_deref(), Some("1a"));
+    }
+
+    #[test]
+    fn flip_usi_move_normal_and_promote_and_drop() {
+        assert_eq!(flip_usi_move("7g7f").as_deref(), Some("3c3d"));
+        assert_eq!(flip_usi_move("7g7f+").as_deref(), Some("3c3d+"));
+        assert_eq!(flip_usi_move("P*5e").as_deref(), Some("P*5e"));
+        assert_eq!(flip_usi_move("8h2b+").as_deref(), Some("2b8h+"));
+    }
+
+    #[test]
+    fn flip_usi_move_is_involutive() {
+        for m in ["7g7f", "7g7f+", "P*5e", "8h2b+", "1a1b", "N*3c"] {
+            let once = flip_usi_move(m).unwrap();
+            let twice = flip_usi_move(&once).unwrap();
+            assert_eq!(twice, m, "flip(flip({m})) should equal {m}");
+        }
+    }
+
+    #[test]
+    fn hirate_flip_swaps_only_turn() {
+        // 平手初期局面の盤面・持ち駒は 180 度回転 + 先後入替で不変。手番のみ b→w。
+        let hirate = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+        let hirate_white = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1";
+        assert_eq!(flipped_key(hirate).as_deref(), Some(hirate_white));
+        // 往復で元(正準形)に戻る。
+        assert_eq!(flipped_key(hirate_white).as_deref(), Some(canonical(hirate).as_str()));
+    }
+
+    #[test]
+    fn flipped_key_swaps_turn_and_side() {
+        // 7g7f 後(後手番)を反転すると、対称なので先手番の同一局面になる。
+        let after_76 = "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2";
+        let flipped = flipped_key(after_76).unwrap();
+        // 反転後は手番 b、盤面は 3c3d を突いた先手側の鏡。
+        assert!(flipped.contains(" b "), "flipped turn should be black: {flipped}");
+        // 往復で元(正準形)に戻る。
+        assert_eq!(flipped_key(&flipped).as_deref(), Some(canonical(after_76).as_str()));
+    }
+
+    #[test]
+    fn flip_round_trip_with_hands() {
+        // 持ち駒あり・成り駒あり・非対称局面での往復整合。
+        let sfen = "l6nl/5+P1gk/2np1S3/p1p4Pp/3P2Sp1/1PPb2P1P/P5GS1/R8/LN4bKL w GR5pnsg 1";
+        let canon = canonical(sfen);
+        let once = flipped_key(&canon).unwrap();
+        let twice = flipped_key(&once).unwrap();
+        assert_eq!(twice, canon, "flip(flip(pos)) should equal pos");
+        // 反転で手番が入れ替わる。
+        assert!(canon.contains(" w "));
+        assert!(once.contains(" b "));
+    }
+
+    #[test]
+    fn flip_move_matches_flipped_position_legality() {
+        // 反転した指し手が反転した局面で合法になることを確認する(整合テスト)。
+        use rshogi_core::types::Move;
+        let sfen = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+        let flipped = flipped_key(sfen).unwrap();
+        let mut fpos = Position::new();
+        fpos.set_sfen(&flipped).unwrap();
+
+        let orig_move = "7g7f";
+        let flipped_move = flip_usi_move(orig_move).unwrap();
+        let mv = Move::from_usi(&flipped_move).unwrap();
+        let mv = fpos.to_move(mv).expect("flipped move decodes");
+        assert!(fpos.pseudo_legal(mv) && fpos.is_legal(mv));
+    }
+}

--- a/crates/rshogi-book/src/lib.rs
+++ b/crates/rshogi-book/src/lib.rs
@@ -1,0 +1,23 @@
+//! rshogi 定跡(opening book)機構 Phase 1。
+//!
+//! YANEURAOU-DB2016 テキスト `.db` 形式(外部で広く流通する定跡 DB フォーマット)の
+//! リーダと、root 局面 1 回の probe(指し手選択)を提供する。ファイルフォーマットのみ
+//! 外部互換とし、probe 機構・実装は rshogi 内で完結する。
+//!
+//! 設計は `rshogi-notes/rshogi/plans/20260704_opening_book_design.md` を正本とする。
+//!
+//! # 概要
+//!
+//! - [`Book`]: `.db` を丸読みした定跡本体。path 版([`Book::from_path`])と
+//!   bytes 版([`Book::from_bytes`])の二本立て API(NNUE ローダ準拠、wasm 互換)。
+//! - [`probe`]: root 局面に対して定跡手を選ぶ。miss 時は [`BookOptions::flipped_book`]
+//!   により先後反転局面で再検索する(FlippedBook)。
+//! - [`BookOptions`]: USI オプションのミラー。
+//! - [`BookRng`] / [`DefaultBookRng`]: 抽選用乱数源(テストで固定注入可能)。
+
+mod flip;
+mod probe;
+mod reader;
+
+pub use probe::{BookOptions, BookProbeResult, BookRng, DefaultBookRng, probe};
+pub use reader::Book;

--- a/crates/rshogi-book/src/probe.rs
+++ b/crates/rshogi-book/src/probe.rs
@@ -1,0 +1,604 @@
+//! 定跡 probe(root 局面 1 回、探索の外で実行)。
+//!
+//! 選択パイプラインは設計メモ(20260704_opening_book_design.md §3)の順序に従う:
+//!
+//! 1. `USI_OwnBook=false` なら不使用
+//! 2. `game_ply > BookMoves` なら不使用
+//! 3. find(ply 込みキー / IgnoreBookPly)。miss かつ FlippedBook なら反転局面で再検索し指し手反転
+//! 4. `to_move` + pseudo-legal + legal で合法性検証、非合法は info string 警告して除去
+//! 5. `BookDepthLimit`(0 で無効): 筆頭手 depth 不足なら局面ごと不採用
+//! 6. `BookEvalDiff` / `BookEvalBlackLimit` / `BookEvalWhiteLimit`: 下限未満を除去
+//! 7. `NarrowBook`: count 情報がある場合のみ出現率 10% 未満を除去
+//! 8. 選択: `ConsiderBookMoveCount` なら count 比例抽選(全 0 は等確率)、false は等確率
+//! 9. ponder 補完: book の ponder が none なら 1 手進めて再 find し筆頭候補を採用
+//! 10. bestmove(+ ponder)を返す
+
+use rshogi_core::position::Position;
+use rshogi_core::types::{Color, Move};
+
+use crate::flip;
+use crate::reader::Book;
+
+/// 定跡選択に用いる乱数源。テストで固定できるよう抽象化する。
+pub trait BookRng {
+    /// `[0, n)` の一様乱数を返す。`n == 0` の場合は 0 を返す。
+    fn rand_below(&mut self, n: u64) -> u64;
+}
+
+/// SplitMix64 ベースの既定乱数源(外部乱数 crate 非依存)。
+///
+/// 定跡手の抽選用途にのみ使うため、統計的品質は SplitMix64 で十分。
+#[derive(Debug, Clone)]
+pub struct DefaultBookRng {
+    state: u64,
+}
+
+impl DefaultBookRng {
+    /// システム時刻から種を採って生成する。
+    pub fn new() -> Self {
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0x9E37_79B9_7F4A_7C15);
+        Self::from_seed(seed)
+    }
+
+    /// 種を明示して生成する(再現性が必要な場合・wasm など)。
+    pub fn from_seed(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+}
+
+impl Default for DefaultBookRng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BookRng for DefaultBookRng {
+    fn rand_below(&mut self, n: u64) -> u64 {
+        if n == 0 {
+            return 0;
+        }
+        self.next_u64() % n
+    }
+}
+
+/// 定跡 probe のオプション群(USI オプションのミラー)。
+///
+/// 既定値は設計メモ(20260704_opening_book_design.md §3)の規定に従う。
+#[derive(Debug, Clone)]
+pub struct BookOptions {
+    /// `USI_OwnBook`: 定跡使用の総合スイッチ。
+    pub own_book: bool,
+    /// `BookMoves`: この手数までしか定跡を使わない。
+    pub book_moves: i32,
+    /// `BookEvalDiff`: 筆頭手評価値からの許容差。
+    pub eval_diff: i32,
+    /// `BookEvalBlackLimit`: 先手番の評価値下限。
+    pub eval_black_limit: i32,
+    /// `BookEvalWhiteLimit`: 後手番の評価値下限。
+    pub eval_white_limit: i32,
+    /// `BookDepthLimit`: 筆頭手の必要 depth 下限(0 で無効)。
+    pub depth_limit: i32,
+    /// `NarrowBook`: 出現率 10% 未満の手を除外するか。
+    pub narrow_book: bool,
+    /// `ConsiderBookMoveCount`: 採択回数比例で抽選するか。
+    pub consider_move_count: bool,
+    /// `FlippedBook`: miss 時に先後反転局面で再検索するか。
+    pub flipped_book: bool,
+}
+
+impl Default for BookOptions {
+    fn default() -> Self {
+        Self {
+            own_book: true,
+            book_moves: 16,
+            eval_diff: 30,
+            eval_black_limit: 0,
+            eval_white_limit: -140,
+            depth_limit: 0,
+            narrow_book: false,
+            consider_move_count: false,
+            flipped_book: true,
+        }
+    }
+}
+
+/// probe 結果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BookProbeResult {
+    /// 採用する指し手(合法性検証済み、32bit 化済み)。
+    pub best_move: Move,
+    /// 予想手(あれば)。
+    pub ponder_move: Option<Move>,
+}
+
+/// probe 内部で扱う合法性検証済みの候補手。
+struct Candidate {
+    /// この局面の座標系での合法手(32bit 化済み)。
+    mv: Move,
+    /// この局面の座標系での ponder(USI 文字列)。book に none なら `None`。
+    ponder_usi: Option<String>,
+    value: i32,
+    depth: i32,
+    move_count: u64,
+}
+
+/// find + flip + 合法性検証 + 並び替えまでを行い、筆頭手が先頭に来た候補列を返す。
+///
+/// 並びは move_count 降順 → value 降順(安定ソート)。
+fn find_candidates(
+    book: &Book,
+    position: &Position,
+    flipped_book: bool,
+    info: &mut dyn FnMut(&str),
+) -> Option<Vec<Candidate>> {
+    let sfen = position.to_sfen();
+
+    // 3. find(ply 込み) → miss なら flip 再検索。
+    let (entry, flipped) = if let Some(entry) = book.find_raw(&sfen) {
+        (entry, false)
+    } else if flipped_book {
+        let flipped_sfen = flip::flipped_key(&sfen)?;
+        (book.find_raw(&flipped_sfen)?, true)
+    } else {
+        return None;
+    };
+
+    // 4. 合法性検証。
+    let mut candidates: Vec<Candidate> = Vec::with_capacity(entry.moves.len());
+    for raw in &entry.moves {
+        let Some(move_usi) = &raw.move_usi else {
+            continue; // none/resign は指し手なし。
+        };
+        // flip ヒット時は指し手を元局面の座標系へ戻す。
+        let move_str = if flipped {
+            match flip::flip_usi_move(move_usi) {
+                Some(s) => s,
+                None => {
+                    info(&format!("Illegal Move In Book DB (unparsable flipped move): {move_usi}"));
+                    continue;
+                }
+            }
+        } else {
+            move_usi.clone()
+        };
+
+        let Some(decoded) = Move::from_usi(&move_str) else {
+            info(&format!("Illegal Move In Book DB (unparsable move): {move_str}"));
+            continue;
+        };
+        // to_move で 16bit → 32bit 化 + 手番/符号化検証。さらに pseudo-legal + legal で
+        // 完全合法性を確認する(探索の movegen を経ずに bestmove として直接返すため)。
+        let Some(mv) = position.to_move(decoded) else {
+            info(&format!("Illegal Move In Book DB: {move_str}"));
+            continue;
+        };
+        if mv == Move::NONE || !position.pseudo_legal(mv) || !position.is_legal(mv) {
+            info(&format!("Illegal Move In Book DB: {move_str}"));
+            continue;
+        }
+
+        let ponder_usi = raw.ponder_usi.as_ref().and_then(|p| {
+            if flipped {
+                flip::flip_usi_move(p)
+            } else {
+                Some(p.clone())
+            }
+        });
+
+        candidates.push(Candidate {
+            mv,
+            ponder_usi,
+            value: raw.value,
+            depth: raw.depth,
+            move_count: raw.move_count,
+        });
+    }
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // move_count 降順 → value 降順(安定ソートでファイル内順序を保つ)。
+    candidates.sort_by(|a, b| b.move_count.cmp(&a.move_count).then_with(|| b.value.cmp(&a.value)));
+
+    Some(candidates)
+}
+
+/// 候補列から採用手の添字を選ぶ(採択回数に比例した 1 パスのオンライン重み付き抽選)。
+fn select_index(
+    candidates: &[Candidate],
+    consider_move_count: bool,
+    rng: &mut dyn BookRng,
+) -> usize {
+    let n = candidates.len();
+    // まず等確率で 1 つ選ぶ。
+    let mut idx = rng.rand_below(n as u64) as usize;
+
+    if consider_move_count {
+        let sum: u64 = candidates.iter().map(|c| c.move_count).sum();
+        let mut cumulative: u64 = 0;
+        for (i, c) in candidates.iter().enumerate() {
+            // 全手 count=0 なら等確率にフォールバック(各手を 1 とみなす)。
+            let weight = if sum == 0 { 1 } else { c.move_count };
+            cumulative += weight;
+            if cumulative != 0 && rng.rand_below(cumulative) < weight {
+                idx = i;
+            }
+        }
+    }
+
+    idx
+}
+
+/// ponder を解決する。book に ponder があれば検証して採用、無ければ 1 手進めて筆頭手を拾う。
+fn resolve_ponder(
+    book: &Book,
+    position: &Position,
+    options: &BookOptions,
+    best_move: Move,
+    book_ponder: &Option<String>,
+) -> Option<Move> {
+    // best_move は find_candidates で完全合法性を検証済み。安全に 1 手進められる。
+    let gives_check = position.gives_check(best_move);
+    let mut child = position.clone();
+    child.do_move(best_move, gives_check);
+
+    if let Some(ponder_usi) = book_ponder {
+        // book 由来の ponder を子局面で検証。合法なら採用、非合法なら ponder なし。
+        let decoded = Move::from_usi(ponder_usi)?;
+        let mv = child.to_move(decoded)?;
+        if mv != Move::NONE && child.pseudo_legal(mv) && child.is_legal(mv) {
+            return Some(mv);
+        }
+        return None;
+    }
+
+    // ponder 補完: 子局面を再 find し筆頭候補を ponder に。
+    let child_candidates = find_candidates(book, &child, options.flipped_book, &mut |_| {})?;
+    child_candidates.first().map(|c| c.mv)
+}
+
+/// root 局面に対して定跡を probe する。ヒットしなければ `None`。
+///
+/// `info` には除外理由等の info string 本文(`"info string "` プレフィックスなし)が渡される。
+pub fn probe(
+    book: &Book,
+    position: &Position,
+    options: &BookOptions,
+    rng: &mut dyn BookRng,
+    mut info: impl FnMut(&str),
+) -> Option<BookProbeResult> {
+    // 1. 総合スイッチ。
+    if !options.own_book {
+        return None;
+    }
+    // 2. 手数制限。
+    if position.game_ply() > options.book_moves {
+        return None;
+    }
+
+    // 3-4. find + flip + 合法性検証 + 並び替え。
+    let mut candidates = find_candidates(book, position, options.flipped_book, &mut info)?;
+
+    // 5. BookDepthLimit(0 で無効): 筆頭手の depth 不足なら局面ごと不採用。
+    if options.depth_limit != 0 && candidates[0].depth < options.depth_limit {
+        info("BookDepthLimit is lower than the depth of this node.");
+        return None;
+    }
+
+    // 6. 評価値フィルタ。
+    {
+        let top_value = candidates[0].value;
+        let side_limit = if position.side_to_move() == Color::Black {
+            options.eval_black_limit
+        } else {
+            options.eval_white_limit
+        };
+        let value_limit = (top_value - options.eval_diff).max(side_limit);
+        let before = candidates.len();
+        candidates.retain(|c| c.value >= value_limit);
+        if candidates.len() != before {
+            info(&format!(
+                "BookEvalDiff = {} : {} moves to {} moves.",
+                options.eval_diff,
+                before,
+                candidates.len()
+            ));
+        }
+        if candidates.is_empty() {
+            return None;
+        }
+    }
+
+    // 7. NarrowBook: count 情報がある場合のみ出現率 10% 未満を除去。
+    if options.narrow_book {
+        let total: u64 = candidates.iter().map(|c| c.move_count).sum();
+        if total > 0 {
+            let before = candidates.len();
+            let threshold = total as f64 * 0.1;
+            candidates.retain(|c| c.move_count as f64 >= threshold);
+            if candidates.len() != before {
+                info(&format!("NarrowBook : {} moves to {} moves.", before, candidates.len()));
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // 8. 選択。
+    let idx = select_index(&candidates, options.consider_move_count, rng);
+    let chosen = &candidates[idx];
+    let best_move = chosen.mv;
+    let book_ponder = chosen.ponder_usi.clone();
+
+    // 9. ponder 解決。
+    let ponder_move = resolve_ponder(book, position, options, best_move, &book_ponder);
+
+    Some(BookProbeResult {
+        best_move,
+        ponder_move,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEADER: &str = "#YANEURAOU-DB2016 1.00";
+    const HIRATE: &str = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+    /// 決定的テスト用の乱数源(与えた列を順に返し、尽きたら 0)。
+    struct SeqRng {
+        values: Vec<u64>,
+        idx: usize,
+    }
+    impl SeqRng {
+        fn new(values: Vec<u64>) -> Self {
+            Self { values, idx: 0 }
+        }
+    }
+    impl BookRng for SeqRng {
+        fn rand_below(&mut self, n: u64) -> u64 {
+            if n == 0 {
+                return 0;
+            }
+            let v = self.values.get(self.idx).copied().unwrap_or(0);
+            self.idx += 1;
+            v % n
+        }
+    }
+
+    fn pos(sfen: &str) -> Position {
+        let mut p = Position::new();
+        p.set_sfen(sfen).unwrap();
+        p
+    }
+
+    fn no_info(_: &str) {}
+
+    #[test]
+    fn probe_hits_and_returns_bestmove() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 16 100\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let mut rng = SeqRng::new(vec![0]);
+        let result =
+            probe(&book, &pos(HIRATE), &BookOptions::default(), &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+        assert_eq!(result.ponder_move.map(|m| m.to_usi()).as_deref(), Some("3c3d"));
+    }
+
+    #[test]
+    fn probe_miss_returns_none() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 16 100\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        // 定跡に無い局面(2 手目 3c3d 後)。flip でもヒットしない。
+        let other = "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 3";
+        let mut rng = SeqRng::new(vec![0]);
+        assert!(probe(&book, &pos(other), &BookOptions::default(), &mut rng, no_info).is_none());
+    }
+
+    #[test]
+    fn own_book_false_disables() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 16 100\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            own_book: false,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        assert!(probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).is_none());
+    }
+
+    #[test]
+    fn book_moves_limit_disables_after_ply() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 16 100\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            book_moves: 0,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        // game_ply=1 > book_moves=0 → 不使用。
+        assert!(probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).is_none());
+    }
+
+    #[test]
+    fn flipped_book_hits_on_one_sided_db() {
+        // 片側正規化定跡: 後手番局面 after_76 を flip した「先手番の正準局面」だけを登録する。
+        let after_76 = "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2";
+        let flipped_sfen = flip::flipped_key(after_76).unwrap(); // 先手番(黒)の局面
+        // 黒視点フレームでの指し手 7g7f、ponder 8c8d を登録。
+        // probe 時に after_76 の座標系へ flip され、白の 3c3d、ponder は 2g2f になる。
+        let data = format!("{HEADER}\nsfen {flipped_sfen}\n7g7f 8c8d 20 16 50\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+
+        let mut rng = SeqRng::new(vec![0]);
+        let result =
+            probe(&book, &pos(after_76), &BookOptions::default(), &mut rng, no_info).unwrap();
+        // flip で戻された指し手が after_76(白番)局面の合法手であること。
+        assert_eq!(result.best_move.to_usi(), "3c3d");
+        assert!(pos(after_76).is_legal(result.best_move));
+        // ponder も flip される(黒視点 8c8d → after_76 側では 2g2f)。
+        assert_eq!(result.ponder_move.map(|m| m.to_usi()).as_deref(), Some("2g2f"));
+    }
+
+    #[test]
+    fn depth_limit_rejects_whole_node() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 5 100\n2g2f 8c8d 25 20 40\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        // 筆頭手(count 降順で 7g7f, depth=5)が depth_limit=16 未満 → 局面ごと不採用。
+        let opts = BookOptions {
+            depth_limit: 16,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        assert!(probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).is_none());
+    }
+
+    #[test]
+    fn depth_limit_zero_is_disabled() {
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 30 0 100\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            depth_limit: 0,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        assert!(probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).is_some());
+    }
+
+    #[test]
+    fn eval_diff_filters_low_value_moves() {
+        // 筆頭手 value=100、2 番手 value=50。eval_diff=30 → 下限 70、50 は除去。
+        // count を等しくして value 順で並ぶようにする。
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 100 16 10\n2g2f 8c8d 50 16 10\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            eval_diff: 30,
+            eval_black_limit: -30000,
+            consider_move_count: false,
+            ..Default::default()
+        };
+        // 候補が 1 手に絞られるので抽選結果は常に 7g7f。
+        let mut rng = SeqRng::new(vec![0, 0, 0]);
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn eval_black_limit_rejects_when_top_too_low() {
+        // 先手番で筆頭手 value=-50 が black_limit=0 を下回る → 全除去。
+        let data = format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d -50 16 10\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            eval_black_limit: 0,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        assert!(probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).is_none());
+    }
+
+    #[test]
+    fn narrow_book_removes_rare_moves() {
+        // count: 90 / 5 / 5 → 5% の 2 手を除去、残 1 手。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 0 0 90\n2g2f 8c8d 0 0 5\n2h6h none 0 0 5\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            narrow_book: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0]);
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn weighted_selection_respects_counts() {
+        // 3 手: count 10 / 20 / 70。ConsiderBookMoveCount=true。
+        // SeqRng を制御して 3 番手(70)が選ばれる系列を作る。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 0 0 70\n2g2f 8c8d 0 0 20\n6g6f 4c4d 0 0 10\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            consider_move_count: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        // 並びは count 降順: [7g7f(70), 2g2f(20), 6g6f(10)]。
+        // select: base=rand_below(3); 次に各手で rand_below(cumulative)。
+        // cumulative: 70, 90, 100。系列 [_, 0, _, _] → i=0 で採用(0<70)、i=1 で 89<20?false、
+        // i=2 で 99<10?false → 7g7f。
+        let mut rng = SeqRng::new(vec![0, 0, 89, 99]);
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn weighted_all_zero_counts_is_uniform() {
+        // 全手 count=0 → 各手 weight=1 の等確率抽選。base の乱数で決まる。
+        let data =
+            format!("{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 0 0 0\n2g2f 8c8d 0 0 0\n6g6f 4c4d 0 0 0\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            consider_move_count: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        // sum=0 なので weight=1、cumulative=1,2,3。系列で i=1 を選ばせる:
+        // base=1、i=0: rand_below(1)=0<1 → idx=0; i=1: rand_below(2)=0<1 → idx=1;
+        // i=2: rand_below(3)=2<1?false → idx=1。
+        let mut rng = SeqRng::new(vec![1, 0, 0, 2]);
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "2g2f");
+    }
+
+    #[test]
+    fn illegal_book_move_is_skipped_with_warning() {
+        // 1 手目に非合法手(自陣に無い駒の移動)を混ぜる。合法な 2g2f のみ残る。
+        let data = format!("{HEADER}\nsfen {HIRATE}\n5e5f 3c3d 0 0 100\n2g2f 8c8d 0 0 50\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let mut warnings = Vec::new();
+        let mut rng = SeqRng::new(vec![0]);
+        let result = probe(&book, &pos(HIRATE), &BookOptions::default(), &mut rng, |m| {
+            warnings.push(m.to_string())
+        })
+        .unwrap();
+        assert_eq!(result.best_move.to_usi(), "2g2f");
+        assert!(warnings.iter().any(|w| w.contains("Illegal Move In Book DB")));
+    }
+
+    #[test]
+    fn ponder_completion_when_book_ponder_none() {
+        // 1 手目 ponder=none。子局面(7g7f 後)を find し筆頭手を ponder に補完。
+        let after_76 = "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2";
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f none 0 0 100\nsfen {after_76}\n3c3d 2g2f 0 0 100\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let mut rng = SeqRng::new(vec![0]);
+        let result =
+            probe(&book, &pos(HIRATE), &BookOptions::default(), &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+        assert_eq!(result.ponder_move.map(|m| m.to_usi()).as_deref(), Some("3c3d"));
+    }
+}

--- a/crates/rshogi-book/src/probe.rs
+++ b/crates/rshogi-book/src/probe.rs
@@ -215,26 +215,29 @@ fn find_candidates(
     Some(candidates)
 }
 
-/// 候補列から採用手の添字を選ぶ(採択回数に比例した 1 パスのオンライン重み付き抽選)。
+/// 候補列から採用手の添字を選ぶ。`consider_move_count=false` は等確率、
+/// `true` は採択回数比例の 1 パス・オンライン重み付き抽選。
 fn select_index(
     candidates: &[Candidate],
     consider_move_count: bool,
     rng: &mut dyn BookRng,
 ) -> usize {
     let n = candidates.len();
-    // まず等確率で 1 つ選ぶ。
-    let mut idx = rng.rand_below(n as u64) as usize;
+    if !consider_move_count {
+        return rng.rand_below(n as u64) as usize;
+    }
 
-    if consider_move_count {
-        let sum: u64 = candidates.iter().map(|c| c.move_count).sum();
-        let mut cumulative: u64 = 0;
-        for (i, c) in candidates.iter().enumerate() {
-            // 全手 count=0 なら等確率にフォールバック(各手を 1 とみなす)。
-            let weight = if sum == 0 { 1 } else { c.move_count };
-            cumulative += weight;
-            if cumulative != 0 && rng.rand_below(cumulative) < weight {
-                idx = i;
-            }
+    // 候補は count 降順ソート済みなので先頭の weight は必ず 1 以上
+    // (全手 count=0 のときは各手を 1 とみなす等確率フォールバック)。
+    // よって cumulative は常に正で、i=0 で必ず idx=0 が採用される。
+    let sum: u64 = candidates.iter().map(|c| c.move_count).sum();
+    let mut idx = 0;
+    let mut cumulative: u64 = 0;
+    for (i, c) in candidates.iter().enumerate() {
+        let weight = if sum == 0 { 1 } else { c.move_count };
+        cumulative += weight;
+        if rng.rand_below(cumulative) < weight {
+            idx = i;
         }
     }
 
@@ -293,7 +296,7 @@ pub fn probe(
 
     // 5. BookDepthLimit(0 で無効): 筆頭手の depth 不足なら局面ごと不採用。
     if options.depth_limit != 0 && candidates[0].depth < options.depth_limit {
-        info("BookDepthLimit is lower than the depth of this node.");
+        info("Top move depth is below BookDepthLimit.");
         return None;
     }
 
@@ -544,10 +547,9 @@ mod tests {
             ..Default::default()
         };
         // 並びは count 降順: [7g7f(70), 2g2f(20), 6g6f(10)]。
-        // select: base=rand_below(3); 次に各手で rand_below(cumulative)。
-        // cumulative: 70, 90, 100。系列 [_, 0, _, _] → i=0 で採用(0<70)、i=1 で 89<20?false、
-        // i=2 で 99<10?false → 7g7f。
-        let mut rng = SeqRng::new(vec![0, 0, 89, 99]);
+        // select: 各手で rand_below(cumulative)。cumulative: 70, 90, 100。
+        // 系列 → i=0 で採用(0<70)、i=1 で 89<20?false、i=2 で 99<10?false → 7g7f。
+        let mut rng = SeqRng::new(vec![0, 89, 99]);
         let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
         assert_eq!(result.best_move.to_usi(), "7g7f");
     }
@@ -565,9 +567,9 @@ mod tests {
             ..Default::default()
         };
         // sum=0 なので weight=1、cumulative=1,2,3。系列で i=1 を選ばせる:
-        // base=1、i=0: rand_below(1)=0<1 → idx=0; i=1: rand_below(2)=0<1 → idx=1;
+        // i=0: rand_below(1)=0<1 → idx=0; i=1: rand_below(2)=0<1 → idx=1;
         // i=2: rand_below(3)=2<1?false → idx=1。
-        let mut rng = SeqRng::new(vec![1, 0, 0, 2]);
+        let mut rng = SeqRng::new(vec![0, 0, 2]);
         let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
         assert_eq!(result.best_move.to_usi(), "2g2f");
     }

--- a/crates/rshogi-book/src/reader.rs
+++ b/crates/rshogi-book/src/reader.rs
@@ -1,0 +1,307 @@
+//! YANEURAOU-DB2016 テキスト `.db` 定跡ファイルのリーダ。
+//!
+//! フォーマット(寛容パース仕様):
+//! - 1 行目ヘッダ `#YANEURAOU-DB2016 1.00`(`#` 行は無条件スキップ)
+//! - `//` 始まりの行はコメントとしてスキップ
+//! - `sfen <SFEN(ply 込み)>` 行が局面区切り。以降の指し手行はその局面に属する
+//! - 指し手行 `move ponder value depth move_count`(空白区切り)。必須は `move`/`ponder`
+//!   のみで、`value`/`depth`/`move_count` は省略可。省略時の既定は
+//!   `value=0, depth=0, move_count=1`。数値化できないフィールドは 0 とみなす
+//!   (`move_count` は「省略=1」だが「不正=0」)
+//! - `move`/`ponder` が `none` / `None` / `resign` のいずれかなら「指し手なし」
+
+use std::collections::HashMap;
+use std::io::{self, BufRead, BufReader, Cursor, Read};
+use std::path::Path;
+
+/// 定跡 1 手ぶんの生データ(USI 文字列のまま保持し、合法性検証は probe 時に行う)。
+#[derive(Debug, Clone)]
+pub(crate) struct RawBookMove {
+    /// 指し手(USI 文字列)。`none`/`resign` 等の「指し手なし」は `None`。
+    pub(crate) move_usi: Option<String>,
+    /// 相手の予想手(USI 文字列)。「指し手なし」は `None`。
+    pub(crate) ponder_usi: Option<String>,
+    /// 評価値。
+    pub(crate) value: i32,
+    /// 探索深さ。
+    pub(crate) depth: i32,
+    /// 採択回数。
+    pub(crate) move_count: u64,
+}
+
+/// 1 局面ぶんの定跡エントリ。
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PositionEntry {
+    pub(crate) moves: Vec<RawBookMove>,
+}
+
+/// メモリ上に丸読みした定跡本体。
+///
+/// キーは SFEN 文字列。`ignore_ply` が `true` のときは末尾の手数(ply)を落とした
+/// SFEN をキーとして格納・検索する(盤面が同じなら手数違いでもヒットする)。
+#[derive(Debug, Clone)]
+pub struct Book {
+    entries: HashMap<String, PositionEntry>,
+    ignore_ply: bool,
+}
+
+/// `move`/`ponder` フィールドを USI 文字列の `Option` に変換する。
+/// `none` / `None` / `resign` は「指し手なし」= `None`。
+fn parse_move_field(token: &str) -> Option<String> {
+    match token {
+        "none" | "None" | "resign" => None,
+        other => Some(other.to_string()),
+    }
+}
+
+/// SFEN 文字列から末尾の手数(ply)を落とす。末尾トークンが数値でない場合はそのまま返す。
+pub(crate) fn strip_ply(sfen: &str) -> &str {
+    match sfen.rsplit_once(' ') {
+        Some((head, tail)) if !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()) => head,
+        _ => sfen,
+    }
+}
+
+/// `ignore_ply` 設定に応じて検索キーを正規化する。
+pub(crate) fn normalize_key(sfen: &str, ignore_ply: bool) -> String {
+    if ignore_ply {
+        strip_ply(sfen).to_string()
+    } else {
+        sfen.to_string()
+    }
+}
+
+impl Book {
+    /// ファイルパスから定跡を読み込む(NNUE ローダの `init_nnue` 相当の path 版 API)。
+    pub fn from_path<P: AsRef<Path>>(path: P, ignore_ply: bool) -> io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        Self::from_reader(BufReader::new(file), ignore_ply)
+    }
+
+    /// バイト列から定跡を読み込む(NNUE ローダの `init_nnue_from_bytes` 相当。wasm 互換)。
+    pub fn from_bytes(bytes: &[u8], ignore_ply: bool) -> io::Result<Self> {
+        Self::from_reader(BufReader::new(Cursor::new(bytes)), ignore_ply)
+    }
+
+    /// 任意の `Read` から定跡を読み込む。
+    pub fn from_reader<R: Read>(reader: R, ignore_ply: bool) -> io::Result<Self> {
+        let mut entries: HashMap<String, PositionEntry> = HashMap::new();
+        let mut current_key: Option<String> = None;
+        let buf = BufReader::new(reader);
+
+        for line in buf.lines() {
+            let line = line?;
+            let line = line.trim_end_matches(['\r', '\n']);
+
+            // 空行はスキップ。
+            if line.trim().is_empty() {
+                continue;
+            }
+            // `#` 始まり(ヘッダ・バージョン識別・NOE 行)はスキップ。
+            if line.starts_with('#') {
+                continue;
+            }
+            // `//` 始まりのコメント行はスキップ。
+            if line.starts_with("//") {
+                continue;
+            }
+
+            if let Some(rest) = line.strip_prefix("sfen ") {
+                // 局面区切り行。ignore_ply に応じてキーを正規化して以降の指し手を紐付ける。
+                let sfen = rest.trim();
+                current_key = Some(normalize_key(sfen, ignore_ply));
+                continue;
+            }
+
+            // 指し手行。直前に sfen 行が無ければ(不正な並び)スキップ。
+            let Some(key) = current_key.as_ref() else {
+                continue;
+            };
+
+            if let Some(bm) = parse_move_line(line) {
+                entries.entry(key.clone()).or_default().moves.push(bm);
+            }
+        }
+
+        Ok(Self {
+            entries,
+            ignore_ply,
+        })
+    }
+
+    /// 登録局面数。
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// 空(登録局面ゼロ)か。
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// この定跡が手数無視(IgnoreBookPly)で構築されたか。
+    pub fn ignore_ply(&self) -> bool {
+        self.ignore_ply
+    }
+
+    /// SFEN 文字列で局面エントリを検索する(内部の `ignore_ply` に従いキー正規化)。
+    pub(crate) fn find_raw(&self, sfen: &str) -> Option<&PositionEntry> {
+        self.entries.get(&normalize_key(sfen, self.ignore_ply))
+    }
+}
+
+/// 指し手行 1 行を `RawBookMove` にパースする。`move` フィールドが空なら `None`。
+fn parse_move_line(line: &str) -> Option<RawBookMove> {
+    let mut tokens = line.split_whitespace();
+    let move_token = tokens.next()?; // move が無い行は無視
+    let move_usi = parse_move_field(move_token);
+    // ponder は省略時 "none" 相当(= None)。
+    let ponder_usi = tokens.next().and_then(parse_move_field);
+    // value/depth: 省略時 0、数値化不能も 0。
+    let value = tokens.next().map_or(0, |t| t.parse::<i32>().unwrap_or(0));
+    let depth = tokens.next().map_or(0, |t| t.parse::<i32>().unwrap_or(0));
+    // move_count: 省略時 1、数値化不能は 0。
+    let move_count = tokens.next().map_or(1, |t| t.parse::<u64>().unwrap_or(0));
+
+    Some(RawBookMove {
+        move_usi,
+        ponder_usi,
+        value,
+        depth,
+        move_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEADER: &str = "#YANEURAOU-DB2016 1.00";
+
+    #[test]
+    fn parse_full_fields() {
+        let bm = parse_move_line("7g7f 3c3d 42 16 123").unwrap();
+        assert_eq!(bm.move_usi.as_deref(), Some("7g7f"));
+        assert_eq!(bm.ponder_usi.as_deref(), Some("3c3d"));
+        assert_eq!(bm.value, 42);
+        assert_eq!(bm.depth, 16);
+        assert_eq!(bm.move_count, 123);
+    }
+
+    #[test]
+    fn parse_omitted_fields_uses_defaults() {
+        // value/depth/move_count 省略 → 0/0/1。
+        let bm = parse_move_line("7g7f 3c3d").unwrap();
+        assert_eq!(bm.value, 0);
+        assert_eq!(bm.depth, 0);
+        assert_eq!(bm.move_count, 1);
+        // value のみ指定 → depth=0, move_count=1。
+        let bm = parse_move_line("7g7f 3c3d 55").unwrap();
+        assert_eq!(bm.value, 55);
+        assert_eq!(bm.depth, 0);
+        assert_eq!(bm.move_count, 1);
+    }
+
+    #[test]
+    fn parse_non_numeric_fields_become_zero() {
+        // 数値化できないフィールドは 0(move_count も存在するので 1 でなく 0)。
+        let bm = parse_move_line("7g7f 3c3d abc def ghi").unwrap();
+        assert_eq!(bm.value, 0);
+        assert_eq!(bm.depth, 0);
+        assert_eq!(bm.move_count, 0);
+    }
+
+    #[test]
+    fn parse_none_variants_are_no_move() {
+        for token in ["none", "None", "resign"] {
+            let line = format!("{token} {token} 0 0 1");
+            let bm = parse_move_line(&line).unwrap();
+            assert!(bm.move_usi.is_none());
+            assert!(bm.ponder_usi.is_none());
+        }
+    }
+
+    #[test]
+    fn parse_ponder_omitted_is_none() {
+        let bm = parse_move_line("7g7f").unwrap();
+        assert_eq!(bm.move_usi.as_deref(), Some("7g7f"));
+        assert!(bm.ponder_usi.is_none());
+    }
+
+    #[test]
+    fn read_book_skips_comments_and_headers() {
+        let data = format!(
+            "{HEADER}\n\
+             // これはコメント\n\
+             sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\n\
+             7g7f 3c3d 30 16 100\n\
+             2g2f 8c8d 25 16 40\n\
+             \n\
+             sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2\n\
+             3c3d none 20 16 10\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        assert_eq!(book.len(), 2);
+        let entry = book
+            .find_raw("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("hirate entry present");
+        assert_eq!(entry.moves.len(), 2);
+        assert_eq!(entry.moves[0].move_usi.as_deref(), Some("7g7f"));
+        assert_eq!(entry.moves[1].move_usi.as_deref(), Some("2g2f"));
+    }
+
+    #[test]
+    fn read_book_ignores_move_line_before_any_sfen() {
+        let data = format!("{HEADER}\n7g7f 3c3d 0 0 1\n");
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        assert!(book.is_empty());
+    }
+
+    #[test]
+    fn ignore_ply_strips_trailing_ply_key() {
+        let data = format!(
+            "{HEADER}\n\
+             sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 99\n\
+             7g7f 3c3d 30 16 100\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), true).unwrap();
+        // 別の手数で検索してもヒットする(ply を無視)。
+        let entry = book
+            .find_raw("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1")
+            .expect("ignore_ply hit");
+        assert_eq!(entry.moves.len(), 1);
+    }
+
+    #[test]
+    fn ignore_ply_merges_duplicate_boards() {
+        // 同一盤面・手数違いの 2 エントリが 1 キーにマージされる。
+        let data = format!(
+            "{HEADER}\n\
+             sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\n\
+             7g7f 3c3d 30 16 100\n\
+             sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 3\n\
+             2g2f 8c8d 25 16 40\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), true).unwrap();
+        assert_eq!(book.len(), 1);
+        let entry = book
+            .find_raw("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 5")
+            .unwrap();
+        assert_eq!(entry.moves.len(), 2);
+    }
+
+    #[test]
+    fn from_bytes_matches_from_reader() {
+        let data = format!(
+            "{HEADER}\nsfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\n7g7f 3c3d 0 0 1\n"
+        );
+        let book = Book::from_bytes(data.as_bytes(), false).unwrap();
+        assert_eq!(book.len(), 1);
+    }
+
+    #[test]
+    fn strip_ply_only_when_numeric_tail() {
+        assert_eq!(strip_ply("a b c 42"), "a b c");
+        assert_eq!(strip_ply("a b -"), "a b -");
+    }
+}

--- a/crates/rshogi-book/src/reader.rs
+++ b/crates/rshogi-book/src/reader.rs
@@ -73,14 +73,16 @@ pub(crate) fn normalize_key(sfen: &str, ignore_ply: bool) -> String {
 
 impl Book {
     /// ファイルパスから定跡を読み込む(NNUE ローダの `init_nnue` 相当の path 版 API)。
+    ///
+    /// バッファリングは `from_reader` 側で行う。
     pub fn from_path<P: AsRef<Path>>(path: P, ignore_ply: bool) -> io::Result<Self> {
         let file = std::fs::File::open(path)?;
-        Self::from_reader(BufReader::new(file), ignore_ply)
+        Self::from_reader(file, ignore_ply)
     }
 
     /// バイト列から定跡を読み込む(NNUE ローダの `init_nnue_from_bytes` 相当。wasm 互換)。
     pub fn from_bytes(bytes: &[u8], ignore_ply: bool) -> io::Result<Self> {
-        Self::from_reader(BufReader::new(Cursor::new(bytes)), ignore_ply)
+        Self::from_reader(Cursor::new(bytes), ignore_ply)
     }
 
     /// 任意の `Read` から定跡を読み込む。

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -24,6 +24,8 @@ env_logger.workspace = true
 # rshogi-core の default features は本 crate の default で明示的に再構築する
 # (preset edition specific build 時に複数 edition が unify されるのを防ぐため)。
 rshogi-core = { version = "0.4", path = "../rshogi-core", default-features = false }
+# 定跡(opening book)リーダ + probe。edition を持ち込まないよう default-features=false。
+rshogi-book = { version = "0.1", path = "../rshogi-book", default-features = false }
 
 [features]
 # default は rshogi-core 側 default (search-no-pass-rules + edition-universal) と一致させる。

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -110,6 +110,21 @@ struct UsiEngine {
     pass_right_value_early: i32,
     /// パス権評価値（終盤）
     pass_right_value_late: i32,
+    // --- 定跡（opening book）関連 ---
+    /// probe パイプラインのオプション群（USI オプションのミラー）
+    book_options: rshogi_book::BookOptions,
+    /// BookFile（定跡ファイル名。`no_book` で無効）
+    book_file: String,
+    /// BookDir（定跡ファイルのディレクトリ）
+    book_dir: String,
+    /// IgnoreBookPly（末尾手数を無視して検索するか。定跡ロード時のキー正規化に使う）
+    ignore_book_ply: bool,
+    /// ロード済み定跡（isready 時にロード。BookFile=no_book なら None）
+    book: Option<rshogi_book::Book>,
+    /// ロード済み定跡の識別子 `(解決済みパス, ignore_book_ply)`。再ロード要否の判定に使う
+    book_loaded_sig: Option<(String, bool)>,
+    /// 定跡手抽選用の乱数源
+    book_rng: rshogi_book::DefaultBookRng,
 }
 
 impl UsiEngine {
@@ -150,6 +165,14 @@ impl UsiEngine {
             initial_pass_count: 2,
             pass_right_value_early: DEFAULT_PASS_RIGHT_VALUE_EARLY,
             pass_right_value_late: DEFAULT_PASS_RIGHT_VALUE_LATE,
+            book_options: rshogi_book::BookOptions::default(),
+            // BookFile 既定は no_book(定跡オフ)。既存 SPRT/tournament の挙動を変えない。
+            book_file: "no_book".to_string(),
+            book_dir: "book".to_string(),
+            ignore_book_ply: false,
+            book: None,
+            book_loaded_sig: None,
+            book_rng: rshogi_book::DefaultBookRng::new(),
         }
     }
 
@@ -268,6 +291,20 @@ impl UsiEngine {
             "option name PassRightValueLate type spin default {DEFAULT_PASS_RIGHT_VALUE_LATE} min 0 max 500"
         );
         println!("option name SPSAParamsFile type string default <auto>");
+        // 定跡（opening book）オプション。既定は BookFile=no_book(オフ)、
+        // BookDepthLimit=0(無効)（設計メモ 20260704_opening_book_design.md §3）。
+        println!("option name USI_OwnBook type check default true");
+        println!("option name BookFile type string default no_book");
+        println!("option name BookDir type string default book");
+        println!("option name BookMoves type spin default 16 min 0 max 10000");
+        println!("option name BookEvalDiff type spin default 30 min 0 max 30000");
+        println!("option name BookEvalBlackLimit type spin default 0 min -30000 max 30000");
+        println!("option name BookEvalWhiteLimit type spin default -140 min -30000 max 30000");
+        println!("option name BookDepthLimit type spin default 0 min 0 max 256");
+        println!("option name NarrowBook type check default false");
+        println!("option name ConsiderBookMoveCount type check default false");
+        println!("option name IgnoreBookPly type check default false");
+        println!("option name FlippedBook type check default true");
         for spec in SearchTuneParams::option_specs() {
             println!(
                 "option name {} type spin default {} min {} max {}",
@@ -347,7 +384,43 @@ impl UsiEngine {
         }
         self.maybe_load_spsa_params();
         self.maybe_report_large_pages();
+        self.maybe_load_book();
         println!("readyok");
+    }
+
+    /// 定跡ファイルのロード（isready 時に実施）。
+    ///
+    /// BookFile=no_book なら何もしない。ロード失敗は info string でエラー出力し、
+    /// 定跡なし（bookless）で継続する。同一パス・同一 IgnoreBookPly なら再ロードしない。
+    fn maybe_load_book(&mut self) {
+        if self.book_file == "no_book" || self.book_file.is_empty() {
+            self.book = None;
+            self.book_loaded_sig = None;
+            return;
+        }
+
+        // BookDir 配下に解決（BookFile が絶対パス/明示パスならそちらが優先される）。
+        let resolved = std::path::Path::new(&self.book_dir).join(&self.book_file);
+        let resolved_str = resolved.to_string_lossy().into_owned();
+        let sig = (resolved_str.clone(), self.ignore_book_ply);
+
+        // 既ロード & 設定不変なら再ロード不要。
+        if self.book.is_some() && self.book_loaded_sig.as_ref() == Some(&sig) {
+            return;
+        }
+
+        match rshogi_book::Book::from_path(&resolved, self.ignore_book_ply) {
+            Ok(book) => {
+                println!("info string book loaded: {resolved_str} ({} positions)", book.len());
+                self.book = Some(book);
+                self.book_loaded_sig = Some(sig);
+            }
+            Err(e) => {
+                println!("info string Error loading book file {resolved_str}: {e}");
+                self.book = None;
+                self.book_loaded_sig = None;
+            }
+        }
     }
 
     /// SPSA params ファイルの自動/明示読み込み。
@@ -859,6 +932,62 @@ impl UsiEngine {
                     eprintln!("info string PassRightValueLate: {}", self.pass_right_value_late);
                 }
             }
+            // --- 定跡（opening book）オプション ---
+            "USI_OwnBook" => {
+                self.book_options.own_book = value == "true" || value == "1";
+            }
+            "BookFile" => {
+                // 実ロードは isready 時。ここでは名前を保持するだけ。
+                self.book_file = if value.is_empty() {
+                    "no_book".to_string()
+                } else {
+                    value
+                };
+            }
+            "BookDir" => {
+                self.book_dir = if value.is_empty() {
+                    "book".to_string()
+                } else {
+                    value
+                };
+            }
+            "BookMoves" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    self.book_options.book_moves = v;
+                }
+            }
+            "BookEvalDiff" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    self.book_options.eval_diff = v;
+                }
+            }
+            "BookEvalBlackLimit" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    self.book_options.eval_black_limit = v;
+                }
+            }
+            "BookEvalWhiteLimit" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    self.book_options.eval_white_limit = v;
+                }
+            }
+            "BookDepthLimit" => {
+                if let Ok(v) = value.parse::<i32>() {
+                    self.book_options.depth_limit = v;
+                }
+            }
+            "NarrowBook" => {
+                self.book_options.narrow_book = value == "true" || value == "1";
+            }
+            "ConsiderBookMoveCount" => {
+                self.book_options.consider_move_count = value == "true" || value == "1";
+            }
+            "IgnoreBookPly" => {
+                self.ignore_book_ply = value == "true" || value == "1";
+            }
+            "FlippedBook" => {
+                self.book_options.flipped_book = value == "true" || value == "1";
+            }
             _ => {
                 // 未知のオプションは無視
             }
@@ -1007,6 +1136,13 @@ impl UsiEngine {
         // 制限を解析
         let limits = self.parse_go_options(tokens);
 
+        // 定跡 probe（探索の外・root で 1 回）。
+        // go infinite / go mate / go ponder では probe しない（Phase 1 の単純化、設計メモ §3）。
+        // book hit 時は探索スレッドを起こさず bestmove を直接出力する。
+        if !limits.infinite && limits.mate == 0 && !limits.ponder && self.try_book_probe() {
+            return;
+        }
+
         // Stochastic_Ponder では 1 手戻した局面から先読みする（YaneuraOu 準拠）
         let mut pos = if self.stochastic_ponder && limits.ponder {
             self.stochastic_ponder_position().unwrap_or_else(|| self.position.clone())
@@ -1071,6 +1207,50 @@ impl UsiEngine {
                 })
                 .expect("failed to spawn search thread"),
         );
+    }
+
+    /// 現在局面を定跡で probe し、hit したら bestmove を直接出力して true を返す。
+    ///
+    /// USI_OwnBook=false / 定跡未ロード / miss の場合は何も出力せず false を返し、
+    /// 呼び出し側は通常探索へフォールバックする。
+    fn try_book_probe(&mut self) -> bool {
+        if !self.book_options.own_book {
+            return false;
+        }
+        let Some(book) = self.book.as_ref() else {
+            return false;
+        };
+
+        // probe 中の info string 本文を集めてから出力する（borrow 競合回避）。
+        let mut infos: Vec<String> = Vec::new();
+        let result = rshogi_book::probe(
+            book,
+            &self.position,
+            &self.book_options,
+            &mut self.book_rng,
+            |msg| infos.push(msg.to_string()),
+        );
+
+        for msg in &infos {
+            println!("info string {msg}");
+        }
+
+        match result {
+            Some(r) => {
+                let best_usi = r.best_move.to_usi();
+                match r.ponder_move {
+                    Some(ponder) => {
+                        println!("bestmove {best_usi} ponder {}", ponder.to_usi());
+                    }
+                    None => {
+                        println!("bestmove {best_usi}");
+                    }
+                }
+                std::io::stdout().flush().ok();
+                true
+            }
+            None => false,
+        }
     }
 
     /// goオプションを解析

--- a/crates/rshogi-usi/tests/book_flow.rs
+++ b/crates/rshogi-usi/tests/book_flow.rs
@@ -1,0 +1,165 @@
+//! 定跡（opening book）の USI 統合テスト。
+//!
+//! - YANEURAOU-DB2016 形式の実 `.db` フィクスチャを与えて position→go で bestmove が返ること
+//! - BookFile=no_book（既定）では定跡関連の出力が一切無く従来挙動が不変であること
+//! - 片側正規化定跡に FlippedBook でヒットすること
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Material 評価で動作させる共通初期化（NNUE ファイル不要）。
+const MATERIAL_INIT: &str = "usi\nsetoption name MaterialLevel value 9\n";
+
+/// テスト用の一意な一時ファイルパスを作り、内容を書き込んで返す。
+fn write_temp_db(tag: &str, contents: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let unique = format!(
+        "rshogi_book_test_{}_{}_{}.db",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    path.push(unique);
+    std::fs::write(&path, contents).expect("write temp .db fixture");
+    path
+}
+
+/// エンジンに一連のコマンドを流し込み stdout をまとめて返す。
+fn run_engine(input: &str) -> String {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("rshogi-usi"));
+    let mut child = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn engine");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        stdin.write_all(input.as_bytes()).expect("write");
+    }
+
+    let output = child.wait_with_output().expect("wait output");
+    assert!(output.status.success(), "engine exited with failure");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// `bestmove` 行（最初のもの）を取り出す。
+fn first_bestmove(stdout: &str) -> Option<&str> {
+    stdout.lines().find(|l| l.starts_with("bestmove"))
+}
+
+#[test]
+fn book_hit_returns_bestmove_from_db() {
+    // YANEURAOU-DB2016 形式の実 .db。平手初期局面に 7g7f(ponder 3c3d) を 1 手だけ登録。
+    let db = "#YANEURAOU-DB2016 1.00\n\
+              sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\n\
+              7g7f 3c3d 30 16 100\n";
+    let path = write_temp_db("hit", db);
+    let path_str = path.to_string_lossy();
+
+    let input = format!(
+        "{MATERIAL_INIT}\
+         setoption name BookFile value {path_str}\n\
+         isready\n\
+         position startpos\n\
+         go depth 10\n\
+         quit\n"
+    );
+    let stdout = run_engine(&input);
+    let _ = std::fs::remove_file(&path);
+
+    assert!(stdout.contains("book loaded"), "book load info missing:\n{stdout}");
+    // 候補が 1 手なので抽選に依らず 7g7f ponder 3c3d が確定する。
+    assert_eq!(
+        first_bestmove(&stdout),
+        Some("bestmove 7g7f ponder 3c3d"),
+        "unexpected bestmove:\n{stdout}"
+    );
+}
+
+#[test]
+fn flipped_book_hit_on_one_sided_db() {
+    // 片側正規化定跡: 後手番局面のみを flip した先手番の正準局面を登録。
+    // 後手番局面 (2 手目、白番) を probe すると flip でヒットする。
+    // flipped_key("...w - 2") = 先手番の対称局面。その黒視点の手 7g7f を登録すると、
+    // 後手番局面では 3c3d に反転される。
+    let flipped_sfen = "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 2";
+    let db = format!(
+        "#YANEURAOU-DB2016 1.00\n\
+         sfen {flipped_sfen}\n\
+         7g7f 8c8d 20 16 50\n"
+    );
+    let path = write_temp_db("flip", &db);
+    let path_str = path.to_string_lossy();
+
+    // 後手番局面 (先手が 7g7f を指した直後) を position で与える。
+    let input = format!(
+        "{MATERIAL_INIT}\
+         setoption name BookFile value {path_str}\n\
+         isready\n\
+         position startpos moves 7g7f\n\
+         go depth 10\n\
+         quit\n"
+    );
+    let stdout = run_engine(&input);
+    let _ = std::fs::remove_file(&path);
+
+    // flip で戻された白の 3c3d(ponder 2g2f)が返る。
+    assert_eq!(
+        first_bestmove(&stdout),
+        Some("bestmove 3c3d ponder 2g2f"),
+        "flipped book hit failed:\n{stdout}"
+    );
+}
+
+#[test]
+fn no_book_default_is_unchanged() {
+    // BookFile 未設定（既定 no_book）では定跡は一切使われず、通常探索の bestmove が返る。
+    let input = format!(
+        "{MATERIAL_INIT}\
+         isready\n\
+         position startpos\n\
+         go depth 6\n\
+         quit\n"
+    );
+    let stdout = run_engine(&input);
+
+    // 定跡関連の出力が一切無いこと（従来挙動が完全不変）。
+    assert!(!stdout.contains("book loaded"), "unexpected book output:\n{stdout}");
+    // 通常探索の bestmove が返ること。
+    let bm = first_bestmove(&stdout).expect("bestmove present");
+    assert!(bm.starts_with("bestmove"), "no bestmove:\n{stdout}");
+    // 探索由来なので info depth 行が出ているはず（book hit ならスキップされる）。
+    assert!(stdout.contains("info "), "expected search info lines:\n{stdout}");
+}
+
+#[test]
+fn own_book_false_falls_back_to_search() {
+    // 定跡はロードするが USI_OwnBook=false なら probe をスキップして通常探索する。
+    let db = "#YANEURAOU-DB2016 1.00\n\
+              sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\n\
+              7g7f 3c3d 30 16 100\n";
+    let path = write_temp_db("ownbook", db);
+    let path_str = path.to_string_lossy();
+
+    let input = format!(
+        "{MATERIAL_INIT}\
+         setoption name BookFile value {path_str}\n\
+         setoption name USI_OwnBook value false\n\
+         isready\n\
+         position startpos\n\
+         go depth 6\n\
+         quit\n"
+    );
+    let stdout = run_engine(&input);
+    let _ = std::fs::remove_file(&path);
+
+    // book はロードされるが probe されないので、通常探索の info 行が出る。
+    assert!(stdout.contains("book loaded"), "book should still load:\n{stdout}");
+    assert!(stdout.contains("info "), "expected search info lines:\n{stdout}");
+    assert!(first_bestmove(&stdout).is_some(), "bestmove present:\n{stdout}");
+}


### PR DESCRIPTION
## 概要

エンジン本体に定跡(opening book)機構を新設する Phase 1。設計の正本は
`rshogi-notes/rshogi/plans/20260704_opening_book_design.md`(調査レポート 3 本は同 `20260704_book_refs/`)。

ファイルフォーマットのみ外部互換(YANEURAOU-DB2016 テキスト `.db`)とし、probe 機構・実装は rshogi 内で完結する。

## 変更内容

新規 crate `crates/rshogi-book`(rshogi-core 依存):
- `.db` リーダ: 寛容パース(value/depth/count 省略可、`none`/`resign`、`#`・`//` スキップ)。path 版+bytes 版 API(wasm 互換、NNUE ローダと同型)
- FlippedBook: 盤 180 度回転+先後入替+持ち駒入替+手番反転。片側正規化済み定跡への反転検索
- probe 選択パイプライン: find→flip→合法性検証→BookDepthLimit→BookEvalDiff/BlackLimit/WhiteLimit→NarrowBook→抽選(ConsiderBookMoveCount 対応)→ponder 補完。乱数は注入可能

rshogi-usi 統合:
- USI オプション 12 種(`USI_OwnBook` / `BookFile` / `BookDir` / `BookMoves` / `BookEvalDiff` / `BookEvalBlackLimit` / `BookEvalWhiteLimit` / `BookDepthLimit` / `NarrowBook` / `ConsiderBookMoveCount` / `IgnoreBookPly` / `FlippedBook`)
- **既定は `BookFile=no_book`(定跡オフ)、`BookDepthLimit=0`(無効)**。book 無効時の挙動は完全不変(既存 SPRT/tournament に影響なし)
- 定跡ロードは isready 時。`cmd_go` の探索 spawn 前に probe を挿入し、hit 時は探索を起こさず bestmove 直接出力。`go infinite`/`mate`/`ponder` ではスキップ

## テスト・検証

- `rshogi-book` 単体 32 件(パーサ寛容仕様 / flip 往復性 / 各フィルタ / 重み付き抽選)+ USI 統合 `book_flow` 4 件
- fmt / clippy / `check-tracked-abs-paths` 通過。既存テストへの影響なし
- 実 `.db`(外部ツールチェーン産・30 局面)での実機スモーク: book hit / 抽選 / ponder / book 外探索フォールバックを確認。参照実装エンジンとの相互運用スモークで bestmove+ponder の一致を確認(持ち駒あり局面の SFEN キー互換含む)

## スコープ外(設計メモ Phase 2)

`.ybb` / Apery 形式、BookOnTheFly、定跡内先読み(TT ウォームアップ)、定跡 DB 生成ツール(`book_from_csa`、別 PR 予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9