### PR TITLE
fix(examples): rebuild_tools.sh — 非ログインシェルで cargo が PATH に無い場合のフォールバック

### DIFF
--- a/docs/examples/floodgate/rebuild_tools.sh
+++ b/docs/examples/floodgate/rebuild_tools.sh
@@ -9,6 +9,16 @@
 set -euo pipefail
 REPO="${RSHOGI_REPO:-$HOME/development/rshogi}"
 
+# 非ログインシェル (ssh host 'cmd' 等) では rustup の PATH が通っておらず、
+# git pull だけ成功してビルドで落ちる。~/.cargo/env をフォールバックで読む。
+if ! command -v cargo >/dev/null 2>&1; then
+  [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: cargo が見つかりません (rustup 未導入か PATH 未設定)。" >&2
+  exit 1
+fi
+
 assume_yes=0
 if [ "${1:-}" = "-y" ] || [ "${1:-}" = "--yes" ]; then
   assume_yes=1


### PR DESCRIPTION
## 概要

`ssh host '~/floodgate/rebuild_tools.sh -y'` のような非ログインシェル実行では rustup の PATH が通っておらず、**git pull だけ成功してビルドが `cargo: command not found` で落ちる**（sh11235 で実際に発生）。`~/.cargo/env` をフォールバックで source し、それでも無ければ git pull より前に明示エラーで終了する。

## レビュー
local 2 reviewer (Claude / Codex) 事前レビュー、両者 APPROVE（set -euo pipefail との相互作用・挿入位置・env 不在ケースを確認済み）。

## 検証
- `PATH=/usr/bin:/bin` で実行 → `~/.cargo/env` フォールバックで cargo 検出
- `HOME=/nonexistent`（env 不在）→ 明示エラーで exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg9SprpeboHNf3agq5Pszg