### PR TITLE
feat(tools): kifu_player — --live 追記監視 / --ratings レート併記 / rate:・date: フィルタ / 日付ソート

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -20,7 +20,7 @@
 
 | ツール | 説明 |
 |--------|------|
-| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き。[詳細](docs/kifu_player.md)） |
+| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視・`--ratings` レート併記付き。[詳細](docs/kifu_player.md)） |
 
 ### 学習データ処理
 
@@ -83,7 +83,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 各ツールの詳細は `docs/` を参照：
 
 - [tournament](docs/tournament.md) - 並列トーナメント・SPRT 検定
-- [kifu_player](docs/kifu_player.md) - PSV / tournament JSONL / CSA 共通の棋譜プレイヤー TUI（評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き）
+- [kifu_player](docs/kifu_player.md) - PSV / tournament JSONL / CSA 共通の棋譜プレイヤー TUI（評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視・`--ratings` レート併記付き）
 - [gensfen](docs/gensfen.md) - 教師局面生成ツールの詳細
 - [benchmark](docs/benchmark.md) - ベンチマークツールの詳細
 - [pack_tools](docs/pack_tools.md) - 学習データ処理ツール群

--- a/crates/tools/docs/kifu_player.md
+++ b/crates/tools/docs/kifu_player.md
@@ -38,8 +38,10 @@ cargo run -p tools --release --features kifu-player --bin kifu_player -- \
   --tournament-dir runs/selfplay/<out-dir>
 ```
 
-out-dir 配下の `*-vs-*.jsonl`（`tournament` が出力するペアファイル）を横断して 1 つの
+out-dir 配下の `*-vs-*.jsonl`（`tournament` が出力するペアファイル）と
+`*_vs_*.jsonl`（`csa_client` の per-game 記録。スキーマは共通）を横断して 1 つの
 対局リストにまとめる。対局データを含まない付随ファイルは自動的に除外する。
+`csa_client` の JSONL dir（`[record].dir/jsonl/`）をそのまま渡せる。
 
 ### CSA を開く
 
@@ -62,6 +64,29 @@ cargo run -p tools --release --features kifu-player --bin kifu_player -- \
 - **評価値**は棋譜に埋め込まれたエンジンのコメントから読み取る。コメントの無い手・対局は
   評価値なし（グラフに打点しない）。片方のエンジンしか評価値を書いていない対局では、
   その側の手だけが打点される。
+
+### live モード（`--live [SECS]`）
+
+```bash
+# floodgate 連続対局の記録 dir を開いたまま、新しい完了局を自動で一覧に追加する
+cargo run -p tools --release --features kifu-player --bin kifu_player -- \
+  --csa ~/floodgate/records --live 5 --ratings ~/floodgate/records/ratings_cache.tsv
+```
+
+`--live [SECS]`（値省略時 5 秒）を付けると、SECS 秒ごとに入力の (パス, サイズ, mtime) の
+フィンガープリントを確認し、変化があったときだけ索引を取り直して一覧を更新する
+（変化が無い間はファイル内容を読まない）。csa_client は終局時に棋譜を一括書き出しするため、
+追加されるのは**完了局**（準リアルタイム。進行中の局の手は追えない）。選択中の対局と表示中の
+手は再読込をまたいで維持される。対局が 1 局も無い記録 dir を開いて待つこともできる。
+`--tournament-dir` でも使えるが、変化のたびに全ファイルを読み直すため巨大な out-dir では
+間隔を長めにする。`--psv` では使えない。一覧タイトルに `[live]` を表示する。
+
+### レート併記（`--ratings <TSV>`）
+
+`name<TAB>rate` の TSV（`floodgate_record --ratings-cache` の出力）を渡すと、対局一覧の
+各行に ` R3706/3512`（先手/後手、片方不明は `-`）を併記し、`rate:>N` フィルタが使える。
+ネットワークは使わない（レートの取得・更新は `floodgate_record --fetch-ratings` 側で行う）。
+名前の突き合わせは floodgate_record と同じ正規化キー（英数字と `-` `_` 以外を `_` に置換）。
 
 ## 画面構成
 
@@ -102,6 +127,8 @@ cargo run -p tools --release --features kifu-player --bin kifu_player -- \
 | `winner:sente\|gote` | 勝者側（`black`/`white` も可） | 完全一致 |
 | `len:>N` / `len:<N` / `len:N` | 手数 | 比較 |
 | `swing:>N` / `swing:<N` / `swing:N` | 評価値の振れ幅（cp） | 比較 |
+| `rate:>N` / `rate:<N` / `rate:N` | 対局の代表レート（両対局者の高い方。`--ratings` 供給時のみ） | 比較 |
+| `date:YYYYMMDD` | ファイル名由来の対局日時（`date:202607` 等の部分指定も可） | 前方一致 |
 | `reversal` | 両者が 300cp 以上優勢になった局面がある（形勢逆転） | 述語 |
 | `decisive` | 勝敗が付いた（引き分け・エラー・不明でない） | 述語 |
 | `sfen:<SFEN>` | 局面本体（各手の着手前局面） | 完全一致（手数フィールドを除く、`Enter` で逐次スキャン） |
@@ -142,10 +169,15 @@ prefix を付けずに**数字のみ**を入力すると、数値フィールド
 保つ安定ソート）。評価値による並べ替えは降順で、評価値の無い対局は末尾へ寄せる。
 
 1. 発見順（デフォルト）
-2. 勝敗別（エラー→先手勝ち→後手勝ち→引き分け→不明）
-3. 対局長（手数の降順）
-4. 決着の大きさ（最終評価値の絶対値の降順）
-5. 評価値の振れ幅（降順）
+2. 日付(新)（ファイル名由来の対局日時の降順。日時の無い対局は末尾）
+3. 勝敗別（エラー→先手勝ち→後手勝ち→引き分け→不明）
+4. 対局長（手数の降順）
+5. 決着の大きさ（最終評価値の絶対値の降順）
+6. 評価値の振れ幅（降順）
+
+日時はファイル名から抽出する（csa_client 記録の `YYYYMMDD_HHMMSS_` prefix、wdoor floodgate の
+末尾 14 桁タイムスタンプに対応）。tournament ペアファイルのように日時を持たないファイルの
+対局は「日付(新)」では末尾に寄り、`date:` フィルタにヒットしない。
 
 ## 評価値急変ジャンプ（`n` / `N`）
 
@@ -169,7 +201,8 @@ prefix を付けずに**数字のみ**を入力すると、数値フィールド
 
 ## スコープ外
 
-- 実行中の tournament のライブ追従（オフライン解析専用）
+- 進行中対局の手単位のライブ追従（`--live` が拾うのは完了局のみ。手単位の追従は
+  csa_client 側のイベント出力が必要で未対応）
 - セッションをまたいだ「最後に見ていた対局」の記憶
 - 棋譜ファイルへの書き込み・KIF/CSA へのエクスポート（`jsonl_to_kif` 等の既存ツールで代替）
 - 評価値グラフの Y 軸の自動スケール（現状は固定範囲）

--- a/crates/tools/docs/kifu_player.md
+++ b/crates/tools/docs/kifu_player.md
@@ -80,6 +80,9 @@ cargo run -p tools --release --features kifu-player --bin kifu_player -- \
 手は再読込をまたいで維持される。対局が 1 局も無い記録 dir を開いて待つこともできる。
 `--tournament-dir` でも使えるが、変化のたびに全ファイルを読み直すため巨大な out-dir では
 間隔を長めにする。`--psv` では使えない。一覧タイトルに `[live]` を表示する。
+SFEN 局面検索とは併用に制約がある: スキャン走査中は再読込を保留し、再読込が走ると
+`sfen:` の絞り込み結果は新しい索引へ引き継げないためクリアされて全件表示に戻る
+（ステータスの件数表示で分かる）。
 
 ### レート併記（`--ratings <TSV>`）
 
@@ -127,7 +130,7 @@ cargo run -p tools --release --features kifu-player --bin kifu_player -- \
 | `winner:sente\|gote` | 勝者側（`black`/`white` も可） | 完全一致 |
 | `len:>N` / `len:<N` / `len:N` | 手数 | 比較 |
 | `swing:>N` / `swing:<N` / `swing:N` | 評価値の振れ幅（cp） | 比較 |
-| `rate:>N` / `rate:<N` / `rate:N` | 対局の代表レート（両対局者の高い方。`--ratings` 供給時のみ） | 比較 |
+| `rate:>N` / `rate:<N` / `rate:N` | 対局の代表レート（両対局者の高い方。`--ratings` 供給時のみ。負レートも比較可: `rate:<0` 等） | 比較 |
 | `date:YYYYMMDD` | ファイル名由来の対局日時（`date:202607` 等の部分指定も可） | 前方一致 |
 | `reversal` | 両者が 300cp 以上優勢になった局面がある（形勢逆転） | 述語 |
 | `decisive` | 勝敗が付いた（引き分け・エラー・不明でない） | 述語 |

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -12,7 +12,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
-| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）付き。[詳細](kifu_player.md)） |
+| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視・`--ratings` レート併記付き。[詳細](kifu_player.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成。消費時間による定跡手判定（手番側ごとの即指しプレフィックス）・レート/勝敗/手数フィルタ・最小 ply 集約・ponder 集計。決定的（[詳細](book_from_csa.md)） |
 
 ## ベンチマーク・評価

--- a/crates/tools/src/bin/floodgate_record.rs
+++ b/crates/tools/src/bin/floodgate_record.rs
@@ -439,14 +439,9 @@ fn write_ratings_cache(path: &Path, map: &BTreeMap<String, f64>) -> Result<()> {
 /// キャッシュ(`name<TAB>rate`)を name -> rating に読み戻す。壊れた行・非有限値は捨てる。
 /// キーは書き出し時と同じ sanitize 名に正規化する(raw 名で書かれた古いキャッシュも引ける)。
 fn read_ratings_cache(path: &std::path::Path) -> Result<BTreeMap<String, f64>> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    Ok(text
-        .lines()
-        .filter_map(|line| line.split_once('\t'))
-        .filter_map(|(n, r)| {
-            let v = r.trim().parse::<f64>().ok().filter(|v| v.is_finite())?;
-            Some((sanitize_for_filename(n.trim()), v))
-        })
+    Ok(fg::read_ratings_tsv(path)?
+        .into_iter()
+        .map(|(n, r)| (sanitize_for_filename(&n), r))
         .collect())
 }
 

--- a/crates/tools/src/bin/kifu_player.rs
+++ b/crates/tools/src/bin/kifu_player.rs
@@ -3,9 +3,11 @@
 //! 詳細は `crates/tools/docs/kifu_player.md` を参照。
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Result, bail};
 use clap::{ArgGroup, Parser};
+use rshogi_csa_client::jsonl::sanitize_for_filename;
 use tools::replay::{CsaSource, GameSource, JsonlSource, PsvSource, tui};
 
 #[derive(Parser, Debug)]
@@ -29,6 +31,16 @@ struct Cli {
     /// 横断）または単一 `.csa` ファイルを指定する。
     #[arg(long)]
     csa: Option<PathBuf>,
+
+    /// SECS 秒ごとに入力を再スキャンし、新しい対局を一覧へ自動追加する（値省略時 5 秒）。
+    /// csa_client の記録 dir を連続対局中に開いておく用途。--psv では使えない。
+    #[arg(long, value_name = "SECS", num_args = 0..=1, default_missing_value = "5")]
+    live: Option<u64>,
+
+    /// レート表 TSV（`name<TAB>rate`、`floodgate_record --ratings-cache` の出力形式）。
+    /// 対局一覧に R を併記し、`rate:>N` フィルタを有効にする（ネットワークは使わない）。
+    #[arg(long)]
+    ratings: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
@@ -43,5 +55,17 @@ fn main() -> Result<()> {
     } else {
         bail!("--psv / --tournament-dir / --csa のいずれか一つを指定してください");
     };
-    tui::run(source)
+    let mut opts = tui::RunOptions::default();
+    if let Some(secs) = cli.live {
+        anyhow::ensure!(secs >= 1, "--live は 1 秒以上を指定してください");
+        opts.live_interval = Some(Duration::from_secs(secs));
+    }
+    if let Some(path) = &cli.ratings {
+        // TUI 内の突き合わせは正規化キーで行うため、読み込み時に変換して渡す。
+        opts.ratings = tools::common::floodgate::read_ratings_tsv(path)?
+            .into_iter()
+            .map(|(name, rate)| (sanitize_for_filename(&name), rate))
+            .collect();
+    }
+    tui::run(source, opts)
 }

--- a/crates/tools/src/common/floodgate.rs
+++ b/crates/tools/src/common/floodgate.rs
@@ -190,6 +190,21 @@ pub fn players_from_path(rel: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// レート表 TSV(`name<TAB>rate`)を読み込む。壊れた行・非有限値は捨てる。
+/// `floodgate_record --ratings-cache` の書き出しと同形式。名前は raw のまま返す
+/// (正規化キーへの変換は用途側で行う)。
+pub fn read_ratings_tsv(path: &Path) -> Result<Vec<(String, f64)>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(text
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .filter_map(|(n, r)| {
+            let v = r.trim().parse::<f64>().ok().filter(|v| v.is_finite())?;
+            Some((n.trim().to_owned(), v))
+        })
+        .collect())
+}
+
 /// プレイヤーファイルを読み込みパターンリストとして返す。
 /// 形式: 1行1名、または TSV (`name\trating`) の場合は最初のフィールドを名前として使用。
 /// 部分一致フィルタ用（[`player_matches`] と組み合わせて使う）。

--- a/crates/tools/src/replay/csa_source.rs
+++ b/crates/tools/src/replay/csa_source.rs
@@ -23,7 +23,8 @@ use crate::kif::format_move_label;
 
 use super::model::{
     EvalAccumulator, GameIndex, GameIndexEntry, GameOutcomeView, GameRecord, GameSource,
-    GameSourceRef, MoveAnnotation, MoveView, PairFileMeta, move_is_legal,
+    GameSourceRef, MoveAnnotation, MoveView, PairFileMeta, date_key_from_filename,
+    fingerprint_paths, move_is_legal,
 };
 
 /// CSA 棋譜（rshogi csa_client 出力形式）の `GameSource` 実装。
@@ -121,10 +122,13 @@ impl GameSource for CsaSource {
                 startpos_idx: None,
                 metrics: acc.finish(),
             });
+            let date_key =
+                path.file_name().and_then(|n| n.to_str()).and_then(date_key_from_filename);
             pair_files.push(PairFileMeta {
                 path: path.clone(),
                 black_label: info.black_name.unwrap_or_else(|| "先手".to_string()),
                 white_label: info.white_name.unwrap_or_else(|| "後手".to_string()),
+                date_key,
             });
         }
 
@@ -133,6 +137,10 @@ impl GameSource for CsaSource {
             pair_files,
             warnings,
         })
+    }
+
+    fn live_fingerprint(&self) -> Result<Option<u64>> {
+        Ok(Some(fingerprint_paths(&self.collect_paths()?)))
     }
 
     fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord> {

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -20,7 +20,8 @@ use crate::selfplay::EvalLog;
 
 use super::model::{
     EvalAccumulator, GameIndex, GameIndexEntry, GameOutcomeView, GameRecord, GameSource,
-    GameSourceRef, MoveAnnotation, MoveView, PairFileMeta,
+    GameSourceRef, MoveAnnotation, MoveView, PairFileMeta, date_key_from_filename,
+    fingerprint_paths,
 };
 
 pub struct JsonlSource {
@@ -33,10 +34,8 @@ impl JsonlSource {
             out_dir: out_dir.into(),
         }
     }
-}
 
-impl GameSource for JsonlSource {
-    fn build_index(&self) -> Result<GameIndex> {
+    fn collect_paths(&self) -> Result<Vec<PathBuf>> {
         let mut paths: Vec<PathBuf> = std::fs::read_dir(&self.out_dir)
             .with_context(|| format!("failed to read directory {}", self.out_dir.display()))?
             .filter_map(|e| e.ok())
@@ -45,6 +44,13 @@ impl GameSource for JsonlSource {
             .collect();
         // file_idx を実行のたびに安定させるため、列挙順をファイル名でソートする。
         paths.sort();
+        Ok(paths)
+    }
+}
+
+impl GameSource for JsonlSource {
+    fn build_index(&self) -> Result<GameIndex> {
+        let paths = self.collect_paths()?;
 
         let mut entries = Vec::new();
         let mut pair_files = Vec::new();
@@ -64,6 +70,10 @@ impl GameSource for JsonlSource {
             pair_files,
             warnings,
         })
+    }
+
+    fn live_fingerprint(&self) -> Result<Option<u64>> {
+        Ok(Some(fingerprint_paths(&self.collect_paths()?)))
     }
 
     fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord> {
@@ -122,10 +132,13 @@ impl GameSource for JsonlSource {
     }
 }
 
+/// tournament のペアファイル(`{A}-vs-{B}.jsonl`)と csa_client の per-game 記録
+/// (`{datetime}_{sente}_vs_{gote}.jsonl`)の両方を対局ファイルとして扱う
+/// (スキーマは共通で、meta 行の検証は `index_one_file` が行う)。
 fn is_pair_jsonl_name(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
-        .is_some_and(|n| n.ends_with(".jsonl") && n.contains("-vs-"))
+        .is_some_and(|n| n.ends_with(".jsonl") && (n.contains("-vs-") || n.contains("_vs_")))
 }
 
 #[derive(Deserialize)]
@@ -301,6 +314,7 @@ fn index_one_file(
         path: path.to_path_buf(),
         black_label: meta_line.engine_cmd.label_black,
         white_label: meta_line.engine_cmd.label_white,
+        date_key: path.file_name().and_then(|n| n.to_str()).and_then(date_key_from_filename),
     }))
 }
 
@@ -493,6 +507,19 @@ mod tests {
         let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
         assert_eq!(index.pair_files.len(), 1);
         assert_eq!(index.pair_files[0].black_label, "a");
+    }
+
+    #[test]
+    fn accepts_csa_client_per_game_jsonl_names() {
+        // csa_client の per-game 記録(`_vs_`)も tournament ペアファイルと同じスキーマで
+        // 索引でき、ファイル名から日時キーが取れる。
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_file(dir.path(), "20260707_010203_A_vs_B.jsonl", &[meta_line("A", "B")]);
+
+        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
+        assert_eq!(index.pair_files.len(), 1);
+        assert_eq!(index.pair_files[0].black_label, "A");
+        assert_eq!(index.pair_files[0].date_key, Some(20260707010203));
     }
 
     #[test]

--- a/crates/tools/src/replay/model.rs
+++ b/crates/tools/src/replay/model.rs
@@ -132,6 +132,54 @@ pub struct PairFileMeta {
     pub path: PathBuf,
     pub black_label: String,
     pub white_label: String,
+    /// ファイル名から抽出した対局日時キー（`YYYYMMDDHHMMSS` の数値）。日付ソート・
+    /// `date:` フィルタ用。ファイル名に日時が無い出典（tournament ペアファイル等)は `None`。
+    pub date_key: Option<u64>,
+}
+
+/// ファイル名から対局日時キー（`YYYYMMDDHHMMSS`）を抽出する。対応する形式:
+/// - csa_client 記録: `20260707_010203_A_vs_B.(csa|jsonl)`（先頭 `YYYYMMDD_HHMMSS`）
+/// - wdoor floodgate: `wdoor+floodgate-300-10F+A+B+20260707010203.csa`（末尾 14 桁）
+pub fn date_key_from_filename(name: &str) -> Option<u64> {
+    let stem = name
+        .strip_suffix(".csa")
+        .or_else(|| name.strip_suffix(".jsonl"))
+        .unwrap_or(name);
+    // 先頭 `YYYYMMDD_HHMMSS`
+    let head: &str = stem.get(..15).unwrap_or(stem);
+    if head.len() == 15
+        && head.as_bytes()[8] == b'_'
+        && head[..8].bytes().all(|b| b.is_ascii_digit())
+        && head[9..].bytes().all(|b| b.is_ascii_digit())
+    {
+        return format!("{}{}", &head[..8], &head[9..]).parse().ok();
+    }
+    // 末尾 14 桁（wdoor の `+YYYYMMDDHHMMSS`）
+    let tail = stem.rsplit('+').next().unwrap_or("");
+    if tail.len() == 14 && tail.bytes().all(|b| b.is_ascii_digit()) {
+        return tail.parse().ok();
+    }
+    None
+}
+
+/// live 再読込判定用に、ファイル集合の (パス, サイズ, mtime) をハッシュする。
+/// 中身は読まない(stat のみ)。stat に失敗したファイルはパスのみで算入する
+/// (書き込み途中の削除等でも fingerprint は変わり、再読込は発火する)。
+pub fn fingerprint_paths(paths: &[PathBuf]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    for path in paths {
+        path.hash(&mut h);
+        if let Ok(md) = std::fs::metadata(path) {
+            md.len().hash(&mut h);
+            if let Ok(mtime) = md.modified()
+                && let Ok(d) = mtime.duration_since(std::time::UNIX_EPOCH)
+            {
+                (d.as_secs(), d.subsec_nanos()).hash(&mut h);
+            }
+        }
+    }
+    h.finish()
 }
 
 /// 索引全体。`entries` は出典を問わず1つの横断リストとしてフラット化されている。
@@ -199,6 +247,14 @@ pub trait GameSource {
     /// `index` は `file_idx` から `PairFileMeta`（出典パス）を引くために使う
     /// （`GameIndexEntry` 自体にはパスを複製しない）。PSV ソースでは未使用。
     fn load_game(&self, index: &GameIndex, entry: &GameIndexEntry) -> Result<GameRecord>;
+
+    /// live 再読込用の軽量フィンガープリント。対象ファイル集合の (パス, サイズ, mtime)
+    /// のみから計算し、中身は読まない(数百ファイルでも stat だけで済む)。値が前回と
+    /// 変わったときだけ `build_index` を取り直す、が想定用途。`None` は live 非対応
+    /// (PSV 等)。既定実装は非対応。
+    fn live_fingerprint(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
 }
 
 /// 対局一覧に出す表示ラベルを、保持済みの文字列ではなくその場で組み立てる
@@ -218,5 +274,28 @@ pub fn display_label(index: &GameIndex, entry: &GameIndexEntry) -> String {
             }
             None => format!("?-vs-? #{:03}", ordinal + 1),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_key_from_filename_supported_formats() {
+        // csa_client 記録形式(先頭 YYYYMMDD_HHMMSS)
+        assert_eq!(
+            date_key_from_filename("20260707_010203_RAMU_TF_vs_Suisho.csa"),
+            Some(20260707010203)
+        );
+        assert_eq!(date_key_from_filename("20260707_010203_A_vs_B.jsonl"), Some(20260707010203));
+        // wdoor floodgate 形式(末尾 14 桁)
+        assert_eq!(
+            date_key_from_filename("wdoor+floodgate-300-10F+A+B+20260707010203.csa"),
+            Some(20260707010203)
+        );
+        // 日時を持たない出典
+        assert_eq!(date_key_from_filename("rsA-vs-rsB.jsonl"), None);
+        assert_eq!(date_key_from_filename("2026_bad.csa"), None);
     }
 }

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -2080,7 +2080,8 @@ mod tests {
 
     #[test]
     fn sort_mode_cycles_through_all_variants() {
-        assert_eq!(SortMode::Discovery.next(), SortMode::Outcome);
+        assert_eq!(SortMode::Discovery.next(), SortMode::Date);
+        assert_eq!(SortMode::Date.next(), SortMode::Outcome);
         assert_eq!(SortMode::Outcome.next(), SortMode::Length);
         assert_eq!(SortMode::Length.next(), SortMode::Decisiveness);
         assert_eq!(SortMode::Decisiveness.next(), SortMode::Swing);

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -1912,7 +1912,7 @@ mod tests {
             vec!["lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 40".to_string()],
         ]);
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
 
         app.start_sfen_scan(HIRATE_SFEN);
         drain_scan(&mut app);
@@ -1930,7 +1930,7 @@ mod tests {
             vec!["lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 7".to_string()];
         let source = fake_source(games);
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
 
         app.start_sfen_scan(HIRATE_SFEN);
         let mut ticks = 0;
@@ -1958,7 +1958,7 @@ mod tests {
         }
         let source = fake_source(games);
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
         app.filter_input = "len:3".to_string();
         app.apply_filter();
         let filtered_before = app.filtered.clone();
@@ -1986,7 +1986,7 @@ mod tests {
             error_ordinals: vec![1],
         };
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
         app.start_sfen_scan(HIRATE_SFEN);
         drain_scan(&mut app);
         assert_eq!(app.filtered, vec![2], "load 失敗の対局は一致に含めない");
@@ -2004,7 +2004,7 @@ mod tests {
             vec!["lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 40".to_string()],
         ]);
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
         // Enter 経由と同じく filter_input を残したままスキャン（`s` の再フィルタ源）。
         app.filter_input = format!("sfen:{HIRATE_SFEN}");
         app.start_sfen_scan(HIRATE_SFEN);
@@ -2021,7 +2021,7 @@ mod tests {
     fn invalid_sfen_query_does_not_start_scan() {
         let source = fake_source(vec![vec!["9/9/9/9/9/9/9/9/9 b - 1".to_string()]]);
         let index = source.build_index().expect("build_index");
-        let mut app = App::new(Box::new(source), index);
+        let mut app = App::new(Box::new(source), index, BTreeMap::new(), None);
         app.start_sfen_scan("   "); // 空
         assert!(app.scan.is_none(), "空クエリではスキャンを開始しない");
         assert!(app.status.contains("不正"), "不正入力はエラー表示: {}", app.status);

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -258,6 +258,7 @@ impl App {
             .collect();
         // `rate:` は App の保持するレート表が要るため `entry_matches` の外で絞る
         // (`sfen:` が逐次スキャンで扱われるのと同様、entry_matches では常に一致扱い)。
+        // floodgate のレートは負値がありうるので符号付きで比較する。
         if let Filter::Field(FieldKind::Rate, spec) = filter {
             self.base_filtered = self
                 .base_filtered
@@ -265,7 +266,7 @@ impl App {
                 .copied()
                 .filter(|&i| {
                     self.entry_rate(&self.index.entries[i])
-                        .is_some_and(|r| matches_numeric_cmp(r.max(0.0).round() as u32, spec))
+                        .is_some_and(|r| matches_signed_cmp(r.round() as i64, spec))
                 })
                 .collect();
         }
@@ -659,6 +660,18 @@ fn matches_numeric_cmp(actual: u32, spec: &str) -> bool {
         n.parse::<u32>().is_ok_and(|n| actual < n)
     } else {
         spec.parse::<u32>().is_ok_and(|n| actual == n)
+    }
+}
+
+/// [`matches_numeric_cmp`] の符号付き版。負値がありうる指標(floodgate レート等)用で、
+/// `rate:>-100` / `rate:<-500` のような負の閾値も受け付ける。
+fn matches_signed_cmp(actual: i64, spec: &str) -> bool {
+    if let Some(n) = spec.strip_prefix('>') {
+        n.parse::<i64>().is_ok_and(|n| actual > n)
+    } else if let Some(n) = spec.strip_prefix('<') {
+        n.parse::<i64>().is_ok_and(|n| actual < n)
+    } else {
+        spec.parse::<i64>().is_ok_and(|n| actual == n)
     }
 }
 
@@ -1653,6 +1666,18 @@ mod tests {
         assert_eq!(combined_rate(None, Some(3500.0)), Some(3500.0));
         assert_eq!(combined_rate(Some(3700.0), None), Some(3700.0));
         assert_eq!(combined_rate(None, None), None);
+    }
+
+    #[test]
+    fn signed_cmp_supports_negative_ratings() {
+        // floodgate には負レートのプレイヤーが実在する。0 に clamp せず符号付きで比較する。
+        assert!(matches_signed_cmp(-1769, "-1769"));
+        assert!(!matches_signed_cmp(-1769, "0"));
+        assert!(matches_signed_cmp(-1769, "<0"));
+        assert!(matches_signed_cmp(-100, ">-500"));
+        assert!(!matches_signed_cmp(-1769, ">-500"));
+        assert!(matches_signed_cmp(3706, ">3500"));
+        assert!(!matches_signed_cmp(3706, ">3800"));
     }
 
     #[test]

--- a/crates/tools/src/replay/tui.rs
+++ b/crates/tools/src/replay/tui.rs
@@ -1,7 +1,9 @@
 //! ratatui ベースの棋譜プレイヤー画面・イベントループ。
 
+use std::collections::BTreeMap;
 use std::io::{self};
-use std::time::Duration;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -22,18 +24,46 @@ use rshogi_core::types::{Color, Move, PieceType, Square};
 
 use crate::kif::piece_label;
 
+use rshogi_csa_client::jsonl::sanitize_for_filename;
+
 use super::model::{
-    GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef, MoveView,
+    GameIndexEntry, GameOutcomeView, GameRecord, GameSource, GameSourceRef, MoveView, PairFileMeta,
 };
 use super::{GameIndex, display_label};
 
+/// TUI 起動オプション。
+#[derive(Default)]
+pub struct RunOptions {
+    /// live 再読込の間隔。指定するとこの間隔でソースのフィンガープリントを確認し、
+    /// 変化があれば索引を取り直して新しい対局を一覧へ追加する。`None` は従来どおり
+    /// 起動時読み込みのみ。
+    pub live_interval: Option<Duration>,
+    /// 正規化名(`sanitize_for_filename` 済み) -> レート。空なら R 併記・`rate:`
+    /// フィルタは不活性。
+    pub ratings: BTreeMap<String, f64>,
+}
+
 /// 棋譜プレイヤー TUI を起動する。`Ctrl-C`／`q` で終了するまでブロックする。
-pub fn run(source: Box<dyn GameSource>) -> Result<()> {
+pub fn run(source: Box<dyn GameSource>, opts: RunOptions) -> Result<()> {
     let index = source.build_index()?;
     for warning in &index.warnings {
         eprintln!("warning: {warning}");
     }
-    if index.entries.is_empty() {
+    let live = match opts.live_interval {
+        Some(interval) => {
+            let Some(fingerprint) = source.live_fingerprint()? else {
+                anyhow::bail!("--live はこの入力形式では使えません(ディレクトリ横断ソースのみ)");
+            };
+            Some(LiveState {
+                interval,
+                last_poll: Instant::now(),
+                fingerprint,
+            })
+        }
+        None => None,
+    };
+    // live 中は「まだ 1 局も無い記録 dir を開いて対局を待つ」使い方を許す。
+    if index.entries.is_empty() && live.is_none() {
         anyhow::bail!("対局が1件も見つかりませんでした");
     }
 
@@ -52,7 +82,7 @@ pub fn run(source: Box<dyn GameSource>) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(source, index);
+    let mut app = App::new(source, index, opts.ratings, live);
     let result = run_event_loop(&mut terminal, &mut app);
 
     disable_raw_mode()?;
@@ -74,6 +104,8 @@ enum Mode {
 enum SortMode {
     /// ファイル列挙順→完了順（従来のデフォルト）。
     Discovery,
+    /// ファイル名由来の対局日時の降順（新しい対局が先頭）。日時の無い対局は末尾。
+    Date,
     /// エラー→黒勝ち→白勝ち→引き分け→不明の順にグルーピング。
     Outcome,
     /// 対局長（手数）の降順。
@@ -87,7 +119,8 @@ enum SortMode {
 impl SortMode {
     fn next(self) -> Self {
         match self {
-            SortMode::Discovery => SortMode::Outcome,
+            SortMode::Discovery => SortMode::Date,
+            SortMode::Date => SortMode::Outcome,
             SortMode::Outcome => SortMode::Length,
             SortMode::Length => SortMode::Decisiveness,
             SortMode::Decisiveness => SortMode::Swing,
@@ -98,6 +131,7 @@ impl SortMode {
     fn label(self) -> &'static str {
         match self {
             SortMode::Discovery => "発見順",
+            SortMode::Date => "日付(新)",
             SortMode::Outcome => "勝敗別",
             SortMode::Length => "対局長",
             SortMode::Decisiveness => "決着の大きさ",
@@ -122,6 +156,15 @@ struct SfenScan {
     matches: Vec<usize>,
 }
 
+/// live 再読込の進行状態。
+struct LiveState {
+    interval: Duration,
+    /// 最後にフィンガープリントを確認した時刻(間隔制御用)。
+    last_poll: Instant,
+    /// 前回確認したソースのフィンガープリント。変化検出にのみ使う。
+    fingerprint: u64,
+}
+
 struct App {
     source: Box<dyn GameSource>,
     index: GameIndex,
@@ -140,10 +183,19 @@ struct App {
     status: String,
     /// 実行中の SFEN 局面検索（逐次スキャン）。`None` なら通常操作。
     scan: Option<SfenScan>,
+    /// 正規化名 -> レート（`RunOptions::ratings`）。
+    ratings: BTreeMap<String, f64>,
+    /// live 再読込の状態。`None` なら従来どおり静的表示。
+    live: Option<LiveState>,
 }
 
 impl App {
-    fn new(source: Box<dyn GameSource>, index: GameIndex) -> Self {
+    fn new(
+        source: Box<dyn GameSource>,
+        index: GameIndex,
+        ratings: BTreeMap<String, f64>,
+        live: Option<LiveState>,
+    ) -> Self {
         let all: Vec<usize> = (0..index.entries.len()).collect();
         let mut app = Self {
             source,
@@ -158,9 +210,25 @@ impl App {
             current_move: 0,
             status: String::new(),
             scan: None,
+            ratings,
+            live,
         };
         app.load_selected();
         app
+    }
+
+    /// 正規化キーでレートを引く。`--ratings` 未供給なら常に `None`。
+    fn rate_of(&self, name: &str) -> Option<f64> {
+        if self.ratings.is_empty() {
+            return None;
+        }
+        self.ratings.get(&sanitize_for_filename(name)).copied()
+    }
+
+    /// 対局の代表レート（両対局者のうち高い方）。`rate:` フィルタ用。
+    fn entry_rate(&self, entry: &GameIndexEntry) -> Option<f64> {
+        let meta = file_meta(&self.index, entry)?;
+        combined_rate(self.rate_of(&meta.black_label), self.rate_of(&meta.white_label))
     }
 
     fn selected_entry(&self) -> Option<&GameIndexEntry> {
@@ -188,6 +256,19 @@ impl App {
         self.base_filtered = (0..self.index.entries.len())
             .filter(|&i| entry_matches(&self.index, &self.index.entries[i], filter))
             .collect();
+        // `rate:` は App の保持するレート表が要るため `entry_matches` の外で絞る
+        // (`sfen:` が逐次スキャンで扱われるのと同様、entry_matches では常に一致扱い)。
+        if let Filter::Field(FieldKind::Rate, spec) = filter {
+            self.base_filtered = self
+                .base_filtered
+                .iter()
+                .copied()
+                .filter(|&i| {
+                    self.entry_rate(&self.index.entries[i])
+                        .is_some_and(|r| matches_numeric_cmp(r.max(0.0).round() as u32, spec))
+                })
+                .collect();
+        }
         self.resort();
     }
 
@@ -195,10 +276,77 @@ impl App {
     /// 集合はそのままに並び順だけ変えるので、SFEN スキャン結果も並べ替えで維持される。
     fn resort(&mut self) {
         let mut filtered = self.base_filtered.clone();
-        sort_filtered(&mut filtered, &self.index.entries, self.sort_mode);
+        sort_filtered(&mut filtered, &self.index.entries, self.sort_mode, |e| {
+            entry_date_key(&self.index, e)
+        });
         self.filtered = filtered;
         self.selected = 0;
         self.load_selected();
+    }
+
+    /// live: 間隔経過時にソースのフィンガープリントを確認し、変化があれば索引を取り直す。
+    /// 失敗はステータス表示に留めて操作を継続する(次の間隔で再試行)。
+    fn maybe_live_reload(&mut self) {
+        let Some(live) = &self.live else { return };
+        if live.last_poll.elapsed() < live.interval {
+            return;
+        }
+        let old_fp = live.fingerprint;
+        if let Some(l) = self.live.as_mut() {
+            l.last_poll = Instant::now();
+        }
+        let fp = match self.source.live_fingerprint() {
+            Ok(Some(fp)) => fp,
+            Ok(None) => return,
+            Err(e) => {
+                self.status = format!("live 再読込チェック失敗: {e}");
+                return;
+            }
+        };
+        if fp == old_fp {
+            return;
+        }
+        if let Some(l) = self.live.as_mut() {
+            l.fingerprint = fp;
+        }
+        match self.source.build_index() {
+            Ok(new_index) => self.replace_index(new_index),
+            Err(e) => self.status = format!("live 再読込失敗: {e}"),
+        }
+    }
+
+    /// 索引を live 再読込の結果へ差し替える。選択中の対局は (出典パス, game_id) で追跡し、
+    /// 見つかれば選択位置・表示中の手を維持する(完了局の内容は追記されない前提で、同一
+    /// キーなら読み直さない)。
+    fn replace_index(&mut self, new_index: GameIndex) {
+        let old_len = self.index.entries.len();
+        let selected_key = self.selected_entry().and_then(|e| entry_key(&self.index, e));
+        let saved_game = self.current_game.take();
+        let saved_move = self.current_move;
+
+        self.index = new_index;
+        // SFEN スキャンの一致集合は旧索引の添字なので新索引へは引き継げない。クリアして
+        // 全件表示へ戻す(ステータスの件数表示で気づける)。
+        if sfen_query_from_input(&self.filter_input).is_some() {
+            self.filter_input.clear();
+        }
+        self.apply_filter();
+
+        if let Some(key) = selected_key
+            && let Some(pos) = self.filtered.iter().position(|&i| {
+                entry_key(&self.index, &self.index.entries[i]).as_ref() == Some(&key)
+            })
+        {
+            self.selected = pos;
+            self.current_game = saved_game;
+            self.current_move = saved_move;
+        }
+        let new_len = self.index.entries.len();
+        self.status = if new_len >= old_len {
+            format!("live: {} 局追加 (計 {new_len} 局)", new_len - old_len)
+        } else {
+            format!("live: 再読込 (計 {new_len} 局)")
+        };
     }
 
     fn cycle_sort_mode(&mut self) {
@@ -386,6 +534,35 @@ fn jsonl_game_id(entry: &GameIndexEntry) -> Option<u32> {
     }
 }
 
+/// 対局の出典ファイルメタ（PSV はファイル単位のメタを持たないため `None`）。
+fn file_meta<'a>(index: &'a GameIndex, entry: &GameIndexEntry) -> Option<&'a PairFileMeta> {
+    match entry.source {
+        GameSourceRef::Jsonl { file_idx, .. } | GameSourceRef::Csa { file_idx, .. } => {
+            index.pair_file(file_idx)
+        }
+        GameSourceRef::Psv { .. } => None,
+    }
+}
+
+fn entry_date_key(index: &GameIndex, entry: &GameIndexEntry) -> Option<u64> {
+    file_meta(index, entry).and_then(|m| m.date_key)
+}
+
+/// live 再読込を跨いで同一対局を同定するキー（出典パス + ファイル内 game_id）。
+/// 再読込で `file_idx` や ordinal は振り直されるため添字では追跡できない。
+fn entry_key(index: &GameIndex, entry: &GameIndexEntry) -> Option<(PathBuf, Option<u32>)> {
+    file_meta(index, entry).map(|m| (m.path.clone(), jsonl_game_id(entry)))
+}
+
+/// 両対局者のレートから対局の代表レート（高い方）を出す。
+fn combined_rate(black: Option<f64>, white: Option<f64>) -> Option<f64> {
+    match (black, white) {
+        (Some(b), Some(w)) => Some(b.max(w)),
+        (b, None) => b,
+        (None, w) => w,
+    }
+}
+
 /// `/` 検索クエリを解析した結果。判定ロジックは `entry_matches` に集約する。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Filter<'a> {
@@ -419,6 +596,12 @@ enum FieldKind {
     Len,
     /// `swing:>N|<N|N`。評価値振れ幅（`max_swing_cp`）で絞り込む。
     Swing,
+    /// `rate:>N|<N|N`。対局の代表レート（両対局者の高い方）で絞り込む。判定はレート表を
+    /// 持つ `App::apply_filter` 側で行う（`entry_matches` では常に一致扱い）。
+    Rate,
+    /// `date:YYYYMMDD`。ファイル名由来の対局日時キーへの前方一致（`date:202607` 等の
+    /// 部分指定も可）。
+    Date,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -449,6 +632,8 @@ fn parse_filter(query: &str) -> Filter<'_> {
             "winner" => Some(FieldKind::Winner),
             "len" => Some(FieldKind::Len),
             "swing" => Some(FieldKind::Swing),
+            "rate" => Some(FieldKind::Rate),
+            "date" => Some(FieldKind::Date),
             _ => None,
         };
         if let Some(field) = field {
@@ -498,6 +683,11 @@ fn entry_matches(index: &GameIndex, entry: &GameIndexEntry, filter: Filter<'_>) 
         Filter::Field(FieldKind::Len, v) => matches_numeric_cmp(entry.ply_count, v),
         Filter::Field(FieldKind::Swing, v) => {
             entry.metrics.max_swing_cp.is_some_and(|s| matches_numeric_cmp(s, v))
+        }
+        // レート表は App が持つため即時フィルタでは絞らない（`apply_filter` で絞る）。
+        Filter::Field(FieldKind::Rate, _) => true,
+        Filter::Field(FieldKind::Date, v) => {
+            entry_date_key(index, entry).is_some_and(|k| k.to_string().starts_with(v))
         }
         Filter::Keyword(KeywordKind::Reversal) => entry.metrics.had_reversal(REVERSAL_THRESHOLD_CP),
         Filter::Keyword(KeywordKind::Decisive) => {
@@ -574,11 +764,22 @@ fn outcome_sort_key(entry: &GameIndexEntry) -> u8 {
 
 /// `filtered`（`index.entries` への index 列）を `mode` に従って安定ソートする。
 /// 安定ソートなので、同一キー内の相対順は呼び出し前の順序（発見順）を維持する。
-fn sort_filtered(filtered: &mut [usize], entries: &[GameIndexEntry], mode: SortMode) {
+/// `date_key` は対局の日時キーを引く closure（`SortMode::Date` のみ使用。テストからは
+/// 索引を組み立てずに注入できる）。
+fn sort_filtered(
+    filtered: &mut [usize],
+    entries: &[GameIndexEntry],
+    mode: SortMode,
+    date_key: impl Fn(&GameIndexEntry) -> Option<u64>,
+) {
     use std::cmp::Reverse;
     // 指標ソートは降順。評価値の無い対局（None）は末尾へ寄せる（`is_none` を第 1 キーに）。
     match mode {
         SortMode::Discovery => {}
+        SortMode::Date => filtered.sort_by_key(|&i| {
+            let k = date_key(&entries[i]);
+            (k.is_none(), Reverse(k.unwrap_or(0)))
+        }),
         SortMode::Outcome => filtered.sort_by_key(|&i| outcome_sort_key(&entries[i])),
         SortMode::Length => filtered.sort_by_key(|&i| Reverse(entries[i].ply_count)),
         SortMode::Decisiveness => filtered.sort_by_key(|&i| {
@@ -591,6 +792,10 @@ fn sort_filtered(filtered: &mut [usize], entries: &[GameIndexEntry], mode: SortM
         }),
     }
 }
+
+/// live 有効時の入力待ちの上限。この間隔で入力待ちを切り上げて再読込チェックへ回る
+/// （実際に fingerprint を見るかは `LiveState::interval` が制御する）。
+const LIVE_POLL_TICK: Duration = Duration::from_millis(250);
 
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
@@ -610,6 +815,19 @@ fn run_event_loop(
                 }
             } else {
                 app.advance_sfen_scan();
+            }
+        } else if app.live.is_some() {
+            // live 中はブロック読みだと新規対局に気づけないため、短い tick で入力待ちを
+            // 切り上げて再読込チェックを回す。
+            if event::poll(LIVE_POLL_TICK)? {
+                if let Event::Key(key) = event::read()?
+                    && key.kind == KeyEventKind::Press
+                    && !app.handle_key(key.code)
+                {
+                    return Ok(());
+                }
+            } else {
+                app.maybe_live_reload();
             }
         } else if let Event::Key(key) = event::read()?
             && key.kind == KeyEventKind::Press
@@ -670,12 +888,13 @@ fn draw_game_list(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::
                     None => "",
                 }
             };
-            ListItem::new(format!("{label}{marker}"))
+            ListItem::new(format!("{label}{marker}{}", rate_suffix(app, entry)))
         })
         .collect();
 
+    let live_mark = if app.live.is_some() { " [live]" } else { "" };
     let title = format!(
-        "対局一覧 ({}/{}) [{}]",
+        "対局一覧 ({}/{}) [{}]{live_mark}",
         app.filtered.len(),
         app.index.entries.len(),
         app.sort_mode.label()
@@ -689,6 +908,26 @@ fn draw_game_list(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout::
         state.select(Some(app.selected));
     }
     frame.render_stateful_widget(list, area, &mut state);
+}
+
+/// `--ratings` 供給時のみ、対局者のレートを ` R3706/3512`（先手/後手）形式で付ける。
+/// 片方だけ引けたら引けない側は `-`、両方引けなければ空文字。
+fn rate_suffix(app: &App, entry: &GameIndexEntry) -> String {
+    if app.ratings.is_empty() {
+        return String::new();
+    }
+    let Some(meta) = file_meta(&app.index, entry) else {
+        return String::new();
+    };
+    let black = app.rate_of(&meta.black_label);
+    let white = app.rate_of(&meta.white_label);
+    if black.is_none() && white.is_none() {
+        return String::new();
+    }
+    let fmt = |r: Option<f64>| {
+        r.map(|r| format!("{}", r.round() as i64)).unwrap_or_else(|| "-".to_string())
+    };
+    format!(" R{}/{}", fmt(black), fmt(white))
 }
 
 /// 対局・盤面・指し手ペインが「表示できる手が無い」ときに、その理由を区別する。
@@ -966,7 +1205,7 @@ fn draw_status_bar(frame: &mut ratatui::Frame, app: &App, area: ratatui::layout:
             app.index.entries.len()
         ),
         Mode::Filter => format!(
-            "検索 [id: pair: outcome: winner:sente|gote len:>N swing:>N reversal sfen: label:]: {}_   （一致 {}件）",
+            "検索 [id: pair: outcome: winner:sente|gote len:>N swing:>N rate:>N date: reversal sfen: label:]: {}_   （一致 {}件）",
             app.filter_input,
             app.filtered.len()
         ),
@@ -1001,8 +1240,9 @@ fn draw_help_popup(frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
         Line::from("n        次の評価値急変手へジャンプ"),
         Line::from("N        前の評価値急変手へジャンプ"),
         Line::from(format!(
-            "s        対局リストの並べ替えを切り替え（{}/{}/{}/{}/{}）",
+            "s        対局リストの並べ替えを切り替え（{}/{}/{}/{}/{}/{}）",
             SortMode::Discovery.label(),
+            SortMode::Date.label(),
             SortMode::Outcome.label(),
             SortMode::Length.label(),
             SortMode::Decisiveness.label(),
@@ -1016,6 +1256,8 @@ fn draw_help_popup(frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
         Line::from(
             "          winner:sente|gote  len:>N|<N|N  swing:>N  reversal  decisive|draw|error",
         ),
+        Line::from("          rate:>N|<N|N  対局の代表レートで絞り込み（--ratings 供給時のみ）"),
+        Line::from("          date:YYYYMMDD  ファイル名由来の対局日時へ前方一致（date:202607 等）"),
         Line::from(
             "          sfen:<SFEN>  局面本体を全対局走査（Enter で実行 / Esc・q で中断 / 手数は無視）",
         ),
@@ -1352,6 +1594,65 @@ mod tests {
 
     fn empty_index() -> GameIndex {
         GameIndex::default()
+    }
+
+    /// `date_key` 付きの pair_files を 1 件持つ索引と、それを指す JSONL エントリを作る。
+    fn index_with_dated_file(date_key: Option<u64>) -> (GameIndex, GameIndexEntry) {
+        let index = GameIndex {
+            entries: Vec::new(),
+            pair_files: vec![PairFileMeta {
+                path: PathBuf::from("20260707_010203_A_vs_B.jsonl"),
+                black_label: "A".to_string(),
+                white_label: "B".to_string(),
+                date_key,
+            }],
+            warnings: Vec::new(),
+        };
+        let entry = jsonl_entry(1, None, None, None, None, false, 0);
+        (index, entry)
+    }
+
+    #[test]
+    fn parse_filter_recognizes_rate_and_date() {
+        assert_eq!(parse_filter("rate:>3800"), Filter::Field(FieldKind::Rate, ">3800"));
+        assert_eq!(parse_filter("date:20260707"), Filter::Field(FieldKind::Date, "20260707"));
+    }
+
+    #[test]
+    fn date_filter_prefix_matches_date_key() {
+        let (index, entry) = index_with_dated_file(Some(20260707010203));
+        assert!(entry_matches(&index, &entry, parse_filter("date:20260707")));
+        assert!(entry_matches(&index, &entry, parse_filter("date:202607")));
+        assert!(!entry_matches(&index, &entry, parse_filter("date:20260708")));
+        // 日時キーの無い対局は date: にヒットしない
+        let (index, entry) = index_with_dated_file(None);
+        assert!(!entry_matches(&index, &entry, parse_filter("date:2026")));
+        // rate: は entry_matches では絞らない(App::apply_filter がレート表で絞る)
+        assert!(entry_matches(&index, &entry, parse_filter("rate:>9999")));
+    }
+
+    #[test]
+    fn sort_date_puts_newest_first_and_none_last() {
+        let entries: Vec<GameIndexEntry> = (0..3u32)
+            .map(|i| jsonl_entry(i, None, None, None, None, false, i as usize))
+            .collect();
+        let keys = [Some(20260706010203u64), None, Some(20260707010203u64)];
+        let mut filtered = vec![0, 1, 2];
+        sort_filtered(&mut filtered, &entries, SortMode::Date, |e| {
+            let GameSourceRef::Jsonl { file_idx, .. } = e.source else {
+                return None;
+            };
+            keys[file_idx]
+        });
+        assert_eq!(filtered, vec![2, 0, 1]); // 新→旧→日時なし
+    }
+
+    #[test]
+    fn combined_rate_takes_max_and_tolerates_missing_side() {
+        assert_eq!(combined_rate(Some(3700.0), Some(3500.0)), Some(3700.0));
+        assert_eq!(combined_rate(None, Some(3500.0)), Some(3500.0));
+        assert_eq!(combined_rate(Some(3700.0), None), Some(3700.0));
+        assert_eq!(combined_rate(None, None), None);
     }
 
     #[test]
@@ -1821,7 +2122,7 @@ mod tests {
             jsonl_entry(4, None, None, None, Some(GameOutcomeView::Win(Color::Black)), false, 0), // idx 3: b-win
         ];
         let mut filtered: Vec<usize> = (0..entries.len()).collect();
-        sort_filtered(&mut filtered, &entries, SortMode::Outcome);
+        sort_filtered(&mut filtered, &entries, SortMode::Outcome, |_| None);
         // error(2) → b-win(1,3、発見順維持) → draw(0)
         assert_eq!(filtered, vec![2, 1, 3, 0]);
     }
@@ -1836,7 +2137,7 @@ mod tests {
         ];
         let key = |mode| {
             let mut f: Vec<usize> = (0..entries.len()).collect();
-            sort_filtered(&mut f, &entries, mode);
+            sort_filtered(&mut f, &entries, mode, |_| None);
             f
         };
         // 対局長 降順。
@@ -1892,7 +2193,7 @@ mod tests {
             jsonl_entry(2, None, None, None, None, false, 0),
         ];
         let mut filtered: Vec<usize> = (0..entries.len()).collect();
-        sort_filtered(&mut filtered, &entries, SortMode::Discovery);
+        sort_filtered(&mut filtered, &entries, SortMode::Discovery, |_| None);
         assert_eq!(filtered, vec![0, 1]);
     }
 


### PR DESCRIPTION
## 概要

kifu_player を floodgate 連続対局の「準リアルタイム観戦・戦績ブラウズ」に使えるようにする (TUI × floodgate 連携の Phase 1)。

```bash
kifu_player --csa ~/floodgate/records --live 5 --ratings ~/floodgate/records/ratings_cache.tsv
```

## 変更点

- **`--live [SECS]`** (省略時 5 秒): ソースの (パス, サイズ, mtime) フィンガープリントを SECS 秒ごとに確認し、**変化があったときだけ**索引を再構築して新規完了局を一覧へ追加 (無変化時はファイル内容を読まない)。選択中の対局・表示中の手は (出典パス, game_id) キーで再読込を跨いで維持。空 dir を開いて対局を待つ運用も可。`--psv` は起動時に明示エラー
- **`--ratings <TSV>`**: `floodgate_record --ratings-cache` の出力を読み、一覧に ` R3706/3512` (先手/後手) を併記。`rate:>N` フィルタ (代表レート = 両対局者の高い方、**負レートも符号付き比較**) を有効化。オフライン完結 (ネットワーク不使用)
- **`date:YYYYMMDD` フィルタ + 「日付(新)」ソート**: ファイル名から日時キーを抽出 (csa_client 記録の `YYYYMMDD_HHMMSS` prefix / wdoor の末尾 14 桁タイムスタンプ)。`date:202607` の部分指定も可
- **JsonlSource が csa_client per-game 記録 (`_vs_`) も索引対象に** (tournament ペアファイルとスキーマ共通。meta 行検証で非対局ファイルは従来どおり skip)
- レート表 TSV リーダを `common::floodgate::read_ratings_tsv` に共通化 (floodgate_record も再利用)

## レビュー / 検証

- **Dual review (独立 2 本)**: Claude (Fable 5) APPROVE / Codex APPROVE。Codex 指摘の「rate: が負レートを 0 に clamp (floodgate には負レートが実在)」を符号付き比較 (`matches_signed_cmp`) で修正、live × SFEN 検索の相互作用を doc に明記。その他 low 指摘 (再読込時の一時 load 破棄等) は許容として記録
- 検証 (sh11235-ws): fmt OK / clippy 0 / replay 84 tests green
- 実機スモーク (tmux + 実 floodgate 棋譜): live 追加検出 (`live: 1 局追加 (計 2 局)`)・`[live]` タイトル・R 併記 (`R3200/3706`)・`rate:>3500`→2 件 / 高閾値→0 件・日付(新)ソートで新しい局が先頭、をすべて確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCCFdxeJgp7jCFXducgp6K