### PR TITLE
feat(book): BookSelectValue — value 最大手の決定的選択オプション

### DIFF
--- a/crates/rshogi-book/Cargo.toml
+++ b/crates/rshogi-book/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rshogi-book"
 version = "0.1.0"
+publish = false
 edition = "2024"
 authors = ["SH11235"]
 description = "Opening book (YANEURAOU-DB2016 .db) reader and probe for rshogi"

--- a/crates/rshogi-book/README.md
+++ b/crates/rshogi-book/README.md
@@ -1,0 +1,27 @@
+# rshogi-book
+
+`rshogi-book` は YANEURAOU-DB2016 テキスト `.db` 形式の定跡を読み込み、root 局面で
+定跡手を 1 手 probe する crate です。USI 統合では `rshogi-usi` の Book 系オプションが
+`BookOptions` に反映されます。
+
+## 定跡 probe オプション
+
+| USI オプション | 既定 | 説明 |
+| --- | --- | --- |
+| `USI_OwnBook` | `true` | 定跡使用の総合スイッチ。`false` なら probe しない。 |
+| `BookFile` | `no_book` | 定跡ファイル名。`no_book` または空なら定跡をロードしない。 |
+| `BookDir` | `book` | 相対 `BookFile` を解決するディレクトリ。 |
+| `BookMoves` | `16` | この手数まで定跡を使う。 |
+| `BookEvalDiff` | `30` | 候補中の最大 value からこの差分以内の手だけ残す。 |
+| `BookEvalBlackLimit` | `0` | 先手番で採用する value 下限。 |
+| `BookEvalWhiteLimit` | `-140` | 後手番で採用する value 下限。 |
+| `BookDepthLimit` | `0` | 筆頭手の depth 下限。`0` は無効。 |
+| `NarrowBook` | `false` | count 情報がある場合、出現率 10% 未満の手を除外する。 |
+| `BookSelectValue` | `false` | 評価値フィルタ後の生存候補から value 最大手を決定的に選ぶ。同値は count 大、さらに同値なら USI 昇順。`true` のとき `NarrowBook` / `ConsiderBookMoveCount` / 等確率抽選より優先する。 |
+| `ConsiderBookMoveCount` | `false` | `true` なら count 比例抽選する。全 count が 0 の場合は等確率。 |
+| `IgnoreBookPly` | `false` | ロード時に SFEN の手数を無視してキーを正規化する。 |
+| `FlippedBook` | `true` | miss 時に先後反転局面で再検索する。 |
+
+選択順序は、合法性検証、`BookDepthLimit`、`BookEvalDiff` / value 下限フィルタの後に
+`BookSelectValue` を評価します。`BookSelectValue=false` の場合は従来どおり
+`NarrowBook` を適用し、その後 `ConsiderBookMoveCount` または等確率抽選で選びます。

--- a/crates/rshogi-book/src/probe.rs
+++ b/crates/rshogi-book/src/probe.rs
@@ -8,10 +8,11 @@
 //! 4. `to_move` + pseudo-legal + legal で合法性検証、非合法は info string 警告して除去
 //! 5. `BookDepthLimit`(0 で無効): 筆頭手 depth 不足なら局面ごと不採用
 //! 6. `BookEvalDiff` / `BookEvalBlackLimit` / `BookEvalWhiteLimit`: 下限未満を除去
-//! 7. `NarrowBook`: count 情報がある場合のみ出現率 10% 未満を除去
-//! 8. 選択: `ConsiderBookMoveCount` なら count 比例抽選(全 0 は等確率)、false は等確率
-//! 9. ponder 補完: book の ponder が none なら 1 手進めて再 find し筆頭候補を採用
-//! 10. bestmove(+ ponder)を返す
+//! 7. `BookSelectValue`: true なら value 最大手を決定的に選ぶ(同値は count 降順 → USI 昇順)
+//! 8. `NarrowBook`: count 情報がある場合のみ出現率 10% 未満を除去
+//! 9. 選択: `ConsiderBookMoveCount` なら count 比例抽選(全 0 は等確率)、false は等確率
+//! 10. ponder 補完: book の ponder が none なら 1 手進めて再 find し筆頭候補を採用
+//! 11. bestmove(+ ponder)を返す
 
 use rshogi_core::position::Position;
 use rshogi_core::types::{Color, Move};
@@ -91,6 +92,8 @@ pub struct BookOptions {
     pub depth_limit: i32,
     /// `NarrowBook`: 出現率 10% 未満の手を除外するか。
     pub narrow_book: bool,
+    /// `BookSelectValue`: value 最大手を決定的に選ぶか。
+    pub select_value: bool,
     /// `ConsiderBookMoveCount`: 採択回数比例で抽選するか。
     pub consider_move_count: bool,
     /// `FlippedBook`: miss 時に先後反転局面で再検索するか。
@@ -107,6 +110,7 @@ impl Default for BookOptions {
             eval_white_limit: -140,
             depth_limit: 0,
             narrow_book: false,
+            select_value: false,
             consider_move_count: false,
             flipped_book: true,
         }
@@ -126,6 +130,8 @@ pub struct BookProbeResult {
 struct Candidate {
     /// この局面の座標系での合法手(32bit 化済み)。
     mv: Move,
+    /// この局面の座標系での USI 文字列。
+    move_usi: String,
     /// この局面の座標系での ponder(USI 文字列)。book に none なら `None`。
     ponder_usi: Option<String>,
     value: i32,
@@ -198,6 +204,7 @@ fn find_candidates(
 
         candidates.push(Candidate {
             mv,
+            move_usi: move_str,
             ponder_usi,
             value: raw.value,
             depth: raw.depth,
@@ -242,6 +249,21 @@ fn select_index(
     }
 
     idx
+}
+
+/// value 最大手を決定的に選ぶ。同値は count 降順 → USI 昇順。
+fn select_value_index(candidates: &[Candidate]) -> usize {
+    candidates
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| {
+            a.value
+                .cmp(&b.value)
+                .then_with(|| a.move_count.cmp(&b.move_count))
+                .then_with(|| b.move_usi.cmp(&a.move_usi))
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(0)
 }
 
 /// ponder を解決する。book に ponder があれば検証して採用、無ければ 1 手進めて筆頭手を拾う。
@@ -324,7 +346,21 @@ pub fn probe(
         }
     }
 
-    // 7. NarrowBook: count 情報がある場合のみ出現率 10% 未満を除去。
+    // 7. BookSelectValue: 評価値フィルタ後の生存候補から value 最大手を決定的に選ぶ。
+    if options.select_value {
+        let idx = select_value_index(&candidates);
+        let chosen = &candidates[idx];
+        let best_move = chosen.mv;
+        let book_ponder = chosen.ponder_usi.clone();
+        let ponder_move = resolve_ponder(book, position, options, best_move, &book_ponder);
+
+        return Some(BookProbeResult {
+            best_move,
+            ponder_move,
+        });
+    }
+
+    // 8. NarrowBook: count 情報がある場合のみ出現率 10% 未満を除去。
     if options.narrow_book {
         let total: u64 = candidates.iter().map(|c| c.move_count).sum();
         if total > 0 {
@@ -341,13 +377,13 @@ pub fn probe(
         return None;
     }
 
-    // 8. 選択。
+    // 9. 選択。
     let idx = select_index(&candidates, options.consider_move_count, rng);
     let chosen = &candidates[idx];
     let best_move = chosen.mv;
     let book_ponder = chosen.ponder_usi.clone();
 
-    // 9. ponder 解決。
+    // 10. ponder 解決。
     let ponder_move = resolve_ponder(book, position, options, best_move, &book_ponder);
 
     Some(BookProbeResult {
@@ -579,6 +615,74 @@ mod tests {
         };
         let mut rng = SeqRng::new(vec![0]);
         let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+        assert_eq!(result.best_move.to_usi(), "7g7f");
+    }
+
+    #[test]
+    fn book_select_value_chooses_highest_value_move() {
+        // value 最大の 2g2f は count が低く NarrowBook なら除去対象だが、
+        // BookSelectValue=true では NarrowBook / count 抽選をスキップして採用する。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 10 16 100\n2g2f 8c8d 80 16 1\n6g6f 4c4d 20 16 50\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            select_value: true,
+            narrow_book: true,
+            consider_move_count: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![0, 0, 0]);
+
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+
+        assert_eq!(result.best_move.to_usi(), "2g2f");
+    }
+
+    #[test]
+    fn book_select_value_tiebreaks_by_count_then_usi() {
+        // value 同値なら count 最大、count も同値なら USI 昇順。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 80 16 40\n2g2f 8c8d 80 16 50\n1g1f 9c9d 80 16 50\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            select_value: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        let mut rng = SeqRng::new(vec![2, 2, 2]);
+
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+
+        assert_eq!(result.best_move.to_usi(), "1g1f");
+    }
+
+    #[test]
+    fn book_select_value_false_keeps_existing_selection_pipeline() {
+        // BookSelectValue=false では value 最大の 2g2f を貪欲選択せず、
+        // 既存どおり NarrowBook 後に count 比例抽選する。
+        let data = format!(
+            "{HEADER}\nsfen {HIRATE}\n7g7f 3c3d 10 16 100\n2g2f 8c8d 80 16 1\n6g6f 4c4d 20 16 50\n"
+        );
+        let book = Book::from_reader(data.as_bytes(), false).unwrap();
+        let opts = BookOptions {
+            select_value: false,
+            narrow_book: true,
+            consider_move_count: true,
+            eval_black_limit: -30000,
+            eval_diff: 30000,
+            ..Default::default()
+        };
+        // NarrowBook 後の並びは [7g7f(100), 6g6f(50)]。
+        // i=0: 0<100 で idx=0、i=1: 149<50? false なので 7g7f のまま。
+        let mut rng = SeqRng::new(vec![0, 149]);
+
+        let result = probe(&book, &pos(HIRATE), &opts, &mut rng, no_info).unwrap();
+
         assert_eq!(result.best_move.to_usi(), "7g7f");
     }
 

--- a/crates/rshogi-usi/src/main.rs
+++ b/crates/rshogi-usi/src/main.rs
@@ -302,6 +302,7 @@ impl UsiEngine {
         println!("option name BookEvalWhiteLimit type spin default -140 min -30000 max 30000");
         println!("option name BookDepthLimit type spin default 0 min 0 max 256");
         println!("option name NarrowBook type check default false");
+        println!("option name BookSelectValue type check default false");
         println!("option name ConsiderBookMoveCount type check default false");
         println!("option name IgnoreBookPly type check default false");
         println!("option name FlippedBook type check default true");
@@ -978,6 +979,9 @@ impl UsiEngine {
             }
             "NarrowBook" => {
                 self.book_options.narrow_book = value == "true" || value == "1";
+            }
+            "BookSelectValue" => {
+                self.book_options.select_value = value == "true" || value == "1";
             }
             "ConsiderBookMoveCount" => {
                 self.book_options.consider_move_count = value == "true" || value == "1";


### PR DESCRIPTION
## 概要

定跡 probe の候補選択に `BookSelectValue` (bool、既定 false) を追加する。

- true のとき、評価値フィルタ (BookEvalDiff/limits) 生存候補から **value 最大手を決定的に選ぶ**(同値タイは count 降順 → USI 昇順)。NarrowBook / ConsiderBookMoveCount / 等確率抽選はスキップ
- 背景: count 比例抽選は母集団バイアスを選択に持ち込む。floodgate 実戦 (2026-07-08 vs test768) で value 最高手 7g7f(35) を保持しながら count 抽選で 6i7h(28) を引き、劣った細ラインに入って敗局する実害を確認
- 既定 false で既存挙動は完全不変 (回帰テストで担保)

## レビュー

- dual review 実施: Fable レビュー APPROVE + Codex adversarial review の指摘 (公開 struct へのフィールド追加の互換性契約) に対し、rshogi-book へ `publish = false` を明示して workspace 内クレート契約とした

## 検証

- fmt / clippy -D warnings / test (rshogi-book 37 + rshogi-usi 15) 全通過
- 新規テスト 3 件: value 最大選択 / 同値タイブレーク / false 時の挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SemVfgKwqeL8es5JC8wy2