### PR TITLE
feat(search): update_all_stats の SF 追従 3 点 + LMR allNode depth スケールを tunable で導入

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -1501,10 +1501,14 @@ impl SearchWorker {
 
                         // quiets_triedはbestMove追加段階で除外済みのため
                         // ペナルティループでの重複チェックは不要
+                        // (適用手ごとに decay_num/1024 で幾何減衰、非rootの経路と同一)
+                        let mut actual_malus = scaled_malus;
                         for &m in quiets_tried.iter() {
-                            h.main_history.update(us, m, -scaled_malus);
+                            actual_malus =
+                                actual_malus * tune.update_all_stats_quiet_malus_decay_num / 1024;
+                            h.main_history.update(us, m, -actual_malus);
 
-                            let low_ply_malus = low_ply_history_bonus(-scaled_malus, &tune);
+                            let low_ply_malus = low_ply_history_bonus(-actual_malus, &tune);
                             h.low_ply_history.update(0, m, low_ply_malus);
 
                             // ContinuationHistory: ply=0ではスキップ
@@ -1517,7 +1521,7 @@ impl SearchWorker {
                             };
                             let to = m.to();
 
-                            let pawn_malus = pawn_history_bonus(-scaled_malus, &tune);
+                            let pawn_malus = pawn_history_bonus(-actual_malus, &tune);
                             h.pawn_history.update(pawn_key_idx, cont_pc, to, pawn_malus);
                         }
                     }

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -2826,6 +2826,11 @@ impl SearchWorker {
             st.stack[ply as usize].stat_score = stat_score;
             r -= stat_score * ctx.tune_params.lmr_step16_stat_score_scale_num / 8192;
 
+            if all_node {
+                r += r * ctx.tune_params.lmr_all_node_scale_num
+                    / (256 * depth + ctx.tune_params.lmr_all_node_scale_offset);
+            }
+
             // =============================================================
             // 探索
             // =============================================================
@@ -3198,7 +3203,21 @@ impl SearchWorker {
             let is_best_capture = pos.capture_stage(best_move);
             let is_tt_move = best_move == tt_move;
             // bonus = min(121*depth-77, 1633) + 375*(bestMove==ttMove)
-            let bonus = stat_bonus(depth, is_tt_move, ctx.tune_params);
+            //         + parentStatScore * num/8192、非PVではさらに探索済み手数でスケール
+            let parent_stat_score = if ply >= 1 {
+                st.stack[(ply - 1) as usize].stat_score
+            } else {
+                0
+            };
+            let mut bonus = stat_bonus(depth, is_tt_move, ctx.tune_params)
+                + parent_stat_score * ctx.tune_params.stat_bonus_parent_stat_num / 8192;
+            if !pv_node {
+                let searched_count = quiets_tried.len() + captures_tried.len();
+                bonus += ((bonus as i64)
+                    * searched_count as i64
+                    * ctx.tune_params.update_all_stats_searched_count_num as i64
+                    / (256 * 1024)) as i32;
+            }
             // malus = min(825*depth-196, 2159) - 16*moveCount
             let malus = stat_malus(depth, move_count, ctx.tune_params);
             let us = pos.side_to_move();
@@ -3222,7 +3241,7 @@ impl SearchWorker {
                 let scaled_bonus =
                     bonus * ctx.tune_params.update_all_stats_quiet_bonus_scale_num / 1024;
 
-                // 他のquiet手にはペナルティ
+                // 他のquiet手にはペナルティ (適用手ごとに decay_num/1024 で幾何減衰)
                 // update_quiet_histories(move, -quietMalus * 1083 / 1024)
                 let scaled_malus =
                     malus * ctx.tune_params.update_all_stats_quiet_malus_scale_num / 1024;
@@ -3284,14 +3303,18 @@ impl SearchWorker {
 
                     // quiets_triedはbestMove追加段階で除外済みのため
                     // ペナルティループでの重複チェックは不要
+                    let mut actual_malus = scaled_malus;
                     for &m in quiets_tried.iter() {
+                        actual_malus = actual_malus
+                            * ctx.tune_params.update_all_stats_quiet_malus_decay_num
+                            / 1024;
                         // MainHistory
-                        h.main_history.update(us, m, -scaled_malus);
+                        h.main_history.update(us, m, -actual_malus);
 
                         // LowPlyHistory
                         if ply < LOW_PLY_HISTORY_SIZE as i32 {
                             let low_ply_malus =
-                                low_ply_history_bonus(-scaled_malus, ctx.tune_params);
+                                low_ply_history_bonus(-actual_malus, ctx.tune_params);
                             h.low_ply_history.update(ply as usize, m, low_ply_malus);
                         }
 
@@ -3305,9 +3328,9 @@ impl SearchWorker {
                         let to = m.to();
 
                         // ContinuationHistoryへのペナルティ
-                        // -malus * 1083/1024 * 955/1024 * weight/1024 + 88*(i<2)
+                        // -actualMalus * 955/1024 * weight/1024 + 88*(i<2) (actualMalus は幾何減衰済み)
                         let cont_scaled_malus =
-                            -scaled_malus * ctx.tune_params.continuation_history_multiplier / 1024;
+                            -actual_malus * ctx.tune_params.continuation_history_multiplier / 1024;
                         for ply_back in 1..=6 {
                             if ply_back > max_ply_back {
                                 continue;
@@ -3342,7 +3365,7 @@ impl SearchWorker {
                         }
 
                         // PawnHistoryへのペナルティ
-                        let pawn_malus = pawn_history_bonus(-scaled_malus, ctx.tune_params);
+                        let pawn_malus = pawn_history_bonus(-actual_malus, ctx.tune_params);
                         h.pawn_history.update(pawn_key_idx, cont_pc, to, pawn_malus);
                     }
                 }

--- a/crates/rshogi-core/src/search/tune_params.rs
+++ b/crates/rshogi-core/src/search/tune_params.rs
@@ -89,6 +89,10 @@ pub struct SearchTuneParams {
     pub lmr_step16_capture_stat_scale_num: i32,
     /// LMR Step16: stat_score 補正の分子（/8192）
     pub lmr_step16_stat_score_scale_num: i32,
+    /// allNode では合成済みの reduction を深さに応じて増幅する。
+    pub lmr_all_node_scale_num: i32,
+    /// allNode reduction 増幅率の深さ依存を調整する。
+    pub lmr_all_node_scale_offset: i32,
     /// LMR再探索: deeper判定のベース値（43 + 2*depth の43）
     pub lmr_research_deeper_base: i32,
     /// LMR再探索: deeper判定の depth 係数（43 + 2*depth の2）
@@ -192,6 +196,8 @@ pub struct SearchTuneParams {
     pub stat_bonus_max: i32,
     /// stat bonus: TT手一致時の加算（375）
     pub stat_bonus_tt_bonus: i32,
+    /// stat bonus に親ノードの statScore を還流する分子（/8192、0 で無効）。
+    pub stat_bonus_parent_stat_num: i32,
     /// stat malus: depth 係数（825）
     pub stat_malus_depth_mult: i32,
     /// stat malus: オフセット（-196）
@@ -244,6 +250,10 @@ pub struct SearchTuneParams {
     pub update_all_stats_quiet_bonus_scale_num: i32,
     /// update_all_stats: quiet malus更新のスケール分子（/1024）
     pub update_all_stats_quiet_malus_scale_num: i32,
+    /// quiet malus を適用手ごとに減衰させる分子（/1024）。
+    pub update_all_stats_quiet_malus_decay_num: i32,
+    /// 非PVノードで探索済み手数を bonus に反映する分子（/(256*1024)、0 で無効）。
+    pub update_all_stats_searched_count_num: i32,
     /// update_all_stats: capture best更新のスケール分子（/1024）
     pub update_all_stats_capture_bonus_scale_num: i32,
     /// update_all_stats: capture malus更新のスケール分子（/1024）
@@ -584,6 +594,18 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
         max: 8192,
     },
     SearchTuneOptionSpec {
+        usi_name: "SPSA_LMR_ALL_NODE_SCALE_NUM",
+        default: 272,
+        min: 0,
+        max: 4096,
+    },
+    SearchTuneOptionSpec {
+        usi_name: "SPSA_LMR_ALL_NODE_SCALE_OFFSET",
+        default: 285,
+        min: 1,
+        max: 8192,
+    },
+    SearchTuneOptionSpec {
         usi_name: "SPSA_LMR_RESEARCH_DEEPER_BASE",
         default: 43,
         min: -1024,
@@ -872,6 +894,12 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
         max: 4096,
     },
     SearchTuneOptionSpec {
+        usi_name: "SPSA_STAT_BONUS_PARENT_STAT_NUM",
+        default: 273,
+        min: 0,
+        max: 8192,
+    },
+    SearchTuneOptionSpec {
         usi_name: "SPSA_STAT_MALUS_DEPTH_MULT",
         default: 825,
         min: 0,
@@ -1026,6 +1054,18 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
         default: 1083,
         min: 0,
         max: 4096,
+    },
+    SearchTuneOptionSpec {
+        usi_name: "SPSA_UPDATE_ALL_QUIET_MALUS_DECAY_NUM",
+        default: 956,
+        min: 0,
+        max: 1024,
+    },
+    SearchTuneOptionSpec {
+        usi_name: "SPSA_UPDATE_ALL_SEARCHED_COUNT_NUM",
+        default: 1024,
+        min: 0,
+        max: 16_384,
     },
     SearchTuneOptionSpec {
         usi_name: "SPSA_UPDATE_ALL_CAPTURE_BONUS_SCALE_NUM",
@@ -1443,6 +1483,8 @@ impl Default for SearchTuneParams {
             lmr_step16_tt_move_penalty: 2018,
             lmr_step16_capture_stat_scale_num: 803,
             lmr_step16_stat_score_scale_num: 794,
+            lmr_all_node_scale_num: 272,
+            lmr_all_node_scale_offset: 285,
             lmr_research_deeper_base: 43,
             lmr_research_deeper_depth_mul: 2,
             lmr_research_shallower_threshold: 9,
@@ -1491,6 +1533,7 @@ impl Default for SearchTuneParams {
             stat_bonus_offset: -77,
             stat_bonus_max: 1633,
             stat_bonus_tt_bonus: 375,
+            stat_bonus_parent_stat_num: 273,
             stat_malus_depth_mult: 825,
             stat_malus_offset: -196,
             stat_malus_max: 2159,
@@ -1517,6 +1560,8 @@ impl Default for SearchTuneParams {
             pawn_history_neg_multiplier: 550,
             update_all_stats_quiet_bonus_scale_num: 881,
             update_all_stats_quiet_malus_scale_num: 1083,
+            update_all_stats_quiet_malus_decay_num: 956,
+            update_all_stats_searched_count_num: 1024,
             update_all_stats_capture_bonus_scale_num: 1482,
             update_all_stats_capture_malus_scale_num: 1397,
             update_all_stats_early_refutation_penalty_scale_num: 614,
@@ -1671,6 +1716,8 @@ impl SearchTuneParams {
             0,
             8192
         );
+        try_apply!("SPSA_LMR_ALL_NODE_SCALE_NUM", lmr_all_node_scale_num, 0, 4096);
+        try_apply!("SPSA_LMR_ALL_NODE_SCALE_OFFSET", lmr_all_node_scale_offset, 1, 8192);
         try_apply!("SPSA_LMR_RESEARCH_DEEPER_BASE", lmr_research_deeper_base, -1024, 1024);
         try_apply!("SPSA_LMR_RESEARCH_DEEPER_DEPTH_MUL", lmr_research_deeper_depth_mul, -64, 64);
         try_apply!(
@@ -1779,6 +1826,7 @@ impl SearchTuneParams {
         try_apply!("SPSA_STAT_BONUS_OFFSET", stat_bonus_offset, -4096, 4096);
         try_apply!("SPSA_STAT_BONUS_MAX", stat_bonus_max, 1, 8192);
         try_apply!("SPSA_STAT_BONUS_TT_BONUS", stat_bonus_tt_bonus, -4096, 4096);
+        try_apply!("SPSA_STAT_BONUS_PARENT_STAT_NUM", stat_bonus_parent_stat_num, 0, 8192);
         try_apply!("SPSA_STAT_MALUS_DEPTH_MULT", stat_malus_depth_mult, 0, 4096);
         try_apply!("SPSA_STAT_MALUS_OFFSET", stat_malus_offset, -4096, 4096);
         try_apply!("SPSA_STAT_MALUS_MAX", stat_malus_max, 1, 8192);
@@ -1824,6 +1872,18 @@ impl SearchTuneParams {
             update_all_stats_quiet_malus_scale_num,
             0,
             4096
+        );
+        try_apply!(
+            "SPSA_UPDATE_ALL_QUIET_MALUS_DECAY_NUM",
+            update_all_stats_quiet_malus_decay_num,
+            0,
+            1024
+        );
+        try_apply!(
+            "SPSA_UPDATE_ALL_SEARCHED_COUNT_NUM",
+            update_all_stats_searched_count_num,
+            0,
+            16_384
         );
         try_apply!(
             "SPSA_UPDATE_ALL_CAPTURE_BONUS_SCALE_NUM",
@@ -2002,6 +2062,23 @@ mod tests {
         assert!(res.clamped);
         assert_eq!(res.applied, 1);
         assert_eq!(params.nmp_reduction_depth_div, 1);
+    }
+
+    #[test]
+    fn sf_gap_params_round_trip() {
+        let mut params = SearchTuneParams::default();
+
+        params.set_from_usi_name("SPSA_STAT_BONUS_PARENT_STAT_NUM", 274).unwrap();
+        params.set_from_usi_name("SPSA_UPDATE_ALL_SEARCHED_COUNT_NUM", 1025).unwrap();
+        params.set_from_usi_name("SPSA_UPDATE_ALL_QUIET_MALUS_DECAY_NUM", 955).unwrap();
+        params.set_from_usi_name("SPSA_LMR_ALL_NODE_SCALE_NUM", 273).unwrap();
+        params.set_from_usi_name("SPSA_LMR_ALL_NODE_SCALE_OFFSET", 286).unwrap();
+
+        assert_eq!(params.stat_bonus_parent_stat_num, 274);
+        assert_eq!(params.update_all_stats_searched_count_num, 1025);
+        assert_eq!(params.update_all_stats_quiet_malus_decay_num, 955);
+        assert_eq!(params.lmr_all_node_scale_num, 273);
+        assert_eq!(params.lmr_all_node_scale_offset, 286);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stockfish master (86f1df71) との update_all_stats / LMR 差分監査で確定した未追従 4 点を、定数を全て SearchTuneParams (SPSA 配線) にして導入する。

| 項目 | SF | 新パラメータ (default = SF 値) |
|--|--|--|
| stat bonus への親 statScore 還流 | `+ (ss-1)->statScore / 30` | `SPSA_STAT_BONUS_PARENT_STAT_NUM` = 273 (/8192 ≈ 1/30) |
| 非 PV での探索済み手数スケール | `bonus += bonus * searched / 256` | `SPSA_UPDATE_ALL_SEARCHED_COUNT_NUM` = 1024 (/(256*1024) = 1/256 完全一致) |
| quiet malus の幾何減衰 | `actualMalus *= 956/1024` を適用手ごと | `SPSA_UPDATE_ALL_QUIET_MALUS_DECAY_NUM` = 956 |
| allNode reduction 深さスケール | `r += r*272/(256*depth+285)` | `SPSA_LMR_ALL_NODE_SCALE_NUM/OFFSET` = 272/285 |

全項目 num=0 / decay=1024 で旧挙動へ neutralize 可能 (SPSA 後 SPRT が失敗した場合の bisect 用)。

調査正典: rshogi-notes `rshogi/20260712-history_bonus_sf_gap/findings.md` (2026-04 実験バッチの教訓を踏まえ、SF 定数直移植ではなく SPSA 込みで評価する前提の実装)。

## Review

ローカル dual review 済み: Codex (APPROVE、初回 REQUEST_CHANGES の除数→分子方式化と陳腐化コメント修正を反映) + Claude Fable (SF 等価性・適用順・stat_score 意味論・comment hygiene 確認)。

## Test plan
- [x] cargo fmt / clippy 警告ゼロ / cargo test (971 passed) / check-tracked-abs-paths
- [ ] merge 後: 全 168 param SPSA (byoyomi 500ms × 20k pairs, ftfact-400, threads=1) → final.params で SPRT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qjek7GJbGFmSANTtDPGpDk