### PR TITLE
fix(csa-client): JSONL の rename にリトライ + 失敗時に tmp パスを明示

### DIFF
--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -57,9 +57,34 @@ pub fn write_game_jsonl(
     write_result(&mut writer, record, result, plies)?;
 
     writer.flush().context("JSONL flush に失敗")?;
-    fs::rename(&tmp, &path)
-        .with_context(|| format!("JSONL の rename に失敗: {}", path.display()))?;
+    rename_with_retry(&tmp, &path)?;
     Ok(path)
+}
+
+/// tmp から最終パスへの rename。Windows では宛先を `FILE_SHARE_DELETE` なしで開く
+/// 第三者プロセス (ウイルススキャナ・エディタ等) と重なると sharing violation で
+/// 失敗しうるため、短いバックオフ付きでリトライする (Unix では通常初回で成功する)。
+/// 最終的に失敗した場合は、手動救済できるよう書き出し済み tmp のパスをエラーに含める。
+fn rename_with_retry(tmp: &Path, path: &Path) -> Result<()> {
+    const ATTEMPTS: u32 = 3;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+    let mut last_err = None;
+    for attempt in 0..ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(BACKOFF);
+        }
+        match fs::rename(tmp, path) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.expect("ATTEMPTS > 0 のため必ず Some")).with_context(|| {
+        format!(
+            "JSONL の rename に失敗しました: {} (書き出し済みの内容は {} に残っています)",
+            path.display(),
+            tmp.display()
+        )
+    })
 }
 
 /// 対局中に同スキーマの JSONL を手単位で追記する live ライター
@@ -537,6 +562,35 @@ mod tests {
         assert_eq!(text.lines().count(), 4, "meta + move x2 + result");
         assert!(text.lines().last().unwrap().contains("\"type\":\"result\""));
         assert!(!path.with_extension("jsonl.tmp").exists(), "tmp 残骸なし");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rename_with_retry_replaces_existing_destination() {
+        let dir = std::env::temp_dir().join("csa_jsonl_rename_retry_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = dir.join("a.jsonl.tmp");
+        let dst = dir.join("a.jsonl");
+        std::fs::write(&tmp, "new").unwrap();
+        std::fs::write(&dst, "old").unwrap();
+        rename_with_retry(&tmp, &dst).unwrap();
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "new");
+        assert!(!tmp.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rename_with_retry_error_mentions_tmp_path() {
+        let dir = std::env::temp_dir().join("csa_jsonl_rename_retry_err_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // tmp が存在しない → 全 attempt 失敗。エラーに tmp パスが含まれ手動救済の
+        // 手がかりになる。
+        let tmp = dir.join("missing.jsonl.tmp");
+        let dst = dir.join("a.jsonl");
+        let err = rename_with_retry(&tmp, &dst).unwrap_err();
+        assert!(format!("{err:#}").contains("missing.jsonl.tmp"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## 概要

#884 の follow-up。`write_game_jsonl` の tmp→rename に短いバックオフ付きリトライ (3 回 × 100ms) を追加する。

Windows では宛先ファイルを `FILE_SHARE_DELETE` なしで開く第三者プロセス (ウイルススキャナ・エディタ・バックアップツール等) と rename が重なると sharing violation で失敗しうる (Rust std 同士の読者/書き手では発生しない — std は既定で FILE_SHARE_DELETE 付きで開く)。リトライで一時的な競合を吸収し、最終失敗時は書き出し済み tmp のパスをエラーメッセージに含めて手動救済できるようにする。

- Unix では挙動不変 (通常初回成功、成功パスに sleep なし)。失敗時の最大追加待機は 200ms で、呼び出し元は対局ループ外の終局後処理
- テスト 2 本 (既存宛先の atomic 置換 / 全滅時のエラーに tmp パス)

## 検証 / レビュー

- ws: fmt OK / clippy 0 / rshogi-csa-client 全 suite green (lib 45 + 統合 47)
- Dual review: Claude (Fable 5) APPROVE (境界・last_err 不変条件・呼び出し元影響を確認) / Codex APPROVE (findings なし)。nice-to-have として「リトライを Windows の sharing violation に限定する」案があったが、最悪 200ms 固定・対局ループ外のため一律リトライのまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCCFdxeJgp7jCFXducgp6K