### PR TITLE
fix(csa-server): time_margin_ms を課金から外し deadline 猶予のみに限定する

### DIFF
--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -435,6 +435,66 @@ mod tests {
     }
 
     #[test]
+    fn live_broadcast_t_matches_export_elapsed_secs() {
+        // #857 test (c): ライブ配信 T (core `apply_move` の `<token>,T<sec>` broadcast) と、
+        //   終局 export / 観戦 snapshot の T (`move_elapsed_secs` が at_ms 差分から再計算)
+        //   が同一手で一致すること。通信マージンを課金から差し引かなくなったため、両者とも
+        //   「(到着 at_ms − 直前手 at_ms) を秒切り捨て」した同じ値になる (旧実装ではライブ側が
+        //   margin を引いて 1 秒/手ずれていた)。
+        use rshogi_core::types::EnteringKingRule;
+        use rshogi_csa_server::{CsaLine, FischerClock, GameRoom, GameRoomConfig, HandleOutcome};
+
+        let play_started_ms: u64 = 1_000_000;
+        let config = GameRoomConfig {
+            game_id: GameId::new("20140101120000"),
+            black: PlayerName::new("alice"),
+            white: PlayerName::new("bob"),
+            max_moves: 256,
+            // margin を課金へ持ち込まないことを確認するため 0 でなく 1000ms を設定する。
+            time_margin_ms: 1_000,
+            entering_king_rule: EnteringKingRule::Point24,
+            initial_sfen: None,
+        };
+        let clock = Box::new(FischerClock::new(60, 5));
+        let mut room = GameRoom::new(config, clock).expect("valid test config");
+        // AGREE を play_started_ms で成立させる (初手の計時起点 = play_started_ms)。
+        room.handle_line(Color::Black, &CsaLine::new("AGREE"), play_started_ms).unwrap();
+        room.handle_line(Color::White, &CsaLine::new("AGREE"), play_started_ms).unwrap();
+
+        // (color, token, at_ms) の着手列。秒境界の端数 (margin を跨ぐ差分) を含める。
+        let seq: [(Color, &str, u64); 4] = [
+            (Color::Black, "+7776FU", play_started_ms + 3_500), // 3500ms → T3
+            (Color::White, "-3334FU", play_started_ms + 8_000), // 4500ms → T4
+            (Color::Black, "+2726FU", play_started_ms + 10_000), // 2000ms → T2
+            (Color::White, "-8384FU", play_started_ms + 15_200), // 5200ms → T5
+        ];
+
+        let mut live_lines: Vec<String> = Vec::new();
+        let mut move_rows: Vec<MoveRow> = Vec::new();
+        for (i, (color, token, at_ms)) in seq.iter().enumerate() {
+            let r = room.handle_line(*color, &CsaLine::new(*token), *at_ms).unwrap();
+            assert!(matches!(r.outcome, HandleOutcome::MoveAccepted { .. }));
+            // broadcasts[0] が `<token>,T<sec>` (ライブ配信 T)。
+            live_lines.push(r.broadcasts[0].line.as_str().to_owned());
+            let color_str = if matches!(color, Color::Black) {
+                "+"
+            } else {
+                "-"
+            };
+            move_rows.push(move_row_at(i as i64 + 1, color_str, token, *at_ms as i64));
+        }
+
+        // export / snapshot 経路の T を at_ms 差分から再計算し、ライブ配信 T と一致を確認。
+        let export_secs = move_elapsed_secs(&move_rows, play_started_ms);
+        assert_eq!(export_secs.len(), live_lines.len());
+        for (i, (_, token, _)) in seq.iter().enumerate() {
+            assert_eq!(live_lines[i], format!("{token},T{}", export_secs[i]));
+        }
+        // 具体値も pin する。
+        assert_eq!(export_secs, vec![3, 4, 2, 5]);
+    }
+
+    #[test]
     fn is_move_broadcast_only_matches_board_advancing_moves() {
         use rshogi_csa_server::types::CsaLine;
         use rshogi_csa_server::{BroadcastEntry, BroadcastTarget};

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -34,7 +34,9 @@ pub enum ClockResult {
 pub trait TimeClock {
     /// 指定した対局者の残時間から `elapsed_ms` ミリ秒分を消費し、時間切れ判定を返す。
     ///
-    /// 呼び出し側が通信マージンを差し引いて渡すこと。
+    /// 呼び出し側は raw な実経過時間を渡す。通信マージンは deadline 側の猶予にのみ
+    /// 使い、課金 (本メソッド) からは差し引かない (#857)。秒/分単位への切り捨ては
+    /// 各実装 (`SecondsCountdownClock` / `FischerClock` / `StopWatchClock`) が行う。
     fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult;
 
     /// Game_Summary の `BEGIN Time` セクションを CSA 仕様の項目・順序・単位で出力する。

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -118,7 +118,9 @@ pub struct GameRoomConfig {
     pub white: PlayerName,
     /// 最大手数（既定 256）。これに達したら `#MAX_MOVES`。
     pub max_moves: u32,
-    /// 通信マージン（ミリ秒）。`consume` 呼び出し前に減算される。
+    /// 通信マージン（ミリ秒）。deadline 側の猶予にのみ使う (#857)。
+    /// `compute_deadline` / turn alarm の予約で加算し、`consume`（課金）からは
+    /// 差し引かない。
     pub time_margin_ms: u64,
     /// `%KACHI` 判定に使う入玉ルール（既定は 24 点法 = `Point24`）。
     pub entering_king_rule: EnteringKingRule,
@@ -492,10 +494,14 @@ impl GameRoom {
         mv: rshogi_core::types::Move,
         now_ms: u64,
     ) -> Result<HandleResult, ServerError> {
-        // 1. 経過時間を計算し通信マージンを差し引いて時計を消費。
+        // 1. 経過時間を計算して時計を消費。通信マージン (`time_margin_ms`) は
+        //    deadline 側の猶予 (`compute_deadline` / turn alarm の予約) にのみ効かせ、
+        //    **課金 (`consume`) からは差し引かない**。margin を毎手の課金控除に使うと
+        //    fischer では実効予算が「total + (inc + margin)×手数」に膨張し、ライブ台帳
+        //    と終局棋譜の T が 1 秒/手ずれる (#857)。秒単位への切り捨ては clock 実装
+        //    (`SecondsCountdownClock` / `FischerClock`) 側で行われる。
         let started = self.turn_started_at_ms.unwrap_or(now_ms);
-        let raw_elapsed_ms = now_ms.saturating_sub(started);
-        let elapsed_ms = raw_elapsed_ms.saturating_sub(self.config.time_margin_ms);
+        let elapsed_ms = now_ms.saturating_sub(started);
         let clock_result = self.clock.consume(from, elapsed_ms);
 
         // 2. 時間切れなら盤面を進めず終局（手は受理しない）。
@@ -704,7 +710,7 @@ fn command_static_name(cmd: &ClientCommand) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::game::clock::SecondsCountdownClock;
+    use crate::game::clock::{FischerClock, SecondsCountdownClock};
 
     fn make_room() -> GameRoom {
         let config = GameRoomConfig {
@@ -905,7 +911,10 @@ mod tests {
     }
 
     #[test]
-    fn time_margin_is_subtracted_before_consume() {
+    fn time_margin_does_not_discount_consume() {
+        // #857: 通信マージンは deadline 猶予にのみ効かせ、課金 (consume) からは
+        // 差し引かない。margin=1500 でも経過 4000ms はそのまま consume(4000ms) され、
+        // 整数秒切り捨てで 4 秒課金される (旧実装は 2500ms→T2 に割り引いていた)。
         let config = GameRoomConfig {
             game_id: GameId::new("g"),
             black: PlayerName::new("a"),
@@ -918,9 +927,10 @@ mod tests {
         let clock = Box::new(SecondsCountdownClock::new(60, 0));
         let mut room = GameRoom::new(config, clock).expect("valid test config");
         agree_both(&mut room);
-        // 経過 4000ms, margin 1500ms → consume(2500ms)。整数秒切り捨てで 2 秒消費。
         let r = room.handle_line(Color::Black, &line("+7776FU"), 4_000).unwrap();
-        assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T2");
+        assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T4");
+        // 本体持ち時間も実時間ぶん (4 秒) 減っている (60 → 56 秒)。
+        assert_eq!(room.clock_remaining_main_ms(Color::Black), 56_000);
     }
 
     // ---- 通信マージン境界値テスト ----
@@ -940,13 +950,14 @@ mod tests {
     }
 
     #[test]
-    fn time_margin_larger_than_elapsed_clamps_to_zero_consume() {
-        // (a) time_margin_ms > elapsed_ms の場合、saturating_sub で consume 引数が 0
-        //     になり、手番は時間消費ゼロで受理される（margin が elapsed を完全吸収）。
+    fn time_margin_does_not_absorb_short_move_elapsed() {
+        // #857: margin > elapsed でも課金は割り引かない。margin=5000 でも経過 1000ms は
+        //     consume(1000ms) されて 1 秒課金される (旧実装は saturating_sub で 0 秒に
+        //     吸収し T0 にしていた)。margin は deadline 側の猶予にのみ残す。
         let mut room = room_with(5_000, 60, 0);
         agree_both(&mut room);
         let r = room.handle_line(Color::Black, &line("+7776FU"), 1_000).unwrap();
-        assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T0");
+        assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T1");
     }
 
     #[test]
@@ -1004,25 +1015,80 @@ mod tests {
     }
 
     #[test]
-    fn move_at_main_plus_margin_boundary_is_accepted() {
-        // (e) 本体 + margin の合算ちょうど: 本体 5 秒 + margin 1500ms のとき
-        //     elapsed 6500ms で着手 → consume(5000ms) → Black の本体を使い切って 0 に
-        //     落ちる（Continue 扱いで対局続行）。MoveAccepted.remaining_main_ms は
-        //     「次手番側 (White) の本体残り」なので、White 未消費の 5000ms が返る。
-        //     Black 側が実際に 0 まで落ちたことは broadcast の `,T5` で確認する。
+    fn delayed_move_within_margin_is_charged_real_time_and_times_up() {
+        // #857 test (b): 本体 5 秒 + margin 1500ms。物理経過 6500ms の遅延着手は、
+        //   deadline 側では救済される (turn_budget + margin が 6500ms を覆うので alarm は
+        //   発火しない) が、課金は実時間どおり: consume(6500ms) は 6 秒に切り捨てられ
+        //   5 秒予算を超過するため TimeUp になる。旧実装は margin を差し引いて
+        //   consume(5000ms) とし「本体ぴったり使い切り」で受理していた (課金割引バグ)。
         let mut room = room_with(1_500, 5, 0);
         agree_both(&mut room);
+        // deadline 猶予: turn_budget(本体5s + grain999ms) + margin1500ms は 6500ms を覆う。
+        let turn_budget_ms = room.clock_turn_budget_ms(Color::Black).max(0) as u64;
+        assert!(turn_budget_ms + room.time_margin_ms() >= 6_500);
+        // しかし課金は実時間 (6 秒) で、5 秒予算を超過するため時間切れ。
         let r = room.handle_line(Color::Black, &line("+7776FU"), 6_500).unwrap();
         assert!(matches!(
             r.outcome,
-            HandleOutcome::MoveAccepted {
-                next_turn: Color::White,
-                remaining_main_ms: 5_000,
-            }
+            HandleOutcome::GameEnded(GameResult::TimeUp {
+                loser: Color::Black
+            })
         ));
-        assert_eq!(r.broadcasts[0].line.as_str(), "+7776FU,T5");
-        // Black 側の本体持ち時間が 0 まで落ちていることを直接確認。
-        assert_eq!(room.clock_remaining_main_ms(Color::Black), 0);
+    }
+
+    #[test]
+    fn fischer_budget_invariant_no_margin_inflation() {
+        // #857 test (a): fischer(total=3, inc=1) + margin=1000。Black が毎手 (inc+1)=2 秒
+        //   使うと、実効予算 total + inc×手数 = 3 + 1×手数 を実時間どおり食い潰し、
+        //   4 手目で時間切れになる。旧実装は margin=1000 を毎手課金から割り引いて
+        //   consume(1000ms)=inc ちょうどにし、予算が減らず永久に時間切れしなかった
+        //   (fischer 予算膨張バグ)。ライブ T の合計が予算 total + inc×手数 を超えない
+        //   ことも確認する。
+        let config = GameRoomConfig {
+            game_id: GameId::new("g"),
+            black: PlayerName::new("a"),
+            white: PlayerName::new("b"),
+            max_moves: 256,
+            time_margin_ms: 1_000,
+            entering_king_rule: EnteringKingRule::Point24,
+            initial_sfen: None,
+        };
+        let clock = Box::new(FischerClock::new(3, 1));
+        let mut room = GameRoom::new(config, clock).expect("valid test config");
+        agree_both(&mut room);
+
+        // Black は 2 秒/手、White は 0 秒/手で交互に指す。turn_started は「直前の指し手の
+        // now_ms」なので、now を 2000 刻みで進めれば Black の各手の経過は 2000ms になる。
+        let black_moves = ["+7776FU", "+2726FU", "+2625FU"];
+        let white_moves = ["-3334FU", "-8384FU", "-8485FU"];
+        let mut black_t_total: u32 = 0;
+        for (i, (bm, wm)) in black_moves.iter().zip(white_moves.iter()).enumerate() {
+            let now = (i as u64 + 1) * 2_000;
+            let rb = room.handle_line(Color::Black, &line(bm), now).unwrap();
+            assert!(
+                matches!(rb.outcome, HandleOutcome::MoveAccepted { .. }),
+                "black move {i} should be accepted"
+            );
+            // ライブ T (broadcast) は実時間 2 秒。
+            assert_eq!(rb.broadcasts[0].line.as_str(), format!("{bm},T2"));
+            black_t_total += 2;
+            // White は同 now で即応 (経過 0 秒)。
+            let rw = room.handle_line(Color::White, &line(wm), now).unwrap();
+            assert!(matches!(rw.outcome, HandleOutcome::MoveAccepted { .. }));
+        }
+        // 4 手目の Black は予算超過で時間切れ。
+        let r = room.handle_line(Color::Black, &line("+2524FU"), 8_000).unwrap();
+        assert!(matches!(
+            r.outcome,
+            HandleOutcome::GameEnded(GameResult::TimeUp {
+                loser: Color::Black
+            })
+        ));
+        // 予算不変条件: 課金できた Black の T 合計 (6 秒) は total + inc×手数 = 3 + 1×3 = 6
+        // 以内に収まる (margin による水増しが無い)。
+        let total_sec = 3u32;
+        let inc_sec = 1u32;
+        assert!(black_t_total <= total_sec + inc_sec * black_moves.len() as u32);
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/game/run_loop.rs
+++ b/crates/rshogi-csa-server/src/game/run_loop.rs
@@ -107,10 +107,13 @@ enum Event {
 /// 手番側の予算（本体 + byoyomi）+ 通信マージン + 通信猶予から
 /// `tokio::time::Instant` を計算する。
 ///
-/// `handle_move` 側は `consume(elapsed_ms - time_margin_ms)` で時計を進めるため、
-/// 物理時間が `turn_budget_ms + time_margin_ms` 以内に届く着手は合法。`run_loop` は
-/// この境界に `TIMEUP_GRACE_MS` を足した時刻まで `recv_line` を待機する
-/// （時間切れ確定と通信マージンの両立）。
+/// `handle_move` 側は `consume(raw elapsed)` で時計を進める（通信マージンを課金から
+/// 差し引かない、#857）。時間切れ判定は「秒切り捨て後の消費が予算を超えるか」で行われ、
+/// `turn_budget_ms` は切り捨て猶予 (`SECOND_GRAIN_MS - 1`) を含む。ここではさらに
+/// `time_margin_ms`（deadline 側の通信猶予）と `TIMEUP_GRACE_MS` を足した時刻まで
+/// `recv_line` を待機し、予算内の着手がネットワーク遅延で早発火の time-up を食らわない
+/// ようにする。物理経過が `turn_budget_ms` を超える着手は `consume` 側で実時間どおり
+/// 課金され time-up し得るが、その受信自体はここでは阻害しない。
 ///
 /// 旧実装は本体残時間のみを渡していたため、既定設定 `byoyomi=10` でも本体切れで
 /// 即 time-up していた。本版は
@@ -480,9 +483,13 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn run_does_not_time_out_within_communication_margin() {
-        // 通信マージン内に届いた手は時間切れ扱いしないこと。
-        // 残時間 1 秒 + マージン 5 秒。物理時間 4 秒経過後に着手 → 合法（消費は max(0, 4-5)=0 秒）。
+    async fn run_charges_real_elapsed_even_within_communication_margin() {
+        // #857: 通信マージンは deadline 側の猶予にのみ効かせ、課金からは差し引かない。
+        // 残時間 1 秒 + マージン 5 秒。物理経過 4 秒の着手は、deadline
+        // (turn_budget 1999ms + margin 5000ms + grace 250ms = 7249ms) 側では alarm が
+        // 発火せず handle_line まで届く (=救済) が、consume は実時間 4 秒を課金するため
+        // 1 秒予算を超過して time-up する。旧実装は margin を差し引いて consume(0 秒) と
+        // し、この着手を「消費ゼロ」で受理していた (課金割引バグ)。
         let config = GameRoomConfig {
             game_id: GameId::new("g"),
             black: PlayerName::new("a"),
@@ -513,10 +520,11 @@ mod tests {
             sente_tx.send(Ok(line("AGREE"))).unwrap();
             advance().await;
             gote_tx.send(Ok(line("AGREE"))).unwrap();
-            // Playing 開始時刻を 0 とすると、4 秒待機して着手 → 物理経過 4 秒 < 1+5=6 秒 = OK。
+            // Playing 開始を 0 として 4 秒待機後に着手。deadline は 7.249 秒なので手は
+            // handle_line まで届くが、実時間 4 秒課金で 1 秒予算を超過して time-up する。
             tokio::time::sleep(Duration::from_secs(4)).await;
             sente_tx.send(Ok(line("+7776FU"))).unwrap();
-            // 続いて gote が即時 %TORYO で対局終了。
+            // sente が既に time-up 済みなので、この %TORYO は届く前に対局が終わる。
             advance().await;
             gote_tx.send(Ok(line("%TORYO"))).unwrap();
         };
@@ -530,11 +538,11 @@ mod tests {
         let (_, result) = tokio::join!(driver, runner);
         let result = result.unwrap();
 
-        // sente の +7776FU は通信マージン内なので合法。最終的に gote の TORYO で sente が勝つ。
+        // sente の +7776FU は deadline 内で届くが、実時間 4 秒課金で 1 秒予算を超過 → time-up。
         assert!(matches!(
             result,
-            GameResult::Toryo {
-                winner: Color::Black
+            GameResult::TimeUp {
+                loser: Color::Black
             }
         ));
     }


### PR DESCRIPTION
Closes #857

通信マージンを毎手の課金控除に使っていたため、fischer の実効予算が「total+(inc+1s)×手数」に膨張し(検証対局で白が実測 791s 消費でも台帳 616s 課金で生存)、ライブ配信 T と終局棋譜 T が 1 秒/手乖離していた。

- `apply_move` の `consume` へ raw elapsed を渡す(margin 減算廃止)。margin は deadline 側(turn alarm 予約 / TCP run_loop の受信待機)にのみ残す
- ライブ配信 T = 終局 export / 観戦 snapshot の T の一致を固定するテストを追加(test c)
- 遅延着手の新セマンティクス: deadline では救済されるが課金は実時間どおり(境界テスト更新)
- fischer 予算不変条件(T 合計 ≤ total+inc×手数)を担保

検証データ・監査: #857 参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9