### PR TITLE
fix(csa-server-workers): 終局済み対局への spectate 初回応答と観戦 slot リークを修正

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -93,8 +93,8 @@ use crate::spectator_control::{
     MonitorDecision, resolve_monitor_target, resolve_monitor_target_with_finished,
 };
 use crate::spectator_snapshot::{
-    SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot, is_move_broadcast,
-    move_elapsed_secs, parse_move_row_line,
+    SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot, initial_spectator_clocks,
+    is_move_broadcast, move_elapsed_secs, parse_move_row_line,
 };
 use crate::ws_route::{WsRoute, parse_ws_route};
 use crate::x1_paths::{
@@ -106,8 +106,9 @@ const DEFAULT_MAX_MOVES: u32 = 256;
 const DEFAULT_TIME_MARGIN_MS: u64 = 1000;
 
 /// 1 部屋あたりの観戦者同時接続上限。`fetch` で `/ws/<id>/spectate` の upgrade
-/// 時にカウントし、上限に達していたら 503 を返す。MVP の DDoS 防御として最低限
-/// の gating であり、ベンチで上限を見直す際は環境変数化を検討する (現状は const)。
+/// 時にカウントし、上限に達していたら accept 後に 1013 で閉じる。MVP の DDoS
+/// 防御として最低限の gating であり、ベンチで上限を見直す際は環境変数化を検討する
+/// (現状は const)。
 const MAX_SPECTATORS_PER_ROOM: usize = 50;
 
 /// Alarm 発火時刻に上乗せする安全側マージン（ミリ秒）。Cloudflare Alarm API
@@ -309,7 +310,7 @@ impl DurableObject for GameRoom {
         let Some(route) = parse_ws_route(&path) else {
             return Response::error("Upgrade required", 426);
         };
-        let room_id = route.room_id();
+        let room_id = route.room_id().to_owned();
 
         // 初回 fetch でのみ room_id を永続化する。`start_match` 側で game_id 生成に
         // 使うため、DO 再構築後でも同じ値を参照できるよう storage に置く。
@@ -320,25 +321,12 @@ impl DurableObject for GameRoom {
             self.state.storage().put(KEY_ROOM_ID, room_id.to_owned()).await?;
         }
 
-        // 観戦者の上限チェック (MVP の DDoS 防御)。room あたり同時接続
-        // `MAX_SPECTATORS_PER_ROOM` を超える spectator upgrade は 503 で拒否。
+        // 観戦者の上限チェック (MVP の DDoS 防御)。ブラウザでは WS handshake の
+        // HTTP status/body が隠れるため、上限到達時も一度 accept して 1013 で閉じる。
         // 対局者経路 (`WsRoute::Player`) には影響しない。
-        if route.is_spectator() {
-            let count = self
-                .state
-                .get_websockets()
-                .iter()
-                .filter(|ws| {
-                    matches!(
-                        ws.deserialize_attachment::<WsAttachment>().ok().flatten(),
-                        Some(WsAttachment::Spectator { .. })
-                    )
-                })
-                .count();
-            if count >= MAX_SPECTATORS_PER_ROOM {
-                return Response::error("spectator capacity exceeded", 503);
-            }
-        }
+        let is_spectator = route.is_spectator();
+        let spectator_room_full =
+            is_spectator && self.count_spectator_sockets() >= MAX_SPECTATORS_PER_ROOM;
 
         let pair = WebSocketPair::new()?;
         let server = pair.server;
@@ -351,6 +339,21 @@ impl DurableObject for GameRoom {
         server
             .serialize_attachment(&pending)
             .map_err(|e| Error::RustError(format!("serialize_attachment: {e}")))?;
+
+        if is_spectator {
+            if spectator_room_full {
+                self.release_spectator_socket(&server, Some(1013), "room full");
+            } else if let Err(e) =
+                self.send_finished_spectator_snapshot_if_needed(&server, &room_id).await
+            {
+                crate::structured_log!(
+                    event: "finished_spectator_initial_push_failed",
+                    component: "game_room",
+                    room_id: room_id,
+                    err: format!("{e:?}"),
+                );
+            }
+        }
 
         crate::structured_log!(
             event: "websocket_upgrade_accepted",
@@ -414,8 +417,9 @@ impl DurableObject for GameRoom {
         _was_clean: bool,
     ) -> Result<()> {
         // attachment が corrupt (JSON が壊れた等) の場合は None と同じ扱いにせざるを
-        // 得ないが、診断のためにエラー内容をログへ残す。現実装では Player 以外 (Pending /
-        // corrupt) は slot 解放できないので何もせず return する。
+        // 得ないが、診断のためにエラー内容をログへ残す。Player 以外は対局状態を
+        // 動かさず、Spectator だけは上限カウントから確実に外れるよう attachment を
+        // Pending に戻す。
         let att: Option<WsAttachment> = ws.deserialize_attachment().unwrap_or_else(|e| {
             crate::structured_log!(
                 event: "websocket_close_deserialize_failed",
@@ -424,8 +428,13 @@ impl DurableObject for GameRoom {
             );
             None
         });
-        let Some(WsAttachment::Player { role, .. }) = att else {
-            return Ok(());
+        let role = match att {
+            Some(WsAttachment::Player { role, .. }) => role,
+            Some(WsAttachment::Spectator { .. }) => {
+                self.release_spectator_socket(&ws, None, "spectator closed");
+                return Ok(());
+            }
+            _ => return Ok(()),
         };
 
         // 終局後に届く close は CoreRoom を再構築して force_abnormal してしまうと
@@ -477,7 +486,18 @@ impl DurableObject for GameRoom {
         Ok(())
     }
 
-    async fn websocket_error(&self, _ws: WebSocket, _error: Error) -> Result<()> {
+    async fn websocket_error(&self, ws: WebSocket, error: Error) -> Result<()> {
+        if matches!(
+            ws.deserialize_attachment::<WsAttachment>().ok().flatten(),
+            Some(WsAttachment::Spectator { .. })
+        ) {
+            crate::structured_log!(
+                event: "spectator_websocket_error",
+                component: "game_room",
+                err: format!("{error:?}"),
+            );
+            self.release_spectator_socket(&ws, Some(1011), "spectator websocket error");
+        }
         Ok(())
     }
 
@@ -1089,6 +1109,48 @@ impl GameRoom {
         Ok(())
     }
 
+    fn count_spectator_sockets(&self) -> usize {
+        let mut count = 0;
+        for ws in self.state.get_websockets() {
+            let att = ws.deserialize_attachment::<WsAttachment>().ok().flatten();
+            let Some(att @ WsAttachment::Spectator { .. }) = att else {
+                continue;
+            };
+            if ws.serialize_attachment(&att).is_ok() {
+                count += 1;
+            } else {
+                let _ = ws.close(Some(1001), Some("stale spectator".to_owned()));
+            }
+        }
+        count
+    }
+
+    fn release_spectator_socket(&self, ws: &WebSocket, code: Option<u16>, reason: &str) {
+        let _ = ws.serialize_attachment(&WsAttachment::Pending);
+        if let Some(code) = code {
+            let _ = ws.close(Some(code), Some(reason.to_owned()));
+        }
+    }
+
+    async fn send_finished_spectator_snapshot_if_needed(
+        &self,
+        ws: &WebSocket,
+        room_id: &str,
+    ) -> Result<()> {
+        let Some(finished) = self.load_finished().await? else {
+            return Ok(());
+        };
+        let cfg_opt: Option<PersistedConfig> = self.state.storage().get(KEY_CONFIG).await?;
+        let monitor_id = cfg_opt.as_ref().map(|c| c.game_id.as_str()).unwrap_or(room_id);
+        let finished_opt = Some(finished);
+
+        send_line(ws, &format!("##[MONITOR2] BEGIN {monitor_id}"))?;
+        self.send_spectator_snapshot(ws, &finished_opt, cfg_opt.as_ref()).await?;
+        send_line(ws, "##[MONITOR2] END")?;
+        self.release_spectator_socket(ws, Some(1000), "spectate finished");
+        Ok(())
+    }
+
     /// 観戦者からの制御行。`%%CHAT` を同一 room の全参加者へ relay し、
     /// `%%MONITOR2OFF` は確認応答後に socket を閉じる。`%%MONITOR2ON` は
     /// snapshot (= Game_Summary + 既存指し手 + 終局結果) を 1 回送出する。
@@ -1160,8 +1222,8 @@ impl GameRoom {
     /// 流れ:
     /// 1. attachment の `snapshot_in_progress = true` をセット (= 以降この ws 宛
     ///    の broadcast は `send_to_spectators` で per-ws pending queue に積まれる)
-    /// 2. `ensure_core_loaded()` 後に `core` 参照スコープを最小化して
-    ///    `SpectatorClocks` を組み、`load_moves()` で snapshot 用の指し手列を確定
+    /// 2. `ensure_core_loaded()` 後に `core` があれば現在残時間、無ければ config
+    ///    由来の初期残時間で `SpectatorClocks` を組み、`load_moves()` で指し手列を確定
     /// 3. `build_spectator_snapshot` の wire 行を順次 send
     /// 4. attachment の queue を flush (`ply > last_ply_in_snapshot` のみ送る) し、
     ///    `snapshot_in_progress = false` に戻して通常 broadcast 経路へ復帰
@@ -1224,20 +1286,17 @@ impl GameRoom {
         // CoreRoom を確保し、clock / current_turn から `SpectatorClocks` を組む。
         // borrow scope は最小化し、await を伴う `load_moves` は borrow 外で呼ぶ。
         self.ensure_core_loaded().await?;
-        let clocks_opt = {
+        let clocks = {
             let borrow = self.core.borrow();
-            borrow.as_ref().map(|core| SpectatorClocks {
-                black_remaining_ms: core.clock_remaining_main_ms(Color::Black).max(0) as u64,
-                white_remaining_ms: core.clock_remaining_main_ms(Color::White).max(0) as u64,
-                side_to_move: core.current_turn(),
-            })
-        };
-        // CoreRoom が `replay_core_room` の InvalidSfen 等で復元できなかった場合
-        // (storage が破損した稀なケース)、安全側に snapshot を諦めて queue を
-        // flush する (flag も false へ戻る)。
-        let Some(clocks) = clocks_opt else {
-            self.flush_spectator_snapshot_queue(ws).await?;
-            return Ok(());
+            borrow
+                .as_ref()
+                .map(|core| SpectatorClocks {
+                    black_remaining_ms: core.clock_remaining_main_ms(Color::Black).max(0) as u64,
+                    white_remaining_ms: core.clock_remaining_main_ms(Color::White).max(0) as u64,
+                    side_to_move: core.current_turn(),
+                })
+                // 終局済み room などで CoreRoom を復元しない場合も snapshot 形式を保つ。
+                .unwrap_or_else(|| initial_spectator_clocks(cfg))
         };
 
         let moves = self.load_moves().await?;

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -94,7 +94,7 @@ use crate::spectator_control::{
 };
 use crate::spectator_snapshot::{
     SpectatorClocks, SpectatorSnapshotInput, build_spectator_snapshot, initial_spectator_clocks,
-    is_move_broadcast, move_elapsed_secs, parse_move_row_line,
+    is_move_broadcast, move_elapsed_secs, move_rows_from_exported_csa, parse_move_row_line,
 };
 use crate::ws_route::{WsRoute, parse_ws_route};
 use crate::x1_paths::{
@@ -1299,7 +1299,7 @@ impl GameRoom {
                 .unwrap_or_else(|| initial_spectator_clocks(cfg))
         };
 
-        let moves = self.load_moves().await?;
+        let moves = self.load_spectator_snapshot_moves(cfg, finished).await?;
         let last_ply_in_snapshot = u32::try_from(moves.len()).unwrap_or(u32::MAX);
 
         let lines = build_spectator_snapshot(SpectatorSnapshotInput {
@@ -1318,6 +1318,60 @@ impl GameRoom {
         self.set_spectator_snapshot_last_ply(ws, last_ply_in_snapshot)?;
         self.flush_spectator_snapshot_queue(ws).await?;
         Ok(())
+    }
+
+    async fn load_spectator_snapshot_moves(
+        &self,
+        cfg: &PersistedConfig,
+        finished: &Option<FinishedState>,
+    ) -> Result<Vec<MoveRow>> {
+        let moves = self.load_moves().await?;
+        if finished.is_none() || !moves.is_empty() {
+            return Ok(moves);
+        }
+
+        let first_prev_ms = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
+        let pending: Option<ExportPendingState> =
+            self.state.storage().get(KEY_EXPORT_PENDING).await.ok().flatten();
+        if let Some(pending) = pending
+            && pending.game_id == cfg.game_id
+        {
+            let rows = move_rows_from_exported_csa(&pending.csa_text, first_prev_ms);
+            if !rows.is_empty() {
+                return Ok(rows);
+            }
+        }
+
+        match self.load_kifu_by_game_id(&GameId::new(cfg.game_id.clone())).await {
+            Ok(Some(csa_text)) => {
+                let rows = move_rows_from_exported_csa(&csa_text, first_prev_ms);
+                if rows.is_empty() {
+                    crate::structured_log!(
+                        event: "finished_spectator_snapshot_moves_empty",
+                        component: "game_room",
+                        game_id: cfg.game_id,
+                    );
+                }
+                Ok(rows)
+            }
+            Ok(None) => {
+                crate::structured_log!(
+                    event: "finished_spectator_snapshot_kifu_missing",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                );
+                Ok(moves)
+            }
+            Err(e) => {
+                crate::structured_log!(
+                    event: "finished_spectator_snapshot_kifu_load_failed",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    err: format!("{e:?}"),
+                );
+                Ok(moves)
+            }
+        }
     }
 
     /// snapshot 完了後に attachment の pending queue を順次 flush する。

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -46,6 +46,19 @@ pub struct SpectatorClocks {
     pub side_to_move: Color,
 }
 
+/// core を復元できない終局済み DO でも Game_Summary を返すための時計 fallback。
+pub(crate) fn initial_spectator_clocks(config: &PersistedConfig) -> SpectatorClocks {
+    let clock = config.clock.build_clock();
+    SpectatorClocks {
+        black_remaining_ms: clock.remaining_main_ms(Color::Black).max(0) as u64,
+        white_remaining_ms: clock.remaining_main_ms(Color::White).max(0) as u64,
+        side_to_move: match config.initial_sfen.as_deref() {
+            Some(sfen) => side_to_move_from_sfen(sfen).unwrap_or(Color::Black),
+            None => Color::Black,
+        },
+    }
+}
+
 /// `build_spectator_snapshot` への入力。
 pub struct SpectatorSnapshotInput<'a> {
     /// 永続化済み対局設定（クロック設定 / 初期 SFEN / プレイヤ名 / game_id 等）。
@@ -387,6 +400,23 @@ mod tests {
         // 正規化後の token 行 (raw の T 値ではなく at_ms 差分の T) が全て含まれる。
         assert!(lines.iter().any(|l| l == "+7776FU,T2"), "missing +7776FU,T2: {lines:?}");
         assert!(lines.iter().any(|l| l == "-3334FU,T3"), "missing -3334FU,T3: {lines:?}");
+    }
+
+    #[test]
+    fn initial_spectator_clocks_uses_config_clock_and_sfen_turn() {
+        let mut cfg = baseline_config();
+        cfg.clock = ClockSpec::CountdownMsec {
+            total_time_ms: 10_000,
+            byoyomi_ms: 100,
+        };
+        cfg.initial_sfen =
+            Some("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1".to_owned());
+
+        let cl = initial_spectator_clocks(&cfg);
+
+        assert_eq!(cl.black_remaining_ms, 10_000);
+        assert_eq!(cl.white_remaining_ms, 10_000);
+        assert_eq!(cl.side_to_move, Color::White);
     }
 
     /// `Game_ID:` / `Name+:` / `Name-:` は config 由来で snapshot に乗る。

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -191,6 +191,51 @@ pub(crate) fn move_elapsed_secs(moves: &[MoveRow], first_prev_ms: u64) -> Vec<u3
         .collect()
 }
 
+/// export 済み CSA V2 本文から snapshot 用の指し手列を復元する。
+///
+/// `KifuRecord::build_v2` が出す通常手 (`+7776FU,T3`) と直後のコメント行だけを
+/// `MoveRow` 互換に戻す。終局後は DO の `moves` テーブルを cleanup するため、
+/// late-joiner snapshot は R2 / export pending の CSA 本文を正とする。
+pub(crate) fn move_rows_from_exported_csa(csa_text: &str, first_prev_ms: u64) -> Vec<MoveRow> {
+    let mut rows: Vec<MoveRow> = Vec::new();
+    let mut cumulative_ms = 0_u64;
+
+    for raw in csa_text.lines() {
+        let line = raw.trim_end_matches('\r');
+        if line.starts_with(['+', '-']) && line.len() >= 7 {
+            let token = &line[..7];
+            let elapsed_sec = line[7..]
+                .strip_prefix(",T")
+                .and_then(|rest| {
+                    let digits_len = rest.bytes().take_while(u8::is_ascii_digit).count();
+                    (digits_len > 0).then(|| rest[..digits_len].parse::<u32>().ok()).flatten()
+                })
+                .unwrap_or(0);
+            cumulative_ms = cumulative_ms.saturating_add(u64::from(elapsed_sec) * 1000);
+            let at_ms = first_prev_ms.saturating_add(cumulative_ms).min(i64::MAX as u64) as i64;
+            rows.push(MoveRow {
+                ply: i64::try_from(rows.len() + 1).unwrap_or(i64::MAX),
+                color: if token.starts_with('+') {
+                    "black"
+                } else {
+                    "white"
+                }
+                .to_owned(),
+                line: line.to_owned(),
+                at_ms,
+            });
+        } else if let Some(comment) = line.strip_prefix('\'')
+            && let Some(last) = rows.last_mut()
+            && !last.line.contains('\'')
+        {
+            last.line.push('\'');
+            last.line.push_str(comment);
+        }
+    }
+
+    rows
+}
+
 /// broadcast entry が「盤面を進めた指し手行」かを判定する共有ヘルパ。
 ///
 /// 指し手 broadcast は `+`/`-` で始まり `ply.is_some()`。終局理由行 (`%TORYO`
@@ -450,6 +495,32 @@ mod tests {
         assert_eq!(parse_move_row_line("+7776FU,T3'note"), ("+7776FU", Some("note")));
         // 末尾改行は除去する。
         assert_eq!(parse_move_row_line("+7776FU,T3\r\n"), ("+7776FU", None));
+    }
+
+    #[test]
+    fn move_rows_from_exported_csa_restores_moves_comments_and_elapsed() {
+        let csa = "\
+V2.2
+N+alice
+N-bob
+$GAME_ID:g1
+PI
++
++7776FU,T3
+-3334FU,T4
+'eval=12 pv 3c3d
+%TORYO
+";
+        let rows = move_rows_from_exported_csa(csa, 1_000);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].ply, 1);
+        assert_eq!(rows[0].color, "black");
+        assert_eq!(rows[0].line, "+7776FU,T3");
+        assert_eq!(rows[0].at_ms, 4_000);
+        assert_eq!(rows[1].ply, 2);
+        assert_eq!(rows[1].color, "white");
+        assert_eq!(rows[1].line, "-3334FU,T4'eval=12 pv 3c3d");
+        assert_eq!(rows[1].at_ms, 8_000);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -73,6 +73,7 @@ export interface HarnessOptions {
   /// 側既定 ([`config::DEFAULT_AGREE_TIMEOUT_SEC`] = 60) にフォールバック。
   agreeTimeoutSeconds?: number;
   allowFloodgateFeatures?: boolean;
+  allowViewerApi?: boolean;
   totalTimeSec?: number;
   byoyomiSec?: number;
   totalTimeMs?: number;
@@ -178,6 +179,7 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       AGREE_TIMEOUT_SECONDS:
         opts.agreeTimeoutSeconds === undefined ? "" : String(opts.agreeTimeoutSeconds),
       ALLOW_FLOODGATE_FEATURES: opts.allowFloodgateFeatures ? "true" : "false",
+      ALLOW_VIEWER_API: opts.allowViewerApi ? "true" : "false",
       WS_ALLOWED_ORIGINS: opts.wsAllowedOrigins ?? "https://example.com",
       LOBBY_QUEUE_SIZE_LIMIT: String(opts.lobbyQueueSizeLimit ?? 100),
       // 未指定時は空文字を渡して server 側 fallback (= 300 秒既定) を使う。

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/spectator_finished.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/spectator_finished.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Miniflare, WebSocket } from "miniflare";
+import {
+  CsaClient,
+  DEFAULT_TEST_CF_CONNECTING_IP,
+  createMiniflare,
+  makeTempPersistRoot,
+} from "./harness.ts";
+import { readLineFromWebSocket } from "./ws_test_helpers";
+
+describe("miniflare smoke: 終局済み spectate", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      allowViewerApi: true,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("終局済み room への spectate は MONITOR2ON を待たずに snapshot と結果コードを push して正常 close する", async () => {
+    const { gameId } = await finishOneGame(mf, "spectate-finished-room-1");
+
+    const res = await dispatchSpectator(mf, gameId);
+    expect(res.status).toBe(101);
+    expect(res.webSocket).toBeTruthy();
+    const ws = res.webSocket!;
+    const buf = readLineFromWebSocket(ws);
+    const closeInfo = waitForClose(ws);
+    ws.accept();
+
+    const lines = await readUntil(buf, "##[MONITOR2] END");
+    expect(lines[0]).toBe(`##[MONITOR2] BEGIN ${gameId}`);
+    expect(lines).toContain("BEGIN Game_Summary");
+    expect(lines).toContain(`Game_ID:${gameId}`);
+    expect(lines).toContain("#RESIGN");
+    expect(lines.at(-1)).toBe("##[MONITOR2] END");
+
+    const closed = await closeInfo;
+    expect(closed.code).toBe(1000);
+    expect(closed.reason).toBe("spectate finished");
+  });
+
+  it("spectator close 後は観戦上限カウントから外れ、50 枠を再利用できる", async () => {
+    const { gameId } = await startOneGame(mf, "spectate-active-room-1");
+
+    const first = await connectSpectator(mf, gameId);
+    await closeWebSocket(first);
+
+    const opened: WebSocket[] = [];
+    try {
+      for (let i = 0; i < 50; i += 1) {
+        opened.push(await connectSpectator(mf, gameId, `127.0.1.${i + 1}`));
+      }
+      const full = await dispatchSpectator(mf, gameId, "127.0.2.1");
+      expect(full.status).toBe(101);
+      expect(full.webSocket).toBeTruthy();
+      const fullWs = full.webSocket!;
+      const fullClose = waitForClose(fullWs);
+      fullWs.accept();
+      await expect(fullClose).resolves.toEqual({ code: 1013, reason: "room full" });
+
+      const reusable = opened.pop();
+      expect(reusable).toBeTruthy();
+      await closeWebSocket(reusable!);
+
+      const replacement = await dispatchSpectator(mf, gameId, "127.0.2.2");
+      expect(replacement.status).toBe(101);
+      expect(replacement.webSocket).toBeTruthy();
+      const replacementWs = replacement.webSocket!;
+      const noClose = expectNoClose(replacementWs);
+      replacementWs.accept();
+      await noClose;
+      opened.push(replacementWs);
+    } finally {
+      for (const ws of opened) {
+        ws.close();
+      }
+    }
+  });
+});
+
+interface StartedGame {
+  gameId: string;
+  black: CsaClient;
+  white: CsaClient;
+}
+
+async function startOneGame(mf: Miniflare, roomId: string): Promise<StartedGame> {
+  const gameName = `${roomId}-game`;
+  const black = await CsaClient.connect(mf, roomId);
+  const blackName = `alice+${gameName}+black`;
+  black.send(`LOGIN ${blackName} pw`);
+  expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+
+  const white = await CsaClient.connect(mf, roomId);
+  const whiteName = `bob+${gameName}+white`;
+  white.send(`LOGIN ${whiteName} pw`);
+  expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+  await black.drainGameSummary();
+  await white.drainGameSummary();
+
+  black.send("AGREE");
+  white.send("AGREE");
+  const startBlack = await black.recvLine();
+  const startWhite = await white.recvLine();
+  expect(startBlack).toBe(startWhite);
+  expect(startBlack.startsWith("START:")).toBe(true);
+
+  return { gameId: startBlack.slice("START:".length), black, white };
+}
+
+async function finishOneGame(
+  mf: Miniflare,
+  roomId: string,
+): Promise<{ gameId: string }> {
+  const game = await startOneGame(mf, roomId);
+
+  game.black.send("+7776FU");
+  await game.black.recvUntil((l) => l.startsWith("+7776FU"));
+  await game.white.recvUntil((l) => l.startsWith("+7776FU"));
+
+  game.white.send("-3334FU");
+  await game.black.recvUntil((l) => l.startsWith("-3334FU"));
+  await game.white.recvUntil((l) => l.startsWith("-3334FU"));
+
+  game.black.send("%TORYO");
+  const blackEnd = await game.black.recvUntil((l) => l === "#LOSE");
+  expect(blackEnd).toContain("#RESIGN");
+
+  await game.black.close();
+  await game.white.close();
+  return { gameId: game.gameId };
+}
+
+async function dispatchSpectator(
+  mf: Miniflare,
+  gameId: string,
+  cfConnectingIp = DEFAULT_TEST_CF_CONNECTING_IP,
+): Promise<Response> {
+  return await mf.dispatchFetch(`https://example.com/ws/${encodeURIComponent(gameId)}/spectate`, {
+    headers: {
+      Upgrade: "websocket",
+      Origin: "https://example.com",
+      "CF-Connecting-IP": cfConnectingIp,
+    },
+  });
+}
+
+async function connectSpectator(
+  mf: Miniflare,
+  gameId: string,
+  cfConnectingIp = DEFAULT_TEST_CF_CONNECTING_IP,
+): Promise<WebSocket> {
+  const res = await dispatchSpectator(mf, gameId, cfConnectingIp);
+  if (res.status !== 101 || !res.webSocket) {
+    throw new Error(`expected 101 with webSocket, got ${res.status}: ${await res.text()}`);
+  }
+  res.webSocket.accept();
+  return res.webSocket;
+}
+
+async function readUntil(
+  buf: ReturnType<typeof readLineFromWebSocket>,
+  terminal: string,
+): Promise<string[]> {
+  const lines: string[] = [];
+  while (true) {
+    const line = await buf.takeLine(5000);
+    lines.push(line);
+    if (line === terminal) return lines;
+  }
+}
+
+async function closeWebSocket(ws: WebSocket): Promise<void> {
+  if (ws.readyState === 2 || ws.readyState === 3) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, 1000);
+    ws.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+    ws.close();
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+async function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  if (ws.readyState === 3) return { code: 1000, reason: "" };
+  return await new Promise((resolve) => {
+    ws.addEventListener(
+      "close",
+      (ev) => {
+        resolve({ code: ev.code, reason: ev.reason });
+      },
+      { once: true },
+    );
+  });
+}
+
+async function expectNoClose(ws: WebSocket): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(resolve, 100);
+    ws.addEventListener(
+      "close",
+      (ev) => {
+        clearTimeout(timer);
+        reject(new Error(`unexpected close: ${ev.code} ${ev.reason}`));
+      },
+      { once: true },
+    );
+  });
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/spectator_finished.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/spectator_finished.test.ts
@@ -43,6 +43,12 @@ describe("miniflare smoke: 終局済み spectate", () => {
     expect(lines[0]).toBe(`##[MONITOR2] BEGIN ${gameId}`);
     expect(lines).toContain("BEGIN Game_Summary");
     expect(lines).toContain(`Game_ID:${gameId}`);
+    const blackMoveIndex = lines.findIndex((line) => line.startsWith("+7776FU,T"));
+    const whiteMoveIndex = lines.findIndex((line) => line.startsWith("-3334FU,T"));
+    const resultIndex = lines.indexOf("#RESIGN");
+    expect(blackMoveIndex).toBeGreaterThan(0);
+    expect(whiteMoveIndex).toBeGreaterThan(blackMoveIndex);
+    expect(resultIndex).toBeGreaterThan(whiteMoveIndex);
     expect(lines).toContain("#RESIGN");
     expect(lines.at(-1)).toBe("##[MONITOR2] END");
 

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -163,11 +163,11 @@ crons = ["0,15,30,45 * * * *"]
 # では allowlist が **必須**: 空・未設定時は Origin の有無にかかわらず 403。
 # 無認可公開を防ぐ fail-closed 既定で、`ALLOW_VIEWER_API` と組で運用する。
 # 実運用では web client URL を実値に書き換えること。
-# Tauri desktop は webview から fetch するときに OS 別の Origin を付与する:
+# Tauri desktop は webview から fetch するときに OS / WebView 別の Origin を付与する:
 #   - macOS / Linux: tauri://localhost
-#   - Windows: https://tauri.localhost
-# 両方を allowlist に登録して desktop からの request も通す。
-WS_ALLOWED_ORIGINS = "https://ramu-shogi.sh11235.com,tauri://localhost,https://tauri.localhost"
+#   - Windows / WebView2: http://tauri.localhost または https://tauri.localhost
+# いずれも allowlist に登録して desktop からの request も通す。
+WS_ALLOWED_ORIGINS = "https://ramu-shogi.sh11235.com,tauri://localhost,http://tauri.localhost,https://tauri.localhost"
 
 # 対局時計。`countdown` (CSA 2014 改訂秒読み、Floodgate 互換) / `countdown_msec`
 # (ms 粒度の短時間対局向け拡張) / `fischer` (増分加算) / `stopwatch` (分単位)。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -148,9 +148,10 @@ crons = ["0,15,30,45 * * * *"]
 # ネイティブ CSA クライアントは素通し。
 # staging では本リポ csa_client の `ws_origin` 既定値 (`https://csa-client-local`)
 # と staging web client + Tauri desktop の Origin を併記する。
-# Tauri desktop は OS 別 Origin (`tauri://localhost` / `https://tauri.localhost`)
-# を webview から自動付与するため、両方を登録する。
-WS_ALLOWED_ORIGINS = "https://stg.ramu-shogi.sh11235.com,https://csa-client-local,tauri://localhost,https://tauri.localhost"
+# Tauri desktop は OS / WebView 別 Origin (`tauri://localhost` /
+# `http://tauri.localhost` / `https://tauri.localhost`) を webview から自動付与
+# するため、いずれも登録する。
+WS_ALLOWED_ORIGINS = "https://stg.ramu-shogi.sh11235.com,https://csa-client-local,tauri://localhost,http://tauri.localhost,https://tauri.localhost"
 
 # 対局時計の方式と値。
 # - `countdown`: CSA 2014 改訂互換、整数秒切り捨て、Floodgate 互換 (`Time_Unit:1sec`)。


### PR DESCRIPTION
Closes #864
Closes #865

## 変更内容

### #864: 終局済み対局への spectate
- 終局済み room への `/ws/<id>/spectate` は `%%MONITOR2ON` を待たずに accept 直後へ `BEGIN + 終局 snapshot + 結果コード + END` を push して close(1000)（初回応答で終局を伝える）
- **slot リーク修正**: `websocket_close` / `websocket_error` で Spectator attachment を `Pending` に戻し観戦カウントから確実に外す（従来は Spectator が一切掃除されず、リトライのたびに accepted socket が積み上がって上限50に到達していた — 実観測された「数回のリトライで観戦上限エラー」の根本原因）
- 再 serialize できない stale spectator socket は数えず close を試行（カウント健全化）
- **満席契約の変更**: 上限到達時は HTTP 503 でなく accept 直後の close(1013, "room full") で通知。ブラウザの WebSocket API は handshake 503 を検知できない（onclose 1006/reason 空）ため。クライアント側は SH11235/ramu-shogi#67（マージ済み）で対応済み
- 終局済みで core 未復元でも config の時計初期値から Game_Summary を返せる fallback を追加

### #865: Tauri desktop Origin
- `WS_ALLOWED_ORIGINS`（staging/production）に `http://tauri.localhost` を追加（`tauri://localhost` / `https://tauri.localhost` は既存）

## 検証
- クリーンコンテキストレビュアー（Opus）2周: 初回 REQUEST_CHANGES（wasm32 コンパイルエラー2件）→ 修正後 **APPROVE**（レビュアー側でも独立にビルド・テスト・smoke を再実行して確認）
- `cargo build -p rshogi-csa-server-workers --lib --release --target wasm32-unknown-unknown` green / fmt / clippy --tests（新規 #[allow] なし、新規警告ゼロ）/ `cargo test -p rshogi-csa-server-workers` green / check-tracked-abs-paths green
- miniflare smoke 13ファイル48テスト全 green。新規追加: 終局済み room への接続で client 無送信のまま snapshot+結果コード+close(1000) を受信 / 50枠到達後の51本目が 101 upgrade → close(1013, "room full") / spectator close 後の slot 再利用

## staging 検証手順（マージ後の自動デプロイ後に実施予定）
1. 終局済み gameId に spectate 接続し、無送信で終局 push + close(1000) を確認
2. 同一 gameId へ複数回接続し 503/満席にならないことを確認
3. live room で 50 接続 → 51本目が 1013 close、1本 close 後に枠が再利用されることを確認

## Tauri 実機確認手順（#865、ユーザー実施）
1. staging デプロイ後、ramu-shogi desktop の API base を staging に向けて起動
2. devtools / CF tail で `/api/v1/games/live` の request Origin を確認（403 でなく 200）
3. live entry から `/ws/<gameId>/spectate` が 101 upgrade されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C