### PR TITLE
test(csa-client): session_events_integration の mock USI engine 起因の flake 2 件を修正

### DIFF
--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -82,6 +82,7 @@ fn write_lines(writer: &mut std::net::TcpStream, lines: &[&str]) {
 fn mock_usi_engine_script() -> PathBuf {
     let script = r#"#!/usr/bin/env bash
 # mock USI engine for csa-client integration test
+go_count=0
 while IFS= read -r line; do
     case "$line" in
         usi)
@@ -96,8 +97,15 @@ while IFS= read -r line; do
         position*)
             ;;
         go*)
-            echo "info depth 5 score cp 100 nodes 1234 nps 5000 time 200 pv 7g7f"
-            echo "bestmove 7g7f"
+            # 2 回目以降の go には応答しない: 即 bestmove を返すと終局通知の
+            # 処理とレースし、echo 待ち前の局面適用・record/live JSONL 追記が
+            # 走り得る。client は終局検出で stop を送るので、bestmove は下の
+            # stop への応答としてのみ返し、読み捨てさせる。
+            go_count=$((go_count + 1))
+            if [ "$go_count" -eq 1 ]; then
+                echo "info depth 5 score cp 100 nodes 1234 nps 5000 time 200 pv 7g7f"
+                echo "bestmove 7g7f"
+            fi
             ;;
         ponderhit)
             echo "info depth 5 score cp 100 nodes 1234 nps 5000 time 200 pv 7g7f"
@@ -118,7 +126,9 @@ done
 }
 
 /// ponder miss 後の次 go で info を出さず即 bestmove を返す mock。
-/// stop で返す bestmove の直後に stale info を出し、次 go に漏れないことを検証する。
+/// stop への応答は stale info → bestmove の順で書く: client の読み捨ては
+/// 「bestmove がその go の最終出力」という出力契約に依拠しており、bestmove の
+/// 後に書くと読み捨てとレースする。
 /// ponderhit はこのシナリオでは到達しない想定（到達したら exit 1 でテストを落とす）。
 fn mock_usi_engine_stale_ponder_info_script() -> PathBuf {
     let script = r#"#!/usr/bin/env bash
@@ -153,8 +163,8 @@ while IFS= read -r line; do
             exit 1
             ;;
         stop)
-            echo "bestmove 3c3d"
             echo "info depth 1 score cp -32001 nodes 0 pv 1c1d"
+            echo "bestmove 3c3d"
             ;;
         quit)
             exit 0


### PR DESCRIPTION
## 概要

#912 の検証中に発見した `session_events_integration` の flake 2 件 (issue #914) の修正。いずれも未変更 main で 10〜15 回以内のストレス実行で再現していたもので、原因はテスト側 mock の設計にある。

Fixes #914

## 1. `ponder_miss_stale_info_does_not_attach_to_next_instant_bestmove`

mock が `stop` への `bestmove` の**後**に stale info を出していたが、client の `drain_pending_engine_lines` は「エンジンは info → bestmove の順に書き、bestmove がその go の最終出力」という不変条件に依拠しており (doc comment に明記、isready バリアは TT クリアによる棋力毀損のため不採用)、mock がこの出力契約に違反していた。stale info の到着が読み捨てとレースし、稀に次 go の instant bestmove に添付されて fail。

**修正**: stop 応答を info → bestmove の USI 準拠順に変更。stale info は `stop_and_wait` の bestmove までの読み捨てループで決定的に破棄される。「漏れたら move 3 に eval が付いて fail する」という regression guard 自体は維持。

## 2. `live_jsonl_grows_during_game`

共有 mock (`mock_usi_engine_script`) が 2 回目の `go` にも指済みの `7g7f` を返すため、終局通知 `#WIN` と bestmove のレースで bestmove が勝つと不正手適用で `SinkAborted(Fatal "no piece at source for USI move: 7g7f")`。

「合法手を返す」だけでは不十分 (`send_bestmove_and_wait_echo` は echo 待ち**前**に局面適用・record・live JSONL 追記を行うため、bestmove が勝つと jsonl 行数 assert が壊れる残余レースが残る — ローカルレビュー指摘)。

**修正**: 2 回目以降の `go` には応答しない方式に変更。`wait_bestmove` はループ先頭で server イベントを毎回チェックするため、engine が無応答なら必ず終局検出 → `stop_and_drain_bestmove` → `ServerInterrupt` の単一経路になり、bestmove は stop への応答としてのみ返されて読み捨てられる (構造的に決定的)。共有 mock を使う他 7 テストは go が最大 1 回のため影響なし (レビューで全件確認済み)。

## 検証

- `cargo fmt` / `cargo clippy --tests` クリーン
- `session_events_integration` 9/9 pass、**40 回連続ストレス実行 40/40 pass** (baseline は 10〜15 回以内に再現)
- ローカル Codex レビュー: 初回 REQUEST_CHANGES (残余レース指摘) → 無応答方式に修正 → **APPROVE** (wait_bestmove/stop_and_drain/観測列 assert の各経路と他 7 テストへの影響なしをコード上で確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgW2Wb3q5AZ3dPwre8nQec