### PR TITLE
feat(tools): ek_testset — 入玉評価テストセット構築・採点ツール

### DIFF
--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -65,23 +65,28 @@ aobazero-onnx = ["dep:ort", "dep:ndarray"]
 # 標準dlshogi ONNX直接推論（DL水匠等、ONNX Runtime + CUDA が必要）
 dlshogi-onnx = ["dep:ort", "dep:ndarray"]
 
+# 棋譜 replay（CSA/PSV/JSONL の parse・盤面再生・勝敗導出。`replay` モジュールの
+# TUI を除く部分）。教師・評価系ツールが TUI 依存 (ratatui/crossterm) なしで
+# 棋譜 replay を使うための軸。
+csa-replay = []
+
 # 棋譜プレイヤー TUI（PSV / tournament JSONL 共通の対局再生ビューア）。
 # default に含める: 素の `cargo build --release` で kifu_player だけ旧版のまま
 # 取り残されるのを防ぐ (required-features 付き bin は feature 無しだとビルド対象外)。
 # TUI 依存 (ratatui/crossterm) を持ち込みたくない学習パイプライン等は
 # `--no-default-features` でオプトアウトする。
-kifu-player = ["dep:ratatui", "dep:crossterm"]
+kifu-player = ["csa-replay", "dep:ratatui", "dep:crossterm"]
 
 [[bin]]
 name = "kifu_player"
 path = "src/bin/kifu_player.rs"
 required-features = ["kifu-player"]
 
-# ek_testset は CSA replay (kifu-player feature 配下) に依存するため gate する。
+# ek_testset は CSA replay に依存する（TUI は不要）ため csa-replay に gate する。
 [[bin]]
 name = "ek_testset"
 path = "src/bin/ek_testset.rs"
-required-features = ["kifu-player"]
+required-features = ["csa-replay"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -72,6 +72,12 @@ name = "kifu_player"
 path = "src/bin/kifu_player.rs"
 required-features = ["kifu-player"]
 
+# ek_testset は CSA replay (kifu-player feature 配下) に依存するため gate する。
+[[bin]]
+name = "ek_testset"
+path = "src/bin/ek_testset.rs"
+required-features = ["kifu-player"]
+
 [dependencies]
 # Workspace dependencies
 anyhow.workspace = true

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -52,6 +52,7 @@
 | `label_bench_positions` | ベンチ局面 jsonl を深い探索でラベル付けし `eval_deep` を追記（ground truth） |
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) で静的評価し `eval_dl` を追記（`dlshogi-onnx` feature、default 有効） |
 | `yardstick_label` / `yardstick_score` | ラベル品質「物差し」。held-out hcpe を labeler でラベル付け（stage 1）→ engine ごとに勝率較正して per-class WDL logloss / 参照天井 / リファレンス一致を採点（stage 2） |
+| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](docs/ek_testset.md)） |
 
 ### NNUE 学習
 
@@ -95,6 +96,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [label_bench_dl](docs/label_bench_dl.md) - label_bench jsonl への DL水匠 (dlshogi ONNX) 評価値追記
 - [yardstick_label](docs/yardstick_label.md) - held-out hcpe を labeler の固定 depth 探索でラベル付け（物差し stage 1）
 - [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
+- [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の ONNX 再スコアリング（qsearch-leaf ラベル / dual-output / `--onnx-sessions` in-flight 多重化対応）
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み）

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -18,7 +18,7 @@ cargo run -p tools --release --bin ek_testset -- build \
 |---|---|
 | `testset.jsonl` | 1 行 1 局面。`sfen`, `stm`, `ply`, `source_csa`, `is_declarable`, `dt_label`, `oc_label`, `floodgate_eval_cp` |
 | `sfens.txt` | `testset.jsonl` と同順の SFEN |
-| `meta.json` | 入力、件数、パラメータ、生成元 CSA 一覧 |
+| `meta.json` | 入力、件数、パラメータ（生成元 CSA はレコードごとの `source_csa` に記録） |
 
 core が `entering_king_point_info` を公開していないため、点数系フィールド
 （`points_stm`, `king_in_enemy_stm`, `enemy_zone_pieces_stm`）は出力しません。DT ラベルは

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -35,5 +35,7 @@ cargo run -p tools --release --bin ek_testset -- eval \
 ```
 
 標準出力と `--out` に同じ JSON を出します。評価値は手番側視点 cp として扱い、DT は宣言可能局面の
-符号一致率と +600cp 超過率、OC は実対局結果との符号一致率、cross entropy、Brier、5 分位 calibration
-を出します。符号一致率では `eval == 0` を一致に含めず、DT/OC とも不一致として扱います。
+符号一致率と +600cp 超過率、OC は実対局結果との符号一致率、cross entropy、Brier、予測勝率を
+[0,1] で 10 等分した等幅ビンの calibration（ビンごとの平均予測勝率と実勝率）を出します。calibration は
+全予測を保持せずビンごとの逐次集計で求めるため、ピークメモリは入力件数に非依存です。符号一致率では
+`eval == 0` を一致に含めず、DT/OC とも不一致として扱います。

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -20,7 +20,7 @@ cargo run -p tools --release --bin ek_testset -- build \
 | `sfens.txt` | `testset.jsonl` と同順の SFEN |
 | `meta.json` | 入力、件数、パラメータ、生成元 CSA 一覧 |
 
-このブランチでは `entering_king_point_info` が core に未公開のため、点数系フィールド
+core が `entering_king_point_info` を公開していないため、点数系フィールド
 （`points_stm`, `king_in_enemy_stm`, `enemy_zone_pieces_stm`）は出力しません。DT ラベルは
 `Position::declaration_win(EnteringKingRule::Point27)` で作ります。
 

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -1,0 +1,39 @@
+# ek_testset
+
+`ek_testset` は、held-out CSA 棋譜から入玉局面の静的評価テストセットを作り、native NNUE 評価で採点するツールです。
+
+## build
+
+```bash
+cargo run -p tools --release --bin ek_testset -- build \
+  --input "$HOME/data/floodgate/extracted/band" \
+  --out-dir runs/ek_testset/band \
+  --min-ply-from-entry -20 \
+  --sample-stride 4
+```
+
+出力:
+
+| ファイル | 内容 |
+|---|---|
+| `testset.jsonl` | 1 行 1 局面。`sfen`, `stm`, `ply`, `source_csa`, `is_declarable`, `dt_label`, `oc_label`, `floodgate_eval_cp` |
+| `sfens.txt` | `testset.jsonl` と同順の SFEN |
+| `meta.json` | 入力、件数、パラメータ、生成元 CSA 一覧 |
+
+このブランチでは `entering_king_point_info` が core に未公開のため、点数系フィールド
+（`points_stm`, `king_in_enemy_stm`, `enemy_zone_pieces_stm`）は出力しません。DT ラベルは
+`Position::declaration_win(EnteringKingRule::Point27)` で作ります。
+
+## eval
+
+```bash
+cargo run -p tools --release --bin ek_testset -- eval \
+  --testset runs/ek_testset/band/testset.jsonl \
+  --eval-file "$SHOGI_DATA/nnue/model.bin" \
+  --progress-file "$SHOGI_DATA/progress/progress.bin" \
+  --out runs/ek_testset/band/metrics.json
+```
+
+標準出力と `--out` に同じ JSON を出します。評価値は手番側視点 cp として扱い、DT は宣言可能局面の
+符号一致率と +600cp 超過率、OC は実対局結果との符号一致率、cross entropy、Brier、5 分位 calibration
+を出します。符号一致率では `eval == 0` を一致に含めず、DT/OC とも不一致として扱います。

--- a/crates/tools/docs/ek_testset.md
+++ b/crates/tools/docs/ek_testset.md
@@ -2,6 +2,14 @@
 
 `ek_testset` は、held-out CSA 棋譜から入玉局面の静的評価テストセットを作り、native NNUE 評価で採点するツールです。
 
+局面には 2 種類のラベルを付け、それぞれ別の指標系で採点します:
+
+- **DT (Declaration Truth / 宣言真値)**: `Position::declaration_win` が「手番側の宣言勝ち成立」と
+  判定した局面に付く「手番側勝ち」ラベル。ルールベースの判定なので ground truth として扱える。
+  評価関数が勝ち確定局面を正しくプラスに読めるかを測る。
+- **OC (Outcome Calibration / 勝敗較正)**: 実対局の最終結果を手番側視点の win/loss にしたラベル。
+  評価値から作る予測勝率 `sigmoid(eval/scale)` が実勝率とどれだけ整合するか（較正）を測る。
+
 ## build
 
 ```bash

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -24,6 +24,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `bench_nnue_eval` | NNUE 推論単体の性能測定（cycles/eval, instructions/eval） |
 | `search_only_ab` | Linux perf ベースの search-only A/B ベンチマーク。起動・ロード時間を除外して正確計測 |
 | `eval_sfens` | SFEN 局面を LayerStacks NNUE で静的評価 |
+| `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](ek_testset.md)） |
 | `compare_eval_nnue` | 教師 NNUE と生徒 NNUE の評価値一致度を検証（MAE・相関係数・スコア帯別誤差） |
 | `compare_nodes` | 2つの USI エンジン間で探索ノード数を深度別に比較。alignment 調査用 |
 | `verify_nnue_accumulator` | NNUE accumulator の refresh vs differential update 一致テスト。PSQT・Threat・LayerStacks 対応 |

--- a/crates/tools/src/bin/ek_testset.rs
+++ b/crates/tools/src/bin/ek_testset.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    tools::ek_testset::run()
+}

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -507,7 +507,9 @@ fn run_eval(args: &EvalArgs) -> Result<()> {
             format!("{}:{}: SFEN を読めません", args.testset.display(), line_no + 1)
         })?;
         stack.reset();
-        let eval_cp = evaluate_dispatch(&pos, &mut stack, &mut acc_cache).raw();
+        // 内部 Value スケール (歩=90) ではなく cp (歩=100) で採点する。DECISIVE_CP /
+        // --scale / floodgate_eval_cp と単位を揃えるため to_cp() で換算する。
+        let eval_cp = evaluate_dispatch(&pos, &mut stack, &mut acc_cache).to_cp();
         builder.push(&record, eval_cp, args.scale);
     }
 

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -165,7 +165,13 @@ struct ScoredLabel {
     label: Label,
 }
 
-#[derive(Debug, Default)]
+/// OC calibration の固定幅ビン数（予測勝率 [0,1] を等幅分割）。
+///
+/// 全予測を保持して分位分割する代わりに、ビンごとの件数・予測和・勝敗和だけを
+/// 逐次加算する。ピークメモリを入力件数に非依存（ビン数固定）にするため。
+const OC_CALIBRATION_BINS: usize = 10;
+
+#[derive(Debug)]
 struct EvalMetricBuilder {
     records: usize,
     dt_evals: Vec<i32>,
@@ -173,7 +179,26 @@ struct EvalMetricBuilder {
     oc_sign_ok: usize,
     oc_ce: f64,
     oc_brier: f64,
-    oc_calibration_rows: Vec<(f64, f64)>,
+    // 等幅ビンごとの逐次集計（件数 / 予測勝率和 / 勝敗和）。
+    oc_cal_count: [usize; OC_CALIBRATION_BINS],
+    oc_cal_pred_sum: [f64; OC_CALIBRATION_BINS],
+    oc_cal_win_sum: [f64; OC_CALIBRATION_BINS],
+}
+
+impl Default for EvalMetricBuilder {
+    fn default() -> Self {
+        Self {
+            records: 0,
+            dt_evals: Vec::new(),
+            oc_n: 0,
+            oc_sign_ok: 0,
+            oc_ce: 0.0,
+            oc_brier: 0.0,
+            oc_cal_count: [0; OC_CALIBRATION_BINS],
+            oc_cal_pred_sum: [0.0; OC_CALIBRATION_BINS],
+            oc_cal_win_sum: [0.0; OC_CALIBRATION_BINS],
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -542,11 +567,14 @@ impl EvalMetricBuilder {
         self.oc_n += 1;
         self.oc_ce += -(target * p.ln() + (1.0 - target) * (1.0 - p).ln());
         self.oc_brier += (p - target).powi(2);
-        self.oc_calibration_rows.push((p, target));
+        // 予測勝率 p を等幅ビンへ振り分けて逐次加算（[0,1) を BINS 等分、p=1.0 は最終ビン）。
+        let bin = ((p * OC_CALIBRATION_BINS as f64) as usize).min(OC_CALIBRATION_BINS - 1);
+        self.oc_cal_count[bin] += 1;
+        self.oc_cal_pred_sum[bin] += p;
+        self.oc_cal_win_sum[bin] += target;
     }
 
-    fn finish(mut self) -> (usize, DtMetrics, OcMetrics) {
-        self.oc_calibration_rows.sort_by(|a, b| a.0.total_cmp(&b.0));
+    fn finish(self) -> (usize, DtMetrics, OcMetrics) {
         let oc = if self.oc_n == 0 {
             OcMetrics::default()
         } else {
@@ -555,10 +583,28 @@ impl EvalMetricBuilder {
                 sign_acc: Some(rate(self.oc_sign_ok, self.oc_n)),
                 wdl_cross_entropy: Some(self.oc_ce / self.oc_n as f64),
                 brier: Some(self.oc_brier / self.oc_n as f64),
-                calibration: calibration_bins(&self.oc_calibration_rows, 5),
+                calibration: self.calibration_bins(),
             }
         };
         (self.records, dt_metrics(&self.dt_evals), oc)
+    }
+
+    /// 等幅ビンの逐次集計から calibration テーブルを構築する（空ビンは省く）。
+    fn calibration_bins(&self) -> Vec<CalibrationBin> {
+        let mut out = Vec::new();
+        for bin in 0..OC_CALIBRATION_BINS {
+            let n = self.oc_cal_count[bin];
+            if n == 0 {
+                continue;
+            }
+            out.push(CalibrationBin {
+                bin,
+                n,
+                avg_pred: self.oc_cal_pred_sum[bin] / n as f64,
+                win_rate: self.oc_cal_win_sum[bin] / n as f64,
+            });
+        }
+        out
     }
 }
 
@@ -576,31 +622,6 @@ fn dt_metrics(evals: &[i32]) -> DtMetrics {
         eval_median: Some(percentile_sorted(&sorted, 0.5)),
         eval_p10: Some(percentile_sorted(&sorted, 0.1)),
     }
-}
-
-fn calibration_bins(rows: &[(f64, f64)], bins: usize) -> Vec<CalibrationBin> {
-    if rows.is_empty() || bins == 0 {
-        return Vec::new();
-    }
-    let mut out = Vec::new();
-    for bin in 0..bins {
-        let start = rows.len() * bin / bins;
-        let end = rows.len() * (bin + 1) / bins;
-        if start == end {
-            continue;
-        }
-        let slice = &rows[start..end];
-        let n = slice.len();
-        let avg_pred = slice.iter().map(|(p, _)| *p).sum::<f64>() / n as f64;
-        let win_rate = slice.iter().map(|(_, y)| *y).sum::<f64>() / n as f64;
-        out.push(CalibrationBin {
-            bin,
-            n,
-            avg_pred,
-            win_rate,
-        });
-    }
-    out
 }
 
 fn percentile_sorted(sorted: &[i32], q: f64) -> i32 {

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -1,8 +1,8 @@
 //! 入玉評価テストセットの構築・採点ツール。
 //!
 //! CSA replay と勝敗導出は `replay::csa_source::CsaSource` に委譲する。宣言判定は
-//! `Position::declaration_win(EnteringKingRule::Point27)` を使う。このブランチには
-//! `entering_king_point_info` が公開されていないため、点数系フィールドは JSONL に出さない。
+//! `Position::declaration_win(EnteringKingRule::Point27)` を使う。core が
+//! `entering_king_point_info` を公開していないため、点数系フィールドは JSONL に出さない。
 
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -62,8 +62,8 @@ struct BuildArgs {
     /// 対象区間を何手ごとにサンプルするか。
     #[arg(long, default_value_t = DEFAULT_SAMPLE_STRIDE)]
     sample_stride: u32,
-    /// draw を除外するか。既定 true。
-    #[arg(long, default_value_t = true)]
+    /// draw を除外するか (`--drop-draw false` で draw 対局も含める)。
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     drop_draw: bool,
 }
 
@@ -115,6 +115,7 @@ struct BuildMeta {
     drop_draw: bool,
     games_indexed: usize,
     games_used: usize,
+    games_skipped_broken: usize,
     records: usize,
     dt_records: usize,
     oc_records: usize,
@@ -171,10 +172,19 @@ struct ScoredLabel {
 /// 逐次加算する。ピークメモリを入力件数に非依存（ビン数固定）にするため。
 const OC_CALIBRATION_BINS: usize = 10;
 
+/// DT 評価値ヒストグラムの片側範囲 [cp]。
+///
+/// 全評価値を保持する代わりに 1cp 幅の固定長ヒストグラムへ逐次加算し、ピークメモリを
+/// 入力件数に非依存にする。範囲は静的評価の実用域を十分覆い、範囲外は端に飽和させる
+/// （分位値は範囲内なら正確、範囲外は ±DT_EVAL_HIST_MAX_CP に丸まる）。
+const DT_EVAL_HIST_MAX_CP: i32 = 32_000;
+const DT_EVAL_HIST_LEN: usize = DT_EVAL_HIST_MAX_CP as usize * 2 + 1;
+
 #[derive(Debug)]
 struct EvalMetricBuilder {
     records: usize,
-    dt_evals: Vec<i32>,
+    // index = clamp(eval_cp) + DT_EVAL_HIST_MAX_CP の件数。
+    dt_hist: Box<[u64]>,
     oc_n: usize,
     oc_sign_ok: usize,
     oc_ce: f64,
@@ -189,7 +199,7 @@ impl Default for EvalMetricBuilder {
     fn default() -> Self {
         Self {
             records: 0,
-            dt_evals: Vec::new(),
+            dt_hist: vec![0; DT_EVAL_HIST_LEN].into_boxed_slice(),
             oc_n: 0,
             oc_sign_ok: 0,
             oc_ce: 0.0,
@@ -241,6 +251,7 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     let mut dt_records = 0usize;
     let mut oc_records = 0usize;
     let mut games_used = 0usize;
+    let mut games_skipped_broken = 0usize;
 
     for entry in &index.entries {
         let Some(outcome) = entry.outcome else {
@@ -252,6 +263,11 @@ fn run_build(args: &BuildArgs) -> Result<()> {
 
         let game = source.load_game(&index, entry)?;
         let source_csa = source_path(&index, entry)?;
+        if !replay_is_complete(&game.moves, entry.ply_count) {
+            games_skipped_broken += 1;
+            eprintln!("warning: {source_csa}: 再生を末尾まで信頼できないため対局ごと除外します");
+            continue;
+        }
         let built = build_records_for_game(
             &game.moves,
             outcome,
@@ -266,7 +282,8 @@ fn run_build(args: &BuildArgs) -> Result<()> {
             if record.dt_label == Some(Label::Win) {
                 dt_records += 1;
             }
-            if matches!(record.oc_label, Label::Win | Label::Loss | Label::Draw) {
+            // eval 側の OC 採点は draw を除外するため、meta の oc_records も win/loss のみ数える。
+            if matches!(record.oc_label, Label::Win | Label::Loss) {
                 oc_records += 1;
             }
             serde_json::to_writer(&mut testset, &record)?;
@@ -285,12 +302,13 @@ fn run_build(args: &BuildArgs) -> Result<()> {
         drop_draw: args.drop_draw,
         games_indexed: index.entries.len(),
         games_used,
+        games_skipped_broken,
         records,
         dt_records,
         oc_records,
         sources: index.pair_files.iter().map(|m| m.path.display().to_string()).collect(),
         notes: vec![
-            "このブランチでは entering_king_point_info が未公開のため points_stm / king_in_enemy_stm / enemy_zone_pieces_stm は省略".to_string(),
+            "core が entering_king_point_info を公開していないため points_stm / king_in_enemy_stm / enemy_zone_pieces_stm は省略".to_string(),
         ],
     };
     let mut meta_writer = BufWriter::new(File::create(&meta_path)?);
@@ -407,6 +425,14 @@ fn king_in_enemy_zone(pos: &Position, side: Color) -> bool {
     }
 }
 
+/// 再生が末尾まで信頼できるか。
+///
+/// `CsaSource::load_game` は core 上で信頼できない手を `Move::NONE` にして再生を打ち切る。
+/// 打ち切られた対局の途中局面へ最終結果ラベルを付けると誤ラベルになるため、対局ごと除外する。
+fn replay_is_complete(moves: &[MoveView], expected_normal_moves: u32) -> bool {
+    moves.len() as u64 == u64::from(expected_normal_moves) && moves.iter().all(|m| m.mv.is_normal())
+}
+
 fn oc_label_for_stm(outcome: GameOutcomeView, stm: Color) -> Label {
     match outcome {
         GameOutcomeView::Win(winner) if winner == stm => Label::Win,
@@ -433,8 +459,8 @@ fn color_label(c: Color) -> char {
 }
 
 fn run_eval(args: &EvalArgs) -> Result<()> {
-    if args.scale <= 0.0 {
-        bail!("--scale は正の値を指定してください");
+    if !args.scale.is_finite() || args.scale <= 0.0 {
+        bail!("--scale は正の有限値を指定してください");
     }
 
     let weights = load_progress_coeff_kpabs(&args.progress_file)
@@ -539,7 +565,8 @@ impl EvalMetricBuilder {
     fn push(&mut self, record: &TestsetRecord, eval_cp: i32, scale: f64) {
         self.records += 1;
         if record.dt_label == Some(Label::Win) {
-            self.dt_evals.push(eval_cp);
+            let clamped = eval_cp.clamp(-DT_EVAL_HIST_MAX_CP, DT_EVAL_HIST_MAX_CP);
+            self.dt_hist[(clamped + DT_EVAL_HIST_MAX_CP) as usize] += 1;
         }
         if matches!(record.oc_label, Label::Win | Label::Loss) {
             self.push_oc(
@@ -586,7 +613,7 @@ impl EvalMetricBuilder {
                 calibration: self.calibration_bins(),
             }
         };
-        (self.records, dt_metrics(&self.dt_evals), oc)
+        (self.records, dt_metrics(&self.dt_hist), oc)
     }
 
     /// 等幅ビンの逐次集計から calibration テーブルを構築する（空ビンは省く）。
@@ -608,26 +635,36 @@ impl EvalMetricBuilder {
     }
 }
 
-fn dt_metrics(evals: &[i32]) -> DtMetrics {
-    if evals.is_empty() {
+fn dt_metrics(hist: &[u64]) -> DtMetrics {
+    let n: u64 = hist.iter().sum();
+    if n == 0 {
         return DtMetrics::default();
     }
-    let mut sorted = evals.to_vec();
-    sorted.sort_unstable();
-    let n = sorted.len();
+    // cp > threshold の件数（threshold は DT_EVAL_HIST_MAX_CP 未満が前提）。
+    let count_above = |threshold: i32| -> u64 {
+        hist[(threshold + 1 + DT_EVAL_HIST_MAX_CP) as usize..].iter().sum()
+    };
     DtMetrics {
-        n,
-        sign_acc: Some(rate(evals.iter().filter(|&&v| v > 0).count(), n)),
-        decisive_acc: Some(rate(evals.iter().filter(|&&v| v > DECISIVE_CP).count(), n)),
-        eval_median: Some(percentile_sorted(&sorted, 0.5)),
-        eval_p10: Some(percentile_sorted(&sorted, 0.1)),
+        n: n as usize,
+        sign_acc: Some(count_above(0) as f64 / n as f64),
+        decisive_acc: Some(count_above(DECISIVE_CP) as f64 / n as f64),
+        eval_median: Some(hist_percentile(hist, n, 0.5)),
+        eval_p10: Some(hist_percentile(hist, n, 0.1)),
     }
 }
 
-fn percentile_sorted(sorted: &[i32], q: f64) -> i32 {
-    debug_assert!(!sorted.is_empty());
-    let idx = ((sorted.len() - 1) as f64 * q).floor() as usize;
-    sorted[idx]
+/// ソート列の `floor((n-1)*q)` 番目に相当する値をヒストグラムの累積和で求める。
+fn hist_percentile(hist: &[u64], n: u64, q: f64) -> i32 {
+    debug_assert!(n > 0);
+    let target = ((n - 1) as f64 * q).floor() as u64;
+    let mut cum = 0u64;
+    for (idx, &count) in hist.iter().enumerate() {
+        cum += count;
+        if cum > target {
+            return idx as i32 - DT_EVAL_HIST_MAX_CP;
+        }
+    }
+    unreachable!("target < n のため累積和は必ず target を超える")
 }
 
 fn rate(num: usize, den: usize) -> f64 {
@@ -681,6 +718,23 @@ mod tests {
         concat!("V2.2\n", "P+51OU00FU\n", "P-59OU\n", "+\n", "'* -80\n", "+0044FU\n", "%TORYO\n",);
 
     #[test]
+    fn drop_draw_flag_is_settable() {
+        let base = ["ek_testset", "build", "--input", "in", "--out-dir", "out"];
+        let cli = Cli::try_parse_from(base).expect("parse default");
+        let Command::Build(args) = cli.command else {
+            panic!("build expected")
+        };
+        assert!(args.drop_draw);
+
+        let with_false = base.iter().chain(&["--drop-draw", "false"]);
+        let cli = Cli::try_parse_from(with_false).expect("parse --drop-draw false");
+        let Command::Build(args) = cli.command else {
+            panic!("build expected")
+        };
+        assert!(!args.drop_draw);
+    }
+
+    #[test]
     fn build_labels_declarable_csa() {
         let records = build_records_from_csa(DECLARABLE_CSA);
         assert!(!records.is_empty());
@@ -709,6 +763,55 @@ mod tests {
         assert_eq!(r.dt_label, None);
         assert_eq!(r.oc_label, Label::Win);
         assert_eq!(r.floodgate_eval_cp, Some(-80));
+    }
+
+    // 打歩は 1 段目に打てないため、core の合法手ゲートで `Move::NONE` にフォールバックする。
+    const ILLEGAL_MOVE_CSA: &str =
+        concat!("V2.2\n", "P+51OU00FU\n", "P-59OU\n", "+\n", "+0011FU\n", "%TORYO\n",);
+
+    fn load_first_game(text: &str) -> (Vec<MoveView>, u32) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_csa(dir.path(), "game.csa", text);
+        let source = CsaSource::new(dir.path());
+        let index = source.build_index().expect("build_index");
+        let entry = &index.entries[0];
+        let game = source.load_game(&index, entry).expect("load_game");
+        (game.moves, entry.ply_count)
+    }
+
+    #[test]
+    fn replay_is_complete_accepts_trusted_and_rejects_illegal_replay() {
+        let (moves, ply_count) = load_first_game(DECLARABLE_CSA);
+        assert!(replay_is_complete(&moves, ply_count));
+
+        let (moves, ply_count) = load_first_game(ILLEGAL_MOVE_CSA);
+        assert!(!replay_is_complete(&moves, ply_count));
+    }
+
+    #[test]
+    fn dt_metrics_from_histogram_match_sorted_semantics() {
+        let dt = |eval_cp: i32| {
+            let mut r = TestsetRecord {
+                sfen: String::new(),
+                stm: 'b',
+                ply: 1,
+                source_csa: String::new(),
+                is_declarable: true,
+                dt_label: Some(Label::Win),
+                oc_label: Label::Win,
+                floodgate_eval_cp: None,
+            };
+            r.sfen = "4k4/9/9/9/9/9/9/9/4K4 b - 1".to_string();
+            (r, eval_cp)
+        };
+        // -40000 は端 (-32000) に飽和する。ソート列は [-32000, 0, 100, 700]。
+        let records = vec![dt(700), dt(-40_000), dt(0), dt(100)];
+        let (dt, _) = compute_metrics(&records, 100.0);
+        assert_eq!(dt.n, 4);
+        assert_eq!(dt.sign_acc, Some(0.5));
+        assert_eq!(dt.decisive_acc, Some(0.25));
+        assert_eq!(dt.eval_median, Some(0));
+        assert_eq!(dt.eval_p10, Some(-32_000));
     }
 
     #[test]

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -119,7 +119,7 @@ struct BuildMeta {
     records: usize,
     dt_records: usize,
     oc_records: usize,
-    sources: Vec<String>,
+    // 生成元 CSA の一覧は持たない（レコードごとの source_csa が生成元を記録する）。
     notes: Vec<String>,
 }
 
@@ -235,11 +235,9 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     fs::create_dir_all(&args.out_dir)
         .with_context(|| format!("出力ディレクトリを作成できません: {}", args.out_dir.display()))?;
 
-    let source = CsaSource::new(&args.input);
-    let index = source.build_index()?;
-    for warning in &index.warnings {
-        eprintln!("warning: {warning}");
-    }
+    // 対局ごとの index/メタをコーパス全体分保持しないよう、CSA を 1 ファイル = 1 対局ずつ
+    // 読み込んで処理する（パス一覧は file_idx を安定させるためソート収集が必要で保持する）。
+    let paths = CsaSource::new(&args.input).collect_paths()?;
 
     let testset_path = args.out_dir.join("testset.jsonl");
     let sfens_path = args.out_dir.join("sfens.txt");
@@ -250,46 +248,58 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     let mut records = 0usize;
     let mut dt_records = 0usize;
     let mut oc_records = 0usize;
+    let mut games_indexed = 0usize;
     let mut games_used = 0usize;
     let mut games_skipped_broken = 0usize;
 
-    for entry in &index.entries {
-        let Some(outcome) = entry.outcome else {
-            continue;
-        };
-        if args.drop_draw && matches!(outcome, GameOutcomeView::Draw) {
-            continue;
+    for path in &paths {
+        let source = CsaSource::new(path);
+        let index = source.build_index()?;
+        for warning in &index.warnings {
+            eprintln!("warning: {warning}");
         }
+        games_indexed += index.entries.len();
 
-        let game = source.load_game(&index, entry)?;
-        let source_csa = source_path(&index, entry)?;
-        if !replay_is_complete(&game.moves, entry.ply_count) {
-            games_skipped_broken += 1;
-            eprintln!("warning: {source_csa}: 再生を末尾まで信頼できないため対局ごと除外します");
-            continue;
-        }
-        let built = build_records_for_game(
-            &game.moves,
-            outcome,
-            &source_csa,
-            args.min_ply_from_entry,
-            args.sample_stride,
-        )?;
-        if !built.is_empty() {
-            games_used += 1;
-        }
-        for record in built {
-            if record.dt_label == Some(Label::Win) {
-                dt_records += 1;
+        for entry in &index.entries {
+            let Some(outcome) = entry.outcome else {
+                continue;
+            };
+            if args.drop_draw && matches!(outcome, GameOutcomeView::Draw) {
+                continue;
             }
-            // eval 側の OC 採点は draw を除外するため、meta の oc_records も win/loss のみ数える。
-            if matches!(record.oc_label, Label::Win | Label::Loss) {
-                oc_records += 1;
+
+            let game = source.load_game(&index, entry)?;
+            let source_csa = source_path(&index, entry)?;
+            if !replay_is_complete(&game.moves, entry.ply_count) {
+                games_skipped_broken += 1;
+                eprintln!(
+                    "warning: {source_csa}: 再生を末尾まで信頼できないため対局ごと除外します"
+                );
+                continue;
             }
-            serde_json::to_writer(&mut testset, &record)?;
-            writeln!(testset)?;
-            writeln!(sfens, "{}", record.sfen)?;
-            records += 1;
+            let built = build_records_for_game(
+                &game.moves,
+                outcome,
+                &source_csa,
+                args.min_ply_from_entry,
+                args.sample_stride,
+            )?;
+            if !built.is_empty() {
+                games_used += 1;
+            }
+            for record in built {
+                if record.dt_label == Some(Label::Win) {
+                    dt_records += 1;
+                }
+                // eval 側の OC 採点は draw を除外するため、meta の oc_records も win/loss のみ数える。
+                if matches!(record.oc_label, Label::Win | Label::Loss) {
+                    oc_records += 1;
+                }
+                serde_json::to_writer(&mut testset, &record)?;
+                writeln!(testset)?;
+                writeln!(sfens, "{}", record.sfen)?;
+                records += 1;
+            }
         }
     }
     testset.flush()?;
@@ -300,13 +310,12 @@ fn run_build(args: &BuildArgs) -> Result<()> {
         min_ply_from_entry: args.min_ply_from_entry,
         sample_stride: args.sample_stride,
         drop_draw: args.drop_draw,
-        games_indexed: index.entries.len(),
+        games_indexed,
         games_used,
         games_skipped_broken,
         records,
         dt_records,
         oc_records,
-        sources: index.pair_files.iter().map(|m| m.path.display().to_string()).collect(),
         notes: vec![
             "core が entering_king_point_info を公開していないため points_stm / king_in_enemy_stm / enemy_zone_pieces_stm は省略".to_string(),
         ],
@@ -791,8 +800,8 @@ mod tests {
     #[test]
     fn dt_metrics_from_histogram_match_sorted_semantics() {
         let dt = |eval_cp: i32| {
-            let mut r = TestsetRecord {
-                sfen: String::new(),
+            let r = TestsetRecord {
+                sfen: "4k4/9/9/9/9/9/9/9/4K4 b - 1".to_string(),
                 stm: 'b',
                 ply: 1,
                 source_csa: String::new(),
@@ -801,7 +810,6 @@ mod tests {
                 oc_label: Label::Win,
                 floodgate_eval_cp: None,
             };
-            r.sfen = "4k4/9/9/9/9/9/9/9/4K4 b - 1".to_string();
             (r, eval_cp)
         };
         // -40000 は端 (-32000) に飽和する。ソート列は [-32000, 0, 100, 700]。

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -252,6 +252,7 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     // 対局ごとの index/メタやパス一覧をコーパス全体分保持しないよう、CSA を
     // 決定的な順序の遅延走査で 1 ファイル = 1 対局ずつ読み込んで処理する。
     for path in csa_paths(&args.input)? {
+        let path = path?;
         let source = CsaSource::new(&path);
         let index = source.build_index()?;
         for warning in &index.warnings {
@@ -338,8 +339,9 @@ fn run_build(args: &BuildArgs) -> Result<()> {
 ///
 /// 全パスを収集・保持せず、ディレクトリごとにファイル名ソートした DFS で遅延走査する
 /// （ピークメモリはディレクトリの fan-out に比例し、総ファイル数に非依存）。
-/// `follow_links(false)` で symlink は辿らない（ループ回避）。
-fn csa_paths(input: &Path) -> Result<Box<dyn Iterator<Item = PathBuf>>> {
+/// `follow_links(false)` で symlink は辿らない（ループ回避）。走査エラーは握りつぶさず
+/// `Err` として返す（欠落したサブツリーを「完全な held-out セット」と誤認させないため）。
+fn csa_paths(input: &Path) -> Result<Box<dyn Iterator<Item = Result<PathBuf>>>> {
     let md = fs::metadata(input)
         .with_context(|| format!("入力を確認できません: {}", input.display()))?;
     if md.is_dir() {
@@ -348,15 +350,15 @@ fn csa_paths(input: &Path) -> Result<Box<dyn Iterator<Item = PathBuf>>> {
                 .follow_links(false)
                 .sort_by_file_name()
                 .into_iter()
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.file_type().is_file()
-                        && e.path().extension().and_then(|x| x.to_str()) == Some("csa")
-                })
-                .map(|e| e.into_path()),
+                .filter_map(|entry| match entry {
+                    Ok(e) => (e.file_type().is_file()
+                        && e.path().extension().and_then(|x| x.to_str()) == Some("csa"))
+                    .then(|| Ok(e.into_path())),
+                    Err(e) => Some(Err(anyhow!(e).context("入力ディレクトリの走査に失敗しました"))),
+                }),
         ))
     } else {
-        Ok(Box::new(std::iter::once(input.to_path_buf())))
+        Ok(Box::new(std::iter::once(Ok(input.to_path_buf()))))
     }
 }
 

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -19,6 +19,7 @@ use rshogi_core::nnue::{
 use rshogi_core::position::Position;
 use rshogi_core::types::{Color, EnteringKingRule, Move, Rank};
 use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
 
 use crate::replay::csa_source::CsaSource;
 use crate::replay::model::{GameIndex, GameIndexEntry, GameOutcomeView, GameSource, MoveView};
@@ -235,10 +236,6 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     fs::create_dir_all(&args.out_dir)
         .with_context(|| format!("出力ディレクトリを作成できません: {}", args.out_dir.display()))?;
 
-    // 対局ごとの index/メタをコーパス全体分保持しないよう、CSA を 1 ファイル = 1 対局ずつ
-    // 読み込んで処理する（パス一覧は file_idx を安定させるためソート収集が必要で保持する）。
-    let paths = CsaSource::new(&args.input).collect_paths()?;
-
     let testset_path = args.out_dir.join("testset.jsonl");
     let sfens_path = args.out_dir.join("sfens.txt");
     let meta_path = args.out_dir.join("meta.json");
@@ -252,8 +249,10 @@ fn run_build(args: &BuildArgs) -> Result<()> {
     let mut games_used = 0usize;
     let mut games_skipped_broken = 0usize;
 
-    for path in &paths {
-        let source = CsaSource::new(path);
+    // 対局ごとの index/メタやパス一覧をコーパス全体分保持しないよう、CSA を
+    // 決定的な順序の遅延走査で 1 ファイル = 1 対局ずつ読み込んで処理する。
+    for path in csa_paths(&args.input)? {
+        let source = CsaSource::new(&path);
         let index = source.build_index()?;
         for warning in &index.warnings {
             eprintln!("warning: {warning}");
@@ -333,6 +332,32 @@ fn run_build(args: &BuildArgs) -> Result<()> {
         testset_path.display()
     );
     Ok(())
+}
+
+/// 入力がディレクトリなら配下の `*.csa` を、単一ファイルならそれ 1 つを列挙する。
+///
+/// 全パスを収集・保持せず、ディレクトリごとにファイル名ソートした DFS で遅延走査する
+/// （ピークメモリはディレクトリの fan-out に比例し、総ファイル数に非依存）。
+/// `follow_links(false)` で symlink は辿らない（ループ回避）。
+fn csa_paths(input: &Path) -> Result<Box<dyn Iterator<Item = PathBuf>>> {
+    let md = fs::metadata(input)
+        .with_context(|| format!("入力を確認できません: {}", input.display()))?;
+    if md.is_dir() {
+        Ok(Box::new(
+            WalkDir::new(input)
+                .follow_links(false)
+                .sort_by_file_name()
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && e.path().extension().and_then(|x| x.to_str()) == Some("csa")
+                })
+                .map(|e| e.into_path()),
+        ))
+    } else {
+        Ok(Box::new(std::iter::once(input.to_path_buf())))
+    }
 }
 
 fn build_records_for_game(

--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -1,0 +1,723 @@
+//! 入玉評価テストセットの構築・採点ツール。
+//!
+//! CSA replay と勝敗導出は `replay::csa_source::CsaSource` に委譲する。宣言判定は
+//! `Position::declaration_win(EnteringKingRule::Point27)` を使う。このブランチには
+//! `entering_king_point_info` が公開されていないため、点数系フィールドは JSONL に出さない。
+
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Parser, Subcommand};
+use rshogi_core::nnue::{
+    AccumulatorStackVariant, LayerStackBucketMode, LayerStacksAccCache,
+    SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS, evaluate_dispatch, get_network, init_nnue,
+    set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
+};
+use rshogi_core::position::Position;
+use rshogi_core::types::{Color, EnteringKingRule, Move, Rank};
+use serde::{Deserialize, Serialize};
+
+use crate::replay::csa_source::CsaSource;
+use crate::replay::model::{GameIndex, GameIndexEntry, GameOutcomeView, GameSource, MoveView};
+
+const DEFAULT_MIN_PLY_FROM_ENTRY: i32 = -20;
+const DEFAULT_SAMPLE_STRIDE: u32 = 4;
+const DEFAULT_SCALE: f64 = 290.0;
+const DECISIVE_CP: i32 = 600;
+const PROB_EPS: f64 = 1e-12;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ek_testset",
+    version,
+    about = "入玉評価テストセットを CSA から構築し、NNUE 静的評価で採点する"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// held-out CSA から入玉評価テストセットを構築する。
+    Build(BuildArgs),
+    /// testset.jsonl を native NNUE 評価で採点する。
+    Eval(EvalArgs),
+}
+
+#[derive(Parser, Debug)]
+struct BuildArgs {
+    /// 入力 CSA ファイルまたは CSA ディレクトリ。
+    #[arg(long)]
+    input: PathBuf,
+    /// 出力ディレクトリ。
+    #[arg(long)]
+    out_dir: PathBuf,
+    /// 玉の敵陣初侵入 ply から何手前以降を対象にするか。
+    #[arg(long, default_value_t = DEFAULT_MIN_PLY_FROM_ENTRY, allow_hyphen_values = true)]
+    min_ply_from_entry: i32,
+    /// 対象区間を何手ごとにサンプルするか。
+    #[arg(long, default_value_t = DEFAULT_SAMPLE_STRIDE)]
+    sample_stride: u32,
+    /// draw を除外するか。既定 true。
+    #[arg(long, default_value_t = true)]
+    drop_draw: bool,
+}
+
+#[derive(Parser, Debug)]
+struct EvalArgs {
+    /// `ek_testset build` が出した testset.jsonl。
+    #[arg(long)]
+    testset: PathBuf,
+    /// NNUE ファイル。
+    #[arg(long)]
+    eval_file: PathBuf,
+    /// LayerStacks progress8kpabs 用 progress.bin。
+    #[arg(long)]
+    progress_file: PathBuf,
+    /// sigmoid(eval / scale) の scale。
+    #[arg(long, default_value_t = DEFAULT_SCALE)]
+    scale: f64,
+    /// metrics.json の出力先。
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct TestsetRecord {
+    sfen: String,
+    stm: char,
+    ply: u32,
+    source_csa: String,
+    is_declarable: bool,
+    dt_label: Option<Label>,
+    oc_label: Label,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    floodgate_eval_cp: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Label {
+    Win,
+    Loss,
+    Draw,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildMeta {
+    input: String,
+    min_ply_from_entry: i32,
+    sample_stride: u32,
+    drop_draw: bool,
+    games_indexed: usize,
+    games_used: usize,
+    records: usize,
+    dt_records: usize,
+    oc_records: usize,
+    sources: Vec<String>,
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EvalMetrics {
+    testset: String,
+    eval_file: String,
+    progress_file: String,
+    scale: f64,
+    records: usize,
+    dt: DtMetrics,
+    oc: OcMetrics,
+}
+
+#[derive(Debug, Serialize, Default, PartialEq)]
+struct DtMetrics {
+    n: usize,
+    sign_acc: Option<f64>,
+    decisive_acc: Option<f64>,
+    eval_median: Option<i32>,
+    eval_p10: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Default, PartialEq)]
+struct OcMetrics {
+    n: usize,
+    sign_acc: Option<f64>,
+    wdl_cross_entropy: Option<f64>,
+    brier: Option<f64>,
+    calibration: Vec<CalibrationBin>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+struct CalibrationBin {
+    bin: usize,
+    n: usize,
+    avg_pred: f64,
+    win_rate: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScoredLabel {
+    eval_cp: i32,
+    label: Label,
+}
+
+#[derive(Debug, Default)]
+struct EvalMetricBuilder {
+    records: usize,
+    dt_evals: Vec<i32>,
+    oc_n: usize,
+    oc_sign_ok: usize,
+    oc_ce: f64,
+    oc_brier: f64,
+    oc_calibration_rows: Vec<(f64, f64)>,
+}
+
+#[derive(Debug, Clone)]
+struct PositionSample {
+    sfen: String,
+    ply: u32,
+    floodgate_eval_cp: Option<i32>,
+}
+
+/// CLI entrypoint。
+pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Build(args) => run_build(&args),
+        Command::Eval(args) => run_eval(&args),
+    }
+}
+
+fn run_build(args: &BuildArgs) -> Result<()> {
+    if args.sample_stride == 0 {
+        bail!("--sample-stride は 1 以上を指定してください");
+    }
+
+    fs::create_dir_all(&args.out_dir)
+        .with_context(|| format!("出力ディレクトリを作成できません: {}", args.out_dir.display()))?;
+
+    let source = CsaSource::new(&args.input);
+    let index = source.build_index()?;
+    for warning in &index.warnings {
+        eprintln!("warning: {warning}");
+    }
+
+    let testset_path = args.out_dir.join("testset.jsonl");
+    let sfens_path = args.out_dir.join("sfens.txt");
+    let meta_path = args.out_dir.join("meta.json");
+    let mut testset = BufWriter::new(File::create(&testset_path)?);
+    let mut sfens = BufWriter::new(File::create(&sfens_path)?);
+
+    let mut records = 0usize;
+    let mut dt_records = 0usize;
+    let mut oc_records = 0usize;
+    let mut games_used = 0usize;
+
+    for entry in &index.entries {
+        let Some(outcome) = entry.outcome else {
+            continue;
+        };
+        if args.drop_draw && matches!(outcome, GameOutcomeView::Draw) {
+            continue;
+        }
+
+        let game = source.load_game(&index, entry)?;
+        let source_csa = source_path(&index, entry)?;
+        let built = build_records_for_game(
+            &game.moves,
+            outcome,
+            &source_csa,
+            args.min_ply_from_entry,
+            args.sample_stride,
+        )?;
+        if !built.is_empty() {
+            games_used += 1;
+        }
+        for record in built {
+            if record.dt_label == Some(Label::Win) {
+                dt_records += 1;
+            }
+            if matches!(record.oc_label, Label::Win | Label::Loss | Label::Draw) {
+                oc_records += 1;
+            }
+            serde_json::to_writer(&mut testset, &record)?;
+            writeln!(testset)?;
+            writeln!(sfens, "{}", record.sfen)?;
+            records += 1;
+        }
+    }
+    testset.flush()?;
+    sfens.flush()?;
+
+    let meta = BuildMeta {
+        input: args.input.display().to_string(),
+        min_ply_from_entry: args.min_ply_from_entry,
+        sample_stride: args.sample_stride,
+        drop_draw: args.drop_draw,
+        games_indexed: index.entries.len(),
+        games_used,
+        records,
+        dt_records,
+        oc_records,
+        sources: index.pair_files.iter().map(|m| m.path.display().to_string()).collect(),
+        notes: vec![
+            "このブランチでは entering_king_point_info が未公開のため points_stm / king_in_enemy_stm / enemy_zone_pieces_stm は省略".to_string(),
+        ],
+    };
+    let mut meta_writer = BufWriter::new(File::create(&meta_path)?);
+    serde_json::to_writer_pretty(&mut meta_writer, &meta)?;
+    writeln!(meta_writer)?;
+    meta_writer.flush()?;
+
+    eprintln!(
+        "wrote {} records (dt={}, oc={}) to {}",
+        records,
+        dt_records,
+        oc_records,
+        testset_path.display()
+    );
+    Ok(())
+}
+
+fn build_records_for_game(
+    moves: &[MoveView],
+    outcome: GameOutcomeView,
+    source_csa: &str,
+    min_ply_from_entry: i32,
+    sample_stride: u32,
+) -> Result<Vec<TestsetRecord>> {
+    let samples = position_samples(moves)?;
+    let first_entry_ply = first_enemy_entry_ply(&samples)?;
+    let Some(first_entry_ply) = first_entry_ply else {
+        return Ok(Vec::new());
+    };
+    let threshold = i64::from(first_entry_ply) + i64::from(min_ply_from_entry);
+    let mut records = Vec::new();
+
+    for sample in samples {
+        let ply = i64::from(sample.ply);
+        if ply < threshold {
+            continue;
+        }
+        if (ply - threshold).rem_euclid(i64::from(sample_stride)) != 0 {
+            continue;
+        }
+
+        let mut pos = Position::new();
+        pos.set_sfen(&sample.sfen)
+            .with_context(|| format!("SFEN を復元できません: {}", sample.sfen))?;
+        let stm = pos.side_to_move();
+        let is_declarable = pos.declaration_win(EnteringKingRule::Point27) != Move::NONE;
+        let oc_label = oc_label_for_stm(outcome, stm);
+
+        records.push(TestsetRecord {
+            sfen: sample.sfen,
+            stm: color_label(stm),
+            ply: sample.ply,
+            source_csa: source_csa.to_string(),
+            is_declarable,
+            dt_label: is_declarable.then_some(Label::Win),
+            oc_label,
+            floodgate_eval_cp: sample.floodgate_eval_cp,
+        });
+    }
+
+    Ok(records)
+}
+
+fn position_samples(moves: &[MoveView]) -> Result<Vec<PositionSample>> {
+    let mut samples = Vec::with_capacity(moves.len() + 1);
+    for mv in moves {
+        samples.push(PositionSample {
+            sfen: mv.sfen_before.clone(),
+            ply: mv.ply,
+            floodgate_eval_cp: mv.annotation.score_cp,
+        });
+    }
+
+    if let Some(last) = moves.last()
+        && last.mv.is_normal()
+    {
+        let mut pos = Position::new();
+        pos.set_sfen(&last.sfen_before)
+            .with_context(|| format!("SFEN を復元できません: {}", last.sfen_before))?;
+        let gives_check = pos.gives_check(last.mv);
+        pos.do_move(last.mv, gives_check);
+        samples.push(PositionSample {
+            sfen: pos.to_sfen(),
+            ply: last.ply.saturating_add(1),
+            floodgate_eval_cp: None,
+        });
+    }
+
+    Ok(samples)
+}
+
+fn first_enemy_entry_ply(samples: &[PositionSample]) -> Result<Option<u32>> {
+    let mut first = None;
+    for sample in samples {
+        let mut pos = Position::new();
+        pos.set_sfen(&sample.sfen)
+            .with_context(|| format!("SFEN を復元できません: {}", sample.sfen))?;
+        if king_in_enemy_zone(&pos, Color::Black) || king_in_enemy_zone(&pos, Color::White) {
+            first = Some(sample.ply);
+            break;
+        }
+    }
+    Ok(first)
+}
+
+fn king_in_enemy_zone(pos: &Position, side: Color) -> bool {
+    match side {
+        Color::Black => {
+            matches!(pos.king_square(side).rank(), Rank::Rank1 | Rank::Rank2 | Rank::Rank3)
+        }
+        Color::White => {
+            matches!(pos.king_square(side).rank(), Rank::Rank7 | Rank::Rank8 | Rank::Rank9)
+        }
+    }
+}
+
+fn oc_label_for_stm(outcome: GameOutcomeView, stm: Color) -> Label {
+    match outcome {
+        GameOutcomeView::Win(winner) if winner == stm => Label::Win,
+        GameOutcomeView::Win(_) => Label::Loss,
+        GameOutcomeView::Draw => Label::Draw,
+    }
+}
+
+fn source_path(index: &GameIndex, entry: &GameIndexEntry) -> Result<String> {
+    let crate::replay::model::GameSourceRef::Csa { file_idx, .. } = entry.source else {
+        bail!("CSA 以外の GameIndexEntry が渡されました");
+    };
+    let meta = index
+        .pair_file(file_idx)
+        .ok_or_else(|| anyhow!("file_idx {file_idx} が index にありません"))?;
+    Ok(meta.path.display().to_string())
+}
+
+fn color_label(c: Color) -> char {
+    match c {
+        Color::Black => 'b',
+        Color::White => 'w',
+    }
+}
+
+fn run_eval(args: &EvalArgs) -> Result<()> {
+    if args.scale <= 0.0 {
+        bail!("--scale は正の値を指定してください");
+    }
+
+    let weights = load_progress_coeff_kpabs(&args.progress_file)
+        .map_err(|e| anyhow!("progress 読み込みに失敗しました: {e}"))?;
+    set_layer_stack_progress_kpabs_weights(weights)
+        .map_err(|e| anyhow!("progress 設定に失敗しました: {e}"))?;
+    set_layer_stack_bucket_mode(LayerStackBucketMode::Progress8KPAbs);
+    init_nnue(&args.eval_file)
+        .with_context(|| format!("NNUE を読み込めません: {}", args.eval_file.display()))?;
+
+    let network = get_network().ok_or_else(|| anyhow!("NNUE が初期化されていません"))?;
+    if !network.is_layer_stacks() {
+        bail!(
+            "ek_testset eval は LayerStacks NNUE のみ対応しています: {}",
+            network.architecture_name()
+        );
+    }
+    let mut stack = AccumulatorStackVariant::from_network(&network);
+    let mut acc_cache: Option<LayerStacksAccCache> =
+        Some(network.as_layer_stacks().new_acc_cache());
+
+    let mut builder = EvalMetricBuilder::default();
+    let file = File::open(&args.testset)
+        .with_context(|| format!("testset を開けません: {}", args.testset.display()))?;
+    for (line_no, line) in BufReader::new(file).lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: TestsetRecord = serde_json::from_str(&line).with_context(|| {
+            format!("{}:{}: JSON を読めません", args.testset.display(), line_no + 1)
+        })?;
+        let mut pos = Position::new();
+        pos.set_sfen(&record.sfen).with_context(|| {
+            format!("{}:{}: SFEN を読めません", args.testset.display(), line_no + 1)
+        })?;
+        stack.reset();
+        let eval_cp = evaluate_dispatch(&pos, &mut stack, &mut acc_cache).raw();
+        builder.push(&record, eval_cp, args.scale);
+    }
+
+    let (records, dt, oc) = builder.finish();
+    let out = EvalMetrics {
+        testset: args.testset.display().to_string(),
+        eval_file: args.eval_file.display().to_string(),
+        progress_file: args.progress_file.display().to_string(),
+        scale: args.scale,
+        records,
+        dt,
+        oc,
+    };
+
+    let stdout = std::io::stdout();
+    let mut locked = stdout.lock();
+    serde_json::to_writer_pretty(&mut locked, &out)?;
+    writeln!(locked)?;
+
+    if let Some(path) = &args.out {
+        write_json_pretty(path, &out)?;
+    }
+    Ok(())
+}
+
+fn load_progress_coeff_kpabs(path: &Path) -> Result<Box<[f32]>, String> {
+    let bytes = fs::read(path).map_err(|e| format!("failed to read '{}': {e}", path.display()))?;
+    let expected = SHOGI_PROGRESS_KP_ABS_NUM_WEIGHTS * size_of::<f64>();
+    if bytes.len() != expected {
+        return Err(format!(
+            "progress.bin size mismatch: got {} bytes, expected {}",
+            bytes.len(),
+            expected
+        ));
+    }
+    let weights: Vec<f32> = bytes
+        .chunks_exact(size_of::<f64>())
+        .map(|chunk| f64::from_le_bytes(chunk.try_into().expect("chunk size is checked")) as f32)
+        .collect();
+    Ok(weights.into_boxed_slice())
+}
+
+fn write_json_pretty<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let mut writer = BufWriter::new(
+        File::create(path).with_context(|| format!("出力できません: {}", path.display()))?,
+    );
+    serde_json::to_writer_pretty(&mut writer, value)?;
+    writeln!(writer)?;
+    writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+fn compute_metrics(records: &[(TestsetRecord, i32)], scale: f64) -> (DtMetrics, OcMetrics) {
+    let mut builder = EvalMetricBuilder::default();
+    for (record, eval_cp) in records {
+        builder.push(record, *eval_cp, scale);
+    }
+    let (_, dt, oc) = builder.finish();
+    (dt, oc)
+}
+
+impl EvalMetricBuilder {
+    fn push(&mut self, record: &TestsetRecord, eval_cp: i32, scale: f64) {
+        self.records += 1;
+        if record.dt_label == Some(Label::Win) {
+            self.dt_evals.push(eval_cp);
+        }
+        if matches!(record.oc_label, Label::Win | Label::Loss) {
+            self.push_oc(
+                ScoredLabel {
+                    eval_cp,
+                    label: record.oc_label,
+                },
+                scale,
+            );
+        }
+    }
+
+    fn push_oc(&mut self, record: ScoredLabel, scale: f64) {
+        let target = match record.label {
+            Label::Win => 1.0,
+            Label::Loss => 0.0,
+            Label::Draw => unreachable!("draw は OC 採点対象外"),
+        };
+        let p = sigmoid(f64::from(record.eval_cp) / scale).clamp(PROB_EPS, 1.0 - PROB_EPS);
+        if (record.eval_cp > 0 && record.label == Label::Win)
+            || (record.eval_cp < 0 && record.label == Label::Loss)
+        {
+            self.oc_sign_ok += 1;
+        }
+        self.oc_n += 1;
+        self.oc_ce += -(target * p.ln() + (1.0 - target) * (1.0 - p).ln());
+        self.oc_brier += (p - target).powi(2);
+        self.oc_calibration_rows.push((p, target));
+    }
+
+    fn finish(mut self) -> (usize, DtMetrics, OcMetrics) {
+        self.oc_calibration_rows.sort_by(|a, b| a.0.total_cmp(&b.0));
+        let oc = if self.oc_n == 0 {
+            OcMetrics::default()
+        } else {
+            OcMetrics {
+                n: self.oc_n,
+                sign_acc: Some(rate(self.oc_sign_ok, self.oc_n)),
+                wdl_cross_entropy: Some(self.oc_ce / self.oc_n as f64),
+                brier: Some(self.oc_brier / self.oc_n as f64),
+                calibration: calibration_bins(&self.oc_calibration_rows, 5),
+            }
+        };
+        (self.records, dt_metrics(&self.dt_evals), oc)
+    }
+}
+
+fn dt_metrics(evals: &[i32]) -> DtMetrics {
+    if evals.is_empty() {
+        return DtMetrics::default();
+    }
+    let mut sorted = evals.to_vec();
+    sorted.sort_unstable();
+    let n = sorted.len();
+    DtMetrics {
+        n,
+        sign_acc: Some(rate(evals.iter().filter(|&&v| v > 0).count(), n)),
+        decisive_acc: Some(rate(evals.iter().filter(|&&v| v > DECISIVE_CP).count(), n)),
+        eval_median: Some(percentile_sorted(&sorted, 0.5)),
+        eval_p10: Some(percentile_sorted(&sorted, 0.1)),
+    }
+}
+
+fn calibration_bins(rows: &[(f64, f64)], bins: usize) -> Vec<CalibrationBin> {
+    if rows.is_empty() || bins == 0 {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for bin in 0..bins {
+        let start = rows.len() * bin / bins;
+        let end = rows.len() * (bin + 1) / bins;
+        if start == end {
+            continue;
+        }
+        let slice = &rows[start..end];
+        let n = slice.len();
+        let avg_pred = slice.iter().map(|(p, _)| *p).sum::<f64>() / n as f64;
+        let win_rate = slice.iter().map(|(_, y)| *y).sum::<f64>() / n as f64;
+        out.push(CalibrationBin {
+            bin,
+            n,
+            avg_pred,
+            win_rate,
+        });
+    }
+    out
+}
+
+fn percentile_sorted(sorted: &[i32], q: f64) -> i32 {
+    debug_assert!(!sorted.is_empty());
+    let idx = ((sorted.len() - 1) as f64 * q).floor() as usize;
+    sorted[idx]
+}
+
+fn rate(num: usize, den: usize) -> f64 {
+    num as f64 / den as f64
+}
+
+fn sigmoid(x: f64) -> f64 {
+    if x >= 0.0 {
+        1.0 / (1.0 + (-x).exp())
+    } else {
+        let e = x.exp();
+        e / (1.0 + e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_csa(dir: &Path, name: &str, text: &str) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = File::create(&path).expect("create");
+        f.write_all(text.as_bytes()).expect("write");
+        path
+    }
+
+    fn build_records_from_csa(text: &str) -> Vec<TestsetRecord> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_csa(dir.path(), "game.csa", text);
+        let source = CsaSource::new(dir.path());
+        let index = source.build_index().expect("build_index");
+        let entry = &index.entries[0];
+        let outcome = entry.outcome.expect("outcome");
+        let game = source.load_game(&index, entry).expect("load_game");
+        build_records_for_game(&game.moves, outcome, "game.csa", -20, 1).expect("records")
+    }
+
+    const DECLARABLE_CSA: &str = concat!(
+        "V2.2\n",
+        "P+51OU11HI21KA31KI41KI61GI71GI81KE91KE12KY22KY00HI00FU00FU00FU00FU00FU00FU00FU00FU00FU\n",
+        "P-59OU00FU\n",
+        "+\n",
+        "'* 1200\n",
+        "+0044FU\n",
+        "'* -30\n",
+        "-0056FU\n",
+        "%KACHI\n",
+    );
+
+    const ENTERED_RESIGN_CSA: &str =
+        concat!("V2.2\n", "P+51OU00FU\n", "P-59OU\n", "+\n", "'* -80\n", "+0044FU\n", "%TORYO\n",);
+
+    #[test]
+    fn build_labels_declarable_csa() {
+        let records = build_records_from_csa(DECLARABLE_CSA);
+        assert!(!records.is_empty());
+        let terminal = records.iter().find(|r| r.ply == 3).expect("terminal sample");
+        assert_eq!(terminal.stm, 'b');
+        assert!(terminal.is_declarable);
+        assert_eq!(terminal.dt_label, Some(Label::Win));
+        assert_eq!(terminal.oc_label, Label::Win);
+        assert_eq!(terminal.floodgate_eval_cp, None);
+    }
+
+    #[test]
+    fn build_keeps_side_relative_floodgate_eval_for_white_stm() {
+        let records = build_records_from_csa(DECLARABLE_CSA);
+        let white = records.iter().find(|r| r.stm == 'w').expect("white sample");
+        assert_eq!(white.floodgate_eval_cp, Some(30));
+    }
+
+    #[test]
+    fn build_labels_entered_but_not_declarable_resign_csa() {
+        let records = build_records_from_csa(ENTERED_RESIGN_CSA);
+        assert!(!records.is_empty());
+        let r = &records[0];
+        assert_eq!(r.stm, 'b');
+        assert!(!r.is_declarable);
+        assert_eq!(r.dt_label, None);
+        assert_eq!(r.oc_label, Label::Win);
+        assert_eq!(r.floodgate_eval_cp, Some(-80));
+    }
+
+    #[test]
+    fn eval_metrics_are_checked_from_synthetic_values() {
+        let base = TestsetRecord {
+            sfen: "4k4/9/9/9/9/9/9/9/4K4 b - 1".to_string(),
+            stm: 'b',
+            ply: 1,
+            source_csa: "x.csa".to_string(),
+            is_declarable: false,
+            dt_label: None,
+            oc_label: Label::Win,
+            floodgate_eval_cp: None,
+        };
+        let mut dt_win = base.clone();
+        dt_win.is_declarable = true;
+        dt_win.dt_label = Some(Label::Win);
+        let mut loss = base.clone();
+        loss.oc_label = Label::Loss;
+        let records = vec![(dt_win, 700), (base, 100), (loss, -100)];
+        let (dt, oc) = compute_metrics(&records, 100.0);
+        assert_eq!(dt.n, 1);
+        assert_eq!(dt.sign_acc, Some(1.0));
+        assert_eq!(dt.decisive_acc, Some(1.0));
+        assert_eq!(dt.eval_median, Some(700));
+        assert_eq!(oc.n, 3);
+        assert_eq!(oc.sign_acc, Some(1.0));
+        let expected_p = sigmoid(1.0);
+        let expected_ce = -((expected_p.ln() * 2.0) + sigmoid(7.0).ln()) / 3.0;
+        assert!((oc.wdl_cross_entropy.unwrap() - expected_ce).abs() < 1e-12);
+        assert_eq!(oc.calibration.iter().map(|b| b.n).sum::<usize>(), 3);
+    }
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -45,9 +45,8 @@ pub mod bench_nnue_eval_tool;
 pub mod common;
 pub mod config;
 pub mod dlshogi_features;
-// ek_testset は CSA replay (`replay` モジュール) に依存するため、同じ
-// `kifu-player` feature に gate する。`--no-default-features` 構成では対象外。
-#[cfg(feature = "kifu-player")]
+// ek_testset は CSA replay (`replay` モジュール) に依存するため csa-replay に gate する。
+#[cfg(feature = "csa-replay")]
 pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;
@@ -57,7 +56,7 @@ pub mod packed_sfen;
 pub mod positions;
 pub mod progress;
 pub mod qsearch_pv;
-#[cfg(feature = "kifu-player")]
+#[cfg(feature = "csa-replay")]
 pub mod replay;
 pub mod report;
 pub mod runner;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -45,6 +45,7 @@ pub mod bench_nnue_eval_tool;
 pub mod common;
 pub mod config;
 pub mod dlshogi_features;
+pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;
 #[cfg(feature = "dlshogi-onnx")]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -45,6 +45,9 @@ pub mod bench_nnue_eval_tool;
 pub mod common;
 pub mod config;
 pub mod dlshogi_features;
+// ek_testset は CSA replay (`replay` モジュール) に依存するため、同じ
+// `kifu-player` feature に gate する。`--no-default-features` 構成では対象外。
+#[cfg(feature = "kifu-player")]
 pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;

--- a/crates/tools/src/replay/csa_source.rs
+++ b/crates/tools/src/replay/csa_source.rs
@@ -52,7 +52,7 @@ impl CsaSource {
     /// 単一ファイルならそれ 1 つを返す。floodgate は `YYYY/MM/DD/*.csa` のように日付
     /// ディレクトリへネストするため再帰する。実行のたびに `file_idx` を安定させるよう
     /// 全体を収集してからソートする。`follow_links(false)` で symlink は辿らない（ループ回避）。
-    pub(crate) fn collect_paths(&self) -> Result<Vec<PathBuf>> {
+    fn collect_paths(&self) -> Result<Vec<PathBuf>> {
         let md = fs::metadata(&self.input)
             .with_context(|| format!("failed to stat {}", self.input.display()))?;
         if md.is_dir() {

--- a/crates/tools/src/replay/csa_source.rs
+++ b/crates/tools/src/replay/csa_source.rs
@@ -52,7 +52,7 @@ impl CsaSource {
     /// 単一ファイルならそれ 1 つを返す。floodgate は `YYYY/MM/DD/*.csa` のように日付
     /// ディレクトリへネストするため再帰する。実行のたびに `file_idx` を安定させるよう
     /// 全体を収集してからソートする。`follow_links(false)` で symlink は辿らない（ループ回避）。
-    fn collect_paths(&self) -> Result<Vec<PathBuf>> {
+    pub(crate) fn collect_paths(&self) -> Result<Vec<PathBuf>> {
         let md = fs::metadata(&self.input)
             .with_context(|| format!("failed to stat {}", self.input.display()))?;
         if md.is_dir() {

--- a/crates/tools/src/replay/mod.rs
+++ b/crates/tools/src/replay/mod.rs
@@ -1,4 +1,5 @@
-//! PSV / tournament JSONL 共通の棋譜プレイヤー（`kifu_player` バイナリの実体）。
+//! CSA / PSV / tournament JSONL 共通の棋譜 replay 層（parse・盤面再生・勝敗導出）と、
+//! その上の棋譜プレイヤー TUI（`kifu_player` バイナリの実体、`kifu-player` feature）。
 
 pub mod csa_source;
 pub mod jsonl_source;

--- a/crates/tools/src/replay/mod.rs
+++ b/crates/tools/src/replay/mod.rs
@@ -4,6 +4,8 @@ pub mod csa_source;
 pub mod jsonl_source;
 pub mod model;
 pub mod psv_source;
+// TUI (ratatui/crossterm) は kifu-player 側にだけ必要なので、csa-replay 単独では含めない。
+#[cfg(feature = "kifu-player")]
 pub mod tui;
 
 pub use csa_source::CsaSource;


### PR DESCRIPTION
## 概要

入玉局面で評価関数が勝ち/負けを正しく評価するかを静的・再現的に測る計測ツール `ek_testset`。fine-tune / 本学習の前後で同一局面を採点し、改善と非劣化を判定するゲートに使う。held-out（学習に一切使わない）floodgate 棋譜から作るためリークしない。

## サブコマンド

### build
held-out CSA を replay（`parse_csa_full`/`derive_outcome` 再利用）し、玉の敵陣初侵入 ply にアンカーした局面を抽出。2 種のラベルを付与：
- **DT（宣言真値）**: `declaration_win(stm)=WIN` を手番側勝ちの ground truth とする。ルールベースでラベラーバイアスに免疫。入玉弱点に最も鋭い計器
- **OC（勝敗較正）**: 実対局結果を手番側視点で win/loss（draw 除外）

`testset.jsonl` / `sfens.txt` / `meta.json` を出力。floodgate 評価値は手番相対で記録。

### eval
`init_nnue` + progress をセットし各 sfen を native 評価（LayerStacks ネット必須、非 LS は明示エラー）。testset を **streaming** で処理しピークメモリを sfen 非依存に。
- DT: sign_acc / decisive_acc / eval percentile
- OC: sign_acc / WDL cross-entropy / Brier / 5 分位 calibration

モデル間比較用に機械可読 JSON を出力。

## 現ベストモデル（RAMU_TF / threatfull-400）のベースライン

held-out R2800-3000 帯（v1/v2 学習プールと完全 disjoint、2,804 局）で測定：

| セット | 主要指標 |
|---|---|
| DT (n=359) | sign_acc **0.997** / decisive_acc **0.978** / eval中央値 +2225cp |
| OC (n=103,799) | sign_acc **0.895** / cross-entropy **0.311** / Brier **0.082** |

**弱点の署名**: 「宣言で勝ち確定」の局面（DT）はほぼ完璧に読める一方、OC 較正で bin3（勝勢と判断した帯）が **予測 98.1% vs 実際 89.9%（gap +8.2%）** と過信。入玉の変換コスト（千日手・持将棋・点数不足での取りこぼし）を織り込めていない。成功した入玉 fine-tune はこの gap 縮小・OC sign_acc/cross-entropy 改善・DT 非劣化を示すはず。

## レビュー
Codex + Claude(Fable) の 2 レビューを複数ラウンド実施し、両者 APPROVE 済み。

**Round 1**（起票前）: 指摘 5 件（H1: floodgate_eval_cp 符号二重反転、M2: eval load-all、M3: fixture 意味的不整合、M4: 非 LS panic、L1: doc）を修正。H1 は JSONL メタ列のみの修正で採点メトリクスに無影響であることを、修正前後のベースライン完全一致で実証。

**Round 2〜6**（起票後）: 追加指摘 9 件を修正。
- `--drop-draw` が clap の SetTrue で false 指定不能だった → `ArgAction::Set` 化
- eval が内部 Value スケール（歩=90）の raw() で採点していた → `to_cp()` で cp（歩=100）に統一（**下表のベースライン数値は raw スケール時の測定。cp 換算で decisive_acc / 中央値 / CE 等は変わるため、fine-tune 比較時に同一バイナリで再計測すること。sign_acc は符号不変なので影響なし**）
- 再生を末尾まで信頼できない CSA（非合法手フォールバック）を対局ごと除外（`games_skipped_broken` を meta に記録）
- build のピークメモリを対局数非依存に: 全対局 index/meta 保持 → 1 ファイルずつ処理、パス一覧の Vec 保持 → walkdir sort_by_file_name の決定的遅延走査、DT 分位の Vec 保持 → 固定長ヒストグラム、meta.sources（全パス複製）削除
- 走査エラーの無言破棄をやめ build を失敗させる / meta.oc_records を win/loss のみに / `--scale` の NaN・inf 拒否 / 文脈依存コメント除去

## テスト
- cargo fmt --check / clippy -p tools（警告0）/ test -p tools（216 pass）/ check-tracked-abs-paths.sh すべて green
- DT/OC ラベル・宣言整合・floodgate_eval_cp 手番相対・streaming 集計値・cross-entropy/calibration のユニットテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147CkyzPB8d5KHi5UeVpadA
