### PR TITLE
fix(csa-server-workers): finalize の live index 削除に config フォールバックと可視化ログを追加

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -1743,13 +1743,35 @@ impl GameRoom {
         // 後追い掃除する契約。`play_started_at_ms` が None のまま終局した
         // (= AGREE 前 abnormal 等) ケースは live entry を put していないので
         // delete も skip する。
-        let live_delete_target = self
-            .config
-            .borrow()
-            .as_ref()
-            .and_then(|c| c.play_started_at_ms.map(|ts| (c.clone(), ts)));
-        if let Some((cfg_snapshot, started_at_ms)) = live_delete_target {
-            self.try_delete_live_games_index(&cfg_snapshot, started_at_ms).await;
+        //
+        // delete key は put と同じ `live_games_index_key(play_started_at_ms, game_id)`
+        // を使う契約 (https://github.com/SH11235/rshogi/issues/853)。in-memory
+        // `self.config` は GameEnded finalize 到達時点で常に Some のはず (core と
+        // lockstep で set される) だが、将来のリファクタや想定外の経路で None に
+        // なっても live entry を取り残さないよう、無ければ永続化済み `KEY_CONFIG`
+        // から読み直して delete key を組む。それでも config が取れない場合だけ、
+        // 無言スキップせず error ログで可視化する (本 issue で「tail に delete
+        // イベント・エラーが出ない」= 無言スキップが調査を難しくしたため)。
+        let in_mem_cfg = self.config.borrow().clone();
+        let cfg_for_delete: Option<PersistedConfig> = match in_mem_cfg {
+            Some(c) => Some(c),
+            None => self.state.storage().get(KEY_CONFIG).await.ok().flatten(),
+        };
+        match cfg_for_delete {
+            Some(cfg) => {
+                // `play_started_at_ms` が None なら live entry は未 put なので削除不要。
+                if let Some(started_at_ms) = cfg.play_started_at_ms {
+                    self.try_delete_live_games_index(&cfg, started_at_ms).await;
+                }
+            }
+            None => {
+                crate::structured_log!(
+                    event: "live_games_index_delete_skip",
+                    component: "game_room",
+                    level: "error",
+                    reason: "config_missing",
+                );
+            }
         }
 
         // moves テーブルを cleanup (https://github.com/SH11235/rshogi/issues/637)。

--- a/crates/rshogi-csa-server-workers/src/live_games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/live_games_index.rs
@@ -182,6 +182,29 @@ mod tests {
         assert_eq!(LIVE_KEY_PREFIX, "live-games-index/");
     }
 
+    /// live entry の put (`try_put_live_games_index`) と finalize での delete
+    /// (`try_delete_live_games_index`) は、同一の
+    /// `live_games_index_key(cfg.play_started_at_ms, cfg.game_id)` を使う契約
+    /// (<https://github.com/SH11235/rshogi/issues/853>)。同じ
+    /// `(started_at_ms, game_id)` から生成した key が bit 一致することと、その
+    /// 正準 key 文字列を固定して、started_ms 部の再計算ずれ (inv 計算 / ゼロパディング
+    /// の変更等) で put/delete の key が乖離し live entry が取り残される退行を防ぐ。
+    #[test]
+    fn put_and_delete_compute_identical_key_for_same_started_at() {
+        // 本番インシデント (#853) の対局 ID と play_started_at_ms 相当 (epoch ms)。
+        let started_at_ms = 1_783_185_845_075_u64;
+        let game_id = "repro-nospec-1783185827-1783185845075";
+        let put_key = live_games_index_key(started_at_ms, game_id).unwrap();
+        let delete_key = live_games_index_key(started_at_ms, game_id).unwrap();
+        assert_eq!(put_key, delete_key, "put と delete で key が乖離してはいけない");
+        // INV_BASE - started_at_ms = 99_999_999_999_999 - 1_783_185_845_075
+        //                          = 98_216_814_154_924 (14 桁ゼロパディング)。
+        assert_eq!(
+            put_key,
+            "live-games-index/98216814154924-repro-nospec-1783185827-1783185845075.json",
+        );
+    }
+
     // `source` の env 切替判定は `games_index::resolve_index_source` (wasm32
     // 限定) に集約済み。ホスト target からは純粋関数
     // `games_index::classify_index_source_from_inputs` のテスト


### PR DESCRIPTION
Closes #853

## 調査結論

現行コードに live-index delete の機能バグは無いことを二重確認(put/delete は同一 `live_games_index_key` を使い、`play_started_at_ms` は write-once)。本番で観測された live 残留の実体は (a) #852 の凍結対局(finalize 不発 → kifu meta 無し → orphan sweep 対象外)と (b) viewer API の 60 秒キャッシュ+sweep 周期内の遅延。正常終局した対局は sweep で除去されることを本番でも確認済み。

## 変更(hardening + observability)

- finalize の live delete で in-memory `self.config` が想定外に None でも取り残さないよう、永続化済み `KEY_CONFIG` から読み直すフォールバックを追加
- それでも config を解決できない唯一の経路を無言スキップにせず `live_games_index_delete_skip (reason: config_missing, level: error)` で可視化(無言スキップが本 issue の調査を困難にしたことへの対策)
- put/delete のキー計算 bit 一致を固定する契約テストを追加(本番インシデントの実 ID 使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9