### PR TITLE
feat(tools): hcpe → PSV 変換ツール hcpe_to_psv を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -43,6 +43,7 @@
 | `fix_scores` | スコアの補正 |
 | `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・重複除去・決定的 shuffle・分割（[詳細](docs/prep_hcpe.md)） |
+| `hcpe_to_psv` | hcpe → PSV 変換（外部公開 hcpe プールの学習/検証投入用、[詳細](docs/hcpe_to_psv.md)） |
 
 ### ベンチマーク・分析
 

--- a/crates/tools/docs/hcpe_to_psv.md
+++ b/crates/tools/docs/hcpe_to_psv.md
@@ -27,21 +27,27 @@ cargo run --release -p tools --bin hcpe_to_psv -- \
 | `--input-dir <DIR>` | 入力ディレクトリ。`--pattern` と組み合わせる | - |
 | `--pattern <GLOB>` | `--input-dir` 使用時の glob パターン | `*.hcpe` |
 | `--output <FILE>` | 出力 PSV ファイル | - |
+| `--chunk <N>` | 並列変換のチャンクサイズ（レコード数） | `65536` |
+| `--threads <N>` | rayon スレッド数（0 = 自動） | `0` |
 
 ## フィールド対応
 
 | hcpe | PSV | 変換 |
 |---|---|---|
-| `hcp` (HuffmanCodedPos, Apery/cshogi 形式) | `sfen` (PackedSfen, YaneuraOu 形式) | Huffman テーブルが異なるため `Position` 経由で再パック |
-| `eval` (手番側視点 cp) | `score` | そのままコピー（両形式で同一規約） |
-| `bestMove16` (cshogi Move16) | `move16` (YaneuraOu Move16) | 駒打ちの駒種 index が 1 ずれるため再エンコード |
+| `hcp` (HuffmanCodedPos, Apery/cshogi 形式) | `sfen` (PackedSfen, YaneuraOu 形式) | Huffman テーブルが異なるため `unpack_hcp_to_parts` → `pack_sfen_from_parts` で直接再パック |
+| `eval` (手番側視点 cp) | `score` | そのままコピー（視点は両形式で同一規約）。詰み帯の数値表現は生成系依存で、値変換は行わない |
+| `bestMove16` (cshogi Move16) | `move16` (**実 YaneuraOu Move16**: bit14=駒打ち/bit15=成り) | `hcpe_move16_to_psv` で再エンコード。リポジトリ内部表現 `move_to_move16` とは別形式 |
 | `gameResult` (絶対視点 0=draw / 1=black_win / 2=white_win) | `game_result` (手番側視点 1=win / -1=loss / 0=draw) | 手番で符号を決定 |
 | （なし） | `game_ply` | hcpe に手数情報が無いため 1 固定 |
 
 ## 挙動
 
 - 入力順（複数ファイルはパスのソート順）を保持して連結出力する。決定的。
-- streaming 処理でピークメモリは入力サイズに非依存。
-- 壊れたレコード（hcp デコード失敗 / bestMove16 不正 / gameResult が 0/1/2 以外）は
-  skip して種別ごとに件数を summary に出す。
+- チャンク読み + rayon 並列。ピークメモリはチャンクサイズのみに依存し入力サイズに非依存。
+  実測 (856,923 局面, 32.5MB): 0.15 秒 / ピーク RSS 10.4MB（逐次 Position 経由の初期実装比 24 倍）。
+- `.partial` へ書き、正常完了時のみ最終パスへ rename する（中断時の途中書き PSV はバイト長が
+  40 の倍数になり下流チェックをすり抜けるため、残さない）。入力と出力の同一パスは拒否。
+- 壊れたレコード（hcp デコード失敗 / bestMove16 の駒打ち駒種不正 / gameResult が 0/1/2 以外）は
+  skip して種別ごとに件数を summary に出す。`bestMove16 == 0`（終局直前レコード等、指し手なし）も
+  skip するが `No bestmove` として別カウントする。
 - 入力サイズが 38 の倍数でないファイルは即エラー。

--- a/crates/tools/docs/hcpe_to_psv.md
+++ b/crates/tools/docs/hcpe_to_psv.md
@@ -1,0 +1,47 @@
+# hcpe_to_psv
+
+`hcpe_to_psv` は、hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード）を
+PSV（YaneuraOu PackedSfenValue, 40B/レコード）へ変換するツールです。
+
+外部公開の hcpe 教師/検証プール（例: dlshogi 系で標準の floodgate 検証局面）を、
+nnue-train の `--data` / `--test-data` が読む PSV 形式にするのが主用途です。
+
+## 使用例
+
+```bash
+# 単一ファイル
+cargo run --release -p tools --bin hcpe_to_psv -- \
+  --input "$SHOGI_DATA/validation/floodgate_hcpe_yamaoka/floodgate.hcpe" \
+  --output "$SHOGI_DATA/validation/floodgate_hcpe_yamaoka/floodgate.psv"
+
+# ディレクトリ内の .hcpe を一括変換（パスのソート順で連結）
+cargo run --release -p tools --bin hcpe_to_psv -- \
+  --input-dir "$SHOGI_DATA/teachers/pool" --output out.psv
+```
+
+## オプション
+
+| オプション | 説明 | 既定値 |
+|---|---|---:|
+| `--input <FILES>` | 入力 hcpe（カンマ区切りで複数可）。`--input-dir` と排他 | - |
+| `--input-dir <DIR>` | 入力ディレクトリ。`--pattern` と組み合わせる | - |
+| `--pattern <GLOB>` | `--input-dir` 使用時の glob パターン | `*.hcpe` |
+| `--output <FILE>` | 出力 PSV ファイル | - |
+
+## フィールド対応
+
+| hcpe | PSV | 変換 |
+|---|---|---|
+| `hcp` (HuffmanCodedPos, Apery/cshogi 形式) | `sfen` (PackedSfen, YaneuraOu 形式) | Huffman テーブルが異なるため `Position` 経由で再パック |
+| `eval` (手番側視点 cp) | `score` | そのままコピー（両形式で同一規約） |
+| `bestMove16` (cshogi Move16) | `move16` (YaneuraOu Move16) | 駒打ちの駒種 index が 1 ずれるため再エンコード |
+| `gameResult` (絶対視点 0=draw / 1=black_win / 2=white_win) | `game_result` (手番側視点 1=win / -1=loss / 0=draw) | 手番で符号を決定 |
+| （なし） | `game_ply` | hcpe に手数情報が無いため 1 固定 |
+
+## 挙動
+
+- 入力順（複数ファイルはパスのソート順）を保持して連結出力する。決定的。
+- streaming 処理でピークメモリは入力サイズに非依存。
+- 壊れたレコード（hcp デコード失敗 / bestMove16 不正 / gameResult が 0/1/2 以外）は
+  skip して種別ごとに件数を summary に出す。
+- 入力サイズが 38 の倍数でないファイルは即エラー。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -63,6 +63,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `psv_to_jsonl` | PSV 形式を JSONL 形式に変換 |
 | `psv_to_hcpe3` | PSV を dlshogi 学習用 hcpe3 / hcpe に変換（cshogi と byte 一致、streaming、`--evalfix-a` で eval 焼き込み） |
 | `pack_to_psv` | GenSfen .pack を PackedSfenValue (PSV) 形式に展開 |
+| `hcpe_to_psv` | hcpe (cshogi HuffmanCodedPosAndEval) を PSV に変換（外部公開 hcpe プールの `--data`/`--test-data` 用、[詳細](hcpe_to_psv.md)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・Bloom 重複除去・決定的 shuffle・件数制限・分割（[詳細](prep_hcpe.md)） |
 
 ## 重複除去・検証

--- a/crates/tools/src/bin/hcpe_to_psv.rs
+++ b/crates/tools/src/bin/hcpe_to_psv.rs
@@ -1,0 +1,238 @@
+//! hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード）→ PSV（PackedSfenValue, 40B/レコード）
+//! 変換ツール。
+//!
+//! 外部公開の hcpe 教師/検証プール（例: dlshogi 系の floodgate 検証局面）を、
+//! nnue-train の `--data` / `--test-data` が読む PSV 形式へ変換する。
+//!
+//! # フィールド対応
+//!
+//! - 局面: `HuffmanCodedPos`（Apery/cshogi 形式）→ `PackedSfen`（YaneuraOu 形式）。
+//!   Huffman テーブルが異なるため `Position` 経由で再パックする。
+//! - eval: 手番側視点 cp（両形式で同一規約）をそのままコピー。
+//! - bestMove16: cshogi 形式 → YaneuraOu Move16 形式（駒打ちの駒種 index が 1 ずれる）。
+//! - gameResult: 絶対視点（0=draw / 1=black_win / 2=white_win）→ 手番側視点
+//!   （1=win / -1=loss / 0=draw）。
+//! - game_ply: hcpe には手数が無いため 1 固定（`unpack_hcp` の SFEN 手数をそのまま使う）。
+//!
+//! # 使用例
+//!
+//! ```bash
+//! cargo run --release -p tools --bin hcpe_to_psv -- \
+//!   --input "$SHOGI_DATA/validation/floodgate_hcpe_yamaoka/floodgate.hcpe" \
+//!   --output "$SHOGI_DATA/validation/floodgate_hcpe_yamaoka/floodgate.psv"
+//! ```
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::PathBuf;
+
+use clap::Parser;
+use rshogi_core::position::Position;
+use rshogi_core::types::Color;
+use tools::packed_sfen::{
+    PackedSfenValue, hcpe_move16_to_move, move_to_move16, pack_position, unpack_hcp,
+};
+use tools::teacher_labeler::HCPE_RECORD_SIZE;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "hcpe_to_psv",
+    about = "hcpe (38B/レコード) を PSV (PackedSfenValue 40B/レコード) に変換する"
+)]
+struct Args {
+    /// 入力 hcpe ファイル（カンマ区切りで複数可）。--input-dir と排他
+    #[arg(long)]
+    input: Option<String>,
+
+    /// 入力ディレクトリ。--pattern と組み合わせて使用。--input と排他
+    #[arg(long)]
+    input_dir: Option<PathBuf>,
+
+    /// --input-dir 使用時の glob パターン
+    #[arg(long, default_value = "*.hcpe")]
+    pattern: String,
+
+    /// 出力ファイルパス（PSV 形式）。入力順を保持して連結する
+    #[arg(long)]
+    output: PathBuf,
+}
+
+#[derive(Default)]
+struct Stats {
+    converted: u64,
+    decode_errors: u64,
+    move_errors: u64,
+    result_errors: u64,
+}
+
+/// gameResult（絶対視点 0=draw / 1=black_win / 2=white_win）を手番側視点の
+/// PSV game_result（1=win / -1=loss / 0=draw）へ変換する。0/1/2 以外は `None`。
+fn convert_game_result(game_result: u8, stm: Color) -> Option<i8> {
+    match game_result {
+        0 => Some(0),
+        1 => Some(if stm == Color::Black { 1 } else { -1 }),
+        2 => Some(if stm == Color::White { 1 } else { -1 }),
+        _ => None,
+    }
+}
+
+/// hcpe 1 レコードを PSV 1 レコードへ変換する。壊れたレコードは `Err` で返し、
+/// 呼び出し側で件数を数えて skip する。
+fn convert_record(bytes: &[u8; HCPE_RECORD_SIZE], stats: &mut Stats) -> Option<PackedSfenValue> {
+    let mut hcp = [0u8; 32];
+    hcp.copy_from_slice(&bytes[0..32]);
+    let eval = i16::from_le_bytes([bytes[32], bytes[33]]);
+    let best_move16 = u16::from_le_bytes([bytes[34], bytes[35]]);
+    let game_result = bytes[36];
+
+    let sfen = match unpack_hcp(&hcp) {
+        Ok(s) => s,
+        Err(_) => {
+            stats.decode_errors += 1;
+            return None;
+        }
+    };
+    let mut pos = Position::new();
+    if pos.set_sfen(&sfen).is_err() {
+        stats.decode_errors += 1;
+        return None;
+    }
+
+    let mv = hcpe_move16_to_move(best_move16);
+    let move16 = move_to_move16(mv);
+    if move16 == 0 {
+        stats.move_errors += 1;
+        return None;
+    }
+
+    let Some(psv_result) = convert_game_result(game_result, pos.side_to_move()) else {
+        stats.result_errors += 1;
+        return None;
+    };
+
+    stats.converted += 1;
+    Some(PackedSfenValue {
+        sfen: pack_position(&pos),
+        score: eval,
+        move16,
+        game_ply: pos.game_ply() as u16,
+        game_result: psv_result,
+        padding: 0,
+    })
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+
+    let paths = tools::common::dedup::collect_input_paths(
+        args.input.as_deref(),
+        args.input_dir.as_ref(),
+        &args.pattern,
+    )?;
+    if paths.is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "入力ファイルが見つかりません"));
+    }
+    for p in &paths {
+        let len = std::fs::metadata(p)?.len();
+        if len % HCPE_RECORD_SIZE as u64 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "{} のサイズ {len} が hcpe レコード長 {HCPE_RECORD_SIZE} の倍数ではありません",
+                    p.display()
+                ),
+            ));
+        }
+    }
+
+    let out_file = File::create(&args.output)?;
+    let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
+    let mut stats = Stats::default();
+
+    for path in &paths {
+        eprintln!("Reading: {}", path.display());
+        let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(path)?);
+        let mut buf = [0u8; HCPE_RECORD_SIZE];
+        loop {
+            match reader.read_exact(&mut buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e),
+            }
+            if let Some(psv) = convert_record(&buf, &mut stats) {
+                writer.write_all(&psv.to_bytes())?;
+            }
+        }
+    }
+    writer.flush()?;
+
+    println!("=== hcpe → PSV Summary ===");
+    println!("Input files:     {}", paths.len());
+    println!("Converted:       {}", stats.converted);
+    println!("Decode errors:   {}", stats.decode_errors);
+    println!("Move errors:     {}", stats.move_errors);
+    println!("Result errors:   {}", stats.result_errors);
+    println!("Output file:     {}", args.output.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tools::packed_sfen::{move_to_hcpe_move16, pack_position_hcp, unpack_sfen};
+
+    fn make_hcpe_record(
+        pos: &Position,
+        eval: i16,
+        best_move16: u16,
+        game_result: u8,
+    ) -> [u8; HCPE_RECORD_SIZE] {
+        let mut rec = [0u8; HCPE_RECORD_SIZE];
+        rec[0..32].copy_from_slice(&pack_position_hcp(pos));
+        rec[32..34].copy_from_slice(&eval.to_le_bytes());
+        rec[34..36].copy_from_slice(&best_move16.to_le_bytes());
+        rec[36] = game_result;
+        rec
+    }
+
+    #[test]
+    fn convert_record_roundtrips_position_eval_move_result() {
+        let mut pos = Position::new();
+        pos.set_hirate();
+        // 平手初期局面の ▲7六歩 (77→76)
+        let mv = {
+            use rshogi_core::movegen::{MoveList, generate_legal_all};
+            let mut moves = MoveList::new();
+            generate_legal_all(&pos, &mut moves);
+            *moves.iter().find(|m| !m.is_drop() && m.to_usi() == "7g7f").unwrap()
+        };
+
+        let rec = make_hcpe_record(&pos, -123, move_to_hcpe_move16(mv), 2);
+        let mut stats = Stats::default();
+        let psv = convert_record(&rec, &mut stats).unwrap();
+
+        assert_eq!(unpack_sfen(&psv.sfen).unwrap(), unpack_sfen(&pack_position(&pos)).unwrap());
+        assert_eq!(psv.score, -123);
+        assert_eq!(psv.move16, move_to_move16(mv));
+        // white_win で手番=先手 → 手番側視点 loss
+        assert_eq!(psv.game_result, -1);
+        assert_eq!(stats.converted, 1);
+    }
+
+    #[test]
+    fn convert_game_result_maps_absolute_to_stm_view() {
+        assert_eq!(convert_game_result(0, Color::Black), Some(0));
+        assert_eq!(convert_game_result(1, Color::Black), Some(1));
+        assert_eq!(convert_game_result(1, Color::White), Some(-1));
+        assert_eq!(convert_game_result(2, Color::White), Some(1));
+        assert_eq!(convert_game_result(3, Color::Black), None);
+    }
+
+    #[test]
+    fn convert_record_rejects_broken_records() {
+        let mut stats = Stats::default();
+        // 全ゼロ: bestMove16=0 → move error (hcp 全ゼロは decode 失敗が先でも可)
+        let rec = [0u8; HCPE_RECORD_SIZE];
+        assert!(convert_record(&rec, &mut stats).is_none());
+        assert_eq!(stats.converted, 0);
+    }
+}

--- a/crates/tools/src/bin/hcpe_to_psv.rs
+++ b/crates/tools/src/bin/hcpe_to_psv.rs
@@ -1,18 +1,26 @@
 //! hcpe（cshogi HuffmanCodedPosAndEval, 38B/レコード）→ PSV（PackedSfenValue, 40B/レコード）
 //! 変換ツール。
 //!
-//! 外部公開の hcpe 教師/検証プール（例: dlshogi 系の floodgate 検証局面）を、
+//! 外部公開の hcpe 教師/検証プール（例: dlshogi 系で標準の floodgate 検証局面）を、
 //! nnue-train の `--data` / `--test-data` が読む PSV 形式へ変換する。
+//!
+//! 盤面は `tools::packed_sfen::unpack_hcp_to_parts` → `pack_sfen_from_parts` で
+//! SFEN 文字列・`Position` 構築を経由せず直接再パックする（ホットパスでのヒープ
+//! 割り当てなし）。move16 / gameResult の形式差も同モジュールの共有変換
+//! （`hcpe_move16_to_psv` / `hcpe_result_to_stm`）で吸収する。
+//! チャンク読み + rayon 並列で入力順を保持したまま変換し、`.partial` へ書いて
+//! 成功時のみ最終パスへ rename する。
 //!
 //! # フィールド対応
 //!
 //! - 局面: `HuffmanCodedPos`（Apery/cshogi 形式）→ `PackedSfen`（YaneuraOu 形式）。
-//!   Huffman テーブルが異なるため `Position` 経由で再パックする。
-//! - eval: 手番側視点 cp（両形式で同一規約）をそのままコピー。
-//! - bestMove16: cshogi 形式 → YaneuraOu Move16 形式（駒打ちの駒種 index が 1 ずれる）。
+//! - eval: 手番側視点 cp（両形式で同一規約）をそのままコピー。詰み帯の数値表現は
+//!   生成系により異なる（例: gensfen は PSV 詰みを ±10000 帯で保存）が、値変換は行わない。
+//! - bestMove16: cshogi 形式 → **実 YaneuraOu Move16** 形式（bit14=駒打ち/bit15=成り。
+//!   リポジトリ内部表現 `move_to_move16` とは別形式）。
 //! - gameResult: 絶対視点（0=draw / 1=black_win / 2=white_win）→ 手番側視点
 //!   （1=win / -1=loss / 0=draw）。
-//! - game_ply: hcpe には手数が無いため 1 固定（`unpack_hcp` の SFEN 手数をそのまま使う）。
+//! - game_ply: hcpe には手数が無いため 1 固定。
 //!
 //! # 使用例
 //!
@@ -22,16 +30,27 @@
 //!   --output "$SHOGI_DATA/validation/floodgate_hcpe_yamaoka/floodgate.psv"
 //! ```
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, IsTerminal, Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
 
+use anyhow::{Context, Result};
 use clap::Parser;
-use rshogi_core::position::Position;
-use rshogi_core::types::Color;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use rayon::prelude::*;
 use tools::packed_sfen::{
-    PackedSfenValue, hcpe_move16_to_move, move_to_move16, pack_position, unpack_hcp,
+    PackedSfenValue, hcpe_move16_to_psv, hcpe_result_to_stm, pack_sfen_from_parts,
+    unpack_hcp_to_parts,
 };
 use tools::teacher_labeler::HCPE_RECORD_SIZE;
+
+const IO_BUF_SIZE: usize = 1 << 20;
+
+/// 非TTY 実行時にテキスト進捗を出す最小間隔（秒）。
+const PROGRESS_LOG_SECS: u64 = 5;
+
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Parser, Debug)]
 #[command(
@@ -51,77 +70,111 @@ struct Args {
     #[arg(long, default_value = "*.hcpe")]
     pattern: String,
 
-    /// 出力ファイルパス（PSV 形式）。入力順を保持して連結する
+    /// 出力ファイルパス（PSV 形式）。入力順（複数ファイルはパスのソート順）を保持して連結する
     #[arg(long)]
     output: PathBuf,
+
+    /// 並列変換のチャンクサイズ（レコード数）
+    #[arg(long, default_value = "65536")]
+    chunk: usize,
+
+    /// rayon スレッド数（0 = 自動）
+    #[arg(long, default_value = "0")]
+    threads: usize,
 }
 
 #[derive(Default)]
 struct Stats {
     converted: u64,
+    /// hcp デコード失敗（Huffman 破損・玉重複・在庫超過）
     decode_errors: u64,
+    /// bestMove16 が不正な駒打ち駒種
     move_errors: u64,
+    /// bestMove16 == 0（終局直前レコード等、指し手なし）。壊れた指し手とは区別する
+    no_bestmove: u64,
+    /// gameResult が 0/1/2 以外
     result_errors: u64,
 }
 
-/// gameResult（絶対視点 0=draw / 1=black_win / 2=white_win）を手番側視点の
-/// PSV game_result（1=win / -1=loss / 0=draw）へ変換する。0/1/2 以外は `None`。
-fn convert_game_result(game_result: u8, stm: Color) -> Option<i8> {
-    match game_result {
-        0 => Some(0),
-        1 => Some(if stm == Color::Black { 1 } else { -1 }),
-        2 => Some(if stm == Color::White { 1 } else { -1 }),
-        _ => None,
+impl Stats {
+    fn merge(&mut self, other: &Stats) {
+        self.converted += other.converted;
+        self.decode_errors += other.decode_errors;
+        self.move_errors += other.move_errors;
+        self.no_bestmove += other.no_bestmove;
+        self.result_errors += other.result_errors;
     }
 }
 
-/// hcpe 1 レコードを PSV 1 レコードへ変換する。壊れたレコードは `Err` で返し、
-/// 呼び出し側で件数を数えて skip する。
-fn convert_record(bytes: &[u8; HCPE_RECORD_SIZE], stats: &mut Stats) -> Option<PackedSfenValue> {
+enum ConvResult {
+    Psv([u8; PackedSfenValue::SIZE]),
+    DecodeError,
+    MoveError,
+    NoBestmove,
+    ResultError,
+}
+
+/// hcpe 1 レコードを PSV 1 レコードへ変換する。壊れたレコードは種別を返して skip する。
+fn convert_record(bytes: &[u8; HCPE_RECORD_SIZE]) -> ConvResult {
     let mut hcp = [0u8; 32];
     hcp.copy_from_slice(&bytes[0..32]);
     let eval = i16::from_le_bytes([bytes[32], bytes[33]]);
     let best_move16 = u16::from_le_bytes([bytes[34], bytes[35]]);
     let game_result = bytes[36];
 
-    let sfen = match unpack_hcp(&hcp) {
-        Ok(s) => s,
-        Err(_) => {
-            stats.decode_errors += 1;
-            return None;
-        }
+    let Ok(parts) = unpack_hcp_to_parts(&hcp) else {
+        return ConvResult::DecodeError;
     };
-    let mut pos = Position::new();
-    if pos.set_sfen(&sfen).is_err() {
-        stats.decode_errors += 1;
-        return None;
-    }
 
-    let mv = hcpe_move16_to_move(best_move16);
-    let move16 = move_to_move16(mv);
+    if best_move16 == 0 {
+        return ConvResult::NoBestmove;
+    }
+    let move16 = hcpe_move16_to_psv(best_move16);
     if move16 == 0 {
-        stats.move_errors += 1;
-        return None;
+        return ConvResult::MoveError;
     }
 
-    let Some(psv_result) = convert_game_result(game_result, pos.side_to_move()) else {
-        stats.result_errors += 1;
-        return None;
+    let Some(psv_result) = hcpe_result_to_stm(game_result, parts.side_to_move) else {
+        return ConvResult::ResultError;
     };
 
-    stats.converted += 1;
-    Some(PackedSfenValue {
-        sfen: pack_position(&pos),
+    let psv = PackedSfenValue {
+        sfen: pack_sfen_from_parts(&parts),
         score: eval,
         move16,
-        game_ply: pos.game_ply() as u16,
+        game_ply: 1,
         game_result: psv_result,
         padding: 0,
-    })
+    };
+    ConvResult::Psv(psv.to_bytes())
 }
 
-fn main() -> io::Result<()> {
+fn write_results(
+    results: &[ConvResult],
+    writer: &mut BufWriter<File>,
+    stats: &mut Stats,
+) -> Result<()> {
+    for result in results {
+        match result {
+            ConvResult::Psv(bytes) => {
+                writer.write_all(bytes)?;
+                stats.converted += 1;
+            }
+            ConvResult::DecodeError => stats.decode_errors += 1,
+            ConvResult::MoveError => stats.move_errors += 1,
+            ConvResult::NoBestmove => stats.no_bestmove += 1,
+            ConvResult::ResultError => stats.result_errors += 1,
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
     let args = Args::parse();
+
+    if args.chunk == 0 {
+        anyhow::bail!("--chunk は 1 以上を指定してください");
+    }
 
     let paths = tools::common::dedup::collect_input_paths(
         args.input.as_deref(),
@@ -129,56 +182,163 @@ fn main() -> io::Result<()> {
         &args.pattern,
     )?;
     if paths.is_empty() {
-        return Err(io::Error::new(io::ErrorKind::InvalidInput, "入力ファイルが見つかりません"));
+        anyhow::bail!("入力ファイルが見つかりません");
     }
+
+    // 入力と出力が同一パスだと File::create が読み取り前に入力を truncate してしまうため拒否する。
+    let out_canonical = args.output.canonicalize().ok();
+    let mut total_records = 0u64;
+    let mut in_canonicals = Vec::with_capacity(paths.len());
     for p in &paths {
+        let canonical = p
+            .canonicalize()
+            .with_context(|| format!("入力パスの正規化に失敗: {}", p.display()))?;
+        if Some(&canonical) == out_canonical.as_ref() {
+            anyhow::bail!("入力と出力が同一ファイルです: {}", canonical.display());
+        }
         let len = std::fs::metadata(p)?.len();
         if len % HCPE_RECORD_SIZE as u64 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "{} のサイズ {len} が hcpe レコード長 {HCPE_RECORD_SIZE} の倍数ではありません",
-                    p.display()
-                ),
-            ));
+            anyhow::bail!(
+                "{} のサイズ {len} が hcpe レコード長 {HCPE_RECORD_SIZE} の倍数ではありません",
+                p.display()
+            );
         }
+        total_records += len / HCPE_RECORD_SIZE as u64;
+        in_canonicals.push(canonical);
     }
 
-    let out_file = File::create(&args.output)?;
-    let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, out_file);
+    if args.threads > 0 {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(args.threads)
+            .build_global()
+            .context("rayon スレッドプールの構築に失敗")?;
+    }
+
+    ctrlc::set_handler(|| {
+        eprintln!("\n中断シグナルを受信しました。処理を終了します...");
+        INTERRUPTED.store(true, Ordering::SeqCst);
+    })
+    .context("Ctrl-C ハンドラの設定に失敗")?;
+
+    // 一時ファイルに書き、正常完了時のみ最終パスへ rename する（中断時の途中書き PSV は
+    // バイト長がほぼ確実に 40 の倍数になり、下流の整合チェックをすり抜けるため）。
+    let tmp_output = {
+        let mut s = args.output.clone().into_os_string();
+        s.push(".partial");
+        PathBuf::from(s)
+    };
+    if tmp_output.exists() {
+        let tmp_canonical = tmp_output
+            .canonicalize()
+            .with_context(|| format!("一時パスの正規化に失敗: {}", tmp_output.display()))?;
+        if in_canonicals.contains(&tmp_canonical) {
+            anyhow::bail!("一時ファイル {} が入力と同一です", tmp_output.display());
+        }
+    }
+    let out_file = File::create(&tmp_output)
+        .with_context(|| format!("{} を作成できません", tmp_output.display()))?;
+    let mut writer = BufWriter::with_capacity(IO_BUF_SIZE, out_file);
+
+    let is_tty = std::io::stderr().is_terminal();
+    let progress = ProgressBar::new(total_records);
+    if is_tty {
+        progress.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({per_sec}) ETA: {eta}",
+                )
+                .expect("valid template"),
+        );
+    } else {
+        progress.set_draw_target(ProgressDrawTarget::hidden());
+        eprintln!("(非TTY: 進捗を {PROGRESS_LOG_SECS} 秒ごとにテキスト出力します)");
+    }
+
     let mut stats = Stats::default();
+    let mut chunk: Vec<[u8; HCPE_RECORD_SIZE]> = Vec::with_capacity(args.chunk);
+    let mut buffer = [0u8; HCPE_RECORD_SIZE];
+    let mut interrupted = false;
+    let start = Instant::now();
+    let mut last_report = start;
 
-    for path in &paths {
+    'files: for path in &paths {
         eprintln!("Reading: {}", path.display());
-        let mut reader = BufReader::with_capacity(8 * 1024 * 1024, File::open(path)?);
-        let mut buf = [0u8; HCPE_RECORD_SIZE];
+        let in_file =
+            File::open(path).with_context(|| format!("{} を開けません", path.display()))?;
+        let mut reader = BufReader::with_capacity(IO_BUF_SIZE, in_file);
+
         loop {
-            match reader.read_exact(&mut buf) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
-                Err(e) => return Err(e),
+            if INTERRUPTED.load(Ordering::Acquire) {
+                interrupted = true;
+                break 'files;
             }
-            if let Some(psv) = convert_record(&buf, &mut stats) {
-                writer.write_all(&psv.to_bytes())?;
+
+            chunk.clear();
+            for _ in 0..args.chunk {
+                match reader.read_exact(&mut buffer) {
+                    Ok(()) => chunk.push(buffer),
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => return Err(e.into()),
+                }
+            }
+            if chunk.is_empty() {
+                break;
+            }
+
+            let results: Vec<ConvResult> = chunk.par_iter().map(convert_record).collect();
+            let mut chunk_stats = Stats::default();
+            write_results(&results, &mut writer, &mut chunk_stats)?;
+            stats.merge(&chunk_stats);
+            progress.inc(results.len() as u64);
+
+            if !is_tty {
+                let now = Instant::now();
+                if now.duration_since(last_report).as_secs() >= PROGRESS_LOG_SECS {
+                    last_report = now;
+                    let done = progress.position();
+                    let secs = start.elapsed().as_secs_f64();
+                    let rate = done as f64 / secs.max(1e-9);
+                    eprintln!(
+                        "進捗: {done}/{total_records} レコード ({rate:.0} rec/s, 経過 {secs:.0}s)"
+                    );
+                }
             }
         }
     }
-    writer.flush()?;
 
+    writer.flush()?;
+    drop(writer);
+
+    if interrupted {
+        progress.abandon_with_message("中断");
+        let _ = std::fs::remove_file(&tmp_output);
+        eprintln!("完了前に中断されました。出力は書き込まれていません。");
+        return Ok(());
+    }
+    progress.finish();
+
+    std::fs::rename(&tmp_output, &args.output).with_context(|| {
+        format!("{} → {} の rename に失敗", tmp_output.display(), args.output.display())
+    })?;
+
+    let elapsed = start.elapsed().as_secs_f64();
     println!("=== hcpe → PSV Summary ===");
     println!("Input files:     {}", paths.len());
     println!("Converted:       {}", stats.converted);
     println!("Decode errors:   {}", stats.decode_errors);
     println!("Move errors:     {}", stats.move_errors);
+    println!("No bestmove:     {}", stats.no_bestmove);
     println!("Result errors:   {}", stats.result_errors);
     println!("Output file:     {}", args.output.display());
+    println!("Elapsed:         {elapsed:.1} sec");
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tools::packed_sfen::{move_to_hcpe_move16, pack_position_hcp, unpack_sfen};
+    use rshogi_core::position::Position;
+    use tools::packed_sfen::{pack_position, pack_position_hcp};
 
     fn make_hcpe_record(
         pos: &Position,
@@ -198,41 +358,65 @@ mod tests {
     fn convert_record_roundtrips_position_eval_move_result() {
         let mut pos = Position::new();
         pos.set_hirate();
-        // 平手初期局面の ▲7六歩 (77→76)
-        let mv = {
-            use rshogi_core::movegen::{MoveList, generate_legal_all};
-            let mut moves = MoveList::new();
-            generate_legal_all(&pos, &mut moves);
-            *moves.iter().find(|m| !m.is_drop() && m.to_usi() == "7g7f").unwrap()
+        // 平手初期局面の ▲7六歩: hcpe move16 = to(59) | from(60)<<7
+        let hcpe_move = 59u16 | (60 << 7);
+
+        let rec = make_hcpe_record(&pos, -123, hcpe_move, 2);
+        let ConvResult::Psv(bytes) = convert_record(&rec) else {
+            panic!("convert should succeed");
         };
+        let psv = PackedSfenValue::from_bytes(&bytes).unwrap();
 
-        let rec = make_hcpe_record(&pos, -123, move_to_hcpe_move16(mv), 2);
-        let mut stats = Stats::default();
-        let psv = convert_record(&rec, &mut stats).unwrap();
-
-        assert_eq!(unpack_sfen(&psv.sfen).unwrap(), unpack_sfen(&pack_position(&pos)).unwrap());
+        assert_eq!(psv.sfen, pack_position(&pos));
         assert_eq!(psv.score, -123);
-        assert_eq!(psv.move16, move_to_move16(mv));
+        // 通常手は YO PSV 形式でも同一ビット
+        assert_eq!(psv.move16, hcpe_move);
+        assert_eq!(psv.game_ply, 1);
         // white_win で手番=先手 → 手番側視点 loss
         assert_eq!(psv.game_result, -1);
-        assert_eq!(stats.converted, 1);
     }
 
     #[test]
-    fn convert_game_result_maps_absolute_to_stm_view() {
-        assert_eq!(convert_game_result(0, Color::Black), Some(0));
-        assert_eq!(convert_game_result(1, Color::Black), Some(1));
-        assert_eq!(convert_game_result(1, Color::White), Some(-1));
-        assert_eq!(convert_game_result(2, Color::White), Some(1));
-        assert_eq!(convert_game_result(3, Color::Black), None);
+    fn convert_record_emits_true_yaneuraou_move16_for_drop_and_promote() {
+        let mut pos = Position::new();
+        pos.set_sfen("9/9/9/9/4k4/9/9/9/4K4 b P 1").expect("set_sfen");
+
+        // 歩打ち 5五: hcpe = to(40) | 81<<7 → YO PSV = to | 1<<7 | bit14
+        let rec = make_hcpe_record(&pos, 10, 40 | (81 << 7), 1);
+        let ConvResult::Psv(bytes) = convert_record(&rec) else {
+            panic!("drop convert should succeed");
+        };
+        let psv = PackedSfenValue::from_bytes(&bytes).unwrap();
+        assert_eq!(psv.move16, 40 | (1 << 7) | 0x4000, "歩打ちは bit14 + 駒種1");
+
+        // 成り手 2三→2二: hcpe bit14 → YO PSV bit15
+        let rec = make_hcpe_record(&pos, 10, 10 | (11 << 7) | 0x4000, 1);
+        let ConvResult::Psv(bytes) = convert_record(&rec) else {
+            panic!("promote convert should succeed");
+        };
+        let psv = PackedSfenValue::from_bytes(&bytes).unwrap();
+        assert_eq!(psv.move16, 10 | (11 << 7) | 0x8000, "成りは bit15");
     }
 
     #[test]
-    fn convert_record_rejects_broken_records() {
-        let mut stats = Stats::default();
-        // 全ゼロ: bestMove16=0 → move error (hcp 全ゼロは decode 失敗が先でも可)
+    fn convert_record_classifies_broken_records() {
+        let mut pos = Position::new();
+        pos.set_hirate();
+
+        // bestMove16 == 0 → NoBestmove（壊れた指し手とは別カウント）
+        let rec = make_hcpe_record(&pos, 0, 0, 1);
+        assert!(matches!(convert_record(&rec), ConvResult::NoBestmove));
+
+        // 不正な駒打ち駒種 (from=88) → MoveError
+        let rec = make_hcpe_record(&pos, 0, 40 | (88 << 7), 1);
+        assert!(matches!(convert_record(&rec), ConvResult::MoveError));
+
+        // gameResult 不正 → ResultError
+        let rec = make_hcpe_record(&pos, 0, 59 | (60 << 7), 3);
+        assert!(matches!(convert_record(&rec), ConvResult::ResultError));
+
+        // hcp 全ゼロ（玉重複）→ DecodeError
         let rec = [0u8; HCPE_RECORD_SIZE];
-        assert!(convert_record(&rec, &mut stats).is_none());
-        assert_eq!(stats.converted, 0);
+        assert!(matches!(convert_record(&rec), ConvResult::DecodeError));
     }
 }

--- a/crates/tools/src/bin/hcpe_to_psv.rs
+++ b/crates/tools/src/bin/hcpe_to_psv.rs
@@ -185,16 +185,20 @@ fn main() -> Result<()> {
         anyhow::bail!("入力ファイルが見つかりません");
     }
 
-    // 入力と出力が同一パスだと File::create が読み取り前に入力を truncate してしまうため拒否する。
-    let out_canonical = args.output.canonicalize().ok();
+    // 入力と出力が同一実体だと File::create が読み取り前に入力を truncate してしまうため拒否する。
+    // パス比較 (canonicalize) では hardlink (別パス・同一 inode) を検出できないので (dev, ino) で判定する。
+    let file_id = |p: &std::path::Path| -> Option<(u64, u64)> {
+        use std::os::unix::fs::MetadataExt;
+        std::fs::metadata(p).ok().map(|m| (m.dev(), m.ino()))
+    };
+    let out_id = file_id(&args.output);
     let mut total_records = 0u64;
-    let mut in_canonicals = Vec::with_capacity(paths.len());
+    let mut in_ids = Vec::with_capacity(paths.len());
     for p in &paths {
-        let canonical = p
-            .canonicalize()
-            .with_context(|| format!("入力パスの正規化に失敗: {}", p.display()))?;
-        if Some(&canonical) == out_canonical.as_ref() {
-            anyhow::bail!("入力と出力が同一ファイルです: {}", canonical.display());
+        let id =
+            file_id(p).with_context(|| format!("入力のメタデータ取得に失敗: {}", p.display()))?;
+        if out_id.is_some() && out_id == Some(id) {
+            anyhow::bail!("入力と出力が同一ファイルです: {}", p.display());
         }
         let len = std::fs::metadata(p)?.len();
         if len % HCPE_RECORD_SIZE as u64 != 0 {
@@ -204,7 +208,7 @@ fn main() -> Result<()> {
             );
         }
         total_records += len / HCPE_RECORD_SIZE as u64;
-        in_canonicals.push(canonical);
+        in_ids.push(id);
     }
 
     if args.threads > 0 {
@@ -227,13 +231,10 @@ fn main() -> Result<()> {
         s.push(".partial");
         PathBuf::from(s)
     };
-    if tmp_output.exists() {
-        let tmp_canonical = tmp_output
-            .canonicalize()
-            .with_context(|| format!("一時パスの正規化に失敗: {}", tmp_output.display()))?;
-        if in_canonicals.contains(&tmp_canonical) {
-            anyhow::bail!("一時ファイル {} が入力と同一です", tmp_output.display());
-        }
+    if let Some(tmp_id) = file_id(&tmp_output)
+        && in_ids.contains(&tmp_id)
+    {
+        anyhow::bail!("一時ファイル {} が入力と同一です", tmp_output.display());
     }
     let out_file = File::create(&tmp_output)
         .with_context(|| format!("{} を作成できません", tmp_output.display()))?;

--- a/crates/tools/src/bin/psv_to_hcpe3.rs
+++ b/crates/tools/src/bin/psv_to_hcpe3.rs
@@ -39,14 +39,15 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use rshogi_core::types::Color;
-use tools::packed_sfen::{PackedSfenValue, pack_hcp_from_parts, unpack_sfen_to_parts};
+use tools::packed_sfen::{
+    PackedSfenValue, pack_hcp_from_parts, psv_move16_to_hcpe, stm_result_to_hcpe,
+    unpack_sfen_to_parts,
+};
+use tools::teacher_labeler::HCPE_RECORD_SIZE;
 
 /// hcpe3 レコード長（hcp[32] + moveNum:u16 + result:u8 + opponent:u8
 /// + selectedMove16:u16 + eval:i16 + candidateNum:u16 + move16:u16 + visitNum:u16）
 const HCPE3_SIZE: usize = 46;
-/// hcpe レコード長（hcp[32] + eval:i16 + bestMove16:u16 + gameResult:u8 + dummy:u8）
-const HCPE_SIZE: usize = 38;
 /// 出力レコードバッファ。両形式の最大長を確保し `len` で実長を持つ。
 const RECORD_BUF: usize = HCPE3_SIZE;
 
@@ -113,40 +114,6 @@ enum ConvResult {
 
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
-/// game_result（手番側視点の ±1/0）を cshogi gameResult（0:DRAW / 1:BLACK_WIN / 2:WHITE_WIN）へ。
-///
-/// 手番側勝ち(`1`)なら勝者 = 手番側、手番側負け(`-1`)なら勝者 = 相手側になる。
-/// cshogi の `to_hcp` 系と同じく BLACK=0 / WHITE=1 を `+1` した値が勝者の色を表す。
-#[inline]
-fn game_result_byte(game_result: i8, side_to_move: Color) -> u8 {
-    let stm = side_to_move.index() as u8;
-    match game_result {
-        1 => stm + 1,
-        -1 => 2 - stm,
-        _ => 0,
-    }
-}
-
-/// YaneuraOu PSV の move16 を hcpe / hcpe3 が要求する move16 へ意味的に復号する。
-///
-/// YaneuraOu PSV の move16 は bit14=駒打ちフラグ（from フィールド=駒種, 歩=1..飛=7）、
-/// bit15=成りフラグ。hcpe 形式は駒打ちを `from = 81 + (駒種 - 1)` で表し、成りを bit14 で
-/// 表すため、両フラグを見て変換する。実 YaneuraOu の手で形式の参照実装 cshogi
-/// `move16_from_psv` と一致することを確認済み。
-#[inline]
-fn move16_psv_to_hcpe(yo_move16: u16) -> u16 {
-    let to = yo_move16 & 0x7f;
-    let from_field = (yo_move16 >> 7) & 0x7f;
-    if yo_move16 & 0x4000 != 0 {
-        // 駒打ち: from フィールドは駒種(1 始まり) → from = 81 + (駒種 - 1) = 80 + from_field
-        to | ((80 + from_field) << 7)
-    } else {
-        // 盤上の手: 成りは YaneuraOu の bit15 → hcpe の bit14 へ移す
-        let promote = if yo_move16 & 0x8000 != 0 { 0x4000 } else { 0 };
-        to | (from_field << 7) | promote
-    }
-}
-
 /// dlshogi 固定 decode 定数 = 1/0.0013226。evalfix bake のスケール分子。
 const EVAL_DECODE_CONST: f64 = 756.0864962951762;
 
@@ -187,7 +154,7 @@ fn build_hcpe(eval: i16, hcp: &[u8; 32], move16: u16, result: u8) -> ConvResult 
     data[37] = 0; // dummy
     ConvResult::Record {
         data,
-        len: HCPE_SIZE,
+        len: HCPE_RECORD_SIZE,
     }
 }
 
@@ -213,8 +180,8 @@ fn convert(
     };
 
     let hcp = pack_hcp_from_parts(&parts);
-    let move16 = move16_psv_to_hcpe(psv.move16);
-    let result = game_result_byte(psv.game_result, parts.side_to_move);
+    let move16 = psv_move16_to_hcpe(psv.move16);
+    let result = stm_result_to_hcpe(psv.game_result, parts.side_to_move);
     let eval = baked_eval(psv.score, eval_scale);
 
     match format {
@@ -468,29 +435,30 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rshogi_core::types::Color;
 
     #[test]
     fn game_result_mapping_matches_oracle() {
         // 手番側勝ち(1): 勝者 = 手番側
-        assert_eq!(game_result_byte(1, Color::Black), 1); // BLACK_WIN
-        assert_eq!(game_result_byte(1, Color::White), 2); // WHITE_WIN
+        assert_eq!(stm_result_to_hcpe(1, Color::Black), 1); // BLACK_WIN
+        assert_eq!(stm_result_to_hcpe(1, Color::White), 2); // WHITE_WIN
         // 手番側負け(-1): 勝者 = 相手側
-        assert_eq!(game_result_byte(-1, Color::Black), 2); // WHITE_WIN
-        assert_eq!(game_result_byte(-1, Color::White), 1); // BLACK_WIN
+        assert_eq!(stm_result_to_hcpe(-1, Color::Black), 2); // WHITE_WIN
+        assert_eq!(stm_result_to_hcpe(-1, Color::White), 1); // BLACK_WIN
         // 引き分け(0): DRAW
-        assert_eq!(game_result_byte(0, Color::Black), 0);
-        assert_eq!(game_result_byte(0, Color::White), 0);
+        assert_eq!(stm_result_to_hcpe(0, Color::Black), 0);
+        assert_eq!(stm_result_to_hcpe(0, Color::White), 0);
     }
 
     #[test]
-    fn move16_psv_to_hcpe_matches_oracle() {
+    fn psv_move16_to_hcpe_matches_oracle() {
         // 実 YaneuraOu PSV move16（bit14=駒打ち, bit15=成り）を hcpe 形式へ。
         // 期待値は cshogi `move16_from_psv` で生成（参照実装）。
-        assert_eq!(move16_psv_to_hcpe(0x0000), 0x0000); // none
-        assert_eq!(move16_psv_to_hcpe(0x078e), 0x078e); // 通常手 2g2f
-        assert_eq!(move16_psv_to_hcpe(0x40a5), 0x28a5); // 歩打ち P*5b（bit14, from=1）
-        assert_eq!(move16_psv_to_hcpe(0x4380), 0x2b80); // 金打ち G*1a（bit14, from=7）
-        assert_eq!(move16_psv_to_hcpe(0x9f46), 0x5f46); // 成り 7i8h+（bit15 → hcpe bit14）
+        assert_eq!(psv_move16_to_hcpe(0x0000), 0x0000); // none
+        assert_eq!(psv_move16_to_hcpe(0x078e), 0x078e); // 通常手 2g2f
+        assert_eq!(psv_move16_to_hcpe(0x40a5), 0x28a5); // 歩打ち P*5b（bit14, from=1）
+        assert_eq!(psv_move16_to_hcpe(0x4380), 0x2b80); // 金打ち G*1a（bit14, from=7）
+        assert_eq!(psv_move16_to_hcpe(0x9f46), 0x5f46); // 成り 7i8h+（bit15 → hcpe bit14）
     }
 
     #[test]

--- a/crates/tools/src/bin/psv_to_hcpe3.rs
+++ b/crates/tools/src/bin/psv_to_hcpe3.rs
@@ -8,9 +8,9 @@
 //!
 //! 盤面の hcp（HuffmanCodedPos, 32B）は、PSV の packed sfen を SFEN 文字列・`Position`
 //! 構築を経由せず `tools::packed_sfen::unpack_sfen_to_parts` → `pack_hcp_from_parts` で
-//! 直接展開する（ホットパスでのヒープ割り当てを避ける）。指し手 move16 と勝敗・eval の
-//! 視点変換は本ファイル内で行う（いずれも hcpe / hcpe3 形式の参照実装 cshogi の
-//! `to_hcp` / `move16_from_psv` と一致）。
+//! 直接展開する（ホットパスでのヒープ割り当てを避ける）。指し手 move16 と勝敗の視点変換は
+//! `tools::packed_sfen` の共有関数 (`psv_move16_to_hcpe` / `stm_result_to_hcpe`) を使う
+//! （いずれも hcpe / hcpe3 形式の参照実装 cshogi の `to_hcp` / `move16_from_psv` と一致）。
 //! load-all を避けてチャンクストリーミングし、ピークメモリを入力件数に非依存にする。
 //!
 //! # 使用例

--- a/crates/tools/src/packed_sfen.rs
+++ b/crates/tools/src/packed_sfen.rs
@@ -528,13 +528,18 @@ pub fn unpack_sfen_to_parts(packed: &[u8; 32]) -> Result<UnpackedSfen, String> {
     })
 }
 
-/// HuffmanCodedPos (Apery/cshogi 形式) をSFEN文字列に変換
+/// HuffmanCodedPos (Apery/cshogi 形式) を String/Position を経由せず素の局面要素へ展開する。
 ///
 /// cshogi の `to_hcp()` が出力する形式。YaneuraOu の PackedSfen とは
 /// 盤上駒・手駒の色ビットと成りビットの順序が逆:
 ///   - PSfen (YaneuraOu): huffman → promotion → color
 ///   - HCP   (Apery):     huffman → color → promotion
-pub fn unpack_hcp(packed: &[u8; 32]) -> Result<String, String> {
+///
+/// `unpack_sfen_to_parts` の HCP 版。大量変換のホットパスはこれと
+/// `pack_sfen_from_parts` を直接使い、文字列・Position 経由の往復を排除する。
+/// `unpack_sfen_to_parts` と同じく玉重複・駒種在庫上限の検証を行う
+/// (後段に `Position::set_sfen` の検証が無い前提で破損レコードをここで弾く)。
+pub fn unpack_hcp_to_parts(packed: &[u8; 32]) -> Result<UnpackedSfen, String> {
     let mut stream = BitStream::new(packed);
 
     // 手番 (1bit)
@@ -557,6 +562,11 @@ pub fn unpack_hcp(packed: &[u8; 32]) -> Result<String, String> {
     let white_king_sq = stream.read_n_bit(7) as u8;
     if white_king_sq >= 81 {
         return Err(format!("Invalid white king position: {white_king_sq}"));
+    }
+    // 先後の玉が同一マスだと後手玉の代入が先手玉を上書きし、玉欠けの不正局面を
+    // 検証なしで下流へ渡してしまう。破損レコードとして弾く。
+    if black_king_sq == white_king_sq {
+        return Err(format!("先手玉と後手玉が同一マス: {black_king_sq}"));
     }
     board[white_king_sq as usize] = Piece::W_KING;
 
@@ -615,10 +625,50 @@ pub fn unpack_hcp(packed: &[u8; 32]) -> Result<String, String> {
 
         let pt = piece_type_from_index(entry.piece_idx).ok_or("Invalid hand piece type")?;
         let color = entry.color.ok_or("Hand piece without color")?;
+        // 破損 hcpe で手駒が過剰だと `Hand::add`（飽和なし）が隣接駒種のビットへ桁あふれする。
+        // 追加前に駒種上限で弾き、ビットフィールドの破壊と count() の誤読を防ぐ。
+        if hands[color.index()].count(pt) >= INVENTORY_MAX[piece_type_to_index(pt)] {
+            return Err(format!("手駒が上限を超過: {pt:?}"));
+        }
         hands[color.index()] = hands[color.index()].add(pt);
     }
 
-    Ok(generate_sfen(&board, &hands, side_to_move))
+    // 駒種ごとの総数（盤上 + 手駒、成りは基底駒種に合算）が上限を超える破損レコードを弾く。
+    let mut totals = [0u32; 8];
+    for &piece in &board {
+        if piece.is_some() {
+            totals[piece_type_to_index(piece.piece_type())] += 1;
+        }
+    }
+    for pt in [
+        PieceType::Pawn,
+        PieceType::Lance,
+        PieceType::Knight,
+        PieceType::Silver,
+        PieceType::Bishop,
+        PieceType::Rook,
+        PieceType::Gold,
+    ] {
+        let idx = piece_type_to_index(pt);
+        let total = totals[idx] + hands[0].count(pt) + hands[1].count(pt);
+        if total > INVENTORY_MAX[idx] {
+            return Err(format!("{pt:?} の総数が上限超過: {total} > {}", INVENTORY_MAX[idx]));
+        }
+    }
+
+    Ok(UnpackedSfen {
+        board,
+        hands,
+        side_to_move,
+        black_king_sq,
+        white_king_sq,
+    })
+}
+
+/// HuffmanCodedPos (Apery/cshogi 形式) をSFEN文字列に変換
+pub fn unpack_hcp(packed: &[u8; 32]) -> Result<String, String> {
+    let parts = unpack_hcp_to_parts(packed)?;
+    Ok(generate_sfen(&parts.board, &parts.hands, parts.side_to_move))
 }
 
 /// HCP 手駒/駒箱の符号エントリ
@@ -1353,6 +1403,56 @@ pub fn pack_position(pos: &Position) -> [u8; 32] {
     stream.finish()
 }
 
+/// 素の局面要素から YaneuraOu PackedSfen(32B) を生成する。`pack_position` の parts 版。
+///
+/// `pack_hcp_from_parts` と対になる関数で、`unpack_hcp_to_parts` の結果を
+/// String/Position を経由せず直接 PSfen 化する。同一局面では `pack_position` と
+/// bit 一致する (回帰テストで保証)。
+pub fn pack_sfen_from_parts(parts: &UnpackedSfen) -> [u8; 32] {
+    let mut stream = BitStreamWriter::new();
+
+    // 1. 手番 (1bit): 0=先手, 1=後手
+    stream.write_one_bit(parts.side_to_move == Color::White);
+
+    // 2. 先手玉位置 (7bit) / 3. 後手玉位置 (7bit)
+    stream.write_n_bit(parts.black_king_sq as u32, 7);
+    stream.write_n_bit(parts.white_king_sq as u32, 7);
+
+    // 4. 盤上の駒 (81マス、玉はスキップ)
+    for &piece in &parts.board {
+        if piece.is_some() && piece.piece_type() == PieceType::King {
+            continue;
+        }
+        write_board_piece(&mut stream, piece);
+    }
+
+    // 5. 手駒 (先手→後手、pack_position と同じ駒種順)
+    let piece_order = [
+        PieceType::Rook,
+        PieceType::Bishop,
+        PieceType::Gold,
+        PieceType::Silver,
+        PieceType::Knight,
+        PieceType::Lance,
+        PieceType::Pawn,
+    ];
+    for &color in &[Color::Black, Color::White] {
+        let hand = parts.hands[color.index()];
+        for &pt in &piece_order {
+            for _ in 0..hand.count(pt) {
+                write_hand_piece(&mut stream, pt, color);
+            }
+        }
+    }
+
+    // 6. 駒箱パディング (pack_position と同一規約)
+    while stream.bit_position() + 3 <= 256 {
+        write_piecebox_padding(&mut stream);
+    }
+
+    stream.finish()
+}
+
 /// Move を Move16形式に変換
 ///
 /// ## Move16形式
@@ -1419,6 +1519,78 @@ pub fn move_to_hcpe_move16(mv: Move) -> u16 {
         let from = mv.from().index() as u16;
         let promote = if mv.is_promotion() { 0x4000 } else { 0 };
         to | (from << 7) | promote
+    }
+}
+
+/// 実 YaneuraOu PSV の move16 を hcpe / hcpe3 形式の move16 へ変換する。
+///
+/// 実 YaneuraOu の Move16 は bit14=駒打ちフラグ（from フィールド=駒種, 歩=1..金=7）、
+/// bit15=成りフラグ。hcpe 形式は駒打ちを `from = 81 + (駒種 - 1)` で表し、成りを
+/// bit14 で表す。形式の参照実装 cshogi `move16_from_psv` と一致する。
+/// リポジトリ内部表現 (`move_to_move16` / `move16_to_move`) とは**別形式**である点に注意。
+#[inline]
+pub fn psv_move16_to_hcpe(yo_move16: u16) -> u16 {
+    let to = yo_move16 & 0x7f;
+    let from_field = (yo_move16 >> 7) & 0x7f;
+    if yo_move16 & 0x4000 != 0 {
+        // 駒打ち: from フィールドは駒種(1 始まり) → from = 81 + (駒種 - 1) = 80 + from_field
+        to | ((80 + from_field) << 7)
+    } else {
+        // 盤上の手: 成りは YaneuraOu の bit15 → hcpe の bit14 へ移す
+        let promote = if yo_move16 & 0x8000 != 0 { 0x4000 } else { 0 };
+        to | (from_field << 7) | promote
+    }
+}
+
+/// hcpe / hcpe3 形式の move16 を実 YaneuraOu PSV の move16 へ変換する
+/// (`psv_move16_to_hcpe` の逆変換)。
+///
+/// 駒打ちの from フィールドが 81+6 (金) を超える不正値は 0 を返す。
+#[inline]
+pub fn hcpe_move16_to_psv(hcpe_move16: u16) -> u16 {
+    if hcpe_move16 == 0 {
+        return 0;
+    }
+    let to = hcpe_move16 & 0x7f;
+    let from_field = (hcpe_move16 >> 7) & 0x7f;
+    if from_field >= 81 {
+        // 駒打ち: hcpe の駒種(0 始まり) → YO の駒種(1 始まり) を from へ、bit14 を立てる
+        if from_field > 81 + 6 {
+            return 0;
+        }
+        to | ((from_field - 80) << 7) | 0x4000
+    } else {
+        // 盤上の手: 成りは hcpe の bit14 → YO の bit15 へ移す
+        let promote = if hcpe_move16 & 0x4000 != 0 { 0x8000 } else { 0 };
+        to | (from_field << 7) | promote
+    }
+}
+
+/// hcpe の gameResult（絶対視点 0=DRAW / 1=BLACK_WIN / 2=WHITE_WIN）を
+/// PSV の game_result（手番側視点 1=win / -1=loss / 0=draw）へ変換する。
+/// 0/1/2 以外は破損レコードとして `None`。`stm_result_to_hcpe` の逆写像。
+#[inline]
+pub fn hcpe_result_to_stm(game_result: u8, stm: Color) -> Option<i8> {
+    match game_result {
+        0 => Some(0),
+        1 => Some(if stm == Color::Black { 1 } else { -1 }),
+        2 => Some(if stm == Color::White { 1 } else { -1 }),
+        _ => None,
+    }
+}
+
+/// PSV の game_result（手番側視点の ±1/0）を hcpe の gameResult
+/// （0=DRAW / 1=BLACK_WIN / 2=WHITE_WIN）へ変換する。
+///
+/// 手番側勝ち(`1`)なら勝者 = 手番側、手番側負け(`-1`)なら勝者 = 相手側になる。
+/// cshogi の `to_hcp` 系と同じく BLACK=0 / WHITE=1 を `+1` した値が勝者の色を表す。
+#[inline]
+pub fn stm_result_to_hcpe(game_result: i8, side_to_move: Color) -> u8 {
+    let stm = side_to_move.index() as u8;
+    match game_result {
+        1 => stm + 1,
+        -1 => 2 - stm,
+        _ => 0,
     }
 }
 
@@ -1932,5 +2104,79 @@ mod tests {
         assert_eq!(psv.move16, psv2.move16);
         assert_eq!(psv.game_ply, psv2.game_ply);
         assert_eq!(psv.game_result, psv2.game_result);
+    }
+
+    #[test]
+    fn hcp_direct_path_matches_position_path() {
+        // hcpe → PSV 方向のホットパス「hcp → unpack_hcp_to_parts → pack_sfen_from_parts」直接経路が、
+        // 従来の「hcp → unpack_hcp(String) → set_sfen → pack_position」と bit 一致することを
+        // 保証する回帰テスト。test_direct_path_matches_position_path の HCP→PSfen 版。
+        let sfens = [
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1", // 平手
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPP1P/1B5R1/LNSGKGSNL b P 1", // 手駒あり
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1+B5R1/LNSGKGSNL b - 1", // 成り駒
+            "lnsgkgsn1/1r5b1/ppppppppp/9/9/9/1PPPPPPPP/1B5R1/LNSGKGSN1 b - 1", // 駒落ち(駒箱)
+            "9/9/9/9/4k4/9/9/9/4K4 w 2G2g 1",                                  // 手駒多数・偏り
+        ];
+        for sfen in sfens {
+            let mut pos = Position::new();
+            pos.set_sfen(sfen).expect("set_sfen should succeed");
+            let hcp = pack_position_hcp(&pos);
+            let reference = pack_position(&pos);
+
+            // 直接経路（String も Position も経由しない）
+            let parts = unpack_hcp_to_parts(&hcp).expect("unpack_hcp_to_parts should succeed");
+            let direct = pack_sfen_from_parts(&parts);
+
+            assert_eq!(direct, reference, "direct path psfen mismatch for {sfen}");
+            assert_eq!(parts.side_to_move, pos.side_to_move(), "side_to_move mismatch for {sfen}");
+        }
+    }
+
+    #[test]
+    fn unpack_hcp_to_parts_rejects_duplicate_king_square() {
+        // 破損 hcp: 先手玉と後手玉が同一マス (unpack_sfen_to_parts と同じ検証を持つこと)
+        let mut w = BitStreamWriter::new();
+        w.write_one_bit(false); // 手番=先手
+        w.write_n_bit(40, 7); // 先手玉 = マス40
+        w.write_n_bit(40, 7); // 後手玉 = マス40（同一 → 不正）
+        let packed = w.finish();
+        assert!(unpack_hcp_to_parts(&packed).is_err(), "同一マスの両玉は破損として弾くべき");
+    }
+
+    #[test]
+    fn psv_hcpe_move16_oracle_fixtures() {
+        // 実 YaneuraOu Move16 (bit14=打ち, from=駒種 1..7 / bit15=成り) と
+        // hcpe Move16 (打ち from=81+idx / bit14=成り) の固定オラクル。
+        // 参照実装 cshogi move16_from_psv の変換規則から作成。
+        let cases: [(u16, u16, &str); 4] = [
+            // (yo_psv, hcpe, label)
+            (59 | (60 << 7), 59 | (60 << 7), "通常手 77→76"),
+            (10 | (11 << 7) | 0x8000, 10 | (11 << 7) | 0x4000, "成り 23→22"),
+            (40 | (1 << 7) | 0x4000, 40 | (81 << 7), "歩打ち 55"),
+            (40 | (7 << 7) | 0x4000, 40 | (87 << 7), "金打ち 55"),
+        ];
+        for (yo, hcpe, label) in cases {
+            assert_eq!(psv_move16_to_hcpe(yo), hcpe, "psv→hcpe: {label}");
+            assert_eq!(hcpe_move16_to_psv(hcpe), yo, "hcpe→psv: {label}");
+        }
+        // 不正な駒打ち駒種 (from > 87) は 0
+        assert_eq!(hcpe_move16_to_psv(40 | (88 << 7)), 0);
+        assert_eq!(hcpe_move16_to_psv(0), 0);
+    }
+
+    #[test]
+    fn hcpe_result_stm_roundtrip_oracle() {
+        // 全 (gameResult, 手番) で hcpe→stm→hcpe が恒等写像であること
+        for game_result in [0u8, 1, 2] {
+            for stm in [Color::Black, Color::White] {
+                let s = hcpe_result_to_stm(game_result, stm).expect("0/1/2 は正当");
+                assert_eq!(stm_result_to_hcpe(s, stm), game_result, "r={game_result} stm={stm:?}");
+            }
+        }
+        // 絶対視点の意味の固定オラクル: BLACK_WIN(1) は先手番で +1、後手番で -1
+        assert_eq!(hcpe_result_to_stm(1, Color::Black), Some(1));
+        assert_eq!(hcpe_result_to_stm(1, Color::White), Some(-1));
+        assert_eq!(hcpe_result_to_stm(3, Color::Black), None);
     }
 }

--- a/crates/tools/src/packed_sfen.rs
+++ b/crates/tools/src/packed_sfen.rs
@@ -1552,6 +1552,10 @@ pub fn hcpe_move16_to_psv(hcpe_move16: u16) -> u16 {
         return 0;
     }
     let to = hcpe_move16 & 0x7f;
+    // 移動先がマス番号 0..80 の範囲外なら破損レコード (旧 Position 経路の Square::from_u8 相当の検証)
+    if to > 80 {
+        return 0;
+    }
     let from_field = (hcpe_move16 >> 7) & 0x7f;
     if from_field >= 81 {
         // 駒打ち: hcpe の駒種(0 始まり) → YO の駒種(1 始まり) を from へ、bit14 を立てる
@@ -2163,6 +2167,9 @@ mod tests {
         // 不正な駒打ち駒種 (from > 87) は 0
         assert_eq!(hcpe_move16_to_psv(40 | (88 << 7)), 0);
         assert_eq!(hcpe_move16_to_psv(0), 0);
+        // 移動先マスが範囲外 (to > 80) の破損レコードは 0 (盤上の手・駒打ちとも)
+        assert_eq!(hcpe_move16_to_psv(85 | (60 << 7)), 0);
+        assert_eq!(hcpe_move16_to_psv(127 | (81 << 7)), 0);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

hcpe（cshogi HuffmanCodedPosAndEval, 38B/rec）を nnue-train の `--data`/`--test-data` が読む PSV（40B/rec）へ変換する `hcpe_to_psv` を追加する。主用途は外部公開 hcpe プール（dlshogi 系標準の floodgate 検証局面等）の学習/検証投入。

## 実装

- 盤面は `unpack_hcp_to_parts` → `pack_sfen_from_parts`（本 PR で `packed_sfen` に追加）で String/Position 非経由の直接再パック。玉重複・駒種在庫上限の検証も parts 経路に移植し、従来 Position 経路との bit 一致回帰テストで保証
- move16 は **実 YaneuraOu 形式**（bit14=駒打ち/bit15=成り）で出力。`hcpe_move16_to_psv` / `psv_move16_to_hcpe` を `packed_sfen` に共有化し、`psv_to_hcpe3` のローカル実装も同関数へ寄せた（既存オラクル期待値は据え置き = 挙動不変）。gameResult 双方向マッピングも同様に共有化
- チャンク読み + rayon 並列（入力順保持）、`.partial` + rename、入出力の同一実体判定は (dev, ino) 比較（hardlink 対応）
- 実測: 856,923 局面 / 32.5MB を 0.15 秒・ピーク RSS 10.4MB（逐次 Position 経由の初期実装比 24 倍）

## レビュー

Claude + Codex の 2 系統 × 2 ラウンドの local dual review 済み。1st ラウンドで move16 のリポ内部表現バグ（駒打ち+成り = レコードの 31.5% に影響）と直変換・並列化を指摘 → 修正、2nd ラウンドの must-fix（移動先マス範囲検証・hardlink truncate 防止）も反映して両者 APPROVE。

## 検証

- `cargo fmt` / `clippy --tests` 警告ゼロ / `cargo test -p tools` 611 passed / abs-paths チェック
- 実データ E2E: 山岡さん公開 floodgate.hcpe 856,923 局面を全件変換（エラー 0）、出力が nodchip 公開 PSV と同じ実 YO move16 形式であることをビットパターン分類で確認

関連: #930（PSV move16 3 系統問題の正典。本 PR の共有関数が移行 branch の前提）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPJxtMf5fXMS8EDDvbQyQT