### PR TITLE
nnue: effect-bucket 3x3-kingfixed の 1024 edition を追加

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -272,6 +272,10 @@ edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-2x2_kingfixed = [
   "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32",
   "nnue-effect-bucket", "effect-bucket-2x2-kingfixed",
 ]
+edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-3x3_kingfixed = [
+  "mode-specific", "layerstack-arch", "ft-halfka_hm_merged", "layerstacks-1024x16x32",
+  "nnue-effect-bucket", "effect-bucket-3x3-kingfixed",
+]
 # LayerStack specific (3072x16x32、none のみ)。FT_OUT=3072 の大型 FT。
 # L0=3072 も progress-diff の NPS 改善を実測で確認済みのため 1536 系と同様に同梱する。
 edition-layerstacks-halfka_hm_merged-3072x16x32-none = [

--- a/crates/rshogi-core/tests/build_rs_checks.rs
+++ b/crates/rshogi-core/tests/build_rs_checks.rs
@@ -315,6 +315,19 @@ fn halfka_effect_bucket_specific_ok() {
 }
 
 #[test]
+fn halfka_effect_bucket_1024_3x3_kingfixed_specific_ok() {
+    let has = lookup(&[
+        "mode-specific",
+        "layerstack-arch",
+        "layerstacks-1024x16x32",
+        "ft-halfka_hm_merged",
+        "nnue-effect-bucket",
+        "effect-bucket-3x3-kingfixed",
+    ]);
+    assert!(validate_feature_combination(&has).is_ok());
+}
+
+#[test]
 fn halfka_effect_bucket_without_mode_rejected() {
     let has = lookup(&[
         "layerstack-arch",

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -111,6 +111,7 @@ edition-layerstacks-halfka_hm_merged-768x8x32-none          = ["rshogi-core/edit
 edition-layerstacks-halfka_hm_merged-512x16x32-none         = ["rshogi-core/edition-layerstacks-halfka_hm_merged-512x16x32-none"]
 edition-layerstacks-halfka_hm_merged_effect_bucket-512x16x32-2x2_kingfixed       = ["rshogi-core/edition-layerstacks-halfka_hm_merged_effect_bucket-512x16x32-2x2_kingfixed"]
 edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-2x2_kingfixed      = ["rshogi-core/edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-2x2_kingfixed"]
+edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-3x3_kingfixed      = ["rshogi-core/edition-layerstacks-halfka_hm_merged_effect_bucket-1024x16x32-3x3_kingfixed"]
 edition-layerstacks-halfka_hm_merged-3072x16x32-none        = ["rshogi-core/edition-layerstacks-halfka_hm_merged-3072x16x32-none"]
 # LS specific preset (halfka_hm_merged 以外の 4 FT、1536x16x32-none で代表整備)。
 edition-layerstacks-halfka_hm_split-1536x16x32-none = ["rshogi-core/edition-layerstacks-halfka_hm_split-1536x16x32-none"]


### PR DESCRIPTION
EffectBucket=3x3 (KPE9 相当、E=利き 3x3 clip) の学習 run を評価する SPRT engine 用に、
1024x16x32 / 3x3-kingfixed の preset edition を追加する。

- crates/rshogi-core/Cargo.toml: edition 定義 (既存 2x2 edition と同構成、config のみ 3x3)
- crates/rshogi-usi/Cargo.toml: edition feature forward
- build_rs_checks: 3x3 config の valid 組合せ test

gate: fmt / clippy / test (default 973 + 3x3 edition) / xtask list-editions / abs-paths 全 PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019298FLc42j4HUGmbAZm5hf