### PR TITLE
feat(tools): floodgate_record — --fetch-ratings で自分/相手の現在レートを併記

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -10,7 +10,7 @@
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定 |
-| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別・相手別・非勝一覧・実戦 NPS。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--fetch-ratings` で wdoor 現在レート併記。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -28,6 +28,9 @@ floodgate_record --dir ~/floodgate/records/jsonl
 
 # 対象エンジンを明示し、注目相手(部分一致)を指定
 floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
+
+# 自分/相手の現在レートを wdoor から取得して併記(キャッシュ併用で障害時フォールバック)
+floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache ratings.tsv
 ```
 
 | オプション | 説明 |
@@ -35,6 +38,10 @@ floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
 | `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし、既定 `.`) |
 | `--me <NAME>` | 集計対象エンジン名。省略時は全局に最も多く出現するエンジンを自動判定 |
 | `--watch <NAMES>` | 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力 |
+| `--fetch-ratings` | wdoor floodgate の現在レート表を**起動の度に**取得し、自分/相手に ` (R<rate>)` を併記(要ネットワーク)。wdoor は per-game レートを出さないので**現在値**(対局時点ではない)。取得・解析は `tools::common::floodgate` を再利用。取得失敗時はレート併記だけ諦め、集計は続行 |
+| `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持) |
+
+レート併記は**名前の完全一致**で引く(表に無い/名前不一致の相手は併記なし)。
 
 ## 出力
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -10,7 +10,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（engine vs engine／NativeBackend） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
-| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別・相手別・非勝一覧・実戦 NPS。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--fetch-ratings` で wdoor 現在レート併記。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
 | `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き。[詳細](kifu_player.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成。消費時間による定跡手判定（手番側ごとの即指しプレフィックス）・レート/勝敗/手数フィルタ・最小 ply 集約・ponder 集計。決定的（[詳細](book_from_csa.md)） |

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -20,7 +20,9 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
+use reqwest::blocking::Client;
 use serde::Deserialize;
+use tools::common::floodgate as fg;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -40,6 +42,16 @@ struct Cli {
     /// 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力。
     #[arg(long, value_delimiter = ',')]
     watch: Vec<String>,
+
+    /// 指定すると wdoor floodgate の現在レートを取得し、自分/相手に ` (R<rate>)` を併記する。
+    /// per-game でなく現在値。ネットワークが要る(取得・解析は `tools::common::floodgate`)。
+    #[arg(long)]
+    fetch_ratings: bool,
+
+    /// `--fetch-ratings` と併用するキャッシュファイル(`name<TAB>rate`)。fetch 成功時はここへ
+    /// 書き出し、失敗時はここを読み戻してフォールバック併記する(一時障害でも直近値を維持)。
+    #[arg(long, requires = "fetch_ratings")]
+    ratings_cache: Option<PathBuf>,
 }
 
 /// JSONL 1 行の必要フィールドだけを拾う(未使用 type 行は無視)。
@@ -184,6 +196,48 @@ fn median(xs: &mut [f64]) -> f64 {
     }
 }
 
+/// wdoor floodgate の現在レート表を取得し name -> rating を作る。
+/// 取得・解析は `tools::common::floodgate`(reqwest, in-repo)を再利用。
+fn fetch_ratings_map() -> Result<BTreeMap<String, f64>> {
+    let client = Client::builder().build().context("reqwest client 生成失敗")?;
+    let (url, html) = fg::fetch_latest_rating_page(&client)?;
+    eprintln!("レート取得: {url}");
+    Ok(fg::parse_rating_page(&html).into_iter().collect())
+}
+
+/// レートマップを `name<TAB>rate` でキャッシュへ書き出す(BTreeMap 順で決定的)。
+fn write_ratings_cache(path: &std::path::Path, map: &BTreeMap<String, f64>) -> Result<()> {
+    use std::io::Write;
+    // 同一 dir の tmp に書いてから rename する(部分書き込みで既存 cache を壊さない)。
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp);
+    {
+        let mut f = std::io::BufWriter::new(
+            std::fs::File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?,
+        );
+        for (name, rate) in map {
+            writeln!(f, "{name}\t{rate}")?;
+        }
+        f.flush()?;
+    }
+    std::fs::rename(&tmp, path).with_context(|| format!("rename to {}", path.display()))?;
+    Ok(())
+}
+
+/// キャッシュ(`name<TAB>rate`)を name -> rating に読み戻す。壊れた行・非有限値は捨てる。
+fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(text
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .filter_map(|(n, r)| {
+            let v = r.trim().parse::<f64>().ok().filter(|v| v.is_finite())?;
+            Some((n.trim().to_owned(), v))
+        })
+        .collect())
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -218,6 +272,49 @@ fn main() -> Result<()> {
                 .map(|(name, _)| name.to_string())
                 .context("対象エンジンを自動判定できない")?
         }
+    };
+
+    // レートは現在値(対局時点ではない)。取得失敗・空取得はレート併記だけ諦め、集計は続行する
+    // (opt-in の補助機能のために primary output を落とさない)。
+    // --ratings-cache 併用時は「取得成功かつ非空」でのみ書き出し、それ以外は cache を読み戻して
+    // フォールバックする(空取得で last-known-good を潰さない)。
+    let ratings: BTreeMap<String, f64> = if cli.fetch_ratings {
+        let fetched = match fetch_ratings_map() {
+            Ok(map) if !map.is_empty() => Some(map),
+            Ok(_) => {
+                eprintln!("⚠ レート表が空(取得 0 件)。キャッシュにフォールバック");
+                None
+            }
+            Err(e) => {
+                eprintln!("⚠ レート取得失敗: {e:#}");
+                None
+            }
+        };
+        match fetched {
+            Some(map) => {
+                if let Some(cache) = &cli.ratings_cache
+                    && let Err(e) = write_ratings_cache(cache, &map)
+                {
+                    eprintln!("⚠ レートキャッシュ書き出し失敗: {e:#}");
+                }
+                map
+            }
+            None => match &cli.ratings_cache {
+                Some(cache) => read_ratings_cache(cache).unwrap_or_else(|e2| {
+                    eprintln!("⚠ キャッシュ読み戻しも失敗(注釈なしで続行): {e2:#}");
+                    BTreeMap::new()
+                }),
+                None => BTreeMap::new(),
+            },
+        }
+    } else {
+        BTreeMap::new()
+    };
+    let rlabel = |name: &str| -> String {
+        ratings
+            .get(name)
+            .map(|r| format!(" (R{})", r.round() as i64))
+            .unwrap_or_default()
     };
 
     // 集計
@@ -269,7 +366,7 @@ fn main() -> Result<()> {
             num as f64 / den as f64 * 100.0
         }
     };
-    println!("集計対象: {me}   完了局 {total} 局 → 集計 {n} 局");
+    println!("集計対象: {me}{}   完了局 {total} 局 → 集計 {n} 局", rlabel(&me));
     if skipped_foreign > 0 || skipped_incomplete > 0 {
         println!(
             "  (除外: 対象不参加 {skipped_foreign} 局 / 中断・未完了 {skipped_incomplete} 局)"
@@ -312,7 +409,7 @@ fn main() -> Result<()> {
 
     println!("\n=== 相手別 ===");
     for (opp, [ow, ol, od]) in &by_opp {
-        println!("  {ow}勝 {ol}敗 {od}分  vs {opp}");
+        println!("  {ow}勝 {ol}敗 {od}分  vs {opp}{}", rlabel(opp));
     }
 
     // 後手勝ちは最上位帯では希少で価値が高いので、相手名付きで individually 列挙する。
@@ -332,7 +429,7 @@ fn main() -> Result<()> {
         } else {
             ""
         };
-        println!("  {}  vs {opp}  ({}, {}手){star}", g.stem, g.reason, g.plies);
+        println!("  {}  vs {opp}{}  ({}, {}手){star}", g.stem, rlabel(opp), g.reason, g.plies);
     }
     if !any_gw {
         println!("  (なし)");
@@ -352,7 +449,13 @@ fn main() -> Result<()> {
             let is_sente = g.sente == me;
             let opp = if is_sente { &g.gote } else { &g.sente };
             let col = if is_sente { "先" } else { "後" };
-            println!("  {}  {col}手  vs {opp}  ({}, {}手)", g.stem, g.reason, g.plies);
+            println!(
+                "  {}  {col}手  vs {opp}{}  ({}, {}手)",
+                g.stem,
+                rlabel(opp),
+                g.reason,
+                g.plies
+            );
         }
         if !any {
             println!("  (なし)");
@@ -379,7 +482,7 @@ fn main() -> Result<()> {
                 Res::Loss => "●",
                 Res::Draw => "△",
             };
-            println!("  {}  {col}手  {mark}  vs {opp}  ({})", g.stem, g.reason);
+            println!("  {}  {col}手  {mark}  vs {opp}{}  ({})", g.stem, rlabel(opp), g.reason);
         }
     }
 
@@ -463,6 +566,32 @@ mod tests {
         assert_eq!(g.sente, "OPP");
         assert_eq!(g.gote, "ME");
         assert!(matches!(result_for(&g, "ME"), Some(Res::Loss)));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn ratings_cache_round_trip() {
+        let path = std::env::temp_dir().join("fg_record_ratings_cache_test.tsv");
+        let mut m = BTreeMap::new();
+        m.insert("RAMU_TF".to_owned(), 3427.0);
+        m.insert("Foo-Bar_1".to_owned(), -12.0); // 負レートも保持
+        write_ratings_cache(&path, &m).unwrap();
+        let back = read_ratings_cache(&path).unwrap();
+        assert_eq!(back.get("RAMU_TF"), Some(&3427.0));
+        assert_eq!(back.get("Foo-Bar_1"), Some(&-12.0));
+        assert_eq!(back.len(), 2);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ratings_cache_drops_non_finite_and_corrupt() {
+        let path = std::env::temp_dir().join("fg_record_ratings_cache_corrupt.tsv");
+        std::fs::write(&path, "Good\t3400\nBadNaN\tNaN\nBadInf\tinf\nNoTab 1\nEmpty\t\n").unwrap();
+        let m = read_ratings_cache(&path).unwrap();
+        assert_eq!(m.get("Good"), Some(&3400.0));
+        assert!(!m.contains_key("BadNaN")); // NaN は is_finite で除外
+        assert!(!m.contains_key("BadInf")); // inf も除外
+        assert_eq!(m.len(), 1); // tab 無し・空 rate も落ちる
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## 概要

`floodgate_record` に `--fetch-ratings` を追加。指定すると wdoor floodgate の現在レート表を取得し、集計対象(自分)と相手に ` (R<rate>)` を併記する(ヘッダ・相手別・後手勝ち・負け/引分・注目相手)。

## 実装

- HTTP 取得と HTML 解析は既存の `tools::common::floodgate`(`reqwest`, in-repo)を再利用:
  `fetch_latest_rating_page`(JST 当日 + 7 日遡及)→ `parse_rating_page`(`<td class="name">`/`<td class="rate">` → name→rating)。**新規依存なし・外部スクリプトなし**。
- wdoor は per-game のレートをクライアントに出さないため、レートは**現在値**(対局時点ではない)。
- `--fetch-ratings` 未指定時は従来どおり(ネットワーク不使用)。

## 検証(floodgate 非稼働機 ws)

- `rustfmt --check` OK / `clippy --tests` 警告 0 / `test` 4 passed
- `--fetch-ratings` で live 取得しレート併記を確認:
  `集計対象: RAMU_TF (R3427)`、相手 `test_mypeta (R4194)` / `Sora_Ginko (R4251)` / `nshogi-dev-5070 (R3735)` 等

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9RuNo1xHuq6SF68rKVcHR