### PR TITLE
feat(csa-client): live_jsonl — 対局中の JSONL 手単位追記で自局リアルタイム観戦 (TUI 連携 Phase 3)

### DIFF
--- a/crates/rshogi-csa-client/src/config.rs
+++ b/crates/rshogi-csa-client/src/config.rs
@@ -170,6 +170,11 @@ pub struct RecordConfig {
     /// JSONL 出力先ディレクトリの上書き。`None` のとき `dir/jsonl/` に保存する。
     #[serde(default)]
     pub jsonl_out: Option<PathBuf>,
+    /// 対局中に JSONL を手単位で live 追記する（`kifu_player --live` での自局
+    /// リアルタイム観戦用）。追記中のファイルには result 行が無く、終局時に
+    /// canonical な全内容へ置き換わる。`save_jsonl` が無効なら効果なし。
+    #[serde(default)]
+    pub live_jsonl: bool,
 }
 
 impl Default for RecordConfig {
@@ -182,6 +187,7 @@ impl Default for RecordConfig {
             save_sfen: true,
             save_jsonl: true,
             jsonl_out: None,
+            live_jsonl: false,
         }
     }
 }
@@ -275,6 +281,14 @@ mod tests {
             ..RecordConfig::default()
         };
         assert_eq!(config.jsonl_dir(), None);
+    }
+
+    #[test]
+    fn record_live_jsonl_defaults_off() {
+        let config: CsaClientConfig = toml::from_str("[record]\nenabled = true\n").unwrap();
+        assert!(!config.record.live_jsonl);
+        let config: CsaClientConfig = toml::from_str("[record]\nlive_jsonl = true\n").unwrap();
+        assert!(config.record.live_jsonl);
     }
 
     #[test]

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -44,8 +44,12 @@ pub fn write_game_jsonl(
     })?;
 
     let path = out_dir.join(jsonl_filename(record));
-    let file = File::create(&path)
-        .with_context(|| format!("JSONL ファイルを作成できません: {}", path.display()))?;
+    // live 追記 (`LiveJsonlWriter`) 有効時は同じパスを読者 (kifu_player --live 等) が
+    // 開いていることがあるため、truncate 書き込みでなく tmp→rename で置き換え、
+    // 読者が常に完全な内容だけを見るようにする。
+    let tmp = path.with_extension("jsonl.tmp");
+    let file = File::create(&tmp)
+        .with_context(|| format!("JSONL ファイルを作成できません: {}", tmp.display()))?;
     let mut writer = BufWriter::new(file);
 
     write_meta(&mut writer, record, config, &path)?;
@@ -53,7 +57,53 @@ pub fn write_game_jsonl(
     write_result(&mut writer, record, result, plies)?;
 
     writer.flush().context("JSONL flush に失敗")?;
+    fs::rename(&tmp, &path)
+        .with_context(|| format!("JSONL の rename に失敗: {}", path.display()))?;
     Ok(path)
+}
+
+/// 対局中に同スキーマの JSONL を手単位で追記する live ライター
+/// (`[record] live_jsonl = true` で session が使う)。meta 行と確定済み move 行のみを
+/// 常に完全な行単位で保ち、result 行は書かない。読者 (kifu_player 等) は result 行の
+/// 無いファイルを進行中対局として扱う。終局時は [`write_game_jsonl`] が同じパスへ
+/// canonical な全内容 (result 行込み) を rename で書き換える。
+pub struct LiveJsonlWriter {
+    writer: BufWriter<File>,
+    /// 書き出し済みの move 行数 (`record.moves` / `jsonl_moves` の消費位置)。
+    written: usize,
+}
+
+impl LiveJsonlWriter {
+    /// 対局開始時 (Game_Summary 確定後) に作る。record が既に持つ手 (途中局面開始・
+    /// resume 済みの手) もすべて書き出してから追記を続ける。
+    pub fn create(out_dir: &Path, record: &GameRecord, config: &CsaClientConfig) -> Result<Self> {
+        fs::create_dir_all(out_dir).with_context(|| {
+            format!("JSONL 出力ディレクトリを作成できません: {}", out_dir.display())
+        })?;
+        let path = out_dir.join(jsonl_filename(record));
+        let file = File::create(&path)
+            .with_context(|| format!("live JSONL を作成できません: {}", path.display()))?;
+        let mut writer = BufWriter::new(file);
+        write_meta(&mut writer, record, config, &path)?;
+        let mut live = Self { writer, written: 0 };
+        live.append_new_moves(record)?;
+        Ok(live)
+    }
+
+    /// record に追加された未書き出しの move 行を追記して flush する。
+    pub fn append_new_moves(&mut self, record: &GameRecord) -> Result<()> {
+        let upto = record.moves.len().min(record.jsonl_moves.len());
+        if self.written >= upto {
+            // flush 済み内容から進んでいなければ何もしない (毎手呼ばれる想定)。
+            return Ok(());
+        }
+        for idx in self.written..upto {
+            let ply = (idx as u32) + 1;
+            write_move_line(&mut self.writer, &record.moves[idx], &record.jsonl_moves[idx], ply)?;
+        }
+        self.written = upto;
+        self.writer.flush().context("live JSONL flush に失敗")
+    }
 }
 
 /// `<datetime>_<sente>_vs_<gote>.jsonl` 形式のファイル名を生成する。
@@ -281,6 +331,30 @@ struct EvalLog {
     pv: Option<Vec<String>>,
 }
 
+fn write_move_line<W: Write>(
+    writer: &mut W,
+    m: &RecordedMove,
+    extra: &JsonlMoveExtra,
+    ply: u32,
+) -> Result<()> {
+    let entry = MoveLog {
+        kind: "move",
+        game_id: 1,
+        ply,
+        side_to_move: side_label_char(m.side_to_move),
+        sfen_before: &extra.sfen_before,
+        move_usi: &extra.move_usi,
+        engine: &extra.engine_label,
+        elapsed_ms: extra.elapsed_ms,
+        think_limit_ms: extra.think_limit_ms,
+        timed_out: false,
+        eval: build_eval_log(m, extra),
+    };
+    serde_json::to_writer(&mut *writer, &entry)?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
 fn write_moves<W: Write>(writer: &mut W, record: &GameRecord) -> Result<u32> {
     let mut plies: u32 = 0;
     // RecordedMove と JsonlMoveExtra は session.rs で同時に push されるため、
@@ -288,23 +362,7 @@ fn write_moves<W: Write>(writer: &mut W, record: &GameRecord) -> Result<u32> {
     for (idx, (m, extra)) in record.moves.iter().zip(record.jsonl_moves.iter()).enumerate() {
         let ply = (idx as u32) + 1;
         plies = ply;
-        let side_char = side_label_char(m.side_to_move);
-        let eval = build_eval_log(m, extra);
-        let entry = MoveLog {
-            kind: "move",
-            game_id: 1,
-            ply,
-            side_to_move: side_char,
-            sfen_before: &extra.sfen_before,
-            move_usi: &extra.move_usi,
-            engine: &extra.engine_label,
-            elapsed_ms: extra.elapsed_ms,
-            think_limit_ms: extra.think_limit_ms,
-            timed_out: false,
-            eval,
-        };
-        serde_json::to_writer(&mut *writer, &entry)?;
-        writer.write_all(b"\n")?;
+        write_move_line(writer, m, extra, ply)?;
     }
     Ok(plies)
 }
@@ -406,5 +464,92 @@ fn winner_label(record: &GameRecord, result: &GameResult) -> Option<String> {
         (GameResult::Lose, Color::Black) => Some(record.gote_name.clone()),
         (GameResult::Lose, Color::White) => Some(record.sente_name.clone()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{GameResult, GameSummary, TimeConfig};
+    use rshogi_csa::{Color, initial_position};
+
+    fn summary() -> GameSummary {
+        GameSummary {
+            game_id: "g".to_owned(),
+            my_color: Color::Black,
+            sente_name: "ME".to_owned(),
+            gote_name: "OPP".to_owned(),
+            position: initial_position(),
+            initial_moves: Vec::new(),
+            black_time: TimeConfig::default(),
+            white_time: TimeConfig::default(),
+            reconnect_token: None,
+        }
+    }
+
+    fn push_move(record: &mut GameRecord, side: Color, sfen_before: &str, usi: &str) {
+        record.add_move("+7776FU", 1, None, side);
+        record.add_jsonl_move(JsonlMoveExtra {
+            sfen_before: sfen_before.to_owned(),
+            move_usi: usi.to_owned(),
+            engine_label: "ME".to_owned(),
+            elapsed_ms: 100,
+            think_limit_ms: 1000,
+            seldepth: None,
+            nodes: None,
+            time_ms: None,
+            nps: None,
+        });
+    }
+
+    #[test]
+    fn live_writer_appends_then_final_write_replaces_with_result() {
+        let dir = std::env::temp_dir().join("csa_live_jsonl_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let config = CsaClientConfig::default();
+        let mut record = GameRecord::new(&summary());
+
+        let mut live = LiveJsonlWriter::create(&dir, &record, &config).unwrap();
+        let path = dir.join(jsonl_filename(&record));
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.lines().count(), 1, "作成直後は meta 行のみ");
+        assert!(text.contains("\"type\":\"meta\""));
+
+        push_move(&mut record, Color::Black, "sfen1", "7g7f");
+        live.append_new_moves(&record).unwrap();
+        push_move(&mut record, Color::White, "sfen2", "3c3d");
+        live.append_new_moves(&record).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.lines().count(), 3, "meta + move x2");
+        assert!(!text.contains("\"type\":\"result\""), "live 中は result 行なし");
+
+        // 新しい手が無ければ追記しない(毎手呼ばれる想定の冪等性)
+        live.append_new_moves(&record).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 3);
+
+        // 終局: 同じパスへ canonical な全内容 (result 行込み) が rename で置き換わる
+        let final_path = write_game_jsonl(&dir, &record, &config, &GameResult::Win).unwrap();
+        assert_eq!(final_path, path);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(text.lines().count(), 4, "meta + move x2 + result");
+        assert!(text.lines().last().unwrap().contains("\"type\":\"result\""));
+        assert!(!path.with_extension("jsonl.tmp").exists(), "tmp 残骸なし");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn live_writer_rewrites_preexisting_moves_on_create() {
+        // 途中局面開始・resume では record が既に手を持つ。create がそれらも書き出す。
+        let dir = std::env::temp_dir().join("csa_live_jsonl_resume_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let config = CsaClientConfig::default();
+        let mut record = GameRecord::new(&summary());
+        push_move(&mut record, Color::Black, "sfen1", "7g7f");
+        push_move(&mut record, Color::White, "sfen2", "3c3d");
+
+        let _live = LiveJsonlWriter::create(&dir, &record, &config).unwrap();
+        let path = dir.join(jsonl_filename(&record));
+        assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 3);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -87,6 +87,9 @@ impl LiveJsonlWriter {
         write_meta(&mut writer, record, config, &path)?;
         let mut live = Self { writer, written: 0 };
         live.append_new_moves(record)?;
+        // 手が 0 の作成直後でも meta 行を読者から見えるようにする
+        // (append_new_moves は書くものが無いと flush しない)。
+        live.writer.flush().context("live JSONL flush に失敗")?;
         Ok(live)
     }
 

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -34,6 +34,7 @@ use crate::events::{
     SearchInfoSnapshot, SearchOrigin, SessionError, SessionEventSink, SessionOutcome,
     SessionProgress, Side, SinkError,
 };
+use crate::jsonl::LiveJsonlWriter;
 use crate::protocol::{
     CsaConnection, GameResult, GameSummary, ReconnectState as ProtocolReconnectState,
     parse_game_result, parse_server_move,
@@ -295,6 +296,9 @@ struct SessionState<'a, E: ?Sized + 'a, S: ?Sized + 'a> {
     /// 直前に ponder miss が発生したか。次の自手番の fresh search に
     /// `SearchOrigin::PonderMiss` を載せるためのフラグ。
     pending_ponder_miss: bool,
+    /// 対局中の JSONL live 追記 (`[record] live_jsonl`)。作成・追記に失敗したら
+    /// `None` に落として対局は続行する(補助機能で進行を妨げない)。
+    live_jsonl: Option<LiveJsonlWriter>,
 }
 
 /// 探索結果の処理結果
@@ -348,6 +352,7 @@ where
         sink,
         info_throttle: SearchInfoThrottle::new(config.game.search_info_emit.clone()),
         pending_ponder_miss: false,
+        live_jsonl: None,
     };
 
     // 途中局面の手順を適用 (Fresh で `initial_moves` がある時のみ。resume では
@@ -373,6 +378,10 @@ where
         push_opponent_jsonl(&mut s.record, initial_sfen_before, usi, move_color, time_sec);
         move_color = opposite(move_color);
     }
+
+    // initial_moves (途中局面開始) や resume 済みの手も含めて書き出すため、
+    // 手順の反映が終わってから live ライターを作る。
+    s.live_jsonl = make_live_writer(config, &s.record);
 
     loop {
         // 各イテレーション先頭で sink.should_continue() を確認
@@ -695,6 +704,7 @@ where
         time_ms: info.time_ms,
         nps: info.nps,
     });
+    live_append(&mut s.live_jsonl, &s.record);
 
     // MoveSent 発火 (送信直後、サーバ echo の time_sec はまだ未確定)
     let move_sent_event = MoveEvent {
@@ -854,6 +864,7 @@ where
                 opposite(s.my_color),
                 time_sec,
             );
+            live_append(&mut s.live_jsonl, &s.record);
 
             // 相手の手 MoveConfirmed
             let opp_event = MoveEvent {
@@ -933,6 +944,7 @@ where
                 opposite(s.my_color),
                 time_sec,
             );
+            live_append(&mut s.live_jsonl, &s.record);
             let opp_event = MoveEvent {
                 player: MovePlayer::Opponent,
                 csa_move: mv.clone(),
@@ -973,6 +985,7 @@ where
             opposite(s.my_color),
             time_sec,
         );
+        live_append(&mut s.live_jsonl, &s.record);
         let opp_event = MoveEvent {
             player: MovePlayer::Opponent,
             csa_move: mv,
@@ -1546,6 +1559,32 @@ fn label_for_color(record: &GameRecord, color: Color) -> String {
         "unknown".to_string()
     } else {
         raw.clone()
+    }
+}
+
+/// `[record] live_jsonl` 有効時に live ライターを作る。失敗は warn に留めて `None`
+/// (live 追記は補助機能で、対局の進行を妨げない)。`save_jsonl` 無効時も `None`。
+fn make_live_writer(config: &CsaClientConfig, record: &GameRecord) -> Option<LiveJsonlWriter> {
+    if !config.record.live_jsonl {
+        return None;
+    }
+    let dir = config.record.jsonl_dir()?;
+    match LiveJsonlWriter::create(&dir, record, config) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            log::warn!("live JSONL の作成に失敗 (追記なしで続行): {e:#}");
+            None
+        }
+    }
+}
+
+/// live JSONL へ未書き出しの手を追記する。失敗したら以後の追記を止める(対局は続行)。
+fn live_append(live: &mut Option<LiveJsonlWriter>, record: &GameRecord) {
+    if let Some(w) = live.as_mut()
+        && let Err(e) = w.append_new_moves(record)
+    {
+        log::warn!("live JSONL 追記に失敗 (以後の追記を停止): {e:#}");
+        *live = None;
     }
 }
 

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -801,3 +801,127 @@ fn nonfatal_sink_does_not_invoke_on_error_and_session_continues() {
     assert!(outcome.is_ok(), "対局は NonFatal でも完了するはず: {outcome:?}");
     assert_eq!(*error_calls.lock().unwrap(), 0, "NonFatal 時は on_error が呼ばれないこと");
 }
+
+// ────────────────────────────────────────────
+// live JSONL (`[record] live_jsonl`) の対局中追記
+// ────────────────────────────────────────────
+
+/// jsonl_dir 内の唯一の `.jsonl` の行数を返す (無ければ 0)。
+fn live_jsonl_line_count(dir: &std::path::Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("jsonl"))
+        .map(|e| std::fs::read_to_string(e.path()).map(|t| t.lines().count()).unwrap_or(0))
+        .sum()
+}
+
+/// MoveConfirmed のたびに live JSONL の行数を観測する sink。
+struct LiveWatchSink {
+    jsonl_dir: PathBuf,
+    observed: Arc<Mutex<Vec<(&'static str, usize)>>>,
+}
+
+impl SessionEventSink for LiveWatchSink {
+    fn on_event(&mut self, event: SessionProgress) -> Result<(), SinkError> {
+        let label = label_for(&event);
+        if label.starts_with("MoveConfirmed") {
+            self.observed
+                .lock()
+                .unwrap()
+                .push((label, live_jsonl_line_count(&self.jsonl_dir)));
+        }
+        Ok(())
+    }
+
+    fn on_error(&mut self, _error: &SessionError) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn live_jsonl_grows_during_game() {
+    // 自分 +7776FU → 相手 -3334FU → #WIN の最小 2 手対局。
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let lines = game_summary_lines("g-live");
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        let agree = read_line(reader);
+        assert!(agree.starts_with("AGREE"), "expected AGREE, got: {agree}");
+        write_lines(writer, &["START:g-live"]);
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"), "expected +7776FU, got: {mv}");
+        write_lines(writer, &["+7776FU,T2"]);
+        write_lines(writer, &["-3334FU,T1"]);
+        write_lines(writer, &["#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let record_root = tempfile_root().join(format!("csa_live_jsonl_e2e_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&record_root);
+    let engine_path = mock_usi_engine_script();
+    let mut config = mock_config(engine_path, SearchInfoEmitPolicy::EveryLine);
+    config.record.enabled = true;
+    config.record.save_jsonl = true;
+    config.record.live_jsonl = true;
+    config.record.dir = record_root.clone();
+    let jsonl_dir = config.record.jsonl_dir().expect("jsonl_dir");
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    let mut engine = UsiEngine::spawn(
+        &config.engine.path,
+        &config.engine.options,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
+    )
+    .expect("spawn engine");
+
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let mut sink = LiveWatchSink {
+        jsonl_dir: jsonl_dir.clone(),
+        observed: Arc::clone(&observed),
+    };
+    let outcome = run_game_session_with_events(
+        &config,
+        &mut conn,
+        &mut engine,
+        Arc::clone(&shutdown),
+        &mut sink,
+    );
+    engine.quit();
+    let outcome = outcome.expect("session outcome");
+
+    // 対局中の観測: 自手確定時点で meta+1 手、相手手確定時点で meta+2 手が
+    // 既にディスク上で読める (= 手単位のリアルタイム追記)。
+    let observed = observed.lock().unwrap();
+    assert_eq!(
+        observed.as_slice(),
+        &[("MoveConfirmedSelf", 2), ("MoveConfirmedOpp", 3)],
+        "observed: {observed:?}"
+    );
+
+    // セッション終了直後 (main の write_game_jsonl 前) の live ファイルは
+    // meta + move x2 のまま result 行を持たない。
+    assert_eq!(live_jsonl_line_count(&jsonl_dir), 3);
+    // main 相当の最終書き出しで canonical (result 行込み) に置き換わる。
+    let path = rshogi_csa_client::jsonl::write_game_jsonl(
+        &jsonl_dir,
+        &outcome.record,
+        &config,
+        &outcome.result,
+    )
+    .expect("final write");
+    let text = std::fs::read_to_string(&path).expect("read final");
+    assert_eq!(text.lines().count(), 4);
+    assert!(text.lines().last().unwrap().contains("\"type\":\"result\""));
+    let _ = std::fs::remove_dir_all(&record_root);
+}

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -20,7 +20,7 @@
 
 | ツール | 説明 |
 |--------|------|
-| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦)・`--ratings` レート併記付き。[詳細](docs/kifu_player.md)） |
+| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦、csa_client の `live_jsonl` と組で自局の手単位リアルタイム観戦)・`--ratings` レート併記付き。[詳細](docs/kifu_player.md)） |
 
 ### 学習データ処理
 
@@ -83,7 +83,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 各ツールの詳細は `docs/` を参照：
 
 - [tournament](docs/tournament.md) - 並列トーナメント・SPRT 検定
-- [kifu_player](docs/kifu_player.md) - PSV / tournament JSONL / CSA 共通の棋譜プレイヤー TUI（評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦)・`--ratings` レート併記付き）
+- [kifu_player](docs/kifu_player.md) - PSV / tournament JSONL / CSA 共通の棋譜プレイヤー TUI（評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦、csa_client の `live_jsonl` と組で自局の手単位リアルタイム観戦)・`--ratings` レート併記付き）
 - [gensfen](docs/gensfen.md) - 教師局面生成ツールの詳細
 - [benchmark](docs/benchmark.md) - ベンチマークツールの詳細
 - [pack_tools](docs/pack_tools.md) - 学習データ処理ツール群

--- a/crates/tools/docs/kifu_player.md
+++ b/crates/tools/docs/kifu_player.md
@@ -103,6 +103,20 @@ kifu_player --csa /tmp/wdoor-live --live 5 --ratings ~/floodgate/records/ratings
 TUI 自体はネットワークに触れない（ミラー dir を読むだけ）ので、オフライン解析の
 `--csa <dir>` 単体利用と完全に同じコードパスで動く。
 
+#### 自エンジンの対局を低遅延で追う（csa_client の live JSONL）
+
+自分の csa_client が指している対局は、wdoor を経由せず直接追える。csa_client の
+設定で `[record] live_jsonl = true` にすると対局中の JSONL に手が逐次追記されるので、
+その dir を live で開くだけでよい:
+
+```bash
+kifu_player --tournament-dir ~/floodgate/records/jsonl --live 3
+```
+
+進行中の対局は result 行が無いため「勝敗不明」として一覧に載り、手が追記されるたびに
+再読込される（末尾の手を表示していれば自動追従）。終局すると通常の完了局に置き換わる。
+評価値・PV は自エンジンの USI info 由来なので wdoor のコメントより情報が濃い。
+
 ### レート併記（`--ratings <TSV>`）
 
 `name<TAB>rate` の TSV（`floodgate_record --ratings-cache` の出力）を渡すと、対局一覧の

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -12,7 +12,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](floodgate_record.md)） |
 | `jsonl_to_kif` | tournament 等の JSONL 対局ログから KIF 棋譜を生成（id/skip/limit でフィルタ可） |
-| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦)・`--ratings` レート併記付き。[詳細](kifu_player.md)） |
+| `kifu_player` | PSV / tournament JSONL / CSA を同じ TUI で再生・閲覧（`kifu-player` feature、評価値グラフ・検索/絞り込み（SFEN 局面検索含む）・`--live` 追記監視 (live-mirror と組で wdoor 観戦、csa_client の `live_jsonl` と組で自局の手単位リアルタイム観戦)・`--ratings` レート併記付き。[詳細](kifu_player.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成。消費時間による定跡手判定（手番側ごとの即指しプレフィックス）・レート/勝敗/手数フィルタ・最小 ply 集約・ponder 集計。決定的（[詳細](book_from_csa.md)） |
 
 ## ベンチマーク・評価

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -239,10 +239,32 @@ fn index_one_file(
     // game_id ごとの評価値指標。move 行は interleave しうるので game_id で束ねる。
     let mut evals: HashMap<u32, EvalAccumulator> = HashMap::new();
 
+    // 進行中対局の末尾行は書き込み途中でありうる (csa_client の live 追記を読者が
+    // 同時に開くのが正常運用)。末尾の切れた行だけは破損でなく「追記中」とみなして
+    // 無視し、その手前までを索引する (次の再読込で完全化する)。
+    let mut last_complete_end: u64 = offset;
     while let Some((line_start, line_len)) = read_line(&mut reader, &mut offset, &mut line_buf)? {
-        let value: Value = serde_json::from_slice(&line_buf).with_context(|| {
-            format!("{}: invalid JSON line at offset {line_start}", path.display())
-        })?;
+        if line_buf.iter().all(|b| b.is_ascii_whitespace()) {
+            last_complete_end = line_start + line_len;
+            continue;
+        }
+        let value: Value = match serde_json::from_slice(&line_buf) {
+            Ok(v) => v,
+            Err(e) => {
+                let at_eof = reader.fill_buf().map(|b| b.is_empty()).unwrap_or(true);
+                if at_eof {
+                    warnings.push(format!(
+                        "{}: 末尾行が JSON として不完全のため無視しました (書き込み途中の可能性)",
+                        path.display()
+                    ));
+                    break;
+                }
+                return Err(e).with_context(|| {
+                    format!("{}: invalid JSON line at offset {line_start}", path.display())
+                });
+            }
+        };
+        last_complete_end = line_start + line_len;
         match value.get("type").and_then(Value::as_str) {
             Some("move") => {
                 let game_id = value.get("game_id").and_then(Value::as_u64).ok_or_else(|| {
@@ -322,7 +344,8 @@ fn index_one_file(
                     file_idx,
                     game_id,
                     start_offset,
-                    end_offset: offset,
+                    // 切れた末尾行を再生範囲に含めない (完全な行までを読む)。
+                    end_offset: last_complete_end,
                 },
                 outcome: None,
                 error: false,
@@ -532,6 +555,31 @@ mod tests {
         let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
         assert_eq!(index.pair_files.len(), 1);
         assert_eq!(index.pair_files[0].black_label, "a");
+    }
+
+    #[test]
+    fn tolerates_torn_tail_line_of_live_file() {
+        // live 追記中のファイルは末尾行が書き込み途中でありうる。切れた末尾行は
+        // 無視して手前までを索引し、再生範囲にも含めない。
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("a-vs-b.jsonl");
+        let mut body = format!(
+            "{}
+{}
+",
+            meta_line("a", "b"),
+            move_line(1, 1, "7g7f")
+        );
+        body.push_str(r#"{"type":"move","game_id":1,"ply":2,"sfen_"#); // 途中で切れた行
+        std::fs::write(&path, body).expect("write");
+
+        let source = JsonlSource::new(dir.path());
+        let index = source.build_index().expect("切れた末尾行で index 全体を落とさない");
+        assert_eq!(index.entries.len(), 1);
+        assert_eq!(index.entries[0].ply_count, 1, "完全な行の 1 手だけを数える");
+        assert!(index.warnings.iter().any(|w| w.contains("不完全")));
+        let game = source.load_game(&index, &index.entries[0]).expect("load_game");
+        assert_eq!(game.moves.len(), 1, "切れた行は再生範囲に含めない");
     }
 
     #[test]

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -251,8 +251,10 @@ fn index_one_file(
         let value: Value = match serde_json::from_slice(&line_buf) {
             Ok(v) => v,
             Err(e) => {
-                let at_eof = reader.fill_buf().map(|b| b.is_empty()).unwrap_or(true);
-                if at_eof {
+                // 改行で終わっていない行 = read_until が EOF に当たった切れた末尾
+                // (JSON 行は生の改行を含まないため)。EOF 到達の再確認だと read と
+                // 確認の間の追記で誤って破損扱いしうるので、行内容だけで判定する。
+                if !line_buf.ends_with(b"\n") {
                     warnings.push(format!(
                         "{}: 末尾行が JSON として不完全のため無視しました (書き込み途中の可能性)",
                         path.display()

--- a/crates/tools/src/replay/jsonl_source.rs
+++ b/crates/tools/src/replay/jsonl_source.rs
@@ -234,6 +234,8 @@ fn index_one_file(
 
     let mut open: HashMap<u32, u64> = HashMap::new();
     let mut closed: HashSet<u32> = HashSet::new();
+    // 進行中対局 (result 行なし) の手数を索引に載せるため move 行を game_id 別に数える。
+    let mut move_counts: HashMap<u32, u32> = HashMap::new();
     // game_id ごとの評価値指標。move 行は interleave しうるので game_id で束ねる。
     let mut evals: HashMap<u32, EvalAccumulator> = HashMap::new();
 
@@ -254,6 +256,7 @@ fn index_one_file(
                     );
                 }
                 open.entry(game_id).or_insert(line_start);
+                *move_counts.entry(game_id).or_default() += 1;
                 if let Some(cp) = move_black_pov_cp(&value) {
                     evals.entry(game_id).or_default().push(cp);
                 }
@@ -303,11 +306,33 @@ fn index_one_file(
     }
 
     if !open.is_empty() {
+        // result 行を伴わない対局 = 進行中 (csa_client の live 追記や実行中の tournament)
+        // または途中終了。勝敗不明の対局として索引する (live 再読込で完了時に置き換わる)。
+        // HashMap の反復順に依存しないよう開始 offset 順で並べる。
+        let mut open_games: Vec<(u32, u64)> = open.into_iter().collect();
+        open_games.sort_by_key(|&(_, start)| start);
         warnings.push(format!(
-            "{}: {} 局が result 行を伴わず終端しました（実行中・途中終了したファイルの可能性）。索引から除外します。",
+            "{}: {} 局が result 行を伴わず終端しました（進行中・途中終了）。勝敗不明として索引します。",
             path.display(),
-            open.len()
+            open_games.len()
         ));
+        for (game_id, start_offset) in open_games {
+            entries.push(GameIndexEntry {
+                source: GameSourceRef::Jsonl {
+                    file_idx,
+                    game_id,
+                    start_offset,
+                    end_offset: offset,
+                },
+                outcome: None,
+                error: false,
+                ply_count: move_counts.get(&game_id).copied().unwrap_or(0),
+                pair_index: None,
+                pair_slot: None,
+                startpos_idx: None,
+                metrics: evals.remove(&game_id).unwrap_or_default().finish(),
+            });
+        }
     }
 
     Ok(Some(PairFileMeta {
@@ -605,17 +630,28 @@ mod tests {
     }
 
     #[test]
-    fn warns_and_drops_incomplete_trailing_game() {
+    fn indexes_incomplete_trailing_game_as_in_progress() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_file(
             dir.path(),
             "a-vs-b.jsonl",
-            &[meta_line("a", "b"), move_line(1, 1, "7g7f")], // result 行が無いまま終端
+            &[
+                meta_line("a", "b"),
+                move_line(1, 1, "7g7f"),
+                move_line(1, 2, "3c3d"), // result 行が無いまま終端 = 進行中
+            ],
         );
 
-        let index = JsonlSource::new(dir.path()).build_index().expect("build_index");
-        assert_eq!(index.entries.len(), 0);
+        let source = JsonlSource::new(dir.path());
+        let index = source.build_index().expect("build_index");
+        assert_eq!(index.entries.len(), 1);
+        assert_eq!(index.entries[0].outcome, None);
+        assert!(!index.entries[0].error);
+        assert_eq!(index.entries[0].ply_count, 2);
         assert!(!index.warnings.is_empty());
+        // 進行中対局も既存のバイト範囲経路でそのまま再生できる。
+        let game = source.load_game(&index, &index.entries[0]).expect("load_game");
+        assert_eq!(game.moves.len(), 2);
     }
 
     #[test]

--- a/docs/csa-client.md
+++ b/docs/csa-client.md
@@ -128,9 +128,18 @@ dir = "./records"
 filename_template = "{datetime}_{sente}_vs_{gote}"
 save_csa = true   # CSA形式
 save_sfen = true  # SFEN局面列（学習データ生成用）
+save_jsonl = true # analyze_selfplay / kifu_player 互換 JSONL（dir/jsonl/ に 1 局 1 ファイル）
+live_jsonl = false # 対局中に JSONL を手単位で live 追記（下記）
 ```
 
 テンプレート変数: `{datetime}`, `{game_id}`, `{sente}`, `{gote}`
+
+`live_jsonl = true` にすると、対局中に JSONL ファイル（`save_jsonl` と同じパス）へ
+確定した手を 1 手ずつ追記する。`kifu_player --tournament-dir <dir>/jsonl --live` で
+開いておくと、**自エンジンの進行中対局を評価値付き・手単位でリアルタイム観戦**できる
+（wdoor を経由しないので低遅延）。追記中のファイルには result 行が無く、読者は
+進行中対局（勝敗不明）として扱う。終局時は従来どおりの完全な内容（result 行込み）へ
+置き換わる。追記の失敗は警告のみで対局は続行する。`save_jsonl = false` なら効果なし。
 
 ## 使い方の例
 


### PR DESCRIPTION
## 概要

TUI × floodgate 連携の Phase 3。csa_client が対局中に per-game JSONL へ確定手を 1 手ずつ追記できるようにし、`kifu_player --live` で**自エンジンの進行中対局を wdoor を経由せず低遅延・評価値付き (自エンジンの USI info 由来) で観戦**できるようにする。

```toml
# csa_client の config
[record]
save_jsonl = true
live_jsonl = true
```
```bash
kifu_player --tournament-dir ~/floodgate/records/jsonl --live 3
```

## 変更点

- **`[record] live_jsonl`** (default false): 対局開始時に最終出力と同じパスへ meta 行を書き、確定手 (自手・相手手・途中局面開始/resume の既存手) を逐次追記 (`LiveJsonlWriter`)。result 行は書かず、終局時に従来の `write_game_jsonl` が canonical な全内容へ **tmp→rename で atomic に置き換え**。追記失敗は warn のみで対局続行
- **kifu_player (JsonlSource)**: result 行の無い対局を除外せず「進行中 (勝敗不明)」として索引。**live 追記中の切れた末尾行** (改行で終わらない不完全 JSON) は「書き込み途中」として無視し手前までを索引 — 追記レースでも crash 残骸でも index 構築が落ちない (中盤の不正行は従来どおり fatal)
- move 行の serialize を `write_move_line` に共通化 (バッチ/live で単一ソース)

## 検証

- **統合テスト** (mock TCP CSA サーバー + mock USI エンジンの実セッション): 自手確定時に meta+1 手、相手手確定時に meta+2 手が**対局中にディスクから読める**ことを sink から観測 (`live_jsonl_grows_during_game`)。terminal では canonical 置き換え (result 行付与・tmp 残骸なし) まで確認
- 単体テスト: live writer の追記/冪等/resume 相当の既存手書き出し/meta flush、torn tail 許容、進行中対局の索引・再生、config 互換
- ws: fmt OK / clippy 0 / csa-client 全 suite + tools replay 86 tests green

## レビュー

Dual review (独立 2 本): Claude (Fable 5) **APPROVE** / Codex 初回 REQUEST_CHANGES (torn tail で dir 全体の索引が落ちる — 行き違いで対応済み commit あり) → 検出条件を Codex 案の「改行なし判定」(TOCTOU なし) へ改善 → **再 APPROVE**。テストが実バグ 1 件 (create 直後の meta 行未 flush) も事前検出・修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCCFdxeJgp7jCFXducgp6K