### PR TITLE
build: edition-layerstacks-halfka_hm_merged-768x16x32-threat を追加

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -239,6 +239,9 @@ edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker = [
 edition-layerstacks-halfka_hm_merged-768x16x32-none = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-768x16x32",
 ]
+edition-layerstacks-halfka_hm_merged-768x16x32-threat = [
+  "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-768x16x32", "nnue-threat",
+]
 edition-layerstacks-halfka_hm_merged-768x8x32-none = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-768x8x32",
 ]

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -99,6 +99,7 @@ edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class            = [
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class_major_pawn = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat_same_class_major_pawn"]
 edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-1024x16x32-threat_step_attacker"]
 edition-layerstacks-halfka_hm_merged-768x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x16x32-none"]
+edition-layerstacks-halfka_hm_merged-768x16x32-threat       = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x16x32-threat"]
 edition-layerstacks-halfka_hm_merged-768x8x32-none          = ["rshogi-core/edition-layerstacks-halfka_hm_merged-768x8x32-none"]
 edition-layerstacks-halfka_hm_merged-512x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-512x16x32-none"]
 edition-layerstacks-halfka_hm_merged-3072x16x32-none        = ["rshogi-core/edition-layerstacks-halfka_hm_merged-3072x16x32-none"]

--- a/docs/build.md
+++ b/docs/build.md
@@ -63,7 +63,7 @@ cargo xtask build --edition layerstacks-halfka_hm_merged-1536x16x32-psqt
 cargo xtask build --edition layerstacks-halfka_hm_merged-1536x16x32-psqt,layerstacks-halfka_hm_merged-1536x16x32-threat
 cargo xtask build --edition X --edition Y
 
-# 全 preset を build (現状 23 件)
+# 全 preset を build (現状 24 件)
 cargo xtask build --all-presets
 
 # engines/ 配下の binary 一覧 + manifest を表表示
@@ -159,7 +159,7 @@ edition-layerstacks
 edition-layerstacks-any-any-any
 edition-layerstacks-halfka_hm_merged-1536x16x32-none
 edition-layerstacks-halfka_hm_merged-1536x16x32-psqt
-... (現状 23 件)
+... (現状 24 件)
 edition-universal
 ```
 


### PR DESCRIPTION
## 概要

threat 幅カーブ実験 (768/1024/1536 同一レシピ) の評価用に、preset edition `edition-layerstacks-halfka_hm_merged-768x16x32-threat` を追加する。

前例 #809 (1024x16x32-threat) と同パターン: LsNetByFt が FT-generic で nnue-threat による FT 拡張をそのまま受けられるため、Cargo.toml の preset 追加のみで成立 (Rust 変更なし)。L0=768 系は nnue-progress-diff が退行するため含めない (build.rs の L0=1536/3072 限定 check とも整合)。

## 検証

- `cargo xtask list-editions` に新 edition が出ることを確認
- `cargo xtask build --edition layerstacks-halfka_hm_merged-768x16x32-threat` 成功、生成 binary で USI handshake (usiok) 確認
- `cargo fmt --check` / `bash scripts/check-tracked-abs-paths.sh` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9abomJpf5ZMy3zff8G6a3