### PR TITLE
tools: book_rescore --onnx-batch-size default を 1024 に変更

### DIFF
--- a/crates/tools/docs/book_rescore.md
+++ b/crates/tools/docs/book_rescore.md
@@ -27,7 +27,6 @@ cargo run -p tools --release --bin book_rescore -- \
   --book input.db \
   --out rescored_static.db \
   --dlshogi-onnx-model /path/to/dlshogi_model.onnx \
-  --onnx-batch-size 256 \
   --onnx-gpu-id 0 \
   --eval-scale 600.0 \
   --journal rescored_static.jsonl \
@@ -44,7 +43,7 @@ cargo run -p tools --release --bin book_rescore -- \
 | `--engine-option <k=v>` | USI option。複数指定可（USI 探索モード） |
 | `--go "<args>"` | `go` に渡す引数。例: `nodes 100000`, `depth 15`（USI 探索モード） |
 | `--dlshogi-onnx-model <path>` | dlshogi 形式 ONNX value head。`--engine` と排他 |
-| `--onnx-batch-size <N>` | ONNX 推論バッチサイズ。既定 256 |
+| `--onnx-batch-size <N>` | ONNX 推論バッチサイズ。既定 1024（GPU 推論の実測で 512〜2048 はフラット、256 は −13% 遅い。CPU 推論・省メモリ環境では小さい値も検討） |
 | `--onnx-gpu-id <id>` | ONNX 推論の GPU ID。`-1` で CPU。既定 0 |
 | `--onnx-tensorrt` | ONNX 推論で TensorRT EP を使う |
 | `--onnx-tensorrt-cache <dir>` | TensorRT エンジンキャッシュ保存先 |

--- a/crates/tools/src/bin/book_rescore.rs
+++ b/crates/tools/src/bin/book_rescore.rs
@@ -30,7 +30,7 @@ struct Cli {
     engine_options: Vec<String>,
     #[arg(long)]
     dlshogi_onnx_model: Option<PathBuf>,
-    #[arg(long, default_value_t = 256)]
+    #[arg(long, default_value_t = 1024)]
     onnx_batch_size: usize,
     #[arg(long, default_value_t = 0)]
     onnx_gpu_id: i32,


### PR DESCRIPTION
## 概要

`book_rescore` の ONNX 静的評価の `--onnx-batch-size` default を 256 → 1024 に変更する。同じ `tools::onnx_value::OnnxValueEvaluator` を使う `label_bench_dl` / `yardstick_label` の既定は既に 1024 で、book_rescore だけ 256 だった。

## 実測 (RTX 3080 Ti、DL水匠 + TensorRT FP16、385k 局面)

共有 OnnxValueEvaluator の batch 掃引 (best of 2):

| batch | 256 | 512 | 1024 | 2048 | 4096 |
|---|---|---|---|---|---|
| pos/s | 21,646 | 25,024 | 24,927 | 24,830 | 24,975 |

512〜2048 はフラット、256 (旧 default) だけ −13%。

## resume 互換性

journal に batch size は記録されず、各局面が独立 JSONL レコードとして推論完了後に flush される (resume は局面キー / go / モデル fingerprint で判定)。旧既定 256 の journal を新既定で再開しても不整合は起きない。中断時の再実行量が最大 1 batch 分 (1024 件) に増えるのみで、既存 doc の「途中結果は all-or-nothing」と整合。

## チェック

- [x] cargo fmt / clippy クリーン
- [x] cargo test -p tools --bin book_rescore pass
- [x] scripts/check-tracked-abs-paths.sh OK
- [x] ローカル Codex レビュー Approve 済み (journal/resume 互換確認込み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pds3K7WfHwSS16NVXPLHLn