### PR TITLE
feat(tools): nnue_saturation — LayerStacks 活性飽和率の実局面計測

### DIFF
--- a/crates/rshogi-core/src/nnue/layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/layer_stacks.rs
@@ -30,6 +30,23 @@ fn sqr_clipped_relu_explicit<const DIM: usize>(input: &[i32; DIM], output: &mut 
     }
 }
 
+/// 活性段ごとの 127 飽和カウント（診断用）。
+///
+/// ClippedReLU / SqrClippedReLU 系の活性は u8 [0,127] に clamp されるため、
+/// 127 到達率が高いほど量子化天井で情報が落ちている。
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LsSaturationCounts {
+    /// FT 出力 (SqrClippedReLU 後 u8) の 127 到達数
+    pub ft_sat: u64,
+    pub ft_total: u64,
+    /// L1→L2 activation (SqrClippedReLU + ClippedReLU) の 127 到達数
+    pub l1_act_sat: u64,
+    pub l1_act_total: u64,
+    /// L2→output activation (ClippedReLU) の 127 到達数
+    pub l2_act_sat: u64,
+    pub l2_act_total: u64,
+}
+
 // =============================================================================
 // LayerStack 単一バケット
 // =============================================================================
@@ -124,6 +141,42 @@ impl<
         self.output.propagate(&l2_relu.0, &mut output_arr);
 
         // Skip connection
+        output_arr[0] + l1_skip
+    }
+
+    /// 順伝播しつつ各活性段の 127 飽和を数える（診断用、ホットパス外）。
+    ///
+    /// スコアは `propagate` と bit 一致する。カウント対象:
+    /// - FT 出力 (SqrClippedReLU 後の入力 `input` そのもの)
+    /// - L1→L2 activation (SqrClippedReLU + ClippedReLU の `LS_L2_IN` 要素)
+    /// - L2→output activation (ClippedReLU の 32 要素)
+    pub fn propagate_counting_saturation(
+        &self,
+        input: &[u8; L1],
+        counts: &mut LsSaturationCounts,
+    ) -> i32 {
+        let mut l1_out = [0i32; LS_L1_OUT];
+        let mut l2_input = Aligned([0u8; LS_L2_PADDED_INPUT]);
+        let mut l2_out = [0i32; NNUE_PYTORCH_L3];
+        let mut l2_relu = Aligned([0u8; OUTPUT_PADDED_INPUT]);
+        let mut output_arr = [0i32; 1];
+
+        counts.ft_sat += input.iter().filter(|&&v| v == 127).count() as u64;
+        counts.ft_total += L1 as u64;
+
+        self.l1.propagate(input, &mut l1_out);
+        let l1_skip = l1_out[Self::MAIN_DIM];
+        l1_sqr_clipped_relu_activation::<LS_L1_OUT, LS_L2_IN>(&l1_out, &mut l2_input.0);
+        counts.l1_act_sat += l2_input.0[..LS_L2_IN].iter().filter(|&&v| v == 127).count() as u64;
+        counts.l1_act_total += LS_L2_IN as u64;
+
+        self.l2.propagate(&l2_input.0, &mut l2_out);
+        clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
+        counts.l2_act_sat +=
+            l2_relu.0[..NNUE_PYTORCH_L3].iter().filter(|&&v| v == 127).count() as u64;
+        counts.l2_act_total += NNUE_PYTORCH_L3 as u64;
+
+        self.output.propagate(&l2_relu.0, &mut output_arr);
         output_arr[0] + l1_skip
     }
 
@@ -830,6 +883,28 @@ mod tests {
         // ゼロ weights でパニックしないことを確認
         let _ = result;
         let _ = bucket; // suppress unused warning
+    }
+
+    #[test]
+    fn propagate_counting_saturation_matches_propagate_and_counts() {
+        let mut bucket = TestLayerStackBucket::new();
+        bucket.l1.biases[0] = 8192; // sqr=(8192^2)>>19=128→127 / clipped=8192>>6=128→127 で両方飽和
+        bucket.l1.biases[1] = 8000; // sqr=122 / clipped=125 で非飽和
+
+        let mut input = Aligned([0u8; TEST_L1]);
+        input.0[0] = 127;
+        input.0[1] = 126;
+
+        let mut counts = LsSaturationCounts::default();
+        let score = bucket.propagate_counting_saturation(&input.0, &mut counts);
+        assert_eq!(score, bucket.propagate(&input.0));
+
+        assert_eq!(counts.ft_sat, 1);
+        assert_eq!(counts.ft_total, TEST_L1 as u64);
+        assert_eq!(counts.l1_act_sat, 2);
+        assert_eq!(counts.l1_act_total, TEST_LS_L2_IN as u64);
+        assert_eq!(counts.l2_act_sat, 0);
+        assert_eq!(counts.l2_act_total, NNUE_PYTORCH_L3 as u64);
     }
 
     #[test]

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -99,7 +99,7 @@ pub use features::{
     HalfKaSplit, HalfKaSplitFeatureSet, TriggerEvent,
 };
 pub use layer_stacks::{
-    LayerStackBucket, LayerStacks, compute_bucket_index, compute_king_ranks,
+    LayerStackBucket, LayerStacks, LsSaturationCounts, compute_bucket_index, compute_king_ranks,
     sqr_clipped_relu_transform,
 };
 pub use layers::{AffineTransform, ClippedReLU};

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -88,6 +88,12 @@ name = "eval_sfens"
 path = "src/bin/eval_sfens.rs"
 required-features = ["nnue-arch"]
 
+# nnue_saturation は LayerStacks NNUE 前提のため nnue-arch に gate する。
+[[bin]]
+name = "nnue_saturation"
+path = "src/bin/nnue_saturation.rs"
+required-features = ["nnue-arch"]
+
 # ek_testset は CSA replay に依存する（TUI は不要）ため csa-replay に gate する。
 [[bin]]
 name = "ek_testset"

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -56,6 +56,7 @@
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) で静的評価し `eval_dl` を追記（`dlshogi-onnx` feature、default 有効） |
 | `yardstick_label` / `yardstick_score` | ラベル品質「物差し」。held-out hcpe を labeler でラベル付け（stage 1）→ engine ごとに勝率較正して per-class WDL logloss / 参照天井 / リファレンス一致を採点（stage 2） |
 | `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](docs/ek_testset.md)） |
+| `nnue_saturation` | LayerStacks NNUE の活性飽和率（ClippedReLU 127 張り付き）を実局面で計測（[詳細](docs/nnue_saturation.md)） |
 
 ### NNUE 学習
 
@@ -102,6 +103,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [yardstick_label](docs/yardstick_label.md) - held-out hcpe を labeler の固定 depth 探索でラベル付け（物差し stage 1）
 - [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
 - [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
+- [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換と任意の宣言勝ち override / diversions deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）

--- a/crates/tools/docs/nnue_saturation.md
+++ b/crates/tools/docs/nnue_saturation.md
@@ -1,0 +1,35 @@
+# nnue_saturation
+
+LayerStacks NNUE の**活性飽和率**を実局面で計測する診断ツールです。ClippedReLU /
+SqrClippedReLU 系の活性は u8 [0,127] に clamp されるため、127 到達率が高いほど
+量子化天井で情報が落ちています（評価値インフレ → 隠れ層飽和、の計器）。
+
+計測する 3 段:
+
+| 段 | 内容 |
+|---|---|
+| `ft` | FT 出力（SqrClippedReLU 後の L1 次元 u8） |
+| `l1_act` | L1→L2 activation（SqrClippedReLU + ClippedReLU の 2×main_dim 要素） |
+| `l2_act` | L2→output activation（ClippedReLU の 32 要素） |
+
+**重み側**（i8 dense weight の ±127 張り付き率、FT i16 の飽和接近）は rshogi-nnue
+(tatara) の `crates/nnue-format/examples/clamp_stats.rs` が担当します。本ツールは
+局面依存の活性側のみを扱います。
+
+## 使い方
+
+```bash
+cargo run -p tools --release --bin nnue_saturation -- \
+  --nnue "$SHOGI_DATA/nnue/model.bin" \
+  --progress-coeff "$SHOGI_DATA/progress/progress.bin" \
+  --sfens sfens.txt \
+  --out saturation.json
+```
+
+出力は JSON（標準出力と `--out`）。全体集計 `total` と、progress bucket 別の
+`per_bucket`（局面が 1 件以上入った bucket のみ）を含みます。各段は
+`*_sat` / `*_total` / `*_rate`（127 到達数 / 総数 / 率）です。
+
+入玉局面（大評価値側）と一般局面で `--sfens` を替えて比較すると、評価値インフレが
+どの帯で天井に当たっているかを切り分けられます。bucket は progress8kpabs なので、
+終盤 bucket ほど入玉局面が集中します。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -25,6 +25,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `bench_nnue_eval` | NNUE 推論単体の性能測定（cycles/eval, instructions/eval） |
 | `search_only_ab` | Linux perf ベースの search-only A/B ベンチマーク。起動・ロード時間を除外して正確計測 |
 | `eval_sfens` | SFEN 局面を LayerStacks NNUE で静的評価（`score` は歩=90 の内部スケール、`score_cp` は cp） |
+| `nnue_saturation` | LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測（[詳細](nnue_saturation.md)） |
 | `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](ek_testset.md)） |
 | `compare_eval_nnue` | 教師 NNUE と生徒 NNUE の評価値一致度を検証（MAE・相関係数・スコア帯別誤差） |
 | `dump_effect_bucket_golden` | 形式一致 golden 用に effect bucket active index を config 別に dump（[詳細](dump_effect_bucket_golden.md)） |

--- a/crates/tools/src/bin/nnue_saturation.rs
+++ b/crates/tools/src/bin/nnue_saturation.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    tools::nnue_saturation_tool::run()
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -50,6 +50,7 @@ pub mod dlshogi_features;
 pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;
+pub mod nnue_saturation_tool;
 #[cfg(feature = "dlshogi-onnx")]
 pub mod onnx_value;
 pub mod packed_sfen;

--- a/crates/tools/src/nnue_saturation_tool.rs
+++ b/crates/tools/src/nnue_saturation_tool.rs
@@ -1,0 +1,226 @@
+//! nnue_saturation - LayerStacks NNUE の活性飽和率を実局面で計測する診断ツール。
+//!
+//! ClippedReLU / SqrClippedReLU 系の活性は u8 [0,127] に clamp されるため、
+//! 127 到達率が高いほど量子化天井で情報が落ちている（評価値インフレの副作用の計器）。
+//! FT 出力 / L1→L2 / L2→output の 3 段を bucket 別に集計する。
+//!
+//! 重み側の i8/i16 飽和は rshogi-nnue (tatara) の
+//! `crates/nnue-format/examples/clamp_stats.rs` が担当する（export 時量子化の話のため）。
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Serialize;
+
+use rshogi_core::nnue::{
+    AccumulatorLayerStacks, LayerStackBucketMode, LsFeatureSpec, LsSaturationCounts, NNUENetwork,
+    NetworkLayerStacks, compute_layer_stack_progress8kpabs_bucket_index,
+    get_layer_stack_progress_kpabs_weights, load_progress_coeff_kpabs, ls_dispatch_ft_size,
+    set_layer_stack_bucket_mode, set_layer_stack_progress_kpabs_weights,
+    sqr_clipped_relu_transform,
+};
+use rshogi_core::position::Position;
+use rshogi_core::types::Color;
+
+#[derive(Parser)]
+#[command(
+    name = "nnue_saturation",
+    about = "LayerStacks NNUE の活性飽和率を実局面で計測"
+)]
+struct Cli {
+    /// NNUE ファイルパス。
+    #[arg(long)]
+    nnue: PathBuf,
+
+    /// SFEN ファイル（1 行 1 局面）。
+    #[arg(long)]
+    sfens: PathBuf,
+
+    /// progress.bin (progress8kpabs 進行度重み) のパス。
+    #[arg(long)]
+    progress_coeff: PathBuf,
+
+    /// 読む局面数の上限（省略時は全件）。
+    #[arg(long)]
+    count: Option<usize>,
+
+    /// 集計 JSON の出力先（省略時は標準出力のみ）。
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+struct SaturationReport {
+    nnue: String,
+    sfens: String,
+    positions: u64,
+    total: StageRates,
+    per_bucket: Vec<BucketReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct BucketReport {
+    bucket: usize,
+    positions: u64,
+    #[serde(flatten)]
+    rates: StageRates,
+}
+
+/// 活性 3 段の飽和率（127 到達数 / 総数）。
+#[derive(Debug, Serialize)]
+struct StageRates {
+    ft_sat: u64,
+    ft_total: u64,
+    ft_rate: f64,
+    l1_act_sat: u64,
+    l1_act_total: u64,
+    l1_act_rate: f64,
+    l2_act_sat: u64,
+    l2_act_total: u64,
+    l2_act_rate: f64,
+}
+
+impl StageRates {
+    fn from_counts(c: &LsSaturationCounts) -> Self {
+        let rate = |sat: u64, total: u64| {
+            if total == 0 {
+                0.0
+            } else {
+                sat as f64 / total as f64
+            }
+        };
+        Self {
+            ft_sat: c.ft_sat,
+            ft_total: c.ft_total,
+            ft_rate: rate(c.ft_sat, c.ft_total),
+            l1_act_sat: c.l1_act_sat,
+            l1_act_total: c.l1_act_total,
+            l1_act_rate: rate(c.l1_act_sat, c.l1_act_total),
+            l2_act_sat: c.l2_act_sat,
+            l2_act_total: c.l2_act_total,
+            l2_act_rate: rate(c.l2_act_sat, c.l2_act_total),
+        }
+    }
+}
+
+fn merge(acc: &mut LsSaturationCounts, c: &LsSaturationCounts) {
+    acc.ft_sat += c.ft_sat;
+    acc.ft_total += c.ft_total;
+    acc.l1_act_sat += c.l1_act_sat;
+    acc.l1_act_total += c.l1_act_total;
+    acc.l2_act_sat += c.l2_act_sat;
+    acc.l2_act_total += c.l2_act_total;
+}
+
+fn run_for_network<
+    const L1: usize,
+    const LS_L1_OUT: usize,
+    const LS_L2_IN: usize,
+    const LS_L2_PADDED_INPUT: usize,
+    FT: LsFeatureSpec,
+>(
+    cli: &Cli,
+    network: &NetworkLayerStacks<L1, LS_L1_OUT, LS_L2_IN, LS_L2_PADDED_INPUT, FT>,
+) -> Result<()> {
+    let file = std::fs::File::open(&cli.sfens)
+        .with_context(|| format!("sfens を開けません: {:?}", cli.sfens))?;
+    let reader = BufReader::new(file);
+
+    let mut pos = Position::new();
+    let mut acc = AccumulatorLayerStacks::<L1>::new();
+    let mut bucket_counts = vec![LsSaturationCounts::default(); network.num_buckets];
+    let mut bucket_positions = vec![0u64; network.num_buckets];
+    let limit = cli.count.unwrap_or(usize::MAX);
+
+    for line in reader.lines().take(limit) {
+        let sfen = line?;
+        let sfen = sfen.trim();
+        if sfen.is_empty() {
+            continue;
+        }
+        pos.set_sfen(sfen).with_context(|| format!("SFEN を読めません: {sfen}"))?;
+        network.refresh_accumulator(&pos, &mut acc);
+
+        let side_to_move = pos.side_to_move();
+        let (us_acc, them_acc) = if side_to_move == Color::Black {
+            (acc.get(Color::Black as usize), acc.get(Color::White as usize))
+        } else {
+            (acc.get(Color::White as usize), acc.get(Color::Black as usize))
+        };
+        let mut transformed = [0u8; L1];
+        sqr_clipped_relu_transform(us_acc, them_acc, &mut transformed);
+
+        let bucket_index = compute_layer_stack_progress8kpabs_bucket_index(
+            &pos,
+            side_to_move,
+            get_layer_stack_progress_kpabs_weights(),
+            network.num_buckets,
+        );
+        network.layer_stacks.buckets[bucket_index]
+            .propagate_counting_saturation(&transformed, &mut bucket_counts[bucket_index]);
+        bucket_positions[bucket_index] += 1;
+    }
+
+    let mut total = LsSaturationCounts::default();
+    for c in &bucket_counts {
+        merge(&mut total, c);
+    }
+    let report = SaturationReport {
+        nnue: cli.nnue.display().to_string(),
+        sfens: cli.sfens.display().to_string(),
+        positions: bucket_positions.iter().sum(),
+        total: StageRates::from_counts(&total),
+        per_bucket: bucket_counts
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| c.ft_total > 0)
+            .map(|(bucket, c)| BucketReport {
+                bucket,
+                positions: bucket_positions[bucket],
+                rates: StageRates::from_counts(c),
+            })
+            .collect(),
+    };
+
+    let stdout = std::io::stdout();
+    let mut locked = stdout.lock();
+    serde_json::to_writer_pretty(&mut locked, &report)?;
+    use std::io::Write;
+    writeln!(locked)?;
+
+    if let Some(path) = &cli.out {
+        let mut writer = std::io::BufWriter::new(
+            std::fs::File::create(path)
+                .with_context(|| format!("出力できません: {}", path.display()))?,
+        );
+        serde_json::to_writer_pretty(&mut writer, &report)?;
+        writeln!(writer)?;
+    }
+    Ok(())
+}
+
+/// CLI entrypoint。
+pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    let weights = load_progress_coeff_kpabs(&cli.progress_coeff)
+        .map_err(|e| anyhow::anyhow!("--progress-coeff を読めません: {e}"))?;
+    set_layer_stack_progress_kpabs_weights(weights)
+        .map_err(|e| anyhow::anyhow!("progress 設定に失敗しました: {e}"))?;
+    set_layer_stack_bucket_mode(LayerStackBucketMode::Progress8KPAbs);
+
+    let network = NNUENetwork::load(&cli.nnue)
+        .with_context(|| format!("NNUE を読み込めません: {:?}", cli.nnue))?;
+    let ls_net = match &network {
+        NNUENetwork::LayerStacks(net) => net,
+        _ => anyhow::bail!("nnue_saturation は LayerStacks NNUE のみ対応"),
+    };
+
+    ls_dispatch_ft_size!(
+        ls_net,
+        |concrete_net| run_for_network(&cli, concrete_net),
+        _ => anyhow::bail!("有効な LayerStacks (FT × L1) バリアントがありません"),
+    )
+}


### PR DESCRIPTION
## 概要

ポナンザ定数検証 (評価値インフレ → u8 活性 [0,127] の 127 張り付き → 表現力低下) の**活性側の計器**。

- core: `LayerStackBucket::propagate_counting_saturation` を追加。`propagate` とスコア bit 一致のまま、FT 出力 / L1→L2 activation / L2→output activation の 3 段で `==127` を数える (padding 除外)。ユニットテスト付き
- tools: `nnue_saturation` bin (nnue-arch gate)。eval_sfens と同じ accumulator + progress8kpabs bucket 経路で実局面を流し、progress bucket 別に集計した JSON を出力

**重み側** (i8 dense の ±127/64 張り付き、FT i16 飽和接近) は rshogi-nnue の `clamp_stats` example が既に担当しているため、本ツールは局面依存の活性側のみを扱う。

## レビュー
Codex + Claude(Fable)。==127 計数・padding 除外・bit 一致・bucket 集計・doc 整合を確認し APPROVE (指摘 0)。

## テスト
cargo fmt / clippy (tools+core、警告0) / cargo test (core 42 layer_stacks tests 含む全 suite pass) / check-tracked-abs-paths.sh green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ws9H5XthUvAJvFKjyv9uCd