### PR TITLE
config(csa-workers): 短時間 Fischer プリセット fischer-60-5F を追加

### DIFF
--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -197,6 +197,7 @@ BYOYOMI_MIN = "1"
 CLOCK_PRESETS = '''[
   {"game_name":"byoyomi-msec-10-100","kind":"countdown_msec","total_time_ms":10000,"byoyomi_ms":100},
   {"game_name":"byoyomi-120-5","kind":"countdown","total_time_sec":120,"byoyomi_sec":5},
+  {"game_name":"fischer-60-5F","kind":"fischer","total_time_sec":60,"increment_sec":5},
   {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10}
 ]'''
 

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -189,6 +189,7 @@ BYOYOMI_MIN = "1"
 CLOCK_PRESETS = '''[
   {"game_name":"byoyomi-msec-10-100","kind":"countdown_msec","total_time_ms":10000,"byoyomi_ms":100},
   {"game_name":"byoyomi-120-5","kind":"countdown","total_time_sec":120,"byoyomi_sec":5},
+  {"game_name":"fischer-60-5F","kind":"fischer","total_time_sec":60,"increment_sec":5},
   {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10}
 ]'''
 


### PR DESCRIPTION
2台マシン跨ぎのエンジン評価対局用に、短時間 Fischer 時計プリセット `fischer-60-5F`(60秒+1手5秒加算)を staging / production の `CLOCK_PRESETS` に追加する。

- 命名: `docs/csa-server/clock_defaults.md` の `fischer-<total_sec>-<increment_sec>F` 規約
- フィールド: `config.rs` のプリセット仕様どおり(`total_time_sec` / `increment_sec`)。同一形式のパーサテストが `config.rs` に既存
- staging と production の preset セットを揃える運用(production 側コメント記載)に従い両方に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9