### PR TITLE
fix(csa-client): fischer 再接続時の台帳が増分ぶん膨張する退行を修正 (#858 follow-up)

### DIFF
--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -329,8 +329,7 @@ where
 
     let mut clock = Clock::from_summary(&summary);
     if let Some(state) = &resume_state {
-        clock.black_time_ms = state.black_remaining_ms.max(0);
-        clock.white_time_ms = state.white_remaining_ms.max(0);
+        clock.apply_resume_remaining(state.black_remaining_ms, state.white_remaining_ms);
     }
 
     let mut s = SessionState {
@@ -1342,6 +1341,20 @@ impl Clock {
         }
     }
 
+    /// 再接続 (`BEGIN Reconnect_State`) の `Black/White_Time_Remaining_Ms` を
+    /// 台帳へ反映する。
+    ///
+    /// サーバーが送る値は `remaining_main_ms` = fischer では slot そのもの
+    /// (次手の増分込み post-increment)。#858 で台帳 btime/wtime は pre-increment
+    /// (増分を足す前の残時間) 規約になったため、各色の増分を差し引いてから
+    /// 書き込む。そのまま代入すると再接続後は台帳が恒久的に +inc 膨張し、
+    /// エンジンへの報告予算がサーバー予算を超えて TimeUp を招く。
+    /// byoyomi / sudden-death は increment=0 なので従来どおり素通しになる。
+    fn apply_resume_remaining(&mut self, black_remaining_ms: i64, white_remaining_ms: i64) {
+        self.black_time_ms = (black_remaining_ms.max(0) - self.black_increment_ms).max(0);
+        self.white_time_ms = (white_remaining_ms.max(0) - self.white_increment_ms).max(0);
+    }
+
     fn increment_ms(&self, color: Color) -> i64 {
         match color {
             Color::Black => self.black_increment_ms,
@@ -2092,5 +2105,44 @@ mod tests {
             "btime 60000 wtime 60000 byoyomi 8500"
         );
         assert_eq!(clock.think_limit_ms(1_500, Color::Black), 8_500);
+    }
+
+    #[test]
+    fn clock_resume_fischer_subtracts_increment_from_server_remaining() {
+        use rshogi_csa::Color;
+        // fischer 再接続: サーバーの Black/White_Time_Remaining_Ms は slot
+        // (次手の増分込み post-increment)。台帳は pre-increment 規約なので、
+        // 各色の増分を差し引いた値になること。差し引かず素通しすると台帳が
+        // +inc 膨張し、以後の全手でエンジン報告予算がサーバー予算を超える。
+        let mut clock = Clock::from_summary(&fischer_summary(60_000, 5_000));
+        clock.apply_resume_remaining(30_000, 25_000);
+        assert_eq!(clock.black_time_ms, 25_000);
+        assert_eq!(clock.white_time_ms, 20_000);
+        // エンジン報告予算 = 台帳 + inc - margin = server slot - margin を維持。
+        assert_eq!(clock.think_limit_ms(1_500, Color::Black), 28_500);
+        assert_eq!(
+            clock.build_go_args(1_500, Color::Black),
+            "btime 23500 wtime 20000 binc 5000 winc 5000"
+        );
+    }
+
+    #[test]
+    fn clock_resume_fischer_clamps_when_remaining_below_increment() {
+        // サーバー slot は生存中 (consume 後) は常に >= inc だが、負値・inc 未満の
+        // 入力でも台帳が負にならないこと (防御的 clamp)。
+        let mut clock = Clock::from_summary(&fischer_summary(60_000, 5_000));
+        clock.apply_resume_remaining(3_000, -1_000);
+        assert_eq!(clock.black_time_ms, 0);
+        assert_eq!(clock.white_time_ms, 0);
+    }
+
+    #[test]
+    fn clock_resume_byoyomi_passes_server_remaining_through() {
+        // byoyomi (inc=0): remaining_main_ms は本体残時間そのもので、従来どおり
+        // 素通しになる (#858 前後で挙動不変)。
+        let mut clock = Clock::from_summary(&byoyomi_summary(60_000, 10_000));
+        clock.apply_resume_remaining(30_000, 25_000);
+        assert_eq!(clock.black_time_ms, 30_000);
+        assert_eq!(clock.white_time_ms, 25_000);
     }
 }

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -204,7 +204,9 @@ pub struct ServerConfig {
     /// 登録されたときは strict mode となり、未登録の `game_name` で LOGIN した
     /// 接続は `LOGIN:incorrect unknown_game_name` で拒否される。
     pub clock_presets: HashMap<GameName, ClockSpec>,
-    /// 通信マージン (ミリ秒)。`GameRoom` の `consume` 前に差し引かれる。
+    /// 通信マージン (ミリ秒)。deadline 側の猶予にのみ使う (#857)。
+    /// `compute_timeup_deadline` で加算し、`GameRoom` の課金 (`consume`) からは
+    /// 差し引かれない。
     pub time_margin_ms: u64,
     /// 最大手数。
     pub max_moves: u32,

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -343,7 +343,7 @@ impl TimeClock for MillisecondsCountdownClock {
     }
 }
 
-/// Fischer 方式の時計（増分加算、**CSA client の会計規則に合わせた init+post hybrid**）。
+/// Fischer 方式の時計（増分加算、init+post hybrid）。
 ///
 /// - `total_time_seconds`: 初期の持ち時間（秒）。
 /// - `increment_seconds`: 1 手ごとに加算される増分（秒）。
@@ -351,17 +351,19 @@ impl TimeClock for MillisecondsCountdownClock {
 /// - 消費で残時間が負に落ちた時点で時間切れ。
 ///
 /// # セマンティクス
-/// 既存 CSA client (`crates/rshogi-csa-client/src/session.rs`) は以下の会計を採用:
 /// ```text
-/// init:          slot = total + increment     // pre-init-increment
+/// init:          slot = total + increment     // 初手予算 = total + inc
 /// consume(e):    slot = slot - e + increment  // post-move-increment
 /// ```
 ///
 /// FIDE 標準 (init=total / 各手 post-increment) とも、完全な pre-increment
-/// (init=total / 各手 pre-increment) とも異なる独特の計算だが、既存 client /
-/// 棋譜ツールとの interop を優先してサーバもこれに合わせる。初手に
-/// `total + increment` 秒の予算があり、以後各手ごとに (残 - elapsed + inc) で
-/// slot が更新される。
+/// (init=total / 各手 pre-increment) とも異なる独特の計算だが、slot は常に
+/// 「手番側が今の 1 手で使える本体予算」を表すと解釈すれば一貫している。
+/// CSA client (#858 以降) の台帳は pre-increment (init=total、consume 毎に
+/// `-e+inc`) で、常に `client 台帳 = server slot - inc` の対応が成立する
+/// (client はエンジンへ btime=台帳 / binc=inc を別送するため、margin 減算前の
+/// btime+binc は server slot と一致する。手番側の実報告は margin を差し引くので
+/// 実効予算 = server slot − margin)。
 ///
 /// - `turn_budget_ms` は「現在の slot (既に +increment 済み) + 秒 grain」を返す。
 #[derive(Debug, Clone)]
@@ -375,8 +377,8 @@ pub struct FischerClock {
 impl FischerClock {
     /// 新しい Fischer 時計を作る。引数単位は「秒」。
     ///
-    /// client と合わせるため初期 slot は `total + increment` (= 初手で使える
-    /// 予算)。以後 `consume` 毎に post-increment で `slot = slot - elapsed + inc`。
+    /// 初期 slot は `total + increment` (= 初手で使える予算)。以後 `consume`
+    /// 毎に post-increment で `slot = slot - elapsed + inc`。
     pub fn new(total_time_seconds: u32, increment_seconds: u32) -> Self {
         let initial = (total_time_seconds as i64 + increment_seconds as i64) * 1000;
         Self {
@@ -408,13 +410,13 @@ impl FischerClock {
 
 impl TimeClock for FischerClock {
     fn consume(&mut self, color: Color, elapsed_ms: u64) -> ClockResult {
-        // CSA client の会計規則に合わせた post-move-increment:
+        // post-move-increment:
         //   new_slot = slot - elapsed + increment
         // 初期 slot は `new` で `total + increment` 済みなので、初手でも
         // `total + increment` 秒の予算を検査できる。2 手目以降は前手の完了時に
         // increment が加算されているため実質的に post-increment 挙動。
-        // client は `black_time_ms = total + inc` + 毎手 `slot -= e; slot += inc`
-        // で動くので、server もこれに一致させる。
+        // client (#858 以降) の台帳は pre-increment (init=total、毎手 `-e+inc`)
+        // で、常に「client 台帳 = server slot - inc」の対応を保つ。
         let elapsed_sec_ms = (elapsed_ms / 1000) as i64 * 1000;
         let increment = self.increment_ms();
         let slot = self.slot_mut(color);

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -968,7 +968,7 @@ mod tests {
         //     でカバーされているが、`GameRoom` 層での挙動もここで固定する。
         let mut room = room_with(0, 5, 10);
         agree_both(&mut room);
-        // margin=0 なので elapsed_ms がそのまま consume に渡る。
+        // elapsed_ms は margin の値に関わらず常にそのまま consume に渡る (#857)。
         let r = room.handle_line(Color::Black, &line("+7776FU"), 5_000).unwrap();
         assert!(matches!(
             r.outcome,


### PR DESCRIPTION
#858 の pre-increment 台帳規約への移行で、再接続(`BEGIN Reconnect_State`)経路だけがサーバーの `Black/White_Time_Remaining_Ms`(= post-increment slot)を素通し代入しており、**再接続後は台帳が恒久的に +inc 膨張**してエンジン報告予算がサーバー予算を inc−margin 超過する退行があった(独立レビューで検出)。

- `Clock::apply_resume_remaining` に集約し、fischer では各色の increment を差し引いて pre-increment 規約へ変換(防御的 0 clamp)。byoyomi / sudden-death は inc=0 で従来どおり
- 再接続後も「エンジン報告予算 ≤ サーバー予算」の不変条件を go 引数レベルで pin するテスト 3 本
- #857/#858 で stale 化した margin / fischer 会計のコメント 3+1 件を更新(挙動変更なし)

レビュー: Fable + 独立レビュアーの二重 APPROVE(不変条件の代数・clamp・テスト数値を相互検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMBFrvuqUpqUi9VsanNwA9