### PR TITLE
fix(tools): nnue_saturation の FT 飽和を pairing 前の因子側で計測

### DIFF
--- a/crates/rshogi-core/src/nnue/layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/layer_stacks.rs
@@ -36,9 +36,6 @@ fn sqr_clipped_relu_explicit<const DIM: usize>(input: &[i32; DIM], output: &mut 
 /// 127 到達率が高いほど量子化天井で情報が落ちている。
 #[derive(Debug, Default, Clone, Copy)]
 pub struct LsSaturationCounts {
-    /// FT 出力 (SqrClippedReLU 後 u8) の 127 到達数
-    pub ft_sat: u64,
-    pub ft_total: u64,
     /// L1→L2 activation (SqrClippedReLU + ClippedReLU) の 127 到達数
     pub l1_act_sat: u64,
     pub l1_act_total: u64,
@@ -147,9 +144,12 @@ impl<
     /// 順伝播しつつ各活性段の 127 飽和を数える（診断用、ホットパス外）。
     ///
     /// スコアは `propagate` と bit 一致する。カウント対象:
-    /// - FT 出力 (SqrClippedReLU 後の入力 `input` そのもの)
     /// - L1→L2 activation (SqrClippedReLU + ClippedReLU の `LS_L2_IN` 要素)
     /// - L2→output activation (ClippedReLU の 32 要素)
+    ///
+    /// FT 段はここでは数えない。FT 出力は clamp 済み因子の積 `(a*b) >> 7` (最大 126) で
+    /// 127 に到達しないため、FT の飽和は pairing 前の accumulator 値 (>= 127) を
+    /// 呼び出し側で数える。
     pub fn propagate_counting_saturation(
         &self,
         input: &[u8; L1],
@@ -160,9 +160,6 @@ impl<
         let mut l2_out = [0i32; NNUE_PYTORCH_L3];
         let mut l2_relu = Aligned([0u8; OUTPUT_PADDED_INPUT]);
         let mut output_arr = [0i32; 1];
-
-        counts.ft_sat += input.iter().filter(|&&v| v == 127).count() as u64;
-        counts.ft_total += L1 as u64;
 
         self.l1.propagate(input, &mut l1_out);
         let l1_skip = l1_out[Self::MAIN_DIM];
@@ -891,16 +888,12 @@ mod tests {
         bucket.l1.biases[0] = 8192; // sqr=(8192^2)>>19=128→127 / clipped=8192>>6=128→127 で両方飽和
         bucket.l1.biases[1] = 8000; // sqr=122 / clipped=125 で非飽和
 
-        let mut input = Aligned([0u8; TEST_L1]);
-        input.0[0] = 127;
-        input.0[1] = 126;
+        let input = Aligned([0u8; TEST_L1]);
 
         let mut counts = LsSaturationCounts::default();
         let score = bucket.propagate_counting_saturation(&input.0, &mut counts);
         assert_eq!(score, bucket.propagate(&input.0));
 
-        assert_eq!(counts.ft_sat, 1);
-        assert_eq!(counts.ft_total, TEST_L1 as u64);
         assert_eq!(counts.l1_act_sat, 2);
         assert_eq!(counts.l1_act_total, TEST_LS_L2_IN as u64);
         assert_eq!(counts.l2_act_sat, 0);

--- a/crates/tools/docs/nnue_saturation.md
+++ b/crates/tools/docs/nnue_saturation.md
@@ -8,7 +8,7 @@ SqrClippedReLU 系の活性は u8 [0,127] に clamp されるため、127 到達
 
 | 段 | 内容 |
 |---|---|
-| `ft` | FT 出力（SqrClippedReLU 後の L1 次元 u8） |
+| `ft` | FT accumulator の因子 clamp(acc, 0, 127) の 127 到達率（両視点 2×L1 因子。SqrClippedReLU の出力は `(a*b) >> 7` で最大 126 のため、飽和は pairing 前の因子側で観測する） |
 | `l1_act` | L1→L2 activation（SqrClippedReLU + ClippedReLU の 2×main_dim 要素） |
 | `l2_act` | L2→output activation（ClippedReLU の 32 要素） |
 

--- a/crates/tools/src/nnue_saturation_tool.rs
+++ b/crates/tools/src/nnue_saturation_tool.rs
@@ -2,7 +2,9 @@
 //!
 //! ClippedReLU / SqrClippedReLU 系の活性は u8 [0,127] に clamp されるため、
 //! 127 到達率が高いほど量子化天井で情報が落ちている（評価値インフレの副作用の計器）。
-//! FT 出力 / L1→L2 / L2→output の 3 段を bucket 別に集計する。
+//! FT accumulator / L1→L2 / L2→output の 3 段を bucket 別に集計する。
+//! FT 段は SqrClippedReLU の pairing 前の因子 clamp(acc, 0, 127) が 127 に到達した割合
+//! （出力は `(a*b) >> 7` で最大 126 のため、出力側では飽和を観測できない）。
 //!
 //! 重み側の i8/i16 飽和は rshogi-nnue (tatara) の
 //! `crates/nnue-format/examples/clamp_stats.rs` が担当する（export 時量子化の話のため）。
@@ -68,7 +70,7 @@ struct BucketReport {
     rates: StageRates,
 }
 
-/// 活性 3 段の飽和率（127 到達数 / 総数）。
+/// 活性 3 段の飽和率（127 到達数 / 総数）。ft は accumulator 因子側で数える。
 #[derive(Debug, Serialize)]
 struct StageRates {
     ft_sat: u64,
@@ -82,8 +84,16 @@ struct StageRates {
     l2_act_rate: f64,
 }
 
+/// bucket ごとの集計（core の活性カウント + tool 側で数える FT 因子カウント）。
+#[derive(Debug, Default, Clone, Copy)]
+struct BucketCounts {
+    ft_sat: u64,
+    ft_total: u64,
+    act: LsSaturationCounts,
+}
+
 impl StageRates {
-    fn from_counts(c: &LsSaturationCounts) -> Self {
+    fn from_counts(c: &BucketCounts) -> Self {
         let rate = |sat: u64, total: u64| {
             if total == 0 {
                 0.0
@@ -95,23 +105,28 @@ impl StageRates {
             ft_sat: c.ft_sat,
             ft_total: c.ft_total,
             ft_rate: rate(c.ft_sat, c.ft_total),
-            l1_act_sat: c.l1_act_sat,
-            l1_act_total: c.l1_act_total,
-            l1_act_rate: rate(c.l1_act_sat, c.l1_act_total),
-            l2_act_sat: c.l2_act_sat,
-            l2_act_total: c.l2_act_total,
-            l2_act_rate: rate(c.l2_act_sat, c.l2_act_total),
+            l1_act_sat: c.act.l1_act_sat,
+            l1_act_total: c.act.l1_act_total,
+            l1_act_rate: rate(c.act.l1_act_sat, c.act.l1_act_total),
+            l2_act_sat: c.act.l2_act_sat,
+            l2_act_total: c.act.l2_act_total,
+            l2_act_rate: rate(c.act.l2_act_sat, c.act.l2_act_total),
         }
     }
 }
 
-fn merge(acc: &mut LsSaturationCounts, c: &LsSaturationCounts) {
+fn merge(acc: &mut BucketCounts, c: &BucketCounts) {
     acc.ft_sat += c.ft_sat;
     acc.ft_total += c.ft_total;
-    acc.l1_act_sat += c.l1_act_sat;
-    acc.l1_act_total += c.l1_act_total;
-    acc.l2_act_sat += c.l2_act_sat;
-    acc.l2_act_total += c.l2_act_total;
+    acc.act.l1_act_sat += c.act.l1_act_sat;
+    acc.act.l1_act_total += c.act.l1_act_total;
+    acc.act.l2_act_sat += c.act.l2_act_sat;
+    acc.act.l2_act_total += c.act.l2_act_total;
+}
+
+/// SqrClippedReLU の因子 clamp(acc, 0, 127) が 127 に到達した数を数える。
+fn count_ft_factor_saturation(acc: &[i16]) -> u64 {
+    acc.iter().filter(|&&v| v >= 127).count() as u64
 }
 
 fn run_for_network<
@@ -130,7 +145,7 @@ fn run_for_network<
 
     let mut pos = Position::new();
     let mut acc = AccumulatorLayerStacks::<L1>::new();
-    let mut bucket_counts = vec![LsSaturationCounts::default(); network.num_buckets];
+    let mut bucket_counts = vec![BucketCounts::default(); network.num_buckets];
     let mut bucket_positions = vec![0u64; network.num_buckets];
     let limit = cli.count.unwrap_or(usize::MAX);
 
@@ -158,12 +173,15 @@ fn run_for_network<
             get_layer_stack_progress_kpabs_weights(),
             network.num_buckets,
         );
+        let bc = &mut bucket_counts[bucket_index];
+        bc.ft_sat += count_ft_factor_saturation(us_acc) + count_ft_factor_saturation(them_acc);
+        bc.ft_total += 2 * L1 as u64;
         network.layer_stacks.buckets[bucket_index]
-            .propagate_counting_saturation(&transformed, &mut bucket_counts[bucket_index]);
+            .propagate_counting_saturation(&transformed, &mut bc.act);
         bucket_positions[bucket_index] += 1;
     }
 
-    let mut total = LsSaturationCounts::default();
+    let mut total = BucketCounts::default();
     for c in &bucket_counts {
         merge(&mut total, c);
     }


### PR DESCRIPTION
## 概要

#924 の FT 段の計測は、SqrClippedReLU 出力が clamp 済み因子の積 `(a*b)>>7` (最大 126) のため `==127` が構造的に発火せず常に 0% だった (初回計測で発覚)。飽和は pairing 前の因子 `clamp(acc, 0, 127)` の 127 到達で観測するのが正しい。

- tool: 両視点 accumulator の `>= 127` を数える方式に変更 (分母 = 2×L1 因子/局面)
- core: dead になった FT 計数を `LsSaturationCounts` / `propagate_counting_saturation` から除去
- doc: ft 段の定義を修正

## レビュー
Codex + Claude(Fable)。因子計数と SIMD 実装 (`min(max(acc,0),127)`) の一致、分母、struct 集約、doc を確認し APPROVE (指摘 0)。

## テスト
cargo fmt / clippy (tools+core、警告0) / cargo test 全 suite pass / check-tracked-abs-paths.sh green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ws9H5XthUvAJvFKjyv9uCd