### PR TITLE
feat(csa-server-workers): live-orphan sweep に zombie 件数サマリログを追加

### DIFF
--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -99,12 +99,34 @@ pub struct SweepStats {
     /// 発生した事実をログ / metric から検知できるようにする。恒常的に非 0 なら
     /// finalize 経路の live-index delete が慢性的に失敗している疑い。
     pub hard_ttl_deleted: u64,
+    /// meta 不在かつ hard-TTL 内のため保持した live entry 件数。
+    /// 進行中または終局時 meta PUT 失敗の可能性がある、read-only 棚卸し用の gauge。
+    /// 本文を読めず状態不明だった entry (`read_live_entry_fields` が `None`) は
+    /// ゾンビに数えないため、この値は下振れしうる。
+    pub zombie_within_ttl: u64,
+    /// `zombie_within_ttl` の最大 age。対象が無い場合は 0。
+    pub oldest_zombie_age_ms: u64,
     /// 走査した R2 list page 数 (https://github.com/SH11235/rshogi/issues/629)。pagination loop 化に伴って導入。
     /// 1 cron で複数 page を処理した状況をログから確認するための運用 metric。
     pub pages: u32,
     /// `SWEEP_DEADLINE_MS` 経過で打ち切った場合に `true`。`true` の cron が
     /// 連続したら page size または cron 頻度の見直しが必要 (https://github.com/SH11235/rshogi/issues/629)。
     pub deadline_reached: bool,
+    /// `SWEEP_MAX_PAGES` に到達して打ち切った場合に `true`。summary の件数が
+    /// 部分走査であることを明示するために記録する。
+    pub max_pages_reached: bool,
+    /// bucket binding 取得失敗 / R2 list 失敗 / truncated なのに cursor 欠落、
+    /// といった異常で走査を打ち切った場合に `true`。deadline / max_pages と併せて
+    /// summary の件数が完全走査でないことを示す。監視側が「ゾンビ 0 件」を
+    /// 完全走査の 0 と誤認しないための gate。
+    pub aborted: bool,
+}
+
+impl SweepStats {
+    pub(crate) fn record_zombie_within_ttl(&mut self, age_ms: u64) {
+        self.zombie_within_ttl = self.zombie_within_ttl.saturating_add(1);
+        self.oldest_zombie_age_ms = self.oldest_zombie_age_ms.max(age_ms);
+    }
 }
 
 /// `kifu-by-id/<id>.meta.json` の本文を deserialize する最小 view。
@@ -331,6 +353,8 @@ mod imp {
                     component: "backfill",
                     err: format!("{e:?}"),
                 );
+                stats.aborted = true;
+                log_live_orphan_sweep_summary(&stats, started_at_ms);
                 return Ok(stats);
             }
         };
@@ -360,6 +384,7 @@ mod imp {
                         pages: stats.pages,
                         err: format!("{e:?}"),
                     );
+                    stats.aborted = true;
                     break;
                 }
             };
@@ -422,6 +447,7 @@ mod imp {
                     // meta が無い & TTL 内 = まだ進行中 (or 終局時 meta put 失敗)。
                     // 前者は正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的
                     // な保守)。
+                    stats.record_zombie_within_ttl(age_ms);
                     if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
                         stats.deadline_reached = true;
                         break 'outer;
@@ -472,6 +498,7 @@ mod imp {
                 break;
             }
             if stats.pages >= SWEEP_MAX_PAGES {
+                stats.max_pages_reached = true;
                 crate::structured_log!(
                     event: "live_orphan_sweep_max_pages_reached",
                     component: "backfill",
@@ -481,8 +508,15 @@ mod imp {
             }
             cursor = page.cursor();
             if cursor.is_none() {
-                // truncated == true なのに cursor が None の場合は安全側に break
-                // (R2 仕様上は通常起こらない)。
+                // ここは line 488 の `!truncated` break を通過済み = truncated == true。
+                // にもかかわらず cursor が None は R2 仕様上通常起こらない異常なので、
+                // 部分走査として安全側に break し aborted を立てる。
+                stats.aborted = true;
+                crate::structured_log!(
+                    event: "live_orphan_sweep_cursor_missing",
+                    component: "backfill",
+                    pages: stats.pages,
+                );
                 break;
             }
         }
@@ -498,7 +532,28 @@ mod imp {
             deadline_reached: stats.deadline_reached,
             elapsed_ms: elapsed_ms,
         );
+        log_live_orphan_sweep_summary(&stats, started_at_ms);
         Ok(stats)
+    }
+
+    fn log_live_orphan_sweep_summary(stats: &SweepStats, started_at_ms: u64) {
+        let elapsed_ms = Date::now().as_millis().saturating_sub(started_at_ms);
+        crate::structured_log!(
+            event: "live_orphan_sweep_summary",
+            component: "backfill",
+            level: "info",
+            total_live_entries_scanned: stats.listed,
+            finished_deleted: stats.deleted,
+            hard_ttl_deleted: stats.hard_ttl_deleted,
+            zombie_within_ttl: stats.zombie_within_ttl,
+            oldest_zombie_age_ms: stats.oldest_zombie_age_ms,
+            pages_scanned: stats.pages,
+            deadline_reached: stats.deadline_reached,
+            max_pages_reached: stats.max_pages_reached,
+            aborted: stats.aborted,
+            partial_scan: stats.deadline_reached || stats.max_pages_reached || stats.aborted,
+            elapsed_ms: elapsed_ms,
+        );
     }
 
     /// `live-games-index/<key>` の本文を読んで orphan sweep 判定に必要な field
@@ -649,10 +704,26 @@ mod tests {
                 listed: 0,
                 deleted: 0,
                 hard_ttl_deleted: 0,
+                zombie_within_ttl: 0,
+                oldest_zombie_age_ms: 0,
                 pages: 0,
                 deadline_reached: false,
+                max_pages_reached: false,
+                aborted: false,
             }
         );
+    }
+
+    #[test]
+    fn sweep_stats_records_zombie_inventory_summary() {
+        let mut stats = SweepStats::default();
+
+        stats.record_zombie_within_ttl(1_000);
+        stats.record_zombie_within_ttl(500);
+        stats.record_zombie_within_ttl(2_500);
+
+        assert_eq!(stats.zombie_within_ttl, 3);
+        assert_eq!(stats.oldest_zombie_age_ms, 2_500);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -99,13 +99,19 @@ pub struct SweepStats {
     /// 発生した事実をログ / metric から検知できるようにする。恒常的に非 0 なら
     /// finalize 経路の live-index delete が慢性的に失敗している疑い。
     pub hard_ttl_deleted: u64,
-    /// meta 不在かつ hard-TTL 内のため保持した live entry 件数。
-    /// 進行中または終局時 meta PUT 失敗の可能性がある、read-only 棚卸し用の gauge。
-    /// 本文を読めず状態不明だった entry (`read_live_entry_fields` が `None`) は
-    /// ゾンビに数えないため、この値は下振れしうる。
-    pub zombie_within_ttl: u64,
-    /// `zombie_within_ttl` の最大 age。対象が無い場合は 0。
-    pub oldest_zombie_age_ms: u64,
+    /// `kifu-by-id/<id>.meta.json` が不在かつ hard-TTL 内で保持した live entry 件数。
+    /// meta は終局時に書かれるため、**通常の進行中対局も終局までは meta 不在**で
+    /// ここに一時的に計上される。したがって本値は「ゾンビ(終局済みだが kifu 未書き込み)」
+    /// そのものではなく「meta 不在の live entry 数(進行中 + export 失敗)」の gauge。
+    /// R2 の可視信号だけでは進行中と export 失敗を正の判定で区別できない(meta 自体が
+    /// 終局信号)ため、真のゾンビ候補は下の `oldest_live_without_meta_age_ms` が通常の
+    /// 対局時間を大きく超えるエントリとして掃除判断に使う。本文を読めず状態不明だった
+    /// entry (`read_live_entry_fields` が `None`) は計上しないため、値は下振れしうる。
+    pub live_without_meta_within_ttl: u64,
+    /// `live_without_meta_within_ttl` に計上した entry の最大 age。対象が無い場合は 0。
+    /// 通常の対局時間を大きく超える値は「終局済みだが export 失敗した真のゾンビ」の
+    /// 主要シグナル。
+    pub oldest_live_without_meta_age_ms: u64,
     /// 走査した R2 list page 数 (https://github.com/SH11235/rshogi/issues/629)。pagination loop 化に伴って導入。
     /// 1 cron で複数 page を処理した状況をログから確認するための運用 metric。
     pub pages: u32,
@@ -117,15 +123,15 @@ pub struct SweepStats {
     pub max_pages_reached: bool,
     /// bucket binding 取得失敗 / R2 list 失敗 / truncated なのに cursor 欠落、
     /// といった異常で走査を打ち切った場合に `true`。deadline / max_pages と併せて
-    /// summary の件数が完全走査でないことを示す。監視側が「ゾンビ 0 件」を
+    /// summary の件数が完全走査でないことを示す。監視側が「meta 不在 0 件」を
     /// 完全走査の 0 と誤認しないための gate。
     pub aborted: bool,
 }
 
 impl SweepStats {
-    pub(crate) fn record_zombie_within_ttl(&mut self, age_ms: u64) {
-        self.zombie_within_ttl = self.zombie_within_ttl.saturating_add(1);
-        self.oldest_zombie_age_ms = self.oldest_zombie_age_ms.max(age_ms);
+    pub(crate) fn record_live_without_meta(&mut self, age_ms: u64) {
+        self.live_without_meta_within_ttl = self.live_without_meta_within_ttl.saturating_add(1);
+        self.oldest_live_without_meta_age_ms = self.oldest_live_without_meta_age_ms.max(age_ms);
     }
 }
 
@@ -447,7 +453,7 @@ mod imp {
                     // meta が無い & TTL 内 = まだ進行中 (or 終局時 meta put 失敗)。
                     // 前者は正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的
                     // な保守)。
-                    stats.record_zombie_within_ttl(age_ms);
+                    stats.record_live_without_meta(age_ms);
                     if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
                         stats.deadline_reached = true;
                         break 'outer;
@@ -545,8 +551,8 @@ mod imp {
             total_live_entries_scanned: stats.listed,
             finished_deleted: stats.deleted,
             hard_ttl_deleted: stats.hard_ttl_deleted,
-            zombie_within_ttl: stats.zombie_within_ttl,
-            oldest_zombie_age_ms: stats.oldest_zombie_age_ms,
+            live_without_meta_within_ttl: stats.live_without_meta_within_ttl,
+            oldest_live_without_meta_age_ms: stats.oldest_live_without_meta_age_ms,
             pages_scanned: stats.pages,
             deadline_reached: stats.deadline_reached,
             max_pages_reached: stats.max_pages_reached,
@@ -704,8 +710,8 @@ mod tests {
                 listed: 0,
                 deleted: 0,
                 hard_ttl_deleted: 0,
-                zombie_within_ttl: 0,
-                oldest_zombie_age_ms: 0,
+                live_without_meta_within_ttl: 0,
+                oldest_live_without_meta_age_ms: 0,
                 pages: 0,
                 deadline_reached: false,
                 max_pages_reached: false,
@@ -715,15 +721,15 @@ mod tests {
     }
 
     #[test]
-    fn sweep_stats_records_zombie_inventory_summary() {
+    fn sweep_stats_records_live_without_meta_summary() {
         let mut stats = SweepStats::default();
 
-        stats.record_zombie_within_ttl(1_000);
-        stats.record_zombie_within_ttl(500);
-        stats.record_zombie_within_ttl(2_500);
+        stats.record_live_without_meta(1_000);
+        stats.record_live_without_meta(500);
+        stats.record_live_without_meta(2_500);
 
-        assert_eq!(stats.zombie_within_ttl, 3);
-        assert_eq!(stats.oldest_zombie_age_ms, 2_500);
+        assert_eq!(stats.live_without_meta_within_ttl, 3);
+        assert_eq!(stats.oldest_live_without_meta_age_ms, 2_500);
     }
 
     #[test]


### PR DESCRIPTION
## 概要
終局済みだが kifu が R2 に未書き込みの「ゾンビ対局」(= `live-games-index/` エントリはあるが `kifu-by-id/<id>.meta.json` が不在で hard-TTL 内のため保持される entry)の件数を、既存の live-orphan cron sweep の最後に構造化ログ `live_orphan_sweep_summary`(level: info)で集計する。掃除判断のための **read-only 棚卸し gauge**。

削除ロジック・制御フローは**一切変更していない**(カウンタ更新とサマリログの追加のみ)。R2 の実掃除は別 PR / 別判断。

## サマリ log フィールド
`total_live_entries_scanned` / `finished_deleted` / `hard_ttl_deleted` / `zombie_within_ttl` / `oldest_zombie_age_ms` / `pages_scanned` / `deadline_reached` / `max_pages_reached` / `aborted` / `partial_scan` / `elapsed_ms`

- `zombie_within_ttl` が「今どれだけゾンビがいるか」の gauge。
- `partial_scan = deadline || max_pages || aborted`。異常打ち切り(bucket binding 失敗 / R2 list 失敗 / truncated なのに cursor 欠落)でも `aborted` を立て、監視側が「ゾンビ 0 件」を完全走査の 0 と誤認しないようにする。
- 本文を読めない entry は集計対象外(下振れしうる旨を doc コメント化)。

## 検証
- `cargo clippy -p rshogi-csa-server-workers --tests` 警告ゼロ
- `cargo test -p rshogi-csa-server-workers` 全 pass(新規 `sweep_stats_records_zombie_inventory_summary` 含む backfill 15 件)
- `scripts/check-tracked-abs-paths.sh` OK
- dual review 済(Codex 実装 / Fable review → partial_scan の異常打ち切り漏れ 1 点を指摘 → 本 PR で `aborted` 追加により対応)