### PR TITLE
feat(tools): relabel_psv — 入玉教師データの score 後処理 + gensfen game_id sidecar

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -33,6 +33,7 @@
 | `shuffle_psv` | PSV ファイルのシャッフル |
 | `split_psv` | PSV ファイルを局面数または容量で分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおり結合 |
+| `relabel_psv` | PSV の score を手番側視点の game_result 由来値へ streaming 置換し、任意で宣言勝ち override / diversions deblunder（[詳細](docs/relabel_psv.md)） |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
@@ -102,6 +103,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
 - [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
+- [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換と任意の宣言勝ち override / diversions deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み）
 - [book_rescore](docs/book_rescore.md) - YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与（実行中は進捗/ETA を stderr 表示）

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -157,6 +157,7 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `--output-training-data PATH` | `<out-dir>/gensfen.psv` | 学習データ出力先 |
+| `--emit-game-id-sidecar PATH` | — | PSV 各レコードと 1:1・同順の `game_id` を u32 little-endian で出力（PSV 専用） |
 | `--training-data-format FORMAT` | psv | `psv`（40バイト固定）/ `pack`（32バイト + メタ）/ `hcpe3`（可変長棋譜 + policy） |
 | `--hcpe3-policy-total N` | 1000 | hcpe3 の policy 分布に割り当てる visit 総票数 |
 | `--hcpe3-policy-temp F` | 600.0 | hcpe3 の policy softmax 温度（centipawn 単位、大きいほど分布を均す） |
@@ -191,6 +192,15 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 |-----------|------|
 | `--out-dir DIR` | 出力ディレクトリ（resume 時必須） |
 | `--resume` | 前回中断したセッションを再開する |
+
+`--emit-game-id-sidecar` と `--resume` は併用できない。既存 run に sidecar が無い場合の
+PSV との 1:1 対応を壊さないため、明示的にエラーとする。sidecar のパスは meta 行の
+`settings.game_id_sidecar` にも記録される。並行実行時は PSV と sidecar の両方をワーカー別の
+一時ファイルへ書き、同じワーカー順で最終ファイルへ連結する。sidecar には JSONL・PSV・
+info log・eval file・metrics の最終出力パス、およびそれらと sidecar の内部ワーカーパスを
+指定できず、衝突時は処理開始前にエラーにする。パスは絶対化し、存在する最深の祖先を
+canonicalize してから残りの未存在コンポーネントを正規化するため、symlink 直後の `..` を
+含む同じパスの別表記も衝突として扱う。
 
 ## 重複回避の詳細
 

--- a/crates/tools/docs/relabel_psv.md
+++ b/crates/tools/docs/relabel_psv.md
@@ -1,5 +1,9 @@
 # relabel_psv — PSV 勝敗ラベルへの score 置換
 
+`--output` が展開後の `--input` または `--game-id-sidecar` と同じファイル実体を
+指す場合は、入力の truncate を防ぐため処理開始前にエラーで拒否します。相対パスの
+別表記、symlink、および Unix 上の hardlink も同一ファイルとして扱います。
+
 `PackedSfenValue` の `score` を、各レコードの `game_result` から得た飽和値へ置換する。
 `game_result` と `score` はどちらもその局面の手番側視点で、勝ちを正、負けを負、引分を 0 とする。
 

--- a/crates/tools/docs/relabel_psv.md
+++ b/crates/tools/docs/relabel_psv.md
@@ -1,0 +1,63 @@
+# relabel_psv — PSV 勝敗ラベルへの score 置換
+
+`PackedSfenValue` の `score` を、各レコードの `game_result` から得た飽和値へ置換する。
+`game_result` と `score` はどちらもその局面の手番側視点で、勝ちを正、負けを負、引分を 0 とする。
+
+処理は40バイトの PSV レコードを逐次読み書きする。入力 PSV の全件をメモリへ保持しない。
+複数入力や glob は辞書順へ固定して処理するため、同じ入力とオプションからは同じ byte 列を得る。
+
+## 基本用法
+
+```bash
+cargo run -p tools --release --bin relabel_psv -- \
+  --input "$SHOGI_DATA/teachers/input-*.psv" \
+  --output "$SHOGI_DATA/teachers/relabelled.psv"
+```
+
+既定の `--win-cp 2500` では次のように必ず上書きする。
+
+| `game_result` | 新しい `score` |
+|---:|---:|
+| `1` | `+2500` |
+| `0` | `0` |
+| `-1` | `-2500` |
+
+`--win-cp` は `1..32000` の範囲で指定する。これにより score-drop の番兵値 32000 と干渉しない。
+
+## 宣言勝ち override
+
+`--declaration-override` を指定すると各 PackedSfen を復号し、手番側が27点法で宣言勝ち可能な
+局面の `score` を、対局結果にかかわらず `+win-cp` にする。復号と局面構築が必要なため既定は無効。
+
+## diversions による deblunder
+
+`gensfen --emit-game-id-sidecar` で作った sidecar と result JSONL を使い、乱択着手までの
+汚染された局面を出力から除外できる。result JSONL の diversion ply は開始局面からの相対手数で、
+`relabel_psv` が各 result 行の `start_sfen` に含まれる開始絶対手数を使って PSV の絶対
+`game_ply` に変換する。
+
+```bash
+cargo run -p tools --release --bin relabel_psv -- \
+  --input "$SHOGI_DATA/teachers/gensfen.psv" \
+  --output "$SHOGI_DATA/teachers/gensfen-relabelled.psv" \
+  --deblunder \
+  --game-id-sidecar "$SHOGI_DATA/teachers/gensfen.game_ids.bin" \
+  --diversions "$SHOGI_DATA/teachers/gensfen.jsonl"
+```
+
+PSV と sidecar は lockstep で読み、件数不一致や末尾の半端レコードをエラーにする。
+sidecar は PSV 1 レコードにつき u32 little-endian の `game_id` 1件である。
+
+| モード | 除外条件 | 既定 |
+|---|---|---|
+| `drop-before-last` | 最後の diversion 以前（diversion が指された局面を含む）を除外し、厳密に後ろだけ残す | yes |
+| `drop-before-any` | 最初の diversion 以前（diversion が指された局面を含む）を除外する | no |
+
+境界 ply 自体も、乱択後の game result で汚染されるため除外する。diversion のない対局は除外しない。
+diversions の map だけを対局数オーダーで
+保持するため、ピークメモリは PSV レコード数に依存しない。
+
+## 統計
+
+stderr に入力件数、勝ち・負け・引分の置換件数、宣言勝ち override 件数、deblunder の除外件数を
+1行で出力する。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -53,6 +53,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `shuffle_psv` | PSV ファイル内のレコード（40バイト単位）をシャッフル |
 | `split_psv` | PSV ファイルを局面数または容量で複数ファイルへ分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
+| `relabel_psv` | PSV の score を手番側視点の game_result 由来値へ streaming 置換し、任意で宣言勝ち override / diversions deblunder（[詳細](relabel_psv.md)） |
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -217,6 +217,11 @@ struct Cli {
     #[arg(long)]
     output_training_data: Option<PathBuf>,
 
+    /// PSV の各レコードに対応する game_id を u32 little-endian で出力する sidecar。
+    /// --training-data-format psv でのみ使用できる。
+    #[arg(long)]
+    emit_game_id_sidecar: Option<PathBuf>,
+
     /// 学習データ出力時に序盤の手数をスキップする（1手目からN手目まで）
     /// ランダム性確保のため、序盤の定跡手順をスキップする
     #[arg(
@@ -377,6 +382,9 @@ struct MetaSettings {
     random_startpos: bool,
     #[serde(default)]
     output_training_data: Option<String>,
+    /// PSV レコードと 1:1・同順の game_id sidecar（u32 little-endian）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    game_id_sidecar: Option<String>,
     #[serde(default)]
     skip_initial_ply: u32,
     #[serde(default = "default_skip_in_check")]
@@ -574,6 +582,8 @@ struct TrainingEntry {
 struct TrainingDataCollector {
     entries: Vec<TrainingEntry>,
     writer: BufWriter<File>,
+    /// PSV と同じループで game_id を書く。PSV 以外では常に None。
+    game_id_writer: Option<BufWriter<File>>,
     format: TrainingFormat,
     /// hcpe3 policy 分布の visit 総票数（softmax 量子化に使用）
     policy_total: u16,
@@ -600,6 +610,7 @@ impl TrainingDataCollector {
         format: TrainingFormat,
         policy_total: u16,
         policy_temp: f64,
+        game_id_path: Option<&Path>,
     ) -> Result<Self> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
@@ -610,6 +621,13 @@ impl TrainingDataCollector {
         }
         let file = File::create(path)
             .with_context(|| format!("failed to create training data file: {}", path.display()))?;
+        let game_id_writer = game_id_path
+            .map(|game_id_path| {
+                File::create(game_id_path).map(BufWriter::new).with_context(|| {
+                    format!("failed to create game_id sidecar: {}", game_id_path.display())
+                })
+            })
+            .transpose()?;
 
         // 平手判定用の PackedSfen を事前計算
         let mut hirate_pos = Position::new();
@@ -619,6 +637,7 @@ impl TrainingDataCollector {
         Ok(Self {
             entries: Vec::new(),
             writer: BufWriter::new(file),
+            game_id_writer,
             format,
             policy_total,
             policy_temp,
@@ -743,7 +762,7 @@ impl TrainingDataCollector {
 
     /// 対局終了時に勝敗を設定して書き出す
     /// InProgress（手数制限/タイムアウト終了）の対局は学習データに含めない
-    fn finish_game(&mut self, outcome: GameOutcome) -> Result<()> {
+    fn finish_game(&mut self, outcome: GameOutcome, game_id: u32) -> Result<()> {
         // InProgressの対局は学習データとして不適切なので破棄
         if outcome == GameOutcome::InProgress {
             self.skipped_in_progress += self.entries.len() as u64;
@@ -756,7 +775,7 @@ impl TrainingDataCollector {
         }
 
         match self.format {
-            TrainingFormat::Psv => self.finish_game_psv(outcome)?,
+            TrainingFormat::Psv => self.finish_game_psv(outcome, game_id)?,
             TrainingFormat::Pack => self.finish_game_pack(outcome)?,
             TrainingFormat::Hcpe3 => self.finish_game_hcpe3(outcome)?,
         }
@@ -766,7 +785,7 @@ impl TrainingDataCollector {
     }
 
     /// PSV 形式で書き出す（PackedSfenValue 40バイト固定長）
-    fn finish_game_psv(&mut self, outcome: GameOutcome) -> Result<()> {
+    fn finish_game_psv(&mut self, outcome: GameOutcome, game_id: u32) -> Result<()> {
         for (idx, entry) in self.entries.iter().enumerate() {
             // game_result: 手番側から見た勝敗
             // 1 = 勝ち, 0 = 引き分け, -1 = 負け
@@ -801,6 +820,12 @@ impl TrainingDataCollector {
             self.writer
                 .write_all(&psv.to_bytes())
                 .with_context(|| format!("failed to write position {idx} of game"))?;
+            // PSV と sidecar の 1:1・同順を構造的に保つため、同じループで連続して書く。
+            if let Some(writer) = self.game_id_writer.as_mut() {
+                writer.write_all(&game_id.to_le_bytes()).with_context(|| {
+                    format!("failed to write game_id for position {idx} of game")
+                })?;
+            }
             self.total_written += 1;
         }
         Ok(())
@@ -904,6 +929,9 @@ impl TrainingDataCollector {
 
     fn flush(&mut self) -> Result<()> {
         self.writer.flush()?;
+        if let Some(writer) = self.game_id_writer.as_mut() {
+            writer.flush()?;
+        }
         Ok(())
     }
 
@@ -1260,6 +1288,7 @@ struct WorkerConfig {
     eval_path: Option<PathBuf>,
     metrics_path: Option<PathBuf>,
     training_data_path: Option<PathBuf>,
+    game_id_sidecar_path: Option<PathBuf>,
     // Output flags
     flush_each_move: bool,
     // Training
@@ -1378,6 +1407,7 @@ fn worker_main(
                 cfg.training_format,
                 cfg.hcpe3_policy_total,
                 cfg.hcpe3_policy_temp,
+                cfg.game_id_sidecar_path.as_deref(),
             )?)
         } else {
             None
@@ -1761,7 +1791,7 @@ fn worker_main(
             }
 
             if let Some(ref mut collector) = training_data_collector {
-                collector.finish_game(outcome)?;
+                collector.finish_game(outcome, game_idx + 1)?;
             }
             writer.flush()?;
 
@@ -2028,6 +2058,12 @@ fn concatenate_temp_files(final_path: &Path, temp_paths: &[PathBuf], append: boo
 fn main() -> Result<()> {
     let mut cli = Cli::parse();
 
+    // 既存 run には sidecar が無い可能性があり、PSV だけへの追記は 1:1 対応を壊す。
+    // 既存 PSV/sidecar の全件検証を暗黙に行わず、安全側で併用を禁止する。
+    if cli.resume && cli.emit_game_id_sidecar.is_some() {
+        bail!("--emit-game-id-sidecar cannot be used with --resume");
+    }
+
     // 時間制限のバリデーション: depth/nodes 指定がなく時間制御もない場合はデフォルト byoyomi を設定
     let has_limit = cli.depth.is_some() || cli.nodes.is_some();
     if !has_limit
@@ -2130,6 +2166,9 @@ fn main() -> Result<()> {
             bail!("unknown training data format: '{}' (expected 'psv', 'pack', or 'hcpe3')", other)
         }
     };
+    if cli.emit_game_id_sidecar.is_some() && training_format != TrainingFormat::Psv {
+        bail!("--emit-game-id-sidecar requires --training-data-format psv");
+    }
 
     validate_hcpe3_opts(
         training_format,
@@ -2150,6 +2189,25 @@ fn main() -> Result<()> {
             .unwrap_or_else(|| default_training_data_path(&output_path, training_data_ext)),
     );
     let training_data_enabled = training_data_path.is_some();
+    let game_id_sidecar_path = cli.emit_game_id_sidecar.clone();
+    if let Some(sidecar_path) = game_id_sidecar_path.as_deref() {
+        validate_game_id_sidecar_path(
+            sidecar_path,
+            &output_path,
+            training_data_path.as_deref(),
+            training_data_ext,
+            cli.concurrency,
+            cli.log_info,
+            cli.emit_eval_file,
+            cli.emit_metrics,
+        )?;
+    }
+    if let Some(parent) = game_id_sidecar_path.as_deref().and_then(Path::parent)
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
 
     let engine_paths = resolve_engine_paths(&cli);
     let threads_black = cli.threads_black.unwrap_or(cli.threads);
@@ -2344,6 +2402,7 @@ fn main() -> Result<()> {
                 sfen: cli.sfen.clone(),
                 random_startpos: cli.random_startpos,
                 output_training_data: training_data_path.as_ref().map(|p| p.display().to_string()),
+                game_id_sidecar: game_id_sidecar_path.as_ref().map(|p| p.display().to_string()),
                 skip_initial_ply: cli.skip_initial_ply,
                 skip_in_check: cli.skip_in_check,
                 shuffle_seed: shuffle_seed_resolved,
@@ -2428,6 +2487,7 @@ fn main() -> Result<()> {
     let mut temp_eval_paths = Vec::new();
     let mut temp_metrics_paths = Vec::new();
     let mut temp_pack_paths = Vec::new();
+    let mut temp_game_id_paths = Vec::new();
 
     for w in 0..cli.concurrency {
         let jsonl_path = output_parent.join(format!("{output_stem}.w{w}.jsonl"));
@@ -2451,6 +2511,9 @@ fn main() -> Result<()> {
         } else {
             None
         };
+        let w_game_id_path = game_id_sidecar_path
+            .as_ref()
+            .map(|_| output_parent.join(format!("{output_stem}.w{w}.game_ids.bin")));
 
         temp_jsonl_paths.push(jsonl_path.clone());
         if let Some(ref p) = w_info_path {
@@ -2464,6 +2527,9 @@ fn main() -> Result<()> {
         }
         if let Some(ref p) = w_training_path {
             temp_pack_paths.push(p.clone());
+        }
+        if let Some(ref p) = w_game_id_path {
+            temp_game_id_paths.push(p.clone());
         }
 
         let cfg = WorkerConfig {
@@ -2498,6 +2564,7 @@ fn main() -> Result<()> {
             eval_path: w_eval_path,
             metrics_path: w_metrics_path,
             training_data_path: w_training_path,
+            game_id_sidecar_path: w_game_id_path,
             flush_each_move: cli.flush_each_move,
             skip_initial_ply: cli.skip_initial_ply,
             skip_in_check: cli.skip_in_check,
@@ -2703,6 +2770,9 @@ fn main() -> Result<()> {
             .unwrap_or_else(|| default_training_data_path(&output_path, training_data_ext));
         concatenate_temp_files(&pack_path, &temp_pack_paths, append_mode)?;
     }
+    if let Some(sidecar_path) = game_id_sidecar_path.as_deref() {
+        concatenate_temp_files(sidecar_path, &temp_game_id_paths, false)?;
+    }
 
     // 最終サマリー
     let actual_games = black_wins + white_wins + draws;
@@ -2744,6 +2814,9 @@ fn main() -> Result<()> {
             "Output: {}",
             training_data_path.as_ref().map_or("-".to_string(), |p| p.display().to_string())
         );
+        if let Some(path) = game_id_sidecar_path.as_deref() {
+            println!("Game ID sidecar: {}", path.display());
+        }
         println!("---------------------");
     }
     println!("gensfen log written to {}", output_path.display());
@@ -2778,6 +2851,108 @@ fn default_training_data_path(jsonl: &Path, ext: &str) -> PathBuf {
     let parent = jsonl.parent().unwrap_or_else(|| Path::new("."));
     let stem = jsonl.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
     parent.join(format!("{stem}.{ext}"))
+}
+
+fn validate_game_id_sidecar_path(
+    sidecar: &Path,
+    output_jsonl: &Path,
+    training_data: Option<&Path>,
+    training_data_ext: &str,
+    concurrency: usize,
+    log_info: bool,
+    emit_eval_file: bool,
+    emit_metrics: bool,
+) -> Result<()> {
+    let normalized_sidecar = normalize_output_path(sidecar)?;
+    let mut final_paths = vec![output_jsonl.to_path_buf()];
+    final_paths.extend(training_data.map(Path::to_path_buf));
+    if log_info {
+        final_paths.push(output_jsonl.with_extension("info.jsonl"));
+    }
+    if emit_eval_file {
+        final_paths.push(default_eval_path(output_jsonl));
+    }
+    if emit_metrics {
+        final_paths.push(default_metrics_path(output_jsonl));
+    }
+    if final_paths
+        .iter()
+        .map(|path| normalize_output_path(path))
+        .collect::<Result<Vec<_>>>()?
+        .contains(&normalized_sidecar)
+    {
+        bail!(
+            "--emit-game-id-sidecar path conflicts with a final output path: {}",
+            sidecar.display()
+        );
+    }
+
+    let parent = output_jsonl.parent().unwrap_or_else(|| Path::new("."));
+    let stem = output_jsonl.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
+    for worker in 0..concurrency {
+        let mut internal_paths = vec![
+            parent.join(format!("{stem}.w{worker}.jsonl")),
+            parent.join(format!("{stem}.w{worker}.{training_data_ext}")),
+            parent.join(format!("{stem}.w{worker}.game_ids.bin")),
+        ];
+        if log_info {
+            internal_paths.push(parent.join(format!("{stem}.w{worker}.info.jsonl")));
+        }
+        if emit_eval_file {
+            internal_paths.push(parent.join(format!("{stem}.w{worker}.eval.txt")));
+        }
+        if emit_metrics {
+            internal_paths.push(parent.join(format!("{stem}.w{worker}.metrics.jsonl")));
+        }
+        if internal_paths
+            .iter()
+            .map(|path| normalize_output_path(path))
+            .collect::<Result<Vec<_>>>()?
+            .contains(&normalized_sidecar)
+        {
+            bail!(
+                "--emit-game-id-sidecar path conflicts with an internal worker path: {}",
+                sidecar.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// 未生成の出力ファイル同士を比較できるよう、存在する最深の祖先を canonicalize し、
+/// 残りの未生成コンポーネントを実体パスに対して正規化する。
+fn normalize_output_path(path: &Path) -> Result<PathBuf> {
+    use std::path::Component;
+
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    let components: Vec<_> = absolute.components().collect();
+    let mut ancestor_len = components.len();
+    let ancestor = loop {
+        let candidate: PathBuf = components[..ancestor_len].iter().collect();
+        if candidate.try_exists()? {
+            break candidate.canonicalize()?;
+        }
+        ancestor_len -= 1;
+    };
+
+    let mut normalized = ancestor;
+    for component in &components[ancestor_len..] {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    Ok(normalized)
 }
 
 fn native_progress_file_required(layer_stack_num_buckets: Option<usize>) -> bool {
@@ -3322,6 +3497,121 @@ mod tests {
     }
 
     #[test]
+    fn game_id_sidecar_rejects_final_and_worker_path_collisions() {
+        let output = Path::new("run/gensfen.jsonl");
+        let training = Path::new("run/gensfen.psv");
+        for collision in [
+            "run/gensfen.jsonl",
+            "run/gensfen.psv",
+            "run/gensfen.info.jsonl",
+            "run/gensfen.eval.txt",
+            "run/gensfen.metrics.jsonl",
+            "run/gensfen.w0.jsonl",
+            "run/gensfen.w1.psv",
+            "run/gensfen.w0.info.jsonl",
+            "run/gensfen.w1.eval.txt",
+            "run/gensfen.w0.metrics.jsonl",
+            "run/gensfen.w1.game_ids.bin",
+            "run/./gensfen.psv",
+            "run/nested/../gensfen.psv",
+        ] {
+            let error = validate_game_id_sidecar_path(
+                Path::new(collision),
+                output,
+                Some(training),
+                "psv",
+                2,
+                true,
+                true,
+                true,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("conflicts"), "{error:#}");
+        }
+        validate_game_id_sidecar_path(
+            Path::new("run/ids.bin"),
+            output,
+            Some(training),
+            "psv",
+            2,
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn psv_game_id_sidecar_matches_result_game_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let psv_path = dir.path().join("short.psv");
+        let sidecar_path = dir.path().join("short.game_ids.bin");
+        let jsonl_path = dir.path().join("short.jsonl");
+
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let packed = pack_position(&pos);
+        let entry = |side_to_move| TrainingEntry {
+            sfen: packed,
+            score: 10,
+            move16: 0,
+            game_ply: 1,
+            side_to_move,
+            hcpe3: None,
+        };
+
+        {
+            let mut collector = TrainingDataCollector::new(
+                &psv_path,
+                0,
+                false,
+                TrainingFormat::Psv,
+                1000,
+                600.0,
+                Some(&sidecar_path),
+            )
+            .unwrap();
+            collector.entries.push(entry(Color::Black));
+            collector.entries.push(entry(Color::White));
+            collector.finish_game(GameOutcome::BlackWin, 7).unwrap();
+            collector.entries.push(entry(Color::Black));
+            collector.finish_game(GameOutcome::Draw, 9).unwrap();
+            collector.flush().unwrap();
+        }
+
+        let mut jsonl = BufWriter::new(File::create(&jsonl_path).unwrap());
+        for game_id in [7, 9] {
+            serde_json::to_writer(
+                &mut jsonl,
+                &serde_json::json!({"type": "result", "game_id": game_id}),
+            )
+            .unwrap();
+            jsonl.write_all(b"\n").unwrap();
+        }
+        jsonl.flush().unwrap();
+
+        let psv_records =
+            std::fs::metadata(&psv_path).unwrap().len() as usize / PackedSfenValue::SIZE;
+        let sidecar = std::fs::read(&sidecar_path).unwrap();
+        let game_ids: Vec<u32> = sidecar
+            .chunks_exact(4)
+            .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect();
+        assert_eq!(psv_records, game_ids.len());
+        assert_eq!(game_ids, [7, 7, 9]);
+
+        let result_ids: Vec<u32> = BufReader::new(File::open(jsonl_path).unwrap())
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<Value>(&line.unwrap()).unwrap()["game_id"]
+                    .as_u64()
+                    .unwrap() as u32
+            })
+            .collect();
+        assert!(game_ids.iter().all(|game_id| result_ids.contains(game_id)));
+    }
+
+    #[test]
     fn finish_game_hcpe3_byte_layout() {
         use rshogi_core::position::Position;
         use rshogi_core::types::Move;
@@ -3342,12 +3632,19 @@ mod tests {
         }];
 
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             col.record_position(&pos, Some(123), None, Some(mv), mv, &candidates);
-            col.finish_game(GameOutcome::BlackWin).unwrap();
+            col.finish_game(GameOutcome::BlackWin, 1).unwrap();
             col.flush().unwrap();
         }
 
@@ -3403,12 +3700,19 @@ mod tests {
         ];
 
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             col.record_position(&pos, Some(100), None, Some(m1), m1, &candidates);
-            col.finish_game(GameOutcome::WhiteWin).unwrap();
+            col.finish_game(GameOutcome::WhiteWin, 1).unwrap();
             col.flush().unwrap();
         }
 
@@ -3511,13 +3815,20 @@ mod tests {
         let candidates = vec![legal_candidate(1, 100, "7g7f")];
 
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             // 実着手 played != 最善手 best。selectedMove16 は replay 用に played を記録する
             col.record_position(&pos, Some(100), None, Some(best), played, &candidates);
-            col.finish_game(GameOutcome::BlackWin).unwrap();
+            col.finish_game(GameOutcome::BlackWin, 1).unwrap();
             col.flush().unwrap();
         }
         let bytes = std::fs::read(&path).unwrap();
@@ -3540,13 +3851,20 @@ mod tests {
         pos.set_hirate();
         let mv = Move::from_usi("7g7f").unwrap();
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             // --random-multi-pv 未指定相当: 候補なし → 実着手の one-hot (visit=1)
             col.record_position(&pos, Some(50), None, Some(mv), mv, &[]);
-            col.finish_game(GameOutcome::BlackWin).unwrap();
+            col.finish_game(GameOutcome::BlackWin, 1).unwrap();
             col.flush().unwrap();
         }
         let bytes = std::fs::read(&path).unwrap();
@@ -3570,9 +3888,16 @@ mod tests {
         pos.set_hirate();
         let m1 = Move::from_usi("7g7f").unwrap();
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             col.record_position(
                 &pos,
@@ -3593,7 +3918,7 @@ mod tests {
                 m2,
                 &[legal_candidate(1, -15, "3c3d")],
             );
-            col.finish_game(GameOutcome::Draw).unwrap();
+            col.finish_game(GameOutcome::Draw, 1).unwrap();
             col.flush().unwrap();
         }
         let bytes = std::fs::read(&path).unwrap();
@@ -3624,9 +3949,16 @@ mod tests {
         let m2 = Move::from_usi("3c3d").unwrap();
         let expected_hcp = pack_position_hcp(&after);
         {
-            let mut col =
-                TrainingDataCollector::new(&path, 0, false, TrainingFormat::Hcpe3, 1000, 600.0)
-                    .unwrap();
+            let mut col = TrainingDataCollector::new(
+                &path,
+                0,
+                false,
+                TrainingFormat::Hcpe3,
+                1000,
+                600.0,
+                None,
+            )
+            .unwrap();
             col.start_game();
             // 局面A を記録 → 評価値欠落でセグメント破棄 → 局面C（着手後）で取り直す
             col.record_position(
@@ -3646,7 +3978,7 @@ mod tests {
                 m2,
                 &[legal_candidate(1, 40, "3c3d")],
             );
-            col.finish_game(GameOutcome::BlackWin).unwrap();
+            col.finish_game(GameOutcome::BlackWin, 1).unwrap();
             col.flush().unwrap();
         }
         let bytes = std::fs::read(&path).unwrap();

--- a/crates/tools/src/bin/relabel_psv.rs
+++ b/crates/tools/src/bin/relabel_psv.rs
@@ -1,0 +1,347 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::{Parser, ValueEnum};
+use rshogi_core::position::Position;
+use rshogi_core::types::{EnteringKingRule, Move};
+use serde_json::Value;
+use tools::packed_sfen::{PackedSfenValue, unpack_sfen};
+
+#[derive(Debug, Parser)]
+#[command(about = "PSV の score を手番側視点の game_result 由来値へ置換する")]
+struct Cli {
+    /// 入力 PSV。カンマ区切りと glob を使用でき、展開後は辞書順で処理する。
+    #[arg(long, required = true, value_delimiter = ',')]
+    input: Vec<String>,
+
+    /// 出力 PSV
+    #[arg(long)]
+    output: PathBuf,
+
+    /// 勝敗を置換する絶対 score（勝ち=正、負け=負、引分=0）
+    #[arg(long, default_value_t = 2500)]
+    win_cp: i16,
+
+    /// 手番側が27点法で宣言勝ち可能なら score を +win-cp にする
+    #[arg(long, default_value_t = false)]
+    declaration_override: bool,
+
+    /// diversions より前の局面を除外する
+    #[arg(long, default_value_t = false)]
+    deblunder: bool,
+
+    /// 入力 PSV と 1:1・同順の u32 little-endian game_id sidecar
+    #[arg(long)]
+    game_id_sidecar: Option<PathBuf>,
+
+    /// gensfen result JSONL。カンマ区切りと glob を使用できる。
+    #[arg(long, value_delimiter = ',')]
+    diversions: Vec<String>,
+
+    /// diversion が複数ある対局で使う除外境界
+    #[arg(long, value_enum, default_value_t = DeblunderMode::DropBeforeLast)]
+    deblunder_mode: DeblunderMode,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum DeblunderMode {
+    /// 最後の diversion ply 以前を除外する
+    DropBeforeLast,
+    /// 最初の diversion ply 以前を除外する
+    DropBeforeAny,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DiversionBounds {
+    first: u16,
+    last: u16,
+}
+
+#[derive(Default)]
+struct Stats {
+    input: u64,
+    wins: u64,
+    losses: u64,
+    draws: u64,
+    declaration_overrides: u64,
+    deblunder_drops: u64,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    run(cli)
+}
+
+fn run(cli: Cli) -> Result<()> {
+    if !(1..32000).contains(&cli.win_cp) {
+        bail!("--win-cp must be in 1..32000");
+    }
+    if cli.deblunder && cli.game_id_sidecar.is_none() {
+        bail!("--deblunder requires --game-id-sidecar");
+    }
+    if cli.deblunder && cli.diversions.is_empty() {
+        bail!("--deblunder requires --diversions");
+    }
+    if !cli.deblunder && (cli.game_id_sidecar.is_some() || !cli.diversions.is_empty()) {
+        bail!("--game-id-sidecar and --diversions require --deblunder");
+    }
+
+    let input_paths = expand_paths(&cli.input, "--input")?;
+    if input_paths.iter().any(|path| path == &cli.output) {
+        bail!("--output must differ from every input path");
+    }
+    if cli.game_id_sidecar.as_deref() == Some(cli.output.as_path()) {
+        bail!("--output must differ from --game-id-sidecar");
+    }
+    let diversion_bounds = if cli.deblunder {
+        load_diversion_bounds(&expand_paths(&cli.diversions, "--diversions")?)?
+    } else {
+        HashMap::new()
+    };
+
+    if let Some(parent) = cli.output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let mut output = BufWriter::new(
+        File::create(&cli.output)
+            .with_context(|| format!("failed to create {}", cli.output.display()))?,
+    );
+    let mut sidecar = cli
+        .game_id_sidecar
+        .as_deref()
+        .map(|path| {
+            File::open(path)
+                .map(BufReader::new)
+                .with_context(|| format!("failed to open game_id sidecar {}", path.display()))
+        })
+        .transpose()?;
+    let mut declaration_pos = cli.declaration_override.then(Position::new);
+    let mut stats = Stats::default();
+
+    for input_path in &input_paths {
+        let mut input = BufReader::new(
+            File::open(input_path)
+                .with_context(|| format!("failed to open input {}", input_path.display()))?,
+        );
+        while let Some(bytes) =
+            read_fixed::<{ PackedSfenValue::SIZE }>(&mut input, input_path, "PSV record")?
+        {
+            stats.input += 1;
+            let mut record = PackedSfenValue::from_bytes(&bytes)
+                .expect("fixed-size PSV record must always decode");
+            let game_id = if let Some(reader) = sidecar.as_mut() {
+                let path = cli.game_id_sidecar.as_deref().expect("validated sidecar path");
+                let id_bytes = read_fixed::<4>(reader, path, "game_id")?.ok_or_else(|| {
+                    anyhow::anyhow!("game_id sidecar ended before PSV record {}", stats.input)
+                })?;
+                Some(u32::from_le_bytes(id_bytes))
+            } else {
+                None
+            };
+
+            match record.game_result {
+                1 => {
+                    stats.wins += 1;
+                    record.score = cli.win_cp;
+                }
+                -1 => {
+                    stats.losses += 1;
+                    record.score = -cli.win_cp;
+                }
+                0 => {
+                    stats.draws += 1;
+                    record.score = 0;
+                }
+                value => bail!(
+                    "invalid game_result {value} at record {} in {}",
+                    stats.input,
+                    input_path.display()
+                ),
+            }
+
+            if let Some(pos) = declaration_pos.as_mut() {
+                let sfen = unpack_sfen(&record.sfen).map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to unpack record {} in {}: {error}",
+                        stats.input,
+                        input_path.display()
+                    )
+                })?;
+                pos.set_sfen(&sfen).map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to decode record {} in {}: {error}",
+                        stats.input,
+                        input_path.display()
+                    )
+                })?;
+                if pos.declaration_win(EnteringKingRule::Point27) == Move::WIN {
+                    record.score = cli.win_cp;
+                    stats.declaration_overrides += 1;
+                }
+            }
+
+            let drop = game_id.and_then(|id| diversion_bounds.get(&id)).is_some_and(|bounds| {
+                let boundary = match cli.deblunder_mode {
+                    DeblunderMode::DropBeforeLast => bounds.last,
+                    DeblunderMode::DropBeforeAny => bounds.first,
+                };
+                record.game_ply <= boundary
+            });
+            if drop {
+                stats.deblunder_drops += 1;
+            } else {
+                output
+                    .write_all(&record.to_bytes())
+                    .with_context(|| format!("failed to write output {}", cli.output.display()))?;
+            }
+        }
+    }
+
+    if let Some(reader) = sidecar.as_mut() {
+        let path = cli.game_id_sidecar.as_deref().expect("validated sidecar path");
+        if read_fixed::<4>(reader, path, "game_id")?.is_some() {
+            bail!("game_id sidecar has more entries than the input PSV files");
+        }
+    }
+    output.flush()?;
+    eprintln!(
+        "input={} win={} loss={} draw={} declaration_override={} deblunder_drop={}",
+        stats.input,
+        stats.wins,
+        stats.losses,
+        stats.draws,
+        stats.declaration_overrides,
+        stats.deblunder_drops
+    );
+    Ok(())
+}
+
+fn expand_paths(patterns: &[String], option: &str) -> Result<Vec<PathBuf>> {
+    let mut paths = BTreeSet::new();
+    for pattern in patterns {
+        let mut matched = false;
+        for entry in
+            glob::glob(pattern).with_context(|| format!("invalid glob for {option}: {pattern}"))?
+        {
+            let path = entry.with_context(|| format!("failed to expand {option}: {pattern}"))?;
+            if path.is_file() {
+                paths.insert(path);
+                matched = true;
+            }
+        }
+        if !matched {
+            bail!("{option} matched no files: {pattern}");
+        }
+    }
+    if paths.is_empty() {
+        bail!("{option} matched no files");
+    }
+    Ok(paths.into_iter().collect())
+}
+
+fn load_diversion_bounds(paths: &[PathBuf]) -> Result<HashMap<u32, DiversionBounds>> {
+    let mut bounds = HashMap::new();
+    for path in paths {
+        let reader = BufReader::new(
+            File::open(path)
+                .with_context(|| format!("failed to open diversions {}", path.display()))?,
+        );
+        for (line_index, line) in reader.lines().enumerate() {
+            let line = line.with_context(|| {
+                format!("failed to read {} line {}", path.display(), line_index + 1)
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(&line).with_context(|| {
+                format!("invalid JSON in {} line {}", path.display(), line_index + 1)
+            })?;
+            if value.get("type").and_then(Value::as_str) != Some("result") {
+                continue;
+            }
+            let game_id = value
+                .get("game_id")
+                .and_then(Value::as_u64)
+                .and_then(|id| u32::try_from(id).ok())
+                .with_context(|| {
+                    format!("invalid game_id in {} line {}", path.display(), line_index + 1)
+                })?;
+            let start_sfen =
+                value.get("start_sfen").and_then(Value::as_str).with_context(|| {
+                    format!("missing start_sfen in {} line {}", path.display(), line_index + 1)
+                })?;
+            let start_ply = start_sfen
+                .split_whitespace()
+                .nth(3)
+                .and_then(|ply| ply.parse::<u32>().ok())
+                .with_context(|| {
+                    format!("invalid start_sfen ply in {} line {}", path.display(), line_index + 1)
+                })?;
+            let diversions =
+                value.get("diversions").and_then(Value::as_array).with_context(|| {
+                    format!("missing diversions in {} line {}", path.display(), line_index + 1)
+                })?;
+            for diversion in diversions {
+                let relative_ply = diversion
+                    .get("ply")
+                    .and_then(Value::as_u64)
+                    .and_then(|ply| u32::try_from(ply).ok())
+                    .with_context(|| {
+                        format!(
+                            "invalid diversion ply in {} line {}",
+                            path.display(),
+                            line_index + 1
+                        )
+                    })?;
+                let ply = relative_ply
+                    .checked_sub(1)
+                    .and_then(|offset| start_ply.checked_add(offset))
+                    .and_then(|ply| u16::try_from(ply).ok())
+                    .with_context(|| {
+                        format!(
+                            "diversion ply overflow in {} line {}: start_ply={}, relative_ply={}",
+                            path.display(),
+                            line_index + 1,
+                            start_ply,
+                            relative_ply
+                        )
+                    })?;
+                bounds
+                    .entry(game_id)
+                    .and_modify(|entry: &mut DiversionBounds| {
+                        entry.first = entry.first.min(ply);
+                        entry.last = entry.last.max(ply);
+                    })
+                    .or_insert(DiversionBounds {
+                        first: ply,
+                        last: ply,
+                    });
+            }
+        }
+    }
+    Ok(bounds)
+}
+
+fn read_fixed<const N: usize>(
+    reader: &mut impl Read,
+    path: &Path,
+    record_name: &str,
+) -> Result<Option<[u8; N]>> {
+    let mut bytes = [0u8; N];
+    let read = reader
+        .read(&mut bytes[..1])
+        .with_context(|| format!("failed to read {} from {}", record_name, path.display()))?;
+    if read == 0 {
+        return Ok(None);
+    }
+    reader
+        .read_exact(&mut bytes[1..])
+        .with_context(|| format!("truncated {} at end of {}", record_name, path.display()))?;
+    Ok(Some(bytes))
+}

--- a/crates/tools/src/bin/relabel_psv.rs
+++ b/crates/tools/src/bin/relabel_psv.rs
@@ -8,6 +8,7 @@ use clap::{Parser, ValueEnum};
 use rshogi_core::position::Position;
 use rshogi_core::types::{EnteringKingRule, Move};
 use serde_json::Value;
+use tools::common::dedup::canonicalize_maybe_new;
 use tools::packed_sfen::{PackedSfenValue, unpack_sfen};
 
 #[derive(Debug, Parser)]
@@ -90,12 +91,7 @@ fn run(cli: Cli) -> Result<()> {
     }
 
     let input_paths = expand_paths(&cli.input, "--input")?;
-    if input_paths.iter().any(|path| path == &cli.output) {
-        bail!("--output must differ from every input path");
-    }
-    if cli.game_id_sidecar.as_deref() == Some(cli.output.as_path()) {
-        bail!("--output must differ from --game-id-sidecar");
-    }
+    validate_output_path(&cli.output, &input_paths, cli.game_id_sidecar.as_deref())?;
     let diversion_bounds = if cli.deblunder {
         load_diversion_bounds(&expand_paths(&cli.diversions, "--diversions")?)?
     } else {
@@ -243,6 +239,65 @@ fn expand_paths(patterns: &[String], option: &str) -> Result<Vec<PathBuf>> {
         bail!("{option} matched no files");
     }
     Ok(paths.into_iter().collect())
+}
+
+/// 出力を truncate する前に、入力または sidecar と同じ実体を指していないか検査する。
+fn validate_output_path(
+    output: &Path,
+    input_paths: &[PathBuf],
+    game_id_sidecar: Option<&Path>,
+) -> Result<()> {
+    let normalized_output = canonicalize_maybe_new(output)
+        .with_context(|| format!("failed to normalize --output {}", output.display()))?;
+
+    for input in input_paths {
+        validate_distinct_file(output, &normalized_output, input, "--input")?;
+    }
+    if let Some(sidecar) = game_id_sidecar {
+        validate_distinct_file(output, &normalized_output, sidecar, "--game-id-sidecar")?;
+    }
+    Ok(())
+}
+
+fn validate_distinct_file(
+    output: &Path,
+    normalized_output: &Path,
+    protected: &Path,
+    option: &str,
+) -> Result<()> {
+    let canonical_protected = protected
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {option} {}", protected.display()))?;
+    if normalized_output == canonical_protected || same_inode(output, protected)? {
+        bail!(
+            "--output {} resolves to the same file as {option} {}; refusing to truncate it",
+            output.display(),
+            protected.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn same_inode(a: &Path, b: &Path) -> Result<bool> {
+    use std::os::unix::fs::MetadataExt;
+
+    let a_metadata = match a.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to stat --output {}", a.display()));
+        }
+    };
+    let b_metadata = b
+        .metadata()
+        .with_context(|| format!("failed to stat protected input {}", b.display()))?;
+    Ok(a_metadata.dev() == b_metadata.dev() && a_metadata.ino() == b_metadata.ino())
+}
+
+#[cfg(not(unix))]
+fn same_inode(_a: &Path, _b: &Path) -> Result<bool> {
+    Ok(false)
 }
 
 fn load_diversion_bounds(paths: &[PathBuf]) -> Result<HashMap<u32, DiversionBounds>> {

--- a/crates/tools/tests/gensfen_sidecar_integration.rs
+++ b/crates/tools/tests/gensfen_sidecar_integration.rs
@@ -1,0 +1,152 @@
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+use tools::packed_sfen::PackedSfenValue;
+
+const BIN: &str = env!("CARGO_BIN_EXE_gensfen");
+
+#[test]
+fn gensfen_rejects_sidecar_collisions_with_normalized_output_paths() {
+    let dir = TempDir::new().unwrap();
+    let out_dir = dir.path().join("out");
+
+    for (extra_arg, sidecar) in [
+        ("--emit-eval-file", out_dir.join("gensfen.eval.txt")),
+        ("--log-info", out_dir.join(".").join("gensfen.info.jsonl")),
+        ("--emit-metrics", out_dir.join("gensfen.w1.metrics.jsonl")),
+        ("--emit-eval-file", out_dir.join(".").join("gensfen.psv")),
+    ] {
+        let result = Command::new(BIN)
+            .args([
+                "--out-dir",
+                out_dir.to_str().unwrap(),
+                "--concurrency",
+                "2",
+                extra_arg,
+                "--emit-game-id-sidecar",
+                sidecar.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(!result.status.success());
+        assert!(
+            String::from_utf8_lossy(&result.stderr).contains("conflicts"),
+            "{}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn gensfen_rejects_sidecar_collision_through_symlink_followed_by_parent_dir() {
+    use std::os::unix::fs::symlink;
+
+    let dir = TempDir::new().unwrap();
+    let out_dir = dir.path().join("out");
+    let real_dir = dir.path().join("real");
+    std::fs::create_dir_all(real_dir.join("sub")).unwrap();
+    std::fs::create_dir_all(&out_dir).unwrap();
+    symlink(real_dir.join("sub"), out_dir.join("link")).unwrap();
+
+    let training_data = real_dir.join("gensfen.psv");
+    let sidecar = out_dir.join("link").join("..").join("gensfen.psv");
+    let result = Command::new(BIN)
+        .args([
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+            "--output-training-data",
+            training_data.to_str().unwrap(),
+            "--emit-game-id-sidecar",
+            sidecar.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!result.status.success());
+    assert!(
+        String::from_utf8_lossy(&result.stderr).contains("conflicts"),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+fn write_sparse_zero_halfkp(path: &std::path::Path) {
+    const VERSION: u32 = 0x7AF3_2F16;
+    const ARCH: &[u8] = b"Features=HalfKP(Friend)[125388->256x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-32](ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))";
+    const FILE_SIZE: u64 = 64_217_066;
+
+    let mut file = OpenOptions::new().create(true).truncate(true).write(true).open(path).unwrap();
+    file.set_len(FILE_SIZE).unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+    file.write_all(&VERSION.to_le_bytes()).unwrap();
+    file.write_all(&0u32.to_le_bytes()).unwrap();
+    file.write_all(&(ARCH.len() as u32).to_le_bytes()).unwrap();
+    file.write_all(ARCH).unwrap();
+}
+
+#[test]
+fn real_native_gensfen_concatenates_psv_and_game_id_sidecar_in_lockstep() {
+    let dir = TempDir::new().unwrap();
+    let out_dir = dir.path().join("out");
+    let eval_file = dir.path().join("zero.nnue");
+    let sidecar = dir.path().join("game_ids.bin");
+    write_sparse_zero_halfkp(&eval_file);
+
+    let result = Command::new(BIN)
+        .args([
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+            "--eval-file",
+            eval_file.to_str().unwrap(),
+            "--games",
+            "2",
+            "--max-moves",
+            "2",
+            "--depth",
+            "1",
+            "--concurrency",
+            "2",
+            "--hash-mb",
+            "1",
+            "--dedup-hash-size",
+            "0",
+            "--startpos-no-repeat=false",
+            "--emit-game-id-sidecar",
+            sidecar.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+
+    let psv = out_dir.join("gensfen.psv");
+    let psv_records = std::fs::metadata(psv).unwrap().len() as usize / PackedSfenValue::SIZE;
+    let sidecar_bytes = std::fs::read(sidecar).unwrap();
+    assert_eq!(sidecar_bytes.len() % 4, 0);
+    let game_ids: Vec<u32> = sidecar_bytes
+        .chunks_exact(4)
+        .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+        .collect();
+    assert!(psv_records > 0);
+    assert_eq!(psv_records, game_ids.len());
+
+    let result_ids: HashSet<u32> =
+        BufReader::new(File::open(out_dir.join("gensfen.jsonl")).unwrap())
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(&line.unwrap()).unwrap())
+            .filter(|value| value["type"] == "result")
+            .map(|value| value["game_id"].as_u64().unwrap() as u32)
+            .collect();
+    assert_eq!(result_ids, HashSet::from([1, 2]));
+    assert!(game_ids.iter().all(|game_id| result_ids.contains(game_id)));
+
+    for worker in 0..2 {
+        assert!(!out_dir.join(format!("gensfen.w{worker}.jsonl")).exists());
+        assert!(!out_dir.join(format!("gensfen.w{worker}.psv")).exists());
+        assert!(!out_dir.join(format!("gensfen.w{worker}.game_ids.bin")).exists());
+    }
+}

--- a/crates/tools/tests/relabel_psv_integration.rs
+++ b/crates/tools/tests/relabel_psv_integration.rs
@@ -41,6 +41,125 @@ fn hirate() -> Position {
     pos
 }
 
+fn assert_rejected_without_modifying(command: &mut Command, protected: &Path) {
+    let original = std::fs::read(protected).unwrap();
+    let result = command.output().unwrap();
+    assert!(!result.status.success());
+    assert!(
+        String::from_utf8_lossy(&result.stderr).contains("resolves to the same file"),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(std::fs::read(protected).unwrap(), original);
+}
+
+#[test]
+fn output_with_equivalent_relative_spelling_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("x.psv");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+
+    assert_rejected_without_modifying(
+        Command::new(BIN)
+            .current_dir(dir.path())
+            .args(["--input", "./x.psv", "--output", "x.psv"]),
+        &input,
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn output_through_symlink_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+    symlink(&input, &output).unwrap();
+
+    assert_rejected_without_modifying(
+        Command::new(BIN).args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+        ]),
+        &input,
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn output_through_hardlink_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+    std::fs::hard_link(&input, &output).unwrap();
+
+    assert_rejected_without_modifying(
+        Command::new(BIN).args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+        ]),
+        &input,
+    );
+}
+
+#[test]
+fn output_distinct_from_input_is_accepted() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("nested/output.psv");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+
+    let result = Command::new(BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output)[0].score, 2500);
+}
+
+#[test]
+fn output_same_as_game_id_sidecar_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let sidecar = dir.path().join("game_ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+    std::fs::write(&sidecar, 42u32.to_le_bytes()).unwrap();
+    std::fs::write(&diversions, "{\"type\":\"meta\"}\n").unwrap();
+
+    assert_rejected_without_modifying(
+        Command::new(BIN).args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            sidecar.to_str().unwrap(),
+            "--deblunder",
+            "--game-id-sidecar",
+            sidecar.to_str().unwrap(),
+            "--diversions",
+            diversions.to_str().unwrap(),
+        ]),
+        &sidecar,
+    );
+}
+
 #[test]
 fn score_is_replaced_from_side_to_move_game_result_and_is_deterministic() {
     let dir = TempDir::new().unwrap();

--- a/crates/tools/tests/relabel_psv_integration.rs
+++ b/crates/tools/tests/relabel_psv_integration.rs
@@ -1,0 +1,206 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use rshogi_core::position::Position;
+use tempfile::TempDir;
+use tools::packed_sfen::{PackedSfenValue, pack_position};
+
+const BIN: &str = env!("CARGO_BIN_EXE_relabel_psv");
+
+fn record(pos: &Position, score: i16, game_ply: u16, game_result: i8) -> PackedSfenValue {
+    PackedSfenValue {
+        sfen: pack_position(pos),
+        score,
+        move16: 0,
+        game_ply,
+        game_result,
+        padding: 0,
+    }
+}
+
+fn write_psv(path: &Path, records: &[PackedSfenValue]) {
+    let mut file = File::create(path).unwrap();
+    for record in records {
+        file.write_all(&record.to_bytes()).unwrap();
+    }
+}
+
+fn read_psv(path: &Path) -> Vec<PackedSfenValue> {
+    std::fs::read(path)
+        .unwrap()
+        .chunks_exact(PackedSfenValue::SIZE)
+        .map(|bytes| PackedSfenValue::from_bytes(bytes).unwrap())
+        .collect()
+}
+
+fn hirate() -> Position {
+    let mut pos = Position::new();
+    pos.set_hirate();
+    pos
+}
+
+#[test]
+fn score_is_replaced_from_side_to_move_game_result_and_is_deterministic() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output_a = dir.path().join("output-a.psv");
+    let output_b = dir.path().join("output-b.psv");
+    let pos = hirate();
+    write_psv(
+        &input,
+        &[
+            record(&pos, -12, 1, 1),
+            record(&pos, 34, 2, -1),
+            record(&pos, 56, 3, 0),
+        ],
+    );
+
+    for output in [&output_a, &output_b] {
+        let result = Command::new(BIN)
+            .args([
+                "--input",
+                input.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--win-cp",
+                "1234",
+            ])
+            .output()
+            .unwrap();
+        assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert!(stderr.contains("input=3 win=1 loss=1 draw=1"));
+    }
+
+    let scores: Vec<i16> = read_psv(&output_a).iter().map(|record| record.score).collect();
+    assert_eq!(scores, [1234, -1234, 0]);
+    assert_eq!(std::fs::read(output_a).unwrap(), std::fs::read(output_b).unwrap());
+}
+
+#[test]
+fn declaration_override_uses_side_to_move_declaration_win() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let mut pos = Position::new();
+    pos.set_sfen("KGG6/SS7/PPPPPP3/9/9/9/2pppppp1/1ss1gg1nl/4k2nl b 2R2B3p 1")
+        .unwrap();
+    write_psv(&input, &[record(&pos, -100, 1, -1)]);
+
+    let result = Command::new(BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--win-cp",
+            "2222",
+            "--declaration-override",
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output)[0].score, 2222);
+    assert!(String::from_utf8_lossy(&result.stderr).contains("declaration_override=1"));
+}
+
+#[test]
+fn deblunder_modes_drop_before_the_selected_diversion_boundary() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let sidecar = dir.path().join("game_ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    let records: Vec<_> = (2..=6).map(|ply| record(&pos, 10, ply, 1)).collect();
+    write_psv(&input, &records);
+    let mut ids = File::create(&sidecar).unwrap();
+    for _ in &records {
+        ids.write_all(&42u32.to_le_bytes()).unwrap();
+    }
+    std::fs::write(
+        &diversions,
+        concat!(
+            "{\"type\":\"meta\"}\n",
+            "{\"type\":\"result\",\"game_id\":42,",
+            "\"start_sfen\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\",",
+            "\"diversions\":[{\"ply\":5},{\"ply\":3}]}\n"
+        ),
+    )
+    .unwrap();
+
+    for (mode, expected_plies, expected_drops) in [
+        ("drop-before-last", vec![6], 4),
+        ("drop-before-any", vec![4, 5, 6], 2),
+    ] {
+        let output = dir.path().join(format!("{mode}.psv"));
+        let result = Command::new(BIN)
+            .args([
+                "--input",
+                input.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--deblunder",
+                "--game-id-sidecar",
+                sidecar.to_str().unwrap(),
+                "--diversions",
+                diversions.to_str().unwrap(),
+                "--deblunder-mode",
+                mode,
+            ])
+            .output()
+            .unwrap();
+        assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+        let plies: Vec<u16> = read_psv(&output).iter().map(|record| record.game_ply).collect();
+        assert_eq!(plies, expected_plies);
+        assert!(
+            String::from_utf8_lossy(&result.stderr)
+                .contains(&format!("deblunder_drop={expected_drops}"))
+        );
+    }
+}
+
+#[test]
+fn deblunder_converts_relative_diversion_ply_from_midgame_start_sfen() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("game_ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    let records: Vec<_> = (100..=103).map(|ply| record(&pos, 10, ply, 1)).collect();
+    write_psv(&input, &records);
+    let mut ids = File::create(&sidecar).unwrap();
+    for _ in &records {
+        ids.write_all(&7u32.to_le_bytes()).unwrap();
+    }
+    std::fs::write(
+        &diversions,
+        concat!(
+            "{\"type\":\"result\",\"game_id\":7,",
+            "\"start_sfen\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 100\",",
+            "\"diversions\":[{\"ply\":2}]}\n"
+        ),
+    )
+    .unwrap();
+
+    let result = Command::new(BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--deblunder",
+            "--game-id-sidecar",
+            sidecar.to_str().unwrap(),
+            "--diversions",
+            diversions.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    let plies: Vec<u16> = read_psv(&output).iter().map(|record| record.game_ply).collect();
+    assert_eq!(plies, [102, 103]);
+    assert!(String::from_utf8_lossy(&result.stderr).contains("deblunder_drop=2"));
+}


### PR DESCRIPTION
## 概要

入玉教師データ（外部 PSV + 自前 gensfen PSV）を NNUE 学習で使う際の score 後処理ツール `relabel_psv` と、その deblunder に必要な gensfen 側の game_id sidecar を追加する。

## 背景

現行学習レシピは λ=0（`--wdl 0.0`）で score をそのまま蒸留するため、入玉領域の score（弱い/異系統エンジンの depth9 評価）が循環ラベルになる。そこで PSV の score を game_result 由来の飽和値へ上書きして勝敗信号ベースにする。さらに自前 gensfen は乱択（`--random-multi-pv`）で悪手を注入した対局があり、乱択 ply より前の局面の game_result が汚染される。これを diversions 来歴で除外（deblunder）する。

## gensfen: `--emit-game-id-sidecar <path>`

- PSV レコードごとに game_id を u32 LE で **1:1・同順** 出力（PSV 形式専用、`--resume` 併用不可）。deblunder の局面→対局対応付けに使う。
- sidecar パスが gensfen の全成果物（training-data / gensfen.jsonl / info-log / eval-file / metrics と各 worker 一時ファイル）と衝突する場合は**正規化パス比較で拒否**。symlink 直後の `..` も「存在する最深祖先を canonicalize」して健全に解決。

## relabel_psv（新規）

- **score 上書き（必須）**: game_result の手番側視点に従い win→`+win_cp` / loss→`-win_cp` / draw→0（`--win-cp` 既定 2500）。
- **`--declaration-override`（任意・既定 off）**: 局面を decode し `declaration_win=WIN` なら `+win_cp`。decode コスト高のため既定 off。
- **`--deblunder`（任意・既定 off）**: `--game-id-sidecar` + `--diversions` を取り、result 行の start_sfen 手数 S で相対 diversion ply r を絶対手数 `S+r-1` に変換し、`game_ply <= 境界`（drop-before-last / drop-before-any）のレコードを除外。
- 全体 streaming。ピークメモリは PSV/sidecar レコード数に非依存（diversions map のみ対局数オーダー）。入力パスは辞書順で決定的。

## レビュー

Codex(gpt-5.6-sol) + Claude(Fable) の 2 レビュー実施。両者が独立に **F1（deblunder の ply 基準不一致＝絶対 game_ply vs 相対 diversion ply で中盤開始データで drop 皆無・High）** を検出。加えて Codex が Medium 複数（sidecar パス衝突検査の網羅不足・字句比較→正規化・symlink+`..` 健全性、テストが実 gensfen 経路未通過）を発見。全て修正し、最終 APPROVE 済み。

## テスト

- cargo fmt --check / clippy -p tools（`--tests -- -D warnings` 含め警告0）/ test -p tools（21 pass）/ check-tracked-abs-paths.sh すべて green
- score 上書きの手番視点符号、declaration override、deblunder（**中盤開始 start_ply=100 で相対→絶対変換を検証する回帰テスト**、両モード）、sidecar の 1:1 lockstep、実 gensfen(NativeBackend)+worker 連結を通す統合テスト、パス衝突（eval-file / 別表記 / symlink+`..`）のテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147CkyzPB8d5KHi5UeVpadA