### PR TITLE
ci(workers): worker-build を @=0.8.1 に固定しキャッシュキーを更新

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -171,10 +171,10 @@ jobs:
       # step を skip して 30〜60 秒短縮する。
       #
       # ⚠️ バージョン更新時の二重管理に注意:
-      #   `cargo install worker-build@^0.8` を `^0.9` 系に上げる場合、本キャッシュキー
-      #   末尾の `v0.8` も同時に `v0.9` へ更新する必要がある。`v0.8` のままだと
-      #   過去 cache が hit して 0.8.x バイナリが使われ続け、新 0.9.x が install
-      #   step で skip される。インストールコマンドとキャッシュキーの **2 箇所同時更新** が必須。
+      #   worker-build は `@=0.8.1` に固定している（`@^0.8` だと 0.8.5 を引き当て、
+      #   wasm-bindgen 0.2.118 と非互換でデプロイが壊れるため）。別バージョンへ上げる場合は
+      #   `cargo install worker-build@=0.8.1` と本キャッシュキー末尾の `v0.8.1` を同時に
+      #   更新する。key を据え置くと過去 cache が hit して旧バイナリが使われ続け skip される。
       #   本 cache key は `deploy-production` job と共有しているので、bump 時は staging /
       #   production 両方の install コマンド + key 末尾の **計 4 箇所同時更新** が必要。
       - name: Cache worker-build binary
@@ -183,10 +183,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/worker-build
-          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
+          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8.1
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
-        run: cargo install -q worker-build@^0.8 --locked
+        run: cargo install -q worker-build@=0.8.1 --locked
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: steps.check.outputs.can_deploy == 'true'
         with:
@@ -388,10 +388,10 @@ jobs:
             exit 1
           }
       # ⚠️ バージョン更新時の二重管理に注意:
-      #   `cargo install worker-build@^0.8` を `^0.9` 系に上げる場合、本キャッシュキー
-      #   末尾の `v0.8` も同時に `v0.9` へ更新する必要がある。`v0.8` のままだと
-      #   過去 cache が hit して 0.8.x バイナリが使われ続け、新 0.9.x が install
-      #   step で skip される。インストールコマンドとキャッシュキーの **2 箇所同時更新** が必須。
+      #   worker-build は `@=0.8.1` に固定している（`@^0.8` だと 0.8.5 を引き当て、
+      #   wasm-bindgen 0.2.118 と非互換でデプロイが壊れるため）。別バージョンへ上げる場合は
+      #   `cargo install worker-build@=0.8.1` と本キャッシュキー末尾の `v0.8.1` を同時に
+      #   更新する。key を据え置くと過去 cache が hit して旧バイナリが使われ続け skip される。
       #   本 cache key は `deploy-staging` job と共有しているので、bump 時は staging /
       #   production 両方の install コマンド + key 末尾の **計 4 箇所同時更新** が必要。
       - name: Cache worker-build binary
@@ -400,10 +400,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/worker-build
-          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
+          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8.1
       - name: Install worker-build
         if: steps.check.outputs.can_deploy == 'true' && steps.cache-worker-build.outputs.cache-hit != 'true'
-        run: cargo install -q worker-build@^0.8 --locked
+        run: cargo install -q worker-build@=0.8.1 --locked
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: steps.check.outputs.can_deploy == 'true'
         with:

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -75,21 +75,21 @@ jobs:
       # と同じキー規約に揃える。
       #
       # ⚠️ バージョン更新時の二重管理に注意:
-      #   `cargo install worker-build@^0.8` を `^0.9` 系に上げる場合、本キャッシュキー
-      #   末尾の `v0.8` も同時に `v0.9` へ更新する必要がある。`v0.8` のままだと
-      #   過去 cache が hit して 0.8.x バイナリが使われ続け、新 0.9.x が install
-      #   step で skip される (`steps.cache-worker-build.outputs.cache-hit == 'true'`)。
-      #   インストールコマンドとキャッシュキーの **2 箇所同時更新** が必須。
+      #   worker-build は `@=0.8.1` に固定している（`@^0.8` だと 0.8.5 を引き当て、
+      #   wasm-bindgen 0.2.118 と非互換でビルドが壊れるため）。別バージョンへ上げる場合は
+      #   `cargo install worker-build@=0.8.1` と本キャッシュキー末尾の `v0.8.1` を同時に
+      #   更新する。key を据え置くと過去 cache が hit して旧バイナリが使われ続ける
+      #   (`steps.cache-worker-build.outputs.cache-hit == 'true'`)。
       #   `deploy-workers.yml` の同箇所と同契約。
       - name: Cache worker-build binary
         id: cache-worker-build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/worker-build
-          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8
+          key: worker-build-${{ runner.os }}-${{ runner.arch }}-v0.8.1
       - name: Install worker-build
         if: steps.cache-worker-build.outputs.cache-hit != 'true'
-        run: cargo install -q worker-build@^0.8 --locked
+        run: cargo install -q worker-build@=0.8.1 --locked
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: crates/rshogi-csa-server-workers/package.json


### PR DESCRIPTION
## 概要
CI の worker-build インストールを exact version pin する。

`cargo install worker-build@^0.8` は最新 0.8.x(現状 **0.8.5**)を引き当てるが、0.8.5 は `Cargo.lock` の **wasm-bindgen 0.2.118** と非互換でデプロイ/wasm ビルドが壊れる。`--locked` は worker-build 自身の依存のみ固定し、worker-build 本体の選択バージョンは固定しない。既知良好の **0.8.1** に `@=0.8.1` で pin する。

併せて `actions/cache` のキー末尾を `v0.8` → `v0.8.1` に bump。据え置くと過去に 0.8.5 を焼いた cache が hit して pin が無効化されるため。

## 変更
- `deploy-workers.yml`: staging/production の install 2 箇所 + cache key 2 箇所
- `workers-smoke.yml`: install 1 箇所 + cache key 1 箇所
- 該当コメント(二重管理の注意書き)を新方針に更新

## 検証
- 全 `worker-build@` install が `@=0.8.1`、全 cache key が `-v0.8.1` に更新済みを grep 確認
- 両 YAML の `yaml.safe_load` パス
- dual review 済(Opus 実装 / Fable approve、指摘なし)