### PR TITLE
perf(csa-server-workers): viewer API の R2 get N+1 を並列化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,6 +2532,7 @@ name = "rshogi-csa-server-workers"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures-util",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",

--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -35,11 +35,13 @@ sha2 = { version = "0.10", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm32-unknown-unknown 以外では参照しない。worker-build / wrangler dev から
-# ビルドされる経路のみで有効化される。`worker` 0.8 が `wasm-bindgen` /
+# ビルドされる経路のみで有効化される。`worker` 0.8 は `wasm-bindgen` /
 # `wasm-bindgen-futures` / `js-sys` / `async-trait` / `futures-util` を内部で
-# 引き込むので、本 crate からは worker のみを直接参照すればよい。
+# 引き込むが、`futures_util::future::join_all` (viewer_api の R2 get 並列化) を
+# 本 crate から直接使うため `futures-util` は明示的な直接依存にしている。
 worker = { version = "0.8", features = ["http"] }
 worker-macros = { version = "0.8", features = ["http"] }
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [features]
 default = []

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -34,6 +34,7 @@
 //!
 //! 1 リクエストで `bucket.list` (1 RTT) + 各 entry `bucket.get` (最大 N=100 RTT)
 //! を消費する N+1 パターンを Cloudflare の `caches.default` で短期キャッシュする。
+//! cache miss 時は各 entry の `bucket.get` を並列実行し、R2 待ち時間を重ねる。
 //! cache key は **request URL 完全一致** (= path + query + method)。同一 cursor +
 //! 同一 limit の重複アクセスのみが hit する。
 //!
@@ -448,8 +449,8 @@ async fn collect_index_page(
         }
     };
 
-    let mut entries: Vec<serde_json::Value> = Vec::with_capacity(page.objects().len());
-    for obj in page.objects() {
+    let objects = page.objects();
+    let fetches = objects.iter().map(|obj| async {
         let key = obj.key();
         // 各 entry を取得 → bytes → JSON value。bytes 経由なのは本文が
         // そのまま `*IndexEntry` の JSON 形式である契約のため。
@@ -461,18 +462,16 @@ async fn collect_index_page(
                     client_kind,
                     &format!("key={key} err={e}"),
                 );
-                continue;
+                return None;
             }
         };
         let Some(fetched) = fetched else {
             // list と get の間に削除されたケース。live entry の場合は終局
             // (delete) と list のレースに該当する。pagination 整合の観点で
             // 落としても問題ない (= live は entry が瞬間的に消えうる契約)。
-            continue;
+            return None;
         };
-        let Some(body) = fetched.body() else {
-            continue;
-        };
+        let body = fetched.body()?;
         let bytes = match body.bytes().await {
             Ok(b) => b,
             Err(e) => {
@@ -481,11 +480,11 @@ async fn collect_index_page(
                     client_kind,
                     &format!("key={key} err={e}"),
                 );
-                continue;
+                return None;
             }
         };
         match serde_json::from_slice::<serde_json::Value>(&bytes) {
-            Ok(v) => entries.push(v),
+            Ok(v) => Some(v),
             Err(e) => {
                 log_viewer_api_failed(
                     &format!("{event_root}_parse"),
@@ -493,9 +492,12 @@ async fn collect_index_page(
                     &format!("key={key} err={e}"),
                 );
                 // 1 件壊れても他を返す (best-effort)。
+                None
             }
         }
-    }
+    });
+    // `join_all` は結果を入力順で返すため、失敗 entry を除いても R2 list 順を保つ。
+    let entries = futures_util::future::join_all(fetches).await.into_iter().flatten().collect();
 
     let next_cursor = if page.truncated() {
         page.cursor()


### PR DESCRIPTION
## Summary

- `/api/v1/games` / `/api/v1/games/live` 一覧ハンドラ `collect_index_page` が R2 の各 entry `get` を逐次 `await` していたため、edge cache miss 時に ttfb が実測で 1.5〜3.0秒 かかっていた(cache HIT 時は 45-70ms、`curl -w` で確認)。
- `futures_util::future::join_all` で R2 get + body 読み込みを並列化。`entries` の順序は R2 list 順を保持し、get失敗/削除済み/JSON parse失敗の best-effort skip 契約とエラーログ内容は変更前と同一。

## 関連

- 関連: #636 (R2 Class B ops 削減目的の N+1 パターン記述。今回はレイテンシ側の根本対応で ops 消費数自体は変わらない)

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --fix --allow-dirty --tests -p rshogi-csa-server-workers` (警告ゼロ)
- [x] `cargo test -p rshogi-csa-server-workers` (unit 343 / integration 37、failures 0)
- [x] `bash scripts/check-tracked-abs-paths.sh`
- [x] local reviewer #1 (Codex 系) APPROVE
- [x] local reviewer #2 (Claude/Fable 系) APPROVE
- [ ] フォローアップ(本PRスコープ外、別issue化推奨): デプロイ後に同じ `curl -w` で before/after を実測記録し、Workers の同時接続数上限(6)との理論値突き合わせ。miniflare での list エンドポイントの順序保持/best-effort skip smoke テスト追加。