### PR TITLE
feat(tools): PSV move16 を実 YaneuraOu 形式 (A) に一本化

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定 |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（USI engine vs engine／NativeBackend、native LS progress 係数、乱択来歴 JSONL 記録） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、乱択来歴 JSONL 記録） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換・`live-mirror --push` MONITOR2 着手通知付きリアルタイムミラー（[詳細](docs/floodgate_pipeline.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と出典 TSV を生成（[詳細](docs/nyugyoku_gensfen.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |
@@ -40,6 +40,8 @@
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
 | `psv_to_jsonl` | PSV 形式 → JSONL 変換（デバッグ・確認用） |
 | `psv_to_hcpe3` | PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み） |
+| `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行（[詳細](docs/migrate_psv_move16.md)） |
+| `pack_to_psv` | GenSfen .pack → PSV 変換（move16 は実 YaneuraOu 形式） |
 | `fix_scores` | スコアの補正 |
 | `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・重複除去・決定的 shuffle・分割（[詳細](docs/prep_hcpe.md)） |
@@ -109,6 +111,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換と任意の宣言勝ち override / diversions deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`--evalfix-a` で eval 焼き込み）
+- [migrate_psv_move16](docs/migrate_psv_move16.md) - 旧 PSV move16 の実 YaneuraOu 形式への移行
 - [book_rescore](docs/book_rescore.md) - YANEURAOU-DB2016 テキスト定跡の候補手に USI 探索または ONNX 静的評価値を付与（実行中は進捗/ETA を stderr 表示）
 - [book_kachi_label](docs/book_kachi_label.md) - YANEURAOU-DB2016 テキスト定跡の候補手に `%KACHI` 決着率を付与する sidecar JSONL を生成
 - [book_extend](docs/book_extend.md) - YANEURAOU-DB2016 テキスト定跡の候補集合へ USI エンジン bestmove を `count=0` で追加

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -40,6 +40,8 @@ runs/gensfen/20260317-120000/
   gensfen.metrics.jsonl  # 対局メトリクス（--emit-metrics 指定時のみ）
 ```
 
+`gensfen.psv` の move16 は実 YaneuraOu 形式 (A: bit14=駒打ち、bit15=成り) で出力されます。
+
 `--out-dir path/to/dir` を指定した場合は、そのディレクトリ内に上記ファイルが生成される。
 
 棋譜（KIF）・サマリファイル・全手 move ログは出力されない（教師局面生成に不要なため）。

--- a/crates/tools/docs/hcpe_to_psv.md
+++ b/crates/tools/docs/hcpe_to_psv.md
@@ -36,7 +36,7 @@ cargo run --release -p tools --bin hcpe_to_psv -- \
 |---|---|---|
 | `hcp` (HuffmanCodedPos, Apery/cshogi 形式) | `sfen` (PackedSfen, YaneuraOu 形式) | Huffman テーブルが異なるため `unpack_hcp_to_parts` → `pack_sfen_from_parts` で直接再パック |
 | `eval` (手番側視点 cp) | `score` | そのままコピー（視点は両形式で同一規約）。詰み帯の数値表現は生成系依存で、値変換は行わない |
-| `bestMove16` (cshogi Move16) | `move16` (**実 YaneuraOu Move16**: bit14=駒打ち/bit15=成り) | `hcpe_move16_to_psv` で再エンコード。リポジトリ内部表現 `move_to_move16` とは別形式 |
+| `bestMove16` (cshogi Move16) | `move16` (**実 YaneuraOu Move16**: bit14=駒打ち/bit15=成り) | `hcpe_move16_to_psv` で再エンコード。旧リポジトリ内部形式 (B) とは別形式 |
 | `gameResult` (絶対視点 0=draw / 1=black_win / 2=white_win) | `game_result` (手番側視点 1=win / -1=loss / 0=draw) | 手番で符号を決定 |
 | （なし） | `game_ply` | hcpe に手数情報が無いため 1 固定 |
 

--- a/crates/tools/docs/migrate_psv_move16.md
+++ b/crates/tools/docs/migrate_psv_move16.md
@@ -1,0 +1,24 @@
+# migrate_psv_move16
+
+旧リポジトリ内部形式 (B) の PSV move16 を、実 YaneuraOu 形式
+(A: bit14=駒打ち、bit15=成り) へ焼き直す one-shot ツールです。
+40バイトレコードを順次処理するため、ピークメモリは入力件数に依存しません。
+
+```bash
+cargo run --release -p tools --bin migrate_psv_move16 -- \
+  --input old.psv --output migrated.psv
+```
+
+| オプション | 既定 | 説明 |
+|---|---|---|
+| `--input <FILE>` | 必須 | B 形式の単一 PSV ファイル |
+| `--output <FILE>` | 必須 | A 形式の出力 PSV ファイル |
+| `--verify-legal` | true | PackedSfen から局面を復元し、各 move16 が合法手か検証 |
+
+変換前に先頭10万レコードを調べ、bit15 があれば A 形式、from=81 の駒打ちがあれば
+hcpe 形式 (C) の混入として停止します。B 形式の確定シグネチャを確認できない入力も
+誤変換防止のため拒否します。
+
+出力は `<output>.partial` に書き、完了後に最終パスへ rename します。move16 の2バイト
+以外は入力レコードをそのまま書き出します。合法手検証の不一致はレコード番号を stderr
+へ出し、変換を継続して終了時に件数を集計します。

--- a/crates/tools/docs/psv_to_hcpe3.md
+++ b/crates/tools/docs/psv_to_hcpe3.md
@@ -8,6 +8,10 @@ dlshogi の学習で使う **hcpe3** / **hcpe** 形式へストリーミング�
 - 特徴: cshogi 製変換スクリプトと **byte 完全一致**、チャンクストリーミングで
   ピークメモリを入力件数に非依存、スレッド数に依らず bit 一致
 
+入力の move16 は実 YaneuraOu 形式 (A: bit14=駒打ち、bit15=成り) が前提です。
+変換前に先頭10万レコードを検査し、旧リポジトリ形式 (B) または hcpe 形式 (C) の
+確定シグネチャがあれば停止します。B 形式の既存 PSV は `migrate_psv_move16` で移行してください。
+
 dlshogi の `train.py` は学習データに hcpe3（対局単位 + 候補手 visits）を要求しますが、
 PSV は局面単位（棋譜構造を持ちません）。そこで各 PSV 局面を「1 局面 = 1 game」の
 退化した hcpe3（`moveNum=1` / `candidateNum=1` / `visitNum=1`）として書き出します。
@@ -17,7 +21,7 @@ policy target は best move の one-hot、value は PSV の評価値から取り
 
 局面の盤面は cshogi `Board.to_hcp` 互換の HuffmanCodedPos（32 バイト）で表現します。
 指し手は hcpe 形式の move16 へ変換します。YaneuraOu PSV の move16 は
-**bit14=駒打ちフラグ（from フィールド=駒種, 歩=1..飛=7）・bit15=成りフラグ**で、
+**bit14=駒打ちフラグ（from フィールド=駒種, 歩=1..金=7）・bit15=成りフラグ**で、
 これを hcpe 形式（駒打ち `from = 81 + (駒種 - 1)`、成り `bit14`）へ意味的に復号します
 （参照実装 cshogi `move16_from_psv` と一致）。勝敗は手番側視点 ±1/0 を
 `0:DRAW / 1:BLACK_WIN / 2:WHITE_WIN` に変換します。

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -177,6 +177,7 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 | `--nnue` | — | NNUE モデル（ONNX / `--engine` 未使用時に必須） |
 | `--use-qsearch` | false | 静的評価の代わりに qsearch 評価を使用 |
 | `--search-depth` | — | 指定深さの alpha-beta 探索スコアを使用（`--use-qsearch` と排他） |
+| `--emit-bestmove` | false | `--search-depth` の探索結果の最善手を実 YaneuraOu PSV 形式 (A) で move16 に出力 |
 | `--hash-mb` | 64 | スレッドごとの置換表サイズ MB（`--search-depth` 時） |
 | `--max-nodes` / `--max-time` | 0（無制限） | 1 局面あたりの探索ノード / ミリ秒上限（`--search-depth` 時のみ有効）。探索爆発ガード |
 | `--max-ply` | 16 | qsearch の最大深さ |

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。JSONL 出力 |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（engine vs engine／NativeBackend、native LS progress 係数、乱択来歴 JSONL 記録） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、乱択来歴 JSONL 記録） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |
@@ -62,7 +62,8 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `fix_scores` | preprocess で上書きされたスコアを元ファイルから復元 |
 | `psv_to_jsonl` | PSV 形式を JSONL 形式に変換 |
 | `psv_to_hcpe3` | PSV を dlshogi 学習用 hcpe3 / hcpe に変換（cshogi と byte 一致、streaming、`--evalfix-a` で eval 焼き込み） |
-| `pack_to_psv` | GenSfen .pack を PackedSfenValue (PSV) 形式に展開 |
+| `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へストリーミング移行（[詳細](migrate_psv_move16.md)） |
+| `pack_to_psv` | GenSfen .pack を PackedSfenValue (PSV) 形式に展開し、move16 を実 YaneuraOu 形式へ変換 |
 | `hcpe_to_psv` | hcpe (cshogi HuffmanCodedPosAndEval) を PSV に変換（外部公開 hcpe プールの `--data`/`--test-data` 用、[詳細](hcpe_to_psv.md)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・Bloom 重複除去・決定的 shuffle・件数制限・分割（[詳細](prep_hcpe.md)） |
 

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -22,8 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::AtomicU64;
 use tools::packed_sfen::{
-    PackedSfenValue, move_to_hcpe_move16, move_to_move16, move16_to_move, pack_position,
-    pack_position_hcp,
+    PackedSfenValue, move_to_psv_move16, pack_position, pack_position_hcp, psv_move16_to_hcpe,
 };
 use tools::selfplay::{
     EngineConfig, EngineProcess, EvalLog, GameEngines, GameOutcome, MultiPvCandidate,
@@ -717,7 +716,7 @@ impl TrainingDataCollector {
         };
 
         // 最善手をMove16形式に変換
-        let move16 = best_move.map_or(0, move_to_move16);
+        let move16 = best_move.map_or(0, move_to_psv_move16);
 
         // PackedSfenを生成
         let packed_sfen = pack_position(pos);
@@ -734,7 +733,7 @@ impl TrainingDataCollector {
 
         // hcpe3 形式は replay 整合のため selectedMove16 を実着手にし、各手に MultiPV policy を持たせる
         let hcpe3 = if self.format == TrainingFormat::Hcpe3 {
-            let selected_move16 = move_to_move16(played_move);
+            let selected_move16 = move_to_psv_move16(played_move);
             let eval = score_mate.map_or(score, mate_to_eval);
             let policy = if candidates.is_empty() {
                 vec![(selected_move16, 1u16)]
@@ -853,9 +852,7 @@ impl TrainingDataCollector {
 
         // 2. 各エントリの指し手とスコア
         for entry in &self.entries {
-            // rshogi の move16 → Move → hcpe move16
-            let mv = move16_to_move(entry.move16);
-            let hcpe_move16 = move_to_hcpe_move16(mv);
+            let hcpe_move16 = psv_move16_to_hcpe(entry.move16);
             self.writer.write_all(&hcpe_move16.to_le_bytes())?;
             self.writer.write_all(&entry.score.to_le_bytes())?;
             self.total_written += 1;
@@ -909,7 +906,7 @@ impl TrainingDataCollector {
                 .hcpe3
                 .as_ref()
                 .ok_or_else(|| anyhow!("hcpe3 format: entry has no policy data"))?;
-            let selected = move_to_hcpe_move16(move16_to_move(h.selected_move16));
+            let selected = psv_move16_to_hcpe(h.selected_move16);
             let candidate_num: u16 =
                 h.policy.len().try_into().map_err(|_| {
                     anyhow!("hcpe3 format: too many candidates ({})", h.policy.len())
@@ -918,7 +915,7 @@ impl TrainingDataCollector {
             self.writer.write_all(&h.eval.to_le_bytes())?;
             self.writer.write_all(&candidate_num.to_le_bytes())?;
             for (move16, visit) in &h.policy {
-                let hcpe_move16 = move_to_hcpe_move16(move16_to_move(*move16));
+                let hcpe_move16 = psv_move16_to_hcpe(*move16);
                 self.writer.write_all(&hcpe_move16.to_le_bytes())?;
                 self.writer.write_all(&visit.to_le_bytes())?;
             }
@@ -1108,7 +1105,7 @@ fn multipv_to_policy(candidates: &[MultiPvCandidate], total: u16, temp: f64) -> 
     let mut out: Vec<(u16, u16)> = Vec::with_capacity(sorted.len());
     for (c, &v) in sorted.iter().zip(&visits) {
         if v > 0 {
-            out.push((move_to_move16(c.first_move), v as u16));
+            out.push((move_to_psv_move16(c.first_move), v as u16));
         }
     }
     out
@@ -3421,7 +3418,7 @@ mod tests {
     #[test]
     fn multipv_to_policy_sorts_and_keeps_pv1() {
         use rshogi_core::types::Move;
-        use tools::packed_sfen::move_to_move16;
+        use tools::packed_sfen::move_to_psv_move16;
         use tools::selfplay::MultiPvCandidate;
 
         let m1 = Move::from_usi("7g7f").unwrap();
@@ -3451,7 +3448,7 @@ mod tests {
         let policy = multipv_to_policy(&candidates, 1000, 600.0);
         assert!(!policy.is_empty());
         // PV1 (m1) が先頭で 1 票以上
-        assert_eq!(policy[0].0, move_to_move16(m1));
+        assert_eq!(policy[0].0, move_to_psv_move16(m1));
         assert!(policy[0].1 >= 1);
         let sum: i32 = policy.iter().map(|(_, v)| *v as i32).sum();
         // largest-remainder で総票数は total に厳密一致する
@@ -3739,7 +3736,7 @@ mod tests {
 
     #[test]
     fn multipv_to_policy_visits_sum_to_total() {
-        use tools::packed_sfen::move_to_move16;
+        use tools::packed_sfen::move_to_psv_move16;
         let candidates = vec![
             legal_candidate(1, 100, "7g7f"),
             legal_candidate(2, 63, "2g2f"),
@@ -3751,7 +3748,7 @@ mod tests {
             let policy = multipv_to_policy(&candidates, total, 600.0);
             let sum: u32 = policy.iter().map(|(_, v)| *v as u32).sum();
             assert_eq!(sum, total as u32, "total={total}");
-            assert_eq!(policy[0].0, move_to_move16(candidates[0].first_move));
+            assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
             assert!(policy[0].1 >= 1);
         }
     }
@@ -3771,7 +3768,7 @@ mod tests {
     #[test]
     fn multipv_to_policy_downweights_losing_mate() {
         use rshogi_core::types::Move;
-        use tools::packed_sfen::move_to_move16;
+        use tools::packed_sfen::move_to_psv_move16;
         use tools::selfplay::MultiPvCandidate;
 
         let good = Move::from_usi("7g7f").unwrap();
@@ -3792,9 +3789,14 @@ mod tests {
             },
         ];
         let policy = multipv_to_policy(&candidates, 1000, 600.0);
-        let good_v = policy.iter().find(|(m, _)| *m == move_to_move16(good)).map_or(0, |(_, v)| *v);
-        let losing_v =
-            policy.iter().find(|(m, _)| *m == move_to_move16(losing)).map_or(0, |(_, v)| *v);
+        let good_v = policy
+            .iter()
+            .find(|(m, _)| *m == move_to_psv_move16(good))
+            .map_or(0, |(_, v)| *v);
+        let losing_v = policy
+            .iter()
+            .find(|(m, _)| *m == move_to_psv_move16(losing))
+            .map_or(0, |(_, v)| *v);
         // 符号付き score_cp で負け詰みは大きく減点され、PV1 を上回らない
         assert!(good_v > losing_v);
     }

--- a/crates/tools/src/bin/hcpe_to_psv.rs
+++ b/crates/tools/src/bin/hcpe_to_psv.rs
@@ -17,7 +17,7 @@
 //! - eval: 手番側視点 cp（両形式で同一規約）をそのままコピー。詰み帯の数値表現は
 //!   生成系により異なる（例: gensfen は PSV 詰みを ±10000 帯で保存）が、値変換は行わない。
 //! - bestMove16: cshogi 形式 → **実 YaneuraOu Move16** 形式（bit14=駒打ち/bit15=成り。
-//!   リポジトリ内部表現 `move_to_move16` とは別形式）。
+//!   旧リポジトリ内部形式 (B) とは別形式）。
 //! - gameResult: 絶対視点（0=draw / 1=black_win / 2=white_win）→ 手番側視点
 //!   （1=win / -1=loss / 0=draw）。
 //! - game_ply: hcpe には手数が無いため 1 固定。

--- a/crates/tools/src/bin/jsonl_to_psv.rs
+++ b/crates/tools/src/bin/jsonl_to_psv.rs
@@ -19,7 +19,7 @@ use rshogi_core::types::{Color, Move};
 use serde::Deserialize;
 use serde_json::Value;
 use tools::common::dedup::collect_input_paths;
-use tools::packed_sfen::{PackedSfenValue, move_to_move16, pack_position};
+use tools::packed_sfen::{PackedSfenValue, move_to_psv_move16, pack_position};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -330,7 +330,7 @@ fn convert_move(mv: &MoveLog, missing_score: MissingScoreMode) -> Result<Option<
     Ok(Some(PendingRecord {
         packed_sfen: pack_position(&pos),
         score,
-        move16: move_to_move16(best_move),
+        move16: move_to_psv_move16(best_move),
         game_ply: pos.game_ply().clamp(0, u16::MAX as i32) as u16,
         side_to_move,
     }))

--- a/crates/tools/src/bin/migrate_psv_move16.rs
+++ b/crates/tools/src/bin/migrate_psv_move16.rs
@@ -31,8 +31,8 @@ struct Cli {
     #[arg(long)]
     output: PathBuf,
 
-    /// 各局面でデコードした指し手の合法性を検証
-    #[arg(long, default_value_t = true)]
+    /// 各局面でデコードした指し手の合法性を検証（`--verify-legal=false` で形式確認のみの高速移行）
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
     verify_legal: bool,
 }
 

--- a/crates/tools/src/bin/migrate_psv_move16.rs
+++ b/crates/tools/src/bin/migrate_psv_move16.rs
@@ -1,0 +1,203 @@
+//! 旧リポジトリ内部形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行する。
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rshogi_core::movegen::{MoveList, generate_legal_all};
+use rshogi_core::position::Position;
+use rshogi_core::types::Move;
+use tools::packed_sfen::{
+    PackedSfenValue, PsvMove16Class, classify_psv_move16, legacy_move16_to_move,
+    move_to_psv_move16, unpack_sfen_to_parts,
+};
+
+const IO_BUF_SIZE: usize = 1 << 20;
+const FORMAT_SCAN_RECORDS: u64 = 100_000;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "migrate_psv_move16",
+    about = "旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行"
+)]
+struct Cli {
+    /// 入力 PSV ファイル
+    #[arg(long)]
+    input: PathBuf,
+
+    /// 出力 PSV ファイル
+    #[arg(long)]
+    output: PathBuf,
+
+    /// 各局面でデコードした指し手の合法性を検証
+    #[arg(long, default_value_t = true)]
+    verify_legal: bool,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct FormatEvidence {
+    legacy_or_hcpe: bool,
+    bit15: bool,
+    hcpe_pawn_drop: bool,
+}
+
+fn inspect_move16s(move16s: impl IntoIterator<Item = u16>) -> FormatEvidence {
+    let mut evidence = FormatEvidence::default();
+    for move16 in move16s {
+        let from = (move16 >> 7) & 0x7f;
+        let drop_bit = move16 & 0x4000 != 0;
+        evidence.bit15 |= move16 & 0x8000 != 0;
+        evidence.hcpe_pawn_drop |= move16 != 0 && !drop_bit && from == 81;
+        evidence.legacy_or_hcpe |= classify_psv_move16(move16) == PsvMove16Class::LegacyOrHcpe;
+    }
+    evidence
+}
+
+fn validate_format_evidence(evidence: &FormatEvidence, scanned: u64) -> Result<()> {
+    if evidence.bit15 {
+        anyhow::bail!("入力には bit15 の move16 があり、既に実 YaneuraOu 形式 (A) です");
+    }
+    if evidence.hcpe_pawn_drop {
+        anyhow::bail!("入力には from=81 の hcpe 形式 (C) の駒打ちが混入しています");
+    }
+    if !evidence.legacy_or_hcpe {
+        anyhow::bail!("先頭 {scanned} レコードから旧リポジトリ形式 (B) を確認できません");
+    }
+    Ok(())
+}
+
+fn validate_input_format(path: &Path, records: u64) -> Result<()> {
+    let file = File::open(path).with_context(|| format!("{} を開けません", path.display()))?;
+    let mut reader = BufReader::with_capacity(IO_BUF_SIZE, file);
+    let mut record = [0u8; PackedSfenValue::SIZE];
+    let mut move16s = Vec::with_capacity(records.min(FORMAT_SCAN_RECORDS) as usize);
+    for _ in 0..records.min(FORMAT_SCAN_RECORDS) {
+        reader.read_exact(&mut record)?;
+        move16s.push(u16::from_le_bytes([record[34], record[35]]));
+    }
+    let evidence = inspect_move16s(move16s);
+    validate_format_evidence(&evidence, records.min(FORMAT_SCAN_RECORDS))
+}
+
+fn convert_record_move16(
+    mut record: [u8; PackedSfenValue::SIZE],
+) -> ([u8; PackedSfenValue::SIZE], Move) {
+    let legacy = u16::from_le_bytes([record[34], record[35]]);
+    let mv = legacy_move16_to_move(legacy);
+    record[34..36].copy_from_slice(&move_to_psv_move16(mv).to_le_bytes());
+    (record, mv)
+}
+
+fn same_move(lhs: Move, rhs: Move) -> bool {
+    lhs.to() == rhs.to()
+        && lhs.is_drop() == rhs.is_drop()
+        && lhs.is_promote() == rhs.is_promote()
+        && if lhs.is_drop() {
+            lhs.drop_piece_type() == rhs.drop_piece_type()
+        } else {
+            lhs.from() == rhs.from()
+        }
+}
+
+fn is_legal_move(psv: &PackedSfenValue, mv: Move) -> bool {
+    if mv.is_none() {
+        return psv.move16 == 0;
+    }
+    let Ok(parts) = unpack_sfen_to_parts(&psv.sfen) else {
+        return false;
+    };
+    let mut pos = Position::new();
+    if pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move).is_err() {
+        return false;
+    }
+    let mut legal_moves = MoveList::new();
+    generate_legal_all(&pos, &mut legal_moves);
+    legal_moves.iter().any(|legal| same_move(*legal, mv))
+}
+
+fn partial_path(output: &Path) -> PathBuf {
+    let mut path = output.as_os_str().to_os_string();
+    path.push(".partial");
+    PathBuf::from(path)
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let metadata = std::fs::metadata(&cli.input)
+        .with_context(|| format!("{} の情報を取得できません", cli.input.display()))?;
+    if metadata.len() % PackedSfenValue::SIZE as u64 != 0 {
+        anyhow::bail!(
+            "入力サイズ {} が PSV レコード長 {} の倍数ではありません",
+            metadata.len(),
+            PackedSfenValue::SIZE
+        );
+    }
+    let records = metadata.len() / PackedSfenValue::SIZE as u64;
+    validate_input_format(&cli.input, records)?;
+
+    let input_canonical = cli.input.canonicalize()?;
+    if cli.output.exists() && cli.output.canonicalize()? == input_canonical {
+        anyhow::bail!("入力と出力が同一ファイルです: {}", cli.input.display());
+    }
+    let tmp_output = partial_path(&cli.output);
+    if tmp_output.exists() && tmp_output.canonicalize()? == input_canonical {
+        anyhow::bail!("一時ファイルが入力と同一ファイルです: {}", tmp_output.display());
+    }
+
+    let input = File::open(&cli.input)?;
+    let output = File::create(&tmp_output)
+        .with_context(|| format!("{} を作成できません", tmp_output.display()))?;
+    let mut reader = BufReader::with_capacity(IO_BUF_SIZE, input);
+    let mut writer = BufWriter::with_capacity(IO_BUF_SIZE, output);
+    let mut record = [0u8; PackedSfenValue::SIZE];
+    let mut legal_errors = 0u64;
+
+    for index in 0..records {
+        reader.read_exact(&mut record)?;
+        let psv = PackedSfenValue::from_bytes(&record).expect("固定長レコード");
+        let (converted, mv) = convert_record_move16(record);
+        if cli.verify_legal && !is_legal_move(&psv, mv) {
+            legal_errors += 1;
+            eprintln!("合法手検証エラー: レコード {} move16=0x{:04x}", index + 1, psv.move16);
+        }
+        writer.write_all(&converted)?;
+    }
+    writer.flush()?;
+    drop(writer);
+    std::fs::rename(&tmp_output, &cli.output).with_context(|| {
+        format!("{} → {} の rename に失敗", tmp_output.display(), cli.output.display())
+    })?;
+
+    eprintln!("変換レコード数: {records}");
+    eprintln!("合法手検証エラー: {legal_errors}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rshogi_core::types::{PieceType, Square};
+
+    #[test]
+    fn legacy_move_is_converted_to_psv() {
+        let mv = Move::new_drop(PieceType::Pawn, Square::SQ_55);
+        let legacy = tools::packed_sfen::move_to_legacy_move16(mv);
+        let mut record = [0x5au8; PackedSfenValue::SIZE];
+        record[34..36].copy_from_slice(&legacy.to_le_bytes());
+        let (converted, decoded) = convert_record_move16(record);
+        assert_eq!(decoded, mv);
+        assert_eq!(u16::from_le_bytes([converted[34], converted[35]]), 40 | (1 << 7) | 0x4000);
+        assert_eq!(&converted[..34], &record[..34]);
+        assert_eq!(&converted[36..], &record[36..]);
+        assert!(inspect_move16s([legacy]).legacy_or_hcpe);
+    }
+
+    #[test]
+    fn a_input_is_detected() {
+        let promoted = 10 | (11 << 7) | 0x8000;
+        let evidence = inspect_move16s([promoted]);
+        assert!(validate_format_evidence(&evidence, 1).is_err());
+    }
+}

--- a/crates/tools/src/bin/pack_to_psv.rs
+++ b/crates/tools/src/bin/pack_to_psv.rs
@@ -37,7 +37,7 @@ use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::position::Position;
 use rshogi_core::types::Color;
 use tools::common::dedup::collect_input_paths;
-use tools::packed_sfen::{PackedSfenValue, hcpe_move16_to_move, pack_position};
+use tools::packed_sfen::{PackedSfenValue, hcpe_move16_to_move, hcpe_move16_to_psv, pack_position};
 
 #[derive(Parser, Debug)]
 #[command(name = "pack_to_psv")]
@@ -225,7 +225,7 @@ fn process_game(
         let psv = PackedSfenValue {
             sfen: packed_sfen,
             score: eval,
-            move16,
+            move16: hcpe_move16_to_psv(move16),
             game_ply,
             game_result,
             padding: 0,

--- a/crates/tools/src/bin/psv_to_hcpe3.rs
+++ b/crates/tools/src/bin/psv_to_hcpe3.rs
@@ -182,6 +182,11 @@ fn convert(
 
     let hcp = pack_hcp_from_parts(&parts);
     let move16 = psv_move16_to_hcpe(psv.move16);
+    // 非 0 の move16 が変換で 0 になった = 範囲外の破損値。黙って bestMove16=0 の
+    // 「一見有効な」レコードを書くと教師 policy が静かに壊れるため、エラーとして skip する。
+    if psv.move16 != 0 && move16 == 0 {
+        return ConvResult::Error(format!("不正な move16: 0x{:04x}", psv.move16));
+    }
     let result = stm_result_to_hcpe(psv.game_result, parts.side_to_move);
     let eval = baked_eval(psv.score, eval_scale);
 

--- a/crates/tools/src/bin/psv_to_hcpe3.rs
+++ b/crates/tools/src/bin/psv_to_hcpe3.rs
@@ -40,8 +40,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use tools::packed_sfen::{
-    PackedSfenValue, pack_hcp_from_parts, psv_move16_to_hcpe, stm_result_to_hcpe,
-    unpack_sfen_to_parts,
+    PackedSfenValue, PsvMove16Class, classify_psv_move16, pack_hcp_from_parts, psv_move16_to_hcpe,
+    stm_result_to_hcpe, unpack_sfen_to_parts,
 };
 use tools::teacher_labeler::HCPE_RECORD_SIZE;
 
@@ -52,6 +52,7 @@ const HCPE3_SIZE: usize = 46;
 const RECORD_BUF: usize = HCPE3_SIZE;
 
 const IO_BUF_SIZE: usize = 1 << 20;
+const MOVE16_GUARD_RECORDS: u64 = 100_000;
 
 /// 非TTY 実行時にテキスト進捗を出す最小間隔（秒）。
 const PROGRESS_LOG_SECS: u64 = 5;
@@ -215,6 +216,23 @@ fn write_results(
     Ok((written, errors))
 }
 
+fn validate_psv_move16_format(path: &PathBuf, records: u64) -> Result<()> {
+    let file = File::open(path).with_context(|| format!("{} を開けません", path.display()))?;
+    let mut reader = BufReader::with_capacity(IO_BUF_SIZE, file);
+    let mut record = [0u8; PackedSfenValue::SIZE];
+    for index in 0..records.min(MOVE16_GUARD_RECORDS) {
+        reader.read_exact(&mut record)?;
+        let move16 = u16::from_le_bytes([record[34], record[35]]);
+        if classify_psv_move16(move16) == PsvMove16Class::LegacyOrHcpe {
+            anyhow::bail!(
+                "レコード {} の move16=0x{move16:04x} は旧リポジトリ形式 (B) または hcpe 形式 (C) です。Issue #930 の migrate_psv_move16 で A 形式へ移行してください",
+                index + 1
+            );
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
@@ -263,6 +281,7 @@ fn main() -> Result<()> {
 
     let file_size = std::fs::metadata(&cli.input)?.len();
     let estimated_records = file_size / PackedSfenValue::SIZE as u64;
+    validate_psv_move16_format(&cli.input, estimated_records)?;
     let total = if cli.limit > 0 {
         estimated_records.min(cli.limit as u64)
     } else {

--- a/crates/tools/src/bin/psv_to_jsonl.rs
+++ b/crates/tools/src/bin/psv_to_jsonl.rs
@@ -27,7 +27,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use tools::packed_sfen::{PackedSfenValue, move16_to_usi, unpack_sfen};
+use tools::packed_sfen::{PackedSfenValue, psv_move16_to_usi, unpack_sfen};
 
 #[derive(Parser)]
 #[command(
@@ -180,7 +180,7 @@ fn main() -> Result<()> {
         };
 
         // Move16をUSI形式に変換
-        let best_move = move16_to_usi(psv.move16);
+        let best_move = psv_move16_to_usi(psv.move16);
 
         // TrainingRecordを作成
         let record = TrainingRecord {

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -67,7 +67,9 @@ use std::time::Instant;
 use rshogi_core::nnue::init_nnue;
 use rshogi_core::position::Position;
 use rshogi_core::search::{LimitsType, Search};
-use tools::packed_sfen::{PackedSfenValue, pack_position, unpack_sfen, unpack_sfen_to_parts};
+use tools::packed_sfen::{
+    PackedSfenValue, move_to_psv_move16, pack_position, unpack_sfen, unpack_sfen_to_parts,
+};
 use tools::progress::{FileProgress, MultiFileProgress};
 // UnpackedSfen は ONNX 経路専用。ONNX 無効ビルドの unused import を避けるため cfg で囲う。
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
@@ -107,6 +109,10 @@ struct Cli {
     /// 指定した深さでalpha-beta探索を実行し、その結果をスコアとして使用
     #[arg(long)]
     search_depth: Option<i32>,
+
+    /// 深さ指定探索の最善手を実 YaneuraOu PSV 形式 (A) で move16 に出力
+    #[arg(long)]
+    emit_bestmove: bool,
 
     /// 置換表サイズ（MB）、--search-depth使用時のみ有効
     #[arg(long, default_value_t = 64)]
@@ -643,6 +649,9 @@ fn main() -> Result<()> {
     }
     if cli.use_qsearch && cli.search_depth.is_some() {
         anyhow::bail!("--use-qsearch and --search-depth are mutually exclusive");
+    }
+    if cli.emit_bestmove && cli.search_depth.is_none() {
+        anyhow::bail!("--emit-bestmove requires --search-depth");
     }
     if !use_engine && !use_onnx && !use_dlshogi_onnx && cli.nnue.is_none() {
         anyhow::bail!(
@@ -1329,7 +1338,7 @@ fn process_record(
     }
 
     // qsearch leaf置換を適用する場合
-    let (final_sfen, stm_changed) = if apply_leaf && !pos.in_check() {
+    let (final_sfen, stm_changed, position_replaced) = if apply_leaf && !pos.in_check() {
         let result = qsearch_with_pv_nnue(
             &mut pos,
             stacks,
@@ -1342,9 +1351,9 @@ fn process_record(
         // PV に沿って葉局面まで進める。STM 反転有無も同時に得る。
         let stm_changed = apply_pv(&mut pos, &result.pv);
         let new_sfen = pack_position(&pos);
-        (new_sfen, stm_changed)
+        (new_sfen, stm_changed, true)
     } else {
-        (psv.sfen, false)
+        (psv.sfen, false, false)
     };
 
     // NNUEで評価
@@ -1387,7 +1396,7 @@ fn process_record(
     let new_psv = PackedSfenValue {
         sfen: final_sfen,
         score: new_score,
-        move16: 0, // 無効値
+        move16: if position_replaced { 0 } else { psv.move16 },
         game_ply: psv.game_ply,
         game_result: new_game_result,
         padding: 0,
@@ -1514,6 +1523,7 @@ fn process_file_with_search(
                                     skip_in_check,
                                     source_fv_scale,
                                     target_fv_scale,
+                                    cli.emit_bestmove,
                                 ));
                                 progress.inc(1);
                             }
@@ -1591,6 +1601,7 @@ fn process_record_with_search(
     skip_in_check: bool,
     source_fv_scale: i32,
     target_fv_scale: i32,
+    emit_bestmove: bool,
 ) -> ProcessResult {
     // PackedSfenValueを読み込み
     let psv = match PackedSfenValue::from_bytes(record) {
@@ -1641,7 +1652,11 @@ fn process_record_with_search(
     let new_psv = PackedSfenValue {
         sfen: psv.sfen,
         score: new_score,
-        move16: 0, // 無効値
+        move16: if emit_bestmove {
+            move_to_psv_move16(search_result.best_move)
+        } else {
+            psv.move16
+        },
         game_ply: psv.game_ply,
         game_result: psv.game_result,
         padding: 0,
@@ -2014,7 +2029,7 @@ fn process_file_with_engine(
             let new_psv = PackedSfenValue {
                 sfen: psv.sfen,
                 score: raw_score.clamp(-(score_clip as i32), score_clip as i32) as i16,
-                move16: 0,
+                move16: psv.move16,
                 game_ply: psv.game_ply,
                 game_result: psv.game_result,
                 padding: 0,
@@ -3341,7 +3356,7 @@ where
                     let new_psv = PackedSfenValue {
                         sfen: psv.sfen,
                         score: new_score,
-                        move16: 0,
+                        move16: psv.move16,
                         game_ply: psv.game_ply,
                         game_result: psv.game_result,
                         padding: 0,

--- a/crates/tools/src/packed_sfen.rs
+++ b/crates/tools/src/packed_sfen.rs
@@ -1603,13 +1603,26 @@ pub fn move_to_hcpe_move16(mv: Move) -> u16 {
 /// 旧リポジトリ内部表現 (B) とは**別形式**である点に注意。
 #[inline]
 pub fn psv_move16_to_hcpe(yo_move16: u16) -> u16 {
+    if yo_move16 == 0 {
+        return 0;
+    }
     let to = yo_move16 & 0x7f;
+    // 移動先がマス番号 0..80 の範囲外なら破損レコード (hcpe_move16_to_psv と対称の検証)
+    if to > 80 {
+        return 0;
+    }
     let from_field = (yo_move16 >> 7) & 0x7f;
     if yo_move16 & 0x4000 != 0 {
-        // 駒打ち: from フィールドは駒種(1 始まり) → from = 81 + (駒種 - 1) = 80 + from_field
+        // 駒打ち: from フィールドは駒種(1 始まり、歩=1..金=7) → from = 81 + (駒種 - 1)
+        if !(1..=7).contains(&from_field) {
+            return 0;
+        }
         to | ((80 + from_field) << 7)
     } else {
-        // 盤上の手: 成りは YaneuraOu の bit15 → hcpe の bit14 へ移す
+        // 盤上の手: from もマス番号範囲内であること。成りは YaneuraOu の bit15 → hcpe の bit14 へ
+        if from_field > 80 {
+            return 0;
+        }
         let promote = if yo_move16 & 0x8000 != 0 { 0x4000 } else { 0 };
         to | (from_field << 7) | promote
     }
@@ -2301,6 +2314,12 @@ mod tests {
         // 移動先マスが範囲外 (to > 80) の破損レコードは 0 (盤上の手・駒打ちとも)
         assert_eq!(hcpe_move16_to_psv(85 | (60 << 7)), 0);
         assert_eq!(hcpe_move16_to_psv(127 | (81 << 7)), 0);
+        // psv→hcpe 方向も対称の検証を持つ: to 範囲外 / 打ちの駒種 0 や 8 以上 / 盤上の手の from 範囲外
+        assert_eq!(psv_move16_to_hcpe(85 | (60 << 7)), 0);
+        assert_eq!(psv_move16_to_hcpe(40 | 0x4000), 0); // 打ちで from=0 (駒種なし)
+        assert_eq!(psv_move16_to_hcpe(40 | (8 << 7) | 0x4000), 0); // 打ちで駒種 8
+        assert_eq!(psv_move16_to_hcpe(40 | (81 << 7)), 0); // 盤上の手で from=81 (B/C 系の破損)
+        assert_eq!(psv_move16_to_hcpe(0), 0);
     }
 
     #[test]

--- a/crates/tools/src/packed_sfen.rs
+++ b/crates/tools/src/packed_sfen.rs
@@ -10,7 +10,7 @@
 //! # 使用例
 //!
 //! ```rust,ignore
-//! use tools::packed_sfen::{PackedSfenValue, unpack_sfen, move16_to_usi};
+//! use tools::packed_sfen::{PackedSfenValue, unpack_sfen, psv_move16_to_usi};
 //!
 //! // バイト列からPackedSfenValueを読み込み
 //! let bytes = [0u8; 40]; // 実際のデータ
@@ -21,7 +21,7 @@
 //! println!("SFEN: {}", sfen);
 //!
 //! // 指し手をUSI形式に変換
-//! let usi_move = move16_to_usi(psv.move16);
+//! let usi_move = psv_move16_to_usi(psv.move16);
 //! println!("Move: {}", usi_move);
 //! ```
 //!
@@ -1040,7 +1040,9 @@ fn generate_hand_sfen(black_hand: &Hand, white_hand: &Hand) -> String {
     result
 }
 
-/// Move16形式をUSI形式の指し手文字列に変換
+/// 旧リポジトリ内部形式 (B) の Move16 を USI 形式へ変換する。
+///
+/// 新規データでは使わず、既存 B データの読み出し・移行専用とする。
 ///
 /// ## Move16形式
 /// - bits 0-6:  移動先マス (to)
@@ -1063,7 +1065,7 @@ fn generate_hand_sfen(black_hand: &Hand, white_hand: &Hand) -> String {
 /// // P*5e の場合: to=40, piece=1(歩)
 /// // move16 = 40 | (82 << 7) = 0x2928
 /// ```
-pub fn move16_to_usi(move16: u16) -> String {
+pub fn legacy_move16_to_usi(move16: u16) -> String {
     if move16 == 0 {
         return "none".to_string();
     }
@@ -1103,8 +1105,10 @@ pub fn move16_to_usi(move16: u16) -> String {
     }
 }
 
-/// Move16形式をMove型に変換
-pub fn move16_to_move(move16: u16) -> Move {
+/// 旧リポジトリ内部形式 (B) の Move16 を Move 型へ変換する。
+///
+/// 新規データでは使わず、既存 B データの読み出し・移行専用とする。
+pub fn legacy_move16_to_move(move16: u16) -> Move {
     if move16 == 0 {
         return Move::NONE;
     }
@@ -1139,6 +1143,45 @@ pub fn move16_to_move(move16: u16) -> Move {
         } else {
             Move::NONE
         }
+    }
+}
+
+/// 実 YaneuraOu PSV 形式 (A) の Move16 を Move 型へ変換する。
+pub fn psv_move16_to_move(move16: u16) -> Move {
+    if move16 == 0 {
+        return Move::NONE;
+    }
+
+    let to = (move16 & 0x7f) as u8;
+    let from_or_pt = ((move16 >> 7) & 0x7f) as u8;
+
+    if move16 & 0x4000 != 0 {
+        let pt = match from_or_pt {
+            1 => PieceType::Pawn,
+            2 => PieceType::Lance,
+            3 => PieceType::Knight,
+            4 => PieceType::Silver,
+            5 => PieceType::Bishop,
+            6 => PieceType::Rook,
+            7 => PieceType::Gold,
+            _ => return Move::NONE,
+        };
+        Square::from_u8(to).map_or(Move::NONE, |to_sq| Move::new_drop(pt, to_sq))
+    } else {
+        match (Square::from_u8(from_or_pt), Square::from_u8(to)) {
+            (Some(from_sq), Some(to_sq)) => Move::new_move(from_sq, to_sq, move16 & 0x8000 != 0),
+            _ => Move::NONE,
+        }
+    }
+}
+
+/// 実 YaneuraOu PSV 形式 (A) の Move16 を USI 形式へ変換する。
+pub fn psv_move16_to_usi(move16: u16) -> String {
+    let mv = psv_move16_to_move(move16);
+    if mv.is_none() {
+        "none".to_string()
+    } else {
+        mv.to_usi()
     }
 }
 
@@ -1453,13 +1496,15 @@ pub fn pack_sfen_from_parts(parts: &UnpackedSfen) -> [u8; 32] {
     stream.finish()
 }
 
-/// Move を Move16形式に変換
+/// Move を旧リポジトリ内部形式 (B) の Move16 へ変換する。
 ///
-/// ## Move16形式
+/// 新規データでは使わず、既存 B データの読み出し・移行専用とする。
+///
+/// ## 旧 Move16 形式
 /// - bits 0-6:  移動先マス (to)
 /// - bits 7-13: 移動元マス (from) または打つ駒種+81
 /// - bit 14:    成りフラグ
-pub fn move_to_move16(mv: Move) -> u16 {
+pub fn move_to_legacy_move16(mv: Move) -> u16 {
     if mv == Move::NONE || mv == Move::NULL {
         return 0;
     }
@@ -1484,6 +1529,34 @@ pub fn move_to_move16(mv: Move) -> u16 {
         // 通常の移動
         let from = mv.from().index() as u16;
         let promote = if mv.is_promotion() { 0x4000 } else { 0 };
+        to | (from << 7) | promote
+    }
+}
+
+/// Move を実 YaneuraOu PSV 形式 (A) の Move16 へ変換する。
+///
+/// 駒打ちは bit14 と from フィールドの駒種 (歩=1..金=7)、成りは bit15 で表す。
+pub fn move_to_psv_move16(mv: Move) -> u16 {
+    if mv == Move::NONE || mv == Move::NULL {
+        return 0;
+    }
+
+    let to = mv.to().index() as u16;
+    if mv.is_drop() {
+        let pt = match mv.drop_piece_type() {
+            PieceType::Pawn => 1,
+            PieceType::Lance => 2,
+            PieceType::Knight => 3,
+            PieceType::Silver => 4,
+            PieceType::Bishop => 5,
+            PieceType::Rook => 6,
+            PieceType::Gold => 7,
+            _ => return 0,
+        };
+        to | (pt << 7) | 0x4000
+    } else {
+        let from = mv.from().index() as u16;
+        let promote = if mv.is_promotion() { 0x8000 } else { 0 };
         to | (from << 7) | promote
     }
 }
@@ -1527,7 +1600,7 @@ pub fn move_to_hcpe_move16(mv: Move) -> u16 {
 /// 実 YaneuraOu の Move16 は bit14=駒打ちフラグ（from フィールド=駒種, 歩=1..金=7）、
 /// bit15=成りフラグ。hcpe 形式は駒打ちを `from = 81 + (駒種 - 1)` で表し、成りを
 /// bit14 で表す。形式の参照実装 cshogi `move16_from_psv` と一致する。
-/// リポジトリ内部表現 (`move_to_move16` / `move16_to_move`) とは**別形式**である点に注意。
+/// 旧リポジトリ内部表現 (B) とは**別形式**である点に注意。
 #[inline]
 pub fn psv_move16_to_hcpe(yo_move16: u16) -> u16 {
     let to = yo_move16 & 0x7f;
@@ -1567,6 +1640,31 @@ pub fn hcpe_move16_to_psv(hcpe_move16: u16) -> u16 {
         // 盤上の手: 成りは hcpe の bit14 → YO の bit15 へ移す
         let promote = if hcpe_move16 & 0x4000 != 0 { 0x8000 } else { 0 };
         to | (from_field << 7) | promote
+    }
+}
+
+/// PSV move16 の分類結果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsvMove16Class {
+    /// 指し手なし。
+    None,
+    /// 通常手、または実 YaneuraOu PSV 形式 (A) として解釈できる値。
+    NormalOrA,
+    /// 旧リポジトリ内部形式 (B) または hcpe 形式 (C) と確定できる値。
+    LegacyOrHcpe,
+}
+
+/// move16 に B/C 形式の確定シグネチャが含まれるか分類する。
+pub fn classify_psv_move16(move16: u16) -> PsvMove16Class {
+    if move16 == 0 {
+        return PsvMove16Class::None;
+    }
+    let from = (move16 >> 7) & 0x7f;
+    let drop_bit = move16 & 0x4000 != 0;
+    if (!drop_bit && (81..=88).contains(&from)) || (drop_bit && (8..=80).contains(&from)) {
+        PsvMove16Class::LegacyOrHcpe
+    } else {
+        PsvMove16Class::NormalOrA
     }
 }
 
@@ -1765,24 +1863,24 @@ mod tests {
     }
 
     #[test]
-    fn test_move16_to_usi() {
+    fn test_legacy_move16_to_usi() {
         // 通常の移動: 7g(60) -> 7f(59)
         // File7=6, Rank7=6 → sq=6*9+6=60
         // File7=6, Rank6=5 → sq=6*9+5=59
         let move16 = 59 | (60 << 7);
-        assert_eq!(move16_to_usi(move16), "7g7f");
+        assert_eq!(legacy_move16_to_usi(move16), "7g7f");
 
         // 成り: 2c(11) -> 2b(10)
         // File2=1, Rank3=2 → sq=1*9+2=11
         // File2=1, Rank2=1 → sq=1*9+1=10
         let move16 = 10 | (11 << 7) | 0x4000;
-        assert_eq!(move16_to_usi(move16), "2c2b+");
+        assert_eq!(legacy_move16_to_usi(move16), "2c2b+");
 
         // 駒打ち: P*5e (歩を5五に打つ)
         // File5=4, Rank5=4 → sq=4*9+4=40
         // 打ち駒: from = 81 + piece_type (歩=1)
         let move16 = 40 | (82 << 7);
-        assert_eq!(move16_to_usi(move16), "P*5e");
+        assert_eq!(legacy_move16_to_usi(move16), "P*5e");
     }
 
     #[test]
@@ -1890,17 +1988,17 @@ mod tests {
     }
 
     #[test]
-    fn test_move16_to_usi_invalid() {
+    fn test_legacy_move16_to_usi_invalid() {
         // move16 = 0 は "none" を返す
-        assert_eq!(move16_to_usi(0), "none");
+        assert_eq!(legacy_move16_to_usi(0), "none");
 
         // 不正な駒種インデックス (81 + 0 = 81, pt_index = 0)
         let move16 = 40 | (81 << 7);
-        assert_eq!(move16_to_usi(move16), "none");
+        assert_eq!(legacy_move16_to_usi(move16), "none");
 
         // 不正な駒種インデックス (81 + 8 = 89)
         let move16 = 40 | (89 << 7);
-        assert_eq!(move16_to_usi(move16), "none");
+        assert_eq!(legacy_move16_to_usi(move16), "none");
     }
 
     #[test]
@@ -2056,7 +2154,7 @@ mod tests {
     }
 
     #[test]
-    fn test_move_to_move16_and_back() {
+    fn test_legacy_move16_roundtrip() {
         // 7七(file=7, rank=7)のマス番号 = (7-1)*9 + (7-1) = 54 + 6 = 60
         // 7六(file=7, rank=6)のマス番号 = (7-1)*9 + (6-1) = 54 + 5 = 59
         let sq_77 = Square::from_u8(60).unwrap();
@@ -2064,8 +2162,8 @@ mod tests {
 
         // 通常の移動
         let mv = Move::new_move(sq_77, sq_76, false);
-        let move16 = move_to_move16(mv);
-        let mv_back = move16_to_move(move16);
+        let move16 = move_to_legacy_move16(mv);
+        let mv_back = legacy_move16_to_move(move16);
         assert_eq!(mv, mv_back);
 
         // 2三(file=2, rank=3)のマス番号 = (2-1)*9 + (3-1) = 9 + 2 = 11
@@ -2075,15 +2173,48 @@ mod tests {
 
         // 成り
         let mv = Move::new_move(sq_23, sq_22, true);
-        let move16 = move_to_move16(mv);
-        let mv_back = move16_to_move(move16);
+        let move16 = move_to_legacy_move16(mv);
+        let mv_back = legacy_move16_to_move(move16);
         assert_eq!(mv, mv_back);
 
         // 駒打ち
         let mv = Move::new_drop(PieceType::Pawn, Square::SQ_55);
-        let move16 = move_to_move16(mv);
-        let mv_back = move16_to_move(move16);
+        let move16 = move_to_legacy_move16(mv);
+        let mv_back = legacy_move16_to_move(move16);
         assert_eq!(mv, mv_back);
+    }
+
+    #[test]
+    fn psv_move16_roundtrip_and_oracles() {
+        let cases = [
+            (
+                Move::new_move(Square::from_u8(60).unwrap(), Square::from_u8(59).unwrap(), false),
+                0x1e3b,
+            ),
+            (
+                Move::new_move(Square::from_u8(11).unwrap(), Square::from_u8(10).unwrap(), true),
+                0x858a,
+            ),
+            (Move::new_drop(PieceType::Pawn, Square::from_u8(37).unwrap()), 0x40a5),
+        ];
+        for (mv, oracle) in cases {
+            assert_eq!(move_to_psv_move16(mv), oracle);
+            assert_eq!(psv_move16_to_move(oracle), mv);
+        }
+        assert_eq!(move_to_psv_move16(Move::NONE), 0);
+        assert_eq!(move_to_psv_move16(Move::NULL), 0);
+        assert_eq!(psv_move16_to_move(0), Move::NONE);
+        assert_eq!(psv_move16_to_usi(0x40a5), "P*5b");
+    }
+
+    #[test]
+    fn classify_psv_move16_signatures() {
+        assert_eq!(classify_psv_move16(0), PsvMove16Class::None);
+        assert_eq!(classify_psv_move16(0x40a5), PsvMove16Class::NormalOrA);
+        assert_eq!(classify_psv_move16(0x858a), PsvMove16Class::NormalOrA);
+        assert_eq!(classify_psv_move16(37 | (81 << 7)), PsvMove16Class::LegacyOrHcpe);
+        assert_eq!(classify_psv_move16(37 | (88 << 7)), PsvMove16Class::LegacyOrHcpe);
+        assert_eq!(classify_psv_move16(37 | (8 << 7) | 0x4000), PsvMove16Class::LegacyOrHcpe);
     }
 
     #[test]

--- a/crates/tools/src/replay/model.rs
+++ b/crates/tools/src/replay/model.rs
@@ -85,7 +85,7 @@ impl EvalAccumulator {
 
 /// `pos` の合法手集合に `mv` が含まれるか。合法手生成は `pos` からのみ手を作るので、CSA/PSV
 /// 由来の非合法手（空マス発・成り不正）を渡しても panic せず判定できる。`Move::raw()` は下位
-/// 16bit（from/to/成り/打ち）で、`from_usi`/`move16_to_move` が埋めない上位ビット（移動後の駒）
+/// 16bit（from/to/成り/打ち）で、`from_usi`/PSV move16 復号が埋めない上位ビット（移動後の駒）
 /// を含まないため、`==` ではなく `raw()` 一致で意味比較する。
 pub fn move_is_legal(pos: &Position, mv: Move) -> bool {
     let mut list = MoveList::new();

--- a/crates/tools/src/replay/psv_source.rs
+++ b/crates/tools/src/replay/psv_source.rs
@@ -13,7 +13,7 @@ use rshogi_core::position::Position;
 use rshogi_core::types::{Color, Move};
 
 use crate::kif::format_move_label;
-use crate::packed_sfen::{PackedSfenValue, move16_to_move, unpack_sfen};
+use crate::packed_sfen::{PackedSfenValue, psv_move16_to_move, unpack_sfen};
 
 use super::model::{
     EvalAccumulator, EvalMetrics, GameIndex, GameIndexEntry, GameOutcomeView, GameRecord,
@@ -149,7 +149,7 @@ impl GameSource for PsvSource {
             let (mv, kif_label) = if psv.move16 == 0 {
                 (Move::NONE, format!("{:>4} (終局局面)", psv.game_ply))
             } else {
-                let mv = move16_to_move(psv.move16);
+                let mv = psv_move16_to_move(psv.move16);
                 // 破損 move16 は合法手生成に一致しない → 通常手にせず生表示にフォールバック。
                 // `format_move_label`（空マス発で `piece_type()` panic）や `render_board` の
                 // `do_move`（成り不正で `promote().unwrap()` panic）が合法手前提のため。

--- a/crates/tools/tests/psv_to_hcpe3_integration.rs
+++ b/crates/tools/tests/psv_to_hcpe3_integration.rs
@@ -1,9 +1,8 @@
 //! psv_to_hcpe3 の bit 一致 / 決定性 integration テスト
 //!
-//! `tests/fixtures/psv_to_hcpe3_sample.psv` を入力に、cshogi 製オラクル
+//! `tests/fixtures/psv_to_hcpe3_yaneuraou_sample.psv` を入力に、cshogi 製オラクル
 //! （`psv_to_hcpe3.py` / dlshogi `psv_to_hcpe.py`）の出力 `.hcpe3` / `.hcpe` と
-//! byte 完全一致することを確認する。fixture は rshogi 自前の gensfen 自己対局 PSV から
-//! 通常手・駒打ち・成り × 先後 × 勝敗 を網羅するよう抽出した 56 局面。
+//! byte 完全一致することを確認する。旧形式 fixture は混入ガードの回帰テストに使う。
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -34,23 +33,19 @@ fn run(input: &Path, output: &Path, format: &str, threads: &str, chunk: &str) {
 }
 
 #[test]
-fn hcpe3_matches_cshogi_oracle() {
+fn legacy_move16_fixture_is_rejected() {
     let input = fixture("psv_to_hcpe3_sample.psv");
-    let expected = std::fs::read(fixture("psv_to_hcpe3_sample.hcpe3")).unwrap();
-    let out = std::env::temp_dir().join("psv_to_hcpe3_it_hcpe3.bin");
-    run(&input, &out, "hcpe3", "1", "200000");
-    let got = std::fs::read(&out).unwrap();
-    assert_eq!(got, expected, "hcpe3 output must byte-match the cshogi oracle");
-}
-
-#[test]
-fn hcpe_matches_cshogi_oracle() {
-    let input = fixture("psv_to_hcpe3_sample.psv");
-    let expected = std::fs::read(fixture("psv_to_hcpe3_sample.hcpe")).unwrap();
-    let out = std::env::temp_dir().join("psv_to_hcpe3_it_hcpe.bin");
-    run(&input, &out, "hcpe", "1", "200000");
-    let got = std::fs::read(&out).unwrap();
-    assert_eq!(got, expected, "hcpe output must byte-match the cshogi oracle");
+    let out = std::env::temp_dir().join("psv_to_hcpe3_it_legacy.bin");
+    let status = Command::new(BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run psv_to_hcpe3");
+    assert!(!status.success(), "legacy move16 input must be rejected");
 }
 
 // 実 YaneuraOu PSV 形式（成り=bit15 / 駒打ち=bit14+from=駒種）の move16 を含む fixture。
@@ -85,8 +80,8 @@ fn hcpe_matches_cshogi_oracle_yaneuraou_format() {
 fn trailing_partial_bytes_are_ignored() {
     // 末尾にレコード長未満の半端バイトがあっても、完全なレコードの出力は ground truth と一致し、
     // ツールは成功終了する（半端バイトはスキップ）。
-    let expected = std::fs::read(fixture("psv_to_hcpe3_sample.hcpe3")).unwrap();
-    let mut psv = std::fs::read(fixture("psv_to_hcpe3_sample.psv")).unwrap();
+    let expected = std::fs::read(fixture("psv_to_hcpe3_yaneuraou_sample.hcpe3")).unwrap();
+    let mut psv = std::fs::read(fixture("psv_to_hcpe3_yaneuraou_sample.psv")).unwrap();
     psv.extend_from_slice(&[0u8; 7]); // 40 バイト境界に満たない末尾
     let truncated_input = std::env::temp_dir().join("psv_to_hcpe3_it_trailing.psv");
     std::fs::write(&truncated_input, &psv).unwrap();
@@ -102,8 +97,8 @@ fn trailing_partial_bytes_are_ignored() {
 #[test]
 fn output_path_with_tmp_extension_is_not_truncated() {
     // `--output *.tmp` でも一時ファイル（.partial 付与）と最終パスが衝突せず正しく出力される。
-    let input = fixture("psv_to_hcpe3_sample.psv");
-    let expected = std::fs::read(fixture("psv_to_hcpe3_sample.hcpe3")).unwrap();
+    let input = fixture("psv_to_hcpe3_yaneuraou_sample.psv");
+    let expected = std::fs::read(fixture("psv_to_hcpe3_yaneuraou_sample.hcpe3")).unwrap();
     let out = std::env::temp_dir().join("psv_to_hcpe3_it_out.tmp");
     run(&input, &out, "hcpe3", "1", "200000");
     assert_eq!(std::fs::read(&out).unwrap(), expected, "output must be correct for *.tmp path");
@@ -112,7 +107,7 @@ fn output_path_with_tmp_extension_is_not_truncated() {
 #[test]
 fn limit_restricts_output_record_count() {
     // --limit N は先頭 N レコードだけ変換する（出力 = N × 46 バイト）。
-    let input = fixture("psv_to_hcpe3_sample.psv");
+    let input = fixture("psv_to_hcpe3_yaneuraou_sample.psv");
     let out = std::env::temp_dir().join("psv_to_hcpe3_it_limit.bin");
     let status = Command::new(BIN)
         .args([
@@ -138,7 +133,7 @@ fn limit_restricts_output_record_count() {
 #[test]
 fn output_is_thread_count_independent() {
     // 出力はスレッド数・チャンク境界に依らず bit 一致でなければならない。
-    let input = fixture("psv_to_hcpe3_sample.psv");
+    let input = fixture("psv_to_hcpe3_yaneuraou_sample.psv");
     let out1 = std::env::temp_dir().join("psv_to_hcpe3_it_t1.bin");
     let out4 = std::env::temp_dir().join("psv_to_hcpe3_it_t4.bin");
     run(&input, &out1, "hcpe3", "1", "200000");


### PR DESCRIPTION
Closes #930

## 概要

PSV の move16 に 3 系統の符号 (A=実 YaneuraOu / B=旧リポ内部 / C=hcpe) が混在していた問題を、実 YaneuraOu 形式 (A) に一本化して解消する。cshogi / nnue-pytorch / dlshogi との相互運用が正しくなる。

## 変更

- **packed_sfen**: A 形式 encode/decode (`move_to_psv_move16` / `psv_move16_to_move` / `psv_move16_to_usi`) と `classify_psv_move16` を追加。旧内部形式 API は `legacy_` 接頭辞へ隔離 (使用は移行ツールのみに限定)。双方向変換 (`psv_move16_to_hcpe` / `hcpe_move16_to_psv`) は破損入力の範囲検証を両方向対称に実施
- **gensfen**: メモリ内 canonical を A に統一。PSV 出力が A になり (バグ修正)、pack/hcpe3 出力は u16 直変換 (`psv_move16_to_hcpe`) 経由で**出力バイト不変**
- **pack_to_psv**: hcpe 形式 move16 の無変換漏れ (C) を修正
- **読み手**: kifu_player (psv_source) / psv_to_jsonl を A デコードへ
- **psv_to_hcpe3**: B/C 確定シグネチャの混入検知ガード (先頭 10 万件検査、発火時は #930 と移行ツールを案内)
- **migrate_psv_move16 (新規)**: 既存 B 形式 PSV の A への一括焼き直し。合法手検証既定 ON、A/C 入力の拒否、.partial+rename、move16 以外のバイト不変
- **rescore_psv**: 局面不変パスは move16 を温存 (従来は 0 で破棄)、葉置換パスは 0 維持、深さ探索専用 `--emit-bestmove` を追加

## 検証

- fmt / clippy 警告ゼロ / `cargo test -p tools` 614 passed / abs-paths チェック
- 実データ E2E: `teachers/selfplay/raw_v77.psv` 全 60,280,416 レコードを migrate_psv_move16 で試験変換 — **合法手検証エラー 0**・非 move16 バイト完全不変・出力 pure A をビットパターン分類で確認
- Claude + Codex の local dual review 済み (Codex must-fix の psv_move16_to_hcpe 範囲検証を反映して両者 APPROVE)

## merge 後の運用タスク

- `$SHOGI_DATA/teachers/selfplay/raw_v77*.psv` を `migrate_psv_move16` で本番焼き直し (過渡期の B/A 混在を作らないため merge とセットで実施)
- 他マシンの旧 gensfen バイナリは rebuild するまで B を吐くため、selfplay 教師生成前に要 rebuild
- 既存 DLSuisho15b 系プール (move16=全ゼロ) は本変更の対象外。165億プールの再リスコアはスコープ外 (#930 参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPJxtMf5fXMS8EDDvbQyQT