### PR TITLE
docs(examples): floodgate 運用スクリプト例一式 (watch/stats/tui/rebuild + watch.ps1)

### DIFF
--- a/crates/tools/docs/floodgate_pipeline.md
+++ b/crates/tools/docs/floodgate_pipeline.md
@@ -55,7 +55,9 @@ cargo run -p tools --bin floodgate_pipeline -- download \
 ### `live-mirror`
 
 当日 (JST) の対局 CSA をローカル dir へミラーし続ける。`kifu_player --csa <dir> --live`
-と組み合わせて、wdoor floodgate のほぼリアルタイム観戦に使う。
+と組み合わせて、wdoor floodgate のほぼリアルタイム観戦に使う。両者を 1 コマンドに
+まとめた wrapper 例が [docs/examples/floodgate/](../../../docs/examples/floodgate/README.md)
+にある（`watch.sh` / `watch.ps1`）。
 
 ```bash
 cargo run -p tools --bin floodgate_pipeline -- live-mirror \

--- a/crates/tools/docs/kifu_player.md
+++ b/crates/tools/docs/kifu_player.md
@@ -120,6 +120,10 @@ kifu_player --csa /tmp/wdoor-live --live 5 --ratings ~/floodgate/records/ratings
 TUI 自体はネットワークに触れない（ミラー dir を読むだけ）ので、オフライン解析の
 `--csa <dir>` 単体利用と完全に同じコードパスで動く。
 
+この 2 プロセスを 1 コマンドにまとめた wrapper 例（`watch.sh` / Windows 用 `watch.ps1`、
+TUI 終了でミラーも自動停止）が
+[docs/examples/floodgate/](../../../docs/examples/floodgate/README.md) にある。
+
 #### 自エンジンの対局を低遅延で追う（csa_client の live JSONL）
 
 自分の csa_client が指している対局は、wdoor を経由せず直接追える。csa_client の

--- a/docs/csa-client.md
+++ b/docs/csa-client.md
@@ -147,7 +147,9 @@ live_jsonl = false # 対局中に JSONL を手単位で live 追記（下記）
 
 実運用の全項目を含む設定例は **[docs/examples/csa-client-floodgate.toml.example](examples/csa-client-floodgate.toml.example)**
 をコピーして使う(`~/floodgate/active.toml` のように OSS repo 外へ置き、名前・トリップ・
-パスを自分の値へ差し替える。認証情報を含むため repo 内には置かない)。要点は接続部分:
+パスを自分の値へ差し替える。認証情報を含むため repo 内には置かない)。日常運用
+(観戦・戦績集計・再ビルド) を 1 コマンド化する wrapper スクリプト例は
+[docs/examples/floodgate/](examples/floodgate/README.md) にある。要点は接続部分:
 
 ```toml
 [server]

--- a/docs/examples/floodgate/README.md
+++ b/docs/examples/floodgate/README.md
@@ -15,7 +15,8 @@ wdoor floodgate まわりの日常運用（観戦・戦績集計・自分の記�
 ## まず観戦だけしたい（config 不要）
 
 ```bash
-cp docs/examples/floodgate/watch.sh ~/floodgate/   # 置き場所は任意
+# repo root で実行（置き場所は任意）
+cp docs/examples/floodgate/watch.sh ~/floodgate/
 ~/floodgate/watch.sh                 # 当日の全対局
 ~/floodgate/watch.sh Sora_Ginko      # 指定 AI の対局のみ（対局者名の部分一致、, 区切りで複数）
 ```
@@ -26,7 +27,9 @@ wdoor から当日の棋譜をミラーし続け、前面で `kifu_player`
 選んで `f` を押すとライブ追従（最新手を表示し続ける）。TUI を閉じる（`q`）とミラーも
 自動停止する。ミラーした棋譜は `~/floodgate-mirror/<対象>/` に残るので後から見返せる。
 
-Windows は `watch.ps1` を使う（PowerShell、Windows Terminal 推奨）。動作は同じ。
+Windows は `watch.ps1` を使う（**PowerShell 7 = pwsh 必須**。Windows PowerShell 5.1 は
+BOM なし UTF-8 の日本語コメントを化けさせるため対象外。Windows Terminal 推奨）。動作は
+同じで、複数指定も `.\watch.ps1 名前,名前` のままでよい。
 
 ## csa_client 運用レイアウト（stats.sh / tui.sh の前提）
 
@@ -52,13 +55,17 @@ config から自動導出する。
 
 | 変数 | 既定 | 使うスクリプト |
 |---|---|---|
-| `RSHOGI_REPO` | `~/development/rshogi` | watch / rebuild_tools |
+| `RSHOGI_REPO` | `~/development/rshogi` | watch / tui / stats / rebuild_tools |
 | `KIFU_PLAYER` | `$RSHOGI_REPO/target/release/kifu_player` | watch / tui |
 | `FLOODGATE_PIPELINE` | 同 `floodgate_pipeline` | watch |
 | `FLOODGATE_RECORD` | 同 `floodgate_record` | stats |
 | `FLOODGATE_WATCH_DIR` | `~/floodgate-mirror` | watch |
 | `FLOODGATE_RATINGS` | `~/floodgate/records/ratings_cache.tsv` | watch |
-| `CSA_CLIENT_CONFIG` | （必須・上記参照） | stats |
+| `FLOODGATE_RECORDS` | `~/floodgate/records` | tui |
+| `CSA_CLIENT_CONFIG` | `~/floodgate/active.toml`（stats.sh が補完） | stats |
+
+シェルスクリプトは bash 前提（Linux / WSL / macOS。空配列展開は bash 3.2 でも動く形で
+ガード済み）。
 
 ## 注意
 

--- a/docs/examples/floodgate/README.md
+++ b/docs/examples/floodgate/README.md
@@ -1,0 +1,67 @@
+# floodgate 運用スクリプト例
+
+wdoor floodgate まわりの日常運用（観戦・戦績集計・自分の記録の閲覧・再ビルド）を
+1 コマンド化するスクリプト例。すべて `$HOME` 相対パス + 環境変数で上書き可能な形で
+書いてあり、標準配置（repo が `~/development/rshogi`、運用 dir が `~/floodgate/`）なら
+無修正で動く。好みの場所（例: `~/floodgate/`）へコピーして使う。
+
+| スクリプト | 用途 | 前提 |
+|---|---|---|
+| `watch.sh` / `watch.ps1` | **wdoor の任意の対局をライブ観戦**（他人同士の対局も可） | ビルド済みバイナリのみ。config・認証・運用 dir 一切不要 |
+| `tui.sh` | 自エンジンの対局記録を TUI で閲覧（live 追従） | csa_client 運用レイアウト（下記） |
+| `stats.sh` | 自エンジンの戦績集計 + wdoor レート併記 | 同上 |
+| `rebuild_tools.sh` | 関連 4 バイナリの一括再ビルド（csa_client 稼働中はガード） | repo clone |
+
+## まず観戦だけしたい（config 不要）
+
+```bash
+cp docs/examples/floodgate/watch.sh ~/floodgate/   # 置き場所は任意
+~/floodgate/watch.sh                 # 当日の全対局
+~/floodgate/watch.sh Sora_Ginko      # 指定 AI の対局のみ（対局者名の部分一致、, 区切りで複数）
+```
+
+裏で `floodgate_pipeline live-mirror`（[詳細](../../../crates/tools/docs/floodgate_pipeline.md)）が
+wdoor から当日の棋譜をミラーし続け、前面で `kifu_player`
+（[詳細](../../../crates/tools/docs/kifu_player.md)）の TUI が開く。TUI 内で進行中の対局を
+選んで `f` を押すとライブ追従（最新手を表示し続ける）。TUI を閉じる（`q`）とミラーも
+自動停止する。ミラーした棋譜は `~/floodgate-mirror/<対象>/` に残るので後から見返せる。
+
+Windows は `watch.ps1` を使う（PowerShell、Windows Terminal 推奨）。動作は同じ。
+
+## csa_client 運用レイアウト（stats.sh / tui.sh の前提）
+
+自エンジンを floodgate に参加させている場合の推奨レイアウト。config は認証情報
+（trip）を含むため repo 外に置く（[設定例](../csa-client-floodgate.toml.example)、
+各項目は [csa-client.md](../../csa-client.md) を参照）:
+
+```
+~/floodgate/
+├── active.toml          # csa_client config（モデル別 config への symlink にすると切替が楽）
+├── records/             # [record].dir。CSA/SFEN 棋譜 + ratings_cache.tsv
+│   └── jsonl/           # per-game JSONL（[record].save_jsonl。tui.sh が読む）
+└── logs/
+```
+
+`.bashrc` 等で `export CSA_CLIENT_CONFIG=~/floodgate/active.toml` しておくと、
+`stats.sh`（= `floodgate_record`）が集計 dir・自分の名前・レートキャッシュのパスを
+config から自動導出する。
+
+## 環境変数での上書き
+
+標準配置でない場合は各スクリプトの env で差し替える:
+
+| 変数 | 既定 | 使うスクリプト |
+|---|---|---|
+| `RSHOGI_REPO` | `~/development/rshogi` | watch / rebuild_tools |
+| `KIFU_PLAYER` | `$RSHOGI_REPO/target/release/kifu_player` | watch / tui |
+| `FLOODGATE_PIPELINE` | 同 `floodgate_pipeline` | watch |
+| `FLOODGATE_RECORD` | 同 `floodgate_record` | stats |
+| `FLOODGATE_WATCH_DIR` | `~/floodgate-mirror` | watch |
+| `FLOODGATE_RATINGS` | `~/floodgate/records/ratings_cache.tsv` | watch |
+| `CSA_CLIENT_CONFIG` | （必須・上記参照） | stats |
+
+## 注意
+
+- **csa_client 稼働中のマシンで重ビルドしない**（対局エンジンと CPU を取り合い持ち時間に
+  影響する）。`rebuild_tools.sh` は稼働を検出して確認を求める。
+- バイナリは glibc の新しいマシンでビルドした物を古いマシンへコピーできない。各機でビルドする。

--- a/docs/examples/floodgate/README.md
+++ b/docs/examples/floodgate/README.md
@@ -65,7 +65,9 @@ config から自動導出する。
 | `CSA_CLIENT_CONFIG` | `~/floodgate/active.toml`（stats.sh が補完） | stats |
 
 シェルスクリプトは bash 前提（Linux / WSL / macOS。空配列展開は bash 3.2 でも動く形で
-ガード済み）。
+ガード済み）。ただし `rebuild_tools.sh` の csa_client 稼働中検出は GNU pgrep の
+`-a`（full command line 出力）前提のため、macOS（BSD pgrep）では効かない。macOS で
+floodgate を常駐させる場合は手動で停止を確認してからビルドすること。
 
 ## 注意
 

--- a/docs/examples/floodgate/rebuild_tools.sh
+++ b/docs/examples/floodgate/rebuild_tools.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# floodgate 関連バイナリ (csa_client / kifu_player / floodgate_record /
+# floodgate_pipeline) を最新ソースで再ビルドする。
+#
+# csa_client (floodgate) 稼働中は、ビルドが対局エンジンと CPU を取り合うため
+# 警告して確認を求める (y で続行 / それ以外は中止)。-y / --yes で確認をスキップ。
+set -euo pipefail
+REPO="${RSHOGI_REPO:-$HOME/development/rshogi}"
+
+assume_yes=0
+if [ "${1:-}" = "-y" ] || [ "${1:-}" = "--yes" ]; then
+  assume_yes=1
+fi
+
+# PID 固定でなく実行時スキャン: floodgate config で動いている csa_client を探す。
+# -x でプロセス名の完全一致に絞り、コマンドライン文字列だけが偶然一致する別プロセス
+# (エディタや本スクリプト自身の起動シェル等) を拾わない。
+running="$(pgrep -ax csa_client | grep floodgate || true)"
+if [ -n "$running" ]; then
+  echo "!! floodgate 用 csa_client が稼働中です:" >&2
+  echo "$running" >&2
+  echo "   負荷: $(uptime | sed 's/.*load average/load average/')" >&2
+  echo "   ビルドは全コアを使い、対局中なら持ち時間に影響しえます。" >&2
+  echo "   安全なのは kill -INT で停止 (現局完了後 graceful) してからの再実行です。" >&2
+  if [ "$assume_yes" -eq 1 ]; then
+    echo "-> --yes 指定のため続行します。" >&2
+  else
+    read -r -p "このまま続行しますか? [y/N] " ans
+    case "$ans" in
+      y|Y) ;;
+      *) echo "中止しました。" >&2; exit 1 ;;
+    esac
+  fi
+fi
+
+cd "$REPO"
+git pull --ff-only
+cargo build --release -p rshogi-csa-client --bin csa_client
+cargo build --release -p tools --features kifu-player \
+  --bin kifu_player --bin floodgate_record --bin floodgate_pipeline
+echo "done: $REPO/target/release/{csa_client,kifu_player,floodgate_record,floodgate_pipeline}"

--- a/docs/examples/floodgate/rebuild_tools.sh
+++ b/docs/examples/floodgate/rebuild_tools.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # floodgate 関連バイナリ (csa_client / kifu_player / floodgate_record /
 # floodgate_pipeline) を最新ソースで再ビルドする。
+# 冒頭で `git pull --ff-only` する (repo が main を checkout し upstream 設定済みである
+# ことが前提。feature branch 作業中などは失敗して止まる = 意図しない pull はしない)。
 #
 # csa_client (floodgate) 稼働中は、ビルドが対局エンジンと CPU を取り合うため
 # 警告して確認を求める (y で続行 / それ以外は中止)。-y / --yes で確認をスキップ。
@@ -36,6 +38,6 @@ fi
 cd "$REPO"
 git pull --ff-only
 cargo build --release -p rshogi-csa-client --bin csa_client
-cargo build --release -p tools --features kifu-player \
+cargo build --release -p tools \
   --bin kifu_player --bin floodgate_record --bin floodgate_pipeline
 echo "done: $REPO/target/release/{csa_client,kifu_player,floodgate_record,floodgate_pipeline}"

--- a/docs/examples/floodgate/stats.sh
+++ b/docs/examples/floodgate/stats.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 # floodgate 戦績集計 (floodgate_record)。dir / 自分の名前 / レートキャッシュ・履歴は
-# active.toml から導出。追加引数はそのまま渡す:
+# config (CSA_CLIENT_CONFIG、既定 ~/floodgate/active.toml) から導出。追加引数はそのまま渡す:
 #   stats.sh
 #   stats.sh --watch test_mypeta,Sora_Ginko,nshogi
 set -euo pipefail
-BIN="${FLOODGATE_RECORD:-$HOME/development/rshogi/target/release/floodgate_record}"
+REPO="${RSHOGI_REPO:-$HOME/development/rshogi}"
+BIN="${FLOODGATE_RECORD:-$REPO/target/release/floodgate_record}"
 export CSA_CLIENT_CONFIG="${CSA_CLIENT_CONFIG:-$HOME/floodgate/active.toml}"
+
+if [ ! -x "$BIN" ]; then
+  echo "error: $BIN がありません。先にビルドしてください:" >&2
+  echo "  cargo build --release -p tools --bin floodgate_record" >&2
+  echo "  (repo: $REPO。場所が違う場合は RSHOGI_REPO で指定)" >&2
+  exit 1
+fi
 exec "$BIN" --fetch-ratings --ratings-max-age 21600 "$@"

--- a/docs/examples/floodgate/stats.sh
+++ b/docs/examples/floodgate/stats.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# floodgate 戦績集計 (floodgate_record)。dir / 自分の名前 / レートキャッシュ・履歴は
+# active.toml から導出。追加引数はそのまま渡す:
+#   stats.sh
+#   stats.sh --watch test_mypeta,Sora_Ginko,nshogi
+set -euo pipefail
+BIN="${FLOODGATE_RECORD:-$HOME/development/rshogi/target/release/floodgate_record}"
+export CSA_CLIENT_CONFIG="${CSA_CLIENT_CONFIG:-$HOME/floodgate/active.toml}"
+exec "$BIN" --fetch-ratings --ratings-max-age 21600 "$@"

--- a/docs/examples/floodgate/tui.sh
+++ b/docs/examples/floodgate/tui.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# floodgate 記録を kifu_player TUI で見る。
+#   tui.sh                              → JSONL を live 追従 + レート併記で開く
+#   tui.sh --csa                        → CSA 棋譜側を開く
+#   tui.sh <kifu_player の追加引数...>  → そのまま渡る
+# 要 PR #882 以降の kifu_player (--live 対応)。それ以前のビルドは floodgate 記録を
+# 開けない (--csa 無し・_vs_ 名 JSONL 非対応) ため、明示エラーで再ビルドを促す。
+set -euo pipefail
+BIN="${KIFU_PLAYER:-$HOME/development/rshogi/target/release/kifu_player}"
+REC="$HOME/floodgate/records"
+
+if ! "$BIN" --help 2>/dev/null | grep -q -- --live; then
+  echo "error: $BIN が旧ビルドで floodgate 記録を開けません。" >&2
+  echo "floodgate 停止時に再ビルドしてください:" >&2
+  echo "  cargo build --release -p tools --features kifu-player --bin kifu_player" >&2
+  exit 1
+fi
+
+extra=(--live 3)
+[ -f "$REC/ratings_cache.tsv" ] && extra+=(--ratings "$REC/ratings_cache.tsv")
+if [ "${1:-}" = "--csa" ]; then
+  shift
+  exec "$BIN" --csa "$REC" "${extra[@]}" "$@"
+fi
+exec "$BIN" --tournament-dir "$REC/jsonl" "${extra[@]}" "$@"

--- a/docs/examples/floodgate/tui.sh
+++ b/docs/examples/floodgate/tui.sh
@@ -6,13 +6,20 @@
 # 要 PR #882 以降の kifu_player (--live 対応)。それ以前のビルドは floodgate 記録を
 # 開けない (--csa 無し・_vs_ 名 JSONL 非対応) ため、明示エラーで再ビルドを促す。
 set -euo pipefail
-BIN="${KIFU_PLAYER:-$HOME/development/rshogi/target/release/kifu_player}"
-REC="$HOME/floodgate/records"
+REPO="${RSHOGI_REPO:-$HOME/development/rshogi}"
+BIN="${KIFU_PLAYER:-$REPO/target/release/kifu_player}"
+REC="${FLOODGATE_RECORDS:-$HOME/floodgate/records}"
 
+if [ ! -x "$BIN" ]; then
+  echo "error: $BIN がありません。先にビルドしてください:" >&2
+  echo "  cargo build --release -p tools --bin kifu_player" >&2
+  echo "  (repo: $REPO。場所が違う場合は RSHOGI_REPO で指定)" >&2
+  exit 1
+fi
 if ! "$BIN" --help 2>/dev/null | grep -q -- --live; then
   echo "error: $BIN が旧ビルドで floodgate 記録を開けません。" >&2
   echo "floodgate 停止時に再ビルドしてください:" >&2
-  echo "  cargo build --release -p tools --features kifu-player --bin kifu_player" >&2
+  echo "  cargo build --release -p tools --bin kifu_player" >&2
   exit 1
 fi
 

--- a/docs/examples/floodgate/watch.ps1
+++ b/docs/examples/floodgate/watch.ps1
@@ -1,0 +1,37 @@
+# wdoor floodgate の対局を 1 コマンドでライブ観戦する (Windows PowerShell 版)。
+# 裏で floodgate_pipeline live-mirror を起動し、前面で kifu_player TUI を開く。
+# TUI を閉じる (q) とミラーも自動停止する。
+#   .\watch.ps1                 → 当日の全対局
+#   .\watch.ps1 名前[,名前...]  → 指定 AI の対局のみ (対局者名の部分一致)
+# ミラー dir は既定 ~\floodgate-mirror\<対象>\ に残る (後から見返せる)。
+param([string]$Watch = "")
+
+$ErrorActionPreference = "Stop"
+$repo = if ($env:RSHOGI_REPO) { $env:RSHOGI_REPO } else { Join-Path $HOME "development/rshogi" }
+$pipeline = if ($env:FLOODGATE_PIPELINE) { $env:FLOODGATE_PIPELINE } else { Join-Path $repo "target/release/floodgate_pipeline.exe" }
+$player = if ($env:KIFU_PLAYER) { $env:KIFU_PLAYER } else { Join-Path $repo "target/release/kifu_player.exe" }
+$base = if ($env:FLOODGATE_WATCH_DIR) { $env:FLOODGATE_WATCH_DIR } else { Join-Path $HOME "floodgate-mirror" }
+
+if ($Watch) {
+    $dir = Join-Path $base ($Watch -replace ",", "+")
+    $mirrorArgs = @("live-mirror", "--out-dir", $dir, "--watch", $Watch)
+} else {
+    $dir = Join-Path $base "all"
+    $mirrorArgs = @("live-mirror", "--out-dir", $dir)
+}
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+
+# レート表キャッシュがあれば併記 (floodgate 運用機で stats.sh を回していれば存在する)
+$playerArgs = @("--csa", $dir, "--live", "5")
+$ratings = if ($env:FLOODGATE_RATINGS) { $env:FLOODGATE_RATINGS } else { Join-Path $HOME "floodgate/records/ratings_cache.tsv" }
+if (Test-Path $ratings) { $playerArgs += @("--ratings", $ratings) }
+
+# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)
+$log = Join-Path $dir "live-mirror.log"
+$mirror = Start-Process -FilePath $pipeline -ArgumentList $mirrorArgs `
+    -RedirectStandardOutput $log -RedirectStandardError "$log.err" -NoNewWindow -PassThru
+try {
+    & $player @playerArgs
+} finally {
+    if (-not $mirror.HasExited) { Stop-Process -Id $mirror.Id -Force }
+}

--- a/docs/examples/floodgate/watch.ps1
+++ b/docs/examples/floodgate/watch.ps1
@@ -1,10 +1,11 @@
-# wdoor floodgate の対局を 1 コマンドでライブ観戦する (Windows PowerShell 版)。
+# wdoor floodgate の対局を 1 コマンドでライブ観戦する (Windows 版。要 PowerShell 7 = pwsh)。
 # 裏で floodgate_pipeline live-mirror を起動し、前面で kifu_player TUI を開く。
 # TUI を閉じる (q) とミラーも自動停止する。
 #   .\watch.ps1                 → 当日の全対局
 #   .\watch.ps1 名前[,名前...]  → 指定 AI の対局のみ (対局者名の部分一致)
 # ミラー dir は既定 ~\floodgate-mirror\<対象>\ に残る (後から見返せる)。
-param([string]$Watch = "")
+# 複数指定は `名前,名前` のままでよい (PowerShell がカンマ区切りを配列として渡す)。
+param([string[]]$Watch = @())
 
 $ErrorActionPreference = "Stop"
 $repo = if ($env:RSHOGI_REPO) { $env:RSHOGI_REPO } else { Join-Path $HOME "development/rshogi" }
@@ -12,9 +13,22 @@ $pipeline = if ($env:FLOODGATE_PIPELINE) { $env:FLOODGATE_PIPELINE } else { Join
 $player = if ($env:KIFU_PLAYER) { $env:KIFU_PLAYER } else { Join-Path $repo "target/release/kifu_player.exe" }
 $base = if ($env:FLOODGATE_WATCH_DIR) { $env:FLOODGATE_WATCH_DIR } else { Join-Path $HOME "floodgate-mirror" }
 
-if ($Watch) {
-    $dir = Join-Path $base ($Watch -replace ",", "+")
-    $mirrorArgs = @("live-mirror", "--out-dir", $dir, "--watch", $Watch)
+# ミラーは裏で起動するためバイナリ不在のエラーがログ行きになり原因が見えない。先に検証する。
+foreach ($bin in @($pipeline, $player)) {
+    if (-not (Test-Path $bin)) {
+        Write-Error ("{0} がありません。先にビルドしてください:`n" -f $bin +
+            "  cargo build --release -p tools --bin kifu_player --bin floodgate_pipeline`n" +
+            "  (repo: $repo。場所が違う場合は RSHOGI_REPO で指定)")
+        exit 1
+    }
+}
+
+$watchJoined = $Watch -join ","
+if ($watchJoined) {
+    # dir 名は引数から作るため、パス区切りは無害化する (名前に / \ は現れない想定の防御)
+    $sub = ($watchJoined -replace ",", "+") -replace '[/\\]', "_"
+    $dir = Join-Path $base $sub
+    $mirrorArgs = @("live-mirror", "--out-dir", $dir, "--watch", $watchJoined)
 } else {
     $dir = Join-Path $base "all"
     $mirrorArgs = @("live-mirror", "--out-dir", $dir)
@@ -26,12 +40,17 @@ $playerArgs = @("--csa", $dir, "--live", "5")
 $ratings = if ($env:FLOODGATE_RATINGS) { $env:FLOODGATE_RATINGS } else { Join-Path $HOME "floodgate/records/ratings_cache.tsv" }
 if (Test-Path $ratings) { $playerArgs += @("--ratings", $ratings) }
 
-# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)
+# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)。
+# Start-Process -ArgumentList は要素をクォートしない実装があるため (Windows PowerShell 5.1)、
+# 空白入りパスでも壊れないよう全要素を自前でクォートして 1 本の文字列にする。
+$quotedArgs = ($mirrorArgs | ForEach-Object { '"{0}"' -f ($_ -replace '"', '\"') }) -join " "
 $log = Join-Path $dir "live-mirror.log"
-$mirror = Start-Process -FilePath $pipeline -ArgumentList $mirrorArgs `
+$mirror = Start-Process -FilePath $pipeline -ArgumentList $quotedArgs `
     -RedirectStandardOutput $log -RedirectStandardError "$log.err" -NoNewWindow -PassThru
 try {
     & $player @playerArgs
+    $status = $LASTEXITCODE
 } finally {
     if (-not $mirror.HasExited) { Stop-Process -Id $mirror.Id -Force }
 }
+exit $status

--- a/docs/examples/floodgate/watch.sh
+++ b/docs/examples/floodgate/watch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# wdoor floodgate の対局を 1 コマンドでライブ観戦する。
+# 裏で floodgate_pipeline live-mirror を起動し、前面で kifu_player TUI を開く。
+# TUI を閉じる (q) とミラーも自動停止する。
+#   watch.sh                     → 当日の全対局
+#   watch.sh 名前[,名前...]      → 指定 AI の対局のみ (対局者名の部分一致)
+# ミラー dir は既定 ~/floodgate-mirror/<対象>/ に残る (後から見返せる)。
+set -euo pipefail
+REPO="${RSHOGI_REPO:-$HOME/development/rshogi}"
+PIPELINE="${FLOODGATE_PIPELINE:-$REPO/target/release/floodgate_pipeline}"
+PLAYER="${KIFU_PLAYER:-$REPO/target/release/kifu_player}"
+BASE="${FLOODGATE_WATCH_DIR:-$HOME/floodgate-mirror}"
+
+watch="${1:-}"
+if [ -n "$watch" ]; then
+  dir="$BASE/${watch//,/+}"
+  mirror_args=(--watch "$watch")
+else
+  dir="$BASE/all"
+  mirror_args=()
+fi
+mkdir -p "$dir"
+
+# レート表キャッシュがあれば併記 (floodgate 運用機で stats.sh を回していれば存在する)
+player_args=()
+ratings="${FLOODGATE_RATINGS:-$HOME/floodgate/records/ratings_cache.tsv}"
+[ -f "$ratings" ] && player_args+=(--ratings "$ratings")
+
+# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)
+"$PIPELINE" live-mirror --out-dir "$dir" "${mirror_args[@]}" >"$dir/live-mirror.log" 2>&1 &
+mirror_pid=$!
+trap 'kill "$mirror_pid" 2>/dev/null || true' EXIT
+
+exec_status=0
+"$PLAYER" --csa "$dir" --live 5 "${player_args[@]}" || exec_status=$?
+exit "$exec_status"

--- a/docs/examples/floodgate/watch.sh
+++ b/docs/examples/floodgate/watch.sh
@@ -11,9 +11,22 @@ PIPELINE="${FLOODGATE_PIPELINE:-$REPO/target/release/floodgate_pipeline}"
 PLAYER="${KIFU_PLAYER:-$REPO/target/release/kifu_player}"
 BASE="${FLOODGATE_WATCH_DIR:-$HOME/floodgate-mirror}"
 
+# ミラーは裏で起動するためバイナリ不在のエラーがログ行きになり原因が見えない。先に検証する。
+for bin in "$PIPELINE" "$PLAYER"; do
+  if [ ! -x "$bin" ]; then
+    echo "error: $bin がありません。先にビルドしてください:" >&2
+    echo "  cargo build --release -p tools --bin kifu_player --bin floodgate_pipeline" >&2
+    echo "  (repo: $REPO。場所が違う場合は RSHOGI_REPO で指定)" >&2
+    exit 1
+  fi
+done
+
 watch="${1:-}"
 if [ -n "$watch" ]; then
-  dir="$BASE/${watch//,/+}"
+  # dir 名は引数から作るため、パス区切りは無害化する (名前に / は現れない想定の防御)
+  sub="${watch//,/+}"
+  sub="${sub//[\/\\]/_}"
+  dir="$BASE/$sub"
   mirror_args=(--watch "$watch")
 else
   dir="$BASE/all"
@@ -26,11 +39,13 @@ player_args=()
 ratings="${FLOODGATE_RATINGS:-$HOME/floodgate/records/ratings_cache.tsv}"
 [ -f "$ratings" ] && player_args+=(--ratings "$ratings")
 
-# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)
-"$PIPELINE" live-mirror --out-dir "$dir" "${mirror_args[@]}" >"$dir/live-mirror.log" 2>&1 &
+# ミラーは裏で回す。ログは dir 内 (kifu_player は *.csa しか読まないので混ざらない)。
+# 空配列の展開は ${arr[@]+...} でガード (bash 4.4 未満の set -u は空配列展開でエラー)。
+"$PIPELINE" live-mirror --out-dir "$dir" ${mirror_args[@]+"${mirror_args[@]}"} \
+  >"$dir/live-mirror.log" 2>&1 &
 mirror_pid=$!
 trap 'kill "$mirror_pid" 2>/dev/null || true' EXIT
 
 exec_status=0
-"$PLAYER" --csa "$dir" --live 5 "${player_args[@]}" || exec_status=$?
+"$PLAYER" --csa "$dir" --live 5 ${player_args[@]+"${player_args[@]}"} || exec_status=$?
 exit "$exec_status"


### PR DESCRIPTION
## 概要

floodgate の日常運用 (観戦・戦績集計・記録閲覧・再ビルド) を 1 コマンド化する wrapper スクリプト例を `docs/examples/floodgate/` に同梱する。#886 の config example と対になる運用側の案内で、個人環境ごとに wrapper を自作・管理していた状態を repo example 参照に一本化できる。

- **watch.sh / watch.ps1**: wdoor の任意の対局をライブ観戦 (live-mirror 裏起動 + kifu_player 前面、TUI 終了でミラー自動停止)。config・認証・運用 dir 不要で、clone + ビルドだけで動く
- **tui.sh / stats.sh**: csa_client 運用レイアウト前提の記録閲覧・戦績集計
- **rebuild_tools.sh**: csa_client 稼働中ガード付きの一括再ビルド
- README に「観戦だけ (config 不要)」/「運用レイアウト」/ env 上書き表 / 落とし穴を記載
- kifu_player.md / floodgate_pipeline.md / csa-client.md から相互参照

すべて $HOME 相対 + env 上書き可で cwd 非依存。標準配置なら無修正で動く。

## レビュー
local 2 reviewer (Claude / Codex) の事前レビューを実施。初回 REQUEST_CHANGES (watch.ps1 のカンマ引数・Start-Process クォート・exit code、tui.sh/stats.sh の env 不整合、バイナリ不在時の無言等) を全件反映し、再レビューで両者 APPROVE。

## 検証
- bash -n 全スクリプト / check-tracked-abs-paths.sh PASS
- watch.sh はダミー player で end-to-end 実動作検証 (引数なし・カンマ・パス区切り入り引数のサニタイズ・ミラー自動停止・バイナリ不在エラー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg9SprpeboHNf3agq5Pszg