### PR TITLE
test(csa-client): mock script 書き込みと spawn の fork を同一 lock で直列化し ETXTBSY flake を解消

### DIFF
--- a/crates/rshogi-csa-client/tests/common/mod.rs
+++ b/crates/rshogi-csa-client/tests/common/mod.rs
@@ -1,0 +1,66 @@
+//! mock USI engine (bash script) を使う integration test 共通のヘルパ。
+//!
+//! `cargo test` の並列実行下では、あるテストが script の write fd を開いている間に
+//! 別テストの `UsiEngine::spawn` が fork すると、子プロセスが write fd を継承したまま
+//! exec 前の窓に入り、その script の exec が `ETXTBSY` (Text file busy) で落ちる
+//! (`O_CLOEXEC` は fork では閉じず exec 時にしか閉じない)。script 書き込みと fork を
+//! [`FORK_WRITE_LOCK`] で直列化することで「write fd open 中の fork」を排除する。
+
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
+
+static SCRIPT_SEQ: AtomicU64 = AtomicU64::new(0);
+/// 書き込みと fork の片方だけを直列化しても ETXTBSY レースが残るため、
+/// [`write_mock_script`] と [`spawn_engine`] の両方が同じ lock を取る。
+static FORK_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+/// 与えた bash script を 0o755 の実行可能ファイルとして一時ディレクトリに書き出し、
+/// path を返す。test ごとに unique な名前を付与する。
+///
+/// tmp path へ書き込み → close → chmod → atomic rename の順にすることで、自スレッドの
+/// write fd が exec と重なる経路を塞ぐ。並行 test の fork に対しては
+/// [`FORK_WRITE_LOCK`] が守る (module doc 参照)。
+pub fn write_mock_script(name: &str, body: &str) -> PathBuf {
+    use std::io::Write;
+    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let seq = SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir();
+    let final_path =
+        dir.join(format!("csa_client_mock_{}_{}_{}.sh", std::process::id(), name, seq));
+    let tmp_path =
+        dir.join(format!("csa_client_mock_{}_{}_{}.sh.tmp", std::process::id(), name, seq));
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp_path)
+            .expect("open tmp script");
+        f.write_all(body.as_bytes()).expect("write mock script");
+        f.sync_all().expect("sync_all");
+    }
+    let mut perms = std::fs::metadata(&tmp_path).expect("stat").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&tmp_path, perms).expect("chmod");
+    std::fs::rename(&tmp_path, &final_path).expect("atomic rename");
+    final_path
+}
+
+/// `UsiEngine::spawn` を [`FORK_WRITE_LOCK`] 下で行う (module doc 参照)。
+///
+/// lock は fork の瞬間だけでなく handshake 完了 (`usiok`/`readyok` 待ち) まで
+/// 保持される。応答を意図的に遅延させる mock を追加すると、並行テストの script
+/// 書き込みが startup_timeout まで巻き込まれてブロックされ得る点に注意。
+pub fn spawn_engine(
+    path: &Path,
+    options: &HashMap<String, toml::Value>,
+    opts: SpawnOptions,
+) -> anyhow::Result<UsiEngine> {
+    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    UsiEngine::spawn(path, options, opts)
+}

--- a/crates/rshogi-csa-client/tests/engine_info_cache.rs
+++ b/crates/rshogi-csa-client/tests/engine_info_cache.rs
@@ -1,7 +1,6 @@
 #![cfg(unix)]
 
 use std::collections::HashMap;
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -10,17 +9,14 @@ use std::time::Duration;
 
 use rshogi_csa_client::engine::{SearchOutcome, SpawnOptions, UsiEngine};
 
+mod common;
+
 fn write_mock_engine(script: &str, name: &str) -> PathBuf {
-    let path = std::env::temp_dir().join(format!("{}_{}.sh", name, std::process::id()));
-    std::fs::write(&path, script).expect("write mock engine script");
-    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).expect("set perms");
-    path
+    common::write_mock_script(name, script)
 }
 
 fn spawn_engine(path: &Path) -> UsiEngine {
-    UsiEngine::spawn(
+    common::spawn_engine(
         path,
         &HashMap::new(),
         SpawnOptions {

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -11,15 +11,16 @@
 #![cfg(unix)]
 
 use std::collections::HashMap;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::time::Duration;
 
-use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
+use rshogi_csa_client::engine::SpawnOptions;
 use rshogi_csa_client::event::Event;
+
+mod common;
+use common::{spawn_engine, write_mock_script};
 
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -31,59 +32,6 @@ fn spawn_opts(stderr_passthrough: bool) -> SpawnOptions {
         startup_timeout: SPAWN_TIMEOUT,
         stderr_passthrough,
     }
-}
-
-/// `write_mock_script` の write fd が開いている間に別スレッドの spawn が fork すると、
-/// 子プロセスが write fd を継承したまま exec 前の窓に入り、その script の exec が
-/// `ETXTBSY` (Text file busy) で落ちる。script 書き込みと fork を [`FORK_WRITE_LOCK`]
-/// で直列化することで「write fd open 中の fork」を排除する。
-fn spawn_mock_engine(
-    path: &Path,
-    options: &HashMap<String, toml::Value>,
-    opts: SpawnOptions,
-) -> anyhow::Result<UsiEngine> {
-    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    UsiEngine::spawn(path, options, opts)
-}
-
-static SCRIPT_SEQ: AtomicU64 = AtomicU64::new(0);
-/// 書き込みと fork の片方だけを直列化しても ETXTBSY レースが残る —
-/// `spawn_mock_engine` の doc comment 参照。
-static FORK_WRITE_LOCK: Mutex<()> = Mutex::new(());
-
-/// 与えた bash script を 0o755 の実行可能ファイルとして一時ディレクトリに書き出し、
-/// path を返す。test ごとに unique な名前を付与する。
-///
-/// tmp path へ書き込み → close → chmod → atomic rename の順にすることで、自スレッドの
-/// write fd が exec と重なる経路を塞ぐ。加えて書き込み区間全体を [`FORK_WRITE_LOCK`] で
-/// 覆い、並行 test の fork (`spawn_mock_engine`) が open 中の write fd を子に継承して
-/// `ETXTBSY` を起こすレースを排除する。
-fn write_mock_script(name: &str, body: &str) -> PathBuf {
-    use std::io::Write;
-    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-    let seq = SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst);
-    let dir = std::env::temp_dir();
-    let final_path =
-        dir.join(format!("csa_client_mock_{}_{}_{}.sh", std::process::id(), name, seq,));
-    // 書き込みは別 path で行い、close 後に rename することで「open 中の fd」が
-    // exec と race する経路を排除する (ETXTBSY 回避)。
-    let tmp_path =
-        dir.join(format!("csa_client_mock_{}_{}_{}.sh.tmp", std::process::id(), name, seq,));
-    {
-        let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(&tmp_path)
-            .expect("open tmp script");
-        f.write_all(body.as_bytes()).expect("write mock script");
-        f.sync_all().expect("sync_all");
-    }
-    let mut perms = std::fs::metadata(&tmp_path).expect("stat").permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&tmp_path, perms).expect("chmod");
-    std::fs::rename(&tmp_path, &final_path).expect("atomic rename");
-    final_path
 }
 
 /// 死亡時の error message が満たすべき共通条件 (path + (exit or status=unknown))
@@ -110,7 +58,7 @@ exit 1
 "#;
     let path = write_mock_script("dying_immediate", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -142,7 +90,7 @@ exit 1
     let path = write_mock_script("dying_after_handshake", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let mut engine =
-        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
+        spawn_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
     // engine プロセスは usiok+readyok を返した直後に exit。
     // new_game() は usinewgame + isready を送る。BrokenPipe か recv Disconnected
     // のいずれかから engine_exited_error() に合流する。
@@ -181,8 +129,7 @@ done
 "#;
     let path = write_mock_script("dying_during_go", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let mut engine =
-        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功");
+    let mut engine = spawn_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功");
     engine.new_game().expect("new_game は成功");
     let shutdown = AtomicBool::new(false);
     let (_tx, server_rx) = mpsc::channel::<Event>();
@@ -219,7 +166,7 @@ exit 1
     let path = write_mock_script("long_stderr_line", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // initialize は usiok 後 isready を送る → engine 死亡で error
-    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 送信前後で engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -249,7 +196,7 @@ exit 1
 "#;
     let path = write_mock_script("crlf_stderr", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -280,7 +227,7 @@ exit 1
 "#;
     let path = write_mock_script("empty_line_not_eof", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -313,7 +260,7 @@ exit 1
     let path = write_mock_script("passthrough_smoke", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // SpawnOptions { stderr_passthrough: true } で起動。
-    let err = match spawn_mock_engine(&path, &opts, spawn_opts(true)) {
+    let err = match spawn_engine(&path, &opts, spawn_opts(true)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -353,10 +300,11 @@ fn descendant_process_killed_via_killpg_on_drop() {
     use std::time::Instant;
 
     // tmpfile に孫 pid を書く同期チャネル。test 側は read で「孫が起動したか」を待つ。
+    static PID_FILE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let pid_file = std::env::temp_dir().join(format!(
         "csa_client_grandchild_pid_{}_{}.txt",
         std::process::id(),
-        SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst),
+        PID_FILE_SEQ.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
     ));
     // 既存 file が残っていれば除去 (sequence 衝突の hedge)。
     let _ = std::fs::remove_file(&pid_file);
@@ -384,7 +332,7 @@ read line
     let path = write_mock_script("grandchild_killpg", &script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let engine =
-        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
+        spawn_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
     let parent_pid = engine.child_pid_for_test();
 
     // 孫 pid が pid_file に書かれるまで待つ (最大 2 秒)。

--- a/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
+++ b/crates/rshogi-csa-client/tests/engine_stderr_diagnostic.rs
@@ -33,19 +33,34 @@ fn spawn_opts(stderr_passthrough: bool) -> SpawnOptions {
     }
 }
 
+/// `write_mock_script` の write fd が開いている間に別スレッドの spawn が fork すると、
+/// 子プロセスが write fd を継承したまま exec 前の窓に入り、その script の exec が
+/// `ETXTBSY` (Text file busy) で落ちる。script 書き込みと fork を [`FORK_WRITE_LOCK`]
+/// で直列化することで「write fd open 中の fork」を排除する。
+fn spawn_mock_engine(
+    path: &Path,
+    options: &HashMap<String, toml::Value>,
+    opts: SpawnOptions,
+) -> anyhow::Result<UsiEngine> {
+    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    UsiEngine::spawn(path, options, opts)
+}
+
 static SCRIPT_SEQ: AtomicU64 = AtomicU64::new(0);
-static TMPDIR_LOCK: Mutex<()> = Mutex::new(());
+/// 書き込みと fork の片方だけを直列化しても ETXTBSY レースが残る —
+/// `spawn_mock_engine` の doc comment 参照。
+static FORK_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// 与えた bash script を 0o755 の実行可能ファイルとして一時ディレクトリに書き出し、
 /// path を返す。test ごとに unique な名前を付与する。
 ///
-/// Linux で `cargo test` を並列実行すると、`std::fs::write` 完了直後の `Command::spawn`
-/// で稀に `Text file busy (ETXTBSY)` を踏むため、tmp 書き出し → `sync_all` → chmod →
-/// atomic rename の順で kernel に「書き終えた実行可能ファイル」を確実に認識させる
-/// (PR #596 review で指摘された flake への対応)。
+/// tmp path へ書き込み → close → chmod → atomic rename の順にすることで、自スレッドの
+/// write fd が exec と重なる経路を塞ぐ。加えて書き込み区間全体を [`FORK_WRITE_LOCK`] で
+/// 覆い、並行 test の fork (`spawn_mock_engine`) が open 中の write fd を子に継承して
+/// `ETXTBSY` を起こすレースを排除する。
 fn write_mock_script(name: &str, body: &str) -> PathBuf {
     use std::io::Write;
-    let _guard = TMPDIR_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = FORK_WRITE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let seq = SCRIPT_SEQ.fetch_add(1, Ordering::SeqCst);
     let dir = std::env::temp_dir();
     let final_path =
@@ -95,7 +110,7 @@ exit 1
 "#;
     let path = write_mock_script("dying_immediate", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -127,7 +142,7 @@ exit 1
     let path = write_mock_script("dying_after_handshake", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let mut engine =
-        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
+        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
     // engine プロセスは usiok+readyok を返した直後に exit。
     // new_game() は usinewgame + isready を送る。BrokenPipe か recv Disconnected
     // のいずれかから engine_exited_error() に合流する。
@@ -167,7 +182,7 @@ done
     let path = write_mock_script("dying_during_go", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let mut engine =
-        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功");
+        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功");
     engine.new_game().expect("new_game は成功");
     let shutdown = AtomicBool::new(false);
     let (_tx, server_rx) = mpsc::channel::<Event>();
@@ -204,7 +219,7 @@ exit 1
     let path = write_mock_script("long_stderr_line", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // initialize は usiok 後 isready を送る → engine 死亡で error
-    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 送信前後で engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -234,7 +249,7 @@ exit 1
 "#;
     let path = write_mock_script("crlf_stderr", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -265,7 +280,7 @@ exit 1
 "#;
     let path = write_mock_script("empty_line_not_eof", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
-    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(false)) {
+    let err = match spawn_mock_engine(&path, &opts, spawn_opts(false)) {
         Ok(_) => panic!("isready 後 engine 死亡 → error が期待される"),
         Err(e) => e,
     };
@@ -298,7 +313,7 @@ exit 1
     let path = write_mock_script("passthrough_smoke", script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     // SpawnOptions { stderr_passthrough: true } で起動。
-    let err = match UsiEngine::spawn(&path, &opts, spawn_opts(true)) {
+    let err = match spawn_mock_engine(&path, &opts, spawn_opts(true)) {
         Ok(_) => panic!("spawn 即時死で error が期待される"),
         Err(e) => e,
     };
@@ -369,7 +384,7 @@ read line
     let path = write_mock_script("grandchild_killpg", &script);
     let opts: HashMap<String, toml::Value> = HashMap::new();
     let engine =
-        UsiEngine::spawn(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
+        spawn_mock_engine(&path, &opts, spawn_opts(false)).expect("初回 handshake は成功する想定");
     let parent_pid = engine.child_pid_for_test();
 
     // 孫 pid が pid_file に書かれるまで待つ (最大 2 秒)。

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -16,7 +16,6 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -24,7 +23,9 @@ use std::thread;
 use std::time::Duration;
 
 use rshogi_csa_client::config::CsaClientConfig;
-use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
+use rshogi_csa_client::engine::SpawnOptions;
+
+mod common;
 use rshogi_csa_client::events::{
     DisconnectReason, MovePlayer, ReconnectState, SearchInfoEmitPolicy, SessionError,
     SessionEventSink, SessionProgress, SinkError,
@@ -79,11 +80,6 @@ fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
 ///   - `gameover ...` -> 何もしない
 ///   - `quit` -> 終了
 fn mock_usi_engine_script() -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let dir = tempfile_root();
-    let seq = SEQ.fetch_add(1, AtomicOrdering::SeqCst);
-    let path = dir.join(format!("mock_usi_engine_{}_{}.sh", std::process::id(), seq));
     let script = r#"#!/usr/bin/env bash
 # mock USI engine for csa-client integration test
 while IFS= read -r line; do
@@ -118,23 +114,13 @@ while IFS= read -r line; do
     esac
 done
 "#;
-    std::fs::write(&path, script).expect("write mock engine script");
-    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).expect("set perms");
-    path
+    common::write_mock_script("mock_usi_engine", script)
 }
 
 /// ponder miss 後の次 go で info を出さず即 bestmove を返す mock。
 /// stop で返す bestmove の直後に stale info を出し、次 go に漏れないことを検証する。
 /// ponderhit はこのシナリオでは到達しない想定（到達したら exit 1 でテストを落とす）。
 fn mock_usi_engine_stale_ponder_info_script() -> PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let dir = tempfile_root();
-    let seq = SEQ.fetch_add(1, AtomicOrdering::SeqCst);
-    let path =
-        dir.join(format!("mock_usi_engine_stale_ponder_info_{}_{}.sh", std::process::id(), seq));
     let script = r#"#!/usr/bin/env bash
 go_count=0
 while IFS= read -r line; do
@@ -176,11 +162,7 @@ while IFS= read -r line; do
     esac
 done
 "#;
-    std::fs::write(&path, script).expect("write mock engine script");
-    let mut perms = std::fs::metadata(&path).expect("stat").permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).expect("set perms");
-    path
+    common::write_mock_script("mock_usi_engine_stale_ponder_info", script)
 }
 
 fn tempfile_root() -> PathBuf {
@@ -334,7 +316,7 @@ fn fresh_session_emits_expected_event_sequence() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -420,7 +402,7 @@ fn ponder_miss_stale_info_does_not_attach_to_next_instant_bestmove() {
 
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -495,7 +477,7 @@ fn resumed_session_emits_resumed_event_and_no_history_replay() {
     conn.login_reconnect("alice", "pw", "g-resume", "tok-xyz")
         .expect("login_reconnect");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -567,7 +549,7 @@ fn resumed_state_last_sfen_matches_summary_position_section() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login_reconnect("alice", "pw", "g-resume-sfen", "tok-xyz")
         .expect("login_reconnect");
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -686,7 +668,7 @@ fn fatal_sink_triggers_clean_closure_and_returns_sink_aborted() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -766,7 +748,7 @@ fn external_shutdown_emits_shutdown_disconnected_and_returns_shutdown_error() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -839,7 +821,7 @@ fn external_shutdown_observed_through_legacy_run_game_session() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -894,7 +876,7 @@ fn nonfatal_sink_does_not_invoke_on_error_and_session_continues() {
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
 
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {
@@ -1008,7 +990,7 @@ fn live_jsonl_grows_during_game() {
     let shutdown = Arc::new(AtomicBool::new(false));
     let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
     conn.login("alice", "pw").expect("login");
-    let mut engine = UsiEngine::spawn(
+    let mut engine = common::spawn_engine(
         &config.engine.path,
         &config.engine.options,
         SpawnOptions {


### PR DESCRIPTION
## 概要

CI で `engine_stderr_diagnostic` の `descendant_process_killed_via_killpg_on_drop` が稀に
`エンジン起動失敗 ...: Text file busy (os error 26)` で落ちる flake の修正。
(例: https://github.com/SH11235/rshogi/actions/runs/29109487854/job/86418121730)

## 原因

fork/exec レース:

1. テスト B が `write_mock_script` 内で `X.sh.tmp` の write fd を開いている
2. その瞬間に並行テスト A の `UsiEngine::spawn` が fork し、子プロセスが B の write fd を継承する (`O_CLOEXEC` は fork では閉じず exec 時にしか閉じない)
3. B が rename して `X.sh` を exec した時点で A の子がまだ exec 前だと、同一 inode に write fd が残っており `ETXTBSY`

`UsiEngine::spawn` は `pre_exec` を使うため Rust std が `posix_spawn` ではなく素の fork+exec になり、この窓が実際に開く。

既存対策 (tmp 書き出し → close → chmod → atomic rename) は自スレッドの fd 経路のみを塞いでおり、script 書き込みは mutex で直列化済みだった一方、fork (spawn) 側が lock 外だったのが穴。

## 修正

- mutex を `FORK_WRITE_LOCK` に改名し、`UsiEngine::spawn` を同 lock 下で呼ぶ `spawn_mock_engine` ヘルパを追加
- 全 8 テストの spawn 呼び出しをヘルパ経由に置換

「write fd が open 中の fork」がプロセス内で起き得なくなり、retry のようなヒューリスティックなしで決定的にレースを排除する。mock は即応答するため直列化の時間影響は誤差範囲 (suite 全体 ~0.6–0.8s)。

## 検証

- `cargo fmt` / `cargo clippy --tests` クリーン、`scripts/check-tracked-abs-paths.sh` OK
- `cargo test -p rshogi-csa-client --test engine_stderr_diagnostic` 8/8 pass
- 30 回連続ストレス実行 30/30 pass
- ローカル Codex レビュー APPROVE 済 (診断・lock 構成・テスト意味保全を確認、コメント規約指摘 2 件は対応済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgW2Wb3q5AZ3dPwre8nQec