### PR TITLE
feat(tools): floodgate_record — csa_client JSONL から 1 エンジンの戦績集計

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -10,6 +10,7 @@
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定 |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別・相手別・非勝一覧・実戦 NPS。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -1,0 +1,47 @@
+# floodgate_record
+
+`csa_client` が per-game に出力する JSONL(`meta` / `move` / `result` 行)から、
+あるエンジンの戦績を集計する CLI。相手が毎局変わる floodgate 連続対局のログ群を、
+先後別・相手別・非勝一覧・実戦 NPS で要約する。
+
+`analyze_selfplay` が 2 エンジンの tournament(Elo/SPRT)を対象にするのに対し、本ツールは
+「1 エンジン vs 多数の相手」を集計する点が異なる。
+
+## 入力
+
+`--dir` 配下の `*.jsonl`(1 局 1 ファイル、`csa_client` の `[record] save_jsonl=true` 出力)。
+各局の判定に使う行:
+
+- `move` 行: `engine`(指した側の名前)/ `ply` / `eval.nps` / `eval.time_ms`。
+  **両対局者の手が engine 名付きで記録される**ため、`ply==1` の `engine` が先手、もう一方が後手。
+  ファイル名に依存せず手番・相手を判定できる。
+- `result` 行: `winner`(勝者名。引き分けは無し)/ `reason` / `plies`。
+
+`result` 行が無いファイル(進行中の局)は自動でスキップする。
+
+## 使い方
+
+```bash
+# 対象エンジンは自動判定(全局に最も多く出現するエンジン=自分)
+floodgate_record --dir ~/floodgate/records/jsonl
+
+# 対象エンジンを明示し、注目相手(部分一致)を指定
+floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
+```
+
+| オプション | 説明 |
+|-----------|------|
+| `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし、既定 `.`) |
+| `--me <NAME>` | 集計対象エンジン名。省略時は全局に最も多く出現するエンジンを自動判定 |
+| `--watch <NAMES>` | 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力 |
+
+## 出力
+
+- 通算 W-L-D と勝率(全体 / 引分除く)
+- 先手番 / 後手番 別の W-L-D
+- 対象エンジンの実戦 NPS(`time_ms>=500` の本探索の median)
+- 相手別 W-L-D
+- 非勝(負け/引分)一覧(手番・相手・reason・手数)
+- `--watch` 指定時: 注目相手との対戦一覧
+
+勝敗判定は `result.winner` を基準にする(`winner==me`→勝ち、他名→負け、無し→引分)。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -10,6 +10,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（engine vs engine／NativeBackend） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別・相手別・非勝一覧・実戦 NPS。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
 | `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き。[詳細](kifu_player.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成。消費時間による定跡手判定（手番側ごとの即指しプレフィックス）・レート/勝敗/手数フィルタ・最小 ply 集約・ponder 集計。決定的（[詳細](book_from_csa.md)） |

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -1,0 +1,368 @@
+//! csa_client が per-game に吐く JSONL(`meta`/`move`/`result` 行)から、ある
+//! エンジンの戦績を集計する CLI。floodgate 連続対局のように相手が毎局変わる
+//! ログ群を、先後別・相手別・非勝一覧・実戦 NPS で要約する。
+//!
+//! JSONL は両対局者の指し手を `engine` 名付きで記録するため、手番・相手・勝敗は
+//! ファイル名に依らず JSONL だけで判定できる(ply1 の `engine` が先手)。
+//!
+//! # 例
+//! ```text
+//! # ~/floodgate/records/jsonl を集計(対象エンジンは自動判定)
+//! floodgate_record --dir ~/floodgate/records/jsonl
+//!
+//! # 対象エンジンを明示し、注目相手を指定
+//! floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use serde::Deserialize;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Aggregate an engine's win/loss record from csa_client per-game JSONL"
+)]
+struct Cli {
+    /// 集計対象 JSONL(`*.jsonl`)のあるディレクトリ(再帰なし)
+    #[arg(long, default_value = ".")]
+    dir: PathBuf,
+
+    /// 集計対象エンジン名。省略時は全 JSONL に最も多く出現するエンジンを自動判定。
+    #[arg(long)]
+    me: Option<String>,
+
+    /// 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力。
+    #[arg(long, value_delimiter = ',')]
+    watch: Vec<String>,
+}
+
+/// JSONL 1 行の必要フィールドだけを拾う(未使用 type 行は無視)。
+#[derive(Deserialize)]
+struct Line {
+    #[serde(rename = "type")]
+    kind: String,
+    ply: Option<u32>,
+    engine: Option<String>,
+    eval: Option<Eval>,
+    winner: Option<String>,
+    reason: Option<String>,
+    plies: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct Eval {
+    nps: Option<f64>,
+    time_ms: Option<u64>,
+}
+
+/// 1 局分の集計素材。
+struct Game {
+    /// ファイル名(datetime prefix を含む。表示・整列用)
+    stem: String,
+    sente: String,
+    gote: String,
+    /// 勝者名。引き分けは `None`。
+    winner: Option<String>,
+    reason: String,
+    plies: u32,
+    /// engine 名 -> その engine の nps サンプル(time_ms>=500 の本探索のみ)
+    nps: BTreeMap<String, Vec<f64>>,
+}
+
+/// me から見た 1 局の結果。
+#[derive(Clone, Copy, PartialEq)]
+enum Res {
+    Win,
+    Loss,
+    Draw,
+}
+
+fn parse_game(path: &std::path::Path) -> Result<Option<Game>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let stem = path.file_stem().map(|s| s.to_string_lossy().into_owned()).unwrap_or_default();
+
+    let mut sente: Option<String> = None;
+    let mut engines: Vec<String> = Vec::new(); // 出現順の distinct engine
+    let mut nps: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    let mut winner: Option<String> = None;
+    let mut reason = String::new();
+    let mut plies = 0u32;
+    let mut has_result = false;
+
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(l) = serde_json::from_str::<Line>(line) else {
+            continue;
+        };
+        match l.kind.as_str() {
+            "move" => {
+                if let Some(eng) = l.engine {
+                    if l.ply == Some(1) {
+                        sente = Some(eng.clone());
+                    }
+                    if !engines.contains(&eng) {
+                        engines.push(eng.clone());
+                    }
+                    if let Some(ev) = l.eval
+                        && let Some(n) = ev.nps
+                        && ev.time_ms.unwrap_or(0) >= 500
+                    {
+                        nps.entry(eng).or_default().push(n);
+                    }
+                }
+            }
+            "result" => {
+                has_result = true;
+                winner = l.winner.filter(|w| !w.is_empty());
+                reason = l.reason.unwrap_or_default();
+                plies = l.plies.unwrap_or(0);
+            }
+            _ => {}
+        }
+    }
+
+    if !has_result {
+        return Ok(None); // 進行中 / 未完了の局はスキップ
+    }
+    let sente = match sente {
+        Some(s) => s,
+        None => return Ok(None), // 手が 1 手も無い異常局
+    };
+    let gote = engines.iter().find(|e| **e != sente).cloned().unwrap_or_default();
+
+    Ok(Some(Game {
+        stem,
+        sente,
+        gote,
+        winner,
+        reason,
+        plies,
+        nps,
+    }))
+}
+
+fn result_for(g: &Game, me: &str) -> Res {
+    match &g.winner {
+        Some(w) if w == me => Res::Win,
+        Some(_) => Res::Loss,
+        None => Res::Draw,
+    }
+}
+
+fn median(xs: &mut [f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = xs.len();
+    if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        (xs[n / 2 - 1] + xs[n / 2]) / 2.0
+    }
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let pattern = cli.dir.join("*.jsonl");
+    let pattern = pattern.to_string_lossy();
+    let mut games: Vec<Game> = Vec::new();
+    for entry in glob::glob(&pattern).with_context(|| format!("glob {pattern}"))? {
+        let path = entry?;
+        if let Some(g) = parse_game(&path)? {
+            games.push(g);
+        }
+    }
+    if games.is_empty() {
+        bail!("完了局の JSONL が {} に見つからない", cli.dir.display());
+    }
+    games.sort_by(|a, b| a.stem.cmp(&b.stem));
+
+    // 対象エンジン: 明示 or 「最も多くの局に出現するエンジン」を自動判定。
+    let me = match cli.me {
+        Some(m) => m,
+        None => {
+            let mut count: BTreeMap<&str, usize> = BTreeMap::new();
+            for g in &games {
+                *count.entry(g.sente.as_str()).or_default() += 1;
+                if !g.gote.is_empty() {
+                    *count.entry(g.gote.as_str()).or_default() += 1;
+                }
+            }
+            count
+                .into_iter()
+                .max_by_key(|(_, c)| *c)
+                .map(|(name, _)| name.to_string())
+                .context("対象エンジンを自動判定できない")?
+        }
+    };
+
+    // 集計
+    let mut w = 0usize;
+    let mut l = 0usize;
+    let mut d = 0usize;
+    // 先後別 [先, 後] それぞれ (W, L, D)
+    let mut by_color = [[0usize; 3]; 2];
+    // 相手別 (W, L, D)
+    let mut by_opp: BTreeMap<String, [usize; 3]> = BTreeMap::new();
+    let mut my_nps: Vec<f64> = Vec::new();
+
+    for g in &games {
+        let is_sente = g.sente == me;
+        let opp = if is_sente { &g.gote } else { &g.sente };
+        let res = result_for(g, &me);
+        let idx = match res {
+            Res::Win => 0,
+            Res::Loss => 1,
+            Res::Draw => 2,
+        };
+        match res {
+            Res::Win => w += 1,
+            Res::Loss => l += 1,
+            Res::Draw => d += 1,
+        }
+        by_color[if is_sente { 0 } else { 1 }][idx] += 1;
+        by_opp.entry(opp.clone()).or_default()[idx] += 1;
+        if let Some(samples) = g.nps.get(&me) {
+            my_nps.extend_from_slice(samples);
+        }
+    }
+
+    let n = games.len();
+    let pct = |num: usize, den: usize| {
+        if den == 0 {
+            0.0
+        } else {
+            num as f64 / den as f64 * 100.0
+        }
+    };
+    println!("集計対象: {me}   ソース: {n} 局");
+    println!(
+        "=== 通算: {w}勝 {l}敗 {d}分  ({n}局)  勝率 {:.0}% (引分除 {:.0}%) ===",
+        pct(w, n),
+        pct(w, w + l)
+    );
+
+    let names = ["先手番", "後手番"];
+    for (i, name) in names.iter().enumerate() {
+        let [cw, cl, cd] = by_color[i];
+        println!("  {name}: {cw}勝 {cl}敗 {cd}分 ({}局)", cw + cl + cd);
+    }
+
+    if !my_nps.is_empty() {
+        let n_nps = my_nps.len();
+        let med = median(&mut my_nps) / 1e6;
+        println!("  実戦NPS(time_ms>=500 の median): {med:.2}M  (n={n_nps})");
+    }
+
+    println!("\n=== 相手別 ===");
+    for (opp, [ow, ol, od]) in &by_opp {
+        println!("  {ow}勝 {ol}敗 {od}分  vs {opp}");
+    }
+
+    println!("\n=== 非勝(負け/引分) ===");
+    let mut any = false;
+    for g in &games {
+        let res = result_for(g, &me);
+        if res == Res::Win {
+            continue;
+        }
+        any = true;
+        let is_sente = g.sente == me;
+        let opp = if is_sente { &g.gote } else { &g.sente };
+        let col = if is_sente { "先" } else { "後" };
+        let mark = if res == Res::Loss { "●敗" } else { "△分" };
+        println!("  {}  {col}手  {mark}  vs {opp}  ({}, {}手)", g.stem, g.reason, g.plies);
+    }
+    if !any {
+        println!("  (なし)");
+    }
+
+    if !cli.watch.is_empty() {
+        println!("\n=== 注目相手との対戦 ===");
+        for g in &games {
+            let is_sente = g.sente == me;
+            let opp = if is_sente { &g.gote } else { &g.sente };
+            if !cli.watch.iter().any(|w| opp.contains(w.as_str())) {
+                continue;
+            }
+            let col = if is_sente { "先" } else { "後" };
+            let mark = match result_for(g, &me) {
+                Res::Win => "○",
+                Res::Loss => "●",
+                Res::Draw => "△",
+            };
+            println!("  {}  {col}手  {mark}  vs {opp}  ({})", g.stem, g.reason);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn game(sente: &str, gote: &str, winner: Option<&str>) -> Game {
+        Game {
+            stem: "t".to_owned(),
+            sente: sente.to_owned(),
+            gote: gote.to_owned(),
+            winner: winner.map(str::to_owned),
+            reason: "win".to_owned(),
+            plies: 100,
+            nps: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn result_for_win_loss_draw() {
+        let me = "ME";
+        assert!(matches!(result_for(&game("ME", "X", Some("ME")), me), Res::Win));
+        assert!(matches!(result_for(&game("X", "ME", Some("X")), me), Res::Loss));
+        // winner なし(引き分け)
+        assert!(matches!(result_for(&game("X", "ME", None), me), Res::Draw));
+    }
+
+    #[test]
+    fn median_odd_even() {
+        assert_eq!(median(&mut [3.0, 1.0, 2.0]), 2.0);
+        assert_eq!(median(&mut [4.0, 1.0, 3.0, 2.0]), 2.5);
+        assert_eq!(median(&mut []), 0.0);
+    }
+
+    #[test]
+    fn parse_game_reads_players_and_result() {
+        // 先手=OPP, 後手=ME, ME(白)勝ちの最小 JSONL を temp file に書いて解析。
+        let dir = std::env::temp_dir();
+        let path = dir.join("fg_record_test_g1.jsonl");
+        let body = concat!(
+            r#"{"type":"meta","timestamp":"t"}"#,
+            "\n",
+            r#"{"type":"move","game_id":1,"ply":1,"engine":"OPP","eval":{"nps":1000000,"time_ms":600}}"#,
+            "\n",
+            r#"{"type":"move","game_id":1,"ply":2,"engine":"ME","eval":{"nps":2000000,"time_ms":600}}"#,
+            "\n",
+            r#"{"type":"result","game_id":1,"outcome":"white_win","reason":"win","plies":2,"winner":"ME"}"#,
+            "\n",
+        );
+        std::fs::write(&path, body).unwrap();
+        let g = parse_game(&path).unwrap().expect("完了局");
+        assert_eq!(g.sente, "OPP");
+        assert_eq!(g.gote, "ME");
+        assert_eq!(g.winner.as_deref(), Some("ME"));
+        assert_eq!(g.plies, 2);
+        // time_ms>=500 の nps が両者ぶん取れている
+        assert_eq!(g.nps.get("ME").map(Vec::len), Some(1));
+        let _ = std::fs::remove_file(&path);
+    }
+}


### PR DESCRIPTION
## 概要

`csa_client` の per-game JSONL(`meta`/`move`/`result` 行)から、あるエンジンの戦績を集計する CLI `floodgate_record` を追加。相手が毎局変わる floodgate 連続対局のログ群を、対象エンジン視点で **通算/先後別/相手別 W-L-D・非勝一覧・実戦 NPS** に要約する。

`analyze_selfplay`(2 エンジン tournament の Elo/SPRT)に対し、本ツールは **1 エンジン vs 多数の相手** を集計する用途。

## 実装ポイント

- `move` 行が**両対局者の指し手を `engine` 名付きで持つ**ため、`ply==1` の `engine` を先手として、ファイル名に依らず手番・相手・勝敗を判定。
- 勝敗は `result.winner` 基準(`winner==me`→勝ち / 他名→負け / 無し→引分)。`result` 行の無い進行中局は自動スキップ。
- 対象エンジンは全局最多出現から自動判定(`--me` で明示可)。`--watch` で注目相手(部分一致)節を出力。

## 変更

- `crates/tools/src/bin/floodgate_record.rs`(bin + 単体テスト 3 件)
- `crates/tools/docs/floodgate_record.md`(doc)+ README / tools-reference 索引

## 検証

floodgate 非稼働機(ws)で実施:
- `rustfmt --check` OK / `cargo clippy -p tools --bin floodgate_record --tests` 警告 0 / `cargo test` 3 passed
- 実データ 23 局で期待どおりの出力(先後別・相手別・非勝一覧・注目相手・NPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9RuNo1xHuq6SF68rKVcHR