### PR TITLE
fix(book): BookEvalDiff の基準を候補中の最大 value に修正

### DIFF
--- a/crates/rshogi-book/src/probe.rs
+++ b/crates/rshogi-book/src/probe.rs
@@ -302,7 +302,7 @@ pub fn probe(
 
     // 6. 評価値フィルタ。
     {
-        let top_value = candidates[0].value;
+        let top_value = candidates.iter().map(|c| c.value).max().unwrap_or(0);
         let side_limit = if position.side_to_move() == Color::Black {
             options.eval_black_limit
         } else {
@@ -499,6 +499,56 @@ mod tests {
         let mut rng = SeqRng::new(vec![0, 0, 0]);
         let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
         assert_eq!(result.best_move.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn eval_diff_anchors_on_max_value_not_highest_count_move() {
+        // count 降順の筆頭手 value=-52 ではなく、候補中の最大 value=-41 を基準にする。
+        // eval_diff=30 なので正しい下限は -71、value=-81 の手は除去される。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d -52 16 100\n2g2f 8c8d -41 16 10\n6g6f 4c4d -81 16 1\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            eval_diff: 30,
+            eval_black_limit: -30000,
+            consider_move_count: false,
+            ..Default::default()
+        };
+
+        let old_anchor_limit = (-52_i32 - opts.eval_diff).max(opts.eval_black_limit);
+        assert_eq!(old_anchor_limit, -82);
+        assert!(-81 >= old_anchor_limit);
+
+        let mut warnings = Vec::new();
+        let mut rng = SeqRng::new(vec![2]);
+        let result =
+            probe(&book, &pos(HIRATE), &opts, &mut rng, |m| warnings.push(m.to_string())).unwrap();
+
+        assert_ne!(result.best_move.to_usi(), "6g6f");
+        assert!(warnings.iter().any(|w| w == "BookEvalDiff = 30 : 3 moves to 2 moves."));
+    }
+
+    #[test]
+    fn eval_diff_keeps_count_only_zero_value_moves() {
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 0 16 30\n2g2f 8c8d 0 16 20\n6g6f 4c4d 0 16 10\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            eval_diff: 30,
+            eval_black_limit: -30000,
+            consider_move_count: false,
+            ..Default::default()
+        };
+
+        let mut warnings = Vec::new();
+        let mut rng = SeqRng::new(vec![2]);
+        let result =
+            probe(&book, &pos(HIRATE), &opts, &mut rng, |m| warnings.push(m.to_string())).unwrap();
+
+        assert_eq!(result.best_move.to_usi(), "6g6f");
+        assert!(!warnings.iter().any(|w| w.starts_with("BookEvalDiff = ")));
     }
 
     #[test]


### PR DESCRIPTION
## 問題

`find_candidates` は候補を count 降順でソートするため、probe() の評価値フィルタの基準 `candidates[0].value` は「count 筆頭手の value」になる。count 筆頭より高評価の候補があるノードでは `value_limit` が不当に緩くなり、BookEvalDiff で除外されるべき手が残留する。

実例(値付き定跡): 初手 2g2f 応手ノードで count 筆頭 8c8d(-52)が基準となり limit=-82、3c3d(-81)が 1cp 差で残留。本来の基準は最大 value の 4a3b(-41)で limit=-71 → 3c3d は除外されるべき。count 筆頭手こそが低評価のノード(頻度は高いが質が低い前例)ほどフィルタが甘くなる構造だった。

## 修正

- 基準を候補中の最大 value に変更(ソート順・BookDepthLimit・NarrowBook は不変)
- count-only 定跡(全 value=0)では最大 value も 0 で挙動不変(後方互換)

## テスト

- 非自明ノード(count 筆頭 -52 / 最大 value -41 / 被除外 -81、eval_diff=30)で除外されることを検証する回帰テスト
- 全 value=0 ノードでフィルタが作動しない互換テスト
- cargo fmt / clippy / test -p rshogi-book PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LstLfBzo6K3dpFYofJ1Saf