### PR TITLE
feat(tools): floodgate_record — csa_client config 連動 + レート鮮度キャッシュ / 履歴記録

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,6 +3359,7 @@ dependencies = [
  "rshogi-book",
  "rshogi-core",
  "rshogi-csa",
+ "rshogi-csa-client",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -64,7 +64,10 @@ fn jsonl_filename(record: &GameRecord) -> String {
     format!("{datetime}_{sente}_vs_{gote}.jsonl")
 }
 
-fn sanitize_for_filename(name: &str) -> String {
+/// ファイル名・JSONL `engine` ラベルの名前正規化。英数字と `-` `_` 以外を `_` に置換する
+/// (空文字は "unknown")。JSONL のラベルと外部由来の名前 (`server.id` 等) を突き合わせる
+/// consumer は、この関数を通して比較しないと `.` や `@` を含む id が一致しない。
+pub fn sanitize_for_filename(name: &str) -> String {
     if name.is_empty() {
         return "unknown".to_string();
     }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -87,6 +87,10 @@ rshogi-csa = { path = "../rshogi-csa" }
 # edition(NNUE)軸には触れないため default-features=false とし、rshogi-core の feature は
 # 本 crate 側の指定に委ねる(rshogi-usi と同じ方針)。
 rshogi-book = { path = "../rshogi-book", default-features = false }
+# csa_client と同一の TOML (CsaClientConfig) を floodgate_record が読むための依存。
+# 設定型の再利用のみで transport / CLI は使わないため、default-features=false で
+# tungstenite / rustls / clap 系依存を切り落とす。
+rshogi-csa-client = { path = "../rshogi-csa-client", default-features = false }
 
 # Additional dependencies
 sysinfo = "0.37"

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -10,7 +10,7 @@
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定 |
-| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--fetch-ratings` で wdoor 現在レート併記。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換（[詳細](docs/floodgate_pipeline.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -41,14 +41,14 @@ floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache
 |-----------|------|
 | `--config <TOML>` | `csa_client` と同一の設定ファイル。`record` 設定から集計 dir、`server.id` から `--me`、`record.dir` からキャッシュ/履歴の既定パスを導出する(対応する明示引数が優先)。省略時は環境変数 `CSA_CLIENT_CONFIG` を参照(空値は未設定扱い)。適用時は導出結果を stderr に 1 行表示する。TOML 内の相対パスは **config ファイルのあるディレクトリ基準**で解決(`csa_client` 実行時 cwd 基準とは異なるので運用 config は絶対パス推奨)。`csa_client` 側の CLI 上書き(`--record-dir` 等)は見えず TOML の値のみ使う。config の `record.enabled` / `record.save_jsonl` が無効で集計元を導出できない場合はエラー(`--dir` 明示で回避可) |
 | `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし)。省略時は config から導出、それも無ければ `.` |
-| `--me <NAME>` | 集計対象エンジン名。省略時は config の `server.id`(JSONL の engine ラベルと同じ正規化を適用: 英数字と `-` `_` 以外は `_`)、それも無ければ全局に最も多く出現するエンジンを自動判定(別ハンドルのログが混在する dir では config / 明示指定が確実) |
+| `--me <NAME>` | 集計対象エンジン名。省略時は config の `server.id`、それも無ければ全局に最も多く出現するエンジンを自動判定(別ハンドルのログが混在する dir では config / 明示指定が確実) |
 | `--watch <NAMES>` | 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力 |
 | `--fetch-ratings` | wdoor floodgate の現在レート表を取得し、自分/相手に ` (R<rate>)` を併記(要ネットワーク)。wdoor は per-game レートを出さないので**現在値**(対局時点ではない)。取得・解析は `tools::common::floodgate` を再利用。取得失敗時はレート併記だけ諦め、集計は続行 |
 | `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持)。config 指定時の既定は `<record.dir>/ratings_cache.tsv` |
 | `--ratings-max-age <SEC>` | `--fetch-ratings` 併用。キャッシュの mtime が SEC 秒以内なら**ネットワーク取得をスキップ**してキャッシュを直接使う。既定 0(常に取得)。レートページは日次生成なので数時間(例: `21600` = 6h)で十分。履歴併用時、履歴に当日(JST)分が無ければ鮮度内でも取得する(スキップで履歴の日付が抜けないように) |
 | `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。書き込みは tmp→rename の全置換(並行実行でも行が壊れない)。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
 
-レート併記は**名前の完全一致**で引く(表に無い/名前不一致の相手は併記なし)。
+**名前の突き合わせはすべて正規化キー**(英数字と `-` `_` 以外を `_` に置換。JSONL のファイル名・meta ラベルと同じ規則)で行う。JSONL の `move.engine` / `result.winner` は raw の CSA 名、ファイル名は正規化済みという混在があるため、集計・`--me`・`--watch`・レート表・キャッシュのキーを入口で同一空間に揃えている。レート併記は正規化キーの**完全一致**で引く(表に無い相手は併記なし)。
 
 ## 出力
 

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -23,11 +23,15 @@
 ## 使い方
 
 ```bash
-# 対象エンジンは自動判定(全局に最も多く出現するエンジン=自分)
-floodgate_record --dir ~/floodgate/records/jsonl
+# csa_client と同じ config から dir / --me / キャッシュ・履歴の既定を導出(推奨)
+floodgate_record --config ~/floodgate/active.toml --fetch-ratings
 
-# 対象エンジンを明示し、注目相手(部分一致)を指定
-floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
+# 環境変数に config を置けば引数はさらに減る(明示引数はいつでも config に優先)
+export CSA_CLIENT_CONFIG=~/floodgate/active.toml
+floodgate_record --fetch-ratings --watch Suisho,dlshogi,nshogi
+
+# config なしの従来形。対象エンジンは自動判定(全局に最も多く出現するエンジン=自分)
+floodgate_record --dir ~/floodgate/records/jsonl
 
 # 自分/相手の現在レートを wdoor から取得して併記(キャッシュ併用で障害時フォールバック)
 floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache ratings.tsv
@@ -35,11 +39,14 @@ floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache
 
 | オプション | 説明 |
 |-----------|------|
-| `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし、既定 `.`) |
-| `--me <NAME>` | 集計対象エンジン名。省略時は全局に最も多く出現するエンジンを自動判定 |
+| `--config <TOML>` | `csa_client` と同一の設定ファイル。`record` 設定から集計 dir、`server.id` から `--me`、`record.dir` からキャッシュ/履歴の既定パスを導出する(対応する明示引数が優先)。省略時は環境変数 `CSA_CLIENT_CONFIG` を参照。TOML 内の相対パスは **config ファイルのあるディレクトリ基準**で解決(`csa_client` 実行時 cwd 基準とは異なるので運用 config は絶対パス推奨)。config の `record.enabled` / `record.save_jsonl` が無効で集計元を導出できない場合はエラー(`--dir` 明示で回避可) |
+| `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし)。省略時は config から導出、それも無ければ `.` |
+| `--me <NAME>` | 集計対象エンジン名。省略時は config の `server.id`、それも無ければ全局に最も多く出現するエンジンを自動判定(別ハンドルのログが混在する dir では config / 明示指定が確実) |
 | `--watch <NAMES>` | 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力 |
-| `--fetch-ratings` | wdoor floodgate の現在レート表を**起動の度に**取得し、自分/相手に ` (R<rate>)` を併記(要ネットワーク)。wdoor は per-game レートを出さないので**現在値**(対局時点ではない)。取得・解析は `tools::common::floodgate` を再利用。取得失敗時はレート併記だけ諦め、集計は続行 |
-| `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持) |
+| `--fetch-ratings` | wdoor floodgate の現在レート表を取得し、自分/相手に ` (R<rate>)` を併記(要ネットワーク)。wdoor は per-game レートを出さないので**現在値**(対局時点ではない)。取得・解析は `tools::common::floodgate` を再利用。取得失敗時はレート併記だけ諦め、集計は続行 |
+| `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持)。config 指定時の既定は `<record.dir>/ratings_cache.tsv` |
+| `--ratings-max-age <SEC>` | `--fetch-ratings` 併用。キャッシュの mtime が SEC 秒以内なら**ネットワーク取得をスキップ**してキャッシュを直接使う。既定 0(常に取得)。レートページは日次生成なので数時間(例: `21600` = 6h)で十分 |
+| `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
 
 レート併記は**名前の完全一致**で引く(表に無い/名前不一致の相手は併記なし)。
 

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -39,14 +39,14 @@ floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache
 
 | オプション | 説明 |
 |-----------|------|
-| `--config <TOML>` | `csa_client` と同一の設定ファイル。`record` 設定から集計 dir、`server.id` から `--me`、`record.dir` からキャッシュ/履歴の既定パスを導出する(対応する明示引数が優先)。省略時は環境変数 `CSA_CLIENT_CONFIG` を参照。TOML 内の相対パスは **config ファイルのあるディレクトリ基準**で解決(`csa_client` 実行時 cwd 基準とは異なるので運用 config は絶対パス推奨)。config の `record.enabled` / `record.save_jsonl` が無効で集計元を導出できない場合はエラー(`--dir` 明示で回避可) |
+| `--config <TOML>` | `csa_client` と同一の設定ファイル。`record` 設定から集計 dir、`server.id` から `--me`、`record.dir` からキャッシュ/履歴の既定パスを導出する(対応する明示引数が優先)。省略時は環境変数 `CSA_CLIENT_CONFIG` を参照(空値は未設定扱い)。適用時は導出結果を stderr に 1 行表示する。TOML 内の相対パスは **config ファイルのあるディレクトリ基準**で解決(`csa_client` 実行時 cwd 基準とは異なるので運用 config は絶対パス推奨)。`csa_client` 側の CLI 上書き(`--record-dir` 等)は見えず TOML の値のみ使う。config の `record.enabled` / `record.save_jsonl` が無効で集計元を導出できない場合はエラー(`--dir` 明示で回避可) |
 | `--dir <PATH>` | 集計対象 JSONL のあるディレクトリ(再帰なし)。省略時は config から導出、それも無ければ `.` |
-| `--me <NAME>` | 集計対象エンジン名。省略時は config の `server.id`、それも無ければ全局に最も多く出現するエンジンを自動判定(別ハンドルのログが混在する dir では config / 明示指定が確実) |
+| `--me <NAME>` | 集計対象エンジン名。省略時は config の `server.id`(JSONL の engine ラベルと同じ正規化を適用: 英数字と `-` `_` 以外は `_`)、それも無ければ全局に最も多く出現するエンジンを自動判定(別ハンドルのログが混在する dir では config / 明示指定が確実) |
 | `--watch <NAMES>` | 注目相手(カンマ区切り・部分一致)。指定時のみ「注目相手との対戦」節を出力 |
 | `--fetch-ratings` | wdoor floodgate の現在レート表を取得し、自分/相手に ` (R<rate>)` を併記(要ネットワーク)。wdoor は per-game レートを出さないので**現在値**(対局時点ではない)。取得・解析は `tools::common::floodgate` を再利用。取得失敗時はレート併記だけ諦め、集計は続行 |
 | `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持)。config 指定時の既定は `<record.dir>/ratings_cache.tsv` |
-| `--ratings-max-age <SEC>` | `--fetch-ratings` 併用。キャッシュの mtime が SEC 秒以内なら**ネットワーク取得をスキップ**してキャッシュを直接使う。既定 0(常に取得)。レートページは日次生成なので数時間(例: `21600` = 6h)で十分 |
-| `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
+| `--ratings-max-age <SEC>` | `--fetch-ratings` 併用。キャッシュの mtime が SEC 秒以内なら**ネットワーク取得をスキップ**してキャッシュを直接使う。既定 0(常に取得)。レートページは日次生成なので数時間(例: `21600` = 6h)で十分。履歴併用時、履歴に当日(JST)分が無ければ鮮度内でも取得する(スキップで履歴の日付が抜けないように) |
+| `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。書き込みは tmp→rename の全置換(並行実行でも行が壊れない)。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
 
 レート併記は**名前の完全一致**で引く(表に無い/名前不一致の相手は併記なし)。
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -10,7 +10,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（engine vs engine／NativeBackend） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
-| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--fetch-ratings` で wdoor 現在レート併記。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
+| `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
 | `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き。[詳細](kifu_player.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成。消費時間による定跡手判定（手番側ごとの即指しプレフィックス）・レート/勝敗/手数フィルタ・最小 ply 集約・ponder 集計。決定的（[詳細](book_from_csa.md)） |

--- a/crates/tools/src/bin/floodgate_pipeline.rs
+++ b/crates/tools/src/bin/floodgate_pipeline.rs
@@ -212,7 +212,7 @@ fn run_fetch_ratings(url: Option<&str>, min_rating: u32, out: &str) -> Result<()
             fg::http_get_text(&client, u)?
         }
         None => {
-            let (u, html) = fg::fetch_latest_rating_page(&client)?;
+            let (u, _date, html) = fg::fetch_latest_rating_page(&client)?;
             eprintln!("Fetched latest rating page: {u}");
             html
         }

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -69,7 +69,8 @@ struct Cli {
 
     /// キャッシュがこの秒数以内に更新済みならネットワーク取得をスキップして
     /// キャッシュを直接使う(0 = 常に取得)。レートページは日次生成なので
-    /// 数時間 (例: 21600 = 6h) で十分。
+    /// 数時間 (例: 21600 = 6h) で十分。履歴併用時、履歴に当日分が無ければ
+    /// 鮮度内でも取得する(履歴を欠かさないため)。
     #[arg(long, default_value_t = 0, requires = "fetch_ratings")]
     ratings_max_age: u64,
 
@@ -91,16 +92,17 @@ struct Effective {
 
 fn resolve_effective(cli: &Cli, config: Option<(&Path, &CsaClientConfig)>) -> Result<Effective> {
     // TOML 内の相対パスは csa_client 実行時の cwd ではなく config ファイル基準で解決する
-    // (集計は別 cwd から叩かれるため。運用 config は絶対パス推奨)。
+    // (集計は別 cwd から叩かれるため。運用 config は絶対パス推奨)。csa_client の CLI
+    // 上書き (--record-dir 等) はここからは見えず、TOML の値のみを使う。
     fn resolve(base: &Path, p: PathBuf) -> PathBuf {
         if p.is_absolute() { p } else { base.join(p) }
     }
-    let config_base = |path: &Path| path.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let based = config.map(|(path, cfg)| (path, path.parent().unwrap_or(Path::new(".")), cfg));
 
-    let dir = match (&cli.dir, config) {
+    let dir = match (&cli.dir, based) {
         (Some(d), _) => d.clone(),
-        (None, Some((path, cfg))) => match cfg.record.jsonl_dir() {
-            Some(d) => resolve(&config_base(path), d),
+        (None, Some((path, base, cfg))) => match cfg.record.jsonl_dir() {
+            Some(d) => resolve(base, d),
             None => bail!(
                 "config {} は JSONL 出力が無効 (record.enabled / record.save_jsonl を確認)。\
                  集計元が導出できないため --dir で明示すること",
@@ -110,25 +112,29 @@ fn resolve_effective(cli: &Cli, config: Option<(&Path, &CsaClientConfig)>) -> Re
         (None, None) => PathBuf::from("."),
     };
 
-    let me = cli
-        .me
-        .clone()
-        .or_else(|| config.map(|(_, c)| c.server.id.clone()).filter(|id| !id.is_empty()));
+    // JSONL 内の engine ラベルは sanitize 済み(`.` や `@` は `_` になる)なので、
+    // server.id 由来の me も同じ正規化を通さないと全局が対象不参加になる。
+    let me = cli.me.clone().or_else(|| {
+        based
+            .map(|(_, _, c)| c.server.id.as_str())
+            .filter(|id| !id.is_empty())
+            .map(rshogi_csa_client::jsonl::sanitize_for_filename)
+    });
 
     // キャッシュ / 履歴の config 既定は --fetch-ratings 時のみ意味を持つ(clap の
     // `requires` と整合。fetch しないのに既定パスを作らない)。
-    let derived = |explicit: &Option<PathBuf>, filename: &str| {
-        if !cli.fetch_ratings {
-            return None;
-        }
-        explicit.clone().or_else(|| {
-            config.map(|(path, cfg)| {
-                resolve(&config_base(path), cfg.record.dir.clone()).join(filename)
-            })
-        })
-    };
-    let ratings_cache = derived(&cli.ratings_cache, "ratings_cache.tsv");
-    let ratings_history = derived(&cli.ratings_history, "ratings_history.tsv");
+    let record_dir = cli
+        .fetch_ratings
+        .then(|| based.map(|(_, base, cfg)| resolve(base, cfg.record.dir.clone())))
+        .flatten();
+    let ratings_cache = cli
+        .ratings_cache
+        .clone()
+        .or_else(|| record_dir.as_ref().map(|d| d.join("ratings_cache.tsv")));
+    let ratings_history = cli
+        .ratings_history
+        .clone()
+        .or_else(|| record_dir.as_ref().map(|d| d.join("ratings_history.tsv")));
 
     Ok(Effective {
         dir,
@@ -282,11 +288,11 @@ fn median(xs: &mut [f64]) -> f64 {
 
 /// wdoor floodgate の現在レート表を取得し (ページ日付 YYYYMMDD, name -> rating) を作る。
 /// 取得・解析は `tools::common::floodgate`(reqwest, in-repo)を再利用。
-fn fetch_ratings_map() -> Result<(Option<String>, BTreeMap<String, f64>)> {
+fn fetch_ratings_map() -> Result<(String, BTreeMap<String, f64>)> {
     let client = Client::builder().build().context("reqwest client 生成失敗")?;
-    let (url, html) = fg::fetch_latest_rating_page(&client)?;
+    let (url, date, html) = fg::fetch_latest_rating_page(&client)?;
     eprintln!("レート取得: {url}");
-    Ok((fg::rating_page_date(&url), fg::parse_rating_page(&html).into_iter().collect()))
+    Ok((date, fg::parse_rating_page(&html).into_iter().collect()))
 }
 
 /// キャッシュの mtime が `max_age_sec` 以内か。0 は常に false(= 常に fetch)。
@@ -302,36 +308,51 @@ fn cache_is_fresh(path: &Path, max_age_sec: u64) -> bool {
         .is_some_and(|age| age.as_secs() <= max_age_sec)
 }
 
+/// 履歴 (`date<TAB>name<TAB>rate` 行) に (date, name) のエントリが既にあるか。
+fn history_has_entry(text: &str, date: &str, name: &str) -> bool {
+    let prefix = format!("{date}\t{name}\t");
+    text.lines().any(|l| l.starts_with(&prefix))
+}
+
+/// 履歴が当日 (JST。レートページの日付は floodgate サーバ基準 = JST) の (date, me) を
+/// 記録済みか。履歴未設定なら true(鮮度スキップを妨げない)。当日ページ未生成の
+/// 早朝帯は fetch が前日ページに解決されて追記なしになるため、当日分が載るまで
+/// 鮮度内でも毎回 fetch になる(1 GET/実行なので許容)。
+fn history_recorded_today(history: Option<&Path>, me: &str) -> bool {
+    let Some(path) = history else { return true };
+    let jst = chrono::FixedOffset::east_opt(9 * 3600).expect("JST は有効なオフセット");
+    let today = chrono::Utc::now().with_timezone(&jst).format("%Y%m%d").to_string();
+    std::fs::read_to_string(path).is_ok_and(|text| history_has_entry(&text, &today, me))
+}
+
 /// 履歴ファイルに `date<TAB>name<TAB>rate` を 1 行追記する。同一 (date, name) の行が
 /// 既にあれば何もしない(レートページは日次生成のため、同日の再実行で重複させない)。
-/// 追記したら `Ok(true)`。
+/// 全体を tmp に書いて rename で置き換えるので、並行実行の追記競合や過去の尻切れ行に
+/// 新行が連結される破損が起きない。追記したら `Ok(true)`。
 fn append_ratings_history(path: &Path, date: &str, name: &str, rate: f64) -> Result<bool> {
-    use std::io::Write;
-    let prefix = format!("{date}\t{name}\t");
-    match std::fs::read_to_string(path) {
-        Ok(text) => {
-            if text.lines().any(|l| l.starts_with(&prefix)) {
-                return Ok(false);
-            }
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+    };
+    if history_has_entry(&text, date, name) {
+        return Ok(false);
     }
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .with_context(|| format!("open {}", path.display()))?;
-    writeln!(f, "{prefix}{rate}")?;
+    let mut lines: Vec<&str> = text.lines().collect();
+    let new_line = format!("{date}\t{name}\t{rate}");
+    lines.push(&new_line);
+    write_atomic(path, &(lines.join("\n") + "\n"))?;
     Ok(true)
 }
 
-/// レートマップを用意する。鮮度内キャッシュがあれば fetch せず直接使う。それ以外は
-/// fetch し、成功時はキャッシュ書き出し + 履歴追記、失敗時はキャッシュ読み戻しで
-/// フォールバック。opt-in の補助機能なので、失敗はすべて警告にとどめ空マップで続行する。
+/// レートマップを用意する。鮮度内キャッシュがあれば fetch せず直接使う(ただし履歴が
+/// 当日分を未記録なら、履歴を欠かさないため鮮度内でも fetch する)。fetch 成功時は
+/// キャッシュ書き出し + 履歴追記、失敗時はキャッシュ読み戻しでフォールバック。
+/// opt-in の補助機能なので、失敗はすべて警告にとどめ空マップで続行する。
 fn obtain_ratings(eff: &Effective, max_age_sec: u64, me: &str) -> BTreeMap<String, f64> {
     if let Some(cache) = &eff.ratings_cache
         && cache_is_fresh(cache, max_age_sec)
+        && history_recorded_today(eff.ratings_history.as_deref(), me)
     {
         match read_ratings_cache(cache) {
             Ok(map) if !map.is_empty() => {
@@ -344,65 +365,66 @@ fn obtain_ratings(eff: &Effective, max_age_sec: u64, me: &str) -> BTreeMap<Strin
     }
     // 取得失敗・空取得はキャッシュへフォールバック。書き出しは「取得成功かつ非空」の
     // ときのみ(空取得で last-known-good を潰さない)。
-    let fetched = match fetch_ratings_map() {
-        Ok((date, map)) if !map.is_empty() => Some((date, map)),
-        Ok(_) => {
-            eprintln!("⚠ レート表が空(取得 0 件)。キャッシュにフォールバック");
-            None
-        }
-        Err(e) => {
-            eprintln!("⚠ レート取得失敗: {e:#}");
-            None
+    let (date, map) = match fetch_ratings_map() {
+        Ok((date, map)) if !map.is_empty() => (date, map),
+        res => {
+            match res {
+                Ok(_) => eprintln!("⚠ レート表が空(取得 0 件)。キャッシュにフォールバック"),
+                Err(e) => eprintln!("⚠ レート取得失敗: {e:#}"),
+            }
+            let Some(cache) = &eff.ratings_cache else {
+                return BTreeMap::new();
+            };
+            return read_ratings_cache(cache).unwrap_or_else(|e| {
+                eprintln!("⚠ キャッシュ読み戻しも失敗(注釈なしで続行): {e:#}");
+                BTreeMap::new()
+            });
         }
     };
-    match fetched {
-        Some((date, map)) => {
-            if let Some(cache) = &eff.ratings_cache
-                && let Err(e) = write_ratings_cache(cache, &map)
-            {
-                eprintln!("⚠ レートキャッシュ書き出し失敗: {e:#}");
-            }
-            if let Some(history) = &eff.ratings_history {
-                match (&date, map.get(me)) {
-                    (Some(d), Some(rate)) => match append_ratings_history(history, d, me, *rate) {
-                        Ok(true) => eprintln!("レート履歴追記: {d} {me} R{rate}"),
-                        Ok(false) => {}
-                        Err(e) => eprintln!("⚠ レート履歴追記失敗: {e:#}"),
-                    },
-                    (None, _) => eprintln!("⚠ ページ日付を URL から特定できず履歴追記をスキップ"),
-                    (_, None) => eprintln!("⚠ {me} がレート表に無いため履歴追記をスキップ"),
-                }
-            }
-            map
-        }
-        None => match &eff.ratings_cache {
-            Some(cache) => read_ratings_cache(cache).unwrap_or_else(|e2| {
-                eprintln!("⚠ キャッシュ読み戻しも失敗(注釈なしで続行): {e2:#}");
-                BTreeMap::new()
-            }),
-            None => BTreeMap::new(),
-        },
+    if let Some(cache) = &eff.ratings_cache
+        && let Err(e) = write_ratings_cache(cache, &map)
+    {
+        eprintln!("⚠ レートキャッシュ書き出し失敗: {e:#}");
     }
+    if let Some(history) = &eff.ratings_history {
+        match map.get(me) {
+            Some(rate) => match append_ratings_history(history, &date, me, *rate) {
+                Ok(true) => eprintln!("レート履歴追記: {date} {me} R{rate}"),
+                Ok(false) => {}
+                Err(e) => eprintln!("⚠ レート履歴追記失敗: {e:#}"),
+            },
+            None => eprintln!("⚠ {me} がレート表に無いため履歴追記をスキップ"),
+        }
+    }
+    map
+}
+
+/// 同一 dir の一時ファイルに書いてから rename で置き換える(部分書き込みで既存
+/// ファイルを壊さない)。親ディレクトリが無ければ作る(config 由来の record.dir が
+/// まだ作られていない初期状態でも cache / 履歴が機能するように)。
+fn write_atomic(path: &Path, content: &str) -> Result<()> {
+    use std::io::Write;
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    std::fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temp file in {}", parent.display()))?;
+    tmp.write_all(content.as_bytes())
+        .with_context(|| format!("write temp file for {}", path.display()))?;
+    tmp.persist(path).with_context(|| format!("rename to {}", path.display()))?;
+    Ok(())
 }
 
 /// レートマップを `name<TAB>rate` でキャッシュへ書き出す(BTreeMap 順で決定的)。
-fn write_ratings_cache(path: &std::path::Path, map: &BTreeMap<String, f64>) -> Result<()> {
-    use std::io::Write;
-    // 同一 dir の tmp に書いてから rename する(部分書き込みで既存 cache を壊さない)。
-    let mut tmp = path.as_os_str().to_owned();
-    tmp.push(".tmp");
-    let tmp = std::path::PathBuf::from(tmp);
-    {
-        let mut f = std::io::BufWriter::new(
-            std::fs::File::create(&tmp).with_context(|| format!("create {}", tmp.display()))?,
-        );
-        for (name, rate) in map {
-            writeln!(f, "{name}\t{rate}")?;
-        }
-        f.flush()?;
+fn write_ratings_cache(path: &Path, map: &BTreeMap<String, f64>) -> Result<()> {
+    use std::fmt::Write;
+    let mut content = String::new();
+    for (name, rate) in map {
+        writeln!(content, "{name}\t{rate}").expect("String への write は失敗しない");
     }
-    std::fs::rename(&tmp, path).with_context(|| format!("rename to {}", path.display()))?;
-    Ok(())
+    write_atomic(path, &content)
 }
 
 /// キャッシュ(`name<TAB>rate`)を name -> rating に読み戻す。壊れた行・非有限値は捨てる。
@@ -421,20 +443,36 @@ fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // config は --config > 環境変数 CSA_CLIENT_CONFIG。指定があるのに読めないのは
-    // 設定ミスなので fail-fast(config 無しで集計したい場合は引数/env を外す)。
-    let config_path = cli
-        .config
-        .clone()
-        .or_else(|| std::env::var_os("CSA_CLIENT_CONFIG").map(PathBuf::from));
+    // config は --config > 環境変数 CSA_CLIENT_CONFIG(空値は未設定扱い)。指定が
+    // あるのに読めないのは設定ミスなので fail-fast(config 無しで集計したい場合は
+    // 引数/env を外す)。
+    let (config_path, config_source) = match cli.config.clone() {
+        Some(p) => (Some(p), "--config"),
+        None => (
+            std::env::var_os("CSA_CLIENT_CONFIG")
+                .filter(|v| !v.is_empty())
+                .map(PathBuf::from),
+            "env CSA_CLIENT_CONFIG",
+        ),
+    };
     let config = config_path
         .as_deref()
         .map(|path| {
-            CsaClientConfig::from_file(path)
-                .with_context(|| format!("config 読み込み失敗: {}", path.display()))
+            CsaClientConfig::from_file(path).with_context(|| {
+                format!("config 読み込み失敗: {} ({config_source})", path.display())
+            })
         })
         .transpose()?;
     let eff = resolve_effective(&cli, config_path.as_deref().zip(config.as_ref()))?;
+    if let Some(path) = &config_path {
+        // env 経由の暗黙適用でも「どの config から何が導出されたか」を可視化する。
+        eprintln!(
+            "config 適用: {} ({config_source}) → dir={}, me={}",
+            path.display(),
+            eff.dir.display(),
+            eff.me.as_deref().unwrap_or("(自動判定)")
+        );
+    }
 
     let pattern = eff.dir.join("*.jsonl");
     let pattern = pattern.to_string_lossy();
@@ -750,17 +788,10 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// clap 定義そのものから既定値を得る(struct literal の複製だと default_value_t と
+    /// 乖離しうる)。
     fn cli_default() -> Cli {
-        Cli {
-            config: None,
-            dir: None,
-            me: None,
-            watch: Vec::new(),
-            fetch_ratings: false,
-            ratings_cache: None,
-            ratings_max_age: 0,
-            ratings_history: None,
-        }
+        Cli::try_parse_from(["floodgate_record"]).unwrap()
     }
 
     fn config_from(toml_text: &str) -> CsaClientConfig {
@@ -850,6 +881,29 @@ mod tests {
         let cfg = config_from("[record]\ndir = \"/d\"\n");
         let eff = resolve_effective(&cli_default(), Some((Path::new("/x/a.toml"), &cfg))).unwrap();
         assert_eq!(eff.me, None);
+    }
+
+    #[test]
+    fn resolve_effective_sanitizes_config_me_like_jsonl_labels() {
+        // JSONL の engine ラベルは sanitize 済みなので `.` を含む server.id は `_` で比較。
+        let cfg = config_from("[server]\nid = \"ramu.v2\"\n[record]\ndir = \"/d\"\n");
+        let eff = resolve_effective(&cli_default(), Some((Path::new("/x/a.toml"), &cfg))).unwrap();
+        assert_eq!(eff.me.as_deref(), Some("ramu_v2"));
+    }
+
+    #[test]
+    fn ratings_history_creates_parent_dir_and_heals_unterminated_line() {
+        let dir = std::env::temp_dir().join("fg_record_history_nested_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("sub").join("hist.tsv");
+        // 親 dir が無くても追記できる(config 由来の record.dir が未作成のケース)
+        assert!(append_ratings_history(&path, "20260707", "ME", 3400.0).unwrap());
+        // 尻切れ行(改行なし)が残っていても新行が連結されない
+        std::fs::write(&path, "20260706\tME\t33").unwrap();
+        assert!(append_ratings_history(&path, "20260707", "ME", 3400.0).unwrap());
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text, "20260706\tME\t33\n20260707\tME\t3400\n");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -25,6 +25,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use reqwest::blocking::Client;
 use rshogi_csa_client::config::CsaClientConfig;
+use rshogi_csa_client::jsonl::sanitize_for_filename;
 use serde::Deserialize;
 use tools::common::floodgate as fg;
 
@@ -112,14 +113,13 @@ fn resolve_effective(cli: &Cli, config: Option<(&Path, &CsaClientConfig)>) -> Re
         (None, None) => PathBuf::from("."),
     };
 
-    // JSONL 内の engine ラベルは sanitize 済み(`.` や `@` は `_` になる)なので、
-    // server.id 由来の me も同じ正規化を通さないと全局が対象不参加になる。
-    let me = cli.me.clone().or_else(|| {
-        based
-            .map(|(_, _, c)| c.server.id.as_str())
-            .filter(|id| !id.is_empty())
-            .map(rshogi_csa_client::jsonl::sanitize_for_filename)
-    });
+    // 集計キーは sanitize 名に統一している(parse_game 参照)ので、CLI / server.id
+    // 由来の me も同じ正規化を通す(英数字と `-` `_` には no-op)。
+    let me = cli
+        .me
+        .as_deref()
+        .or_else(|| based.map(|(_, _, c)| c.server.id.as_str()).filter(|id| !id.is_empty()))
+        .map(sanitize_for_filename);
 
     // キャッシュ / 履歴の config 既定は --fetch-ratings 時のみ意味を持つ(clap の
     // `requires` と整合。fetch しないのに既定パスを作らない)。
@@ -208,6 +208,10 @@ fn parse_game(path: &std::path::Path) -> Result<Option<Game>> {
         match l.kind.as_str() {
             "move" => {
                 if let Some(eng) = l.engine {
+                    // JSONL の move.engine / result.winner は raw の CSA 名、ファイル名と
+                    // meta ラベルは sanitize 済みという混在なので、集計キーは入口で
+                    // sanitize に統一する(`.` 等を含む名前でも突き合わせが揃う)。
+                    let eng = sanitize_for_filename(&eng);
                     if l.ply == Some(1) {
                         sente_ply1 = Some(eng.clone());
                     }
@@ -224,7 +228,7 @@ fn parse_game(path: &std::path::Path) -> Result<Option<Game>> {
             }
             "result" => {
                 has_result = true;
-                winner = l.winner.filter(|w| !w.is_empty());
+                winner = l.winner.filter(|w| !w.is_empty()).map(|w| sanitize_for_filename(&w));
                 reason = l.reason.unwrap_or_default();
                 plies = l.plies.unwrap_or(0);
             }
@@ -287,12 +291,17 @@ fn median(xs: &mut [f64]) -> f64 {
 }
 
 /// wdoor floodgate の現在レート表を取得し (ページ日付 YYYYMMDD, name -> rating) を作る。
-/// 取得・解析は `tools::common::floodgate`(reqwest, in-repo)を再利用。
+/// 取得・解析は `tools::common::floodgate`(reqwest, in-repo)を再利用。キーは集計側と
+/// 同じ sanitize 名に正規化する(raw 表示名が `.` 等を含んでも引ける。衝突は後勝ち)。
 fn fetch_ratings_map() -> Result<(String, BTreeMap<String, f64>)> {
     let client = Client::builder().build().context("reqwest client 生成失敗")?;
     let (url, date, html) = fg::fetch_latest_rating_page(&client)?;
     eprintln!("レート取得: {url}");
-    Ok((date, fg::parse_rating_page(&html).into_iter().collect()))
+    let map = fg::parse_rating_page(&html)
+        .into_iter()
+        .map(|(name, rate)| (sanitize_for_filename(&name), rate))
+        .collect();
+    Ok((date, map))
 }
 
 /// キャッシュの mtime が `max_age_sec` 以内か。0 は常に false(= 常に fetch)。
@@ -428,6 +437,7 @@ fn write_ratings_cache(path: &Path, map: &BTreeMap<String, f64>) -> Result<()> {
 }
 
 /// キャッシュ(`name<TAB>rate`)を name -> rating に読み戻す。壊れた行・非有限値は捨てる。
+/// キーは書き出し時と同じ sanitize 名に正規化する(raw 名で書かれた古いキャッシュも引ける)。
 fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
     let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     Ok(text
@@ -435,7 +445,7 @@ fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
         .filter_map(|line| line.split_once('\t'))
         .filter_map(|(n, r)| {
             let v = r.trim().parse::<f64>().ok().filter(|v| v.is_finite())?;
-            Some((n.trim().to_owned(), v))
+            Some((sanitize_for_filename(n.trim()), v))
         })
         .collect())
 }
@@ -507,6 +517,9 @@ fn main() -> Result<()> {
                 .context("対象エンジンを自動判定できない")?
         }
     };
+
+    // 注目相手パターンも sanitize 名の集計キーに部分一致させる(`.` 入りパターンでも当たる)。
+    let watch: Vec<String> = cli.watch.iter().map(|w| sanitize_for_filename(w)).collect();
 
     // レートは現在値(対局時点ではない)。取得失敗・空取得はレート併記だけ諦め、集計は続行する
     // (opt-in の補助機能のために primary output を落とさない)。
@@ -629,7 +642,7 @@ fn main() -> Result<()> {
         }
         any_gw = true;
         let opp = &g.sente;
-        let star = if cli.watch.iter().any(|w| opp.contains(w.as_str())) {
+        let star = if watch.iter().any(|w| opp.contains(w.as_str())) {
             "  ★上位AI"
         } else {
             ""
@@ -667,7 +680,7 @@ fn main() -> Result<()> {
         }
     }
 
-    if !cli.watch.is_empty() {
+    if !watch.is_empty() {
         println!("\n=== 注目相手との対戦 ===");
         for g in &games {
             if g.sente != me && g.gote != me {
@@ -675,7 +688,7 @@ fn main() -> Result<()> {
             }
             let is_sente = g.sente == me;
             let opp = if is_sente { &g.gote } else { &g.sente };
-            if !cli.watch.iter().any(|w| opp.contains(w.as_str())) {
+            if !watch.iter().any(|w| opp.contains(w.as_str())) {
                 continue;
             }
             let Some(res) = result_for(g, &me) else {
@@ -885,10 +898,41 @@ mod tests {
 
     #[test]
     fn resolve_effective_sanitizes_config_me_like_jsonl_labels() {
-        // JSONL の engine ラベルは sanitize 済みなので `.` を含む server.id は `_` で比較。
+        // 集計キーは sanitize 名に統一しているので `.` を含む server.id は `_` で比較。
         let cfg = config_from("[server]\nid = \"ramu.v2\"\n[record]\ndir = \"/d\"\n");
         let eff = resolve_effective(&cli_default(), Some((Path::new("/x/a.toml"), &cfg))).unwrap();
         assert_eq!(eff.me.as_deref(), Some("ramu_v2"));
+    }
+
+    #[test]
+    fn parse_game_sanitizes_raw_names() {
+        // move.engine / result.winner は raw の CSA 名で書かれるため、集計キーは
+        // sanitize 名に揃えて読み込む。
+        let path = std::env::temp_dir().join("fg_record_test_sanitize.jsonl");
+        let body = concat!(
+            r#"{"type":"move","ply":1,"engine":"ramu.v2"}"#,
+            "\n",
+            r#"{"type":"move","ply":2,"engine":"opp@x"}"#,
+            "\n",
+            r#"{"type":"result","outcome":"black_win","reason":"resign","plies":2,"winner":"ramu.v2"}"#,
+            "\n",
+        );
+        std::fs::write(&path, body).unwrap();
+        let g = parse_game(&path).unwrap().expect("完了局");
+        assert_eq!(g.sente, "ramu_v2");
+        assert_eq!(g.gote, "opp_x");
+        assert!(matches!(result_for(&g, "ramu_v2"), Some(Res::Win)));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ratings_cache_normalizes_names() {
+        // raw 名で書かれた古いキャッシュも sanitize キーで引ける。
+        let path = std::env::temp_dir().join("fg_record_cache_sanitize.tsv");
+        std::fs::write(&path, "ramu.v2\t3400\n").unwrap();
+        let m = read_ratings_cache(&path).unwrap();
+        assert_eq!(m.get("ramu_v2"), Some(&3400.0));
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -11,16 +11,20 @@
 //! # ~/floodgate/records/jsonl を集計(対象エンジンは自動判定)
 //! floodgate_record --dir ~/floodgate/records/jsonl
 //!
+//! # csa_client と同じ config から dir / --me / キャッシュ既定を導出(明示引数が優先)
+//! floodgate_record --config ~/floodgate/active.toml --fetch-ratings
+//!
 //! # 対象エンジンを明示し、注目相手を指定
 //! floodgate_record --dir ./jsonl --me RAMU_TF --watch Suisho,dlshogi,nshogi
 //! ```
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use reqwest::blocking::Client;
+use rshogi_csa_client::config::CsaClientConfig;
 use serde::Deserialize;
 use tools::common::floodgate as fg;
 
@@ -31,11 +35,20 @@ use tools::common::floodgate as fg;
     about = "Aggregate an engine's win/loss record from csa_client per-game JSONL"
 )]
 struct Cli {
-    /// 集計対象 JSONL(`*.jsonl`)のあるディレクトリ(再帰なし)
-    #[arg(long, default_value = ".")]
-    dir: PathBuf,
+    /// csa_client と同一の TOML 設定ファイル。指定時は `record` 設定から集計 dir を、
+    /// `server.id` から --me を、`record.dir` からレートキャッシュ/履歴の既定パスを導出する
+    /// (対応する明示引数が常に優先)。省略時は環境変数 `CSA_CLIENT_CONFIG` を参照する。
+    /// TOML 内の相対パスは config ファイルのあるディレクトリ基準で解決する。
+    #[arg(long)]
+    config: Option<PathBuf>,
 
-    /// 集計対象エンジン名。省略時は全 JSONL に最も多く出現するエンジンを自動判定。
+    /// 集計対象 JSONL(`*.jsonl`)のあるディレクトリ(再帰なし)。省略時は --config の
+    /// `record` 設定から導出し、それも無ければカレントディレクトリ。
+    #[arg(long)]
+    dir: Option<PathBuf>,
+
+    /// 集計対象エンジン名。省略時は --config の `server.id`、それも無ければ
+    /// 全 JSONL に最も多く出現するエンジンを自動判定。
     #[arg(long)]
     me: Option<String>,
 
@@ -50,8 +63,79 @@ struct Cli {
 
     /// `--fetch-ratings` と併用するキャッシュファイル(`name<TAB>rate`)。fetch 成功時はここへ
     /// 書き出し、失敗時はここを読み戻してフォールバック併記する(一時障害でも直近値を維持)。
+    /// --config 指定時の既定は `<record.dir>/ratings_cache.tsv`。
     #[arg(long, requires = "fetch_ratings")]
     ratings_cache: Option<PathBuf>,
+
+    /// キャッシュがこの秒数以内に更新済みならネットワーク取得をスキップして
+    /// キャッシュを直接使う(0 = 常に取得)。レートページは日次生成なので
+    /// 数時間 (例: 21600 = 6h) で十分。
+    #[arg(long, default_value_t = 0, requires = "fetch_ratings")]
+    ratings_max_age: u64,
+
+    /// fetch 成功時に自分のレートを `ページ日付<TAB>名前<TAB>レート` で追記する履歴
+    /// ファイル。同一 (日付, 名前) は再追記しない(その日最初の観測値を記録)。
+    /// --config 指定時の既定は `<record.dir>/ratings_history.tsv`。
+    #[arg(long, requires = "fetch_ratings")]
+    ratings_history: Option<PathBuf>,
+}
+
+/// CLI と config から解決した実効入力。優先順位は常に 明示 CLI > config 由来 > 既定。
+struct Effective {
+    dir: PathBuf,
+    /// 対象エンジン名。`None` は最頻出エンジンの自動判定に委ねる。
+    me: Option<String>,
+    ratings_cache: Option<PathBuf>,
+    ratings_history: Option<PathBuf>,
+}
+
+fn resolve_effective(cli: &Cli, config: Option<(&Path, &CsaClientConfig)>) -> Result<Effective> {
+    // TOML 内の相対パスは csa_client 実行時の cwd ではなく config ファイル基準で解決する
+    // (集計は別 cwd から叩かれるため。運用 config は絶対パス推奨)。
+    fn resolve(base: &Path, p: PathBuf) -> PathBuf {
+        if p.is_absolute() { p } else { base.join(p) }
+    }
+    let config_base = |path: &Path| path.parent().unwrap_or(Path::new(".")).to_path_buf();
+
+    let dir = match (&cli.dir, config) {
+        (Some(d), _) => d.clone(),
+        (None, Some((path, cfg))) => match cfg.record.jsonl_dir() {
+            Some(d) => resolve(&config_base(path), d),
+            None => bail!(
+                "config {} は JSONL 出力が無効 (record.enabled / record.save_jsonl を確認)。\
+                 集計元が導出できないため --dir で明示すること",
+                path.display()
+            ),
+        },
+        (None, None) => PathBuf::from("."),
+    };
+
+    let me = cli
+        .me
+        .clone()
+        .or_else(|| config.map(|(_, c)| c.server.id.clone()).filter(|id| !id.is_empty()));
+
+    // キャッシュ / 履歴の config 既定は --fetch-ratings 時のみ意味を持つ(clap の
+    // `requires` と整合。fetch しないのに既定パスを作らない)。
+    let derived = |explicit: &Option<PathBuf>, filename: &str| {
+        if !cli.fetch_ratings {
+            return None;
+        }
+        explicit.clone().or_else(|| {
+            config.map(|(path, cfg)| {
+                resolve(&config_base(path), cfg.record.dir.clone()).join(filename)
+            })
+        })
+    };
+    let ratings_cache = derived(&cli.ratings_cache, "ratings_cache.tsv");
+    let ratings_history = derived(&cli.ratings_history, "ratings_history.tsv");
+
+    Ok(Effective {
+        dir,
+        me,
+        ratings_cache,
+        ratings_history,
+    })
 }
 
 /// JSONL 1 行の必要フィールドだけを拾う(未使用 type 行は無視)。
@@ -196,13 +280,109 @@ fn median(xs: &mut [f64]) -> f64 {
     }
 }
 
-/// wdoor floodgate の現在レート表を取得し name -> rating を作る。
+/// wdoor floodgate の現在レート表を取得し (ページ日付 YYYYMMDD, name -> rating) を作る。
 /// 取得・解析は `tools::common::floodgate`(reqwest, in-repo)を再利用。
-fn fetch_ratings_map() -> Result<BTreeMap<String, f64>> {
+fn fetch_ratings_map() -> Result<(Option<String>, BTreeMap<String, f64>)> {
     let client = Client::builder().build().context("reqwest client 生成失敗")?;
     let (url, html) = fg::fetch_latest_rating_page(&client)?;
     eprintln!("レート取得: {url}");
-    Ok(fg::parse_rating_page(&html).into_iter().collect())
+    Ok((fg::rating_page_date(&url), fg::parse_rating_page(&html).into_iter().collect()))
+}
+
+/// キャッシュの mtime が `max_age_sec` 以内か。0 は常に false(= 常に fetch)。
+/// mtime が取得できない・未来時刻の場合は鮮度不明として false に倒す。
+fn cache_is_fresh(path: &Path, max_age_sec: u64) -> bool {
+    if max_age_sec == 0 {
+        return false;
+    }
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .is_some_and(|age| age.as_secs() <= max_age_sec)
+}
+
+/// 履歴ファイルに `date<TAB>name<TAB>rate` を 1 行追記する。同一 (date, name) の行が
+/// 既にあれば何もしない(レートページは日次生成のため、同日の再実行で重複させない)。
+/// 追記したら `Ok(true)`。
+fn append_ratings_history(path: &Path, date: &str, name: &str, rate: f64) -> Result<bool> {
+    use std::io::Write;
+    let prefix = format!("{date}\t{name}\t");
+    match std::fs::read_to_string(path) {
+        Ok(text) => {
+            if text.lines().any(|l| l.starts_with(&prefix)) {
+                return Ok(false);
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open {}", path.display()))?;
+    writeln!(f, "{prefix}{rate}")?;
+    Ok(true)
+}
+
+/// レートマップを用意する。鮮度内キャッシュがあれば fetch せず直接使う。それ以外は
+/// fetch し、成功時はキャッシュ書き出し + 履歴追記、失敗時はキャッシュ読み戻しで
+/// フォールバック。opt-in の補助機能なので、失敗はすべて警告にとどめ空マップで続行する。
+fn obtain_ratings(eff: &Effective, max_age_sec: u64, me: &str) -> BTreeMap<String, f64> {
+    if let Some(cache) = &eff.ratings_cache
+        && cache_is_fresh(cache, max_age_sec)
+    {
+        match read_ratings_cache(cache) {
+            Ok(map) if !map.is_empty() => {
+                eprintln!("レート: キャッシュ利用 ({} が {max_age_sec} 秒以内)", cache.display());
+                return map;
+            }
+            Ok(_) => eprintln!("⚠ 鮮度内キャッシュが空。fetch にフォールバック"),
+            Err(e) => eprintln!("⚠ 鮮度内キャッシュ読み込み失敗: {e:#}。fetch にフォールバック"),
+        }
+    }
+    // 取得失敗・空取得はキャッシュへフォールバック。書き出しは「取得成功かつ非空」の
+    // ときのみ(空取得で last-known-good を潰さない)。
+    let fetched = match fetch_ratings_map() {
+        Ok((date, map)) if !map.is_empty() => Some((date, map)),
+        Ok(_) => {
+            eprintln!("⚠ レート表が空(取得 0 件)。キャッシュにフォールバック");
+            None
+        }
+        Err(e) => {
+            eprintln!("⚠ レート取得失敗: {e:#}");
+            None
+        }
+    };
+    match fetched {
+        Some((date, map)) => {
+            if let Some(cache) = &eff.ratings_cache
+                && let Err(e) = write_ratings_cache(cache, &map)
+            {
+                eprintln!("⚠ レートキャッシュ書き出し失敗: {e:#}");
+            }
+            if let Some(history) = &eff.ratings_history {
+                match (&date, map.get(me)) {
+                    (Some(d), Some(rate)) => match append_ratings_history(history, d, me, *rate) {
+                        Ok(true) => eprintln!("レート履歴追記: {d} {me} R{rate}"),
+                        Ok(false) => {}
+                        Err(e) => eprintln!("⚠ レート履歴追記失敗: {e:#}"),
+                    },
+                    (None, _) => eprintln!("⚠ ページ日付を URL から特定できず履歴追記をスキップ"),
+                    (_, None) => eprintln!("⚠ {me} がレート表に無いため履歴追記をスキップ"),
+                }
+            }
+            map
+        }
+        None => match &eff.ratings_cache {
+            Some(cache) => read_ratings_cache(cache).unwrap_or_else(|e2| {
+                eprintln!("⚠ キャッシュ読み戻しも失敗(注釈なしで続行): {e2:#}");
+                BTreeMap::new()
+            }),
+            None => BTreeMap::new(),
+        },
+    }
 }
 
 /// レートマップを `name<TAB>rate` でキャッシュへ書き出す(BTreeMap 順で決定的)。
@@ -241,7 +421,22 @@ fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let pattern = cli.dir.join("*.jsonl");
+    // config は --config > 環境変数 CSA_CLIENT_CONFIG。指定があるのに読めないのは
+    // 設定ミスなので fail-fast(config 無しで集計したい場合は引数/env を外す)。
+    let config_path = cli
+        .config
+        .clone()
+        .or_else(|| std::env::var_os("CSA_CLIENT_CONFIG").map(PathBuf::from));
+    let config = config_path
+        .as_deref()
+        .map(|path| {
+            CsaClientConfig::from_file(path)
+                .with_context(|| format!("config 読み込み失敗: {}", path.display()))
+        })
+        .transpose()?;
+    let eff = resolve_effective(&cli, config_path.as_deref().zip(config.as_ref()))?;
+
+    let pattern = eff.dir.join("*.jsonl");
     let pattern = pattern.to_string_lossy();
     let mut games: Vec<Game> = Vec::new();
     for entry in glob::glob(&pattern).with_context(|| format!("glob {pattern}"))? {
@@ -251,12 +446,13 @@ fn main() -> Result<()> {
         }
     }
     if games.is_empty() {
-        bail!("完了局の JSONL が {} に見つからない", cli.dir.display());
+        bail!("完了局の JSONL が {} に見つからない", eff.dir.display());
     }
     games.sort_by(|a, b| a.stem.cmp(&b.stem));
 
-    // 対象エンジン: 明示 or 「最も多くの局に出現するエンジン」を自動判定。
-    let me = match cli.me {
+    // 対象エンジン: 明示 CLI / config の server.id、無ければ「最も多くの局に出現する
+    // エンジン」を自動判定。
+    let me = match eff.me.clone() {
         Some(m) => m,
         None => {
             let mut count: BTreeMap<&str, usize> = BTreeMap::new();
@@ -276,37 +472,8 @@ fn main() -> Result<()> {
 
     // レートは現在値(対局時点ではない)。取得失敗・空取得はレート併記だけ諦め、集計は続行する
     // (opt-in の補助機能のために primary output を落とさない)。
-    // --ratings-cache 併用時は「取得成功かつ非空」でのみ書き出し、それ以外は cache を読み戻して
-    // フォールバックする(空取得で last-known-good を潰さない)。
     let ratings: BTreeMap<String, f64> = if cli.fetch_ratings {
-        let fetched = match fetch_ratings_map() {
-            Ok(map) if !map.is_empty() => Some(map),
-            Ok(_) => {
-                eprintln!("⚠ レート表が空(取得 0 件)。キャッシュにフォールバック");
-                None
-            }
-            Err(e) => {
-                eprintln!("⚠ レート取得失敗: {e:#}");
-                None
-            }
-        };
-        match fetched {
-            Some(map) => {
-                if let Some(cache) = &cli.ratings_cache
-                    && let Err(e) = write_ratings_cache(cache, &map)
-                {
-                    eprintln!("⚠ レートキャッシュ書き出し失敗: {e:#}");
-                }
-                map
-            }
-            None => match &cli.ratings_cache {
-                Some(cache) => read_ratings_cache(cache).unwrap_or_else(|e2| {
-                    eprintln!("⚠ キャッシュ読み戻しも失敗(注釈なしで続行): {e2:#}");
-                    BTreeMap::new()
-                }),
-                None => BTreeMap::new(),
-            },
-        }
+        obtain_ratings(&eff, cli.ratings_max_age, &me)
     } else {
         BTreeMap::new()
     };
@@ -581,6 +748,141 @@ mod tests {
         assert_eq!(back.get("Foo-Bar_1"), Some(&-12.0));
         assert_eq!(back.len(), 2);
         let _ = std::fs::remove_file(&path);
+    }
+
+    fn cli_default() -> Cli {
+        Cli {
+            config: None,
+            dir: None,
+            me: None,
+            watch: Vec::new(),
+            fetch_ratings: false,
+            ratings_cache: None,
+            ratings_max_age: 0,
+            ratings_history: None,
+        }
+    }
+
+    fn config_from(toml_text: &str) -> CsaClientConfig {
+        toml::from_str(toml_text).unwrap()
+    }
+
+    #[test]
+    fn resolve_effective_no_config_defaults() {
+        let eff = resolve_effective(&cli_default(), None).unwrap();
+        assert_eq!(eff.dir, PathBuf::from("."));
+        assert_eq!(eff.me, None);
+        assert_eq!(eff.ratings_cache, None);
+        assert_eq!(eff.ratings_history, None);
+    }
+
+    #[test]
+    fn resolve_effective_derives_from_config() {
+        let cfg = config_from("[server]\nid = \"RAMU_TF\"\n[record]\ndir = \"/data/records\"\n");
+        let cli = Cli {
+            fetch_ratings: true,
+            ..cli_default()
+        };
+        let eff = resolve_effective(&cli, Some((Path::new("/etc/fg/active.toml"), &cfg))).unwrap();
+        assert_eq!(eff.dir, PathBuf::from("/data/records/jsonl"));
+        assert_eq!(eff.me.as_deref(), Some("RAMU_TF"));
+        assert_eq!(eff.ratings_cache, Some(PathBuf::from("/data/records/ratings_cache.tsv")));
+        assert_eq!(eff.ratings_history, Some(PathBuf::from("/data/records/ratings_history.tsv")));
+    }
+
+    #[test]
+    fn resolve_effective_cli_overrides_config() {
+        let cfg = config_from("[server]\nid = \"RAMU_TF\"\n[record]\ndir = \"/data/records\"\n");
+        let cli = Cli {
+            dir: Some(PathBuf::from("/explicit/jsonl")),
+            me: Some("OTHER".to_owned()),
+            fetch_ratings: true,
+            ratings_cache: Some(PathBuf::from("/explicit/cache.tsv")),
+            ratings_history: Some(PathBuf::from("/explicit/hist.tsv")),
+            ..cli_default()
+        };
+        let eff = resolve_effective(&cli, Some((Path::new("/etc/fg/active.toml"), &cfg))).unwrap();
+        assert_eq!(eff.dir, PathBuf::from("/explicit/jsonl"));
+        assert_eq!(eff.me.as_deref(), Some("OTHER"));
+        assert_eq!(eff.ratings_cache, Some(PathBuf::from("/explicit/cache.tsv")));
+        assert_eq!(eff.ratings_history, Some(PathBuf::from("/explicit/hist.tsv")));
+    }
+
+    #[test]
+    fn resolve_effective_relative_paths_use_config_dir() {
+        // TOML 内相対パスは config ファイルのディレクトリ基準。jsonl_out 上書きも尊重。
+        let cfg = config_from("[record]\ndir = \"records\"\n");
+        let eff = resolve_effective(
+            &cli_default(),
+            Some((Path::new("/home/u/floodgate/active.toml"), &cfg)),
+        )
+        .unwrap();
+        assert_eq!(eff.dir, PathBuf::from("/home/u/floodgate/records/jsonl"));
+        // --fetch-ratings なしでは config 由来のキャッシュ/履歴既定も作らない
+        assert_eq!(eff.ratings_cache, None);
+        assert_eq!(eff.ratings_history, None);
+
+        let cfg = config_from("[record]\ndir = \"records\"\njsonl_out = \"jl\"\n");
+        let eff = resolve_effective(
+            &cli_default(),
+            Some((Path::new("/home/u/floodgate/active.toml"), &cfg)),
+        )
+        .unwrap();
+        assert_eq!(eff.dir, PathBuf::from("/home/u/floodgate/jl"));
+    }
+
+    #[test]
+    fn resolve_effective_rejects_config_without_jsonl() {
+        let cfg = config_from("[record]\nenabled = false\n");
+        let err = resolve_effective(&cli_default(), Some((Path::new("/x/a.toml"), &cfg)));
+        assert!(err.is_err());
+        // --dir 明示があれば config の JSONL 無効は問題にならない
+        let cli = Cli {
+            dir: Some(PathBuf::from("/y")),
+            ..cli_default()
+        };
+        let eff = resolve_effective(&cli, Some((Path::new("/x/a.toml"), &cfg))).unwrap();
+        assert_eq!(eff.dir, PathBuf::from("/y"));
+    }
+
+    #[test]
+    fn resolve_effective_empty_server_id_falls_back_to_autodetect() {
+        let cfg = config_from("[record]\ndir = \"/d\"\n");
+        let eff = resolve_effective(&cli_default(), Some((Path::new("/x/a.toml"), &cfg))).unwrap();
+        assert_eq!(eff.me, None);
+    }
+
+    #[test]
+    fn ratings_history_append_is_idempotent_per_date_and_name() {
+        let path = std::env::temp_dir().join("fg_record_ratings_history_test.tsv");
+        let _ = std::fs::remove_file(&path);
+        assert!(append_ratings_history(&path, "20260707", "RAMU_TF", 3427.0).unwrap());
+        // 同一 (日付, 名前) は再追記しない(値が違っても最初の観測値を保持)
+        assert!(!append_ratings_history(&path, "20260707", "RAMU_TF", 3500.0).unwrap());
+        // 別日付・別名は追記。名前が prefix 一致するだけの別エンジンも混同しない
+        assert!(append_ratings_history(&path, "20260708", "RAMU_TF", 3440.0).unwrap());
+        assert!(append_ratings_history(&path, "20260707", "RAMU", 100.0).unwrap());
+        let text = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "20260707\tRAMU_TF\t3427",
+                "20260708\tRAMU_TF\t3440",
+                "20260707\tRAMU\t100"
+            ]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn cache_freshness() {
+        let path = std::env::temp_dir().join("fg_record_cache_fresh_test.tsv");
+        std::fs::write(&path, "A\t1\n").unwrap();
+        assert!(cache_is_fresh(&path, 3600)); // 直前に書いたので鮮度内
+        assert!(!cache_is_fresh(&path, 0)); // 0 = 常に fetch
+        let _ = std::fs::remove_file(&path);
+        assert!(!cache_is_fresh(&path, 3600)); // 存在しないファイルは stale 扱い
     }
 
     #[test]

--- a/crates/tools/src/common/floodgate.rs
+++ b/crates/tools/src/common/floodgate.rs
@@ -112,6 +112,15 @@ pub fn rating_page_url(root: &str, date_yyyymmdd: &str) -> Result<String> {
     join_url(root, &format!("{RATING_PAGE_REL_PREFIX}{date_yyyymmdd}.html"))
 }
 
+/// レーティングページ URL からページ日付 (`YYYYMMDD`) を取り出す。
+/// [`rating_page_url`] が組む `players-floodgate-YYYYMMDD.html` 形式の逆変換で、
+/// 形式が合わなければ `None`。
+pub fn rating_page_date(url: &str) -> Option<String> {
+    let stem = url.rsplit('/').next()?.strip_suffix(".html")?;
+    let date = stem.rsplit('-').next()?;
+    (date.len() == 8 && date.bytes().all(|b| b.is_ascii_digit())).then(|| date.to_string())
+}
+
 /// 直近のレーティングページを取得し (URL, HTML) を返す。
 ///
 /// ページは日次生成の日付スタンプ付きで当日分が未生成のこともあるため、
@@ -236,6 +245,15 @@ mod tests {
             u,
             "https://wdoor.c.u-tokyo.ac.jp/shogi/x/rating/players-floodgate-20260620.html"
         );
+    }
+    #[test]
+    fn test_rating_page_date() {
+        let u = rating_page_url(DEFAULT_ROOT, "20260620").unwrap();
+        assert_eq!(rating_page_date(&u).as_deref(), Some("20260620"));
+        // 日付部が 8 桁数字でない・形式外は None
+        assert_eq!(rating_page_date("https://x/players-floodgate-2026062.html"), None);
+        assert_eq!(rating_page_date("https://x/players-floodgate-20260620"), None);
+        assert_eq!(rating_page_date("https://x/other.html"), None);
     }
     #[test]
     fn test_parse_rating_page() {

--- a/crates/tools/src/common/floodgate.rs
+++ b/crates/tools/src/common/floodgate.rs
@@ -112,20 +112,11 @@ pub fn rating_page_url(root: &str, date_yyyymmdd: &str) -> Result<String> {
     join_url(root, &format!("{RATING_PAGE_REL_PREFIX}{date_yyyymmdd}.html"))
 }
 
-/// レーティングページ URL からページ日付 (`YYYYMMDD`) を取り出す。
-/// [`rating_page_url`] が組む `players-floodgate-YYYYMMDD.html` 形式の逆変換で、
-/// 形式が合わなければ `None`。
-pub fn rating_page_date(url: &str) -> Option<String> {
-    let stem = url.rsplit('/').next()?.strip_suffix(".html")?;
-    let date = stem.rsplit('-').next()?;
-    (date.len() == 8 && date.bytes().all(|b| b.is_ascii_digit())).then(|| date.to_string())
-}
-
-/// 直近のレーティングページを取得し (URL, HTML) を返す。
+/// 直近のレーティングページを取得し (URL, ページ日付 `YYYYMMDD`, HTML) を返す。
 ///
 /// ページは日次生成の日付スタンプ付きで当日分が未生成のこともあるため、
 /// 今日から数日遡って最初に取得できたページを採用する。
-pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String)> {
+pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String, String)> {
     const LOOKBACK_DAYS: i64 = 7;
     // ファイル名は floodgate サーバ (JST/+0900) 基準の日付なので、ホスト TZ に依存せず
     // JST で当日を求める。UTC など JST より遅れた TZ のホストでは現地 today が当日分を
@@ -134,10 +125,10 @@ pub fn fetch_latest_rating_page(client: &Client) -> Result<(String, String)> {
     let today = chrono::Utc::now().with_timezone(&jst).date_naive();
     let mut last_err: Option<anyhow::Error> = None;
     for back in 0..=LOOKBACK_DAYS {
-        let date = today - chrono::Duration::days(back);
-        let url = rating_page_url(DEFAULT_ROOT, &date.format("%Y%m%d").to_string())?;
+        let date = (today - chrono::Duration::days(back)).format("%Y%m%d").to_string();
+        let url = rating_page_url(DEFAULT_ROOT, &date)?;
         match http_get_text(client, &url) {
-            Ok(html) => return Ok((url, html)),
+            Ok(html) => return Ok((url, date, html)),
             Err(e) => last_err = Some(e),
         }
     }
@@ -245,15 +236,6 @@ mod tests {
             u,
             "https://wdoor.c.u-tokyo.ac.jp/shogi/x/rating/players-floodgate-20260620.html"
         );
-    }
-    #[test]
-    fn test_rating_page_date() {
-        let u = rating_page_url(DEFAULT_ROOT, "20260620").unwrap();
-        assert_eq!(rating_page_date(&u).as_deref(), Some("20260620"));
-        // 日付部が 8 桁数字でない・形式外は None
-        assert_eq!(rating_page_date("https://x/players-floodgate-2026062.html"), None);
-        assert_eq!(rating_page_date("https://x/players-floodgate-20260620"), None);
-        assert_eq!(rating_page_date("https://x/other.html"), None);
     }
     #[test]
     fn test_parse_rating_page() {


### PR DESCRIPTION
## 概要

floodgate_record に csa_client 設定連動と、レート取得の鮮度キャッシュ・履歴記録を追加する。運用上は `--config ~/floodgate/active.toml --fetch-ratings` (または `CSA_CLIENT_CONFIG` を export して引数なし) だけで、集計 dir / 対象エンジン / キャッシュ / 履歴がすべて導出される。

## 変更点

- **`--config <TOML>`** (env `CSA_CLIENT_CONFIG` フォールバック、空値は未設定扱い): csa_client と同一の `CsaClientConfig` を読み、集計 dir (`record.jsonl_dir()`)・`--me` (`server.id`)・キャッシュ/履歴の既定パス (`<record.dir>/ratings_{cache,history}.tsv`) を導出。明示 CLI 引数が常に優先。適用時は導出結果を stderr に 1 行表示。TOML 内相対パスは config ファイル基準で解決 (doc に明記)
- **`--ratings-max-age <SEC>`**: キャッシュ mtime が鮮度内ならネットワーク取得をスキップ (既定 0 = 常に取得)。履歴併用時は履歴に当日 (JST) 分が無ければ鮮度内でも取得し、履歴の日付抜けを防ぐ
- **`--ratings-history <FILE>`**: fetch 成功時に自分のレートを `ページ日付\t名前\tレート` で冪等追記 (同一日付+名前は再追記しない)。書き込みは tmp→rename の全置換で並行実行や尻切れ行にも安全
- config 由来の `me` は JSONL の engine ラベルと同じ正規化 (`sanitize_for_filename` を pub 化) で比較 — `.` や `@` を含む server.id が全局不参加になる事故を防ぐ
- `fetch_latest_rating_page` が (URL, ページ日付, HTML) を返すよう変更 (URL 逆パース削除)。tools → rshogi-csa-client を `default-features = false` で依存し設定型を単一ソース化

## レビュー / 検証

- フル差分レビュー (8 角度並列 finder + 検証): correctness 指摘 6 件 (sanitize 不一致 / max-age×履歴の食い合わせ / 親 dir 未作成 / 履歴追記の非原子性 / 空 env / URL 逆パースの脆さ) をすべて対応済み。相対パス解決の csa_client 側統一は挙動変更になるため見送り (doc 記載)
- sh11235-ws で fmt / clippy 0 / test green (floodgate_record 16・common 5・rshogi-csa-client 70)
- E2E スモーク (実 wdoor): config 導出→取得→キャッシュ書き出し (427 名)→履歴追記→max-age スキップ→履歴欠落時の強制 fetch→sanitize 比較→空 env、すべて期待どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCCFdxeJgp7jCFXducgp6K