### PR TITLE
fix(csa-server): viewer 経路の DO/ライフサイクル欠陥 4 件を修正 + 観戦者への評価値配信

### DIFF
--- a/crates/rshogi-csa-server-workers/src/attachment.rs
+++ b/crates/rshogi-csa-server-workers/src/attachment.rs
@@ -127,11 +127,19 @@ pub enum WsAttachment {
         ///
         /// 設計上は in-memory のみ扱いだが、DO の WebSocket Hibernation 経由で
         /// 異なる handler 呼び出し間で参照する必要があるため attachment 経由で
-        /// 永続化する (= `serialize_attachment` に乗る)。Hibernation 後に「snapshot
-        /// 送信中」状態が復帰してしまうのを防ぐため、`#[serde(default)]` で
-        /// `false` を既定値として復元する規則 (= 万一 hibernation 中に snapshot
-        /// 送信処理が中断したら、復帰後の DO は queue を空 / フラグ false で
-        /// 開始する)。
+        /// 永続化する (= `serialize_attachment` に乗る)。
+        ///
+        /// `#[serde(default)]` は **field が欠落した旧 schema** (snapshot 3 field
+        /// 導入前) の attachment を deserialize したときに `false` で復元する
+        /// ための既定値である。`true` で serialize 済みの値を復元時に `false` へ
+        /// 戻す効果は **無い** (serde default は field 不在時にのみ適用され、
+        /// `true`→`true` で round-trip する。`spectator_snapshot_state_round_trips_via_serde`
+        /// が固定)。したがって snapshot 送信がエラーで中断してこの flag が `true`
+        /// のまま永続化されると、以降の broadcast が `send_to_spectators` の per-ws
+        /// pending queue に積まれ続け、観戦者が無音フリーズする。中断時は送信経路側
+        /// が明示的に `false` へ戻す責務を持つ (`GameRoom::send_spectator_snapshot`
+        /// のエラー経路が [`WsAttachment::reset_spectator_snapshot`] で flag を落とし
+        /// queue を空にしたうえで ws を close する)。
         #[serde(default)]
         snapshot_in_progress: bool,
         /// snapshot に含めた最終 ply (1 始まり、初手前なら 0)。
@@ -206,6 +214,26 @@ impl WsAttachment {
             snapshot_in_progress: false,
             last_ply_in_snapshot: 0,
             pending_queue: Vec::new(),
+        }
+    }
+
+    /// Spectator の snapshot 送信状態を初期状態 (flag=false / queue 空) に戻す。
+    ///
+    /// snapshot 送信経路がエラーで中断すると、`snapshot_in_progress = true` の
+    /// まま attachment が残り、`send_to_spectators` が以降の broadcast を per-ws
+    /// pending queue に積み続けて観戦者が無音フリーズする。エラー経路でこの
+    /// helper を通して flag を落とし queue を空にする。`last_ply_in_snapshot` は
+    /// flag=false では参照されないため `0` に戻す。Spectator 以外の variant は
+    /// 変更せず元の値を返す。
+    pub fn reset_spectator_snapshot(self) -> Self {
+        match self {
+            Self::Spectator { room_id, .. } => Self::Spectator {
+                room_id,
+                snapshot_in_progress: false,
+                last_ply_in_snapshot: 0,
+                pending_queue: Vec::new(),
+            },
+            other => other,
         }
     }
 }
@@ -380,6 +408,37 @@ mod tests {
         let s = serde_json::to_string(&att).unwrap();
         let restored: WsAttachment = serde_json::from_str(&s).unwrap();
         assert_eq!(att, restored);
+    }
+
+    #[test]
+    fn reset_spectator_snapshot_clears_flag_and_queue() {
+        // snapshot 送信中 (flag=true, queue 非空) の attachment を reset すると
+        // flag=false / last_ply=0 / queue 空になる。room_id は保持する。
+        let att = WsAttachment::Spectator {
+            room_id: "room-xyz".to_owned(),
+            snapshot_in_progress: true,
+            last_ply_in_snapshot: 7,
+            pending_queue: vec![
+                ("+5756FU,T2".to_owned(), Some(8)),
+                ("##[CHAT] alice: hi".to_owned(), None),
+            ],
+        };
+        assert_eq!(
+            att.reset_spectator_snapshot(),
+            WsAttachment::Spectator {
+                room_id: "room-xyz".to_owned(),
+                snapshot_in_progress: false,
+                last_ply_in_snapshot: 0,
+                pending_queue: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn reset_spectator_snapshot_is_noop_for_non_spectator() {
+        // Player / Pending は snapshot 状態を持たないので変更されない。
+        let player = WsAttachment::player(Role::Black, "alice", "g");
+        assert_eq!(player.clone().reset_spectator_snapshot(), player);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -59,6 +59,23 @@ pub(crate) const SWEEP_DEADLINE_MS: u64 = 25_000;
 /// 避けるための break 条件。100 page = 100,000 件で十分な余白。
 pub(crate) const SWEEP_MAX_PAGES: u32 = 100;
 
+/// live entry の hard-TTL backstop (72 時間)。
+///
+/// 通常の sweep は「primary meta (`kifu-by-id/<id>.meta.json`) が存在する live
+/// entry」だけを消し、meta 未配置の entry は「進行中」または「終局時 meta PUT
+/// 失敗」の両義があるため保守的に残す (設計 v3 §3)。しかし
+/// `force_finalize_unrecoverable` 経路は R2 export / meta を書かずに終局させる
+/// ため、inline の live-index delete が retry を尽くして失敗すると、meta が
+/// 永遠に現れず通常 sweep でも回収できない幽霊 entry が残る (#853 系)。
+///
+/// これを回収するため、`started_at_ms` (= `play_started_at_ms`) が本 TTL より
+/// 古い live entry は meta の有無に関わらず削除する。72 時間はどんな持ち時間の
+/// 正規対局よりも遥かに長く、正当に進行中の対局が誤って消える現実的リスクは
+/// 無い。仮に消しても実害は「`/api/v1/games/live` 一覧から隠れる」だけで、
+/// 対局そのもの (DO / WS / 終局処理) には一切影響しない。誤削除の検知のため、
+/// hard-TTL 削除は必ず error レベルの structured_log を残す。
+pub(crate) const LIVE_ENTRY_HARD_TTL_MS: u64 = 72 * 60 * 60 * 1000;
+
 /// `run_games_index_backfill` の進捗統計。テスト容易性のため値型で返す。
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct BackfillStats {
@@ -77,6 +94,11 @@ pub struct SweepStats {
     pub listed: u64,
     /// `kifu-by-id/<id>.meta.json` が存在する (= 終局済) ため delete した件数。
     pub deleted: u64,
+    /// meta 不在だが `LIVE_ENTRY_HARD_TTL_MS` を超過したため delete した件数
+    /// (hard-TTL backstop)。`deleted` とは別カウントにして、幽霊 entry の回収が
+    /// 発生した事実をログ / metric から検知できるようにする。恒常的に非 0 なら
+    /// finalize 経路の live-index delete が慢性的に失敗している疑い。
+    pub hard_ttl_deleted: u64,
     /// 走査した R2 list page 数 (https://github.com/SH11235/rshogi/issues/629)。pagination loop 化に伴って導入。
     /// 1 cron で複数 page を処理した状況をログから確認するための運用 metric。
     pub pages: u32,
@@ -97,19 +119,30 @@ pub(crate) struct MetaForIndexKey {
     pub ended_at_ms: u64,
 }
 
-/// `live-games-index/<inv>-<id>.json` の本文から `game_id` field のみ取り出す
-/// 最小 view。orphan sweep 判定に必要なのは `game_id` のみなので、それ以外の
-/// 形式 (clock 等) には依存しない。
+/// `live-games-index/<inv>-<id>.json` の本文から orphan sweep 判定に必要な field
+/// のみ取り出す最小 view。`game_id` (meta key 構築 + ログ用) と `started_at_ms`
+/// (hard-TTL backstop 用) だけを持ち、それ以外の形式 (clock 等) には依存しない。
 #[derive(Debug, Deserialize)]
-pub(crate) struct LiveEntryGameId {
+pub(crate) struct LiveEntryFields {
     pub game_id: String,
+    pub started_at_ms: u64,
+}
+
+/// hard-TTL backstop の削除判定 (純粋関数、host からテスト可能)。
+///
+/// `age_ms` = sweep 実行時刻 − live entry の `started_at_ms`。これが
+/// [`LIVE_ENTRY_HARD_TTL_MS`] 以上なら、primary meta が不在でも幽霊 entry と
+/// みなして削除対象にする (境界は「以上」= inclusive)。
+pub(crate) fn live_entry_hard_ttl_expired(age_ms: u64) -> bool {
+    age_ms >= LIVE_ENTRY_HARD_TTL_MS
 }
 
 #[cfg(target_arch = "wasm32")]
 mod imp {
     use super::{
-        BackfillStats, KIFU_BY_ID_PREFIX, LiveEntryGameId, META_SUFFIX, MetaForIndexKey, PAGE_SIZE,
-        SWEEP_DEADLINE_MS, SWEEP_MAX_PAGES, SweepStats,
+        BackfillStats, KIFU_BY_ID_PREFIX, LIVE_ENTRY_HARD_TTL_MS, LiveEntryFields, META_SUFFIX,
+        MetaForIndexKey, PAGE_SIZE, SWEEP_DEADLINE_MS, SWEEP_MAX_PAGES, SweepStats,
+        live_entry_hard_ttl_expired,
     };
     use worker::{Date, Env, Result};
 
@@ -261,9 +294,18 @@ mod imp {
     /// 設計 v3 §3 に従い、判定キーは `kifu-by-id/<id>.csa` ではなく `.meta.json`。
     /// CSA 本体 put は失敗していても meta が書かれていれば終局確定 +
     /// finalize_if_ended 経路を通った証拠になる。逆もまた然りで、両方失敗した
-    /// orphan は本 sweep では消さない (= eventual に live 一覧に残るが、次回
-    /// cron で finalize 経路の副作用で meta が put された後に消える、または
-    /// 手動オペレーションで対処)。
+    /// orphan は本 sweep の **通常経路** では消さない (= eventual に live 一覧に
+    /// 残るが、次回 cron で finalize 経路の副作用で meta が put された後に消える、
+    /// または手動オペレーションで対処)。
+    ///
+    /// ただし meta を書かない `force_finalize_unrecoverable` 経路の inline
+    /// live-index delete が retry を尽くして失敗すると、meta が永遠に現れず通常
+    /// 経路では回収できない幽霊 entry が残る (#853 系)。これに対する最終防衛線と
+    /// して **hard-TTL backstop** を持つ: live entry の `started_at_ms` が
+    /// [`LIVE_ENTRY_HARD_TTL_MS`] (72h) より古ければ meta の有無に関わらず削除し、
+    /// error レベルログ + `SweepStats.hard_ttl_deleted` を計上する。正当に進行中の
+    /// 対局が誤って消えても実害は「live 一覧から隠れる」だけで対局自体には影響
+    /// しない ([`live_entry_hard_ttl_expired`] / `docs/csa-server/viewer_access_control.md` §7.4)。
     ///
     /// https://github.com/SH11235/rshogi/issues/629 で pagination loop 化した。R2 list の `truncated` が `true`
     /// の間は cursor を辿って次 page を処理し、以下のいずれかの条件で打ち切る:
@@ -327,11 +369,14 @@ mod imp {
                 let live_key = obj.key();
                 stats.listed = stats.listed.saturating_add(1);
 
-                // live entry 本文から game_id を取り出す。key 文字列パースより
-                // 本文の `game_id` field を信頼するほうが、key 形式の将来変更
-                // に対して頑健。
-                let game_id = match read_live_entry_game_id(&bucket, &live_key).await {
-                    Some(id) => id,
+                // live entry 本文から game_id / started_at_ms を取り出す。key 文字列
+                // パースより本文 field を信頼するほうが、key 形式の将来変更に
+                // 対して頑健。
+                let LiveEntryFields {
+                    game_id,
+                    started_at_ms: entry_started_at_ms,
+                } = match read_live_entry_fields(&bucket, &live_key).await {
+                    Some(f) => f,
                     None => {
                         if Date::now().as_millis().saturating_sub(started_at_ms)
                             >= SWEEP_DEADLINE_MS
@@ -364,9 +409,19 @@ mod imp {
                         continue;
                     }
                 };
-                if head_result.is_none() {
-                    // meta が無い = まだ進行中 (or 終局時 meta put 失敗)。前者は
-                    // 正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的な保守)。
+
+                // hard-TTL backstop: meta 不在でも `started_at_ms` が
+                // `LIVE_ENTRY_HARD_TTL_MS` より古ければ削除する。TTL 判定の「now」
+                // 基準には sweep 開始時刻 (`started_at_ms` 変数、最大 25s の stale)
+                // を流用する (72h に対して無視できる)。`force_finalize_unrecoverable`
+                // 経路の live-index delete が retry を尽くして失敗した幽霊 entry を
+                // 回収するための最終防衛線 (#853 系)。
+                let age_ms = started_at_ms.saturating_sub(entry_started_at_ms);
+                let hard_ttl_expired = live_entry_hard_ttl_expired(age_ms);
+                if head_result.is_none() && !hard_ttl_expired {
+                    // meta が無い & TTL 内 = まだ進行中 (or 終局時 meta put 失敗)。
+                    // 前者は正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的
+                    // な保守)。
                     if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
                         stats.deadline_reached = true;
                         break 'outer;
@@ -388,7 +443,24 @@ mod imp {
                     }
                     continue;
                 }
-                stats.deleted = stats.deleted.saturating_add(1);
+                if head_result.is_none() {
+                    // hard-TTL backstop 経路で幽霊 entry を回収した。誤削除の検知
+                    // と finalize 経路の慢性失敗の検知のため、必ず error レベルで
+                    // 残す (通常 orphan delete とは別カウント)。
+                    stats.hard_ttl_deleted = stats.hard_ttl_deleted.saturating_add(1);
+                    crate::structured_log!(
+                        event: "live_orphan_sweep_hard_ttl_deleted",
+                        component: "backfill",
+                        level: "error",
+                        game_id: game_id,
+                        live_key: live_key,
+                        started_at_ms: entry_started_at_ms,
+                        age_ms: age_ms,
+                        ttl_ms: LIVE_ENTRY_HARD_TTL_MS,
+                    );
+                } else {
+                    stats.deleted = stats.deleted.saturating_add(1);
+                }
 
                 if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
                     stats.deadline_reached = true;
@@ -421,6 +493,7 @@ mod imp {
             component: "backfill",
             listed: stats.listed,
             deleted: stats.deleted,
+            hard_ttl_deleted: stats.hard_ttl_deleted,
             pages: stats.pages,
             deadline_reached: stats.deadline_reached,
             elapsed_ms: elapsed_ms,
@@ -428,11 +501,12 @@ mod imp {
         Ok(stats)
     }
 
-    /// `live-games-index/<key>` の本文を読んで `game_id` field を返す。
+    /// `live-games-index/<key>` の本文を読んで orphan sweep 判定に必要な field
+    /// (`game_id` / `started_at_ms`) を返す。
     ///
     /// 失敗はすべて構造化ログで記録した上で `None` を返し、呼び出し側で entry
     /// を skip させる (sweep 全体を停止しない)。
-    async fn read_live_entry_game_id(bucket: &worker::Bucket, key: &str) -> Option<String> {
+    async fn read_live_entry_fields(bucket: &worker::Bucket, key: &str) -> Option<LiveEntryFields> {
         let fetched = match bucket.get(key).execute().await {
             Ok(o) => o,
             Err(e) => {
@@ -459,8 +533,8 @@ mod imp {
                 return None;
             }
         };
-        match serde_json::from_slice::<LiveEntryGameId>(&bytes) {
-            Ok(v) => Some(v.game_id),
+        match serde_json::from_slice::<LiveEntryFields>(&bytes) {
+            Ok(v) => Some(v),
             Err(e) => {
                 crate::structured_log!(
                     event: "live_orphan_sweep_parse_failed",
@@ -514,9 +588,9 @@ mod tests {
     }
 
     #[test]
-    fn live_entry_game_id_deserializes_from_live_entry_wire() {
+    fn live_entry_fields_deserializes_from_live_entry_wire() {
         // `LiveGamesIndexEntry` の wire (`live_games_index::tests::live_entry_serializes_with_expected_fields`
-        // と整合) から `game_id` のみ抽出できる。
+        // と整合) から `game_id` / `started_at_ms` を抽出できる。
         let json = r#"{
             "game_id": "g1",
             "started_at_ms": 1777391025209,
@@ -525,8 +599,32 @@ mod tests {
             "clock": {"kind": "fischer", "total_sec": 300, "increment_sec": 5},
             "source": "kifu"
         }"#;
-        let parsed: LiveEntryGameId = serde_json::from_str(json).unwrap();
+        let parsed: LiveEntryFields = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.game_id, "g1");
+        assert_eq!(parsed.started_at_ms, 1_777_391_025_209);
+    }
+
+    #[test]
+    fn live_entry_fields_rejects_missing_started_at_ms() {
+        // `started_at_ms` 欠落は parse error → sweep 経路で skip (hard-TTL 判定
+        // 材料が無いため保守的に触らない)。
+        let json = r#"{"game_id": "g1"}"#;
+        assert!(serde_json::from_str::<LiveEntryFields>(json).is_err());
+    }
+
+    #[test]
+    fn live_entry_hard_ttl_expired_boundary() {
+        // TTL 未満は保持、ちょうど TTL 以上で削除対象 (inclusive 境界)。
+        assert!(!live_entry_hard_ttl_expired(0));
+        assert!(!live_entry_hard_ttl_expired(LIVE_ENTRY_HARD_TTL_MS - 1));
+        assert!(live_entry_hard_ttl_expired(LIVE_ENTRY_HARD_TTL_MS));
+        assert!(live_entry_hard_ttl_expired(LIVE_ENTRY_HARD_TTL_MS + 1));
+    }
+
+    #[test]
+    fn live_entry_hard_ttl_is_72_hours() {
+        // 定数の値をリグレッションで固定する (72h = 259_200_000ms)。
+        assert_eq!(LIVE_ENTRY_HARD_TTL_MS, 259_200_000);
     }
 
     #[test]
@@ -550,6 +648,7 @@ mod tests {
             SweepStats {
                 listed: 0,
                 deleted: 0,
+                hard_ttl_deleted: 0,
                 pages: 0,
                 deadline_reached: false,
             }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -93,7 +93,8 @@ use crate::spectator_control::{
     MonitorDecision, resolve_monitor_target, resolve_monitor_target_with_finished,
 };
 use crate::spectator_snapshot::{
-    SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot,
+    SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot, is_move_broadcast,
+    move_elapsed_secs, parse_move_row_line,
 };
 use crate::ws_route::{WsRoute, parse_ws_route};
 use crate::x1_paths::{
@@ -1060,7 +1061,26 @@ impl GameRoom {
                 self.reschedule_turn_alarm(&result.outcome).await?;
                 self.dispatch_broadcasts(&result.broadcasts).await?;
             }
-            HandleOutcome::GameEnded(_) | HandleOutcome::Continue => {
+            HandleOutcome::GameEnded(_) => {
+                // 千日手 / 連続王手千日手 / 最大手数で「盤面を進めた最終手」がある
+                // 終局では、その手を broadcast だけでなく moves テーブルにも永続化
+                // する。core `apply_move` は本手を `do_move` してから `GameEnded` を
+                // 返し、`<token>,T<sec>` の move broadcast を積む (room.rs:509-513)
+                // ため、この行が append されないと R2 棋譜 export と late-joiner
+                // snapshot から終局手が欠落する。判定は move broadcast
+                // (`'+'/'-'` 始まり + ply=Some) の有無で行い、%TORYO / %KACHI /
+                // TimeUp / 反則負け等の盤面を進めない終局では該当 entry が無く
+                // append されない。append は MoveAccepted 経路と同じく raw client
+                // 行を保存し、broadcast より前に行う (append→dispatch→alarm cleanup
+                // の順を保ち、alarm cleanup を dispatch より前へ出さない = 1033-1047
+                // の broadcast→alarm cleanup 順序の根拠を崩さない)。
+                if result.broadcasts.iter().any(is_move_broadcast) {
+                    self.append_move(color, line, now).await?;
+                }
+                self.dispatch_broadcasts(&result.broadcasts).await?;
+                self.reschedule_turn_alarm(&result.outcome).await?;
+            }
+            HandleOutcome::Continue => {
                 self.dispatch_broadcasts(&result.broadcasts).await?;
                 self.reschedule_turn_alarm(&result.outcome).await?;
             }
@@ -1149,6 +1169,14 @@ impl GameRoom {
     /// 例外経路: `cfg` が無いケース (= LOGIN 前の DO に観戦者だけが入ってきた
     /// case)。snapshot は組まずに END を返してそのまま通常 broadcast 経路に
     /// 載せる (player から手が指されるまで配信は無いので queue 不要)。
+    ///
+    /// エラー経路: flag を `true` にセットした後の失敗 (`ensure_core_loaded` /
+    /// `load_moves` / `send_line` / attachment 更新) は必ずリセットして復旧する。
+    /// flag が `true` のまま抜けると `send_to_spectators` が以降の broadcast を
+    /// per-ws pending queue に積み続け、観戦者が queue overflow まで無音フリーズ
+    /// する。中断時は attachment を [`WsAttachment::reset_spectator_snapshot`] で
+    /// best-effort リセットし、client の reconnect ロジックで綺麗に復旧できるよう
+    /// ws を close (1011) してからエラーを伝播する。
     async fn send_spectator_snapshot(
         &self,
         ws: &WebSocket,
@@ -1158,6 +1186,7 @@ impl GameRoom {
         let Some(cfg) = cfg_opt else {
             // 対局未開始 (LOGIN 前) の DO に観戦者が入ったケース。snapshot は
             // 出さずそのまま終了する (Game_Summary に必要な game_id すら無いため)。
+            // flag はまだ立てていないのでリセット不要。
             return Ok(());
         };
 
@@ -1165,6 +1194,33 @@ impl GameRoom {
         // ここで初期化し、過去 invocation の残骸が混ざらないようにする。
         self.set_spectator_snapshot_state(ws, true, 0, Vec::new())?;
 
+        // ここから先の失敗は flag=true を残さない。中断したら reset + close する。
+        if let Err(e) = self.send_spectator_snapshot_body(ws, cfg, finished).await {
+            if let Ok(Some(att)) = ws.deserialize_attachment::<WsAttachment>() {
+                let reset = att.reset_spectator_snapshot();
+                let _ = ws.serialize_attachment(&reset);
+            }
+            let _ = ws.close(Some(1011), Some("snapshot failed".to_owned()));
+            crate::structured_log!(
+                event: "spectator_snapshot_failed",
+                component: "game_room",
+                game_id: cfg.game_id,
+                err: format!("{e:?}"),
+            );
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// `send_spectator_snapshot` の本体。`snapshot_in_progress = true` 前提で
+    /// snapshot 行を組んで送信し、queue を flush して flag を `false` に戻す。
+    /// いずれかの `?` で早期 return したときのリセット責務は呼び出し側が担う。
+    async fn send_spectator_snapshot_body(
+        &self,
+        ws: &WebSocket,
+        cfg: &PersistedConfig,
+        finished: &Option<FinishedState>,
+    ) -> Result<()> {
         // CoreRoom を確保し、clock / current_turn から `SpectatorClocks` を組む。
         // borrow scope は最小化し、await を伴う `load_moves` は borrow 外で呼ぶ。
         self.ensure_core_loaded().await?;
@@ -1177,7 +1233,8 @@ impl GameRoom {
             })
         };
         // CoreRoom が `replay_core_room` の InvalidSfen 等で復元できなかった場合
-        // (storage が破損した稀なケース)、安全側に snapshot を諦めて END だけ返す。
+        // (storage が破損した稀なケース)、安全側に snapshot を諦めて queue を
+        // flush する (flag も false へ戻る)。
         let Some(clocks) = clocks_opt else {
             self.flush_spectator_snapshot_queue(ws).await?;
             return Ok(());
@@ -1198,7 +1255,7 @@ impl GameRoom {
 
         // snapshot 完了。attachment の last_ply を更新し、queue を flush する。
         // queue 内の手は `ply > last_ply_in_snapshot` のみ送る (= snapshot に
-        // 含まれた手と重複しない broadcast のみ)。
+        // 含まれた手と重複しない broadcast のみ)。flush は flag を false へ戻す。
         self.set_spectator_snapshot_last_ply(ws, last_ply_in_snapshot)?;
         self.flush_spectator_snapshot_queue(ws).await?;
         Ok(())
@@ -2113,19 +2170,20 @@ impl GameRoom {
                 return ExportAttempt::Skipped;
             }
         };
-        // MoveRow は raw CSA 行（例: `+7776FU,T3`）を保持しているので、トークン部のみを
-        // 抽出して `KifuMove` に変換する。消費時間は at_ms 差分から秒に丸める。
+        // MoveRow は client が送ってきた raw CSA 行 (`+7776FU,T3` や Floodgate
+        // 形式 `+7776FU,'* 123 pv...`) を保持している。snapshot と同じ共有ヘルパ
+        // (`parse_move_row_line` / `move_elapsed_secs`) で token / コメントを抽出し、
+        // 消費時間は at_ms 差分から秒に丸めて `KifuMove` に変換する。Floodgate の
+        // 評価値 PV コメントは `KifuMove::comment` に載せて棋譜 `'` 行として残す。
+        let first_prev_ms = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
+        let elapsed = move_elapsed_secs(&moves_rows, first_prev_ms);
         let mut kifu_moves: Vec<KifuMove> = Vec::with_capacity(moves_rows.len());
-        let mut prev_ts: u64 = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
-        for m in &moves_rows {
-            let token_str = m.line.split(',').next().unwrap_or(&m.line);
-            let at_ms = m.at_ms.max(0) as u64;
-            let elapsed_ms = at_ms.saturating_sub(prev_ts);
-            prev_ts = at_ms;
+        for (m, sec) in moves_rows.iter().zip(elapsed) {
+            let (token_str, comment) = parse_move_row_line(&m.line);
             kifu_moves.push(KifuMove {
                 token: rshogi_csa_server::types::CsaMoveToken::new(token_str),
-                elapsed_sec: (elapsed_ms / 1000) as u32,
-                comment: None,
+                elapsed_sec: sec,
+                comment: comment.map(str::to_owned),
             });
         }
 

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -8,8 +8,10 @@
 //!
 //! 1. 観戦者向け `BEGIN Game_Summary` ブロック（`Black/White_Time_Remaining_Ms:`
 //!    末尾拡張行を含む、player 経路の `Your_Turn:` / `Reconnect_Token:` は含まない）
-//! 2. これまでの move 行 (1 行 1 手): `<token>,T<elapsed_sec>` 形式
-//!    （broadcast の通常形式と一致）
+//! 2. これまでの move 行 (1 手あたり 1〜2 行): まず `<token>,T<elapsed_sec>`
+//!    （broadcast の通常形式と一致。`elapsed_sec` は `at_ms` 差分から再計算する）、
+//!    続いてコメントが付いていれば `'<comment>` 行（Floodgate 評価値 PV。ライブ
+//!    broadcast の観戦者専用コメント行と同一形式）
 //! 3. （終局済 DO の場合のみ）終局結果コード行 (`#RESIGN` / `#TIME_UP` 等)
 //!
 //! `BEGIN Position` / `END Position` は Game_Summary の `position_section` 内部に
@@ -105,12 +107,24 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
         lines.push(raw_line.to_owned());
     }
 
-    // 既存の指し手 (broadcast move 行と完全に同一書式)。`MoveRow::line` は
-    // `+7776FU,T3` のような raw CSA 行をそのまま保持しているため、改行除去
-    // だけ済ませて push する。
-    for m in input.moves {
-        let trimmed = m.line.trim_end_matches(['\r', '\n']);
-        lines.push(trimmed.to_owned());
+    // 既存の指し手を broadcast と同一 wire 形式に正規化して push する。
+    // `MoveRow::line` は client が送ってきた raw 行 (`+7776FU,T3` や Floodgate
+    // 形式 `+7776FU,'* 123 +7776FU...`) をそのまま保持しているため、
+    // - token 部を取り出し、消費時間は broadcast 同様 `at_ms` 差分から再計算した
+    //   `<token>,T<sec>` を出す (raw 行の `T` 値や `,T` 欠落に依存しない)
+    // - コメントが付いていれば直後に `'<comment>` 行を 1 行足す (Floodgate
+    //   評価値 PV。ライブ broadcast の観戦者専用コメント行と同じ形式で、観戦
+    //   client は `'` 始まり行を無視する互換性がある)
+    // export (`export_kifu_to_r2`) と同じ行 parse (`parse_move_row_line`) /
+    // elapsed 計算 (`move_elapsed_secs`) を共有する。
+    let first_prev_ms = input.config.play_started_at_ms.unwrap_or(input.config.matched_at_ms);
+    let elapsed = move_elapsed_secs(input.moves, first_prev_ms);
+    for (m, sec) in input.moves.iter().zip(elapsed) {
+        let (token, comment) = parse_move_row_line(&m.line);
+        lines.push(format!("{token},T{sec}"));
+        if let Some(c) = comment {
+            lines.push(format!("'{c}"));
+        }
     }
 
     // 終局済 DO の場合は最終結果コード行を追加。終局時に CoreRoom 側で broadcast
@@ -122,6 +136,57 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
     }
 
     lines
+}
+
+/// `MoveRow::line` の raw CSA 行を `(token, comment)` に分解する共有ヘルパ。
+///
+/// `MoveRow::line` は client が送ってきた行をそのまま保持しており、次の形が
+/// あり得る:
+/// - `+7776FU` （コメント無し・時間フィールド無し）
+/// - `+7776FU,T3` （時間フィールド付き）
+/// - `+7776FU,'* 123 +7776FU -3334FU` （Floodgate 形式のコメント付き）
+/// - `+7776FU,T3'コメント` （時間 + コメント）
+///
+/// `token` は最初の `,` より前 (`command.rs::parse_move` と同じ token 抽出)。
+/// `comment` は最初の `'` より後 (存在すれば。`'` プレフィックスは含めない)。
+/// snapshot (`build_spectator_snapshot`) と export (`export_kifu_to_r2`) で
+/// この 1 箇所を共有し、wire 形式の食い違いを防ぐ。
+pub(crate) fn parse_move_row_line(line: &str) -> (&str, Option<&str>) {
+    let trimmed = line.trim_end_matches(['\r', '\n']);
+    let token = trimmed.split(',').next().unwrap_or(trimmed);
+    let comment = trimmed.split_once('\'').map(|(_, c)| c);
+    (token, comment)
+}
+
+/// `moves` を先頭から走査し、各手の消費時間 (秒、切り捨て) を `at_ms` 差分から
+/// 算出する共有ヘルパ。
+///
+/// `first_prev_ms` は初手の計時起点 (= `play_started_at_ms`、無ければ
+/// `matched_at_ms`)。以降は 1 手前の `at_ms` を起点にする。負値 `at_ms` は
+/// `0` に丸め、起点より小さい `at_ms` は `saturating_sub` で `0` 秒にする。
+/// snapshot と export で同一の経過秒を出すためのロジック集約。
+pub(crate) fn move_elapsed_secs(moves: &[MoveRow], first_prev_ms: u64) -> Vec<u32> {
+    let mut prev_ts = first_prev_ms;
+    moves
+        .iter()
+        .map(|m| {
+            let at_ms = m.at_ms.max(0) as u64;
+            let elapsed_ms = at_ms.saturating_sub(prev_ts);
+            prev_ts = at_ms;
+            (elapsed_ms / 1000) as u32
+        })
+        .collect()
+}
+
+/// broadcast entry が「盤面を進めた指し手行」かを判定する共有ヘルパ。
+///
+/// 指し手 broadcast は `+`/`-` で始まり `ply.is_some()`。終局理由行 (`%TORYO`
+/// 等) や勝敗コード行 (`#RESIGN` 等)、観戦者専用コメント行 (`'...`) はいずれも
+/// これに該当しない。workers の `finalize`（`GameEnded` 経路）が「盤面を進めた
+/// 終局手を moves テーブルへ永続化すべきか」を判定するのに使う
+/// (https://github.com/SH11235/rshogi/issues/853 系: 終局手の棋譜欠落防止)。
+pub(crate) fn is_move_broadcast(entry: &rshogi_csa_server::BroadcastEntry) -> bool {
+    entry.ply.is_some() && entry.line.as_str().starts_with(['+', '-'])
 }
 
 #[cfg(test)]
@@ -151,12 +216,13 @@ mod tests {
         }
     }
 
-    fn move_row(ply: i64, color: &str, line: &str) -> MoveRow {
+    /// `at_ms` を明示して MoveRow を作る (経過秒の正規化テスト用)。
+    fn move_row_at(ply: i64, color: &str, line: &str, at_ms: i64) -> MoveRow {
         MoveRow {
             ply,
             color: color.to_owned(),
             line: line.to_owned(),
-            at_ms: 1_000_000 + ply * 1_000,
+            at_ms,
         }
     }
 
@@ -213,14 +279,17 @@ mod tests {
         );
     }
 
-    /// シナリオ 2: 数手後 (= moves 3 件、進行中)。
+    /// シナリオ 2: 数手後 (= moves 3 件、進行中)。raw 行は token のみでも、
+    /// 出力は `at_ms` 差分から計算した `<token>,T<sec>` に正規化される。
     #[test]
     fn snapshot_after_three_moves_appends_move_lines_in_order() {
         let cfg = baseline_config();
+        // raw 行は bare token (T フィールド無し)。play_started_at_ms=1_000_000
+        // を起点に、各 at_ms 差分から T が算出される。
         let moves = vec![
-            move_row(1, "black", "+7776FU,T3"),
-            move_row(2, "white", "-3334FU,T2"),
-            move_row(3, "black", "+8833UM,T4"),
+            move_row_at(1, "black", "+7776FU", 1_003_000), // 3s
+            move_row_at(2, "white", "-3334FU", 1_005_000), // 2s
+            move_row_at(3, "black", "+8833UM", 1_009_000), // 4s
         ];
         let cl = clocks(597_000, 598_000, Color::White);
         let lines = build_spectator_snapshot(SpectatorSnapshotInput {
@@ -230,7 +299,7 @@ mod tests {
             finalized: None,
         });
 
-        // 全 move 行が順序通り含まれる。
+        // 正規化後の move 行が順序通り含まれる。
         let move_indices: Vec<usize> = ["+7776FU,T3", "-3334FU,T2", "+8833UM,T4"]
             .iter()
             .map(|m| {
@@ -251,54 +320,54 @@ mod tests {
         assert!(!lines.iter().any(|l| l.starts_with('#')));
     }
 
-    /// シナリオ 3: 終局直後 (= moves に %TORYO が含まれる + finalized も Some)。
-    /// 一見すると move 行重複 (`%TORYO`) と result code (`#RESIGN`) の二重記録に
-    /// 見えるが、クライアントは onEnd を `#RESIGN` 等で確定する仕様で、`%TORYO`
-    /// は通常の move stream と同じ位置で再生されるだけ (UI 側は idempotent)。
+    /// シナリオ 3: 経過秒の正規化 + Floodgate コメント行の展開。raw 行の `T` 値は
+    /// 無視して `at_ms` 差分から再計算し、コメントは token 行の直後に `'` 始まりで
+    /// 1 行足す (ライブ broadcast の観戦者専用コメント行と同一 wire 形式)。
     #[test]
-    fn snapshot_after_toryo_with_finalized_appends_result_code_line() {
+    fn snapshot_normalizes_time_and_emits_comment_lines() {
         let cfg = baseline_config();
         let moves = vec![
-            move_row(1, "black", "+7776FU,T3"),
-            move_row(2, "white", "-3334FU,T2"),
-            move_row(3, "black", "%TORYO,T1"),
+            // raw の `,T99` は無視され、at_ms 差分の 3s に正規化される。
+            move_row_at(1, "black", "+7776FU,T99", 1_003_000),
+            // Floodgate 形式: token 行 + `'` コメント行の 2 行に展開される。
+            move_row_at(2, "white", "-3334FU,'* -50 -3334FU +2726FU", 1_006_000),
         ];
-        let cl = clocks(596_000, 598_000, Color::Black);
-        let finished = FinishedState {
-            result_code: "#RESIGN".to_owned(),
-            ended_at_ms: 1_010_000,
-            exported_at_ms: Some(1_010_500),
-        };
+        let cl = clocks(597_000, 597_000, Color::Black);
         let lines = build_spectator_snapshot(SpectatorSnapshotInput {
             config: &cfg,
             moves: &moves,
             clocks: &cl,
-            finalized: Some(&finished),
+            finalized: None,
         });
 
-        // `%TORYO` 行と `#RESIGN` 行が両方入り、`#RESIGN` は最終位置。
-        let toryo_idx = lines
+        // raw の T99 は出ず、at_ms 差分の T3 に正規化される。
+        assert!(
+            lines.iter().any(|l| l == "+7776FU,T3"),
+            "missing normalized +7776FU,T3: {lines:?}"
+        );
+        assert!(!lines.iter().any(|l| l.contains("T99")), "raw T99 must not leak: {lines:?}");
+        // コメントは token 行の直後に `'` 始まりで 1 行。
+        let mv_idx = lines
             .iter()
-            .position(|l| l == "%TORYO,T1")
-            .unwrap_or_else(|| panic!("missing %TORYO,T1: {lines:?}"));
-        let resign_idx = lines
+            .position(|l| l == "-3334FU,T3")
+            .unwrap_or_else(|| panic!("missing -3334FU,T3: {lines:?}"));
+        let cmt_idx = lines
             .iter()
-            .position(|l| l == "#RESIGN")
-            .unwrap_or_else(|| panic!("missing #RESIGN: {lines:?}"));
-        assert!(toryo_idx < resign_idx);
-        assert_eq!(resign_idx, lines.len() - 1, "result code must be last: {lines:?}");
+            .position(|l| l == "'* -50 -3334FU +2726FU")
+            .unwrap_or_else(|| panic!("missing comment line: {lines:?}"));
+        assert_eq!(cmt_idx, mv_idx + 1, "comment must follow its move line: {lines:?}");
     }
 
     /// シナリオ 4: 終局済 DO 接続経路 (moves 全部 + finalized で snapshot を 1 回送る)。
-    /// シナリオ 3 と入力は似るが、観戦者が「new connection した時点で既に finished」
-    /// だったケース。snapshot は 1 回送って close する経路 (DO 側) なので、本関数の
-    /// 戻り値としてはシナリオ 3 と同じ「全 moves + 結果コード」になる。
+    /// 観戦者が「new connection した時点で既に finished」だったケース。snapshot は
+    /// 1 回送って close する経路 (DO 側) で、戻り値は「全 moves (正規化済) + 結果
+    /// コード」になる。
     #[test]
     fn snapshot_for_finished_do_emits_full_history_with_result_code() {
         let cfg = baseline_config();
         let moves = vec![
-            move_row(1, "black", "+7776FU,T3"),
-            move_row(2, "white", "-3334FU,T2"),
+            move_row_at(1, "black", "+7776FU,T3", 1_002_000), // 2s
+            move_row_at(2, "white", "-3334FU,T2", 1_005_000), // 3s
         ];
         let cl = clocks(594_000, 597_000, Color::Black);
         let finished = FinishedState {
@@ -315,14 +384,9 @@ mod tests {
 
         // `#TIME_UP` で終端する。
         assert_eq!(lines.last().map(String::as_str), Some("#TIME_UP"));
-        // 全 moves が含まれる (順序保証は他テストで確認済みのため、ここでは含有のみ)。
-        for m in &moves {
-            assert!(
-                lines.iter().any(|l| l == &m.line),
-                "missing move line {:?}: {lines:?}",
-                m.line
-            );
-        }
+        // 正規化後の token 行 (raw の T 値ではなく at_ms 差分の T) が全て含まれる。
+        assert!(lines.iter().any(|l| l == "+7776FU,T2"), "missing +7776FU,T2: {lines:?}");
+        assert!(lines.iter().any(|l| l == "-3334FU,T3"), "missing -3334FU,T3: {lines:?}");
     }
 
     /// `Game_ID:` / `Name+:` / `Name-:` は config 由来で snapshot に乗る。
@@ -339,5 +403,71 @@ mod tests {
         assert!(lines.iter().any(|l| l == "Game_ID:room-1-test"));
         assert!(lines.iter().any(|l| l == "Name+:alice"));
         assert!(lines.iter().any(|l| l == "Name-:bob"));
+    }
+
+    #[test]
+    fn parse_move_row_line_extracts_token_and_optional_comment() {
+        // bare token: comment 無し。
+        assert_eq!(parse_move_row_line("+7776FU"), ("+7776FU", None));
+        // T フィールドのみ: comment 無し。
+        assert_eq!(parse_move_row_line("+7776FU,T3"), ("+7776FU", None));
+        // Floodgate 形式 (`,'`): comment はプレフィックス `'` を除いた本体。
+        assert_eq!(
+            parse_move_row_line("+7776FU,'* 123 +7776FU -3334FU"),
+            ("+7776FU", Some("* 123 +7776FU -3334FU"))
+        );
+        // T + comment: token は最初の `,` まで、comment は最初の `'` 以降。
+        assert_eq!(parse_move_row_line("+7776FU,T3'note"), ("+7776FU", Some("note")));
+        // 末尾改行は除去する。
+        assert_eq!(parse_move_row_line("+7776FU,T3\r\n"), ("+7776FU", None));
+    }
+
+    #[test]
+    fn move_elapsed_secs_computes_from_at_ms_deltas() {
+        let moves = vec![
+            move_row_at(1, "black", "+7776FU", 1_003_000), // prev 1_000_000 → 3s
+            move_row_at(2, "white", "-3334FU", 1_005_500), // prev 1_003_000 → 2s (切り捨て)
+            move_row_at(3, "black", "+8833UM", 1_005_000), // prev 1_005_500 → 0s (逆行は 0)
+        ];
+        assert_eq!(move_elapsed_secs(&moves, 1_000_000), vec![3, 2, 0]);
+        // 空入力は空 Vec。
+        assert_eq!(move_elapsed_secs(&[], 1_000_000), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn is_move_broadcast_only_matches_board_advancing_moves() {
+        use rshogi_csa_server::types::CsaLine;
+        use rshogi_csa_server::{BroadcastEntry, BroadcastTarget};
+
+        let mv = BroadcastEntry {
+            target: BroadcastTarget::All,
+            line: CsaLine::new("+7776FU,T3"),
+            ply: Some(1),
+        };
+        assert!(is_move_broadcast(&mv));
+
+        // 観戦者専用コメント行 (`'...`) は move ではない。
+        let comment = BroadcastEntry {
+            target: BroadcastTarget::Spectators,
+            line: CsaLine::new("'* 123 +7776FU"),
+            ply: Some(1),
+        };
+        assert!(!is_move_broadcast(&comment));
+
+        // 終局理由行 / 勝敗コード行 (ply=None) は move ではない。
+        let toryo = BroadcastEntry {
+            target: BroadcastTarget::All,
+            line: CsaLine::new("#RESIGN"),
+            ply: None,
+        };
+        assert!(!is_move_broadcast(&toryo));
+
+        // '+'/'-' 始まりでも ply=None なら move ではない (防御的)。
+        let no_ply = BroadcastEntry {
+            target: BroadcastTarget::All,
+            line: CsaLine::new("+7776FU,T3"),
+            ply: None,
+        };
+        assert!(!is_move_broadcast(&no_ply));
     }
 }

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -50,7 +50,10 @@ pub enum BroadcastTarget {
     White,
     /// 両対局者に送る（観戦者は含めない）。
     Players,
-    /// 観戦者だけに送る（観戦機能未実装の本構成でも経路だけ用意しておく）。
+    /// 観戦者だけに送る（対局者には送らない）。終局理由の観戦者向けメッセージ
+    /// や、指し手に付随する Floodgate 評価値コメント `'<comment>` の配信に使う。
+    /// 評価値コメントを対局者へ送らないのは、エンジン解析が相手に漏れないように
+    /// するため。
     Spectators,
     /// 両対局者 + 同一ルームの全観戦者に送る（引き分け・無勝負時の同報）。
     All,
@@ -283,7 +286,9 @@ impl GameRoom {
                 self.verify_game_id(game_id.as_ref())?;
                 self.handle_reject(from)
             }
-            ClientCommand::Move { token, .. } => self.handle_move(from, &token, now_ms),
+            ClientCommand::Move { token, comment } => {
+                self.handle_move(from, &token, comment.as_deref(), now_ms)
+            }
             ClientCommand::Toryo => self.handle_toryo(from),
             ClientCommand::Kachi => self.handle_kachi(from),
             ClientCommand::Chudan => self.handle_chudan(from),
@@ -435,6 +440,7 @@ impl GameRoom {
         &mut self,
         from: Color,
         token: &CsaMoveToken,
+        comment: Option<&str>,
         now_ms: u64,
     ) -> Result<HandleResult, ServerError> {
         if !matches!(self.status, GameStatus::Playing) {
@@ -452,7 +458,7 @@ impl GameRoom {
         }
 
         match self.validator.validate_move(&self.pos, token) {
-            Ok(mv) => self.apply_move(from, token, mv, now_ms),
+            Ok(mv) => self.apply_move(from, token, comment, mv, now_ms),
             Err(violation) => {
                 // 構文・手番不一致は protocol error（状態変更なし）。
                 // それ以外の合法性違反は反則負けとして終局。
@@ -482,6 +488,7 @@ impl GameRoom {
         &mut self,
         from: Color,
         token: &CsaMoveToken,
+        comment: Option<&str>,
         mv: rshogi_core::types::Move,
         now_ms: u64,
     ) -> Result<HandleResult, ServerError> {
@@ -511,6 +518,21 @@ impl GameRoom {
             line: CsaLine::new(format!("{},T{}", token.as_str(), elapsed_sec)),
             ply: Some(self.moves_played),
         }];
+
+        // 4.5 指し手にコメント (Floodgate 評価値 PV 等) が付いていれば、観戦者
+        //     だけに `'<comment>` 行を追加配信する。対局者へは送らない
+        //     (エンジン解析が相手に漏れないようにするため)。ply は本手と同一に
+        //     して、観戦者 snapshot の pending-queue dedup
+        //     (`ply > last_ply_in_snapshot`) が本手行と揃うようにする。終局手
+        //     (千日手 / 連続王手千日手 / 最大手数) でも本手 broadcast は残るので、
+        //     ここで push しておけば終局経路でもコメントが配信される。
+        if let Some(c) = comment {
+            broadcasts.push(BroadcastEntry {
+                target: BroadcastTarget::Spectators,
+                line: CsaLine::new(format!("'{c}")),
+                ply: Some(self.moves_played),
+            });
+        }
 
         // 5. 千日手・連続王手千日手判定。
         match self.validator.classify_repetition(&self.pos) {
@@ -779,6 +801,40 @@ mod tests {
         assert_eq!(r.broadcasts.len(), 1);
         assert_eq!(r.broadcasts[0].target, BroadcastTarget::All);
         assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T3");
+    }
+
+    #[test]
+    fn move_with_comment_broadcasts_spectator_only_comment_line() {
+        let mut room = make_room();
+        agree_both(&mut room);
+        // Floodgate 形式の評価値コメント付き指し手。
+        let r = room
+            .handle_line(Color::Black, &line("+7776FU,'* 123 +7776FU -3334FU"), 3_000)
+            .unwrap();
+        assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        // 本手 broadcast (全員宛) + 観戦者専用コメント broadcast の 2 件。
+        assert_eq!(r.broadcasts.len(), 2);
+        let mv = &r.broadcasts[0];
+        assert_eq!(mv.target, BroadcastTarget::All);
+        assert_eq!(mv.line.as_str(), "+7776FU,T3");
+        assert_eq!(mv.ply, Some(1));
+        let cmt = &r.broadcasts[1];
+        // 観戦者だけに送る (対局者には漏らさない)。
+        assert_eq!(cmt.target, BroadcastTarget::Spectators);
+        assert_eq!(cmt.line.as_str(), "'* 123 +7776FU -3334FU");
+        // ply は本手と同一 (snapshot pending-queue dedup を本手行と揃えるため)。
+        assert_eq!(cmt.ply, Some(1));
+    }
+
+    #[test]
+    fn move_without_comment_has_no_spectator_comment_broadcast() {
+        let mut room = make_room();
+        agree_both(&mut room);
+        let r = room.handle_line(Color::Black, &line("+7776FU,T3"), 3_000).unwrap();
+        assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+        // コメントが無ければ本手 broadcast の 1 件のみ (余分な観戦者行を出さない)。
+        assert_eq!(r.broadcasts.len(), 1);
+        assert!(!r.broadcasts.iter().any(|b| b.line.as_str().starts_with('\'')));
     }
 
     #[test]
@@ -1211,6 +1267,17 @@ mod tests {
         }
         assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#SENNICHITE"));
         assert!(last.broadcasts.iter().any(|b| b.line.as_str() == "#DRAW"));
+        // 終局手 (盤面を進めた最終手) の move broadcast が HandleResult に残る
+        // ことを固定する。workers 側 `finalize` はこの entry を検出して moves
+        // テーブルへ永続化するため、消えると終局手が棋譜から欠落する
+        // (https://github.com/SH11235/rshogi/issues/853 系の欠損)。
+        assert!(
+            last.broadcasts
+                .iter()
+                .any(|b| { b.ply.is_some() && b.line.as_str().starts_with(['+', '-']) }),
+            "final move broadcast must be present: {:?}",
+            last.broadcasts
+        );
     }
 
     #[test]

--- a/docs/csa-server/protocol-reference.md
+++ b/docs/csa-server/protocol-reference.md
@@ -80,6 +80,7 @@ CSA プロトコル一般仕様や本家 Floodgate 運用は §2 の外部参照
 | `START:<game_id>` | 両者 AGREE 後の対局開始通知 | `crates/rshogi-csa-server/src/game/room.rs::GameRoom::handle_agree` |
 | `REJECT:<game_id>` | どちらかが REJECT した | TCP `server.rs::drive_game_inner` の AGREE 結果が false の経路 (`server.rs::wait_both_agree` の戻り値で分岐) |
 | `<token>,T<sec>` | 1 手分の broadcast (各 client / 観戦者へ送出)。`T<sec>` 値はサーバー側 `room.rs` で計算した経過秒 | `room.rs::GameRoom::handle_move` (broadcast 行作成)、TCP `server.rs::parse_move_broadcast` (受信側ヘルパ) |
+| `'<comment>` | **観戦者専用**の付随行。直前の `<token>,T<sec>` に付いた Floodgate 評価値コメント (`* <eval> <pv...>` 等) を、対局者を除く観戦者だけへ 1 行配信する (`BroadcastTarget::Spectators`)。対局者へ送らないのはエンジン解析が相手に漏れないようにするため。指し手行と同一 ply で送られ、既存 viewer client は `'` 始まり行を無視する互換性がある。指し手にコメントが無ければ本行は出ない | `room.rs::GameRoom::apply_move` (comment 付き手のとき追加)、Workers `game_room.rs::dispatch_broadcasts`→`send_to_spectators` / TCP `server.rs::dispatch` (いずれも Spectators 経路) |
 
 ## 5. x1 拡張コマンド一覧
 
@@ -113,7 +114,7 @@ CSA 標準を超えた `%%` 系拡張コマンド。受理条件は frontend で
 | `%%WHO` | ログイン中プレイヤ一覧。`##[WHO] <name> <status>` を name 昇順、終端 `##[WHO] END` | ✅ | ❌ | `info.rs::who_lines` |
 | `%%LIST` | アクティブ対局一覧。`##[LIST] <game_id> <black> <white> <game_name> <started_at>` + END | ✅ | ❌ | `info.rs::list_lines` |
 | `%%SHOW <game_id>` | 1 対局のサマリ。未登録は `##[SHOW] NOT_FOUND <game_id>` 後 END | ✅ | ❌ | `info.rs::show_lines` |
-| `%%MONITOR2ON <game_id>` | 観戦購読 (broadcast 受信開始)。応答 `##[MONITOR2] BEGIN <id>` / 不在 `##[MONITOR2] NOT_FOUND <game_id>` / 多重 `##[MONITOR2] BUSY <game_id>`。`<id>` は **TCP では要求された `<game_id>`**、**Workers では `monitor_id` (active_game_id があればそれ、無ければ `room_id`)** が入る | ✅ | ✅ (spectator 経路) | TCP `server.rs` の `ClientCommand::Monitor2On` arm / Workers `game_room.rs::GameRoom::handle_spectator_line` の `Monitor2On` arm |
+| `%%MONITOR2ON <game_id>` | 観戦購読 (broadcast 受信開始)。応答 `##[MONITOR2] BEGIN <id>` / 不在 `##[MONITOR2] NOT_FOUND <game_id>` / 多重 `##[MONITOR2] BUSY <game_id>`。`<id>` は **TCP では要求された `<game_id>`**、**Workers では `monitor_id` (active_game_id があればそれ、無ければ `room_id`)** が入る。**Workers の snapshot 本文** (`BEGIN`〜`END` 間) は Game_Summary ブロックに続けて各手を `<token>,T<sec>` (`T<sec>` は `at_ms` 差分から再計算) で流し、コメント付きの手は直後に `'<comment>` 行を 1 行足す (ライブ broadcast の観戦者専用コメント行と同一形式)。終局済 DO では末尾に結果コード行 (`#RESIGN` 等) が付く | ✅ | ✅ (spectator 経路) | TCP `server.rs` の `ClientCommand::Monitor2On` arm / Workers `game_room.rs::GameRoom::handle_spectator_line` の `Monitor2On` arm、snapshot 本文は `spectator_snapshot.rs::build_spectator_snapshot` |
 | `%%MONITOR2OFF <game_id>` | 観戦購読解除。応答 `##[MONITOR2OFF] <id>` + END (`<id>` は §MONITOR2ON と同じ規則。TCP は `<game_id>`、Workers は `monitor_id`)。Workers では未登録 `<game_id>` を渡された場合 `##[MONITOR2OFF] NOT_FOUND <requested>` + END で返す経路がある | ✅ | ✅ (spectator 経路) | TCP `server.rs` の `Monitor2Off` arm / Workers `game_room.rs::GameRoom::handle_spectator_line` の `Monitor2Off` arm |
 | `%%CHAT <message>` | room へ chat 配信。応答 `##[CHAT] OK <game_id>` / 未観戦時 `##[CHAT] NOT_MONITORING` (broadcast 形式は `##[CHAT] <handle>: <message>`) | ✅ | ✅ (player + spectator) | TCP `server.rs` の `Chat` arm / Workers `game_room.rs` の `Chat` arm (player + spectator 経路) |
 | `%%VERSION` | 実装名 + バージョン 1 行。`##[VERSION] rshogi-csa-server <CARGO_PKG_VERSION>`。**他の x1 応答と異なり END 終端行なし** (§6 の例外) | ✅ | ❌ | `info.rs::version_lines` |

--- a/docs/csa-server/viewer_access_control.md
+++ b/docs/csa-server/viewer_access_control.md
@@ -163,7 +163,12 @@ stale window」「export retry pending」に起因する。
   `export_kifu_to_r2()` → `KEY_FINISHED` set → `live-games-index/` delete の順で
   動く。途中で DO が落ちる、または R2 delete が transient error で失敗すると、
   終局済対局の live entry が一時的に残る (orphan)。orphan は cron sweep
-  (https://github.com/SH11235/rshogi/issues/629) が best-effort で掃除する
+  (https://github.com/SH11235/rshogi/issues/629) が best-effort で掃除する。
+  通常の sweep は primary meta (`kifu-by-id/<id>.meta.json`) の存在を消去条件に
+  するため、**meta を書かない** `force_finalize_unrecoverable` 経路 (復元不能で
+  `#ABNORMAL` 強制終局) の inline delete が retry を尽くして失敗すると、meta が
+  永遠に現れず通常 sweep でも回収できない幽霊 entry が残りうる。これは §7.4 の
+  hard-TTL backstop で最終的に回収する
 - **export retry pending**: meta PUT / by-id PUT が失敗して
   `KEY_EXPORT_PENDING` outbox に積まれている場合
   (https://github.com/SH11235/rshogi/issues/623)、live は delete 済でも単局
@@ -190,6 +195,16 @@ stale window」「export retry pending」に起因する。
   (15 分間隔) の各発火で sweep する (0 分は backfill も併走)。R2 list deadline
   (25s) や page 上限 (100 page) に達すると 1 cron 内で完了しない場合がある
   (次 cron で継続)
+- **hard-TTL backstop**: 通常 sweep が消せない幽霊 entry
+  (meta 不在のまま残った `force_finalize_unrecoverable` 由来の orphan 等) を
+  回収する最終防衛線。live entry の `started_at_ms` が `LIVE_ENTRY_HARD_TTL_MS`
+  (**72 時間**) より古ければ、meta の有無に関わらず削除する。72h はどんな正規
+  対局の持ち時間よりも遥かに長いため、進行中対局を誤って消す現実的リスクは無い。
+  仮に誤削除しても実害は「`/api/v1/games/live` 一覧から隠れる」だけで、対局
+  そのもの (DO / WS / 終局処理) には一切影響しない。hard-TTL 削除は必ず
+  `event=live_orphan_sweep_hard_ttl_deleted` の error レベル structured_log を
+  残し、`SweepStats.hard_ttl_deleted` で件数を計上する (恒常的に非 0 なら
+  finalize 経路の live-index delete が慢性的に失敗している疑い)
 - **list の網羅性**: 保証しない (1 page 上限あり、`next_cursor` で連結)
 
 ### 7.5 viewer 運用目標 (informative, 計測値ではない)


### PR DESCRIPTION
## 概要

live viewer の DO/ライフサイクル監査で確定した 4 欠陥の修正と、Floodgate 評価値コメントの観戦者リアルタイム配信（同一コード経路のため一括実装）。

## 修正内容

### 1. 終局手の永続化漏れ（最優先・棋譜データ欠損）
千日手/連続王手千日手/最大手数の終局手は core が `do_move` 済みで move broadcast に載るのに、workers の `handle_game_line` は `MoveAccepted` arm でしか `append_move` しないため、**R2 棋譜 export と late-joiner snapshot から終局手が欠落**していた（broadcasts から着手を記録する TCP 実装には無い、Workers 固有の欠陥）。`GameEnded` arm で move broadcast（`is_move_broadcast`: `+`/`-` 始まり + ply=Some）を検出した場合に raw client 行を永続化する。

### 2. snapshot 中断での観戦者無音フリーズ
`snapshot_in_progress=true` セット後のエラー経路（`ensure_core_loaded`/`load_moves`/`send_line`）で flag が attachment に固着し、以降の broadcast が pending queue に積まれるだけで配信されなくなっていた。中断時は `reset_spectator_snapshot`（flag=false/queue 空）で戻し、ws を 1011 close して client の再接続で復旧させる。「`#[serde(default)]` が hibernation 復帰で flag を false に戻す」という誤った invariant コメントも訂正（serde default は field 欠落時のみ適用）。

### 3. live-games-index の幽霊 entry（回収不能 orphan）
`force_finalize_unrecoverable` 経路は meta を書かないため、inline delete が retry を尽くして失敗すると「meta 存在」を削除条件とする cron sweep で**永久に回収不能**だった。`started_at_ms` が 72h（`LIVE_ENTRY_HARD_TTL_MS`）超過の entry は meta 不在でも削除する hard-TTL backstop を追加（`live_orphan_sweep_hard_ttl_deleted` error ログ + `SweepStats.hard_ttl_deleted` 計上）。

### 4. snapshot wire 形式の不一致
moves テーブルは client の raw 行（T 無し・Floodgate コメント付きあり得る）を保持するのに snapshot が素通し再生しており、live broadcast（`<token>,T<sec>`）と食い違っていた（後着観戦者は消費時間が全手 0 になる）。`parse_move_row_line` / `move_elapsed_secs` を snapshot / export で共有し、`<token>,T<sec>` + コメント別行に正規化。

### 5.（機能）評価値のリアルタイム観戦配信
`ClientCommand::Move` の comment を `handle_move`→`apply_move` に配線し、コメント付きの手は**同一 ply** の `BroadcastTarget::Spectators` entry として `'<comment>` 行を追加配信（**対局者へは送らない** = エンジン解析の相手漏れ防止）。R2 棋譜 export にも `KifuMove::comment` として `'` 行を残す。既存 viewer client は `'` 始まり行を無視するため後方互換。docs（protocol-reference §4/§5、viewer_access_control §7）更新済み。

## テスト / 品質ゲート

- `cargo fmt --check` clean / clippy（3 crate, host）警告 0 / `check-tracked-abs-paths.sh` OK
- `cargo test`: core+workers **713 passed, 0 failed** / tcp **57 passed, 0 failed**
- 新規テスト: spectator comment broadcast（有/無）、終局手 broadcast 固定、`reset_spectator_snapshot`、hard-TTL 境界、`parse_move_row_line`、snapshot 正規化 ほか

## デプロイ後の確認（別途）

staging デプロイ後に `csa-e2e-staging` の観戦シナリオ（+ 千日手系の異常終局）で実機確認を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL