### PR TITLE
fix(ci): Security Audit の RUSTSEC-2026-0204 / RUSTSEC-2026-0205 を解消

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2659,25 +2659,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2775,24 +2760,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## 原因

CI「Security Audit」job (`cargo audit --deny warnings`) が 2026-07-06 公開の RustSec advisory 2 件により、main を含む全ブランチで恒常 fail していた（特定 PR の変更とは無関係）。

1. **RUSTSEC-2026-0204** — `crossbeam-epoch 0.9.18`（vulnerability）
   - `Atomic`/`Shared` の `fmt::Pointer` impl が無効ポインタ（`null` 等）を dereference する問題。修正版 `>= 0.9.20`。
   - 依存経路: `rayon`（crates/tools）、`metrics-exporter-prometheus`（crates/rshogi-csa-server-tcp）
2. **RUSTSEC-2026-0205** — `scc 2.4.0`（unsound warning、`--deny warnings` で fail）
   - `Array::insert` が compare 関数の panic 時に exception safety を破り double-free になり得る問題。修正版 `>= 3.8.4`。
   - 依存経路: `serial_test 3.4.0`（crates/rshogi-usi の dev-dependency）のみ

## 修正方針

audit 設定への ignore 追加は行わず、依存の minor/patch bump のみで解消（`Cargo.lock` のみの変更、コード変更なし）。

- `cargo update -p crossbeam-epoch` → 0.9.18 → **0.9.20**（advisory 修正版）
- `cargo update -p serial_test` → 3.4.0 → **3.5.0**。serial_test 3.5.0 は scc 依存自体を削除している（parking_lot ベースに移行）ため、`scc`/`sdd` が依存ツリーから完全に消える。

## ローカル検証

- `cargo audit --deny warnings`（CI と同一コマンド）: **before = fail（上記 2 件検出、exit 1）→ after = pass（exit 0、検出 0 件）**
- `cargo fmt && cargo clippy --fix --allow-dirty --tests`: 差分なし・警告ゼロ
- `cargo test --workspace --no-fail-fast`: 91 suite pass / fail は `send_line_appends_crlf` の 1 件のみ。これは既知の flaky で、**依存 bump 前の origin/main でも同様に fail することを確認済み**（別 PR「fix(csa-server-tcp): send_line を write_all 1 回に統合…」で修正中のもの）。本 PR とは無関係。
- `bash scripts/check-tracked-abs-paths.sh`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gNbLbmGMnpq93axNvQWJo