### PR TITLE
docs: floodgate_record のビルド/実行手順と floodgate config の完全サンプルを追記

### DIFF
--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -20,6 +20,17 @@
 
 `result` 行が無いファイル(進行中の局)は自動でスキップする。
 
+## ビルドと実行
+
+```bash
+# ビルド(以降の例はビルド済みバイナリ名で表記する)
+cargo build --release -p tools --bin floodgate_record
+# → target/release/floodgate_record
+
+# ビルドせず直接実行する場合は次の形に読み替える
+cargo run --release -p tools --bin floodgate_record -- <args>
+```
+
 ## 使い方
 
 ```bash
@@ -47,6 +58,19 @@ floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache
 | `--ratings-cache <FILE>` | `--fetch-ratings` 併用。fetch 成功時は `name<TAB>rate` を FILE へ書き出し、失敗時は FILE を読み戻してフォールバック併記する(一時障害でも直近値を維持)。config 指定時の既定は `<record.dir>/ratings_cache.tsv` |
 | `--ratings-max-age <SEC>` | `--fetch-ratings` 併用。キャッシュの mtime が SEC 秒以内なら**ネットワーク取得をスキップ**してキャッシュを直接使う。既定 0(常に取得)。レートページは日次生成なので数時間(例: `21600` = 6h)で十分。履歴併用時、履歴に当日(JST)分が無ければ鮮度内でも取得する(スキップで履歴の日付が抜けないように) |
 | `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。書き込みは tmp→rename の全置換(並行実行でも行が壊れない)。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
+
+`--config` に渡す TOML は csa_client の設定そのもので、本ツールが読むのは次の部分
+(完全な floodgate 用 config の例は `docs/csa-client.md` を参照):
+
+```toml
+[server]
+id = "YourEngineName"      # --me の既定値になる
+
+[record]
+dir = "/path/to/floodgate/records"  # 集計 dir は <dir>/jsonl/、キャッシュ・履歴の既定は <dir>/ 直下
+save_jsonl = true                   # false だと集計元が無くエラー(--dir 明示で回避可)
+# jsonl_out = "/path/to/elsewhere"  # JSONL 出力先を上書きしている場合はそちらを集計
+```
 
 **名前の突き合わせはすべて正規化キー**(英数字と `-` `_` 以外を `_` に置換。JSONL のファイル名・meta ラベルと同じ規則)で行う。JSONL の `move.engine` / `result.winner` は raw の CSA 名、ファイル名は正規化済みという混在があるため、集計・`--me`・`--watch`・レート表・キャッシュのキーを入口で同一空間に揃えている。レート併記は正規化キーの**完全一致**で引く(表に無い相手は併記なし)。
 

--- a/crates/tools/docs/floodgate_record.md
+++ b/crates/tools/docs/floodgate_record.md
@@ -60,7 +60,9 @@ floodgate_record --dir ~/floodgate/records/jsonl --fetch-ratings --ratings-cache
 | `--ratings-history <FILE>` | `--fetch-ratings` 併用。fetch 成功時に自分(`--me`)の現在レートを `ページ日付<TAB>名前<TAB>レート` で FILE へ追記する(R 推移のローカル記録)。同一(日付, 名前)は再追記せず**その日最初の観測値**を保持。書き込みは tmp→rename の全置換(並行実行でも行が壊れない)。config 指定時の既定は `<record.dir>/ratings_history.tsv` |
 
 `--config` に渡す TOML は csa_client の設定そのもので、本ツールが読むのは次の部分
-(完全な floodgate 用 config の例は `docs/csa-client.md` を参照):
+(完全な floodgate 用 config の例は
+[docs/examples/csa-client-floodgate.toml.example](../../../docs/examples/csa-client-floodgate.toml.example)、
+解説は [docs/csa-client.md](../../../docs/csa-client.md) を参照):
 
 ```toml
 [server]

--- a/docs/csa-client.md
+++ b/docs/csa-client.md
@@ -145,56 +145,21 @@ live_jsonl = false # 対局中に JSONL を手単位で live 追記（下記）
 
 ### floodgate で連続対局
 
-実運用の全項目を含む config の例（`~/floodgate/active.toml` のように OSS repo 外へ置き、
-名前・トリップ・パスを自分の値へ差し替える）:
+実運用の全項目を含む設定例は **[docs/examples/csa-client-floodgate.toml.example](examples/csa-client-floodgate.toml.example)**
+をコピーして使う(`~/floodgate/active.toml` のように OSS repo 外へ置き、名前・トリップ・
+パスを自分の値へ差し替える。認証情報を含むため repo 内には置かない)。要点は接続部分:
 
 ```toml
 [server]
-host = "wdoor.c.u-tokyo.ac.jp"   # 本番 floodgate。scheme 省略 = TCP 経路
+host = "wdoor.c.u-tokyo.ac.jp"
 port = 4081
-id = "YourEngineName"            # floodgate 上の公開エンジン名（事前登録不要・任意）
-password = "floodgate-300-10F,your-secret-trip"  # <game_name>,<trip>（必須。理由は下記）
-floodgate = true                 # 評価値/PV コメントを送信
-
-[server.keepalive]
-tcp = true                       # 中間 NAT の無通信切断対策
-ping_interval_sec = 60
-
-[engine]
-path = "/path/to/your-usi-engine"
-startup_timeout_sec = 30
-
-[engine.options]                 # 任意の USI オプションを Name = Value で列挙
-EvalFile = "/path/to/model.bin"
-Threads = 16
-USI_Hash = 2048
-Stochastic_Ponder = true
-
-[time]
-margin_msec = 1500               # 秒読みマージン。エンジン側 NetworkDelay と併用可
+id = "YourEngineName"
+password = "floodgate-300-10F,your-secret-trip"  # <game_name>,<trip>(必須。理由は下記)
+floodgate = true
 
 [game]
-max_games = 0                    # 0 = 無制限連続対局
+max_games = 0
 ponder = true
-restart_engine_every_game = false
-
-[retry]
-initial_delay_sec = 10
-max_delay_sec = 60
-
-[record]
-enabled = true
-dir = "/path/to/floodgate/records"
-filename_template = "{datetime}_{sente}_vs_{gote}"
-save_csa = true
-save_sfen = true
-save_jsonl = true                # 戦績集計 (floodgate_record) と TUI 閲覧が読む
-live_jsonl = true                # 対局中の手単位追記（kifu_player --live で自局観戦）
-
-[log]
-level = "info"
-dir = "/path/to/floodgate/logs"
-stdout = true
 ```
 
 ```bash

--- a/docs/csa-client.md
+++ b/docs/csa-client.md
@@ -145,17 +145,56 @@ live_jsonl = false # 対局中に JSONL を手単位で live 追記（下記）
 
 ### floodgate で連続対局
 
+実運用の全項目を含む config の例（`~/floodgate/active.toml` のように OSS repo 外へ置き、
+名前・トリップ・パスを自分の値へ差し替える）:
+
 ```toml
 [server]
-host = "wdoor.c.u-tokyo.ac.jp"
+host = "wdoor.c.u-tokyo.ac.jp"   # 本番 floodgate。scheme 省略 = TCP 経路
 port = 4081
-id = "rshogi_test"
-password = "floodgate-300-10F,your_trip"  # <game_name>,<trip>（必須。理由は下記）
-floodgate = true
+id = "YourEngineName"            # floodgate 上の公開エンジン名（事前登録不要・任意）
+password = "floodgate-300-10F,your-secret-trip"  # <game_name>,<trip>（必須。理由は下記）
+floodgate = true                 # 評価値/PV コメントを送信
+
+[server.keepalive]
+tcp = true                       # 中間 NAT の無通信切断対策
+ping_interval_sec = 60
+
+[engine]
+path = "/path/to/your-usi-engine"
+startup_timeout_sec = 30
+
+[engine.options]                 # 任意の USI オプションを Name = Value で列挙
+EvalFile = "/path/to/model.bin"
+Threads = 16
+USI_Hash = 2048
+Stochastic_Ponder = true
+
+[time]
+margin_msec = 1500               # 秒読みマージン。エンジン側 NetworkDelay と併用可
 
 [game]
-max_games = 0
+max_games = 0                    # 0 = 無制限連続対局
 ponder = true
+restart_engine_every_game = false
+
+[retry]
+initial_delay_sec = 10
+max_delay_sec = 60
+
+[record]
+enabled = true
+dir = "/path/to/floodgate/records"
+filename_template = "{datetime}_{sente}_vs_{gote}"
+save_csa = true
+save_sfen = true
+save_jsonl = true                # 戦績集計 (floodgate_record) と TUI 閲覧が読む
+live_jsonl = true                # 対局中の手単位追記（kifu_player --live で自局観戦）
+
+[log]
+level = "info"
+dir = "/path/to/floodgate/logs"
+stdout = true
 ```
 
 ```bash

--- a/docs/examples/csa-client-floodgate.toml.example
+++ b/docs/examples/csa-client-floodgate.toml.example
@@ -1,0 +1,51 @@
+# csa_client で wdoor floodgate に連続対局(レーティング)参加するための設定例。
+# `~/floodgate/active.toml` のように OSS repo 外へコピーし、名前・トリップ・パスを
+# 自分の値へ差し替えて使う(認証情報と絶対パスを含むため repo には置かない)。
+# 各項目の意味は docs/csa-client.md を参照。
+
+[server]
+host = "wdoor.c.u-tokyo.ac.jp"   # 本番 floodgate。scheme 省略 = TCP 経路
+port = 4081
+id = "YourEngineName"            # floodgate 上の公開エンジン名(事前登録不要・任意)
+password = "floodgate-300-10F,your-secret-trip"  # <game_name>,<trip>。game_name で参加プールを選ぶ(必須)
+floodgate = true                 # 評価値/PV コメントを送信
+
+[server.keepalive]
+tcp = true                       # 中間 NAT の無通信切断対策
+ping_interval_sec = 60
+
+[engine]
+path = "/path/to/your-usi-engine"
+startup_timeout_sec = 30
+
+[engine.options]                 # 任意の USI オプションを Name = Value で列挙
+EvalFile = "/path/to/model.bin"
+Threads = 16
+USI_Hash = 2048
+Stochastic_Ponder = true
+
+[time]
+margin_msec = 1500               # 秒読みマージン。エンジン側 NetworkDelay と併用可
+
+[game]
+max_games = 0                    # 0 = 無制限連続対局(SIGINT で現局完了後に graceful 終了)
+ponder = true
+restart_engine_every_game = false
+
+[retry]
+initial_delay_sec = 10
+max_delay_sec = 60
+
+[record]
+enabled = true
+dir = "/path/to/floodgate/records"
+filename_template = "{datetime}_{sente}_vs_{gote}"
+save_csa = true
+save_sfen = true
+save_jsonl = true                # 戦績集計(floodgate_record)と TUI 閲覧が読む
+live_jsonl = true                # 対局中の手単位追記(kifu_player --live で自局観戦)
+
+[log]
+level = "info"
+dir = "/path/to/floodgate/logs"
+stdout = true


### PR DESCRIPTION
## 概要

docs のみの改善 2 点:

1. **`crates/tools/docs/floodgate_record.md`**: 使い方の例がビルド済みバイナリ名から始まっており初見に不親切だったため、冒頭に「ビルドと実行」節 (`cargo build --release -p tools --bin floodgate_record` / `cargo run` への読み替え) を追加。あわせて `--config` が読む設定項目の最小サンプル TOML を掲載。
2. **`docs/csa-client.md`**: floodgate 節の部分的な config 例を、実運用構成ベースの**全セクション込みサンプル** (名前・トリップ・パスは匿名化、`/path/to/...` プレースホルダ) に置き換え。`live_jsonl` など最近の項目も反映し、floodgate_record.md から相互参照。

検証: `check-tracked-abs-paths.sh` OK (機体固有パスなし)。コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCCFdxeJgp7jCFXducgp6K