### PR TITLE
ci: Test job のビルドで LTO を無効化 + push トリガーを main に限定

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,6 +2,10 @@ name: Rust CI
 
 on:
   push:
+    # PR ブランチへの push は pull_request イベント側で検証されるため、
+    # push トリガーは main のみに限定し同一コミットの二重 run を避ける。
+    branches:
+      - main
     paths:
       - 'crates/**'
       - 'Cargo.toml'
@@ -130,6 +134,16 @@ jobs:
         with:
           cache-on-failure: true
       - name: Run tests
+        # `[profile.release]` の `lto = "thin"` はテストバイナリ (~90 個) 各々の
+        # リンクに適用され、Test job のビルド時間の大半を占める。テスト実行自体は
+        # 全 workspace で ~20 秒なので、CI のテストビルドでは LTO を無効化し
+        # codegen-units を広げて並列コンパイルを優先する (フルビルド実測で 4.8 倍短縮)。
+        # overflow-checks 等の release 設定は維持される。本番配備物はそもそも
+        # `production` プロファイル (fat LTO) の別 codegen であり、本 job の目的は
+        # ロジック検証なので LTO の有無はカバレッジに影響しない。
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "off"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: cargo test --release --workspace -- --test-threads=2
       - name: sccache stats
         if: always()


### PR DESCRIPTION
## 背景

Rust CI が ~20 分かかっていた。内訳を計測したところ、クリティカルパスは Test job 単体 (19.5 分) で、うちテスト実行は全 2,624 件で **~18 秒**、残り 18 分超が release ビルドだった (他 job は全て 1〜2 分)。sccache / rust-cache は正常に効いており (hit 100%)、ボトルネックは `[profile.release]` の `lto = "thin"` が ~90 個のテストバイナリのリンク各々に適用されることによるもの。

## 変更内容

1. **Run tests step で `CARGO_PROFILE_RELEASE_LTO=off` / `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16` を上書き**
   - フルビルド実測 (32 core): 10m55s → **2m16s (4.8 倍)**。4 core runner でも同程度の比率を期待
   - overflow-checks 等の release 設定は維持。本番配備物は元々 `production` プロファイル (fat LTO) の別 codegen であり、本 job の目的はロジック検証なので LTO の有無はカバレッジに影響しない
2. **`push` トリガーを `branches: [main]` に限定**
   - 現状 PR ブランチへの push ごとに `push` + `pull_request` の 2 run が必ず並走しており、Actions 消費とキャッシュ帯域を半減できる

## 期待効果

CI 全体の所要時間: ~20 分 → **~5〜7 分** (この PR の CI 結果で実測確認)

注: profile 設定変更により初回 run は deps の再コンパイルでキャッシュミスするため、効果測定は 2 回目以降の run で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6CGonNSSKp19WAxjP5pN7