### PR TITLE
feat(csa-server-workers): D1検索インデックスと GET /api/v1/games/search を追加

### DIFF
--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = { version = "0.10", default-features = false }
 # `wasm-bindgen-futures` / `js-sys` / `async-trait` / `futures-util` を内部で
 # 引き込むが、`futures_util::future::join_all` (viewer_api の R2 get 並列化) を
 # 本 crate から直接使うため `futures-util` は明示的な直接依存にしている。
-worker = { version = "0.8", features = ["http"] }
+worker = { version = "0.8", features = ["d1", "http"] }
 worker-macros = { version = "0.8", features = ["http"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 

--- a/crates/rshogi-csa-server-workers/migrations/0001_games_search_index.sql
+++ b/crates/rshogi-csa-server-workers/migrations/0001_games_search_index.sql
@@ -1,0 +1,20 @@
+CREATE TABLE games_search_index (
+    game_id TEXT PRIMARY KEY,
+    sente_name TEXT NOT NULL,
+    gote_name TEXT NOT NULL,
+    started_at_ms INTEGER NOT NULL,
+    ended_at_ms INTEGER NOT NULL,
+    result_kind TEXT NOT NULL,
+    source TEXT NOT NULL,
+    moves_count INTEGER NOT NULL,
+    wire_result_kind TEXT NOT NULL,
+    end_reason TEXT NOT NULL,
+    clock_json TEXT NOT NULL
+);
+
+CREATE INDEX games_search_index_ended_at_ms
+    ON games_search_index (ended_at_ms DESC);
+CREATE TABLE games_search_backfill_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    r2_cursor TEXT NOT NULL
+);

--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -46,6 +46,85 @@ pub(crate) const META_SUFFIX: &str = ".meta.json";
 /// 経由で複数ページ一気に処理する案 (設計 v2 §5 (a)) を別 issue で検討する。
 pub(crate) const PAGE_SIZE: u32 = 1000;
 
+/// D1 state に保存する完了マーカー。R2 cursor と衝突しない予約値。
+const GAMES_SEARCH_BACKFILL_COMPLETE: &str = "__COMPLETE__";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchBackfillStart {
+    Scan,
+    ReturnComplete,
+}
+
+fn search_backfill_start(cursor: Option<&str>) -> SearchBackfillStart {
+    if cursor == Some(GAMES_SEARCH_BACKFILL_COMPLETE) {
+        SearchBackfillStart::ReturnComplete
+    } else {
+        SearchBackfillStart::Scan
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchBackfillItemOutcome {
+    PermanentSkip,
+    R2GetError,
+    R2BodyMissing,
+    R2BodyReadError,
+    D1UpsertError,
+    DeadlineExceeded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchBackfillItemControl {
+    Continue,
+    RetryPage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchBackfillStateOperation<'a> {
+    RetryPage,
+    CursorMissing,
+    UpdateCursor(&'a str),
+    MarkComplete,
+}
+
+#[derive(Debug, Default)]
+struct SearchBackfillPageState {
+    retry_page: bool,
+}
+
+impl SearchBackfillPageState {
+    fn record(&mut self, outcome: SearchBackfillItemOutcome) -> SearchBackfillItemControl {
+        match outcome {
+            SearchBackfillItemOutcome::PermanentSkip => SearchBackfillItemControl::Continue,
+            SearchBackfillItemOutcome::R2GetError
+            | SearchBackfillItemOutcome::R2BodyMissing
+            | SearchBackfillItemOutcome::R2BodyReadError
+            | SearchBackfillItemOutcome::D1UpsertError
+            | SearchBackfillItemOutcome::DeadlineExceeded => {
+                self.retry_page = true;
+                SearchBackfillItemControl::RetryPage
+            }
+        }
+    }
+
+    fn finish<'a>(
+        self,
+        truncated: bool,
+        next_cursor: Option<&'a str>,
+    ) -> SearchBackfillStateOperation<'a> {
+        if self.retry_page {
+            SearchBackfillStateOperation::RetryPage
+        } else if truncated {
+            next_cursor.map_or(
+                SearchBackfillStateOperation::CursorMissing,
+                SearchBackfillStateOperation::UpdateCursor,
+            )
+        } else {
+            SearchBackfillStateOperation::MarkComplete
+        }
+    }
+}
+
 /// `run_live_orphan_sweep` の 1 cron 内 pagination 上限 (https://github.com/SH11235/rshogi/issues/629)。
 ///
 /// Cloudflare Workers の cron 起動は wall-clock 30s 制限を持つため、安全側
@@ -168,14 +247,18 @@ pub(crate) fn live_entry_hard_ttl_expired(age_ms: u64) -> bool {
 #[cfg(target_arch = "wasm32")]
 mod imp {
     use super::{
-        BackfillStats, KIFU_BY_ID_PREFIX, LIVE_ENTRY_HARD_TTL_MS, LiveEntryFields, META_SUFFIX,
-        MetaForIndexKey, PAGE_SIZE, SWEEP_DEADLINE_MS, SWEEP_MAX_PAGES, SweepStats,
-        live_entry_hard_ttl_expired,
+        BackfillStats, GAMES_SEARCH_BACKFILL_COMPLETE, KIFU_BY_ID_PREFIX, LIVE_ENTRY_HARD_TTL_MS,
+        LiveEntryFields, META_SUFFIX, MetaForIndexKey, PAGE_SIZE, SWEEP_DEADLINE_MS,
+        SWEEP_MAX_PAGES, SearchBackfillItemOutcome, SearchBackfillPageState, SearchBackfillStart,
+        SearchBackfillStateOperation, SweepStats, live_entry_hard_ttl_expired,
+        search_backfill_start,
     };
     use worker::{Date, Env, Result};
 
     use crate::config::ConfigKeys;
+    use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
     use crate::games_index::games_index_key;
+    use crate::games_search_index::{OwnedGamesIndexEntry, upsert_owned};
     use crate::live_games_index::LIVE_KEY_PREFIX;
     use crate::x1_paths::kifu_by_id_meta_key;
 
@@ -313,6 +396,151 @@ mod imp {
             skipped: stats.skipped,
             elapsed_ms: elapsed_ms,
         );
+        Ok(stats)
+    }
+
+    /// R2 `games-index/` をページングし、D1 検索 index を冪等 upsert する。
+    /// 1 cron で最大 25 秒だけ処理し、Workers の実行時間上限へ余裕を残す。
+    pub async fn run_games_search_backfill(env: &Env) -> Result<BackfillStats> {
+        const DEADLINE_MS: u64 = 25_000;
+        let started_at_ms = Date::now().as_millis();
+        let mut stats = BackfillStats::default();
+        let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
+            Ok(bucket) => bucket,
+            Err(e) => {
+                crate::structured_log!(event: "games_search_backfill_bucket_failed", component: "backfill", err: format!("{e:?}"));
+                return Ok(stats);
+            }
+        };
+        let db = match env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING) {
+            Ok(db) => db,
+            Err(e) => {
+                crate::structured_log!(event: "games_search_backfill_d1_failed", component: "backfill", err: format!("{e:?}"));
+                return Ok(stats);
+            }
+        };
+        let mut cursor = match db
+            .prepare("SELECT r2_cursor FROM games_search_backfill_state WHERE singleton = 1")
+            .first::<String>(Some("r2_cursor"))
+            .await
+        {
+            Ok(cursor) => cursor,
+            Err(e) => {
+                crate::structured_log!(event: "games_search_backfill_state_read_failed", component: "backfill", err: format!("{e:?}"));
+                return Ok(stats);
+            }
+        };
+        if search_backfill_start(cursor.as_deref()) == SearchBackfillStart::ReturnComplete {
+            return Ok(stats);
+        }
+        loop {
+            if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+                break;
+            }
+            let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX).limit(PAGE_SIZE);
+            if let Some(value) = cursor.as_deref() {
+                builder = builder.cursor(value);
+            }
+            let page = match builder.execute().await {
+                Ok(page) => page,
+                Err(e) => {
+                    crate::structured_log!(event: "games_search_backfill_list_failed", component: "backfill", err: format!("{e:?}"));
+                    break;
+                }
+            };
+            let mut page_state = SearchBackfillPageState::default();
+            for object in page.objects() {
+                if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+                    page_state.record(SearchBackfillItemOutcome::DeadlineExceeded);
+                    break;
+                }
+                let key = object.key();
+                stats.listed = stats.listed.saturating_add(1);
+                let fetched = match bucket.get(&key).execute().await {
+                    Ok(Some(object)) => object,
+                    Ok(None) => {
+                        crate::structured_log!(event: "games_search_backfill_get_missing", component: "backfill", key: key);
+                        stats.skipped = stats.skipped.saturating_add(1);
+                        continue;
+                    }
+                    Err(e) => {
+                        crate::structured_log!(event: "games_search_backfill_get_failed", component: "backfill", key: key, err: format!("{e:?}"));
+                        page_state.record(SearchBackfillItemOutcome::R2GetError);
+                        stats.skipped = stats.skipped.saturating_add(1);
+                        break;
+                    }
+                };
+                let Some(body) = fetched.body() else {
+                    crate::structured_log!(event: "games_search_backfill_body_missing", component: "backfill", key: key);
+                    page_state.record(SearchBackfillItemOutcome::R2BodyMissing);
+                    stats.skipped = stats.skipped.saturating_add(1);
+                    break;
+                };
+                let bytes = match body.bytes().await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        crate::structured_log!(event: "games_search_backfill_read_failed", component: "backfill", key: key, err: format!("{e:?}"));
+                        page_state.record(SearchBackfillItemOutcome::R2BodyReadError);
+                        stats.skipped = stats.skipped.saturating_add(1);
+                        break;
+                    }
+                };
+                let entry = match serde_json::from_slice::<OwnedGamesIndexEntry>(&bytes) {
+                    Ok(entry) => entry,
+                    Err(e) => {
+                        // JSON 破損は恒久エラーとしてこの object だけを skip する。
+                        crate::structured_log!(event: "games_search_backfill_parse_failed", component: "backfill", key: key, err: format!("{e:?}"));
+                        stats.skipped = stats.skipped.saturating_add(1);
+                        page_state.record(SearchBackfillItemOutcome::PermanentSkip);
+                        continue;
+                    }
+                };
+                match upsert_owned(env, &entry).await {
+                    Ok(()) => stats.put = stats.put.saturating_add(1),
+                    Err(e) => {
+                        crate::structured_log!(event: "games_search_backfill_upsert_failed", component: "backfill", game_id: entry.game_id, err: format!("{e:?}"));
+                        stats.skipped = stats.skipped.saturating_add(1);
+                        page_state.record(SearchBackfillItemOutcome::D1UpsertError);
+                        break;
+                    }
+                }
+                if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+                    page_state.record(SearchBackfillItemOutcome::DeadlineExceeded);
+                    break;
+                }
+            }
+            let next_cursor = page.cursor();
+            let operation = page_state.finish(page.truncated(), next_cursor.as_deref());
+            let state_value = match operation {
+                SearchBackfillStateOperation::RetryPage => break,
+                SearchBackfillStateOperation::CursorMissing => {
+                    crate::structured_log!(event: "games_search_backfill_cursor_missing", component: "backfill");
+                    break;
+                }
+                SearchBackfillStateOperation::UpdateCursor(value) => value,
+                SearchBackfillStateOperation::MarkComplete => GAMES_SEARCH_BACKFILL_COMPLETE,
+            };
+            let bind = [worker::wasm_bindgen::JsValue::from_str(state_value)];
+            let state_statement = match db
+                .prepare("INSERT INTO games_search_backfill_state (singleton, r2_cursor) VALUES (1, ?) ON CONFLICT(singleton) DO UPDATE SET r2_cursor=excluded.r2_cursor")
+                .bind(&bind)
+            {
+                Ok(statement) => statement,
+                Err(e) => {
+                    crate::structured_log!(event: "games_search_backfill_state_prepare_failed", component: "backfill", err: format!("{e:?}"));
+                    break;
+                }
+            };
+            if let Err(e) = state_statement.run().await {
+                crate::structured_log!(event: "games_search_backfill_state_write_failed", component: "backfill", err: format!("{e:?}"));
+                break;
+            }
+            if operation == SearchBackfillStateOperation::MarkComplete {
+                break;
+            }
+            cursor = Some(state_value.to_owned());
+        }
+        crate::structured_log!(event: "games_search_backfill_progress", component: "backfill", listed: stats.listed, put: stats.put, skipped: stats.skipped);
         Ok(stats)
     }
 
@@ -610,7 +838,7 @@ mod imp {
 }
 
 #[cfg(target_arch = "wasm32")]
-pub use imp::{run_games_index_backfill, run_live_orphan_sweep};
+pub use imp::{run_games_index_backfill, run_games_search_backfill, run_live_orphan_sweep};
 
 #[cfg(test)]
 mod tests {
@@ -698,6 +926,55 @@ mod tests {
                 put: 0,
                 skipped: 0
             }
+        );
+    }
+
+    #[test]
+    fn search_backfill_deadline_selects_retry_page_and_keeps_cursor() {
+        let mut state = SearchBackfillPageState::default();
+        assert_eq!(
+            state.record(SearchBackfillItemOutcome::DeadlineExceeded),
+            SearchBackfillItemControl::RetryPage
+        );
+        assert_eq!(state.finish(true, Some("next")), SearchBackfillStateOperation::RetryPage);
+    }
+
+    #[test]
+    fn search_backfill_temporary_io_failures_keep_cursor() {
+        for failure in [
+            SearchBackfillItemOutcome::R2GetError,
+            SearchBackfillItemOutcome::R2BodyMissing,
+            SearchBackfillItemOutcome::R2BodyReadError,
+            SearchBackfillItemOutcome::D1UpsertError,
+        ] {
+            let mut state = SearchBackfillPageState::default();
+            assert_eq!(state.record(failure), SearchBackfillItemControl::RetryPage, "{failure:?}");
+            assert_eq!(
+                state.finish(true, Some("next")),
+                SearchBackfillStateOperation::RetryPage,
+                "{failure:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn search_backfill_json_parse_failure_advances_cursor() {
+        let mut state = SearchBackfillPageState::default();
+        assert_eq!(
+            state.record(SearchBackfillItemOutcome::PermanentSkip),
+            SearchBackfillItemControl::Continue
+        );
+        assert_eq!(
+            state.finish(true, Some("next")),
+            SearchBackfillStateOperation::UpdateCursor("next")
+        );
+    }
+
+    #[test]
+    fn search_backfill_completion_marker_causes_early_return() {
+        assert_eq!(
+            search_backfill_start(Some(GAMES_SEARCH_BACKFILL_COMPLETE)),
+            SearchBackfillStart::ReturnComplete
         );
     }
 

--- a/crates/rshogi-csa-server-workers/src/backfill.rs
+++ b/crates/rshogi-csa-server-workers/src/backfill.rs
@@ -8,11 +8,12 @@
 //! - [`run_live_orphan_sweep`]: `live-games-index/` を pagination loop で list
 //!   し、対応する `kifu-by-id/<id>.meta.json` (= 終局済 primary 判定キー、設計
 //!   v3 §3) が存在する live entry を delete する (orphan 掃除)。https://github.com/SH11235/rshogi/issues/629 で
-//!   1 page → 複数 page (`SWEEP_DEADLINE_MS` 内) に拡張した。
+//!   1 page → 複数 page (共有 deadline 内) に拡張した。
 //!
 //! `run_games_index_backfill` は 1 page (1000 件) のみ処理し、cursor の持ち越し
 //! は行わない (= 次回 cron で続行する eventual semantics)。
-//! `run_live_orphan_sweep` は cron 30s 制限の安全側 (`SWEEP_DEADLINE_MS`) 内で
+//! games-search backfill と `run_live_orphan_sweep` は cron 30s 制限の安全側
+//! (`SCHEDULED_WORK_DEADLINE_MS`) を共有し、
 //! 複数 page を処理し、超過分は次回 cron に持ち越す (cursor は再開しない =
 //! 先頭から再走査するが、live key は新しい対局順なので大きな問題にならない)。
 //! admin invoke endpoint や 1 万件超の bulk 並列化はスコープ外
@@ -52,12 +53,46 @@ const GAMES_SEARCH_BACKFILL_COMPLETE: &str = "__COMPLETE__";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SearchBackfillStart {
     Scan,
-    ReturnComplete,
+    HealRecent,
+}
+
+impl SearchBackfillStart {
+    /// ログ用の識別文字列。運用時に Scan(通常バックフィル) と
+    /// HealRecent(完了後の自己修復) を区別できるようにする。
+    fn as_log_str(self) -> &'static str {
+        match self {
+            Self::Scan => "scan",
+            Self::HealRecent => "heal_recent",
+        }
+    }
+}
+
+impl SearchBackfillStart {
+    fn initial_cursor(self, saved_cursor: Option<String>) -> Option<String> {
+        match self {
+            Self::Scan => saved_cursor,
+            Self::HealRecent => None,
+        }
+    }
+
+    fn list_limit(self) -> u32 {
+        match self {
+            Self::Scan => PAGE_SIZE,
+            Self::HealRecent => GAMES_SEARCH_HEAL_LIMIT,
+        }
+    }
+
+    fn max_pages(self) -> Option<u32> {
+        match self {
+            Self::Scan => None,
+            Self::HealRecent => Some(1),
+        }
+    }
 }
 
 fn search_backfill_start(cursor: Option<&str>) -> SearchBackfillStart {
     if cursor == Some(GAMES_SEARCH_BACKFILL_COMPLETE) {
-        SearchBackfillStart::ReturnComplete
+        SearchBackfillStart::HealRecent
     } else {
         SearchBackfillStart::Scan
     }
@@ -125,15 +160,33 @@ impl SearchBackfillPageState {
     }
 }
 
-/// `run_live_orphan_sweep` の 1 cron 内 pagination 上限 (https://github.com/SH11235/rshogi/issues/629)。
+/// games-search backfill と orphan sweep が共有する 1 cron 内の処理期限。
 ///
 /// Cloudflare Workers の cron 起動は wall-clock 30s 制限を持つため、安全側
-/// マージン (5s) を引いた 25s で打ち切り、未処理 page は次回 cron に持ち越す。
-/// 各 object 処理は `head` + 条件付き `delete` (Class B) で平均 5-10ms 想定の
-/// ため、1 page (1000 件) で約 5-10s。25s なら 2-3 page を安全に処理できる。
-pub(crate) const SWEEP_DEADLINE_MS: u64 = 25_000;
+/// マージン (5s) を引いた 25s を cron 発火時刻から共有する。search backfill が
+/// 長引いた場合、後続 sweep の残り時間はその分だけ減り、0 にもなりうる
+/// (:15/:30/:45 は sweep 単独で従来同等の実質 25s を使えるため、:00 で
+/// sweep が飢餓しても最大 15 分で全予算に回復する)。
+pub(crate) const SCHEDULED_WORK_DEADLINE_MS: u64 = 25_000;
 
-/// `run_live_orphan_sweep` の安全側 page 上限 (https://github.com/SH11235/rshogi/issues/629)。`SWEEP_DEADLINE_MS`
+/// 完了後の自己修復で毎 cron に再 upsert する最新 games-index 件数。
+///
+/// 「1 時間あたりの終局数が本値を超えない」という前提の下でのみ、D1 upsert
+/// 失敗からの eventual recovery を保証する (この前提を超える局数が同一時間内に
+/// 終局すると、押し出された古いエントリの再訪は保証されない)。R2 が正本のため
+/// 実害は検索結果からの一時的な欠落のみで、`games_search_backfill_state` の
+/// `r2_cursor` を手動でリセットすれば全走査を再開できる。
+const GAMES_SEARCH_HEAL_LIMIT: u32 = 100;
+
+fn shared_budget_remaining_ms(started_at_ms: u64, now_ms: u64) -> u64 {
+    SCHEDULED_WORK_DEADLINE_MS.saturating_sub(now_ms.saturating_sub(started_at_ms))
+}
+
+fn shared_deadline_reached(started_at_ms: u64, now_ms: u64) -> bool {
+    shared_budget_remaining_ms(started_at_ms, now_ms) == 0
+}
+
+/// `run_live_orphan_sweep` の安全側 page 上限 (https://github.com/SH11235/rshogi/issues/629)。共有 deadline
 /// を超えなくても、cursor が永遠に truncated を返し続ける異常時に無限 loop を
 /// 避けるための break 条件。100 page = 100,000 件で十分な余白。
 pub(crate) const SWEEP_MAX_PAGES: u32 = 100;
@@ -194,7 +247,7 @@ pub struct SweepStats {
     /// 走査した R2 list page 数 (https://github.com/SH11235/rshogi/issues/629)。pagination loop 化に伴って導入。
     /// 1 cron で複数 page を処理した状況をログから確認するための運用 metric。
     pub pages: u32,
-    /// `SWEEP_DEADLINE_MS` 経過で打ち切った場合に `true`。`true` の cron が
+    /// 共有 deadline 経過で打ち切った場合に `true`。`true` の cron が
     /// 連続したら page size または cron 頻度の見直しが必要 (https://github.com/SH11235/rshogi/issues/629)。
     pub deadline_reached: bool,
     /// `SWEEP_MAX_PAGES` に到達して打ち切った場合に `true`。summary の件数が
@@ -248,10 +301,9 @@ pub(crate) fn live_entry_hard_ttl_expired(age_ms: u64) -> bool {
 mod imp {
     use super::{
         BackfillStats, GAMES_SEARCH_BACKFILL_COMPLETE, KIFU_BY_ID_PREFIX, LIVE_ENTRY_HARD_TTL_MS,
-        LiveEntryFields, META_SUFFIX, MetaForIndexKey, PAGE_SIZE, SWEEP_DEADLINE_MS,
-        SWEEP_MAX_PAGES, SearchBackfillItemOutcome, SearchBackfillPageState, SearchBackfillStart,
-        SearchBackfillStateOperation, SweepStats, live_entry_hard_ttl_expired,
-        search_backfill_start,
+        LiveEntryFields, META_SUFFIX, MetaForIndexKey, PAGE_SIZE, SWEEP_MAX_PAGES,
+        SearchBackfillItemOutcome, SearchBackfillPageState, SearchBackfillStateOperation,
+        SweepStats, live_entry_hard_ttl_expired, search_backfill_start, shared_deadline_reached,
     };
     use worker::{Date, Env, Result};
 
@@ -400,10 +452,11 @@ mod imp {
     }
 
     /// R2 `games-index/` をページングし、D1 検索 index を冪等 upsert する。
-    /// 1 cron で最大 25 秒だけ処理し、Workers の実行時間上限へ余裕を残す。
-    pub async fn run_games_search_backfill(env: &Env) -> Result<BackfillStats> {
-        const DEADLINE_MS: u64 = 25_000;
-        let started_at_ms = Date::now().as_millis();
+    /// cron 発火時刻から sweep と共有する 25 秒以内だけ処理する。
+    pub async fn run_games_search_backfill(
+        env: &Env,
+        scheduled_started_at_ms: u64,
+    ) -> Result<BackfillStats> {
         let mut stats = BackfillStats::default();
         let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
             Ok(bucket) => bucket,
@@ -419,7 +472,7 @@ mod imp {
                 return Ok(stats);
             }
         };
-        let mut cursor = match db
+        let saved_cursor = match db
             .prepare("SELECT r2_cursor FROM games_search_backfill_state WHERE singleton = 1")
             .first::<String>(Some("r2_cursor"))
             .await
@@ -430,14 +483,17 @@ mod imp {
                 return Ok(stats);
             }
         };
-        if search_backfill_start(cursor.as_deref()) == SearchBackfillStart::ReturnComplete {
-            return Ok(stats);
-        }
+        let start = search_backfill_start(saved_cursor.as_deref());
+        let mut cursor = start.initial_cursor(saved_cursor);
+        let mut pages = 0_u32;
         loop {
-            if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+            if shared_deadline_reached(scheduled_started_at_ms, Date::now().as_millis()) {
                 break;
             }
-            let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX).limit(PAGE_SIZE);
+            // 完了後の自己修復は newest-first の先頭 100 件を cursor なしで 1 page
+            // だけ再 upsert する固定コスト処理。独立した deadline は設けず、開始前と
+            // 各 object 後の共有 deadline 判定に含める。
+            let mut builder = bucket.list().prefix(GAMES_INDEX_PREFIX).limit(start.list_limit());
             if let Some(value) = cursor.as_deref() {
                 builder = builder.cursor(value);
             }
@@ -448,9 +504,10 @@ mod imp {
                     break;
                 }
             };
+            pages = pages.saturating_add(1);
             let mut page_state = SearchBackfillPageState::default();
             for object in page.objects() {
-                if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+                if shared_deadline_reached(scheduled_started_at_ms, Date::now().as_millis()) {
                     page_state.record(SearchBackfillItemOutcome::DeadlineExceeded);
                     break;
                 }
@@ -504,10 +561,13 @@ mod imp {
                         break;
                     }
                 }
-                if Date::now().as_millis().saturating_sub(started_at_ms) >= DEADLINE_MS {
+                if shared_deadline_reached(scheduled_started_at_ms, Date::now().as_millis()) {
                     page_state.record(SearchBackfillItemOutcome::DeadlineExceeded);
                     break;
                 }
+            }
+            if start.max_pages().is_some_and(|max_pages| pages >= max_pages) {
+                break;
             }
             let next_cursor = page.cursor();
             let operation = page_state.finish(page.truncated(), next_cursor.as_deref());
@@ -540,7 +600,7 @@ mod imp {
             }
             cursor = Some(state_value.to_owned());
         }
-        crate::structured_log!(event: "games_search_backfill_progress", component: "backfill", listed: stats.listed, put: stats.put, skipped: stats.skipped);
+        crate::structured_log!(event: "games_search_backfill_progress", component: "backfill", mode: start.as_log_str(), listed: stats.listed, put: stats.put, skipped: stats.skipped);
         Ok(stats)
     }
 
@@ -567,7 +627,8 @@ mod imp {
     /// の間は cursor を辿って次 page を処理し、以下のいずれかの条件で打ち切る:
     ///
     /// 1. `truncated() == false` (全件処理完了)
-    /// 2. 経過時間 ≥ `SWEEP_DEADLINE_MS` (cron 30s 制限を圧迫しないための安全
+    /// 2. cron 発火からの経過時間 ≥ `SCHEDULED_WORK_DEADLINE_MS` (search backfill
+    ///    と共有する安全
     ///    側打ち切り。object loop 内でも判定して 1 page 完走を待たない)
     /// 3. `pages >= SWEEP_MAX_PAGES` (異常時の無限 loop ガード)
     ///
@@ -575,8 +636,11 @@ mod imp {
     /// live key prefix の昇順 lexicographic に依存した再走査)。
     ///
     /// 各失敗は logfmt で記録し `Err` を伝播しない。
-    pub async fn run_live_orphan_sweep(env: &Env) -> Result<SweepStats> {
-        let started_at_ms = Date::now().as_millis();
+    pub async fn run_live_orphan_sweep(
+        env: &Env,
+        scheduled_started_at_ms: u64,
+    ) -> Result<SweepStats> {
+        let started_at_ms = scheduled_started_at_ms;
         let mut stats = SweepStats::default();
 
         let bucket = match env.bucket(ConfigKeys::KIFU_BUCKET_BINDING) {
@@ -601,7 +665,7 @@ mod imp {
             // 前に確認しておかないと 30s cron 制限の境界で 1 page 余分に R2 list
             // を発行してしまうケースが残る。1 page 取得 (R2 list) は約 50-200ms
             // 必要なので、deadline ギリギリで再 list するより安全側で break する。
-            if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+            if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                 stats.deadline_reached = true;
                 break 'outer;
             }
@@ -637,9 +701,7 @@ mod imp {
                 } = match read_live_entry_fields(&bucket, &live_key).await {
                     Some(f) => f,
                     None => {
-                        if Date::now().as_millis().saturating_sub(started_at_ms)
-                            >= SWEEP_DEADLINE_MS
-                        {
+                        if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                             stats.deadline_reached = true;
                             break 'outer;
                         }
@@ -659,9 +721,7 @@ mod imp {
                             meta_key: meta_key,
                             err: format!("{e:?}"),
                         );
-                        if Date::now().as_millis().saturating_sub(started_at_ms)
-                            >= SWEEP_DEADLINE_MS
-                        {
+                        if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                             stats.deadline_reached = true;
                             break 'outer;
                         }
@@ -682,7 +742,7 @@ mod imp {
                     // 前者は正常状態、後者は本 sweep の対象外 (設計 v3 §3 の意図的
                     // な保守)。
                     stats.record_live_without_meta(age_ms);
-                    if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                    if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                         stats.deadline_reached = true;
                         break 'outer;
                     }
@@ -697,7 +757,7 @@ mod imp {
                         live_key: live_key,
                         err: format!("{e:?}"),
                     );
-                    if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                    if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                         stats.deadline_reached = true;
                         break 'outer;
                     }
@@ -722,7 +782,7 @@ mod imp {
                     stats.deleted = stats.deleted.saturating_add(1);
                 }
 
-                if Date::now().as_millis().saturating_sub(started_at_ms) >= SWEEP_DEADLINE_MS {
+                if shared_deadline_reached(started_at_ms, Date::now().as_millis()) {
                     stats.deadline_reached = true;
                     break 'outer;
                 }
@@ -971,11 +1031,22 @@ mod tests {
     }
 
     #[test]
-    fn search_backfill_completion_marker_causes_early_return() {
-        assert_eq!(
-            search_backfill_start(Some(GAMES_SEARCH_BACKFILL_COMPLETE)),
-            SearchBackfillStart::ReturnComplete
-        );
+    fn search_backfill_completion_marker_runs_one_bounded_healing_page() {
+        let start = search_backfill_start(Some(GAMES_SEARCH_BACKFILL_COMPLETE));
+        assert_eq!(start, SearchBackfillStart::HealRecent);
+        assert_eq!(start.list_limit(), 100);
+        assert_eq!(start.max_pages(), Some(1));
+        assert_eq!(start.initial_cursor(Some(GAMES_SEARCH_BACKFILL_COMPLETE.to_owned())), None);
+        assert_eq!(start.as_log_str(), "heal_recent");
+        assert_eq!(search_backfill_start(None).as_log_str(), "scan");
+    }
+
+    #[test]
+    fn shared_budget_consumed_by_search_leaves_nothing_for_sweep() {
+        let cron_started_at_ms = 1_000;
+        let search_finished_at_ms = cron_started_at_ms + SCHEDULED_WORK_DEADLINE_MS;
+        assert_eq!(shared_budget_remaining_ms(cron_started_at_ms, search_finished_at_ms), 0);
+        assert!(shared_deadline_reached(cron_started_at_ms, search_finished_at_ms));
     }
 
     #[test]
@@ -1011,18 +1082,18 @@ mod tests {
 
     #[test]
     fn sweep_deadline_is_safely_below_workers_30s_limit() {
-        // Cloudflare Workers cron の wall-clock 制限は 30s。`SWEEP_DEADLINE_MS`
-        // は安全側マージン (≥ 5s) を確保していないと、deadline 検知後の
+        // Cloudflare Workers cron の wall-clock 制限は 30s。search backfill と
+        // sweep の共有 deadline は安全側マージン (≥ 5s) を確保していないと、検知後の
         // pagination break + 後続ログ出力中に 30s 制限を踏む恐れがある。
         const _: () = assert!(
-            SWEEP_DEADLINE_MS + 5_000 <= 30_000,
-            "SWEEP_DEADLINE_MS must leave at least a 5s margin under the 30s cron limit",
+            SCHEDULED_WORK_DEADLINE_MS + 5_000 <= 30_000,
+            "shared scheduled work deadline must leave a 5s margin under the 30s cron limit",
         );
     }
 
     #[test]
     fn sweep_max_pages_caps_runaway_pagination() {
-        // `SWEEP_DEADLINE_MS` を超えなくても、cursor が壊れて truncated を
+        // 共有 deadline を超えなくても、cursor が壊れて truncated を
         // 返し続けるような異常時に無限 loop を避けるための gate。1 page =
         // 1000 件で 100 page = 100,000 件は live-games-index の現実的な
         // 上限を大きく超えている。

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -230,6 +230,12 @@ impl ConfigKeys {
         Self::FLOODGATE_HISTORY_BUCKET_BINDING,
     ];
 
+    /// 終局済棋譜の検索用 D1 database binding。
+    pub const GAMES_SEARCH_DB_BINDING: &'static str = "GAMES_SEARCH_DB";
+
+    /// Wrangler に宣言する D1 binding の網羅列挙。
+    pub const ALL_D1_BINDINGS: &'static [&'static str] = &[Self::GAMES_SEARCH_DB_BINDING];
+
     /// `wrangler.toml` の `[[durable_objects.bindings]] name = "..."` で宣言される
     /// べき名前の網羅列挙。新規 DO binding 定数を追加したら必ず本配列にも追加する。
     pub const ALL_DO_BINDINGS: &'static [&'static str] = &[

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -2483,18 +2483,35 @@ impl GameRoom {
                 );
             }
         };
-        if let Err(e) = bucket.put(&index_key, body.clone()).execute().await {
+        let games_index_written = match bucket.put(&index_key, body.clone()).execute().await {
+            Ok(_) => true,
+            Err(e) => {
+                crate::structured_log!(
+                    event: "games_index_put_failed",
+                    component: "game_room",
+                    game_id: cfg.game_id,
+                    inv_key: index_key,
+                    err: format!("{e:?}"),
+                );
+                failed_keys.push(FailedExportObject {
+                    key: index_key.clone(),
+                    body_kind: ExportBodyKind::Meta,
+                });
+                false
+            }
+        };
+
+        // R2 が正本なので D1 検索 index は best-effort。欠落は cron backfill が
+        // 後から補完し、ここでの失敗は対局終了・R2 retry 判定へ影響させない。
+        if games_index_written
+            && let Err(e) = crate::games_search_index::upsert_entry(&self.env, &entry).await
+        {
             crate::structured_log!(
-                event: "games_index_put_failed",
+                event: "games_search_index_upsert_failed",
                 component: "game_room",
                 game_id: cfg.game_id,
-                inv_key: index_key,
                 err: format!("{e:?}"),
             );
-            failed_keys.push(FailedExportObject {
-                key: index_key.clone(),
-                body_kind: ExportBodyKind::Meta,
-            });
         }
 
         if failed_keys.is_empty() {

--- a/crates/rshogi-csa-server-workers/src/games_search_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_search_index.rs
@@ -1,0 +1,361 @@
+//! D1 を使った終局済棋譜の検索用二次インデックス。
+//!
+//! R2 の `games-index/*.json` が正本であり、本モジュールの書き込みはすべて
+//! best-effort とする。検索レスポンスを R2 一覧と同じ wire format に戻せるよう、
+//! 検索カラムに加えて `end_reason` と `clock_json` も保持する。
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_arch = "wasm32")]
+use crate::games_index::GamesIndexEntry;
+
+pub const DEFAULT_PAGE_SIZE: u32 = 20;
+pub const MAX_PAGE_SIZE: u32 = 100;
+
+pub fn validate_pagination(page: u32, page_size: u32) -> Result<(), String> {
+    if page == 0 {
+        return Err("page must be a positive integer".into());
+    }
+    if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+        return Err(format!("pageSize must be 1..={MAX_PAGE_SIZE}"));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchParams {
+    pub name: Option<String>,
+    pub result: Option<String>,
+    pub source: Option<String>,
+    pub from: Option<u64>,
+    pub to: Option<u64>,
+    pub page: u32,
+    pub page_size: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryValue {
+    Text(String),
+    Integer(f64),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SearchQuery {
+    pub count_sql: String,
+    pub rows_sql: String,
+    pub filter_values: Vec<QueryValue>,
+    pub limit: u32,
+    pub offset: u64,
+}
+
+/// 検索条件から placeholder 付き SQL と bind 値を組み立てる。
+pub fn build_search_query(params: &SearchParams) -> SearchQuery {
+    let mut clauses = Vec::new();
+    let mut values = Vec::new();
+    if let Some(name) = &params.name {
+        clauses.push("(sente_name LIKE ? ESCAPE '\\' COLLATE NOCASE OR gote_name LIKE ? ESCAPE '\\' COLLATE NOCASE)");
+        let escaped = name.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
+        let pattern = format!("%{escaped}%");
+        values.push(QueryValue::Text(pattern.clone()));
+        values.push(QueryValue::Text(pattern));
+    }
+    if let Some(result) = &params.result {
+        clauses.push("result_kind = ?");
+        values.push(QueryValue::Text(result.clone()));
+    }
+    if let Some(source) = &params.source {
+        clauses.push("source = ?");
+        values.push(QueryValue::Text(source.clone()));
+    }
+    if let Some(from) = params.from {
+        clauses.push("ended_at_ms >= ?");
+        values.push(QueryValue::Integer(from as f64));
+    }
+    if let Some(to) = params.to {
+        clauses.push("ended_at_ms <= ?");
+        values.push(QueryValue::Integer(to as f64));
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", clauses.join(" AND "))
+    };
+    let columns = "game_id, started_at_ms, ended_at_ms, sente_name, gote_name, wire_result_kind, end_reason, moves_count, clock_json, source";
+    SearchQuery {
+        count_sql: format!("SELECT COUNT(*) AS total_count FROM games_search_index{where_sql}"),
+        rows_sql: format!(
+            "SELECT {columns} FROM games_search_index{where_sql} ORDER BY ended_at_ms DESC, game_id ASC LIMIT ? OFFSET ?"
+        ),
+        filter_values: values,
+        limit: params.page_size,
+        offset: u64::from(params.page - 1) * u64::from(params.page_size),
+    }
+}
+
+/// R2 wire の `end_reason` を検索 API の詳細結果分類へ変換する。
+pub fn result_kind_for_search(end_reason: &str) -> &'static str {
+    match end_reason {
+        "RESIGN" => "resignation",
+        "TIME_UP" => "time_expired",
+        "ILLEGAL" => "abort",
+        "JISHOGI" => "jishogi",
+        "OUTE_SENNICHITE" => "oute_sennichite",
+        "SENNICHITE" => "draw",
+        "MAX_MOVES" => "max_moves",
+        "ABNORMAL" => "abnormal",
+        _ => "abort",
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OwnedGamesIndexEntry {
+    pub game_id: String,
+    pub started_at_ms: u64,
+    pub ended_at_ms: u64,
+    pub black_handle: String,
+    pub white_handle: String,
+    pub result_kind: String,
+    pub end_reason: String,
+    pub moves_count: u32,
+    pub clock: serde_json::Value,
+    pub source: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchRow {
+    game_id: String,
+    started_at_ms: u64,
+    ended_at_ms: u64,
+    sente_name: String,
+    gote_name: String,
+    wire_result_kind: String,
+    end_reason: String,
+    moves_count: u32,
+    clock_json: String,
+    source: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchGameSummary {
+    game_id: String,
+    started_at_ms: u64,
+    ended_at_ms: u64,
+    black_handle: String,
+    white_handle: String,
+    result_kind: String,
+    end_reason: String,
+    moves_count: u32,
+    clock: serde_json::Value,
+    source: String,
+}
+
+impl SearchRow {
+    /// R2 の正準 entry を D1 行と同じ表現へ変換する。
+    pub fn from_owned(entry: &OwnedGamesIndexEntry) -> Result<Self, serde_json::Error> {
+        Ok(Self {
+            game_id: entry.game_id.clone(),
+            started_at_ms: entry.started_at_ms,
+            ended_at_ms: entry.ended_at_ms,
+            sente_name: entry.black_handle.clone(),
+            gote_name: entry.white_handle.clone(),
+            wire_result_kind: entry.result_kind.clone(),
+            end_reason: entry.end_reason.clone(),
+            moves_count: entry.moves_count,
+            clock_json: serde_json::to_string(&entry.clock)?,
+            source: entry.source.clone(),
+        })
+    }
+
+    pub fn into_summary(self) -> Result<SearchGameSummary, serde_json::Error> {
+        Ok(SearchGameSummary {
+            game_id: self.game_id,
+            started_at_ms: self.started_at_ms,
+            ended_at_ms: self.ended_at_ms,
+            black_handle: self.sente_name,
+            white_handle: self.gote_name,
+            result_kind: self.wire_result_kind,
+            end_reason: self.end_reason,
+            moves_count: self.moves_count,
+            clock: serde_json::from_str(&self.clock_json)?,
+            source: self.source,
+        })
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn upsert_entry(env: &worker::Env, entry: &GamesIndexEntry<'_>) -> worker::Result<()> {
+    let clock_json = serde_json::to_string(&entry.clock)?;
+    upsert_fields(
+        env,
+        UpsertFields {
+            game_id: entry.game_id,
+            sente: entry.black_handle,
+            gote: entry.white_handle,
+            started_at_ms: entry.started_at_ms,
+            ended_at_ms: entry.ended_at_ms,
+            wire_result_kind: entry.result_kind,
+            end_reason: entry.end_reason,
+            moves_count: entry.moves_count,
+            clock_json: &clock_json,
+            source: entry.source,
+        },
+    )
+    .await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn upsert_owned(env: &worker::Env, entry: &OwnedGamesIndexEntry) -> worker::Result<()> {
+    let clock_json = serde_json::to_string(&entry.clock)?;
+    upsert_fields(
+        env,
+        UpsertFields {
+            game_id: &entry.game_id,
+            sente: &entry.black_handle,
+            gote: &entry.white_handle,
+            started_at_ms: entry.started_at_ms,
+            ended_at_ms: entry.ended_at_ms,
+            wire_result_kind: &entry.result_kind,
+            end_reason: &entry.end_reason,
+            moves_count: entry.moves_count,
+            clock_json: &clock_json,
+            source: &entry.source,
+        },
+    )
+    .await
+}
+
+#[cfg(target_arch = "wasm32")]
+struct UpsertFields<'a> {
+    game_id: &'a str,
+    sente: &'a str,
+    gote: &'a str,
+    started_at_ms: u64,
+    ended_at_ms: u64,
+    wire_result_kind: &'a str,
+    end_reason: &'a str,
+    moves_count: u32,
+    clock_json: &'a str,
+    source: &'a str,
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn upsert_fields(env: &worker::Env, fields: UpsertFields<'_>) -> worker::Result<()> {
+    use worker::wasm_bindgen::JsValue;
+    let db = env.d1(crate::config::ConfigKeys::GAMES_SEARCH_DB_BINDING)?;
+    let values = [
+        JsValue::from_str(fields.game_id),
+        JsValue::from_str(fields.sente),
+        JsValue::from_str(fields.gote),
+        JsValue::from_f64(fields.started_at_ms as f64),
+        JsValue::from_f64(fields.ended_at_ms as f64),
+        JsValue::from_str(result_kind_for_search(fields.end_reason)),
+        JsValue::from_str(fields.source),
+        JsValue::from_f64(f64::from(fields.moves_count)),
+        JsValue::from_str(fields.wire_result_kind),
+        JsValue::from_str(fields.end_reason),
+        JsValue::from_str(fields.clock_json),
+    ];
+    db.prepare("INSERT INTO games_search_index (game_id, sente_name, gote_name, started_at_ms, ended_at_ms, result_kind, source, moves_count, wire_result_kind, end_reason, clock_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(game_id) DO UPDATE SET sente_name=excluded.sente_name, gote_name=excluded.gote_name, started_at_ms=excluded.started_at_ms, ended_at_ms=excluded.ended_at_ms, result_kind=excluded.result_kind, source=excluded.source, moves_count=excluded.moves_count, wire_result_kind=excluded.wire_result_kind, end_reason=excluded.end_reason, clock_json=excluded.clock_json")
+        .bind(&values)?.run().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn base_params() -> SearchParams {
+        SearchParams {
+            name: None,
+            result: None,
+            source: None,
+            from: None,
+            to: None,
+            page: 1,
+            page_size: 20,
+        }
+    }
+    #[test]
+    fn query_supports_all_filters() {
+        let query = build_search_query(&SearchParams {
+            name: Some("藤井".into()),
+            result: Some("resignation".into()),
+            source: Some("kifu".into()),
+            from: Some(100),
+            to: Some(200),
+            ..base_params()
+        });
+        for clause in [
+            "sente_name LIKE ? ESCAPE '\\' COLLATE NOCASE",
+            "result_kind = ?",
+            "source = ?",
+            "ended_at_ms >= ?",
+            "ended_at_ms <= ?",
+        ] {
+            assert!(query.count_sql.contains(clause));
+        }
+        assert_eq!(query.filter_values[0], QueryValue::Text("%藤井%".into()));
+    }
+
+    #[test]
+    fn name_filter_escapes_like_wildcards_as_literals() {
+        let query = build_search_query(&SearchParams {
+            name: Some(r"a%b_c\d".into()),
+            ..base_params()
+        });
+        assert_eq!(
+            query.filter_values,
+            vec![
+                QueryValue::Text(r"%a\%b\_c\\d%".into()),
+                QueryValue::Text(r"%a\%b\_c\\d%".into()),
+            ]
+        );
+        assert!(query.rows_sql.contains("LIKE ? ESCAPE '\\' COLLATE NOCASE"));
+    }
+    #[test]
+    fn query_calculates_one_based_page_offset() {
+        let query = build_search_query(&SearchParams {
+            page: 3,
+            page_size: 25,
+            ..base_params()
+        });
+        assert_eq!((query.limit, query.offset), (25, 50));
+    }
+    #[test]
+    fn result_kind_matches_canonical_mapping_for_all_end_reasons() {
+        for (end_reason, expected) in [
+            ("RESIGN", "resignation"),
+            ("TIME_UP", "time_expired"),
+            ("ILLEGAL", "abort"),
+            ("JISHOGI", "jishogi"),
+            ("OUTE_SENNICHITE", "oute_sennichite"),
+            ("SENNICHITE", "draw"),
+            ("MAX_MOVES", "max_moves"),
+            ("ABNORMAL", "abnormal"),
+        ] {
+            assert_eq!(result_kind_for_search(end_reason), expected, "{end_reason}");
+        }
+        assert_eq!(result_kind_for_search("UNKNOWN"), "abort");
+    }
+
+    #[test]
+    fn search_summary_preserves_games_index_wire_shape() {
+        let original = serde_json::json!({
+            "game_id": "g-1", "started_at_ms": 100, "ended_at_ms": 200,
+            "black_handle": "alice", "white_handle": "bob",
+            "result_kind": "WIN_BLACK", "end_reason": "RESIGN", "moves_count": 42,
+            "clock": {"kind": "fischer", "total_sec": 300, "increment_sec": 5},
+            "source": "kifu"
+        });
+        let entry: OwnedGamesIndexEntry = serde_json::from_value(original.clone()).unwrap();
+        let summary = SearchRow::from_owned(&entry).unwrap().into_summary().unwrap();
+        assert_eq!(serde_json::to_value(summary).unwrap(), original);
+    }
+
+    #[test]
+    fn pagination_rejects_zero_and_over_maximum() {
+        assert!(validate_pagination(0, 20).is_err());
+        assert!(validate_pagination(1, 0).is_err());
+        assert!(validate_pagination(1, 101).is_err());
+        assert!(validate_pagination(1, 100).is_ok());
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -162,7 +162,8 @@ fn minute_of_hour(epoch_ms: f64) -> i64 {
 /// ミリ秒なので、起動が数秒遅延しても分判定は予定どおり安定する:
 ///
 /// - 分が [`BACKFILL_MINUTE`] (0 分) のとき: `run_games_index_backfill` →
-///   `run_live_orphan_sweep` を順次実行する。
+///   `run_games_search_backfill` → `run_live_orphan_sweep` を順次実行する。後二者は
+///   cron 発火直後の時刻を共有し、合わせて 25 秒以内に打ち切る。
 /// - それ以外 (15 / 30 / 45 分) のとき: `run_live_orphan_sweep` のみ。
 ///   delete best-effort 失敗時の復旧遅延を 15 分以内に詰めるための高頻度経路
 ///   (https://github.com/SH11235/rshogi/issues/629)。
@@ -178,6 +179,7 @@ pub async fn scheduled(
     env: worker::Env,
     _ctx: worker::ScheduleContext,
 ) {
+    let started_at_ms = worker::Date::now().as_millis();
     let cron = event.cron();
     // 単一 cron のため発火の区別は cron 文字列でなくスケジュール時刻の分で行う。
     let minute = minute_of_hour(event.schedule());
@@ -192,7 +194,7 @@ pub async fn scheduled(
                 err: format!("{e:?}"),
             );
         }
-        if let Err(e) = backfill::run_games_search_backfill(&env).await {
+        if let Err(e) = backfill::run_games_search_backfill(&env, started_at_ms).await {
             crate::structured_log!(
                 event: "games_search_backfill_failed",
                 component: "scheduled",
@@ -201,7 +203,7 @@ pub async fn scheduled(
             );
         }
     }
-    if let Err(e) = backfill::run_live_orphan_sweep(&env).await {
+    if let Err(e) = backfill::run_live_orphan_sweep(&env, started_at_ms).await {
         crate::structured_log!(
             event: "live_orphan_sweep_failed",
             component: "scheduled",

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -43,6 +43,7 @@ pub mod datetime;
 pub mod export_retry;
 pub mod floodgate_history;
 pub mod games_index;
+pub mod games_search_index;
 // `handle_auth` は `WORKERS_HANDLE_AUTH` whitelist の parse + password SHA256
 // 比較を担う。`HandleAuthRegistry` + `verify` は I/O 非依存の
 // pure helper でホスト target からテストできるよう `pub mod` で公開する。
@@ -186,6 +187,14 @@ pub async fn scheduled(
         if let Err(e) = backfill::run_games_index_backfill(&env).await {
             crate::structured_log!(
                 event: "games_index_backfill_failed",
+                component: "scheduled",
+                cron: cron,
+                err: format!("{e:?}"),
+            );
+        }
+        if let Err(e) = backfill::run_games_search_backfill(&env).await {
+            crate::structured_log!(
+                event: "games_search_backfill_failed",
                 component: "scheduled",
                 cron: cron,
                 err: format!("{e:?}"),

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -1,6 +1,6 @@
 //! viewer 配信 HTTP API (`/api/v1/games`) のルーティングと R2 アクセス。
 //!
-//! v3 設計 (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338088406) に準拠する 3 エンドポイント:
+//! v3 設計 (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338088406) に準拠する 4 エンドポイント:
 //!
 //! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧 (終局済)
 //!   `KIFU_BUCKET.list({prefix: "games-index/", cursor, limit})` を 1 回呼び、
@@ -14,6 +14,8 @@
 //!   semantics、`/api/v1/games/<id>` のような単局エンドポイントは進行中対局には
 //!   設けない (= viewer 側は live entry を **発見手段** として扱い、行クリック時に
 //!   WS spectate 接続で実状態を確認する)。
+//! - `GET /api/v1/games/search` D1 検索 (終局済)
+//!   選手名・結果・source・終局日時で絞り込み、page pagination で返す。
 //! - `GET /api/v1/games/<game_id>` 単局 (終局済)
 //!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
 //!   `kifu-by-id/<encoded_game_id>.meta.json` から取得した正準メタ (https://github.com/SH11235/rshogi/issues/551
@@ -96,6 +98,10 @@ use worker::{Env, Headers, Method, Request, Response, Result, Url};
 use crate::client_kind::normalize_client_kind;
 use crate::config::{ConfigKeys, OriginAllowList, is_viewer_api_enabled};
 use crate::games_index::KEY_PREFIX as GAMES_INDEX_PREFIX;
+use crate::games_search_index::{
+    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, QueryValue, SearchGameSummary, SearchParams, SearchRow,
+    build_search_query, validate_pagination,
+};
 use crate::live_games_index::LIVE_KEY_PREFIX;
 use crate::origin::{OriginDecision, evaluate};
 use crate::x1_paths::{kifu_by_id_meta_key, kifu_by_id_object_key};
@@ -141,6 +147,9 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     if path == "/api/v1/games" {
         return Ok(Some(handle_list(req, env, &url).await?));
     }
+    if path == "/api/v1/games/search" {
+        return Ok(Some(handle_search(req, env, &url).await?));
+    }
     // `/api/v1/games/live` は `/api/v1/games/<game_id>` より先にマッチさせる
     // (`live` という ID の単局取得を 1 件目で誤って受けないため)。
     if path == "/api/v1/games/live" {
@@ -165,10 +174,10 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
 /// viewer 配信 API 配下のパスかどうかを判定する純粋ロジック。
 ///
 /// `OPTIONS` preflight 経路で対象パスをゲートするためにも使用する。
-/// `/api/v1/games` (一覧)、`/api/v1/games/live` (live 一覧)、
+/// `/api/v1/games` (一覧)、`/api/v1/games/live` (live 一覧)、検索、
 /// `/api/v1/games/<id>` (単局) のみを true とする。
 fn is_viewer_api_path(path: &str) -> bool {
-    if path == "/api/v1/games" || path == "/api/v1/games/live" {
+    if matches!(path, "/api/v1/games" | "/api/v1/games/live" | "/api/v1/games/search") {
         return true;
     }
     if let Some(rest) = path.strip_prefix("/api/v1/games/") {
@@ -232,6 +241,151 @@ struct ListResponse {
 struct LiveListResponse {
     live_games: Vec<serde_json::Value>,
     next_cursor: Option<String>,
+}
+
+// 他のレスポンス (`ListResponse` の `next_cursor` 等) と同じく wire は snake_case
+// のまま返す (client 側の decode 層が snake_case → camelCase 変換を担う規約)。
+#[derive(Debug, Serialize)]
+struct SearchResponse {
+    games: Vec<SearchGameSummary>,
+    page: u32,
+    page_size: u32,
+    total_count: u64,
+}
+
+fn parse_search_params(url: &Url) -> std::result::Result<SearchParams, String> {
+    let mut params = SearchParams {
+        name: None,
+        result: None,
+        source: None,
+        from: None,
+        to: None,
+        page: 1,
+        page_size: DEFAULT_PAGE_SIZE,
+    };
+    for (key, value) in url.query_pairs() {
+        let value = value.into_owned();
+        match key.as_ref() {
+            "name" => params.name = Some(value),
+            "result" => params.result = Some(value),
+            "source" => params.source = Some(value),
+            "from" => {
+                params.from =
+                    Some(value.parse().map_err(|_| "from must be an epoch millisecond integer")?)
+            }
+            "to" => {
+                params.to =
+                    Some(value.parse().map_err(|_| "to must be an epoch millisecond integer")?)
+            }
+            "page" => params.page = value.parse().map_err(|_| "page must be a positive integer")?,
+            "pageSize" => {
+                params.page_size =
+                    value.parse().map_err(|_| format!("pageSize must be 1..={MAX_PAGE_SIZE}"))?
+            }
+            _ => {}
+        }
+    }
+    validate_pagination(params.page, params.page_size)?;
+    Ok(params)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn d1_bind_values(values: &[QueryValue]) -> Vec<worker::wasm_bindgen::JsValue> {
+    values
+        .iter()
+        .map(|value| match value {
+            QueryValue::Text(value) => worker::wasm_bindgen::JsValue::from_str(value),
+            QueryValue::Integer(value) => worker::wasm_bindgen::JsValue::from_f64(*value),
+        })
+        .collect()
+}
+
+async fn handle_search(req: &Request, env: &Env, url: &Url) -> Result<Response> {
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+    let params = match parse_search_params(url) {
+        Ok(params) => params,
+        Err(message) => return with_cors(no_store_error(message, 400)?, req, env),
+    };
+    let query = build_search_query(&params);
+    let db = match env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING) {
+        Ok(db) => db,
+        Err(e) => {
+            log_viewer_api_failed(
+                "games_search_d1_binding",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let filter_values = d1_bind_values(&query.filter_values);
+    #[derive(serde::Deserialize)]
+    struct CountRow {
+        total_count: u64,
+    }
+    let count_statement = match db.prepare(&query.count_sql).bind(&filter_values) {
+        Ok(statement) => statement,
+        Err(e) => {
+            log_viewer_api_failed(
+                "games_search_count_prepare",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let count = match count_statement.first::<CountRow>(None).await {
+        Ok(Some(row)) => row.total_count,
+        Ok(None) => 0,
+        Err(e) => {
+            log_viewer_api_failed("games_search_count", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let mut row_values = filter_values;
+    row_values.push(worker::wasm_bindgen::JsValue::from_f64(f64::from(query.limit)));
+    row_values.push(worker::wasm_bindgen::JsValue::from_f64(query.offset as f64));
+    let rows_statement = match db.prepare(&query.rows_sql).bind(&row_values) {
+        Ok(statement) => statement,
+        Err(e) => {
+            log_viewer_api_failed(
+                "games_search_rows_prepare",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let rows = match rows_statement.all().await.and_then(|result| result.results::<SearchRow>()) {
+        Ok(rows) => rows,
+        Err(e) => {
+            log_viewer_api_failed("games_search_rows", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let games: std::result::Result<Vec<_>, _> =
+        rows.into_iter().map(SearchRow::into_summary).collect();
+    let games = match games {
+        Ok(games) => games,
+        Err(e) => {
+            log_viewer_api_failed(
+                "games_search_clock_parse",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let mut response = Response::from_json(&SearchResponse {
+        games,
+        page: params.page,
+        page_size: params.page_size,
+        total_count: count,
+    })?;
+    set_cache_control(&mut response, CacheableKind::List.cache_control_header())?;
+    with_cors(response, req, env)
 }
 
 /// 単局 API レスポンスの wire 形状。
@@ -866,7 +1020,29 @@ mod tests {
     fn is_viewer_api_path_accepts_root_paths() {
         assert!(is_viewer_api_path("/api/v1/games"));
         assert!(is_viewer_api_path("/api/v1/games/live"));
+        assert!(is_viewer_api_path("/api/v1/games/search"));
         assert!(is_viewer_api_path("/api/v1/games/abc-123"));
+    }
+
+    #[test]
+    fn parse_search_params_rejects_pagination_boundaries() {
+        for query in ["page=0", "pageSize=0", "pageSize=101"] {
+            let url =
+                Url::parse(&format!("https://example.com/api/v1/games/search?{query}")).unwrap();
+            assert!(parse_search_params(&url).is_err(), "query={query}");
+        }
+        let url =
+            Url::parse("https://example.com/api/v1/games/search?page=1&pageSize=100").unwrap();
+        assert!(parse_search_params(&url).is_ok());
+    }
+
+    #[test]
+    fn parse_search_params_rejects_invalid_time_bounds() {
+        for query in ["from=invalid", "to=-1", "to=1.5"] {
+            let url =
+                Url::parse(&format!("https://example.com/api/v1/games/search?{query}")).unwrap();
+            assert!(parse_search_params(&url).is_err(), "query={query}");
+        }
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_environment_toml_consistency.rs
@@ -27,6 +27,7 @@ struct EnvironmentBindings {
     /// 失敗 message に出す toml ファイル名。
     file_name: &'static str,
     r2_bindings: Vec<String>,
+    d1_bindings: Vec<String>,
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
     compatibility_date: Option<String>,
@@ -56,6 +57,16 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
 
     let r2_bindings = doc
         .get("r2_buckets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("binding").and_then(|v| v.as_str()).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let d1_bindings = doc
+        .get("d1_databases")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
@@ -103,6 +114,7 @@ fn load_environment_bindings(label: &'static str, file_name: &'static str) -> En
         label,
         file_name,
         r2_bindings,
+        d1_bindings,
         do_bindings,
         vars_keys,
         compatibility_date,
@@ -142,6 +154,10 @@ fn assert_bidirectional(
 
 fn assert_r2_bindings_match(env: &EnvironmentBindings) {
     assert_bidirectional(env, "r2_bindings", ConfigKeys::ALL_R2_BINDINGS, &env.r2_bindings);
+}
+
+fn assert_d1_bindings_match(env: &EnvironmentBindings) {
+    assert_bidirectional(env, "d1_bindings", ConfigKeys::ALL_D1_BINDINGS, &env.d1_bindings);
 }
 
 fn assert_do_bindings_match(env: &EnvironmentBindings) {
@@ -346,6 +362,11 @@ fn wrangler_production_r2_bindings_match_config_keys() {
 }
 
 #[test]
+fn wrangler_production_d1_bindings_match_config_keys() {
+    assert_d1_bindings_match(&PRODUCTION);
+}
+
+#[test]
 fn wrangler_production_do_bindings_match_config_keys() {
     assert_do_bindings_match(&PRODUCTION);
 }
@@ -380,6 +401,11 @@ fn wrangler_production_declares_scheduled_cron_trigger() {
 #[test]
 fn wrangler_staging_r2_bindings_match_config_keys() {
     assert_r2_bindings_match(&STAGING);
+}
+
+#[test]
+fn wrangler_staging_d1_bindings_match_config_keys() {
+    assert_d1_bindings_match(&STAGING);
 }
 
 #[test]

--- a/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
+++ b/crates/rshogi-csa-server-workers/tests/wrangler_template_consistency.rs
@@ -27,6 +27,7 @@ use rshogi_csa_server_workers::config::ConfigKeys;
 /// 各種 binding / `[vars]` キーを集約する。
 struct TemplateBindings {
     r2_bindings: Vec<String>,
+    d1_bindings: Vec<String>,
     do_bindings: Vec<String>,
     vars_keys: Vec<String>,
     /// `[triggers] crons = [...]` の値を保持する (https://github.com/SH11235/rshogi/issues/551)。空配列は未宣言。
@@ -50,6 +51,16 @@ fn load_template_bindings() -> TemplateBindings {
     // `[[r2_buckets]]` 配列の各エントリから `binding = "..."` を集める。
     let r2_bindings = doc
         .get("r2_buckets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("binding").and_then(|v| v.as_str()).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let d1_bindings = doc
+        .get("d1_databases")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
@@ -87,6 +98,7 @@ fn load_template_bindings() -> TemplateBindings {
 
     TemplateBindings {
         r2_bindings,
+        d1_bindings,
         do_bindings,
         vars_keys,
         crons,
@@ -131,6 +143,11 @@ fn assert_bidirectional(category: &str, code_side: &[&'static str], template_sid
 #[test]
 fn wrangler_template_r2_bindings_match_config_keys() {
     assert_bidirectional("r2_bindings", ConfigKeys::ALL_R2_BINDINGS, &TEMPLATE.r2_bindings);
+}
+
+#[test]
+fn wrangler_template_d1_bindings_match_config_keys() {
+    assert_bidirectional("d1_bindings", ConfigKeys::ALL_D1_BINDINGS, &TEMPLATE.d1_bindings);
 }
 
 /// `wrangler.toml.example` の `[[durable_objects.bindings]]` 配列が、

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -124,6 +124,13 @@ bucket_name = "rshogi-csa-kifu-prod"
 binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-prod"
 
+# `wrangler d1 create rshogi-csa-games-search-prod` の出力で database_id を置換する。
+[[d1_databases]]
+binding = "GAMES_SEARCH_DB"
+database_name = "rshogi-csa-games-search-prod"
+database_id = "REPLACE_WITH_PRODUCTION_D1_DATABASE_ID"
+migrations_dir = "migrations"
+
 # --- Cron triggers ---
 # `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を単一 cron で起動する。
 # Cloudflare の account あたり cron trigger 上限 (5) に収めるため、以前の

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -112,6 +112,13 @@ bucket_name = "rshogi-csa-kifu-staging"
 binding = "FLOODGATE_HISTORY_BUCKET"
 bucket_name = "rshogi-csa-floodgate-history-staging"
 
+# `wrangler d1 create rshogi-csa-games-search-staging` の出力で database_id を置換する。
+[[d1_databases]]
+binding = "GAMES_SEARCH_DB"
+database_name = "rshogi-csa-games-search-staging"
+database_id = "REPLACE_WITH_STAGING_D1_DATABASE_ID"
+migrations_dir = "migrations"
+
 # --- Cron triggers ---
 # `[event(scheduled)]` ハンドラ (`lib.rs::scheduled`) を単一 cron で起動する。
 # Cloudflare の account あたり cron trigger 上限 (5) に収めるため、以前の

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -106,6 +106,12 @@ preview_bucket_name = "local-floodgate-history-dev"
 [triggers]
 crons = ["0,15,30,45 * * * *"]
 
+[[d1_databases]]
+binding = "GAMES_SEARCH_DB"
+database_name = "rshogi-csa-games-search-local"
+database_id = "REPLACE_WITH_LOCAL_D1_DATABASE_ID"
+migrations_dir = "migrations"
+
 # --- 変数 ---
 # WebSocket Upgrade 時の Origin 許可リスト（カンマ区切り）。ブラウザ経由
 # （Origin ヘッダ付き）のリクエストに対する CSRF 防御に使う。


### PR DESCRIPTION
## Summary

- 終局済み棋譜一覧に、先手/後手名の部分一致・結果種別・source・終局日時範囲での検索とページ番号方式のpaginationを追加。既存の `/api/v1/games`(R2 cursor一覧)は変更せず、R2 `games-index` を正本としたまま D1 に二次インデックスを新設。
- 終局時、R2 games-index PUT成功時のみD1へbest-effort upsert(D1失敗はログのみで対局終了フローには影響しない)。
- 既存R2 games-indexからD1への1回限りのcron backfill。25秒deadlineをページ内の各オブジェクト単位でも確認し、一時的なR2/D1障害ではcursorを据え置いて次回再試行、JSON parse失敗のみ恒久skip。完了後は完了マーカーで以降のフルスキャンをスキップする。
- name検索はSQLiteのLIKEワイルドカード(`%`/`_`)をエスケープしリテラル部分一致として扱う。
- 検索結果種別の分類は、client側(ramu-shogi `decodeResult`)の既存マッピングと1:1で一致させている。

## 設計判断

- D1はあくまで検索専用の二次インデックスで、R2が正本(source of truth)。この設計により、D1書き込みが一時的に欠落しても検索結果に一時的な欠けが生じるのみで、棋譜本体・通常一覧には一切影響しない。
- live(進行中対局)一覧のD1統合は今回のスコープ外(別途検討)。

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --fix --allow-dirty --tests -p rshogi-csa-server-workers`(警告ゼロ)
- [x] `cargo test -p rshogi-csa-server-workers`
- [x] `bash scripts/check-tracked-abs-paths.sh`
- [x] `cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- [x] local reviewer #1 (Codex系) APPROVE
- [x] local reviewer #2 (Claude/Fable系) APPROVE
- [ ] デプロイ前に必須: 各wrangler設定のD1 database ID placeholderを実IDに置換し、migrationを適用する