### PR TITLE
fix(csa-server-workers): cold-start の計時起点張り直しを廃止し幽霊 TimeUp を解消 + 復元不能時の安全網

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -510,12 +510,12 @@ impl DurableObject for GameRoom {
 
         self.ensure_core_loaded().await?;
 
-        // hibernation evict を跨ぐと、最後の手で予約した絶対 deadline alarm が evict
-        // 中に到来して発火し得る。cold-start 復元では ensure_core_loaded が
-        // turn_started_at を now へ張り直すため、まだ残時間があれば「実際の時間切れ
-        // ではなく evict 滞留での早発火」とみなし、force_time_up せず残時間で alarm を
-        // 張り直す。warm な真の時間切れでは alarm は turn_budget + margin + safety 後に
-        // 発火し、残時間は 0 になるのでこの分岐を通らない。
+        // 計時起点は「直前の指し手の at_ms（初手前は play_started_at_ms）」で統一され
+        // (https://github.com/SH11235/rshogi/issues/852)、cold-start 復元でも張り直さ
+        // ない。ここでは `now` 時点の真の残時間を再計算し、まだ残っていれば
+        // (turn alarm を貼り直す前の古い予約が早発火した等) 残時間ぶんで貼り直し、
+        // `0` なら実際の時間切れとして force_time_up する。休眠を跨いだ長考の time_up
+        // は、実ギャップで残時間が `0` になるためこの経路で正しく発火する。
         let now_ms = self.now_ms();
         let remaining_ms = {
             let borrow = self.core.borrow();
@@ -992,18 +992,28 @@ impl GameRoom {
             return Ok(());
         }
 
-        self.ensure_core_loaded().await?;
+        // `now` は ensure_core_loaded の**前**(= メッセージ到着時点)で採る。計時起点は
+        // 直前の指し手の at_ms なので、着手側に課金されるのは「到着時刻 - 起点」=
+        // 思考 + ネットワーク時間のみとなり、cold-start の復元 I/O(R2 リトライ +
+        // O(手数) の replay)は課金されない。後で採ると msec 級の短い時計では
+        // 復元 I/O だけで TimeUp し得る (https://github.com/SH11235/rshogi/issues/852)。
         let now = self.now_ms();
+        self.ensure_core_loaded().await?;
         let color = role.to_core();
 
         let result = {
             let mut borrow = self.core.borrow_mut();
             let Some(core) = borrow.as_mut() else {
+                // core 復元不能で安全網 (`force_finalize_unrecoverable`) が既に
+                // #ABNORMAL 強制終局済み (or 対局未成立)。無言破棄せず WS を閉じて
+                // 終局として応答する (https://github.com/SH11235/rshogi/issues/852)。
                 crate::structured_log!(
                     event: "handle_game_line_core_missing",
                     component: "game_room",
                     handle: handle,
                 );
+                let _ =
+                    ws.close(Some(1000), Some("game finished (unrecoverable state)".to_owned()));
                 return Ok(());
             };
             match core.handle_line(color, &csa, now) {
@@ -2535,49 +2545,131 @@ impl GameRoom {
                 // (`ReplaySummary` の variant 間サイズ差対策、persistence.rs 参照)。
                 *self.core.borrow_mut() = Some(*core);
                 *self.config.borrow_mut() = Some(cfg);
+
+                // live-games-index put が抜けたまま hibernation で isolate が落ちた
+                // ケースを救済する (https://github.com/SH11235/rshogi/issues/549 §5)。
+                self.retry_live_games_index_if_needed().await?;
+
+                // 計時起点は「直前の指し手の at_ms（初手前は play_started_at_ms）」で
+                // 統一し、live / replay / alarm すべてで同じ規則を使う
+                // (https://github.com/SH11235/rshogi/issues/852)。replay 完了時点で
+                // core の turn_started_at_ms は最終手の at_ms に一致している
+                // (`apply_move` が各手で now_ms=at_ms へ更新するため) ので、cold-start
+                // でも起点を「今」へ張り直さない。張り直すと休眠を跨いだ長考が毎回
+                // チャラになり、実ギャップ全額課金の replay 計時と乖離して幽霊 TimeUp
+                // → core 復元失敗で対局が凍結・live 永久残留する。休眠を跨いだ長考の
+                // 時間切れは `alarm` ハンドラが真の残時間 (`current_turn_remaining_ms`)
+                // で判定して force_time_up する。
             }
+            // 復元不能系 (InvalidSfen / UnknownColor / MoveReplayFailed)。root fix
+            // (計時統一) 後は幽霊 TimeUp 自体が起きないが、データ破損等での復元不能は
+            // 残るため、無言 no-op (= 着手の無言破棄 / live 永久残留) をやめ、対局を
+            // #ABNORMAL で強制終局させて live index からも確実に外す安全網
+            // (https://github.com/SH11235/rshogi/issues/852)。
             ReplaySummary::InvalidSfen { reason } => {
                 crate::structured_log!(
                     event: "replay_invalid_sfen",
                     component: "game_room",
+                    level: "error",
                     reason: reason,
                 );
+                self.force_finalize_unrecoverable(&cfg, "replay_invalid_sfen").await?;
             }
             ReplaySummary::UnknownColor { ply, color } => {
                 crate::structured_log!(
                     event: "replay_unknown_color",
                     component: "game_room",
+                    level: "error",
                     ply: ply,
                     color: color,
                 );
+                self.force_finalize_unrecoverable(&cfg, "replay_unknown_color").await?;
             }
             ReplaySummary::MoveReplayFailed { ply, line, reason } => {
                 crate::structured_log!(
                     event: "replay_move_failed",
                     component: "game_room",
+                    level: "error",
                     ply: ply,
                     line: line,
                     reason: reason,
                 );
+                self.force_finalize_unrecoverable(&cfg, "replay_move_failed").await?;
             }
         }
+        Ok(())
+    }
 
-        // live-games-index put が抜けたまま hibernation で isolate が落ちた
-        // ケースを救済する (https://github.com/SH11235/rshogi/issues/549 §5)。
-        self.retry_live_games_index_if_needed().await?;
+    /// cold-start replay が非 Restored (復元不能) だったとき、対局を `#ABNORMAL`
+    /// で強制終局させ、live-games-index から確実に外す安全網
+    /// (https://github.com/SH11235/rshogi/issues/852)。
+    ///
+    /// root fix (計時統一) 後は幽霊 TimeUp 自体が起きないが、永続化データの破損等で
+    /// replay できないケースは残る。従来はログのみで core=None のままだったため、
+    /// 着手が無言破棄され、観戦 snapshot は空、時間切れ alarm も no-op、finalize
+    /// 不発で live に永久残留していた。本メソッドは:
+    ///
+    /// 1. `KEY_FINISHED` を `#ABNORMAL`（勝敗不明の中断扱い、`GameResult::Abnormal`）
+    ///    で確定させ、以後の着手を終局済み扱いにする
+    /// 2. grace / alarm 系タグを片付ける
+    /// 3. live-games-index entry を削除する (play_started 済みで put 済みのケース)
+    /// 4. 復元できなかった moves を破棄する (再 replay しても同じ失敗になるため)
+    /// 5. error レベルの構造化ログを出す (root fix 後は稀な経路なので alert 対象)
+    /// 6. 両 WS を閉じて「終局として応答」する (無言破棄をやめる)
+    ///
+    /// R2 棋譜 export は局面を組めない (= replay できない) ため行わず、
+    /// `exported_at_ms: None` を残す。
+    async fn force_finalize_unrecoverable(
+        &self,
+        cfg: &PersistedConfig,
+        reason_event: &str,
+    ) -> Result<()> {
+        use rshogi_csa_server::game::result::GameResult;
+        use rshogi_csa_server::record::kifu::primary_result_code;
 
-        // replay 後の turn_started_at_ms は最後の手の歴史的時刻のまま。hibernation
-        // evict を跨いだ復元で最初の手が即 TimeUp になるのを防ぐため、計測起点を
-        // 現在時刻へ張り直す。上の retry I/O より後に行うのは、cold start が対局者の
-        // 着手で起きた場合、retry の R2 待ち時間がそのまま次手の elapsed に課金され、
-        // 短い byoyomi / msec 時計では復元 I/O だけで TimeUp になり得るため。
-        // ここに到達した時点で core が Some なのは直前の replay が Restored だった
-        // 場合のみ (warm path は早期 return 済み)。Playing 以外は setter 側で no-op。
-        // evict 中に予約済み絶対 deadline alarm が早発火するケースは `alarm` ハンドラ
-        // 側で `current_turn_remaining_ms` を再判定して reschedule することで救済する。
-        let now_ms = self.now_ms();
-        if let Some(core) = self.core.borrow_mut().as_mut() {
-            core.reset_turn_started_at(now_ms);
+        // 既に終局済みなら二重終局しない (race ガード)。
+        if self.load_finished().await?.is_some() {
+            return Ok(());
+        }
+
+        let ended_at_ms = self.now_ms();
+        let result_code = primary_result_code(&GameResult::Abnormal { winner: None });
+        let finished = FinishedState {
+            result_code: result_code.to_owned(),
+            ended_at_ms,
+            exported_at_ms: None,
+        };
+        // KEY_FINISHED を最優先で確定させ、以後の着手が終局済み扱いになるようにする。
+        self.state.storage().put(KEY_FINISHED, &finished).await?;
+
+        // grace / agree-timeout / turn alarm 系のタグを片付ける。
+        self.delete_grace_alarm_state().await?;
+
+        // live-games-index を削除する (play_started 済み = entry を put 済みの
+        // ケースのみ対象。未 put の場合は削除不要)。
+        if let Some(started_at_ms) = cfg.play_started_at_ms {
+            self.try_delete_live_games_index(cfg, started_at_ms).await;
+        }
+
+        // 復元できなかった moves は破棄する (KEY_FINISHED ガードで再 replay は
+        // 走らないが、storage を残す意味がないため cleanup する)。
+        self.clear_moves().await;
+
+        // core は生成できていない (= None) が、防御的に take しておく。
+        self.core.borrow_mut().take();
+
+        crate::structured_log!(
+            event: "unrecoverable_force_finalized",
+            component: "game_room",
+            level: "error",
+            game_id: cfg.game_id,
+            reason_event: reason_event,
+            result_code: result_code,
+        );
+
+        // 両 WS を穏やかに閉じる (無言破棄をやめ、終局として応答する)。
+        for ws in self.state.get_websockets() {
+            let _ = ws.close(Some(1000), Some("game finished (unrecoverable state)".to_owned()));
         }
         Ok(())
     }

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -597,18 +597,23 @@ mod tests {
     }
 
     /// hibernation evict を跨いだ cold start で replay 直後の `turn_started_at_ms`
-    /// は最後の手の歴史的時刻のまま残る。張り直さずに次の手を指すと、復元時刻と
-    /// の差（evict 滞留ぶん = 数十分）がそのまま elapsed になり即 `TimeUp` する。
-    /// この対照テストはバグ条件が実際に成立することを固定する。
+    /// は最後の手の at_ms のまま残る (#852 の計時統一)。DO 側は起点を「今」へ
+    /// 張り直さないため、休眠滞留を跨いで実時間が予算を超えていれば、live 側の次の
+    /// 手でも replay 同様に `TimeUp` する。live と replay が同じ規則で課金される
+    /// (= 乖離しない) ことを固定する対照テスト
+    /// (<https://github.com/SH11235/rshogi/issues/852>)。
     #[test]
-    fn cold_start_without_reset_spuriously_times_out() {
+    fn cold_start_charges_real_elapsed_and_times_out_when_over_budget() {
         let mut cfg = baseline_config();
         cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
         let moves = vec![move_row(1, "black", "+7776FU,T3", 3_000)];
         let ReplaySummary::Restored { mut core } = replay_core_room(&cfg, &moves) else {
             panic!("expected Restored");
         };
-        // 黒の手の 30 分後に白が指す（白番の長考中に DO が evict された状況）。
+        // 黒の手 (at_ms = PLAY_STARTED + 3s) の 30 分後に白が指す（白番の長考中に DO
+        // が evict され、復帰後に着手した状況）。本体 60s + 秒読み 10s の予算を実時間が
+        // 大きく超えるため、live 側 (handle_line) でも TimeUp(White) になる。これが
+        // 従来 replay 側だけが TimeUp し live と乖離していた幽霊 TimeUp を解消する。
         let resumed_at_ms = PLAY_STARTED_AT_MS + 30 * 60_000;
         let result = core
             .handle_line(Color::White, &CsaLine::new("-3334FU,T1"), resumed_at_ms + 1_000)
@@ -620,32 +625,68 @@ mod tests {
                     loser: Color::White
                 })
             ),
-            "張り直し無しでは復元滞留ぶんで即 TimeUp するはず: {:?}",
+            "実時間が予算超過なら live 側でも TimeUp するはず: {:?}",
             result.outcome
         );
     }
 
-    /// `reset_turn_started_at(now)` を復元直後に呼べば、計測起点が現在時刻に
-    /// 張り直され、復元後の最初の手が evict 滞留ぶんで誤 `TimeUp` しない。
+    /// 「大きな at_ms ギャップ (長考) を含む手列」でも各手の実消費が予算内なら、
+    /// replay は `MoveReplayFailed` にならず `Restored` する (#852 root fix の対照)。
+    /// 本番で発症した fischer-60-5F を模し、40 秒級の長考を 2 手繋いでも 60s バンク +
+    /// 5s increment の予算内なので TimeUp しない
+    /// (<https://github.com/SH11235/rshogi/issues/852>)。
     #[test]
-    fn cold_start_reset_turn_started_at_avoids_spurious_time_up() {
+    fn cold_start_replay_with_large_but_within_budget_fischer_gaps_restores() {
+        let mut cfg = baseline_config();
+        cfg.clock = ClockSpec::Fischer {
+            total_time_sec: 60,
+            increment_sec: 5,
+        };
+        cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
+        // 黒 40s 長考 → 白 40s 長考。いずれも 60s バンク + 5s increment の予算内。
+        let moves = vec![
+            move_row(1, "black", "+7776FU,T40", 40_000),
+            move_row(2, "white", "-3334FU,T40", 80_000),
+        ];
+        let ReplaySummary::Restored { core } = replay_core_room(&cfg, &moves) else {
+            panic!("予算内の長考なら Restored のはず (MoveReplayFailed になってはいけない)");
+        };
+        assert_eq!(core.moves_played(), 2);
+        // 予算内なので両者とも残時間が正 (TimeUp していない)。
+        assert!(core.clock_remaining_main_ms(Color::Black) > 0);
+        assert!(core.clock_remaining_main_ms(Color::White) > 0);
+    }
+
+    /// cold-start 復元後の alarm 判定を固定する (#852)。計時起点を張り直さないので、
+    /// 実時間が予算を超えた `now` では `current_turn_remaining_ms` が `0` を返し、
+    /// alarm は `force_time_up` を発火する。予算内の `now` では残時間が正で、alarm は
+    /// 残時間ぶん貼り直す (<https://github.com/SH11235/rshogi/issues/852>)。
+    #[test]
+    fn cold_start_alarm_decides_time_up_from_real_remaining() {
         let mut cfg = baseline_config();
         cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
         let moves = vec![move_row(1, "black", "+7776FU,T3", 3_000)];
         let ReplaySummary::Restored { mut core } = replay_core_room(&cfg, &moves) else {
             panic!("expected Restored");
         };
-        let resumed_at_ms = PLAY_STARTED_AT_MS + 30 * 60_000;
-        core.reset_turn_started_at(resumed_at_ms);
-        let result = core
-            .handle_line(Color::White, &CsaLine::new("-3334FU,T1"), resumed_at_ms + 1_000)
-            .expect("post-restore move must not spuriously time out");
-        match result.outcome {
-            HandleOutcome::MoveAccepted { next_turn, .. } => {
-                assert_eq!(next_turn, Color::Black);
-            }
-            other => panic!("expected MoveAccepted, got {other:?}"),
-        }
+        // 次手番は白。計時起点は黒の手の at_ms (= PLAY_STARTED + 3s) のまま。
+        let turn_start = PLAY_STARTED_AT_MS + 3_000;
+        let budget = core.clock_turn_budget_ms(Color::White).max(0) as u64;
+        assert!(budget > 0);
+        // 予算内の now → 残時間が正 → alarm は reschedule する。
+        let within = turn_start + budget / 2;
+        assert_eq!(core.current_turn_remaining_ms(within), Some(budget - budget / 2));
+        // 予算超過の now (30 分後) → 残 0 → alarm は force_time_up する。
+        let over = turn_start + 30 * 60_000;
+        assert_eq!(core.current_turn_remaining_ms(over), Some(0));
+        // 実際に force_time_up が GameEnded(TimeUp{White}) を返すこと。
+        let result = core.force_time_up(core.current_turn());
+        assert!(matches!(
+            result.outcome,
+            HandleOutcome::GameEnded(GameResult::TimeUp {
+                loser: Color::White
+            })
+        ));
     }
 
     /// `MoveRow::at_ms` が 0 未満や `play_started_at_ms` より小さい異常値でも、

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -316,25 +316,15 @@ impl GameRoom {
         self.finish(result)
     }
 
-    /// cold-start 復元直後に、現在手番の経過計測起点を現在時刻へ張り直す。
-    ///
-    /// replay は局面と時計消費を再現するが `turn_started_at_ms` には最後の手の
-    /// 歴史的時刻が残る。張り直さないと復元後の最初の手で `apply_move` の
-    /// `now_ms - turn_started_at_ms` が evict 滞留ぶん過大になり即 `TimeUp` する。
-    /// `Playing` 以外は起点を持たない（`AgreeWaiting` 復元では `None` のまま）ため no-op。
-    pub fn reset_turn_started_at(&mut self, now_ms: u64) {
-        if matches!(self.status, GameStatus::Playing) {
-            self.turn_started_at_ms = Some(now_ms);
-        }
-    }
-
     /// 現在手番が `now_ms` 時点で残している持ち時間 (ms)。`0` は時間切れ。
     /// `Playing` 以外は `None`。
     ///
-    /// turn alarm 発火時に「evict 滞留での早発火か、実際の時間切れか」を区別する
-    /// ために使う。`reset_turn_started_at` で cold-start 復元時に起点が `now` へ
-    /// 張り直されるため、evict 早発火では満額の残時間が返り、warm な真の時間切れ
-    /// （alarm は `turn_budget + margin + safety` 後に発火）では `0` が返る。
+    /// turn alarm 発火時に「まだ残時間があるか、実際の時間切れか」を区別する
+    /// ために使う。計時起点 `turn_started_at_ms` は「直前の指し手の at_ms（初手前は
+    /// play_started_at_ms）」で統一されており、cold-start 復元後も張り直さない
+    /// (<https://github.com/SH11235/rshogi/issues/852>)。休眠を跨いだ長考が予算を
+    /// 超えていれば `0`（= 時間切れ）が返り、alarm 側は force_time_up する。実時間が
+    /// まだ予算内なら残時間が正で返り、alarm は残時間ぶん貼り直す。
     pub fn current_turn_remaining_ms(&self, now_ms: u64) -> Option<u64> {
         if !matches!(self.status, GameStatus::Playing) {
             return None;
@@ -753,20 +743,6 @@ mod tests {
     }
 
     #[test]
-    fn reset_turn_started_at_sets_now_when_playing_and_noop_before_start() {
-        // START 前 (AgreeWaiting) は起点を作らない。
-        let mut room = make_room();
-        room.reset_turn_started_at(12_345);
-        assert!(matches!(room.status(), GameStatus::AgreeWaiting));
-        assert_eq!(room.turn_started_at_ms, None);
-
-        // START 後 (Playing) は計測起点を渡した now へ張り直す。
-        agree_both(&mut room);
-        room.reset_turn_started_at(67_890);
-        assert_eq!(room.turn_started_at_ms, Some(67_890));
-    }
-
-    #[test]
     fn current_turn_remaining_ms_is_none_before_start() {
         let room = make_room();
         assert_eq!(room.current_turn_remaining_ms(0), None);
@@ -778,11 +754,11 @@ mod tests {
         agree_both(&mut room); // now=0 で START → 現手番の計測起点も 0、満額 budget
         let budget = room.clock_turn_budget_ms(room.current_turn()).max(0) as u64;
         assert!(budget > 0);
-        // 経過 0 → 残 == budget（evict 早発火: 復元で起点が now に張り直された状況に相当）
+        // 経過 0 → 残 == budget（起点は手番開始時刻のまま。まだ実時間を消費していない）
         assert_eq!(room.current_turn_remaining_ms(0), Some(budget));
         // 経過 < budget → 残 = budget - elapsed
         assert_eq!(room.current_turn_remaining_ms(budget / 2), Some(budget - budget / 2));
-        // budget 到達/超過 → 0（warm な真の時間切れ: alarm は budget+margin+safety 後に発火）
+        // budget 到達/超過 → 0（実時間が予算を超えた時間切れ。alarm は force_time_up する）
         assert_eq!(room.current_turn_remaining_ms(budget), Some(0));
         assert_eq!(room.current_turn_remaining_ms(budget + 5_000), Some(0));
     }


### PR DESCRIPTION
Closes #852

## 修正内容

**root fix — 計時の一貫化**: cold-start 復元時の `reset_turn_started_at(now)` を廃止し、計時起点を「直前の指し手の `at_ms`(初手前は play_started_at_ms)」で live / replay / alarm 統一。休眠を跨いだ長考が実時間どおり課金され、replay との乖離(幽霊 TimeUp → core 復元失敗 → 対局凍結・live 永久残留)が根絶される。cold alarm の永久リスケも自然解消。未使用化した core API `reset_turn_started_at` は削除(YAGNI)。

**安全網**: 復元不能(`MoveReplayFailed`/`InvalidSfen`/`UnknownColor`)時に `#ABNORMAL` で強制 finalize(KEY_FINISHED 確定 → grace/alarm 片付け → live index 削除 → moves cleanup → error レベル構造化ログ → 両 WS close)。着手の無言破棄をやめ WS close で終局として応答。

**レビュー追補(Fable)**: `handle_game_line` の `now` サンプリングを `ensure_core_loaded` の前(メッセージ到着時点)へ移動 — cold-start の復元 I/O を着手側に課金しない(msec 級時計での復元 I/O 起因 TimeUp を防止)。

## セマンティクス変更

- 休眠跨ぎの長考は実時間どおり課金(従来はチャラ)。実時間が予算超過なら正しく #TIME_UP で自発終局
- wire プロトコル互換は不変

## 検証

- 新規テスト: 予算内長考の復元 / 予算超過の一貫 TimeUp / cold alarm の真の残時間判定
- host 全テスト pass、wasm32 check clean、clippy 新規警告ゼロ
- 本番再現(観戦ゼロ・ply81 凍結)の一次証拠は #852 と本機 incident ディレクトリ参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9