### PR TITLE
feat(csa-server-workers): 結果コード契約マニフェスト + generate-and-compare テスト

### DIFF
--- a/crates/rshogi-csa-server-workers/contracts/README.md
+++ b/crates/rshogi-csa-server-workers/contracts/README.md
@@ -1,0 +1,3 @@
+# result-codes.json
+
+`result-codes.json` は rshogi 側で管理する結果コード契約の canonical copy です。ramu-shogi にはこのファイルの byte-identical copy を置き、完全再現性を保つため `generated_from` などの非決定的なフィールドは追加しないでください。

--- a/crates/rshogi-csa-server-workers/contracts/result-codes.json
+++ b/crates/rshogi-csa-server-workers/contracts/result-codes.json
@@ -1,0 +1,56 @@
+{
+  "variants": [
+    {
+      "variant": "Toryo",
+      "csa_code": "#RESIGN",
+      "end_reason": "RESIGN"
+    },
+    {
+      "variant": "TimeUp",
+      "csa_code": "#TIME_UP",
+      "end_reason": "TIME_UP"
+    },
+    {
+      "variant": "IllegalMove",
+      "csa_code": "#ILLEGAL_MOVE",
+      "end_reason": "ILLEGAL"
+    },
+    {
+      "variant": "Kachi",
+      "csa_code": "#JISHOGI",
+      "end_reason": "JISHOGI"
+    },
+    {
+      "variant": "OuteSennichite",
+      "csa_code": "#OUTE_SENNICHITE",
+      "end_reason": "OUTE_SENNICHITE"
+    },
+    {
+      "variant": "Sennichite",
+      "csa_code": "#SENNICHITE",
+      "end_reason": "SENNICHITE"
+    },
+    {
+      "variant": "MaxMoves",
+      "csa_code": "#MAX_MOVES",
+      "end_reason": "MAX_MOVES"
+    },
+    {
+      "variant": "Abnormal",
+      "csa_code": "#ABNORMAL",
+      "end_reason": "ABNORMAL"
+    }
+  ],
+  "csa_outcome_codes": [
+    "#WIN",
+    "#LOSE",
+    "#DRAW",
+    "#CENSORED"
+  ],
+  "result_kinds": [
+    "WIN_BLACK",
+    "WIN_WHITE",
+    "DRAW",
+    "ABORT"
+  ]
+}

--- a/crates/rshogi-csa-server-workers/tests/result_codes_contract.rs
+++ b/crates/rshogi-csa-server-workers/tests/result_codes_contract.rs
@@ -1,0 +1,170 @@
+use rshogi_csa_server::{
+    game::result::{GameResult, IllegalReason},
+    record::kifu::primary_result_code,
+    types::Color,
+};
+use rshogi_csa_server_workers::games_index::classify_result;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ResultCodesContract {
+    variants: Vec<ResultVariantRow>,
+    csa_outcome_codes: Vec<&'static str>,
+    result_kinds: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct ResultVariantRow {
+    variant: &'static str,
+    csa_code: &'static str,
+    end_reason: &'static str,
+}
+
+#[test]
+fn result_codes_contract_matches_committed_manifest() {
+    let generated = build_contract_json();
+    let committed = include_str!("../contracts/result-codes.json");
+
+    assert_eq!(generated, committed);
+}
+
+fn build_contract_json() -> String {
+    let contract = ResultCodesContract {
+        variants: variant_rows(),
+        csa_outcome_codes: csa_outcome_codes(),
+        result_kinds: result_kinds(),
+    };
+
+    let mut json = serde_json::to_string_pretty(&contract).expect("contract serializes to JSON");
+    json.push('\n');
+    json
+}
+
+fn variant_rows() -> Vec<ResultVariantRow> {
+    [
+        GameResult::Toryo {
+            winner: Color::Black,
+        },
+        GameResult::TimeUp {
+            loser: Color::Black,
+        },
+        GameResult::IllegalMove {
+            loser: Color::Black,
+            reason: IllegalReason::Generic,
+        },
+        GameResult::Kachi {
+            winner: Color::Black,
+        },
+        GameResult::OuteSennichite {
+            loser: Color::Black,
+        },
+        GameResult::Sennichite,
+        GameResult::MaxMoves,
+        GameResult::Abnormal { winner: None },
+    ]
+    .iter()
+    .map(result_variant_row)
+    .collect()
+}
+
+fn result_variant_row(result: &GameResult) -> ResultVariantRow {
+    let variant = match result {
+        GameResult::Toryo { .. } => "Toryo",
+        GameResult::TimeUp { .. } => "TimeUp",
+        GameResult::IllegalMove { .. } => "IllegalMove",
+        GameResult::Kachi { .. } => "Kachi",
+        GameResult::OuteSennichite { .. } => "OuteSennichite",
+        GameResult::Sennichite => "Sennichite",
+        GameResult::MaxMoves => "MaxMoves",
+        GameResult::Abnormal { .. } => "Abnormal",
+    };
+    let (_, end_reason) = classify_result(result);
+
+    ResultVariantRow {
+        variant,
+        csa_code: primary_result_code(result),
+        end_reason,
+    }
+}
+
+fn csa_outcome_codes() -> Vec<&'static str> {
+    let mut codes = Vec::new();
+    for result in outcome_representative_results() {
+        let reason_code = primary_result_code(&result);
+        for (_, lines) in result.server_messages().sends {
+            for line in lines {
+                if line != reason_code && !codes.contains(&line.as_str()) {
+                    codes.push(outcome_code_name(&line));
+                }
+            }
+        }
+    }
+    codes
+}
+
+fn outcome_representative_results() -> Vec<GameResult> {
+    vec![
+        GameResult::Toryo {
+            winner: Color::Black,
+        },
+        GameResult::TimeUp {
+            loser: Color::Black,
+        },
+        GameResult::IllegalMove {
+            loser: Color::Black,
+            reason: IllegalReason::Generic,
+        },
+        GameResult::Kachi {
+            winner: Color::Black,
+        },
+        GameResult::OuteSennichite {
+            loser: Color::Black,
+        },
+        GameResult::Sennichite,
+        GameResult::MaxMoves,
+        GameResult::Abnormal {
+            winner: Some(Color::Black),
+        },
+        GameResult::Abnormal { winner: None },
+    ]
+}
+
+fn outcome_code_name(code: &str) -> &'static str {
+    match code {
+        "#WIN" => "#WIN",
+        "#LOSE" => "#LOSE",
+        "#DRAW" => "#DRAW",
+        "#CENSORED" => "#CENSORED",
+        other => panic!("unknown CSA outcome code: {other}"),
+    }
+}
+
+fn result_kinds() -> Vec<&'static str> {
+    let mut kinds = Vec::new();
+    for result in result_kind_representative_results() {
+        let (kind, _) = classify_result(&result);
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
+    }
+    kinds
+}
+
+fn result_kind_representative_results() -> Vec<GameResult> {
+    // 先頭 4 件で committed JSON の順序 (WIN_BLACK, WIN_WHITE, DRAW, ABORT) を固定し、
+    // 続けて全 variant(両色を含む outcome 代表値)を回す。これにより、いずれかの
+    // variant が将来新しい result_kind を生むようになれば集合が増えて byte 不一致で
+    // 検知できる(4 代表値だけだと非代表 variant 経由の新 kind を取りこぼす)。
+    let mut results = vec![
+        GameResult::Toryo {
+            winner: Color::Black,
+        },
+        GameResult::Toryo {
+            winner: Color::White,
+        },
+        GameResult::Sennichite,
+        GameResult::Abnormal { winner: None },
+    ];
+    results.extend(outcome_representative_results());
+    results
+}


### PR DESCRIPTION
## 概要
対局結果コードの語彙を rshogi 単一ソース化するための **canonical マニフェスト**
`crates/rshogi-csa-server-workers/contracts/result-codes.json` と、その一致を強制する
generate-and-compare テストを追加。web client(ramu-shogi)はこのファイルの
**byte-identical コピー**を持ち、両側の contract test で同期を担保する
(#ABNORMAL 欠落による再接続ループ障害の根本対策)。

## 設計(Fable 設計レビュー採用)
- JSON は決定的な語彙のみ(variant 行 `{variant,csa_code,end_reason}` / `csa_outcome_codes` / `result_kinds`)。`generated_from` 等の非決定フィールドは持たせず、再現性を担保。
- `tests/result_codes_contract.rs` は `GameResult` の **exhaustive match(wildcard 無し)** で JSON を再構築し `primary_result_code`/`classify_result`/`server_messages` からコードを導出、`include_str!` と byte 一致を assert。
  - variant 追加 → 非網羅 match でコンパイル失敗(compile-time 保護)
  - 語彙変更 → cargo test の byte 不一致で失敗(rust-ci が追加設定なしに強制)
- runtime fallback(既存の未知 `#`→abort)は維持。2 リポジトリ間コピー漏れのみ CI で直接は捕まらないため、ramu 側に scheduled 乖離検知 workflow を追加(別 PR)。

## 検証
- `cargo test -p rshogi-csa-server-workers`(contract test pass)/ `cargo clippy --tests` 警告ゼロ
- dual review: Codex 実装 → Fable review(result_kinds の代表値が全 variant を網羅せず非代表 variant 経由の新 kind を取りこぼす点を指摘 → 全 variant を回すよう修正)

対の web client PR: SH11235/ramu-shogi#83