### PR TITLE
refactor(tools): 進捗表示を tools::progress に共通化し book_rescore に進捗を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -13,7 +13,7 @@
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |
-| `book_rescore` | YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与（[詳細](docs/book_rescore.md)） |
+| `book_rescore` | YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与、実行中は進捗/ETA を stderr 表示（[詳細](docs/book_rescore.md)） |
 
 ### 棋譜閲覧
 
@@ -94,7 +94,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の ONNX 再スコアリング（qsearch-leaf ラベル / dual-output / `--onnx-sessions` in-flight 多重化対応）
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み）
-- [book_rescore](docs/book_rescore.md) - YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与
+- [book_rescore](docs/book_rescore.md) - YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与（実行中は進捗/ETA を stderr 表示）
 
 各ツールのオプション一覧は `--help` で確認できます。
 

--- a/crates/tools/docs/book_rescore.md
+++ b/crates/tools/docs/book_rescore.md
@@ -55,6 +55,10 @@ cargo run -p tools --release --bin book_rescore -- \
 | `--parallel <N>` | 並列エンジン数。既定 1 |
 | `--no-parent-search` | 親局面探索を無効化。既定有効 |
 
+## 進捗表示
+
+探索タスク（親局面・子局面の一意な探索数）を分母に、進捗を stderr へ表示します。`go nodes N` × 局面数で数時間規模になり得るため、% / 処理速度（pos/s）/ 残り時間 / 完了予定時刻を出します。TTY ではプログレスバー、非TTY（ログリダイレクト時）では `[book_rescore] ...` の 1 行ログを定期的に出力します（`rescore_psv` と共通の `tools::progress` を使用）。分母は `--resume` で skip された局面を除いた「実際に探索するタスク数」です。
+
 ## value の規約
 
 各候補手は、親局面にその手を適用した子局面を探索して評価します。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -30,7 +30,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) value head で静的評価し `eval_dl`（先手視点 cp）を追記（`dlshogi-onnx` feature、default 有効） |
 | `yardstick_label` | ラベル品質「物差し」ステージ 1。held-out hcpe を labeler（NNUE + 固定 depth）の決定的探索でラベル付けし採点用 jsonl（手番側視点 `wdl`/`eval_ref`/`eval_label` + class）を出す |
 | `yardstick_score` | ラベル品質「物差し」ステージ 2。`yardstick_label` 出力を engine ごとに勝率スケール較正し per-class の WDL logloss / 参照天井（符号一致）/ リファレンス一致（win-prob MAE・Spearman）を出す |
-| `book_rescore` | YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与し、journal/resume と集計 report を出力 |
+| `book_rescore` | YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与し、journal/resume と集計 report を出力（実行中は進捗/ETA を stderr 表示） |
 
 ## NNUE 学習
 

--- a/crates/tools/src/bin/book_rescore.rs
+++ b/crates/tools/src/bin/book_rescore.rs
@@ -11,6 +11,7 @@ use crossbeam_channel as chan;
 use rshogi_core::position::Position;
 use rshogi_core::types::{Color, Move};
 use serde::{Deserialize, Serialize};
+use tools::progress::MultiFileProgress;
 use tools::selfplay::{EngineConfig, EngineProcess};
 
 const BOOK_HEADER: &str = "#YANEURAOU-DB2016 1.00";
@@ -498,30 +499,48 @@ fn run_static_onnx(
         .with_context(|| format!("journal を追記オープンできません: {}", cli.journal.display()))?;
     let writer = Mutex::new(BufWriter::new(journal_file));
 
-    // `--onnx-batch-size` 単位で推論→即 journal 追記する。全 tasks を 1 回で評価して
-    // から追記すると、途中の SIGTERM/OOM/ORT エラーで 1 件も保存されず --resume が
-    // 最初からやり直しになる。batch ごとに区切ることで、完了済み batch は journal に
-    // 残り（中断耐性）、保持する局面も 1 batch 分に抑えられる（メモリ非依存）。
-    let batch_size = cli.onnx_batch_size.max(1);
-    for chunk in tasks.chunks(batch_size) {
-        let positions: Vec<Position> = chunk.iter().map(|task| task.position.clone()).collect();
-        let child_scores = evaluator.evaluate(&positions)?;
-        for (task, child_score) in chunk.iter().zip(child_scores) {
-            let record = JournalRecord {
-                kind: JournalKind::Child,
-                sfen: task.key.clone(),
-                go: "static".to_string(),
-                engine_fingerprint: engine_fingerprint.to_string(),
-                value: Some(value_from_child_score(child_score)),
-                depth: Some(0),
-                bestmove: None,
-            };
-            append_journal_record(&writer, &record)?;
-            if let (Some(value), Some(depth)) = (record.value, record.depth) {
-                journal.child.insert(record.sfen, EvalRecord { value, depth });
+    // 進捗表示（子局面タスク数を分母に、batch 完了ごとに前進）。
+    let progress = MultiFileProgress::new(tasks.len() as u64, 1, "book_rescore");
+    let file_progress = progress.start_file("book", 1, tasks.len() as u64);
+
+    // 本体を closure に閉じ込め、途中の `?` 早期 return でもバーを確実に締める
+    // （成功→finish、失敗→abandon）。
+    let outcome = (|| -> Result<()> {
+        // `--onnx-batch-size` 単位で推論→即 journal 追記する。全 tasks を 1 回で評価して
+        // から追記すると、途中の SIGTERM/OOM/ORT エラーで 1 件も保存されず --resume が
+        // 最初からやり直しになる。batch ごとに区切ることで、完了済み batch は journal に
+        // 残り（中断耐性）、保持する局面も 1 batch 分に抑えられる（メモリ非依存）。
+        let batch_size = cli.onnx_batch_size.max(1);
+        for chunk in tasks.chunks(batch_size) {
+            let positions: Vec<Position> = chunk.iter().map(|task| task.position.clone()).collect();
+            let child_scores = evaluator.evaluate(&positions)?;
+            for (task, child_score) in chunk.iter().zip(child_scores) {
+                let record = JournalRecord {
+                    kind: JournalKind::Child,
+                    sfen: task.key.clone(),
+                    go: "static".to_string(),
+                    engine_fingerprint: engine_fingerprint.to_string(),
+                    value: Some(value_from_child_score(child_score)),
+                    depth: Some(0),
+                    bestmove: None,
+                };
+                append_journal_record(&writer, &record)?;
+                if let (Some(value), Some(depth)) = (record.value, record.depth) {
+                    journal.child.insert(record.sfen, EvalRecord { value, depth });
+                }
+                file_progress.inc(1);
             }
         }
+        Ok(())
+    })();
+    match &outcome {
+        Ok(()) => file_progress.finish_with_message("完了"),
+        Err(_) => file_progress.abandon_with_message("中断"),
     }
+    // 単一ファイルジョブなので overall は無く finish() は no-op（最終行は
+    // file_progress 側が出す）。複数ファイル化した場合の overall 締め用に呼んでおく。
+    progress.finish();
+    outcome?;
     Ok(())
 }
 
@@ -594,69 +613,92 @@ fn run_search_tasks(
     }
     drop(result_tx);
 
-    let journal_file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&cli.journal)
-        .with_context(|| format!("journal を追記オープンできません: {}", cli.journal.display()))?;
-    let writer = Mutex::new(BufWriter::new(journal_file));
+    // 進捗表示（探索タスク数を分母に、完了ごとに前進）。`go nodes N` × 局面数で
+    // 数時間規模になり得るため、% / pos/s / 残り時間 / 完了予定時刻を出す。worker
+    // 起動後に生成し、engine 起動時間を elapsed/ETA に混ぜない。
+    let progress = MultiFileProgress::new(task_count as u64, 1, "book_rescore");
+    let file_progress = progress.start_file("book", 1, task_count as u64);
 
-    let mut first_error: Option<anyhow::Error> = None;
-    let mut processed_count = 0usize;
-    for message in result_rx {
-        match message {
-            WorkerMessage::Task(Ok(search_result)) => {
-                processed_count += 1;
-                append_journal_record(&writer, &search_result.record)?;
-                match search_result.record.kind {
-                    JournalKind::Child => {
-                        if let (Some(value), Some(depth)) =
-                            (search_result.record.value, search_result.record.depth)
-                        {
-                            journal
-                                .child
-                                .insert(search_result.record.sfen, EvalRecord { value, depth });
+    // 本体を closure に閉じ込め、`?`/早期 return でもバーを確実に締める
+    // （成功→finish、失敗→abandon）。
+    let fp = &file_progress;
+    let outcome = (move || -> Result<()> {
+        let journal_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&cli.journal)
+            .with_context(|| {
+                format!("journal を追記オープンできません: {}", cli.journal.display())
+            })?;
+        let writer = Mutex::new(BufWriter::new(journal_file));
+
+        let mut first_error: Option<anyhow::Error> = None;
+        let mut processed_count = 0usize;
+        for message in result_rx {
+            match message {
+                WorkerMessage::Task(Ok(search_result)) => {
+                    processed_count += 1;
+                    fp.inc(1);
+                    append_journal_record(&writer, &search_result.record)?;
+                    match search_result.record.kind {
+                        JournalKind::Child => {
+                            if let (Some(value), Some(depth)) =
+                                (search_result.record.value, search_result.record.depth)
+                            {
+                                journal
+                                    .child
+                                    .insert(search_result.record.sfen, EvalRecord { value, depth });
+                            }
+                        }
+                        JournalKind::Parent => {
+                            journal.parent.insert(
+                                search_result.record.sfen,
+                                ParentRecord {
+                                    bestmove: search_result.record.bestmove,
+                                },
+                            );
                         }
                     }
-                    JournalKind::Parent => {
-                        journal.parent.insert(
-                            search_result.record.sfen,
-                            ParentRecord {
-                                bestmove: search_result.record.bestmove,
-                            },
-                        );
+                }
+                WorkerMessage::Task(Err(err)) => {
+                    processed_count += 1;
+                    fp.inc(1);
+                    if first_error.is_none() {
+                        first_error = Some(err);
                     }
                 }
+                WorkerMessage::Fatal(err) if first_error.is_none() => first_error = Some(err),
+                WorkerMessage::Fatal(_) => {}
             }
-            WorkerMessage::Task(Err(err)) => {
-                processed_count += 1;
-                if first_error.is_none() {
-                    first_error = Some(err);
-                }
-            }
-            WorkerMessage::Fatal(err) if first_error.is_none() => first_error = Some(err),
-            WorkerMessage::Fatal(_) => {}
         }
-    }
 
-    for handle in handles {
-        handle.join().map_err(|_| anyhow!("worker thread が panic しました"))?;
+        for handle in handles {
+            handle.join().map_err(|_| anyhow!("worker thread が panic しました"))?;
+        }
+        if processed_count < task_count {
+            return Err(search_tasks_incomplete_error(
+                processed_count,
+                task_count,
+                &cli.journal,
+                first_error,
+            ));
+        }
+        if let Some(err) = first_error {
+            return Err(err.context(format!(
+                "探索中にエラーが発生しました。journal には途中結果が追記済みのため --resume で再開できます: {}",
+                cli.journal.display()
+            )));
+        }
+        Ok(())
+    })();
+    match &outcome {
+        Ok(()) => file_progress.finish_with_message("完了"),
+        Err(_) => file_progress.abandon_with_message("中断"),
     }
-    if processed_count < task_count {
-        return Err(search_tasks_incomplete_error(
-            processed_count,
-            task_count,
-            &cli.journal,
-            first_error,
-        ));
-    }
-    if let Some(err) = first_error {
-        return Err(err.context(format!(
-            "探索中にエラーが発生しました。journal には途中結果が追記済みのため --resume で再開できます: {}",
-            cli.journal.display()
-        )));
-    }
-    Ok(())
+    // 単一ファイルジョブなので overall は無く finish() は no-op（最終行は
+    // file_progress 側が出す）。複数ファイル化した場合の overall 締め用に呼んでおく。
+    progress.finish();
+    outcome
 }
 
 fn worker_loop(

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -47,23 +47,27 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use glob::glob;
-use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
 use rayon::prelude::*;
 use std::cell::RefCell;
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, BufWriter, IsTerminal, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
+// Arc/Mutex/Instant は ONNX 直推論パイプライン専用（バッチ供給の Receiver 共有・
+// フェーズ計時）。ONNX 無効ビルドでの unused import を避けるため cfg で囲う。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, Instant};
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+use std::time::Instant;
 
 use rshogi_core::nnue::init_nnue;
 use rshogi_core::position::Position;
 use rshogi_core::search::{LimitsType, Search};
 use tools::packed_sfen::{PackedSfenValue, pack_position, unpack_sfen, unpack_sfen_to_parts};
+use tools::progress::{FileProgress, MultiFileProgress};
 // UnpackedSfen は ONNX 経路専用。ONNX 無効ビルドの unused import を避けるため cfg で囲う。
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 use tools::packed_sfen::UnpackedSfen;
@@ -607,335 +611,6 @@ fn expand_input_patterns(patterns: &[String]) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-// ============================================================
-// 進捗表示（% / 残り時間 / 完了予定時刻）
-// ============================================================
-
-/// 件数を k/M 短縮表記にする（523456 -> "523.5k", 1000000 -> "1.00M"）。
-fn compact_count(n: u64) -> String {
-    if n >= 1_000_000 {
-        format!("{:.2}M", n as f64 / 1.0e6)
-    } else if n >= 1_000 {
-        format!("{:.1}k", n as f64 / 1.0e3)
-    } else {
-        n.to_string()
-    }
-}
-
-/// 秒速を短縮表記にする（8338.0 -> "8.3k"）。
-fn compact_rate(per_sec: f64) -> String {
-    if per_sec >= 1_000_000.0 {
-        format!("{:.2}M", per_sec / 1.0e6)
-    } else if per_sec >= 1_000.0 {
-        format!("{:.1}k", per_sec / 1.0e3)
-    } else {
-        format!("{per_sec:.0}")
-    }
-}
-
-/// Duration を `H:MM:SS`（1h 以上）または `MM:SS` に整形する。
-fn fmt_hms(d: Duration) -> String {
-    let s = d.as_secs();
-    let (h, m, sec) = (s / 3600, (s % 3600) / 60, s % 60);
-    if h > 0 {
-        format!("{h}:{m:02}:{sec:02}")
-    } else {
-        format!("{m:02}:{sec:02}")
-    }
-}
-
-/// `now + eta` をローカル時刻 `MM/DD HH:MM` にする。長時間ジョブは日跨ぎするため
-/// 日付を必ず付ける。速度未確定（per_sec が 0）のときのみ `--/-- --:--`。
-/// 完了時は eta=0 だが per_sec は確定済みで、`now + 0` が現在時刻＝到着時刻になる。
-fn finish_clock(eta: Duration, per_sec: f64) -> String {
-    if per_sec <= 0.0 {
-        return "--/-- --:--".to_string();
-    }
-    match chrono::Duration::from_std(eta) {
-        Ok(d) => (chrono::Local::now() + d).format("%m/%d %H:%M").to_string(),
-        Err(_) => "--/-- --:--".to_string(),
-    }
-}
-
-/// テンプレートに共通のカスタムキー（短縮件数・完了予定時刻）を足す。
-fn with_progress_keys(style: ProgressStyle) -> ProgressStyle {
-    style
-        .with_key("cpos", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
-            let _ = write!(w, "{}", compact_count(s.pos()));
-        })
-        .with_key("clen", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
-            let _ = write!(w, "{}", compact_count(s.len().unwrap_or(0)));
-        })
-        .with_key("finish_at", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
-            let _ = write!(w, "{}", finish_clock(s.eta(), s.per_sec()));
-        })
-}
-
-#[cfg(test)]
-mod progress_format_tests {
-    use super::{Duration, compact_count, compact_rate, fmt_hms};
-
-    #[test]
-    fn compact_count_thresholds() {
-        assert_eq!(compact_count(0), "0");
-        assert_eq!(compact_count(999), "999");
-        assert_eq!(compact_count(1_000), "1.0k");
-        assert_eq!(compact_count(523_456), "523.5k");
-        assert_eq!(compact_count(1_000_000), "1.00M");
-        assert_eq!(compact_count(3_840_000), "3.84M");
-    }
-
-    #[test]
-    fn compact_rate_thresholds() {
-        assert_eq!(compact_rate(500.0), "500");
-        assert_eq!(compact_rate(8338.0), "8.3k");
-        assert_eq!(compact_rate(1_500_000.0), "1.50M");
-    }
-
-    #[test]
-    fn fmt_hms_minutes_and_hours() {
-        assert_eq!(fmt_hms(Duration::from_secs(0)), "00:00");
-        assert_eq!(fmt_hms(Duration::from_secs(90)), "01:30");
-        assert_eq!(fmt_hms(Duration::from_secs(600)), "10:00");
-        assert_eq!(fmt_hms(Duration::from_secs(3661)), "1:01:01");
-    }
-}
-
-/// 非TTY 時に定期ログ行を間引くための状態。
-struct LogThrottle {
-    last: Option<Instant>,
-    last_pct: f64,
-}
-
-const LOG_INTERVAL: Duration = Duration::from_secs(15);
-const LOG_PCT_STEP: f64 = 5.0;
-
-/// rescore 全体の進捗管理。glob の全ファイルを分母とした overall バーと、
-/// ファイル単位バーを束ねる。TTY ではバー描画、非TTY では定期ログ行に切替える。
-struct RescoreProgress {
-    multi: MultiProgress,
-    /// overall バーは複数ファイル時のみ（単一ファイルは per-file バーがそのまま全体）。
-    overall: Option<ProgressBar>,
-    total_files: usize,
-    is_tty: bool,
-    log: Arc<Mutex<LogThrottle>>,
-}
-
-impl RescoreProgress {
-    fn new(overall_total: u64, total_files: usize) -> Self {
-        let is_tty = std::io::stderr().is_terminal();
-        let multi = if is_tty {
-            MultiProgress::new()
-        } else {
-            // 非TTY ではバー描画をやめ、進捗は定期ログ行で出す（CR スパム回避）。
-            MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
-        };
-        let overall = if total_files > 1 {
-            let pb = multi.add(ProgressBar::new(overall_total));
-            pb.set_style(
-                with_progress_keys(ProgressStyle::default_bar().template(
-                    "全体 {percent:>3}% {cpos}/{clen} ({prefix}) {per_sec} 残り {eta_precise} 完了 {finish_at}",
-                ).expect("valid template")),
-            );
-            if is_tty {
-                pb.enable_steady_tick(Duration::from_millis(500));
-            }
-            Some(pb)
-        } else {
-            None
-        };
-        Self {
-            multi,
-            overall,
-            total_files,
-            is_tty,
-            log: Arc::new(Mutex::new(LogThrottle {
-                last: None,
-                last_pct: 0.0,
-            })),
-        }
-    }
-
-    /// 完了済み / skip されたファイル 1 個分を overall に反映する（per-file バーは作らない）。
-    fn skip_file(&self, n: u64) {
-        if let Some(o) = &self.overall {
-            o.inc(n);
-        }
-    }
-
-    /// 処理するファイル 1 個分の per-file 進捗ハンドルを作る。`shard_idx` は 1 始まり。
-    fn start_file(&self, label: &str, shard_idx: usize, len: u64) -> FileProgress {
-        let file = self.multi.add(ProgressBar::new(len));
-        if self.total_files > 1 {
-            file.set_style(
-                with_progress_keys(
-                    ProgressStyle::default_bar()
-                        .template("└ {prefix} {percent:>3}% {bar:30.cyan/blue} {cpos}/{clen}")
-                        .expect("valid template"),
-                )
-                .progress_chars("██░"),
-            );
-            file.set_prefix(label.to_string());
-            if let Some(o) = &self.overall {
-                o.set_prefix(format!("shard {shard_idx}/{}", self.total_files));
-            }
-        } else {
-            file.set_style(
-                with_progress_keys(
-                    ProgressStyle::default_bar()
-                        .template("[{elapsed_precise}] {bar:30.cyan/blue} {percent:>3}% {cpos}/{clen} {per_sec} 残り {eta_precise} 完了 {finish_at}")
-                        .expect("valid template"),
-                )
-                .progress_chars("██░"),
-            );
-        }
-        if self.is_tty {
-            file.enable_steady_tick(Duration::from_millis(500));
-        }
-        FileProgress {
-            file,
-            overall: self.overall.clone(),
-            is_tty: self.is_tty,
-            log: Arc::clone(&self.log),
-            label: label.to_string(),
-            shard_idx,
-            total_files: self.total_files,
-        }
-    }
-
-    /// 全ファイル完了。非TTY では overall の最終行を必ず 1 行出す。
-    fn finish(&self) {
-        if let Some(o) = &self.overall {
-            if !self.is_tty {
-                eprintln!(
-                    "[rescore] overall done {}/{} ({} files) {} pos/s took {}",
-                    compact_count(o.position()),
-                    compact_count(o.length().unwrap_or(0)),
-                    self.total_files,
-                    compact_rate(o.per_sec()),
-                    fmt_hms(o.elapsed()),
-                );
-            }
-            o.finish_and_clear();
-        }
-    }
-}
-
-/// 1 ファイル分の進捗ハンドル。`inc` で per-file と overall を同時に進める。
-/// 複数スレッドから呼ぶ search/engine 用に `Clone`（内部の ProgressBar / Arc は共有）。
-#[derive(Clone)]
-struct FileProgress {
-    file: ProgressBar,
-    overall: Option<ProgressBar>,
-    is_tty: bool,
-    log: Arc<Mutex<LogThrottle>>,
-    label: String,
-    shard_idx: usize,
-    total_files: usize,
-}
-
-impl FileProgress {
-    /// resume で既処理だった分を起点として進める（per-file/overall とも前進）。
-    /// 追記再開する ONNX 直推論モード専用。NNUE/USI モードは出力を File::create で
-    /// truncate して全件を再処理するため起点補正は不要（全件 inc で 100% に到達する）。
-    #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
-    fn advance_start(&self, n: u64) {
-        if n == 0 {
-            return;
-        }
-        self.file.inc(n);
-        if let Some(o) = &self.overall {
-            o.inc(n);
-        }
-    }
-
-    fn inc(&self, n: u64) {
-        self.file.inc(n);
-        if let Some(o) = &self.overall {
-            o.inc(n);
-        }
-        if !self.is_tty {
-            self.maybe_log(false);
-        }
-    }
-
-    fn set_message(&self, msg: &'static str) {
-        self.file.set_message(msg);
-    }
-
-    fn finish_with_message(&self, msg: &'static str) {
-        if !self.is_tty {
-            self.maybe_log(true);
-        }
-        if self.total_files > 1 {
-            // 複数ファイル時は overall を残して per-file バーだけ消す。
-            self.file.finish_and_clear();
-        } else {
-            self.file.finish_with_message(msg);
-        }
-    }
-
-    fn abandon_with_message(&self, msg: &'static str) {
-        self.file.abandon_with_message(msg);
-    }
-
-    /// 非TTY 用の 1 行ログ。`force` 時は throttle を無視して必ず出す。
-    fn maybe_log(&self, force: bool) {
-        // overall（複数ファイル）か per-file（単一）を「全体進捗」として使う。
-        let primary = self.overall.as_ref().unwrap_or(&self.file);
-        let pos = primary.position();
-        let len = primary.length().unwrap_or(0);
-        let pct = if len > 0 {
-            pos as f64 / len as f64 * 100.0
-        } else {
-            0.0
-        };
-
-        {
-            let mut th = self.log.lock().expect("log throttle poisoned");
-            if !force {
-                let due_time = th.last.map(|t| t.elapsed() >= LOG_INTERVAL).unwrap_or(true);
-                let due_pct = pct - th.last_pct >= LOG_PCT_STEP;
-                if !due_time && !due_pct {
-                    return;
-                }
-            }
-            th.last = Some(Instant::now());
-            th.last_pct = pct;
-        }
-
-        let rate = compact_rate(primary.per_sec());
-        let elapsed = fmt_hms(primary.elapsed());
-        // remaining = 残り時間（duration）、eta_clock = 完了予定の絶対時刻（ETA 本来の意味）。
-        let remaining = fmt_hms(primary.eta());
-        let eta_clock = finish_clock(primary.eta(), primary.per_sec());
-        if self.overall.is_some() {
-            let fpos = self.file.position();
-            let flen = self.file.length().unwrap_or(0);
-            let fpct = if flen > 0 {
-                fpos as f64 / flen as f64 * 100.0
-            } else {
-                0.0
-            };
-            eprintln!(
-                "[rescore] overall {pct:.1}% {}/{} shard {}/{} ({} {fpct:.1}%) {rate} pos/s elapsed {elapsed} remaining {remaining} ETA {eta_clock}",
-                compact_count(pos),
-                compact_count(len),
-                self.shard_idx,
-                self.total_files,
-                self.label,
-            );
-        } else {
-            eprintln!(
-                "[rescore] {} {pct:.1}% {}/{} {rate} pos/s elapsed {elapsed} remaining {remaining} ETA {eta_clock}",
-                self.label,
-                compact_count(pos),
-                compact_count(len),
-            );
-        }
-    }
-}
-
 fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
@@ -1240,7 +915,7 @@ fn main() -> Result<()> {
             }
         })
         .sum();
-    let rprog = RescoreProgress::new(overall_total, total_files);
+    let rprog = MultiFileProgress::new(overall_total, total_files, "rescore");
     for (file_idx, input_path) in input_files.iter().enumerate() {
         if INTERRUPTED.load(Ordering::SeqCst) {
             eprintln!("Processing interrupted");

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -51,6 +51,7 @@ pub mod kif;
 pub mod onnx_value;
 pub mod packed_sfen;
 pub mod positions;
+pub mod progress;
 pub mod qsearch_pv;
 #[cfg(feature = "kifu-player")]
 pub mod replay;

--- a/crates/tools/src/progress.rs
+++ b/crates/tools/src/progress.rs
@@ -1,0 +1,359 @@
+//! 複数ファイル / 長時間ジョブ向けの進捗表示ユーティリティ。
+//!
+//! rescore 系ツール（`rescore_psv` 等）と `book_rescore` で共有する。TTY では
+//! `indicatif` のバー描画、非TTY では CR スパムを避けて定期的な 1 行ログに切替える。
+//! overall バー（全ファイル分母）と per-file バーを束ね、% / pos/s / 残り時間 /
+//! 完了予定時刻を表示する。
+
+use std::io::IsTerminal;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
+
+// ============================================================
+// 進捗表示（% / 残り時間 / 完了予定時刻）
+// ============================================================
+
+/// 件数を k/M 短縮表記にする（523456 -> "523.5k", 1000000 -> "1.00M"）。
+fn compact_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.2}M", n as f64 / 1.0e6)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1.0e3)
+    } else {
+        n.to_string()
+    }
+}
+
+/// 秒速を短縮表記にする（8338.0 -> "8.3k"）。
+fn compact_rate(per_sec: f64) -> String {
+    if per_sec >= 1_000_000.0 {
+        format!("{:.2}M", per_sec / 1.0e6)
+    } else if per_sec >= 1_000.0 {
+        format!("{:.1}k", per_sec / 1.0e3)
+    } else {
+        format!("{per_sec:.0}")
+    }
+}
+
+/// Duration を `H:MM:SS`（1h 以上）または `MM:SS` に整形する。
+fn fmt_hms(d: Duration) -> String {
+    let s = d.as_secs();
+    let (h, m, sec) = (s / 3600, (s % 3600) / 60, s % 60);
+    if h > 0 {
+        format!("{h}:{m:02}:{sec:02}")
+    } else {
+        format!("{m:02}:{sec:02}")
+    }
+}
+
+/// `now + eta` をローカル時刻 `MM/DD HH:MM` にする。長時間ジョブは日跨ぎするため
+/// 日付を必ず付ける。速度未確定（per_sec が 0）のときのみ `--/-- --:--`。
+/// 完了時は eta=0 だが per_sec は確定済みで、`now + 0` が現在時刻＝到着時刻になる。
+fn finish_clock(eta: Duration, per_sec: f64) -> String {
+    if per_sec <= 0.0 {
+        return "--/-- --:--".to_string();
+    }
+    match chrono::Duration::from_std(eta) {
+        Ok(d) => (chrono::Local::now() + d).format("%m/%d %H:%M").to_string(),
+        Err(_) => "--/-- --:--".to_string(),
+    }
+}
+
+/// テンプレートに共通のカスタムキー（短縮件数・完了予定時刻）を足す。
+fn with_progress_keys(style: ProgressStyle) -> ProgressStyle {
+    style
+        .with_key("cpos", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
+            let _ = write!(w, "{}", compact_count(s.pos()));
+        })
+        .with_key("clen", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
+            let _ = write!(w, "{}", compact_count(s.len().unwrap_or(0)));
+        })
+        .with_key("finish_at", |s: &ProgressState, w: &mut dyn std::fmt::Write| {
+            let _ = write!(w, "{}", finish_clock(s.eta(), s.per_sec()));
+        })
+}
+
+/// 非TTY 時に定期ログ行を間引くための状態。
+struct LogThrottle {
+    last: Option<Instant>,
+    last_pct: f64,
+}
+
+const LOG_INTERVAL: Duration = Duration::from_secs(15);
+const LOG_PCT_STEP: f64 = 5.0;
+
+/// 複数入力ファイル（または 1 個の長時間ジョブ）の進捗管理。全ファイルを分母とした
+/// overall バーと、ファイル単位バーを束ねる。TTY ではバー描画、非TTY では定期ログ行に
+/// 切替える。
+pub struct MultiFileProgress {
+    multi: MultiProgress,
+    /// overall バーは複数ファイル時のみ（単一ファイルは per-file バーがそのまま全体）。
+    overall: Option<ProgressBar>,
+    total_files: usize,
+    is_tty: bool,
+    /// 非TTY ログ行の先頭タグ（例: "rescore" → `[rescore] ...`）。ツール識別用。
+    tag: &'static str,
+    log: Arc<Mutex<LogThrottle>>,
+}
+
+impl MultiFileProgress {
+    /// `tag` は非TTY ログ行の先頭に `[tag]` として付く（ツール名等）。
+    pub fn new(overall_total: u64, total_files: usize, tag: &'static str) -> Self {
+        let is_tty = std::io::stderr().is_terminal();
+        let multi = if is_tty {
+            MultiProgress::new()
+        } else {
+            // 非TTY ではバー描画をやめ、進捗は定期ログ行で出す（CR スパム回避）。
+            MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+        };
+        let overall = if total_files > 1 {
+            let pb = multi.add(ProgressBar::new(overall_total));
+            pb.set_style(
+                with_progress_keys(ProgressStyle::default_bar().template(
+                    "全体 {percent:>3}% {cpos}/{clen} ({prefix}) {per_sec} 残り {eta_precise} 完了 {finish_at}",
+                ).expect("valid template")),
+            );
+            if is_tty {
+                pb.enable_steady_tick(Duration::from_millis(500));
+            }
+            Some(pb)
+        } else {
+            None
+        };
+        Self {
+            multi,
+            overall,
+            total_files,
+            is_tty,
+            tag,
+            log: Arc::new(Mutex::new(LogThrottle {
+                last: None,
+                last_pct: 0.0,
+            })),
+        }
+    }
+
+    /// 完了済み / skip されたファイル 1 個分を overall に反映する（per-file バーは作らない）。
+    pub fn skip_file(&self, n: u64) {
+        if let Some(o) = &self.overall {
+            o.inc(n);
+        }
+    }
+
+    /// 処理するファイル 1 個分の per-file 進捗ハンドルを作る。`shard_idx` は 1 始まり。
+    pub fn start_file(&self, label: &str, shard_idx: usize, len: u64) -> FileProgress {
+        let file = self.multi.add(ProgressBar::new(len));
+        if self.total_files > 1 {
+            file.set_style(
+                with_progress_keys(
+                    ProgressStyle::default_bar()
+                        .template("└ {prefix} {percent:>3}% {bar:30.cyan/blue} {cpos}/{clen}")
+                        .expect("valid template"),
+                )
+                .progress_chars("██░"),
+            );
+            file.set_prefix(label.to_string());
+            if let Some(o) = &self.overall {
+                o.set_prefix(format!("shard {shard_idx}/{}", self.total_files));
+            }
+        } else {
+            file.set_style(
+                with_progress_keys(
+                    ProgressStyle::default_bar()
+                        .template("[{elapsed_precise}] {bar:30.cyan/blue} {percent:>3}% {cpos}/{clen} {per_sec} 残り {eta_precise} 完了 {finish_at}")
+                        .expect("valid template"),
+                )
+                .progress_chars("██░"),
+            );
+        }
+        if self.is_tty {
+            file.enable_steady_tick(Duration::from_millis(500));
+        }
+        FileProgress {
+            file,
+            overall: self.overall.clone(),
+            is_tty: self.is_tty,
+            log: Arc::clone(&self.log),
+            label: label.to_string(),
+            shard_idx,
+            total_files: self.total_files,
+            tag: self.tag,
+        }
+    }
+
+    /// 全ファイル完了。非TTY では overall の最終行を必ず 1 行出す。
+    pub fn finish(&self) {
+        if let Some(o) = &self.overall {
+            if !self.is_tty {
+                eprintln!(
+                    "[{}] overall done {}/{} ({} files) {} pos/s took {}",
+                    self.tag,
+                    compact_count(o.position()),
+                    compact_count(o.length().unwrap_or(0)),
+                    self.total_files,
+                    compact_rate(o.per_sec()),
+                    fmt_hms(o.elapsed()),
+                );
+            }
+            o.finish_and_clear();
+        }
+    }
+}
+
+/// 1 ファイル分の進捗ハンドル。`inc` で per-file と overall を同時に進める。
+/// 複数スレッドから呼ぶ search/engine 用に `Clone`（内部の ProgressBar / Arc は共有）。
+#[derive(Clone)]
+pub struct FileProgress {
+    file: ProgressBar,
+    overall: Option<ProgressBar>,
+    is_tty: bool,
+    log: Arc<Mutex<LogThrottle>>,
+    label: String,
+    shard_idx: usize,
+    total_files: usize,
+    tag: &'static str,
+}
+
+impl FileProgress {
+    /// resume で既処理だった分を起点として進める（per-file/overall とも前進）。
+    /// 追記再開型ツールで、既に journal/出力に記録済みの件数を進捗の起点へ反映する
+    /// 用途。出力を File::create で truncate して全件を再処理する型のツールでは呼ぶ
+    /// 必要はない（全件 inc で 100% に到達するため）。
+    pub fn advance_start(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.file.inc(n);
+        if let Some(o) = &self.overall {
+            o.inc(n);
+        }
+    }
+
+    /// per-file と overall を同時に `n` 前進させる。非TTY では throttle 付きの
+    /// 定期ログ行を出す（TTY ではバー更新のみ）。
+    pub fn inc(&self, n: u64) {
+        self.file.inc(n);
+        if let Some(o) = &self.overall {
+            o.inc(n);
+        }
+        if !self.is_tty {
+            self.maybe_log(false);
+        }
+    }
+
+    /// per-file バーに一時メッセージを設定する（TTY 表示用）。
+    pub fn set_message(&self, msg: &'static str) {
+        self.file.set_message(msg);
+    }
+
+    /// per-file を正常完了として締める。複数ファイル時は overall を残して per-file
+    /// バーだけ消し、単一ファイル時は完了メッセージ付きで確定する。非TTY では
+    /// 最終ログ行を必ず 1 行出す。
+    pub fn finish_with_message(&self, msg: &'static str) {
+        if !self.is_tty {
+            self.maybe_log(true);
+        }
+        if self.total_files > 1 {
+            // 複数ファイル時は overall を残して per-file バーだけ消す。
+            self.file.finish_and_clear();
+        } else {
+            self.file.finish_with_message(msg);
+        }
+    }
+
+    /// per-file を中断（失敗）として締める。バーは消さずメッセージを残す。
+    /// エラー経路での終了表示に使う。
+    pub fn abandon_with_message(&self, msg: &'static str) {
+        self.file.abandon_with_message(msg);
+    }
+
+    /// 非TTY 用の 1 行ログ。`force` 時は throttle を無視して必ず出す。
+    fn maybe_log(&self, force: bool) {
+        // overall（複数ファイル）か per-file（単一）を「全体進捗」として使う。
+        let primary = self.overall.as_ref().unwrap_or(&self.file);
+        let pos = primary.position();
+        let len = primary.length().unwrap_or(0);
+        let pct = if len > 0 {
+            pos as f64 / len as f64 * 100.0
+        } else {
+            0.0
+        };
+
+        {
+            let mut th = self.log.lock().expect("log throttle poisoned");
+            if !force {
+                let due_time = th.last.map(|t| t.elapsed() >= LOG_INTERVAL).unwrap_or(true);
+                let due_pct = pct - th.last_pct >= LOG_PCT_STEP;
+                if !due_time && !due_pct {
+                    return;
+                }
+            }
+            th.last = Some(Instant::now());
+            th.last_pct = pct;
+        }
+
+        let rate = compact_rate(primary.per_sec());
+        let elapsed = fmt_hms(primary.elapsed());
+        // remaining = 残り時間（duration）、eta_clock = 完了予定の絶対時刻（ETA 本来の意味）。
+        let remaining = fmt_hms(primary.eta());
+        let eta_clock = finish_clock(primary.eta(), primary.per_sec());
+        if self.overall.is_some() {
+            let fpos = self.file.position();
+            let flen = self.file.length().unwrap_or(0);
+            let fpct = if flen > 0 {
+                fpos as f64 / flen as f64 * 100.0
+            } else {
+                0.0
+            };
+            eprintln!(
+                "[{}] overall {pct:.1}% {}/{} shard {}/{} ({} {fpct:.1}%) {rate} pos/s elapsed {elapsed} remaining {remaining} ETA {eta_clock}",
+                self.tag,
+                compact_count(pos),
+                compact_count(len),
+                self.shard_idx,
+                self.total_files,
+                self.label,
+            );
+        } else {
+            eprintln!(
+                "[{}] {} {pct:.1}% {}/{} {rate} pos/s elapsed {elapsed} remaining {remaining} ETA {eta_clock}",
+                self.tag,
+                self.label,
+                compact_count(pos),
+                compact_count(len),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod progress_format_tests {
+    use super::{Duration, compact_count, compact_rate, fmt_hms};
+
+    #[test]
+    fn compact_count_thresholds() {
+        assert_eq!(compact_count(0), "0");
+        assert_eq!(compact_count(999), "999");
+        assert_eq!(compact_count(1_000), "1.0k");
+        assert_eq!(compact_count(523_456), "523.5k");
+        assert_eq!(compact_count(1_000_000), "1.00M");
+        assert_eq!(compact_count(3_840_000), "3.84M");
+    }
+
+    #[test]
+    fn compact_rate_thresholds() {
+        assert_eq!(compact_rate(500.0), "500");
+        assert_eq!(compact_rate(8338.0), "8.3k");
+        assert_eq!(compact_rate(1_500_000.0), "1.50M");
+    }
+
+    #[test]
+    fn fmt_hms_minutes_and_hours() {
+        assert_eq!(fmt_hms(Duration::from_secs(0)), "00:00");
+        assert_eq!(fmt_hms(Duration::from_secs(90)), "01:30");
+        assert_eq!(fmt_hms(Duration::from_secs(600)), "10:00");
+        assert_eq!(fmt_hms(Duration::from_secs(3661)), "1:01:01");
+    }
+}


### PR DESCRIPTION
## 概要

`rescore_psv` 内に private で埋まっていた進捗表示ヘルパを共有モジュール `tools::progress` に抽出し（挙動保存）、進捗表示が無かった `book_rescore` に進捗を追加する。`book_rescore`（#869 / #870）は `go nodes N × 局面数` や ONNX バッチ推論で数時間規模になり得るが、これまで進捗出力が皆無だった。

## 変更内容

- **新規 `crates/tools/src/progress.rs`（`tools::progress`）**
  - `rescore_psv` から抽出: `compact_count` / `compact_rate` / `fmt_hms` / `finish_clock` / `with_progress_keys`（module private）、`MultiFileProgress`（旧 `RescoreProgress` を中立名へリネーム）/ `FileProgress`（公開、`///` doc 付き）。
  - 非TTY ログの先頭タグを `new(total, files, tag)` でパラメータ化 → `rescore_psv` は `"rescore"` を渡し**既存出力文言はバイト単位で不変**。`book_rescore` は `"book_rescore"`。
  - 整形ヘルパの単体テスト（3 本）も同梱移設。
- **`rescore_psv.rs`**: 抽出ブロック（約 333 行）を削除し共有モジュール参照へ置換（挙動不変）。ONNX 専用になった `Arc`/`Mutex`/`Instant` import を `#[cfg(...onnx)]` で gate。
- **`book_rescore.rs`**: USI 探索モード（`run_search_tasks`）と ONNX 静的モード（`run_static_onnx`）の両方に進捗を追加（% / pos/s / 残り時間 / 完了予定時刻）。分母は `--resume` skip 除外後の実タスク数。本体を IIFE (`Result`) に閉じ込め、正常→`finish`・エラー→`abandon` を全経路で一度だけ呼ぶ。USI モードは進捗生成を worker 起動後に移し engine 起動時間を elapsed に混ぜない。
- **doc**: `book_rescore.md` に「進捗表示」節を追加。

## テスト

- `cargo fmt --check` / `cargo clippy --tests`（default・`--no-default-features --features nnue-arch` の両構成で警告ゼロ）/ `cargo test -p tools`（lib 113・book_rescore 9・rescore_psv 7 ほか全 pass、エラー経路の `worker_spawn_failure` 含む）/ 絶対パスチェック all green。

## レビュー

ローカルで独立 dual review（Codex + Fable）を実施し、指摘（進捗 finish のエラー経路漏れ・公開メソッド doc・不要な pub / cfg gate 等）を反映後、両者から **APPROVE** 取得済み。

## 補足

`rescore_psv` の CLI・出力セマンティクスは不変のため同 doc は更新不要。engine 駆動そのものの共通化（`rescore_psv` engine mode を `EngineProcess` + work-stealing へ寄せる）は別課題として #874 に切り出し済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFaPZQMaCuTsFv8sYJA7yU