### PR TITLE
fix(csa-server-tcp): send_line を write_all 1 回に統合し send_line_appends_crlf の flaky を解消

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/transport.rs
+++ b/crates/rshogi-csa-server-tcp/src/transport.rs
@@ -30,6 +30,12 @@ pub struct TcpTransport {
     /// 2 チャンクにまたがったときにチャンク単位で `from_utf8` すると誤った `Io` エラーに
     /// 落ちる。改行バイトで 1 行が確定した時点でだけ UTF-8 検証する。
     line_buf: Vec<u8>,
+    /// 送信 1 回分（本文 + CRLF）を組み立てるバッファ。
+    ///
+    /// 本文と CRLF を別々の `write_all` で送ると 2 syscall / 2 セグメントに
+    /// 分かれ、受信側が本文だけを先に観測しうる。1 バッファにまとめて
+    /// `write_all` 1 回で送るために接続ごとに保持し、使い回す。
+    send_buf: Vec<u8>,
 }
 
 impl TcpTransport {
@@ -44,6 +50,7 @@ impl TcpTransport {
             writer: write_half,
             peer,
             line_buf: Vec::with_capacity(256),
+            send_buf: Vec::with_capacity(256),
         }
     }
 
@@ -111,16 +118,15 @@ impl ClientTransport for TcpTransport {
     }
 
     async fn send_line(&mut self, line: &CsaLine) -> Result<(), TransportError> {
-        // CSA 1.2.1 は CR+LF を要求する。
-        let bytes = line.as_str().as_bytes();
+        // CSA 1.2.1 は CR+LF を要求する。本文 + CRLF を 1 バッファに組んで
+        // `write_all` 1 回で送る（分割送信だと受信側が本文だけを先に観測しうる）。
+        self.send_buf.clear();
+        self.send_buf.extend_from_slice(line.as_str().as_bytes());
+        self.send_buf.extend_from_slice(b"\r\n");
         self.writer
-            .write_all(bytes)
+            .write_all(&self.send_buf)
             .await
-            .map_err(|e| TransportError::Io(format!("write_all(body): {e}")))?;
-        self.writer
-            .write_all(b"\r\n")
-            .await
-            .map_err(|e| TransportError::Io(format!("write_all(crlf): {e}")))?;
+            .map_err(|e| TransportError::Io(format!("write_all: {e}")))?;
         self.writer
             .flush()
             .await
@@ -197,10 +203,16 @@ mod tests {
         let (mut transport, mut client) = loopback_pair().await;
         transport.send_line(&CsaLine::new("START:g1")).await.unwrap();
         // クライアント側は生 TcpStream で読むので CRLF 込みで比較。
+        // 単発 read は TCP 分割で本文だけ返る short read がありうるため、
+        // 期待バイト数に達するまで読む `read_exact` を使う。
+        // CRLF 欠落の退行時に read_exact がハングしないよう timeout で包む。
         use tokio::io::AsyncReadExt;
-        let mut buf = [0u8; 32];
-        let n = client.read(&mut buf).await.unwrap();
-        assert_eq!(&buf[..n], b"START:g1\r\n");
+        let mut buf = [0u8; 10];
+        tokio::time::timeout(Duration::from_secs(1), client.read_exact(&mut buf))
+            .await
+            .expect("read_exact timed out")
+            .unwrap();
+        assert_eq!(&buf, b"START:g1\r\n");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/rshogi-csa-server-tcp/src/transport.rs
+++ b/crates/rshogi-csa-server-tcp/src/transport.rs
@@ -19,6 +19,13 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 
+/// 送信バッファの初期 capacity。通常の CSA 行はこの範囲に収まる。
+const SEND_BUF_INIT_CAPACITY: usize = 256;
+
+/// 送信後も保持を許す capacity の上限。巨大な行（長い `%%CHAT` の broadcast 等）で
+/// 一時的に伸びた capacity を長寿命接続が持ち続けないよう、超過時は縮める。
+const SEND_BUF_MAX_RETAIN: usize = 4096;
+
 /// TCP 接続 1 本分の行 I/O アダプタ。
 pub struct TcpTransport {
     reader: BufReader<OwnedReadHalf>,
@@ -50,7 +57,7 @@ impl TcpTransport {
             writer: write_half,
             peer,
             line_buf: Vec::with_capacity(256),
-            send_buf: Vec::with_capacity(256),
+            send_buf: Vec::with_capacity(SEND_BUF_INIT_CAPACITY),
         }
     }
 
@@ -119,8 +126,15 @@ impl ClientTransport for TcpTransport {
 
     async fn send_line(&mut self, line: &CsaLine) -> Result<(), TransportError> {
         // CSA 1.2.1 は CR+LF を要求する。本文 + CRLF を 1 バッファに組んで
-        // `write_all` 1 回で送る（分割送信だと受信側が本文だけを先に観測しうる）。
+        // `write_all` 1 回で送り、アプリ層起因の分割送信を排除する。
+        // なお TCP はストリームなので 1 write でも受信側の read が複数回に
+        // 分かれることはあり得る（受信側は行確定・期待長まで読む前提）。
         self.send_buf.clear();
+        // 巨大な行（%%CHAT broadcast 等）で伸びた capacity を接続に残さない。
+        // clear 直後（= 空）に縮めるので、直前送信の内容量に関わらず安全。
+        if self.send_buf.capacity() > SEND_BUF_MAX_RETAIN {
+            self.send_buf.shrink_to(SEND_BUF_INIT_CAPACITY);
+        }
         self.send_buf.extend_from_slice(line.as_str().as_bytes());
         self.send_buf.extend_from_slice(b"\r\n");
         self.writer
@@ -207,12 +221,24 @@ mod tests {
         // 期待バイト数に達するまで読む `read_exact` を使う。
         // CRLF 欠落の退行時に read_exact がハングしないよう timeout で包む。
         use tokio::io::AsyncReadExt;
-        let mut buf = [0u8; 10];
+        const EXPECTED: &[u8; 10] = b"START:g1\r\n";
+        let mut buf = [0u8; EXPECTED.len()];
         tokio::time::timeout(Duration::from_secs(1), client.read_exact(&mut buf))
             .await
             .expect("read_exact timed out")
             .unwrap();
-        assert_eq!(&buf, b"START:g1\r\n");
+        assert_eq!(&buf, EXPECTED);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_line_shrinks_oversized_buffer() {
+        // 巨大な行で伸びた send_buf の capacity が、次の送信時に上限まで縮むこと。
+        let (mut transport, _client) = loopback_pair().await;
+        let big = "X".repeat(SEND_BUF_MAX_RETAIN * 2);
+        transport.send_line(&CsaLine::new(&big)).await.unwrap();
+        assert!(transport.send_buf.capacity() > SEND_BUF_MAX_RETAIN);
+        transport.send_line(&CsaLine::new("PING")).await.unwrap();
+        assert!(transport.send_buf.capacity() <= SEND_BUF_MAX_RETAIN);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

- `send_line` が本文と CRLF を別々の `write_all`（2 syscall）で送っていたため、loopback の受信側の単発 `read` が本文だけ読んで返る short read（正当な TCP 挙動）が発生し、`transport::tests::send_line_appends_crlf` が環境依存で落ちていた（PR #896 の workspace テストで恒常ノイズ化）
- 送信側: 接続ごとの再利用バッファ `send_buf` に本文 + CRLF を組んで `write_all` 1 回で送信（ワイヤ上のバイト列は不変、アプリ層の分割送信を排除）
- テスト側: single-read 前提をやめ timeout 付き `read_exact` で期待長まで読む（1 write 化しても OS 側分割の可能性は残るため、恒久的な flake 排除の本体はこちら）

## 補足

- 同ファイルの他テストに single-read 前提は無いことを確認済み（recv 系は改行確定までループする `recv_line` 経由）
- `send_buf.clear()` は組み立て前に行うため、エラー/キャンセル経路でも次回送信に残骸が混入しない

## Test plan

- [x] `cargo fmt --all -- --check` / `cargo clippy --fix --allow-dirty --tests` warning ゼロ
- [x] `cargo test`（workspace 全体）pass / `scripts/check-tracked-abs-paths.sh` OK
- [x] `send_line_appends_crlf` 30/30 連続 pass（修正前はこの環境で恒常 fail）
- [x] local reviewer #1 (Codex 系) APPROVE
- [x] local reviewer #2 (汎用) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gNbLbmGMnpq93axNvQWJo