### PR TITLE
feat(tools): relabel_psv — diversion の result 整合性フィルタで乱択汚染 prefix のみ除外 (drop-contaminated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ crates.io への `rshogi-core` publish は (v1.3.0 リリース以降) `vX.Y.Z` 
 バージョンを bump する (publish される tarball とタグの内容を常に一致させ、「バージョン
 番号が動いていない = core 変更なし」という誤推定を防ぐため)。
 
+## Unreleased
+
+- **relabel_psv**: 処理完了時の stderr 統計を human-readable な1行から JSON 1行へ変更。
+
 ## v1.3.0 — 2026-07-11
 
 v1.2.0 後の機能追加リリース。定跡 (opening book) 機構一式 — 新規クレート `rshogi-book`

--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -33,7 +33,7 @@
 | `shuffle_psv` | PSV ファイルのシャッフル |
 | `split_psv` | PSV ファイルを局面数または容量で分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおり結合 |
-| `relabel_psv` | PSV の score を手番側視点の game_result 由来値へ streaming 置換し、任意で宣言勝ち override / diversions deblunder（[詳細](docs/relabel_psv.md)） |
+| `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](docs/relabel_psv.md)） |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
@@ -108,7 +108,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
-- [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換と任意の宣言勝ち override / diversions deblunder
+- [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応）
 - [migrate_psv_move16](docs/migrate_psv_move16.md) - 旧 PSV move16 の実 YaneuraOu 形式への移行

--- a/crates/tools/docs/relabel_psv.md
+++ b/crates/tools/docs/relabel_psv.md
@@ -1,14 +1,13 @@
 # relabel_psv — PSV 勝敗ラベルへの score 置換
 
-`--output` が展開後の `--input` または `--game-id-sidecar` と同じファイル実体を
-指す場合は、入力の truncate を防ぐため処理開始前にエラーで拒否します。相対パスの
-別表記、symlink、および Unix 上の hardlink も同一ファイルとして扱います。
-
-`PackedSfenValue` の `score` を、各レコードの `game_result` から得た飽和値へ置換する。
+`PackedSfenValue` の `score` を、各レコードの `game_result` から得た値へ置換する。
 `game_result` と `score` はどちらもその局面の手番側視点で、勝ちを正、負けを負、引分を 0 とする。
 
-処理は40バイトの PSV レコードを逐次読み書きする。入力 PSV の全件をメモリへ保持しない。
-複数入力や glob は辞書順へ固定して処理するため、同じ入力とオプションからは同じ byte 列を得る。
+処理は40バイトの PSV レコードを逐次読み書きする。複数入力や glob は辞書順へ固定して
+処理するため、同じ入力とオプションからは同じ byte 列を得る。`--output` や
+`--emit-verdict-sidecar` が入力 PSV、game_id sidecar、diversions result JSONL、または互いに同じ
+ファイル実体を指す場合は、truncate を防ぐため処理開始前に拒否する。相対パスの別表記、symlink、
+Unix 上の hardlink も検査する。
 
 ## 基本用法
 
@@ -18,7 +17,7 @@ cargo run -p tools --release --bin relabel_psv -- \
   --output "$SHOGI_DATA/teachers/relabelled.psv"
 ```
 
-既定の `--win-cp 2500` では次のように必ず上書きする。
+既定の `--win-cp 2500` では次のように上書きする。
 
 | `game_result` | 新しい `score` |
 |---:|---:|
@@ -26,7 +25,7 @@ cargo run -p tools --release --bin relabel_psv -- \
 | `0` | `0` |
 | `-1` | `-2500` |
 
-`--win-cp` は `1..32000` の範囲で指定する。これにより score-drop の番兵値 32000 と干渉しない。
+`--win-cp` は `1..32000` の範囲で指定する。score-drop の番兵値 32000 とは干渉しない。
 
 ## 宣言勝ち override
 
@@ -35,33 +34,123 @@ cargo run -p tools --release --bin relabel_psv -- \
 
 ## diversions による deblunder
 
-`gensfen --emit-game-id-sidecar` で作った sidecar と result JSONL を使い、乱択着手までの
-汚染された局面を出力から除外できる。result JSONL の diversion ply は開始局面からの相対手数で、
-`relabel_psv` が各 result 行の `start_sfen` に含まれる開始絶対手数を使って PSV の絶対
-`game_ply` に変換する。
+`gensfen --emit-game-id-sidecar` で作った sidecar と result JSONL を指定する。
+result JSONL の diversion `ply` は開始局面からの相対手数であり、`start_sfen` の開始手数を使って
+PSV の絶対 `game_ply` へ `start_ply + ply - 1` で変換する。PSV と sidecar は lockstep で読み、
+件数不一致や末尾の半端レコードをエラーにする。
 
 ```bash
 cargo run -p tools --release --bin relabel_psv -- \
   --input "$SHOGI_DATA/teachers/gensfen.psv" \
   --output "$SHOGI_DATA/teachers/gensfen-relabelled.psv" \
   --deblunder \
+  --deblunder-mode drop-contaminated \
   --game-id-sidecar "$SHOGI_DATA/teachers/gensfen.game_ids.bin" \
   --diversions "$SHOGI_DATA/teachers/gensfen.jsonl"
 ```
 
-PSV と sidecar は lockstep で読み、件数不一致や末尾の半端レコードをエラーにする。
-sidecar は PSV 1 レコードにつき u32 little-endian の `game_id` 1件である。
-
 | モード | 除外条件 | 既定 |
 |---|---|---|
-| `drop-before-last` | 最後の diversion 以前（diversion が指された局面を含む）を除外し、厳密に後ろだけ残す | yes |
-| `drop-before-any` | 最初の diversion 以前（diversion が指された局面を含む）を除外する | no |
+| `drop-before-last` | 最後の diversion 以前を除外する | yes |
+| `drop-before-any` | 最初の diversion 以前を除外する | no |
+| `drop-contaminated` | 汚染と判定した diversion のうち最大 ply 以前を除外する | no |
 
-境界 ply 自体も、乱択後の game result で汚染されるため除外する。diversion のない対局は除外しない。
-diversions の map だけを対局数オーダーで
-保持するため、ピークメモリは PSV レコード数に依存しない。
+`--deblunder-mode` を明示する場合は `--deblunder` も必須である。モードだけを指定した実行は、
+フィルタなしの出力を防ぐため開始前にエラーにする。
 
-## 統計
+境界 ply のレコード自体も除外する。`drop-before-last` と `drop-before-any` は従来どおり
+レコード単位の streaming 処理を行う。
 
-stderr に入力件数、勝ち・負け・引分の置換件数、宣言勝ち override 件数、deblunder の除外件数を
-1行で出力する。
+### `drop-contaminated` の判定
+
+判定に使う値は diversion ply の PSV レコードに保存された relabel 前の元 `score` (`e`)、
+同じレコードの `game_result` (`r`)、result JSONL の `score_gap_cp` (`g`) である。`g` は
+比較前に `-10000..=10000` へ clamp する。`--flip-threshold` の既定値は 300 cp、
+`--gap-threshold` の既定値は 100 cp で、どちらも `0..=10000` の範囲を取る。
+
+| 条件 | 判定 |
+|---|---|
+| `kind=random` | 汚染 |
+| `r=±1`, `|e| >= flip-threshold`, `sign(e) == sign(r)` | 温存 |
+| `r=±1`, `|e| >= flip-threshold`, `sign(e) != sign(r)` | flip 汚染 |
+| `r=±1`, `|e| < flip-threshold` | `g < gap-threshold` なら温存、それ以外は gap 汚染 |
+| `r=0` | `e` を使わず gap-only |
+| diversion ply の PSV レコードが欠落 | gap-only。欠落だけを理由に汚染とはしない |
+
+複数 diversion は個別に判定し、汚染 diversion の最大絶対 ply を除外境界にする。
+汚染 diversion がなければその対局は全レコードを温存する。同じ最大 ply に複数の汚染理由が
+ある場合、verdict 表示用の優先順位は `random > missing_record > flip > gap` とする。
+`kind=multipv` の diversion に `score_gap_cp` がない場合は判定を続行できないため、エラーで停止する。
+
+このモードだけは game_id が変わるまで1対局ぶんをバッファし、判定後に flush する。一度 flush した
+game_id が再出現した場合や、PSV の game_id が result JSONL に存在しない場合はエラーにする。
+したがって、game_id が非連続になる shuffle 済み PSV には適用できない。`drop-contaminated` は
+shuffle 前に適用する。
+
+ピークメモリは1対局の PSV レコード、result JSONL 由来の対局 map とその連続性フラグで決まる。
+対局 map の基礎部分は対局数 × 約47バイトが目安で、10億局面を約1,000万対局とすると約470MBになる。
+これに diversion 配列と allocator の管理領域が加わる。入力 PSV の総レコード数そのものには依存しない。
+
+## dry-run と2段階運用
+
+`--dry-run` は出力 PSV を作成せず、通常実行と同じ判定と統計集計を行う。このとき `--output` は
+省略でき、指定しても作成しない。verdict sidecar は `--dry-run` と併用して出力できる。
+
+```bash
+# 1. drop 率と gap 分布を確認
+relabel_psv ... --deblunder-mode drop-contaminated --dry-run
+
+# 2. 閾値を合意した後に PSV を生成
+relabel_psv ... --deblunder-mode drop-contaminated \
+  --flip-threshold 300 --gap-threshold 100 --output relabelled.psv
+```
+
+## verdict sidecar
+
+`--emit-verdict-sidecar PATH` は、入力 PSV の全レコードと 1:1・同順の u8 を1バイトずつ書く。
+drop されないレコードも必ず1件書く。`--dry-run` と併用できる。
+
+| 値 | 名前 | 意味 |
+|---:|---|---|
+| 0 | `kept` | 温存。diversion がない対局や汚染境界より後ろも含む |
+| 1 | `dropped_flip` | 最大汚染境界の理由が score と result の符号不一致 |
+| 2 | `dropped_gap` | 最大汚染境界の理由が gap 判定 |
+| 3 | `dropped_missing_record` | diversion レコード欠落後の gap 判定 |
+| 4 | `dropped_random` | 最大汚染境界の理由が `kind=random` |
+| 5 | `dropped_legacy` | `drop-before-last` / `drop-before-any` による除外 |
+
+## 統計 JSON
+
+処理完了時に stderr へ JSON を1行出力する。
+
+| フィールド | 内容 |
+|---|---|
+| `input_positions` | 入力局面数 |
+| `wins` / `losses` / `draws` | game_result 別の relabel 件数 |
+| `declaration_overrides` | 宣言勝ち override 件数 |
+| `declaration_overrides_dropped` | override 対象かつ deblunder で除外された件数 |
+| `deblunder_dropped_positions` | 除外局面数 |
+| `diversion_games` | 入力 PSV に現れ、diversion を持つ対局数 |
+| `contaminated_games` / `preserved_games` | 汚染あり / 汚染なしと判定した diversion 対局数 |
+| `decisions.flip_contaminated` | flip 汚染 diversion 数 |
+| `decisions.gap_contaminated` | レコードが存在する gap 汚染 diversion 数 |
+| `decisions.missing_record_contaminated` | 欠落フォールバック後の汚染 diversion 数 |
+| `decisions.missing_record_preserved` | 欠落フォールバック後の温存 diversion 数 |
+| `decisions.random_contaminated` | random 汚染 diversion 数 |
+| `draw_games_by_reason.max_moves` / `sennichite` / `other` | 入力 PSV に現れる `r=0` 対局の result `reason` 別件数 |
+
+`gap_histogram` は、入力 PSV に1レコード以上現れた対局について、clamp 後の `g` を全 MultiPV
+diversion から集計する。result JSONL にだけ存在し、入力 PSV に現れない対局は集計対象外である。
+`boundaries_cp` は固定で `[0,50,100,200,300,500,1000,3000]`、`counts` は9要素で、順に
+`g < 0`, `[0,50)`, `[50,100)`, `[100,200)`, `[200,300)`, `[300,500)`, `[500,1000)`,
+`[1000,3000)`, `g >= 3000` を表す。`score_gap_cp=null` の random diversion は histogram に含めない。
+`kind=random` は生成側で乱択前の保存局面を消去するため、汚染境界以前の PSV レコードが存在しない
+ことがある。この場合、`contaminated_games > 0` でも `deblunder_dropped_positions == 0` になり得る。
+
+## 判定の限界
+
+- この判定は、乱択が結果を変えなかったことの因果的証明ではない。result とラベルの整合性フィルタである。
+- 識別力は形勢決定的な局面に偏る。`|e| < flip-threshold` の互角局面は gap 判定だけに依存する。
+- `g` は未クランプの生スコア差、`e` は PSV の `±10000` clip 値が入力であり、元のスケールが異なる。
+- `gap-threshold` は生成 run の `--random-multi-pv-diff` と結合する。diff が gap-threshold 未満の run では gap 汚染分岐が発生しない。
+- 既定値 flip=300 / gap=100 は仮置きである。本番 smoke の gap 分布と閾値ごとの温存率を確認して確定する。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -54,7 +54,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `shuffle_psv` | PSV ファイル内のレコード（40バイト単位）をシャッフル |
 | `split_psv` | PSV ファイルを局面数または容量で複数ファイルへ分割 |
 | `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
-| `relabel_psv` | PSV の score を手番側視点の game_result 由来値へ streaming 置換し、任意で宣言勝ち override / diversions deblunder（[詳細](relabel_psv.md)） |
+| `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](relabel_psv.md)） |
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |

--- a/crates/tools/src/bin/relabel_psv.rs
+++ b/crates/tools/src/bin/relabel_psv.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
@@ -7,9 +8,12 @@ use anyhow::{Context, Result, bail};
 use clap::{Parser, ValueEnum};
 use rshogi_core::position::Position;
 use rshogi_core::types::{EnteringKingRule, Move};
+use serde::Serialize;
 use serde_json::Value;
 use tools::common::dedup::canonicalize_maybe_new;
 use tools::packed_sfen::{PackedSfenValue, unpack_sfen};
+
+const GAP_HISTOGRAM_BOUNDARIES_CP: [i32; 8] = [0, 50, 100, 200, 300, 500, 1000, 3000];
 
 #[derive(Debug, Parser)]
 #[command(about = "PSV の score を手番側視点の game_result 由来値へ置換する")]
@@ -18,9 +22,9 @@ struct Cli {
     #[arg(long, required = true, value_delimiter = ',')]
     input: Vec<String>,
 
-    /// 出力 PSV
+    /// 出力 PSV。--dry-run では省略でき、指定しても作成しない。
     #[arg(long)]
-    output: PathBuf,
+    output: Option<PathBuf>,
 
     /// 勝敗を置換する絶対 score（勝ち=正、負け=負、引分=0）
     #[arg(long, default_value_t = 2500)]
@@ -43,16 +47,37 @@ struct Cli {
     diversions: Vec<String>,
 
     /// diversion が複数ある対局で使う除外境界
-    #[arg(long, value_enum, default_value_t = DeblunderMode::DropBeforeLast)]
-    deblunder_mode: DeblunderMode,
+    #[arg(long, value_enum)]
+    deblunder_mode: Option<DeblunderMode>,
+
+    /// 元 score による勝敗符号判定を使う最小絶対値
+    #[arg(long, default_value_t = 300)]
+    flip_threshold: i32,
+
+    /// score_gap_cp だけで汚染とする最小値
+    #[arg(long, default_value_t = 100)]
+    gap_threshold: i32,
+
+    /// PSV を書かず、判定と統計だけ実行する
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+
+    /// 入力 PSV と 1:1・同順の u8 verdict sidecar
+    #[arg(long)]
+    emit_verdict_sidecar: Option<PathBuf>,
 }
 
-#[derive(Clone, Copy, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum DeblunderMode {
     /// 最後の diversion ply 以前を除外する
-    DropBeforeLast,
+    #[value(name = "drop-before-last")]
+    Last,
     /// 最初の diversion ply 以前を除外する
-    DropBeforeAny,
+    #[value(name = "drop-before-any")]
+    Any,
+    /// 元 score、game_result、score_gap_cp の整合性で汚染 diversion を選ぶ
+    #[value(name = "drop-contaminated")]
+    Contaminated,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -61,14 +86,148 @@ struct DiversionBounds {
     last: u16,
 }
 
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DiversionKind {
+    MultiPv,
+    Random,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Diversion {
+    ply: u16,
+    kind: DiversionKind,
+    gap_cp: Option<i32>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum GameEndReason {
+    MaxMoves,
+    Sennichite,
+    Other,
+}
+
+#[derive(Debug)]
+struct GameInfo {
+    reason: GameEndReason,
+    diversions: Vec<Diversion>,
+    finished: Cell<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum Verdict {
+    Kept = 0,
+    DroppedFlip = 1,
+    DroppedGap = 2,
+    DroppedMissingRecord = 3,
+    DroppedRandom = 4,
+    DroppedLegacy = 5,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ContaminationReason {
+    Flip,
+    Gap,
+    MissingRecord,
+    Random,
+}
+
+impl ContaminationReason {
+    fn verdict(self) -> Verdict {
+        match self {
+            Self::Flip => Verdict::DroppedFlip,
+            Self::Gap => Verdict::DroppedGap,
+            Self::MissingRecord => Verdict::DroppedMissingRecord,
+            Self::Random => Verdict::DroppedRandom,
+        }
+    }
+
+    fn priority(self) -> u8 {
+        match self {
+            Self::Gap => 0,
+            Self::Flip => 1,
+            Self::MissingRecord => 2,
+            Self::Random => 3,
+        }
+    }
+}
+
+#[derive(Default, Serialize)]
+struct DecisionBreakdown {
+    flip_contaminated: u64,
+    gap_contaminated: u64,
+    missing_record_contaminated: u64,
+    missing_record_preserved: u64,
+    random_contaminated: u64,
+}
+
+#[derive(Default, Serialize)]
+struct DrawReasonStats {
+    max_moves: u64,
+    sennichite: u64,
+    other: u64,
+}
+
+#[derive(Serialize)]
+struct GapHistogram {
+    boundaries_cp: [i32; 8],
+    counts: [u64; 9],
+}
+
+impl Default for GapHistogram {
+    fn default() -> Self {
+        Self {
+            boundaries_cp: GAP_HISTOGRAM_BOUNDARIES_CP,
+            counts: [0; 9],
+        }
+    }
+}
+
+impl GapHistogram {
+    fn observe(&mut self, gap_cp: i32) {
+        let bucket = self
+            .boundaries_cp
+            .iter()
+            .position(|boundary| gap_cp < *boundary)
+            .unwrap_or(self.counts.len() - 1);
+        self.counts[bucket] += 1;
+    }
+}
+
+#[derive(Default, Serialize)]
 struct Stats {
-    input: u64,
+    input_positions: u64,
     wins: u64,
     losses: u64,
     draws: u64,
     declaration_overrides: u64,
-    deblunder_drops: u64,
+    declaration_overrides_dropped: u64,
+    deblunder_dropped_positions: u64,
+    diversion_games: u64,
+    contaminated_games: u64,
+    preserved_games: u64,
+    gap_histogram: GapHistogram,
+    decisions: DecisionBreakdown,
+    draw_games_by_reason: DrawReasonStats,
+}
+
+struct BufferedRecord {
+    record: PackedSfenValue,
+    original_score: i16,
+    input_path_index: usize,
+    input_record_index: u64,
+}
+
+#[derive(Clone, Copy)]
+struct DropBoundary {
+    ply: u16,
+    reason: ContaminationReason,
+}
+
+struct RecordSinks<'a> {
+    output: &'a mut Option<BufWriter<File>>,
+    verdict: &'a mut Option<BufWriter<File>>,
+    declaration_pos: &'a mut Option<Position>,
 }
 
 fn main() -> Result<()> {
@@ -77,37 +236,26 @@ fn main() -> Result<()> {
 }
 
 fn run(cli: Cli) -> Result<()> {
-    if !(1..32000).contains(&cli.win_cp) {
-        bail!("--win-cp must be in 1..32000");
-    }
-    if cli.deblunder && cli.game_id_sidecar.is_none() {
-        bail!("--deblunder requires --game-id-sidecar");
-    }
-    if cli.deblunder && cli.diversions.is_empty() {
-        bail!("--deblunder requires --diversions");
-    }
-    if !cli.deblunder && (cli.game_id_sidecar.is_some() || !cli.diversions.is_empty()) {
-        bail!("--game-id-sidecar and --diversions require --deblunder");
-    }
-
+    validate_cli(&cli)?;
     let input_paths = expand_paths(&cli.input, "--input")?;
-    validate_output_path(&cli.output, &input_paths, cli.game_id_sidecar.as_deref())?;
-    let diversion_bounds = if cli.deblunder {
-        load_diversion_bounds(&expand_paths(&cli.diversions, "--diversions")?)?
+    let diversion_paths = if cli.deblunder {
+        expand_paths(&cli.diversions, "--diversions")?
     } else {
-        HashMap::new()
+        Vec::new()
     };
+    validate_generated_paths(&cli, &input_paths, &diversion_paths)?;
 
-    if let Some(parent) = cli.output.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    let mut output = BufWriter::new(
-        File::create(&cli.output)
-            .with_context(|| format!("failed to create {}", cli.output.display()))?,
-    );
+    let mut output = if cli.dry_run {
+        None
+    } else {
+        let path = cli.output.as_deref().context("internal error: validated --output is absent")?;
+        Some(create_writer(path, "output")?)
+    };
+    let mut verdict_writer = cli
+        .emit_verdict_sidecar
+        .as_deref()
+        .map(|path| create_writer(path, "verdict sidecar"))
+        .transpose()?;
     let mut sidecar = cli
         .game_id_sidecar
         .as_deref()
@@ -119,102 +267,433 @@ fn run(cli: Cli) -> Result<()> {
         .transpose()?;
     let mut declaration_pos = cli.declaration_override.then(Position::new);
     let mut stats = Stats::default();
+    let mut sinks = RecordSinks {
+        output: &mut output,
+        verdict: &mut verdict_writer,
+        declaration_pos: &mut declaration_pos,
+    };
 
-    for input_path in &input_paths {
-        let mut input = BufReader::new(
-            File::open(input_path)
-                .with_context(|| format!("failed to open input {}", input_path.display()))?,
-        );
+    let deblunder_mode = cli.deblunder_mode.unwrap_or(DeblunderMode::Last);
+    match deblunder_mode {
+        DeblunderMode::Contaminated => {
+            let games = load_game_info(&diversion_paths)?;
+            run_drop_contaminated(
+                &cli,
+                &input_paths,
+                &games,
+                &mut sidecar,
+                &mut sinks,
+                &mut stats,
+            )?;
+        }
+        DeblunderMode::Last | DeblunderMode::Any => {
+            let bounds = if cli.deblunder {
+                load_diversion_bounds(&diversion_paths)?
+            } else {
+                HashMap::new()
+            };
+            run_streaming(
+                &cli,
+                deblunder_mode == DeblunderMode::Last,
+                &input_paths,
+                &bounds,
+                &mut sidecar,
+                &mut sinks,
+                &mut stats,
+            )?;
+        }
+    }
+
+    validate_sidecar_end(&cli, &mut sidecar)?;
+    if let Some(writer) = sinks.output.as_mut() {
+        writer.flush()?;
+    }
+    if let Some(writer) = sinks.verdict.as_mut() {
+        writer.flush()?;
+    }
+    eprintln!("{}", serde_json::to_string(&stats)?);
+    Ok(())
+}
+
+fn validate_cli(cli: &Cli) -> Result<()> {
+    if !(1..32000).contains(&cli.win_cp) {
+        bail!("--win-cp must be in 1..32000");
+    }
+    if !(0..=10000).contains(&cli.flip_threshold) {
+        bail!("--flip-threshold must be in 0..=10000");
+    }
+    if !(0..=10000).contains(&cli.gap_threshold) {
+        bail!("--gap-threshold must be in 0..=10000");
+    }
+    if !cli.dry_run && cli.output.is_none() {
+        bail!("--output is required unless --dry-run is used");
+    }
+    if cli.deblunder && cli.game_id_sidecar.is_none() {
+        bail!("--deblunder requires --game-id-sidecar");
+    }
+    if cli.deblunder && cli.diversions.is_empty() {
+        bail!("--deblunder requires --diversions");
+    }
+    if !cli.deblunder && (cli.game_id_sidecar.is_some() || !cli.diversions.is_empty()) {
+        bail!("--game-id-sidecar and --diversions require --deblunder");
+    }
+    if !cli.deblunder && cli.deblunder_mode.is_some() {
+        bail!("--deblunder-mode requires --deblunder; add --deblunder or remove --deblunder-mode");
+    }
+    Ok(())
+}
+
+fn create_writer(path: &Path, label: &str) -> Result<BufWriter<File>> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    File::create(path)
+        .map(BufWriter::new)
+        .with_context(|| format!("failed to create {label} {}", path.display()))
+}
+
+fn run_streaming(
+    cli: &Cli,
+    use_last_diversion: bool,
+    input_paths: &[PathBuf],
+    bounds: &HashMap<u32, DiversionBounds>,
+    sidecar: &mut Option<BufReader<File>>,
+    sinks: &mut RecordSinks<'_>,
+    stats: &mut Stats,
+) -> Result<()> {
+    for input_path in input_paths {
+        let mut input = open_input(input_path)?;
         while let Some(bytes) =
             read_fixed::<{ PackedSfenValue::SIZE }>(&mut input, input_path, "PSV record")?
         {
-            stats.input += 1;
             let mut record = PackedSfenValue::from_bytes(&bytes)
-                .expect("fixed-size PSV record must always decode");
-            let game_id = if let Some(reader) = sidecar.as_mut() {
-                let path = cli.game_id_sidecar.as_deref().expect("validated sidecar path");
-                let id_bytes = read_fixed::<4>(reader, path, "game_id")?.ok_or_else(|| {
-                    anyhow::anyhow!("game_id sidecar ended before PSV record {}", stats.input)
-                })?;
-                Some(u32::from_le_bytes(id_bytes))
-            } else {
-                None
-            };
-
-            match record.game_result {
-                1 => {
-                    stats.wins += 1;
-                    record.score = cli.win_cp;
-                }
-                -1 => {
-                    stats.losses += 1;
-                    record.score = -cli.win_cp;
-                }
-                0 => {
-                    stats.draws += 1;
-                    record.score = 0;
-                }
-                value => bail!(
-                    "invalid game_result {value} at record {} in {}",
-                    stats.input,
-                    input_path.display()
-                ),
-            }
-
-            if let Some(pos) = declaration_pos.as_mut() {
-                let sfen = unpack_sfen(&record.sfen).map_err(|error| {
-                    anyhow::anyhow!(
-                        "failed to unpack record {} in {}: {error}",
-                        stats.input,
-                        input_path.display()
-                    )
-                })?;
-                pos.set_sfen(&sfen).map_err(|error| {
-                    anyhow::anyhow!(
-                        "failed to decode record {} in {}: {error}",
-                        stats.input,
-                        input_path.display()
-                    )
-                })?;
-                if pos.declaration_win(EnteringKingRule::Point27) == Move::WIN {
-                    record.score = cli.win_cp;
-                    stats.declaration_overrides += 1;
-                }
-            }
-
-            let drop = game_id.and_then(|id| diversion_bounds.get(&id)).is_some_and(|bounds| {
-                let boundary = match cli.deblunder_mode {
-                    DeblunderMode::DropBeforeLast => bounds.last,
-                    DeblunderMode::DropBeforeAny => bounds.first,
+                .context("failed to decode fixed-size PSV record")?;
+            stats.input_positions += 1;
+            let game_id = read_game_id(cli, sidecar, stats.input_positions)?;
+            let drop = game_id.and_then(|id| bounds.get(&id)).is_some_and(|game_bounds| {
+                let boundary = if use_last_diversion {
+                    game_bounds.last
+                } else {
+                    game_bounds.first
                 };
                 record.game_ply <= boundary
             });
-            if drop {
-                stats.deblunder_drops += 1;
-            } else {
-                output
-                    .write_all(&record.to_bytes())
-                    .with_context(|| format!("failed to write output {}", cli.output.display()))?;
+            let overridden = relabel_record(
+                cli,
+                &mut record,
+                input_path,
+                stats.input_positions,
+                sinks.declaration_pos,
+                stats,
+            )?;
+            flush_record(
+                cli,
+                record,
+                drop.then_some(Verdict::DroppedLegacy),
+                overridden,
+                sinks.output,
+                sinks.verdict,
+                stats,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn run_drop_contaminated(
+    cli: &Cli,
+    input_paths: &[PathBuf],
+    games: &HashMap<u32, GameInfo>,
+    sidecar: &mut Option<BufReader<File>>,
+    sinks: &mut RecordSinks<'_>,
+    stats: &mut Stats,
+) -> Result<()> {
+    let mut current_game_id = None;
+    let mut records = Vec::new();
+    for (input_path_index, input_path) in input_paths.iter().enumerate() {
+        let mut input = open_input(input_path)?;
+        let mut input_record_index = 0;
+        while let Some(bytes) =
+            read_fixed::<{ PackedSfenValue::SIZE }>(&mut input, input_path, "PSV record")?
+        {
+            let record = PackedSfenValue::from_bytes(&bytes)
+                .context("failed to decode fixed-size PSV record")?;
+            stats.input_positions += 1;
+            input_record_index += 1;
+            let game_id = read_game_id(cli, sidecar, stats.input_positions)?
+                .context("internal error: drop-contaminated sidecar is absent")?;
+            let game_info = games.get(&game_id).with_context(|| {
+                format!(
+                    "game_id {game_id} at record {input_record_index} in {} is absent from result JSONL",
+                    input_path.display()
+                )
+            })?;
+
+            if current_game_id.is_some_and(|current| current != game_id) {
+                let finished = current_game_id.context("internal error: current game is absent")?;
+                process_game(cli, finished, &mut records, input_paths, games, sinks, stats)?;
+                games
+                    .get(&finished)
+                    .context("internal error: current game metadata is absent")?
+                    .finished
+                    .set(true);
+                if game_info.finished.get() {
+                    bail!(
+                        "game_id {game_id} reappeared non-contiguously at record {input_record_index} in {}",
+                        input_path.display()
+                    );
+                }
+            }
+            current_game_id = Some(game_id);
+            records.push(BufferedRecord {
+                original_score: record.score,
+                record,
+                input_path_index,
+                input_record_index,
+            });
+        }
+    }
+
+    if let Some(game_id) = current_game_id {
+        process_game(cli, game_id, &mut records, input_paths, games, sinks, stats)?;
+    }
+    Ok(())
+}
+
+fn process_game(
+    cli: &Cli,
+    game_id: u32,
+    records: &mut Vec<BufferedRecord>,
+    input_paths: &[PathBuf],
+    games: &HashMap<u32, GameInfo>,
+    sinks: &mut RecordSinks<'_>,
+    stats: &mut Stats,
+) -> Result<()> {
+    let info = games.get(&game_id).context("internal error: game metadata is absent")?;
+    if records.first().is_some_and(|record| record.record.game_result == 0) {
+        match info.reason {
+            GameEndReason::MaxMoves => stats.draw_games_by_reason.max_moves += 1,
+            GameEndReason::Sennichite => stats.draw_games_by_reason.sennichite += 1,
+            GameEndReason::Other => stats.draw_games_by_reason.other += 1,
+        }
+    }
+    let boundary = assess_game(cli, records, info, stats)?;
+
+    for buffered in records.drain(..) {
+        let mut record = buffered.record;
+        let drop_reason = boundary
+            .filter(|drop_boundary| record.game_ply <= drop_boundary.ply)
+            .map(|drop_boundary| drop_boundary.reason.verdict());
+        let overridden = relabel_record(
+            cli,
+            &mut record,
+            &input_paths[buffered.input_path_index],
+            buffered.input_record_index,
+            sinks.declaration_pos,
+            stats,
+        )?;
+        flush_record(cli, record, drop_reason, overridden, sinks.output, sinks.verdict, stats)?;
+    }
+    Ok(())
+}
+
+fn assess_game(
+    cli: &Cli,
+    records: &[BufferedRecord],
+    info: &GameInfo,
+    stats: &mut Stats,
+) -> Result<Option<DropBoundary>> {
+    if info.diversions.is_empty() {
+        return Ok(None);
+    }
+    stats.diversion_games += 1;
+    let mut boundary: Option<DropBoundary> = None;
+
+    for diversion in &info.diversions {
+        if let Some(gap) = diversion.gap_cp {
+            stats.gap_histogram.observe(gap);
+        }
+        let contamination = match diversion.kind {
+            DiversionKind::Random => {
+                stats.decisions.random_contaminated += 1;
+                Some(ContaminationReason::Random)
+            }
+            DiversionKind::MultiPv => {
+                let gap = diversion
+                    .gap_cp
+                    .context("multipv diversion requires score_gap_cp in drop-contaminated mode")?;
+                match records.iter().find(|record| record.record.game_ply == diversion.ply) {
+                    None if gap >= cli.gap_threshold => {
+                        stats.decisions.missing_record_contaminated += 1;
+                        Some(ContaminationReason::MissingRecord)
+                    }
+                    None => {
+                        stats.decisions.missing_record_preserved += 1;
+                        None
+                    }
+                    Some(record) => {
+                        let result = record.record.game_result;
+                        let score = i32::from(record.original_score);
+                        if result != 0 && score.abs() >= cli.flip_threshold {
+                            if score.signum() == i32::from(result).signum() {
+                                None
+                            } else {
+                                stats.decisions.flip_contaminated += 1;
+                                Some(ContaminationReason::Flip)
+                            }
+                        } else if gap >= cli.gap_threshold {
+                            stats.decisions.gap_contaminated += 1;
+                            Some(ContaminationReason::Gap)
+                        } else {
+                            None
+                        }
+                    }
+                }
+            }
+        };
+
+        if let Some(reason) = contamination {
+            let candidate = DropBoundary {
+                ply: diversion.ply,
+                reason,
+            };
+            if boundary.is_none_or(|current| {
+                candidate.ply > current.ply
+                    || (candidate.ply == current.ply
+                        && candidate.reason.priority() > current.reason.priority())
+            }) {
+                boundary = Some(candidate);
             }
         }
     }
 
+    if boundary.is_some() {
+        stats.contaminated_games += 1;
+    } else {
+        stats.preserved_games += 1;
+    }
+    Ok(boundary)
+}
+
+fn relabel_record(
+    cli: &Cli,
+    record: &mut PackedSfenValue,
+    input_path: &Path,
+    record_index: u64,
+    declaration_pos: &mut Option<Position>,
+    stats: &mut Stats,
+) -> Result<bool> {
+    match record.game_result {
+        1 => {
+            stats.wins += 1;
+            record.score = cli.win_cp;
+        }
+        -1 => {
+            stats.losses += 1;
+            record.score = -cli.win_cp;
+        }
+        0 => {
+            stats.draws += 1;
+            record.score = 0;
+        }
+        value => bail!(
+            "invalid game_result {value} at record {record_index} in {}",
+            input_path.display()
+        ),
+    }
+
+    let mut overridden = false;
+    if let Some(pos) = declaration_pos.as_mut() {
+        let sfen = unpack_sfen(&record.sfen).map_err(|error| {
+            anyhow::anyhow!(
+                "failed to unpack record {record_index} in {}: {error}",
+                input_path.display()
+            )
+        })?;
+        pos.set_sfen(&sfen).map_err(|error| {
+            anyhow::anyhow!(
+                "failed to decode record {record_index} in {}: {error}",
+                input_path.display()
+            )
+        })?;
+        if pos.declaration_win(EnteringKingRule::Point27) == Move::WIN {
+            record.score = cli.win_cp;
+            stats.declaration_overrides += 1;
+            overridden = true;
+        }
+    }
+    Ok(overridden)
+}
+
+fn flush_record(
+    cli: &Cli,
+    record: PackedSfenValue,
+    drop_verdict: Option<Verdict>,
+    declaration_overridden: bool,
+    output: &mut Option<BufWriter<File>>,
+    verdict_writer: &mut Option<BufWriter<File>>,
+    stats: &mut Stats,
+) -> Result<()> {
+    let verdict = drop_verdict.unwrap_or(Verdict::Kept);
+    if let Some(writer) = verdict_writer.as_mut() {
+        let path = cli
+            .emit_verdict_sidecar
+            .as_deref()
+            .context("internal error: verdict writer path is absent")?;
+        writer
+            .write_all(&[verdict as u8])
+            .with_context(|| format!("failed to write verdict sidecar {}", path.display()))?;
+    }
+    if drop_verdict.is_some() {
+        stats.deblunder_dropped_positions += 1;
+        if declaration_overridden {
+            stats.declaration_overrides_dropped += 1;
+        }
+    } else if let Some(writer) = output.as_mut() {
+        let path = cli.output.as_deref().context("internal error: output writer path is absent")?;
+        writer
+            .write_all(&record.to_bytes())
+            .with_context(|| format!("failed to write output {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn open_input(path: &Path) -> Result<BufReader<File>> {
+    File::open(path)
+        .map(BufReader::new)
+        .with_context(|| format!("failed to open input {}", path.display()))
+}
+
+fn read_game_id(
+    cli: &Cli,
+    sidecar: &mut Option<BufReader<File>>,
+    record_index: u64,
+) -> Result<Option<u32>> {
+    let Some(reader) = sidecar.as_mut() else {
+        return Ok(None);
+    };
+    let path = cli
+        .game_id_sidecar
+        .as_deref()
+        .context("internal error: sidecar reader path is absent")?;
+    let id_bytes = read_fixed::<4>(reader, path, "game_id")?
+        .ok_or_else(|| anyhow::anyhow!("game_id sidecar ended before PSV record {record_index}"))?;
+    Ok(Some(u32::from_le_bytes(id_bytes)))
+}
+
+fn validate_sidecar_end(cli: &Cli, sidecar: &mut Option<BufReader<File>>) -> Result<()> {
     if let Some(reader) = sidecar.as_mut() {
-        let path = cli.game_id_sidecar.as_deref().expect("validated sidecar path");
+        let path = cli
+            .game_id_sidecar
+            .as_deref()
+            .context("internal error: sidecar reader path is absent")?;
         if read_fixed::<4>(reader, path, "game_id")?.is_some() {
             bail!("game_id sidecar has more entries than the input PSV files");
         }
     }
-    output.flush()?;
-    eprintln!(
-        "input={} win={} loss={} draw={} declaration_override={} deblunder_drop={}",
-        stats.input,
-        stats.wins,
-        stats.losses,
-        stats.draws,
-        stats.declaration_overrides,
-        stats.deblunder_drops
-    );
     Ok(())
 }
 
@@ -241,20 +720,47 @@ fn expand_paths(patterns: &[String], option: &str) -> Result<Vec<PathBuf>> {
     Ok(paths.into_iter().collect())
 }
 
-/// 出力を truncate する前に、入力または sidecar と同じ実体を指していないか検査する。
-fn validate_output_path(
-    output: &Path,
+fn validate_generated_paths(
+    cli: &Cli,
     input_paths: &[PathBuf],
-    game_id_sidecar: Option<&Path>,
+    diversion_paths: &[PathBuf],
 ) -> Result<()> {
-    let normalized_output = canonicalize_maybe_new(output)
-        .with_context(|| format!("failed to normalize --output {}", output.display()))?;
-
-    for input in input_paths {
-        validate_distinct_file(output, &normalized_output, input, "--input")?;
+    let mut protected: Vec<(&Path, &str)> =
+        input_paths.iter().map(|path| (path.as_path(), "--input")).collect();
+    if let Some(path) = cli.game_id_sidecar.as_deref() {
+        protected.push((path, "--game-id-sidecar"));
     }
-    if let Some(sidecar) = game_id_sidecar {
-        validate_distinct_file(output, &normalized_output, sidecar, "--game-id-sidecar")?;
+    protected.extend(diversion_paths.iter().map(|path| (path.as_path(), "--diversions")));
+    let output = (!cli.dry_run).then_some(cli.output.as_deref()).flatten();
+    if let Some(path) = output {
+        validate_generated_path(path, "--output", &protected)?;
+    }
+    if let Some(path) = cli.emit_verdict_sidecar.as_deref() {
+        validate_generated_path(path, "--emit-verdict-sidecar", &protected)?;
+        if let Some(output_path) = output {
+            let normalized = canonicalize_maybe_new(path).with_context(|| {
+                format!("failed to normalize --emit-verdict-sidecar {}", path.display())
+            })?;
+            let normalized_output = canonicalize_maybe_new(output_path).with_context(|| {
+                format!("failed to normalize --output {}", output_path.display())
+            })?;
+            if normalized == normalized_output || same_inode(path, output_path)? {
+                bail!(
+                    "generated path {} resolves to the same file as --output {}; refusing to truncate it",
+                    path.display(),
+                    output_path.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_generated_path(path: &Path, label: &str, protected: &[(&Path, &str)]) -> Result<()> {
+    let normalized = canonicalize_maybe_new(path)
+        .with_context(|| format!("failed to normalize {label} {}", path.display()))?;
+    for (protected_path, protected_label) in protected {
+        validate_distinct_file(path, &normalized, protected_path, protected_label)?;
     }
     Ok(())
 }
@@ -270,7 +776,7 @@ fn validate_distinct_file(
         .with_context(|| format!("failed to canonicalize {option} {}", protected.display()))?;
     if normalized_output == canonical_protected || same_inode(output, protected)? {
         bail!(
-            "--output {} resolves to the same file as {option} {}; refusing to truncate it",
+            "generated path {} resolves to the same file as {option} {}; refusing to truncate it",
             output.display(),
             protected.display()
         );
@@ -286,7 +792,7 @@ fn same_inode(a: &Path, b: &Path) -> Result<bool> {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => {
-            return Err(error).with_context(|| format!("failed to stat --output {}", a.display()));
+            return Err(error).with_context(|| format!("failed to stat output {}", a.display()));
         }
     };
     let b_metadata = b
@@ -320,53 +826,15 @@ fn load_diversion_bounds(paths: &[PathBuf]) -> Result<HashMap<u32, DiversionBoun
             if value.get("type").and_then(Value::as_str) != Some("result") {
                 continue;
             }
-            let game_id = value
-                .get("game_id")
-                .and_then(Value::as_u64)
-                .and_then(|id| u32::try_from(id).ok())
-                .with_context(|| {
-                    format!("invalid game_id in {} line {}", path.display(), line_index + 1)
-                })?;
-            let start_sfen =
-                value.get("start_sfen").and_then(Value::as_str).with_context(|| {
-                    format!("missing start_sfen in {} line {}", path.display(), line_index + 1)
-                })?;
-            let start_ply = start_sfen
-                .split_whitespace()
-                .nth(3)
-                .and_then(|ply| ply.parse::<u32>().ok())
-                .with_context(|| {
-                    format!("invalid start_sfen ply in {} line {}", path.display(), line_index + 1)
-                })?;
+            let game_id = parse_game_id(&value, path, line_index)?;
+            let start_ply = parse_start_ply(&value, path, line_index)?;
             let diversions =
                 value.get("diversions").and_then(Value::as_array).with_context(|| {
                     format!("missing diversions in {} line {}", path.display(), line_index + 1)
                 })?;
             for diversion in diversions {
-                let relative_ply = diversion
-                    .get("ply")
-                    .and_then(Value::as_u64)
-                    .and_then(|ply| u32::try_from(ply).ok())
-                    .with_context(|| {
-                        format!(
-                            "invalid diversion ply in {} line {}",
-                            path.display(),
-                            line_index + 1
-                        )
-                    })?;
-                let ply = relative_ply
-                    .checked_sub(1)
-                    .and_then(|offset| start_ply.checked_add(offset))
-                    .and_then(|ply| u16::try_from(ply).ok())
-                    .with_context(|| {
-                        format!(
-                            "diversion ply overflow in {} line {}: start_ply={}, relative_ply={}",
-                            path.display(),
-                            line_index + 1,
-                            start_ply,
-                            relative_ply
-                        )
-                    })?;
+                let relative_ply = parse_relative_ply(diversion, path, line_index)?;
+                let ply = absolute_ply(start_ply, relative_ply, path, line_index)?;
                 bounds
                     .entry(game_id)
                     .and_modify(|entry: &mut DiversionBounds| {
@@ -383,6 +851,128 @@ fn load_diversion_bounds(paths: &[PathBuf]) -> Result<HashMap<u32, DiversionBoun
     Ok(bounds)
 }
 
+fn load_game_info(paths: &[PathBuf]) -> Result<HashMap<u32, GameInfo>> {
+    let mut games = HashMap::new();
+    for path in paths {
+        let reader = BufReader::new(
+            File::open(path)
+                .with_context(|| format!("failed to open diversions {}", path.display()))?,
+        );
+        for (line_index, line) in reader.lines().enumerate() {
+            let line = line.with_context(|| {
+                format!("failed to read {} line {}", path.display(), line_index + 1)
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(&line).with_context(|| {
+                format!("invalid JSON in {} line {}", path.display(), line_index + 1)
+            })?;
+            if value.get("type").and_then(Value::as_str) != Some("result") {
+                continue;
+            }
+            let game_id = parse_game_id(&value, path, line_index)?;
+            let start_ply = parse_start_ply(&value, path, line_index)?;
+            let reason = match value.get("reason").and_then(Value::as_str) {
+                Some("max_moves") => GameEndReason::MaxMoves,
+                Some("sennichite") => GameEndReason::Sennichite,
+                _ => GameEndReason::Other,
+            };
+            let values = value.get("diversions").and_then(Value::as_array).with_context(|| {
+                format!("missing diversions in {} line {}", path.display(), line_index + 1)
+            })?;
+            let mut diversions = Vec::with_capacity(values.len());
+            for diversion in values {
+                diversions.push(parse_diversion(diversion, start_ply, path, line_index)?);
+            }
+            if games
+                .insert(
+                    game_id,
+                    GameInfo {
+                        reason,
+                        diversions,
+                        finished: Cell::new(false),
+                    },
+                )
+                .is_some()
+            {
+                bail!(
+                    "duplicate result for game_id {game_id} in {} line {}",
+                    path.display(),
+                    line_index + 1
+                );
+            }
+        }
+    }
+    Ok(games)
+}
+
+fn parse_game_id(value: &Value, path: &Path, line_index: usize) -> Result<u32> {
+    value
+        .get("game_id")
+        .and_then(Value::as_u64)
+        .and_then(|id| u32::try_from(id).ok())
+        .with_context(|| format!("invalid game_id in {} line {}", path.display(), line_index + 1))
+}
+
+fn parse_start_ply(value: &Value, path: &Path, line_index: usize) -> Result<u32> {
+    value
+        .get("start_sfen")
+        .and_then(Value::as_str)
+        .and_then(|sfen| sfen.split_whitespace().nth(3))
+        .and_then(|ply| ply.parse::<u32>().ok())
+        .with_context(|| {
+            format!("invalid start_sfen ply in {} line {}", path.display(), line_index + 1)
+        })
+}
+
+fn parse_diversion(
+    value: &Value,
+    start_ply: u32,
+    path: &Path,
+    line_index: usize,
+) -> Result<Diversion> {
+    let relative_ply = parse_relative_ply(value, path, line_index)?;
+    let ply = absolute_ply(start_ply, relative_ply, path, line_index)?;
+    let kind = match value.get("kind").and_then(Value::as_str) {
+        Some("random") => DiversionKind::Random,
+        Some("multipv") | None => DiversionKind::MultiPv,
+        Some(kind) => {
+            bail!("invalid diversion kind {kind:?} in {} line {}", path.display(), line_index + 1)
+        }
+    };
+    let gap_cp = value
+        .get("score_gap_cp")
+        .and_then(Value::as_i64)
+        .and_then(|gap| i32::try_from(gap).ok())
+        .map(|gap| gap.clamp(-10000, 10000));
+    Ok(Diversion { ply, kind, gap_cp })
+}
+
+fn parse_relative_ply(value: &Value, path: &Path, line_index: usize) -> Result<u32> {
+    value
+        .get("ply")
+        .and_then(Value::as_u64)
+        .and_then(|ply| u32::try_from(ply).ok())
+        .with_context(|| {
+            format!("invalid diversion ply in {} line {}", path.display(), line_index + 1)
+        })
+}
+
+fn absolute_ply(start_ply: u32, relative_ply: u32, path: &Path, line_index: usize) -> Result<u16> {
+    relative_ply
+        .checked_sub(1)
+        .and_then(|offset| start_ply.checked_add(offset))
+        .and_then(|ply| u16::try_from(ply).ok())
+        .with_context(|| {
+            format!(
+                "diversion ply overflow in {} line {}: start_ply={start_ply}, relative_ply={relative_ply}",
+                path.display(),
+                line_index + 1
+            )
+        })
+}
+
 fn read_fixed<const N: usize>(
     reader: &mut impl Read,
     path: &Path,
@@ -391,12 +981,12 @@ fn read_fixed<const N: usize>(
     let mut bytes = [0u8; N];
     let read = reader
         .read(&mut bytes[..1])
-        .with_context(|| format!("failed to read {} from {}", record_name, path.display()))?;
+        .with_context(|| format!("failed to read {record_name} from {}", path.display()))?;
     if read == 0 {
         return Ok(None);
     }
     reader
         .read_exact(&mut bytes[1..])
-        .with_context(|| format!("truncated {} at end of {}", record_name, path.display()))?;
+        .with_context(|| format!("truncated {record_name} at end of {}", path.display()))?;
     Ok(Some(bytes))
 }

--- a/crates/tools/tests/relabel_psv_integration.rs
+++ b/crates/tools/tests/relabel_psv_integration.rs
@@ -1,13 +1,15 @@
-use std::fs::File;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
 use std::process::Command;
 
 use rshogi_core::position::Position;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 use tools::packed_sfen::{PackedSfenValue, pack_position};
 
 const BIN: &str = env!("CARGO_BIN_EXE_relabel_psv");
+const GENSFEN_BIN: &str = env!("CARGO_BIN_EXE_gensfen");
 
 fn record(pos: &Position, score: i16, game_ply: u16, game_result: i8) -> PackedSfenValue {
     PackedSfenValue {
@@ -33,6 +35,63 @@ fn read_psv(path: &Path) -> Vec<PackedSfenValue> {
         .chunks_exact(PackedSfenValue::SIZE)
         .map(|bytes| PackedSfenValue::from_bytes(bytes).unwrap())
         .collect()
+}
+
+fn write_game_ids(path: &Path, game_ids: &[u32]) {
+    let mut file = File::create(path).unwrap();
+    for game_id in game_ids {
+        file.write_all(&game_id.to_le_bytes()).unwrap();
+    }
+}
+
+fn read_stats(stderr: &[u8]) -> Value {
+    let line = String::from_utf8_lossy(stderr).lines().last().unwrap().to_owned();
+    serde_json::from_str(&line)
+        .unwrap_or_else(|error| panic!("invalid stats JSON: {error}: {line}"))
+}
+
+fn result_line(game_id: u32, start_ply: u16, reason: &str, diversions: Value) -> Value {
+    json!({
+        "type": "result",
+        "game_id": game_id,
+        "start_sfen": format!(
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - {start_ply}"
+        ),
+        "reason": reason,
+        "diversions": diversions,
+    })
+}
+
+fn write_jsonl(path: &Path, values: &[Value]) {
+    let mut file = File::create(path).unwrap();
+    for value in values {
+        serde_json::to_writer(&mut file, value).unwrap();
+        file.write_all(b"\n").unwrap();
+    }
+}
+
+fn contaminated_command(
+    input: &Path,
+    output: Option<&Path>,
+    sidecar: &Path,
+    diversions: &Path,
+) -> Command {
+    let mut command = Command::new(BIN);
+    command.args([
+        "--input",
+        input.to_str().unwrap(),
+        "--deblunder",
+        "--deblunder-mode",
+        "drop-contaminated",
+        "--game-id-sidecar",
+        sidecar.to_str().unwrap(),
+        "--diversions",
+        diversions.to_str().unwrap(),
+    ]);
+    if let Some(output) = output {
+        command.args(["--output", output.to_str().unwrap()]);
+    }
+    command
 }
 
 fn hirate() -> Position {
@@ -161,6 +220,43 @@ fn output_same_as_game_id_sidecar_is_rejected() {
 }
 
 #[test]
+fn output_same_as_diversions_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let sidecar = dir.path().join("game_ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+    write_game_ids(&sidecar, &[42]);
+    write_jsonl(&diversions, &[result_line(42, 1, "resign", json!([]))]);
+
+    assert_rejected_without_modifying(
+        &mut contaminated_command(&input, Some(&diversions), &sidecar, &diversions),
+        &diversions,
+    );
+}
+
+#[test]
+fn verdict_same_as_diversions_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("game_ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+    write_game_ids(&sidecar, &[42]);
+    write_jsonl(&diversions, &[result_line(42, 1, "resign", json!([]))]);
+
+    assert_rejected_without_modifying(
+        contaminated_command(&input, Some(&output), &sidecar, &diversions)
+            .args(["--emit-verdict-sidecar", diversions.to_str().unwrap()]),
+        &diversions,
+    );
+    assert!(!output.exists());
+}
+
+#[test]
 fn score_is_replaced_from_side_to_move_game_result_and_is_deterministic() {
     let dir = TempDir::new().unwrap();
     let input = dir.path().join("input.psv");
@@ -189,8 +285,11 @@ fn score_is_replaced_from_side_to_move_game_result_and_is_deterministic() {
             .output()
             .unwrap();
         assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        assert!(stderr.contains("input=3 win=1 loss=1 draw=1"));
+        let stats = read_stats(&result.stderr);
+        assert_eq!(stats["input_positions"], 3);
+        assert_eq!(stats["wins"], 1);
+        assert_eq!(stats["losses"], 1);
+        assert_eq!(stats["draws"], 1);
     }
 
     let scores: Vec<i16> = read_psv(&output_a).iter().map(|record| record.score).collect();
@@ -222,7 +321,31 @@ fn declaration_override_uses_side_to_move_declaration_win() {
         .unwrap();
     assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
     assert_eq!(read_psv(&output)[0].score, 2222);
-    assert!(String::from_utf8_lossy(&result.stderr).contains("declaration_override=1"));
+    assert_eq!(read_stats(&result.stderr)["declaration_overrides"], 1);
+}
+
+#[test]
+fn explicit_deblunder_mode_requires_deblunder() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1)]);
+
+    for mode in ["drop-before-last", "drop-before-any", "drop-contaminated"] {
+        let result = Command::new(BIN)
+            .args([
+                "--input",
+                input.to_str().unwrap(),
+                "--dry-run",
+                "--deblunder-mode",
+                mode,
+            ])
+            .output()
+            .unwrap();
+        assert!(!result.status.success());
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert!(stderr.contains("--deblunder-mode requires --deblunder"), "{stderr}");
+    }
 }
 
 #[test]
@@ -273,11 +396,41 @@ fn deblunder_modes_drop_before_the_selected_diversion_boundary() {
         assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
         let plies: Vec<u16> = read_psv(&output).iter().map(|record| record.game_ply).collect();
         assert_eq!(plies, expected_plies);
-        assert!(
-            String::from_utf8_lossy(&result.stderr)
-                .contains(&format!("deblunder_drop={expected_drops}"))
-        );
+        assert_eq!(read_stats(&result.stderr)["deblunder_dropped_positions"], expected_drops);
     }
+}
+
+#[test]
+fn legacy_deblunder_writes_dropped_legacy_verdict() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let verdict = dir.path().join("verdict.bin");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 10, 1, 1), record(&pos, 10, 2, 1)]);
+    write_game_ids(&sidecar, &[42, 42]);
+    write_jsonl(&diversions, &[result_line(42, 1, "resign", json!([{"ply": 1}]))]);
+
+    let result = Command::new(BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--deblunder",
+            "--game-id-sidecar",
+            sidecar.to_str().unwrap(),
+            "--diversions",
+            diversions.to_str().unwrap(),
+            "--emit-verdict-sidecar",
+            verdict.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(std::fs::read(verdict).unwrap(), [5, 0]);
 }
 
 #[test]
@@ -321,5 +474,482 @@ fn deblunder_converts_relative_diversion_ply_from_midgame_start_sfen() {
     assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
     let plies: Vec<u16> = read_psv(&output).iter().map(|record| record.game_ply).collect();
     assert_eq!(plies, [102, 103]);
-    assert!(String::from_utf8_lossy(&result.stderr).contains("deblunder_drop=2"));
+    assert_eq!(read_stats(&result.stderr)["deblunder_dropped_positions"], 2);
+}
+
+#[test]
+fn buffered_record_error_reports_exact_input_path_and_record() {
+    let dir = TempDir::new().unwrap();
+    let input_a = dir.path().join("a.psv");
+    let input_b = dir.path().join("b.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input_a, &[record(&pos, 10, 1, 1)]);
+    write_psv(&input_b, &[record(&pos, 10, 1, 2)]);
+    write_game_ids(&sidecar, &[1, 2]);
+    write_jsonl(
+        &diversions,
+        &[
+            result_line(1, 1, "resign", json!([])),
+            result_line(2, 1, "resign", json!([])),
+        ],
+    );
+    let inputs = format!("{},{}", input_a.display(), input_b.display());
+
+    let result = contaminated_command(Path::new(&inputs), Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(stderr.contains("invalid game_result 2 at record 1"), "{stderr}");
+    assert!(stderr.contains(&input_b.display().to_string()), "{stderr}");
+}
+
+#[test]
+fn missing_diversion_record_falls_back_to_gap_only() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    let records = [record(&pos, 500, 10, 1), record(&pos, 500, 20, 1)];
+    write_psv(&input, &records);
+    write_game_ids(&sidecar, &[1, 2]);
+    write_jsonl(
+        &diversions,
+        &[
+            result_line(
+                1,
+                10,
+                "resign",
+                json!([{"ply": 2, "kind": "multipv", "score_gap_cp": 150}]),
+            ),
+            result_line(
+                2,
+                20,
+                "resign",
+                json!([{"ply": 2, "kind": "multipv", "score_gap_cp": 50}]),
+            ),
+        ],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output).iter().map(|r| r.game_ply).collect::<Vec<_>>(), [20]);
+    let stats = read_stats(&result.stderr);
+    assert_eq!(stats["decisions"]["missing_record_contaminated"], 1);
+    assert_eq!(stats["decisions"]["missing_record_preserved"], 1);
+    assert_eq!(
+        stats["gap_histogram"]["boundaries_cp"],
+        json!([0, 50, 100, 200, 300, 500, 1000, 3000])
+    );
+    assert_eq!(stats["gap_histogram"]["counts"], json!([0, 0, 1, 1, 0, 0, 0, 0, 0]));
+}
+
+#[test]
+fn draw_uses_gap_only_even_when_original_score_is_decisive() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 800, 30, 0), record(&pos, 800, 40, 0)]);
+    write_game_ids(&sidecar, &[3, 11]);
+    write_jsonl(
+        &diversions,
+        &[
+            result_line(
+                3,
+                30,
+                "max_moves",
+                json!([{"ply": 1, "kind": "multipv", "score_gap_cp": 50}]),
+            ),
+            result_line(
+                11,
+                40,
+                "other_draw",
+                json!([{"ply": 1, "kind": "multipv", "score_gap_cp": 150}]),
+            ),
+        ],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output).len(), 1);
+    let stats = read_stats(&result.stderr);
+    assert_eq!(stats["preserved_games"], 1);
+    assert_eq!(stats["contaminated_games"], 1);
+    assert_eq!(stats["decisions"]["gap_contaminated"], 1);
+    assert_eq!(stats["draw_games_by_reason"]["max_moves"], 1);
+    assert_eq!(stats["draw_games_by_reason"]["other"], 1);
+}
+
+#[test]
+fn random_diversion_is_contaminated() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let verdict = dir.path().join("verdict.bin");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 0, 40, 0), record(&pos, 0, 41, 0)]);
+    write_game_ids(&sidecar, &[4, 4]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            4,
+            40,
+            "sennichite",
+            json!([{"ply": 1, "kind": "random", "score_gap_cp": null}]),
+        )],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .args(["--emit-verdict-sidecar", verdict.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output).iter().map(|r| r.game_ply).collect::<Vec<_>>(), [41]);
+    assert_eq!(std::fs::read(verdict).unwrap(), [4, 0]);
+    let stats = read_stats(&result.stderr);
+    assert_eq!(stats["decisions"]["random_contaminated"], 1);
+    assert_eq!(stats["draw_games_by_reason"]["sennichite"], 1);
+}
+
+#[test]
+fn declaration_override_is_counted_when_record_is_dropped() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let mut pos = Position::new();
+    pos.set_sfen("KGG6/SS7/PPPPPP3/9/9/9/2pppppp1/1ss1gg1nl/4k2nl b 2R2B3p 1")
+        .unwrap();
+    write_psv(&input, &[record(&pos, -100, 1, -1)]);
+    write_game_ids(&sidecar, &[12]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            12,
+            1,
+            "resign",
+            json!([{"ply": 1, "kind": "random"}]),
+        )],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .arg("--declaration-override")
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(read_psv(&output).is_empty());
+    let stats = read_stats(&result.stderr);
+    assert_eq!(stats["declaration_overrides"], 1);
+    assert_eq!(stats["declaration_overrides_dropped"], 1);
+}
+
+#[test]
+fn multipv_without_score_gap_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 0, 1, 0)]);
+    write_game_ids(&sidecar, &[13]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            13,
+            1,
+            "max_moves",
+            json!([{"ply": 1, "kind": "multipv"}]),
+        )],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(!result.status.success());
+    assert!(
+        String::from_utf8_lossy(&result.stderr).contains("multipv diversion requires score_gap_cp")
+    );
+}
+
+#[test]
+fn matching_decisive_score_preserves_game_even_with_large_gap() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, 500, 50, 1), record(&pos, 400, 51, 1)]);
+    write_game_ids(&sidecar, &[5, 5]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            5,
+            50,
+            "resign",
+            json!([{"ply": 1, "kind": "multipv", "score_gap_cp": 9000}]),
+        )],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output).len(), 2);
+    assert_eq!(read_stats(&result.stderr)["preserved_games"], 1);
+}
+
+#[test]
+fn multiple_diversions_use_maximum_contaminated_ply_in_both_orders() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    let mut records = Vec::new();
+    let mut ids = Vec::new();
+    for game_id in [6, 7] {
+        for ply in 1..=5 {
+            let score = match (game_id, ply) {
+                (6, 2) | (7, 4) => 500,
+                (6, 4) | (7, 2) => -500,
+                _ => 0,
+            };
+            records.push(record(&pos, score, ply, 1));
+            ids.push(game_id);
+        }
+    }
+    write_psv(&input, &records);
+    write_game_ids(&sidecar, &ids);
+    let ds = json!([
+        {"ply": 2, "kind": "multipv", "score_gap_cp": 0},
+        {"ply": 4, "kind": "multipv", "score_gap_cp": 0}
+    ]);
+    write_jsonl(
+        &diversions,
+        &[
+            result_line(6, 1, "resign", ds.clone()),
+            result_line(7, 1, "resign", ds),
+        ],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    let plies: Vec<u16> = read_psv(&output).iter().map(|r| r.game_ply).collect();
+    assert_eq!(plies, [5, 3, 4, 5]);
+}
+
+#[test]
+fn non_contiguous_game_id_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let output = dir.path().join("output.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(
+        &input,
+        &[
+            record(&pos, 0, 1, 0),
+            record(&pos, 0, 1, 0),
+            record(&pos, 0, 2, 0),
+        ],
+    );
+    write_game_ids(&sidecar, &[8, 9, 8]);
+    write_jsonl(
+        &diversions,
+        &[
+            result_line(8, 1, "max_moves", json!([])),
+            result_line(9, 1, "max_moves", json!([])),
+        ],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(!result.status.success());
+    assert!(String::from_utf8_lossy(&result.stderr).contains("reappeared non-contiguously"));
+}
+
+#[test]
+fn output_and_verdict_are_deterministic_and_dry_run_matches_stats() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let sidecar = dir.path().join("ids.bin");
+    let diversions = dir.path().join("games.jsonl");
+    let pos = hirate();
+    write_psv(&input, &[record(&pos, -500, 1, 1), record(&pos, 0, 2, 1)]);
+    write_game_ids(&sidecar, &[10, 10]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            10,
+            1,
+            "resign",
+            json!([{"ply": 1, "kind": "multipv", "score_gap_cp": 150}]),
+        )],
+    );
+
+    let mut full_stats = None;
+    for suffix in ["a", "b"] {
+        let output = dir.path().join(format!("output-{suffix}.psv"));
+        let verdict = dir.path().join(format!("verdict-{suffix}.bin"));
+        let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+            .args(["--emit-verdict-sidecar", verdict.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+        full_stats = Some(read_stats(&result.stderr));
+    }
+    assert_eq!(
+        std::fs::read(dir.path().join("output-a.psv")).unwrap(),
+        std::fs::read(dir.path().join("output-b.psv")).unwrap()
+    );
+    assert_eq!(
+        std::fs::read(dir.path().join("verdict-a.bin")).unwrap(),
+        std::fs::read(dir.path().join("verdict-b.bin")).unwrap()
+    );
+
+    let dry_output = dir.path().join("must-not-exist.psv");
+    let dry_verdict = dir.path().join("dry-verdict.bin");
+    let result = contaminated_command(&input, None, &sidecar, &diversions)
+        .args([
+            "--dry-run",
+            "--emit-verdict-sidecar",
+            dry_verdict.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(!dry_output.exists());
+    assert_eq!(read_stats(&result.stderr), full_stats.unwrap());
+    assert_eq!(
+        std::fs::read(dry_verdict).unwrap(),
+        std::fs::read(dir.path().join("verdict-a.bin")).unwrap()
+    );
+}
+
+fn write_sparse_zero_halfkp(path: &Path) {
+    const VERSION: u32 = 0x7AF3_2F16;
+    const ARCH: &[u8] = b"Features=HalfKP(Friend)[125388->256x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-32](ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))";
+    const FILE_SIZE: u64 = 64_217_066;
+
+    let mut file = OpenOptions::new().create(true).truncate(true).write(true).open(path).unwrap();
+    file.set_len(FILE_SIZE).unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
+    file.write_all(&VERSION.to_le_bytes()).unwrap();
+    file.write_all(&0u32.to_le_bytes()).unwrap();
+    file.write_all(&(ARCH.len() as u32).to_le_bytes()).unwrap();
+    file.write_all(ARCH).unwrap();
+}
+
+#[test]
+fn real_native_gensfen_midgame_diversion_reads_exact_absolute_ply_score() {
+    let dir = TempDir::new().unwrap();
+    let out_dir = dir.path().join("gensfen");
+    let eval_file = dir.path().join("zero.nnue");
+    let generated_sidecar = dir.path().join("generated-ids.bin");
+    write_sparse_zero_halfkp(&eval_file);
+
+    let generated = Command::new(GENSFEN_BIN)
+        .args([
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+            "--eval-file",
+            eval_file.to_str().unwrap(),
+            "--sfen",
+            "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 100",
+            "--games",
+            "1",
+            "--max-moves",
+            "4",
+            "--depth",
+            "1",
+            "--concurrency",
+            "1",
+            "--hash-mb",
+            "1",
+            "--dedup-hash-size",
+            "0",
+            "--startpos-no-repeat=false",
+            "--emit-game-id-sidecar",
+            generated_sidecar.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(generated.status.success(), "{}", String::from_utf8_lossy(&generated.stderr));
+
+    let all_records = read_psv(&out_dir.join("gensfen.psv"));
+    let all_ids: Vec<u32> = std::fs::read(&generated_sidecar)
+        .unwrap()
+        .chunks_exact(4)
+        .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+        .collect();
+    let game_id = *all_ids.first().expect("NativeBackend run must produce PSV records");
+    let mut records: Vec<PackedSfenValue> = all_records
+        .into_iter()
+        .zip(all_ids)
+        .filter(|(_, id)| *id == game_id)
+        .map(|(record, _)| record)
+        .collect();
+    records.sort_by_key(|record| record.game_ply);
+    assert!(records.len() >= 3, "NativeBackend run must produce at least three PSV records");
+    let absolute_ply = records[1].game_ply;
+    assert!(records.iter().any(|record| record.game_ply == absolute_ply - 1));
+    assert!(records.iter().any(|record| record.game_ply == absolute_ply + 1));
+    let relative_ply = absolute_ply - 100 + 1;
+    for record in &mut records {
+        record.game_result = 1;
+        record.score = if record.game_ply == absolute_ply {
+            500
+        } else {
+            -500
+        };
+    }
+
+    let input = dir.path().join("isolated.psv");
+    let sidecar = dir.path().join("isolated-ids.bin");
+    let diversions = dir.path().join("isolated.jsonl");
+    let output = dir.path().join("relabelled.psv");
+    write_psv(&input, &records);
+    write_game_ids(&sidecar, &vec![game_id; records.len()]);
+    write_jsonl(
+        &diversions,
+        &[result_line(
+            game_id,
+            100,
+            "resign",
+            json!([{
+                "ply": relative_ply,
+                "kind": "multipv",
+                "score_gap_cp": 150
+            }]),
+        )],
+    );
+
+    let result = contaminated_command(&input, Some(&output), &sidecar, &diversions)
+        .output()
+        .unwrap();
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert_eq!(read_psv(&output).len(), records.len());
+    assert_eq!(read_stats(&result.stderr)["preserved_games"], 1);
 }


### PR DESCRIPTION
## 概要

gensfen の multiPV 乱択 (diversion) が勝敗を反転させた対局の prefix **だけ**を除外し、反転していない対局の prefix は温存する `relabel_psv --deblunder-mode drop-contaminated` を追加する。

## 背景

gensfen は game_result を対局の全局面に一律で書き込むため、`--random-multi-pv` で PV1 以外を選んだ対局では乱択 ply 以前の局面の result ラベルが真値からずれる。既存の `--deblunder` は `score_gap_cp` 不問で diversion 以前を全 drop するため、**勝敗が反転していない対局の prefix まで捨てて**教師局面の多様性 (=データ量) を損なっていた。

diversion 局面の PSV レコードには乱択直前の **PV1 eval** が記録されている (実着手 played_mv は hcpe3 の selectedMove16 にしか使われない)。この元 score と game_result の整合性で汚染を判定する。

## 判定 (result 整合性フィルタ)

diversion 局面の元 score を `e`、game_result を `r` (両方手番側視点)、`score_gap_cp` を `g` (±10000 clamp) として:

| 条件 | 判定 |
|---|---|
| kind=random | 汚染 |
| r=±1, \|e\| >= flip-threshold, sign 一致 | 温存 (形勢決定的で結果と整合。gap 大でも label は真値どおり) |
| r=±1, \|e\| >= flip-threshold, sign 不一致 | 汚染 (本来勝ちが逆転) |
| r=±1, \|e\| < flip-threshold (互角) | gap-only (g < 閾値 → 温存 / 以上 → 汚染) |
| r=0 (引分) | gap-only (max_moves 打ち切り Draw と反転の confound 回避) |
| レコード欠落 (dedup / 王手 skip 等) | gap-only フォールバック |

汚染 diversion の最大 ply を境界に prefix (境界含む) を除外。汚染ゼロの対局は 1 レコードも落とさない。

これは「乱択が結果を変えなかったこと」の因果的証明ではなく result との整合性フィルタであり、識別力が形勢決定的な局面に偏る (互角局面は gap 判定に依存する) 限界を doc に明記した。

## 追加フラグ

- `--deblunder-mode drop-contaminated` (既存 `drop-before-last` / `drop-before-any` は互換維持)
- `--flip-threshold` (既定 300) / `--gap-threshold` (既定 100) — **暫定値**。本番 smoke の gap 分布と閾値ごとの温存率を見て確定する
- `--dry-run` — 出力を書かず統計のみ。drop 率を確認してから本 run する 2 段階運用
- `--emit-verdict-sidecar` — レコードごとの判定を u8 で出力 (0=kept, 1=dropped_flip, 2=dropped_gap, 3=dropped_missing_record, 4=dropped_random, 5=dropped_legacy)。閾値比較を巨大 PSV の複製なしで行える

## その他の変更

- stderr 統計を 1 行 JSON 化 (判定内訳・draw reason 別・gap histogram)。**破壊的変更**として CHANGELOG に記載
- `--deblunder-mode` を明示したのに `--deblunder` が無い場合、従来は streaming 経路に落ちて exit 0 で全件出力される silent no-op になっていた。fail-closed 化 (3 モードすべて)
- 生成物パスの衝突検査に `--diversions` を追加。result JSONL を `--output` / `--emit-verdict-sidecar` に指定した際の truncate を writer 作成前に拒否 (従来は JSONL を破壊してから空の bounds で処理していた)

## 設計

対局レコードは worker ファイル内で連続して書かれるため、1 対局ぶんだけバッファする single-pass 方式。ピークメモリは PSV レコード数に非依存 (常駐は対局 map の約 47B/対局、10 億局面 ≒ 1000 万対局で約 470MB)。非連続な game_id の再出現は fail-closed (shuffle 済み PSV には適用不可、shuffle 前に適用する旨を doc 明記)。

## テスト

`cargo test -p tools` green (relabel_psv 統合テスト **24 本**)。

最重要は off-by-one 回帰テスト: 実 gensfen (NativeBackend) を中盤 (start_ply=100) から回した PSV に対し、diversion ply の前後レコードが両方存在することを assert した上で、当該 ply だけ score=+500 / 他を -500、gap=150 に設定。1 ply ずれれば flip 汚染 (隣接レコードあり) か gap 汚染 (欠落フォールバック) で必ず落ちる。`absolute_ply` に off-by-one を注入するミューテーション検証で、この 1 本を含む 6 テストが FAILED になることを確認済み。

他: 判定表の全分岐 (r=0 gap-only / 欠落フォールバック / random / 複数 diversion の両順序)、決定性 (同一入力 2 回で PSV と verdict sidecar が bit 一致)、`--dry-run` と本 run の統計一致、パス衝突 (output / verdict が diversions・sidecar・input と同一実体、相対表記・symlink・hardlink)、非連続 game_id の拒否、エラー context の入力パス・レコード通番。

## レビュー

Codex + Claude (Fable) の 2 レビュアーで独立レビュー。初回は両者 REQUEST_CHANGES:
- Codex: (High) diversions パスが生成物保護から漏れ result JSONL が truncate される / (Medium) off-by-one テストが誤実装でも通り得る
- Fable: (High) `--deblunder-mode` の silent no-op / (Medium) エラー context の欠落・`GameInfo.reason` の per-game heap alloc・doc 未記載挙動 3 件 / (Low) 7 件

全指摘を修正し、再レビューで**両者 APPROVE** (新規指摘なし)。

## チェック

- `cargo fmt --check` green
- `cargo clippy -p tools --tests -- -D warnings` 警告 0
- `cargo test -p tools` green
- `bash scripts/check-tracked-abs-paths.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4HZgkNw1y1WD9Ur3kyK9M