### PR TITLE
fix(tools): gensfen — 数日規模の無人生成でデータを失わない resume / クラッシュ耐性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ crates.io への `rshogi-core` publish は (v1.3.0 リリース以降) `vX.Y.Z` 
 バージョンを bump する (publish される tarball とタグの内容を常に一致させ、「バージョン
 番号が動いていない = core 変更なし」という誤推定を防ぐため)。
 
+## Unreleased
+
+- **gensfen resume の互換性変更**: worker temp を永続 checkpoint として扱い、完了 `game_id` の
+  欠番再実行、全 worker 成果物の result 境界復旧、既定毎対局 fsync、journal による冪等な複数成果物
+  finalization、正常終了 worker 成果物の fail-closed 検証、final 長・staging 中 SHA-256・PSV/sidecar
+  件数検査、fresh run の全 final path 上書き拒否、worker エラーの非ゼロ終了を追加。meta に native/USI
+  実行ファイルと path-valued USI option を含む生成条件 fingerprint・内容 SHA-256 を記録する。従来の
+  fingerprint/commit offset を持たない worker checkpoint は安全に復元できないため resume を拒否する。
+  既存 temp は退避してから新規 run を開始する必要がある。
+
 ## v1.3.0 — 2026-07-11
 
 v1.2.0 後の機能追加リリース。定跡 (opening book) 機構一式 — 新規クレート `rshogi-book`

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -33,7 +33,7 @@ cargo build -p tools --bin gensfen --release
 
 ```
 runs/gensfen/20260317-120000/
-  gensfen.jsonl          # 対局結果ログ（result 行のみの JSONL）
+  gensfen.jsonl          # 実行条件 meta と対局結果 result の JSONL
   gensfen.psv            # 学習データ（PackedSfenValue, 40バイト/局面）
   gensfen.info.jsonl     # info ログ（--log-info 指定時のみ）
   gensfen.eval.txt       # 評価値推移（--emit-eval-file 指定時のみ）
@@ -188,6 +188,7 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 | `--emit-eval-file` | false | 評価値推移を `gensfen.eval.txt` に出力 |
 | `--emit-metrics` | false | 対局メトリクス JSONL を出力 |
 | `--flush-each-move` | false | 毎手フラッシュ（安全だが低速） |
+| `--fsync-interval-games N` | 1 | worker ごとの fsync 間隔。1 は毎対局、0 は fsync 無効 |
 
 ### 中断・再開
 
@@ -195,9 +196,11 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 |-----------|------|
 | `--out-dir DIR` | 出力ディレクトリ（resume 時必須） |
 | `--resume` | 前回中断したセッションを再開する |
+| `--force-unlock` | 残留した out-dir lock を削除して取得し直す。記録 PID の終了確認後だけ使用する |
 
-`--emit-game-id-sidecar` と `--resume` は併用できない。既存 run に sidecar が無い場合の
-PSV との 1:1 対応を壊さないため、明示的にエラーとする。sidecar のパスは meta 行の
+`--emit-game-id-sidecar` と `--resume` は併用できる。sidecar の有無は生成条件 fingerprint で
+照合し、PSV と sidecar のコミット済みレコード数が一致しない checkpoint は再開を拒否する。
+sidecar のパスは meta 行の
 `settings.game_id_sidecar` にも記録される。並行実行時は PSV と sidecar の両方をワーカー別の
 一時ファイルへ書き、同じワーカー順で最終ファイルへ連結する。sidecar には JSONL・PSV・
 info log・eval file・metrics の最終出力パス、およびそれらと sidecar の内部ワーカーパスを
@@ -216,6 +219,11 @@ canonicalize してから残りの未存在コンポーネントを正規化す�
 `timeout`、`illegal_move`、`no_bestmove` で破棄した対局の pending 集合はそのまま捨てるため、
 後続の正常対局から未出力局面を除外しない。pending のメモリ使用量は 1 対局の手数に比例し、
 対局終了時に解放される。
+
+dedup テーブル自体は checkpoint に永続化しない。数千万局面の既存 PSV を走査しても元の
+Zobrist key を復元できず、direct-map テーブルの完全な再構築には別 sidecar が必要になるためである。
+`--resume` は空の dedup テーブルから再開し、中断前のデータとの重複を検出できない旨を stderr に
+警告する。同一プロセス内と resume 後それぞれの重複検出は有効で、教師レコード自体は破損しない。
 
 通常手の局面で重複検出した場合は:
 1. それまでに蓄積した学習エントリを全クリア
@@ -404,18 +412,187 @@ policy の票数は各候補の eval を温度 `--hcpe3-policy-temp` の softmax
 
 ### 仕組み
 
-1. Ctrl-C で中断すると、進行中の対局の完了を待ってからグレースフルに終了する
-2. 完了済みの対局データはすべて出力ファイルに書き込まれる
-3. `--resume` 付きで同じコマンドを再実行すると、出力 JSONL から完了済み対局数を
-   自動検出して続きから実行する
+1. 各 worker は `.wN.jsonl` と `.wN.psv` / `.wN.pack` / `.wN.hcpe3`、必要なら
+   `.wN.game_ids.bin` を checkpoint として追記する。既存の非空 checkpoint を新規実行で
+   truncate せず、`--resume` なしなら退避を求めて停止する。
+2. 1 対局の教師データ、sidecar、info、eval、metrics を先に書き、各ファイルの byte offset と
+   `fsync_boundary` を含む JSONL result を最後に書く。`fsync_boundary=true` は、その result までの
+   全 worker 成果物を fsync した後に result を書き、worker JSONL も fsync する境界を表す。
+3. `--resume` は最終 JSONL と全 worker JSONL の `game_id` を bitset に復元する。最大 ID ではなく
+   集合で判定するため、並列中断で `100` が欠け `101` が完了していても `100` を再実行する。
+   bitset は 1 対局 1 bit（100万局で約 122 KiB）で、result 全体をメモリに保持しない。
+4. 全 result に記録された offset の単調性、PSV 40 byte / sidecar 4 byte 境界、PSV と sidecar の
+   1:1 件数を先に検証する。全成果物に存在し、かつ `fsync_boundary=true` の最後の result までを
+   復旧境界とし、それ以降の result suffix と各成果物を truncate し、
+   その game_id を未完了へ戻す。result は全成果物の後に書かれ、offset は単調増加するため、同じ境界へ
+   戻してから再対局すれば教師レコードは二重化も欠落もしない。
+   各 offset は worker checkpoint 内のコミット境界で worker ごとに 0 から始まる。最終 JSONL は
+   監査用に result をそのまま連結するため、最終 PSV / sidecar / 補助出力内の offset ではない。
+5. 今回 worker を起動して正常終了した場合は、JSONL、教師データ、有効な sidecar / info / eval /
+   metrics が全 worker 分存在することと、各ファイル長が最後の result の offset に一致することを
+   journal 作成前に検証する。全局完了済み resume は worker を起動しないため checkpoint を要求しない。
+6. worker エラー時も、全 worker checkpoint を手順 4 で復旧してから staging する。このため result
+   書き込み、flush/fsync、sidecar 部分書き込みの途中で失敗しても、未コミット末尾は最終成果物へ
+   入らない。コミット済み分を最終化した後、worker 別エラーを表示して非ゼロ終了する。
+   エラー原因には部分書き込みや fsync 失敗も含まれ、flush 済みの整合状態と安全に区別できないため、
+   `--fsync-interval-games N` が `N > 1` なら worker ごとに最大 `N - 1` 局、`0` ならその worker が
+   今回の起動で完了した全局を破棄する。破棄した `game_id` は次の `--resume` で再対局する。
+7. resume 開始時は `gensfen.finalized.json` の確定長と最終成果物の実長を照合する。PSV と sidecar は
+   最終成果物同士のレコード件数も照合する。短縮、欠落、件数不一致は worker を起動する前に停止する。
+
+self-heal するのは、不完全な JSON 末尾、result のない成果物末尾、または最後の fsync 境界より後の
+末尾 result の連続 suffix である。result が非ゼロ offset で参照する成果物自体が欠落している場合は、
+電源断による短い末尾とは区別して、どのファイルも truncate せず停止する。完全な JSON 行の構文/必須フィールド不正、offset の後退、PSV の
+`PackedSfenValue::SIZE` 境界不正、sidecar の 4-byte 境界不正、PSV と sidecar の件数不一致、確定済み
+final の不一致、旧形式で offset がない checkpoint は安全な切り戻し境界を証明できないため停止する。
+
+### finalization journal
+
+複数成果物の rename は単独ではトランザクションにならないため、次の journal 方式で冪等化する。
+
+1. 既存 final と全 worker checkpoint から同一ディレクトリの `.merge.tmp` を生成する。既存 final の
+   コピー中に prefix の SHA-256 と長さを旧 `gensfen.finalized.json` と照合し、不一致なら worker
+   checkpoint を追加せず停止する。続けて完成内容の SHA-256 と長さを計算し、各 merge file を fsync する。
+2. final path、merge path、SHA-256、長さ、削除対象 worker checkpoint を
+   `.gensfen.finalization.json` に書き、file と親 directory を fsync する。
+3. 各 merge file を final へ rename して親 directory を fsync する。通常経路では手順 1 でコピーと
+   同時に確定した長さと SHA-256 を使い、merge file を再読込しない。起動時に journal があれば、
+   merge が残る項目は長さと SHA-256 を検証して rename を再実行し、merge が無い項目は final の長さと
+   SHA-256 が journal と一致することを確認して rename 済みと判定する。
+4. 全項目の確定後、最終成果物の確定長と SHA-256 を `gensfen.finalized.json` へ atomic に更新する。
+   worker checkpoint を削除・directory fsync した後、最後に journal を削除する。
+
+クラッシュ点ごとの復旧動作は次のとおり。
+
+- journal 永続化前: final は未変更。worker checkpoint から merge を再生成する。
+- journal 永続化後、最初の rename 前: journal の全 rename を実行する。
+- 任意の rename 間: merge の有無と SHA-256 で各項目の完了を識別し、未完了項目だけ rename する。
+  既に final へ入った worker checkpoint を再連結しないため、二重化しない。
+- 全 rename 後、finalized state 更新前: 全 final の SHA-256 を確認して state 更新から続行する。
+- finalized state 更新後、worker checkpoint 削除中: final を確認し、残った checkpoint だけ削除する。
+- worker checkpoint 削除後、journal 削除前: final を確認して journal を削除する。checkpoint の欠落は
+  正常な cleanup 済みとして扱う。
+- journal 削除後: `gensfen.finalized.json` が確定世代を表す。resume は確定長を事前検証し、staging の
+  既存 final コピー中に確定 SHA-256 も検証してから追記する。
+
+通常の resume は確定長を事前検証し、staging に必要な既存 final の read と同時に確定 SHA-256 を検証する。
+検証専用の追加 read は行わない。rename 途中からの復旧で「merge が無い = rename 済み」を判定するときも、
+該当 final を SHA-256 検証する。
+staging 中のピーク追加ディスクは「既存 final 全体 + 今回の worker checkpoint 全体」と同量になる。
+PSV は 1 局面 40 bytes、game_id sidecar は 1 局面 4 bytes なので、補助出力を除く固定費は 1 億局面で
+4,400,000,000 bytes（約 4.10 GiB）の空きと 8,800,000,000 bytes の read+write、10 億局面では
+44,000,000,000 bytes（約 40.98 GiB）の空きと 88,000,000,000 bytes の read+write である。aggregate の
+実効 I/O 帯域を 100〜500 MB/s と置くと、固定部分だけで 1 億局面は約 18〜88 秒、10 億局面は約
+3〜15 分を要する。JSONL、info、eval、metrics を有効にした場合は各実ファイル長をこの値へ加算する。
+通常時の I/O は各入力の逐次 read 1 回と merge への write 1 回で、SHA-256 はコピーと同時に計算するため
+追加 read はない。
+
+この実装は final への in-place append よりディスクを使うが、journal が固定した完全な merge を rename し、
+final 自体を途中状態へ変更しない復旧モデルを維持する。数日 run の障害復旧経路を同時に変更しないことを
+優先してフルコピーを採用している。必要な空き容量と finalization 時間を事前に確保できない構成では使用せず、
+補助出力を含む実長から上記の式で見積もる。
+
+### 生成条件 fingerprint
+
+meta の `fingerprint` には次を構造化して保存する。`--resume` では全フィールドを照合し、差がある
+フィールド名（例: `search.nodes`, `model.eval_file_sha256`）を列挙して停止する。条件変更を強制する
+上書きフラグは設けていない。
+
+- native/USI モード、native 自身の実行ファイル SHA-256、native eval file のパスと SHA-256、
+  progress file のパスと SHA-256
+- USI engine のパスと実行ファイル SHA-256、先後の args / USI options / threads、Hash、TT 設定
+- nodes/depth、時間制御、max_moves、timeout と USI 時間管理設定、ponder、concurrency
+- startpos file のパスと SHA-256、読み込み後の開始局面列 SHA-256、単一 SFEN、選択方式、seed
+- skip 条件、training format、hcpe3 policy 条件、sidecar の有無、dedup table size
+- info / eval / metrics の有無（worker checkpoint の復旧対象を固定するため）
+- MultiPV/random move の全条件
+
+`--games` は合計目標を増やして続きを生成できるよう fingerprint から除外する。ただし既存の最大
+`game_id` より小さい値への変更は拒否する。ログ flush/fsync 頻度は教師ラベルを変えないため fingerprint
+には含めない。`--output-training-data` と `--emit-game-id-sidecar` の出力パスは fingerprint ではなく、
+`gensfen.finalized.json` の確定出力 path として resume 時に照合する。
+
+起動時は JSONL、training、sidecar、info、eval、metrics の全 final path、全 worker checkpoint、
+全 `.merge.tmp`、finalization journal と atomic temporary file、finalized state、lock を、存在する
+最深の親まで canonicalize して比較する。symlink や `..` を介した別表記を含め、同じ実体 path を二つの
+用途へ割り当てた構成はディレクトリ作成や lock 取得より前に拒否する。final path と internal path は
+`symlink_metadata` で検査し、dangling symlink、directory、特殊ファイルをリンク先へ辿らず拒否する。
+atomic temporary file と新規 `.merge.tmp` は create-new で作成する。journal と journal temporary file が
+無い resume で残っている通常ファイルの `.merge.tmp` は、journal 永続化前の中断物として削除して worker
+checkpoint から再生成する。journal 本体が無い状態で不完全・不正な journal temporary file が残っている場合も、
+final は未変更なので temporary file を削除し、worker checkpoint から staging と journal を再生成する。
+worker checkpoint の存在検査は `symlink_metadata`、読み書き・追記・truncate は
+`O_NOFOLLOW` 付き open を使い、journal、finalized state、復旧対象 `.merge.tmp` を読む場合も symlink を辿らない。
+
+USI option は `名前=値` の形式を解析し、名前を大小文字を無視して判定する。名前が `File`、`Dir`、
+`Path` で終わる option、または `LS_PROGRESS_COEFF` は値をファイルまたはディレクトリのパスとして扱う。
+相対パスは USI engine が継承する gensfen の起動時 working directory を基準に絶対化する。実在する
+ファイルは内容、ディレクトリは相対パス順のファイル名と全内容を SHA-256 化する。`BookFile=no_book`
+のように実在しない値は `content_sha256: null` として記録し、値文字列と解決先は引き続き fingerprint で
+照合する。したがって `EvalFile`、`EvalDir`、`BookFile` など同じパスの内容差し替えも resume を拒否する。別名の option、
+engine args に埋め込まれたパス、engine が内部で暗黙に読む資源までは識別できない。USI モードでは
+モデルを `EvalFile` / `EvalDir` / `NNUE` / `ModelFile` 系 option で必ず明示する。両側のいずれかに
+明示 option が無い場合は起動時に警告する。暗黙モデルを使った run は、engine binary が同一でも
+resume 前後のモデル同一性を証明できないため、本番の無人実行には使用しない。
+
+### flush / fsync 境界
+
+既定の `--fsync-interval-games 1` は、各対局で教師データ、sidecar、info、eval、metrics を
+`sync_all` し、その後に `fsync_boundary=true` の result JSONL を書いて `sync_all` する。worker
+checkpoint の新規作成後は親 directory も fsync するため、通常の fsync 契約を満たす filesystem では
+各完了対局までのファイル内容と directory entry を復旧境界として扱える。
+`N > 1` は worker ごとに N 局を一つの fsync 世代にまとめる。境界 result が確認できればその N 局を
+まとめて採用し、次の未完了世代はファイル長が残っていても全て rollback する。したがって最大 N-1 局を
+再対局する。`0` は実行中の対局単位 fsync 境界を一度も作らないため、クラッシュ後は worker checkpoint
+の全 result を未証明として rollback する。正常終了から finalization へ進む経路では flush 済み内容を
+使用するが、OS クラッシュ・電源断に対する途中進捗保証はない。
+ファイル長が短い状態は offset 検証で検出できるが、長さは正しく未永続ブロックだけがゼロ埋めされた状態は
+検出できない。既定の ext4 `data=ordered` では想定しない前提であり、異なる filesystem/mount option では
+耐障害性を別途確認する。
+
+`--flush-each-move` は、その時点までの result buffer と `--log-info` の info 行を OS buffer へ flush
+する。対局中の教師局面は勝敗確定までメモリ上にあるため、このフラグは進行中対局の教師データを保護せず、
+fsync も行わない。対局完了の耐久性は `--fsync-interval-games` が制御する。
+
+fsync コストの目安として、即時応答する mock USI engine、200局、1 worker、1手引き分け、NVMe 上の
+ext4 一時ディレクトリ（tmpfs ではない）で 3 回測定した wall time は、interval 0 が各 0.03 秒、
+interval 1 が 0.18〜0.19 秒、interval 10 が各 0.05 秒だった。これは同じ filesystem 内の比較であり、
+別 filesystem、controller cache、mount option では barrier コストが変わる。探索時間がほぼゼロの fsync
+最悪寄り測定で、実運用の比率は本番と同じ filesystem で再測定する。耐久性を優先して既定値は 1 とする。
+
+sidecar fault 判定のコストは、release ビルドの PSV + sidecar 書き出しループで 200 万 record を
+NVMe/ext4 上へ出力し、fault 無効で各 5 回測定した。判定ありは 49.794〜57.382 ns/record
+（中央値 52.308）、判定を除いた比較版は 47.995〜63.781 ns/record（中央値 52.895）で、除去による
+改善は測定できなかった。このため fault 点は現状の record loop 内に維持する。
 
 ### 注意事項
 
 - `--resume` には `--out-dir` の指定が必須
+- out-dir には PID を記録した `.gensfen.lock` を O_EXCL で作成し、二重起動を拒否する。正常終了と通常の
+  error/panic では削除するが、強制終了（Ctrl-C 2 回）・SIGKILL・電源断では残る。lock の PID が存在しないことを確認してから
+  `--force-unlock` で回収する。PID 再利用や同時回収の race を避けるため自動 stale 削除はしない
+- supervisor で無人再起動する場合は、再起動ラッパーを単一起動に制限し、`.gensfen.lock` の JSON に
+  記録された PID の生存を確認する。PID が存在する間は再起動せず、存在しない場合だけ同じ引数へ
+  `--resume --force-unlock` を追加して再起動する。PID の生存を確認せず常に `--force-unlock` すると、
+  稼働中プロセスの lock を奪って二重起動するため禁止する
 - `--games` は合計の目標対局数を指定する（追加分ではない）
-- `--shuffle-seed` は meta から自動復元される。CLI で異なる seed を指定するとエラー
-- 学習データ（.psv）、info ログ、eval ファイルなどもすべて追記される
+- `--resume` なしでは有効な全 final path にファイル、ディレクトリ、symlink のいずれかが既にあれば、
+  空でも上書きせず副作用前に停止する。worker checkpoint、`.merge.tmp`、journal、finalized state、
+  atomic temporary file も上書きしない。internal path に symlink、directory、特殊ファイルがあれば
+  `--resume` の有無にかかわらず停止する。前回分を続行する場合は同じ条件で `--resume`、別 run にする場合は
+  出力を退避する
+- seed は meta から自動復元される。開始局面選択と game_id ごとの MultiPV/random move を再現する。
+  CLI で異なる `--shuffle-seed` を指定するとエラー
+- native mode は gensfen 実行ファイル自身の SHA-256 も照合し、条件変更を強制する上書きフラグは設けない。
+  長時間 run は開始前に release バイナリを run 専用の固定パスへコピーし、初回と resume の両方をその
+  コピーから起動する。run 中の再ビルドや別バイナリへの差し替えは resume を fail-closed で拒否する
+- 学習データ（.psv）、info ログ、eval、metrics はすべて result と同じ offset 境界で追記・復旧される。
+  未完了対局の途中ログは resume 前に除去される
+- 終了時の `Positions written in this invocation` は今回のプロセスが新規に書いた局面数であり、resume 前に
+  確定済みだった局面を含まない。PSV の確定総局面数は最終ファイル長を 40 bytes で割って確認できる
 - Ctrl-C を 2 回押すと強制終了する（進行中の対局は破棄される）
+- 同一 seed の通し実行と resume は完了 `game_id` 集合と各 game_id の開始局面・乱択列を一致させる。
+  並列 scheduling と resume 時に空へ戻る共有 dedup table のため、成果物全体の bit 一致は保証しない
 
 ## 使用例
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。JSONL 出力 |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示 |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -1,9 +1,11 @@
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::thread;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -15,7 +17,8 @@ use rand::seq::SliceRandom;
 use rshogi_core::movegen::{MoveList, generate_legal, is_legal_with_pass};
 use rshogi_core::nnue::{
     compute_layer_stack_progress8kpabs_bucket_index, get_layer_stack_progress_kpabs_weights,
-    get_network, load_progress_coeff_kpabs_from_bytes, set_layer_stack_progress_kpabs_weights,
+    get_network, init_nnue_from_bytes, load_progress_coeff_kpabs_from_bytes,
+    set_layer_stack_progress_kpabs_weights,
 };
 use rshogi_core::position::{EnteringKingPointInfo, Position};
 use rshogi_core::types::{Color, EnteringKingRule, Move};
@@ -204,6 +207,10 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     flush_each_move: bool,
 
+    /// 完了対局を永続化する fsync 間隔。1 は毎対局、0 は fsync 無効。
+    #[arg(long, default_value_t = 1)]
+    fsync_interval_games: u32,
+
     /// 評価値行を別ファイルに書き出す（startpos moves 行 + 評価値列）
     #[arg(long, default_value_t = false)]
     emit_eval_file: bool,
@@ -262,6 +269,11 @@ struct Cli {
     /// --out で指定した出力ファイルが存在する場合、完了済み対局数を検出して続きから実行する。
     #[arg(long, default_value_t = false)]
     resume: bool,
+
+    /// 残留した out-dir lock を削除して取得し直す。
+    /// lock 内の PID のプロセスが終了済みであることを確認してから指定する。
+    #[arg(long, default_value_t = false)]
+    force_unlock: bool,
 
     // =========================================================================
     // gensfen 重複回避オプション
@@ -346,6 +358,8 @@ struct MetaLog {
     start_positions: Vec<String>,
     output: String,
     info_log: Option<String>,
+    /// resume 時に教師データの生成条件が同一であることを検証する。
+    fingerprint: Value,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -439,6 +453,7 @@ struct ResolvedEnginePaths {
 struct ResultLog<'a> {
     #[serde(rename = "type")]
     kind: &'static str,
+    worker_id: usize,
     game_id: u32,
     start_pos_index: usize,
     start_sfen: &'a str,
@@ -453,6 +468,60 @@ struct ResultLog<'a> {
     enemy_zone_pieces_black: u32,
     enemy_zone_pieces_white: u32,
     diversions: &'a [DiversionLog],
+    /// この result より先にコミット済みの worker 教師ファイル長。
+    training_bytes: u64,
+    /// この result より先にコミット済みの worker sidecar 長。
+    sidecar_bytes: Option<u64>,
+    /// この result より先にコミット済みの worker info log 長。
+    info_bytes: Option<u64>,
+    /// この result より先にコミット済みの worker eval file 長。
+    eval_bytes: Option<u64>,
+    /// この result より先にコミット済みの worker metrics 長。
+    metrics_bytes: Option<u64>,
+    /// ファイル長だけでは電源断前に永続化済みだった世代を識別できないため記録する。
+    fsync_boundary: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct CheckpointLengths {
+    training: u64,
+    sidecar: Option<u64>,
+    info: Option<u64>,
+    eval: Option<u64>,
+    metrics: Option<u64>,
+}
+
+fn write_committed_result<W, F>(
+    writer: &mut W,
+    result: ResultLog<'_>,
+    fsync_boundary: bool,
+    persist_training: F,
+) -> Result<()>
+where
+    W: Write,
+    F: FnOnce() -> Result<CheckpointLengths>,
+{
+    let lengths = persist_training()?;
+    if injected_fault("before_result") {
+        bail!("injected failure before result write");
+    }
+    if injected_fault("result_partial") {
+        writer.write_all(b"{\"type\":\"result\"")?;
+        writer.flush()?;
+        bail!("injected partial result write");
+    }
+    let committed = ResultLog {
+        training_bytes: lengths.training,
+        sidecar_bytes: lengths.sidecar,
+        info_bytes: lengths.info,
+        eval_bytes: lengths.eval,
+        metrics_bytes: lengths.metrics,
+        fsync_boundary,
+        ..result
+    };
+    serde_json::to_writer(&mut *writer, &committed)?;
+    writer.write_all(b"\n")?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -719,6 +788,7 @@ struct TrainingDataCollector {
 }
 
 impl TrainingDataCollector {
+    #[cfg(test)]
     fn new(
         path: &Path,
         skip_initial_ply: u32,
@@ -728,6 +798,28 @@ impl TrainingDataCollector {
         policy_temp: f64,
         game_id_path: Option<&Path>,
     ) -> Result<Self> {
+        Self::open(
+            path,
+            skip_initial_ply,
+            skip_in_check,
+            format,
+            policy_total,
+            policy_temp,
+            game_id_path,
+            false,
+        )
+    }
+
+    fn open(
+        path: &Path,
+        skip_initial_ply: u32,
+        skip_in_check: bool,
+        format: TrainingFormat,
+        policy_total: u16,
+        policy_temp: f64,
+        game_id_path: Option<&Path>,
+        append: bool,
+    ) -> Result<Self> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
         {
@@ -735,13 +827,13 @@ impl TrainingDataCollector {
                 format!("failed to create training data directory: {}", parent.display())
             })?;
         }
-        let file = File::create(path)
-            .with_context(|| format!("failed to create training data file: {}", path.display()))?;
+        let file = open_worker_checkpoint(path, append)
+            .with_context(|| format!("failed to open training data file: {}", path.display()))?;
         let game_id_writer = game_id_path
             .map(|game_id_path| {
-                File::create(game_id_path).map(BufWriter::new).with_context(|| {
-                    format!("failed to create game_id sidecar: {}", game_id_path.display())
-                })
+                open_worker_checkpoint(game_id_path, append).map(BufWriter::new).with_context(
+                    || format!("failed to open game_id sidecar: {}", game_id_path.display()),
+                )
             })
             .transpose()?;
 
@@ -964,6 +1056,10 @@ impl TrainingDataCollector {
                 .with_context(|| format!("failed to write position {idx} of game"))?;
             // PSV と sidecar の 1:1・同順を構造的に保つため、同じループで連続して書く。
             if let Some(writer) = self.game_id_writer.as_mut() {
+                if injected_fault("sidecar_partial") {
+                    writer.write_all(&game_id.to_le_bytes()[..2])?;
+                    bail!("injected partial sidecar write");
+                }
                 writer.write_all(&game_id.to_le_bytes()).with_context(|| {
                     format!("failed to write game_id for position {idx} of game")
                 })?;
@@ -1071,6 +1167,26 @@ impl TrainingDataCollector {
         self.writer.flush()?;
         if let Some(writer) = self.game_id_writer.as_mut() {
             writer.flush()?;
+        }
+        Ok(())
+    }
+
+    fn committed_lengths(&mut self) -> Result<(u64, Option<u64>)> {
+        self.flush()?;
+        let training = self.writer.get_ref().metadata()?.len();
+        let sidecar = self
+            .game_id_writer
+            .as_ref()
+            .map(|writer| writer.get_ref().metadata().map(|meta| meta.len()))
+            .transpose()?;
+        Ok((training, sidecar))
+    }
+
+    fn sync_all(&mut self) -> Result<()> {
+        self.flush()?;
+        self.writer.get_ref().sync_all()?;
+        if let Some(writer) = self.game_id_writer.as_mut() {
+            writer.get_ref().sync_all()?;
         }
         Ok(())
     }
@@ -1322,6 +1438,20 @@ fn has_entering_king_rule_option(options: &[String]) -> bool {
     })
 }
 
+fn has_explicit_usi_model_option(options: &[String]) -> bool {
+    options.iter().any(|option| {
+        option.split_once('=').is_some_and(|(name, value)| {
+            let name = name.trim().to_ascii_lowercase();
+            !value.trim().is_empty()
+                && (name.contains("evalfile")
+                    || name.contains("evaldir")
+                    || name.contains("nnue")
+                    || name.contains("modelfile")
+                    || name.contains("modeldir"))
+        })
+    })
+}
+
 fn winner_for_side(side: Color) -> GameOutcome {
     match side {
         Color::Black => GameOutcome::BlackWin,
@@ -1558,7 +1688,7 @@ struct InfoLogger {
 }
 
 impl InfoLogger {
-    fn new(path: &Path) -> Result<Self> {
+    fn new(path: &Path, append: bool) -> Result<Self> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
         {
@@ -1566,8 +1696,8 @@ impl InfoLogger {
                 format!("failed to create info-log directory {}", parent.display())
             })?;
         }
-        let file = File::create(path)
-            .with_context(|| format!("failed to create info log {}", path.display()))?;
+        let file = open_worker_checkpoint(path, append)
+            .with_context(|| format!("failed to open info log {}", path.display()))?;
         Ok(Self {
             writer: BufWriter::new(file),
         })
@@ -1582,6 +1712,56 @@ impl InfoLogger {
     fn flush(&mut self) -> Result<()> {
         self.writer.flush()?;
         Ok(())
+    }
+
+    fn committed_len(&mut self, sync: bool) -> Result<u64> {
+        self.writer.flush()?;
+        if sync {
+            self.writer.get_ref().sync_all()?;
+        }
+        Ok(self.writer.get_ref().metadata()?.len())
+    }
+}
+
+fn committed_writer_len(writer: &mut BufWriter<File>, sync: bool) -> Result<u64> {
+    writer.flush()?;
+    if sync {
+        writer.get_ref().sync_all()?;
+    }
+    Ok(writer.get_ref().metadata()?.len())
+}
+
+struct FaultSpec {
+    point: String,
+    occurrence: Option<u64>,
+}
+
+static FAULT_SPEC: OnceLock<Option<FaultSpec>> = OnceLock::new();
+static FAULT_MATCHES: AtomicU64 = AtomicU64::new(0);
+
+fn fault_spec() -> Option<&'static FaultSpec> {
+    FAULT_SPEC
+        .get_or_init(|| {
+            let value = std::env::var("RSHOGI_GENSFEN_FAULT").ok()?;
+            let (point, occurrence) = match value.rsplit_once(':') {
+                Some((point, occurrence)) => {
+                    let occurrence = occurrence.parse::<u64>().ok().filter(|value| *value > 0)?;
+                    (point.to_string(), Some(occurrence))
+                }
+                None => (value, None),
+            };
+            Some(FaultSpec { point, occurrence })
+        })
+        .as_ref()
+}
+
+fn injected_fault(point: &str) -> bool {
+    let Some(spec) = fault_spec().filter(|spec| spec.point == point) else {
+        return false;
+    };
+    match spec.occurrence {
+        Some(target) => FAULT_MATCHES.fetch_add(1, Ordering::Relaxed) + 1 == target,
+        None => true,
     }
 }
 
@@ -1613,6 +1793,7 @@ fn make_game_ticket<R: Rng + ?Sized>(
 }
 
 struct WorkerGameResult {
+    game_id: u32,
     outcome: GameOutcome,
     outcome_reason: OutcomeReason,
 }
@@ -1663,6 +1844,9 @@ struct WorkerConfig {
     game_id_sidecar_path: Option<PathBuf>,
     // Output flags
     flush_each_move: bool,
+    fsync_interval_games: u32,
+    append_checkpoints: bool,
+    run_seed: u64,
     // Training
     skip_initial_ply: u32,
     skip_in_check: bool,
@@ -1698,7 +1882,7 @@ fn worker_main(
     rx: chan::Receiver<Option<GameTicket>>,
     tx: chan::Sender<WorkerGameResult>,
     shutdown: Arc<AtomicBool>,
-) -> WorkerOutput {
+) -> Result<WorkerOutput> {
     let run = || -> Result<WorkerOutput> {
         // Create game engines (NativeBackend or UsiBackend)
         let mut engines = if cfg.native_mode {
@@ -1753,26 +1937,28 @@ fn worker_main(
         };
 
         // Open temp output files
-        let mut writer = BufWriter::new(File::create(&cfg.jsonl_path).with_context(|| {
-            format!("worker {}: failed to create {}", cfg.worker_id, cfg.jsonl_path.display())
-        })?);
+        let mut writer = BufWriter::new(
+            open_worker_checkpoint(&cfg.jsonl_path, cfg.append_checkpoints).with_context(|| {
+                format!("worker {}: failed to open {}", cfg.worker_id, cfg.jsonl_path.display())
+            })?,
+        );
         let mut info_logger = if let Some(ref path) = cfg.info_path {
-            Some(InfoLogger::new(path)?)
+            Some(InfoLogger::new(path, cfg.append_checkpoints)?)
         } else {
             None
         };
         let mut eval_writer = if let Some(ref path) = cfg.eval_path {
-            Some(BufWriter::new(File::create(path)?))
+            Some(BufWriter::new(open_checkpoint(path, cfg.append_checkpoints)?))
         } else {
             None
         };
         let mut metrics_writer = if let Some(ref path) = cfg.metrics_path {
-            Some(BufWriter::new(File::create(path)?))
+            Some(BufWriter::new(open_checkpoint(path, cfg.append_checkpoints)?))
         } else {
             None
         };
         let mut training_data_collector = if let Some(ref path) = cfg.training_data_path {
-            Some(TrainingDataCollector::new(
+            Some(TrainingDataCollector::open(
                 path,
                 cfg.skip_initial_ply,
                 cfg.skip_in_check,
@@ -1780,13 +1966,26 @@ fn worker_main(
                 cfg.hcpe3_policy_total,
                 cfg.hcpe3_policy_temp,
                 cfg.game_id_sidecar_path.as_deref(),
+                cfg.append_checkpoints,
             )?)
         } else {
             None
         };
+        for path in [
+            Some(cfg.jsonl_path.as_path()),
+            cfg.info_path.as_deref(),
+            cfg.eval_path.as_deref(),
+            cfg.metrics_path.as_deref(),
+            cfg.training_data_path.as_deref(),
+            cfg.game_id_sidecar_path.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            sync_parent(path)?;
+        }
 
         let dedup_hash = cfg.dedup_hash.clone();
-        let mut rng = rand::rng();
         let mut dedup_hits = 0u64;
         let mut dedup_discarded = 0u64;
         let mut multipv_diversions = 0u64;
@@ -1795,6 +1994,7 @@ fn worker_main(
         let mut interval_games = 0u32;
         let mut interval_dedup_hits = 0u64;
         let mut interval_positions_checked = 0u64;
+        let mut committed_games = 0u32;
         let progress_weights =
             cfg.layer_stack_num_buckets.map(|_| get_layer_stack_progress_kpabs_weights());
         let mut progress_bucket_counts = cfg
@@ -1809,6 +2009,10 @@ fn worker_main(
             }
 
             let game_idx = ticket.game_idx;
+            use rand::SeedableRng;
+            let mut rng = rand::rngs::StdRng::seed_from_u64(
+                cfg.run_seed ^ u64::from(game_idx + 1).wrapping_mul(0x9e37_79b9_7f4a_7c15),
+            );
             engines.prepare_game(cfg.keep_tt)?;
 
             let parsed = &cfg.start_defs[ticket.startpos_idx];
@@ -2146,6 +2350,9 @@ fn worker_main(
 
                 if cfg.flush_each_move {
                     writer.flush()?;
+                    if let Some(logger) = info_logger.as_mut() {
+                        logger.flush()?;
+                    }
                 }
 
                 if terminal || outcome != GameOutcome::InProgress {
@@ -2161,6 +2368,7 @@ fn worker_main(
             let final_meta = final_entering_king_meta(&pos);
             let result = ResultLog {
                 kind: "result",
+                worker_id: cfg.worker_id,
                 game_id: game_idx + 1,
                 start_pos_index,
                 start_sfen: &start_sfen,
@@ -2175,10 +2383,13 @@ fn worker_main(
                 enemy_zone_pieces_black: final_meta.black.enemy_zone_pieces,
                 enemy_zone_pieces_white: final_meta.white.enemy_zone_pieces,
                 diversions: &diversions,
+                training_bytes: 0,
+                sidecar_bytes: None,
+                info_bytes: None,
+                eval_bytes: None,
+                metrics_bytes: None,
+                fsync_boundary: false,
             };
-            serde_json::to_writer(&mut writer, &result)?;
-            writer.write_all(b"\n")?;
-
             if let Some(w) = eval_writer.as_mut() {
                 let start_cmd = &cfg.start_commands[ticket.startpos_idx];
                 let moves_text = if move_list.is_empty() {
@@ -2222,9 +2433,47 @@ fn worker_main(
             {
                 pending_dedup_keys.publish(dedup_hash);
             }
+            committed_games += 1;
+            let sync_due = cfg.fsync_interval_games > 0
+                && committed_games.is_multiple_of(cfg.fsync_interval_games);
+            write_committed_result(&mut writer, result, sync_due, || {
+                let (training, sidecar) = if let Some(collector) = training_data_collector.as_mut()
+                {
+                    if sync_due {
+                        collector.sync_all()?;
+                    }
+                    collector.committed_lengths()?
+                } else {
+                    (0, None)
+                };
+                let info = info_logger
+                    .as_mut()
+                    .map(|logger| logger.committed_len(sync_due))
+                    .transpose()?;
+                let eval = eval_writer
+                    .as_mut()
+                    .map(|writer| committed_writer_len(writer, sync_due))
+                    .transpose()?;
+                let metrics = metrics_writer
+                    .as_mut()
+                    .map(|writer| committed_writer_len(writer, sync_due))
+                    .transpose()?;
+                Ok(CheckpointLengths {
+                    training,
+                    sidecar,
+                    info,
+                    eval,
+                    metrics,
+                })
+            })?;
             writer.flush()?;
 
+            if sync_due {
+                writer.get_ref().sync_all()?;
+            }
+
             let _ = tx.send(WorkerGameResult {
+                game_id: game_idx + 1,
                 outcome,
                 outcome_reason,
             });
@@ -2278,6 +2527,12 @@ fn worker_main(
         if let Some(w) = metrics_writer.as_mut() {
             w.flush()?;
         }
+        if cfg.fsync_interval_games > 0 {
+            if let Some(collector) = training_data_collector.as_mut() {
+                collector.sync_all()?;
+            }
+            writer.get_ref().sync_all()?;
+        }
 
         // gensfen 統計
         if dedup_hits > 0 || random_moves_played > 0 || multipv_diversions > 0 {
@@ -2304,16 +2559,16 @@ fn worker_main(
         Ok(WorkerOutput { training_stats })
     };
 
-    match run() {
-        Ok(output) => output,
-        Err(e) => {
-            eprintln!("worker {}: error: {e}", cfg.worker_id);
-            shutdown.store(true, Ordering::Relaxed);
-            WorkerOutput {
-                training_stats: TrainingStats::default(),
-            }
-        }
+    let output = run().with_context(|| format!("worker {} failed", cfg.worker_id));
+    if output.is_err() {
+        shutdown.store(true, Ordering::Relaxed);
     }
+    output
+}
+
+fn open_checkpoint(path: &Path, append: bool) -> Result<File> {
+    open_worker_checkpoint(path, append)
+        .with_context(|| format!("failed to open checkpoint {}", path.display()))
 }
 
 // ---------------------------------------------------------------------------
@@ -2321,9 +2576,71 @@ fn worker_main(
 // ---------------------------------------------------------------------------
 
 /// 前回中断した教師局面生成セッションの進捗状態
+#[derive(Clone, Debug, Default)]
+struct CompletedGames {
+    words: Vec<u64>,
+    len: u32,
+}
+
+impl CompletedGames {
+    fn insert(&mut self, game_id: u32) -> bool {
+        if game_id == 0 {
+            return false;
+        }
+        let index = (game_id - 1) as usize;
+        let word = index / 64;
+        if self.words.len() <= word {
+            self.words.resize(word + 1, 0);
+        }
+        let mask = 1u64 << (index % 64);
+        if self.words[word] & mask != 0 {
+            return false;
+        }
+        self.words[word] |= mask;
+        self.len += 1;
+        true
+    }
+
+    fn contains(&self, game_id: u32) -> bool {
+        if game_id == 0 {
+            return false;
+        }
+        let index = (game_id - 1) as usize;
+        self.words
+            .get(index / 64)
+            .is_some_and(|word| word & (1u64 << (index % 64)) != 0)
+    }
+
+    fn len(&self) -> u32 {
+        self.len
+    }
+
+    fn max_id(&self) -> Option<u32> {
+        self.words.iter().rposition(|word| *word != 0).map(|word_index| {
+            let word = self.words[word_index];
+            (word_index * 64 + (64 - word.leading_zeros() as usize)) as u32
+        })
+    }
+
+    fn merge(&mut self, other: &Self) -> Result<()> {
+        for (word_index, &word) in other.words.iter().enumerate() {
+            let mut remaining = word;
+            while remaining != 0 {
+                let bit = remaining.trailing_zeros() as usize;
+                let game_id = (word_index * 64 + bit + 1) as u32;
+                if !self.insert(game_id) {
+                    bail!("duplicate completed game_id {game_id} across resume checkpoints");
+                }
+                remaining &= remaining - 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
 struct ResumeState {
-    /// 完了済み対局数（max game_id ベース）
-    completed_games: u32,
+    completed_games: CompletedGames,
     black_wins: u32,
     white_wins: u32,
     draws: u32,
@@ -2333,24 +2650,23 @@ struct ResumeState {
     progress_file: Option<String>,
     /// meta 行に保存された progress_file 内容の SHA-256（存在しない場合は None）
     progress_file_sha256: Option<String>,
+    fingerprint: Option<Value>,
 }
 
-/// 既存の JSONL 出力ファイルを解析し、完了済み対局数と勝敗を取得する。
-/// ワーカー並行実行で result 行の順序が保証されないため、game_id の最大値を
-/// completed_games とする。
-fn parse_resume_state(path: &Path) -> Result<ResumeState> {
-    let file = File::open(path)
+/// 既存の最終 JSONL を解析し、完了済み game_id の集合と勝敗を取得する。
+fn parse_resume_state(path: &Path, max_game_id: u32) -> Result<ResumeState> {
+    let file = open_regular_file_nofollow(path)
         .with_context(|| format!("failed to open {} for resume", path.display()))?;
     let reader = BufReader::new(file);
 
-    let mut max_game_id: u32 = 0;
+    let mut completed_games = CompletedGames::default();
     let mut black_wins: u32 = 0;
     let mut white_wins: u32 = 0;
     let mut draws: u32 = 0;
     let mut shuffle_seed: Option<u64> = None;
     let mut progress_file: Option<String> = None;
     let mut progress_file_sha256: Option<String> = None;
-    let mut last_parse_error = false;
+    let mut fingerprint = None;
 
     for line in reader.lines() {
         let line = line?;
@@ -2358,17 +2674,8 @@ fn parse_resume_state(path: &Path) -> Result<ResumeState> {
         if trimmed.is_empty() {
             continue;
         }
-        let value: Value = match serde_json::from_str(trimmed) {
-            Ok(v) => {
-                last_parse_error = false;
-                v
-            }
-            Err(_) => {
-                // 最終行の不完全な書き込みを許容
-                last_parse_error = true;
-                continue;
-            }
-        };
+        let value: Value = serde_json::from_str(trimmed)
+            .with_context(|| format!("invalid JSONL in resume file {}", path.display()))?;
         match value.get("type").and_then(|v| v.as_str()) {
             Some("meta") => {
                 // meta 行から resume に必要な設定を復元
@@ -2383,39 +2690,547 @@ fn parse_resume_state(path: &Path) -> Result<ResumeState> {
                         .and_then(|v| v.as_str())
                         .map(ToString::to_string);
                 }
+                fingerprint = value.get("fingerprint").cloned();
             }
             Some("result") => {
-                if let Some(gid) = value.get("game_id").and_then(|v| v.as_u64()) {
-                    max_game_id = max_game_id.max(gid as u32);
+                let gid: u32 = value
+                    .get("game_id")
+                    .and_then(Value::as_u64)
+                    .context("result without game_id")?
+                    .try_into()
+                    .context("game_id exceeds u32")?;
+                if gid == 0 || gid > max_game_id {
+                    bail!(
+                        "result game_id {gid} is outside 1..={max_game_id} in {}",
+                        path.display()
+                    );
                 }
                 match value.get("outcome").and_then(|v| v.as_str()) {
                     Some("black_win") => black_wins += 1,
                     Some("white_win") => white_wins += 1,
                     Some("draw") => draws += 1,
-                    _ => {}
+                    _ => bail!("invalid result outcome in {}", path.display()),
+                }
+                if !completed_games.insert(gid) {
+                    bail!("duplicate result game_id {gid} in {}", path.display());
                 }
             }
             _ => {}
         }
     }
 
-    // 最終行以外でパースエラーが起きた場合の警告は不要（last_parse_error は最終行のみ）
-    let _ = last_parse_error;
-
     Ok(ResumeState {
-        completed_games: max_game_id,
+        completed_games,
         black_wins,
         white_wins,
         draws,
         shuffle_seed,
         progress_file,
         progress_file_sha256,
+        fingerprint,
     })
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     format!("{:x}", Sha256::digest(bytes))
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut file =
+        File::open(path).with_context(|| format!("failed to hash {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn sha256_path_content(path: &Path) -> Result<Option<String>> {
+    use sha2::{Digest, Sha256};
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => return sha256_file(path).map(Some),
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            bail!("USI option path is neither a file nor a directory: {}", path.display())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect USI option path {}", path.display()));
+        }
+    }
+    let mut hasher = Sha256::new();
+    let entries = walkdir::WalkDir::new(path).follow_links(true).sort_by_file_name().into_iter();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("failed to walk {}", path.display()))?;
+        if entry.path() == path || entry.file_type().is_dir() {
+            continue;
+        }
+        let relative = entry.path().strip_prefix(path)?;
+        let relative = relative.to_string_lossy();
+        hasher.update((relative.len() as u64).to_le_bytes());
+        hasher.update(relative.as_bytes());
+        let mut file = File::open(entry.path())?;
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+    }
+    Ok(Some(format!("{:x}", hasher.finalize())))
+}
+
+fn usi_option_path_fingerprints(options: &[String]) -> Result<Vec<Value>> {
+    let engine_cwd =
+        std::env::current_dir().context("failed to resolve engine working directory")?;
+    let mut fingerprints = Vec::new();
+    for option in options {
+        let Some((name, value)) = option.split_once('=') else {
+            continue;
+        };
+        let name = name.trim();
+        let value = value.trim();
+        let normalized: String = name
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
+            .flat_map(char::to_lowercase)
+            .collect();
+        if !(normalized.ends_with("file")
+            || normalized.ends_with("dir")
+            || normalized.ends_with("path")
+            || normalized == "ls_progress_coeff")
+        {
+            continue;
+        }
+        let path = Path::new(value);
+        let resolved_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            engine_cwd.join(path)
+        };
+        fingerprints.push(serde_json::json!({
+            "name": name,
+            "value": value,
+            "resolved_path": resolved_path,
+            "content_sha256": sha256_path_content(&resolved_path).with_context(|| {
+                format!("failed to fingerprint path-valued USI option {name}={value}")
+            })?,
+        }));
+    }
+    Ok(fingerprints)
+}
+
+fn validate_resume_fingerprint(meta: Option<&Value>, current: &Value) -> Result<()> {
+    let meta = meta.context(
+        "--resume: meta has no generation fingerprint; move existing outputs aside and start a new run",
+    )?;
+    if meta == current {
+        return Ok(());
+    }
+    let mut differences = Vec::new();
+    collect_json_differences("", meta, current, &mut differences);
+    differences.sort();
+    bail!(
+        "--resume: generation fingerprint mismatch in fields: {}",
+        differences.join(", ")
+    )
+}
+
+fn collect_json_differences(prefix: &str, left: &Value, right: &Value, out: &mut Vec<String>) {
+    match (left.as_object(), right.as_object()) {
+        (Some(left), Some(right)) => {
+            for key in left.keys().chain(right.keys()) {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                if out.iter().any(|existing| existing == &path) {
+                    continue;
+                }
+                match (left.get(key), right.get(key)) {
+                    (Some(a), Some(b)) if a != b => collect_json_differences(&path, a, b, out),
+                    (Some(_), Some(_)) => {}
+                    _ => out.push(path),
+                }
+            }
+        }
+        _ => out.push(prefix.to_string()),
+    }
+}
+
+fn recover_worker_checkpoint(
+    jsonl_path: &Path,
+    training_path: Option<&Path>,
+    sidecar_path: Option<&Path>,
+    info_path: Option<&Path>,
+    eval_path: Option<&Path>,
+    metrics_path: Option<&Path>,
+    format: TrainingFormat,
+    worker_id: usize,
+    max_game_id: u32,
+) -> Result<ResumeState> {
+    let jsonl_file = checkpoint_file_state(Some(jsonl_path))?;
+    let training_file = checkpoint_file_state(training_path)?;
+    let sidecar_file = checkpoint_file_state(sidecar_path)?;
+    let info_file = checkpoint_file_state(info_path)?;
+    let eval_file = checkpoint_file_state(eval_path)?;
+    let metrics_file = checkpoint_file_state(metrics_path)?;
+    if !jsonl_file.exists {
+        if [
+            training_file,
+            sidecar_file,
+            info_file,
+            eval_file,
+            metrics_file,
+        ]
+        .into_iter()
+        .any(|file| file.len > 0)
+        {
+            bail!(
+                "resume checkpoint {} is missing while training data remains; move the worker temp files aside before retrying",
+                jsonl_path.display()
+            );
+        }
+        return Ok(empty_resume_state());
+    }
+
+    let mut state = empty_resume_state();
+    let mut parsed_state = empty_resume_state();
+    let mut committed = CheckpointLengths {
+        training: 0,
+        sidecar: sidecar_path.map(|_| 0),
+        info: info_path.map(|_| 0),
+        eval: eval_path.map(|_| 0),
+        metrics: metrics_path.map(|_| 0),
+    };
+    let mut reader = BufReader::new(open_regular_file_nofollow(jsonl_path)?);
+    let mut line = Vec::new();
+    let mut parsed = committed;
+    let mut committed_jsonl_len = 0u64;
+    let mut complete_len = 0u64;
+    let mut line_index = 0usize;
+    let mut durable_prefix_ended = false;
+    let mut results_after_boundary = 0u64;
+    let mut seen_games = CompletedGames::default();
+    loop {
+        line.clear();
+        let read = reader.read_until(b'\n', &mut line)?;
+        if read == 0 {
+            break;
+        }
+        if !line.ends_with(b"\n") {
+            break;
+        }
+        complete_len += read as u64;
+        line_index += 1;
+        let line = &line[..line.len() - 1];
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_slice(line).with_context(|| {
+            format!("invalid JSON in {} at line {}", jsonl_path.display(), line_index)
+        })?;
+        if value.get("type").and_then(Value::as_str) != Some("result") {
+            bail!("unexpected non-result line in worker checkpoint {}", jsonl_path.display());
+        }
+        let game_id: u32 = value
+            .get("game_id")
+            .and_then(Value::as_u64)
+            .context("worker result has no game_id")?
+            .try_into()
+            .context("worker game_id exceeds u32")?;
+        if game_id == 0 || game_id > max_game_id {
+            bail!(
+                "worker game_id {game_id} is outside 1..={max_game_id} in {}",
+                jsonl_path.display()
+            );
+        }
+        let row_worker_id = value
+            .get("worker_id")
+            .and_then(Value::as_u64)
+            .context("worker result has no worker_id")? as usize;
+        if row_worker_id != worker_id {
+            bail!("worker_id mismatch in {}", jsonl_path.display());
+        }
+        let next_training = value
+            .get("training_bytes")
+            .and_then(Value::as_u64)
+            .with_context(|| {
+                format!(
+                    "{} has legacy result without training_bytes; move temp files aside rather than overwriting them",
+                    jsonl_path.display()
+                )
+            })?;
+        let read_optional_offset =
+            |field: &str, enabled: bool| -> Result<Option<u64>> {
+                if enabled {
+                    Ok(Some(value.get(field).and_then(Value::as_u64).with_context(|| {
+                        format!("{} result has no {field}", jsonl_path.display())
+                    })?))
+                } else if value.get(field).is_some_and(|offset| !offset.is_null()) {
+                    bail!("{} unexpectedly has {field}", jsonl_path.display())
+                } else {
+                    Ok(None)
+                }
+            };
+        let next = CheckpointLengths {
+            training: next_training,
+            sidecar: read_optional_offset("sidecar_bytes", sidecar_path.is_some())?,
+            info: read_optional_offset("info_bytes", info_path.is_some())?,
+            eval: read_optional_offset("eval_bytes", eval_path.is_some())?,
+            metrics: read_optional_offset("metrics_bytes", metrics_path.is_some())?,
+        };
+        validate_referenced_files_exist(
+            next,
+            [
+                ("training data", training_path, training_file),
+                ("game_id sidecar", sidecar_path, sidecar_file),
+                ("info log", info_path, info_file),
+                ("eval file", eval_path, eval_file),
+                ("metrics", metrics_path, metrics_file),
+            ],
+            jsonl_path,
+        )?;
+        validate_checkpoint_monotonic(parsed, next, jsonl_path)?;
+        validate_checkpoint_record_boundaries(next, format, jsonl_path)?;
+        parsed = next;
+        let outcome = value
+            .get("outcome")
+            .and_then(Value::as_str)
+            .with_context(|| format!("invalid result outcome in {}", jsonl_path.display()))?;
+        if !matches!(outcome, "black_win" | "white_win" | "draw") {
+            bail!("invalid result outcome in {}", jsonl_path.display());
+        }
+        if !seen_games.insert(game_id) {
+            bail!("duplicate game_id {game_id} in {}", jsonl_path.display());
+        }
+        let fsync_boundary = value
+            .get("fsync_boundary")
+            .and_then(Value::as_bool)
+            .with_context(|| {
+                format!(
+                    "{} has legacy result without fsync_boundary; move temp files aside rather than overwriting them",
+                    jsonl_path.display()
+                )
+            })?;
+        match outcome {
+            "black_win" => parsed_state.black_wins += 1,
+            "white_win" => parsed_state.white_wins += 1,
+            "draw" => parsed_state.draws += 1,
+            _ => unreachable!(),
+        }
+        parsed_state.completed_games.insert(game_id);
+        results_after_boundary += 1;
+        if durable_prefix_ended || !fsync_boundary {
+            continue;
+        }
+        if !checkpoint_fits_files(
+            next,
+            training_file.len,
+            sidecar_file.len,
+            info_file.len,
+            eval_file.len,
+            metrics_file.len,
+        ) {
+            durable_prefix_ended = true;
+            continue;
+        }
+        state = parsed_state.clone();
+        committed = next;
+        committed_jsonl_len = complete_len;
+        results_after_boundary = 0;
+    }
+
+    // ここまでの検証で全成果物を同じ result 境界へ戻せることが確定している。
+    truncate_if_needed(jsonl_path, committed_jsonl_len, jsonl_file.len)?;
+    if let Some(path) = training_path {
+        truncate_if_needed(path, committed.training, training_file.len)?;
+    }
+    if let (Some(path), Some(len)) = (sidecar_path, committed.sidecar) {
+        truncate_if_needed(path, len, sidecar_file.len)?;
+    }
+    if let (Some(path), Some(len)) = (info_path, committed.info) {
+        truncate_if_needed(path, len, info_file.len)?;
+    }
+    if let (Some(path), Some(len)) = (eval_path, committed.eval) {
+        truncate_if_needed(path, len, eval_file.len)?;
+    }
+    if let (Some(path), Some(len)) = (metrics_path, committed.metrics) {
+        truncate_if_needed(path, len, metrics_file.len)?;
+    }
+    if results_after_boundary > 0 {
+        eprintln!(
+            "warning: recovered {} by discarding {results_after_boundary} result row(s) after the last proven fsync boundary",
+            jsonl_path.display()
+        );
+    }
+    Ok(state)
+}
+
+fn checkpoint_fits_files(
+    lengths: CheckpointLengths,
+    training_len: u64,
+    sidecar_len: u64,
+    info_len: u64,
+    eval_len: u64,
+    metrics_len: u64,
+) -> bool {
+    lengths.training <= training_len
+        && lengths.sidecar.is_none_or(|len| len <= sidecar_len)
+        && lengths.info.is_none_or(|len| len <= info_len)
+        && lengths.eval.is_none_or(|len| len <= eval_len)
+        && lengths.metrics.is_none_or(|len| len <= metrics_len)
+}
+
+fn validate_checkpoint_record_boundaries(
+    lengths: CheckpointLengths,
+    format: TrainingFormat,
+    path: &Path,
+) -> Result<()> {
+    if format != TrainingFormat::Psv {
+        return Ok(());
+    }
+    if !lengths.training.is_multiple_of(PackedSfenValue::SIZE as u64) {
+        bail!(
+            "committed PSV length in {} is not on a {}-byte record boundary",
+            path.display(),
+            PackedSfenValue::SIZE
+        );
+    }
+    if let Some(sidecar) = lengths.sidecar {
+        if !sidecar.is_multiple_of(4) {
+            bail!(
+                "committed game_id sidecar length in {} is not on a 4-byte record boundary",
+                path.display()
+            );
+        }
+        if sidecar / 4 != lengths.training / PackedSfenValue::SIZE as u64 {
+            bail!("PSV and game_id sidecar committed record counts differ in {}", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn validate_checkpoint_monotonic(
+    previous: CheckpointLengths,
+    next: CheckpointLengths,
+    path: &Path,
+) -> Result<()> {
+    let fields = [
+        ("training_bytes", Some(previous.training), Some(next.training)),
+        ("sidecar_bytes", previous.sidecar, next.sidecar),
+        ("info_bytes", previous.info, next.info),
+        ("eval_bytes", previous.eval, next.eval),
+        ("metrics_bytes", previous.metrics, next.metrics),
+    ];
+    for (name, previous, next) in fields {
+        if let (Some(previous), Some(next)) = (previous, next)
+            && next < previous
+        {
+            bail!("non-monotonic {name} in {}: {next} < {previous}", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn truncate_if_needed(path: &Path, committed: u64, actual: u64) -> Result<()> {
+    if committed != actual {
+        truncate_file(path, committed)?;
+    }
+    Ok(())
+}
+
+fn empty_resume_state() -> ResumeState {
+    ResumeState {
+        completed_games: CompletedGames::default(),
+        black_wins: 0,
+        white_wins: 0,
+        draws: 0,
+        shuffle_seed: None,
+        progress_file: None,
+        progress_file_sha256: None,
+        fingerprint: None,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CheckpointFileState {
+    exists: bool,
+    len: u64,
+}
+
+fn checkpoint_file_state(path: Option<&Path>) -> Result<CheckpointFileState> {
+    match path {
+        Some(path) => match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.is_file() => Ok(CheckpointFileState {
+                exists: true,
+                len: meta.len(),
+            }),
+            Ok(_) => bail!("worker checkpoint {} is not a regular file", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(CheckpointFileState {
+                exists: false,
+                len: 0,
+            }),
+            Err(error) => Err(error).with_context(|| format!("failed to stat {}", path.display())),
+        },
+        None => Ok(CheckpointFileState {
+            exists: false,
+            len: 0,
+        }),
+    }
+}
+
+fn validate_referenced_files_exist(
+    lengths: CheckpointLengths,
+    files: [(&str, Option<&Path>, CheckpointFileState); 5],
+    jsonl_path: &Path,
+) -> Result<()> {
+    let offsets = [
+        Some(lengths.training),
+        lengths.sidecar,
+        lengths.info,
+        lengths.eval,
+        lengths.metrics,
+    ];
+    for ((label, path, file), offset) in files.into_iter().zip(offsets) {
+        if offset.is_some_and(|offset| offset > 0) && !file.exists {
+            bail!(
+                "resume checkpoint {} references missing {label} {} at non-zero offset; no files were truncated",
+                jsonl_path.display(),
+                path.context("enabled checkpoint path missing")?.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn file_len_or_zero(path: Option<&Path>) -> Result<u64> {
+    Ok(checkpoint_file_state(path)?.len)
+}
+
+fn truncate_file(path: &Path, len: u64) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let file = options.open(path)?;
+    if !file.metadata()?.is_file() {
+        bail!("worker checkpoint {} is not a regular file", path.display());
+    }
+    file.set_len(len)?;
+    file.sync_all()?;
+    Ok(())
 }
 
 fn validate_resume_progress_file(
@@ -2457,29 +3272,641 @@ fn validate_resume_progress_content(
     }
 }
 
-/// Concatenate worker temp files.
-/// `append=true`: append to existing file (for JSONL with meta line).
-/// `append=false`: create new file.
-fn concatenate_temp_files(final_path: &Path, temp_paths: &[PathBuf], append: bool) -> Result<()> {
-    let mut out: File = if append {
-        std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(final_path)
-            .with_context(|| format!("failed to open {} for appending", final_path.display()))?
-    } else {
-        File::create(final_path)
-            .with_context(|| format!("failed to create {}", final_path.display()))?
-    };
-    for tmp in temp_paths {
-        match File::open(tmp) {
-            Ok(mut f) => {
-                std::io::copy(&mut f, &mut out)?;
-                std::fs::remove_file(tmp)?;
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FinalizationOutput {
+    final_path: PathBuf,
+    staged_path: PathBuf,
+    len: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct FinalizationJournal {
+    schema: u32,
+    outputs: Vec<FinalizationOutput>,
+    worker_temps: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FinalizedState {
+    schema: u32,
+    outputs: Vec<FinalizedOutput>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FinalizedOutput {
+    path: PathBuf,
+    len: u64,
+    sha256: String,
+}
+
+#[derive(Serialize)]
+struct RunLockInfo {
+    pid: u32,
+}
+
+#[derive(Debug)]
+struct RunDirLock {
+    path: PathBuf,
+    body: Vec<u8>,
+}
+
+impl RunDirLock {
+    fn acquire(output_path: &Path, force_unlock: bool) -> Result<Self> {
+        let path = output_path.with_file_name(".gensfen.lock");
+        if force_unlock {
+            match std::fs::remove_file(&path) {
+                Ok(()) => eprintln!("--force-unlock: 残留 lock {} を削除しました", path.display()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to remove stale lock {}", path.display())
+                    });
+                }
             }
+        }
+
+        let body = serde_json::to_vec(&RunLockInfo {
+            pid: std::process::id(),
+        })?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW);
+        let mut file = match options.open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let owner = read_regular_file_nofollow(&path)
+                    .and_then(|bytes| String::from_utf8(bytes).map_err(Into::into))
+                    .unwrap_or_else(|_| "<read error>".into());
+                bail!(
+                    "out-dir is locked by another gensfen process: {}\n  lock: {}\n  process が終了済みなら --force-unlock を指定してください",
+                    path.display(),
+                    owner.trim()
+                );
+            }
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to create lock {}", path.display()));
+            }
+        };
+        file.write_all(&body)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        sync_parent(&path)?;
+        let mut stored_body = body;
+        stored_body.push(b'\n');
+        Ok(Self {
+            path,
+            body: stored_body,
+        })
+    }
+}
+
+impl Drop for RunDirLock {
+    fn drop(&mut self) {
+        if read_regular_file_nofollow(&self.path).ok().as_deref() == Some(self.body.as_slice()) {
+            let _ = std::fs::remove_file(&self.path);
+            let _ = sync_parent(&self.path);
+        }
+    }
+}
+
+fn finalization_journal_path(output_path: &Path) -> PathBuf {
+    output_path.with_file_name(".gensfen.finalization.json")
+}
+
+fn finalized_state_path(output_path: &Path) -> PathBuf {
+    output_path.with_file_name("gensfen.finalized.json")
+}
+
+fn atomic_temp_path(path: &Path) -> PathBuf {
+    path.with_extension("json.tmp")
+}
+
+fn sync_parent(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+fn open_regular_file_nofollow(path: &Path) -> Result<File> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!("{} is not a regular file", path.display());
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let file = options
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    if !file.metadata()?.is_file() {
+        bail!("{} is not a regular file", path.display());
+    }
+    Ok(file)
+}
+
+fn create_new_file_nofollow(path: &Path) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    options
+        .open(path)
+        .with_context(|| format!("failed to create {}", path.display()))
+}
+
+fn open_worker_checkpoint(path: &Path, append: bool) -> Result<File> {
+    if append {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => bail!("worker checkpoint {} is not a regular file", path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    open_worker_checkpoint_after_type_check(path, append)
+}
+
+fn open_worker_checkpoint_after_type_check(path: &Path, append: bool) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true);
+    if append {
+        options.create(true).append(true);
+    } else {
+        options.create_new(true);
+    }
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let file = options
+        .open(path)
+        .with_context(|| format!("failed to open worker checkpoint {}", path.display()))?;
+    if !file.metadata()?.is_file() {
+        bail!("worker checkpoint {} is not a regular file", path.display());
+    }
+    Ok(file)
+}
+
+fn read_regular_file_nofollow(path: &Path) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    open_regular_file_nofollow(path)?.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn is_not_found(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+}
+
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let tmp = atomic_temp_path(path);
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => bail!("{} is not a regular file", path.display()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    let mut file = create_new_file_nofollow(&tmp)?;
+    serde_json::to_writer(&mut file, value)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+    let is_finalization_journal =
+        path.file_name().is_some_and(|name| name == ".gensfen.finalization.json");
+    if is_finalization_journal && injected_fault("before_journal_rename") {
+        bail!("injected failure before finalization journal rename");
+    }
+    std::fs::rename(&tmp, path)?;
+    if is_finalization_journal && injected_fault("after_journal_rename") {
+        std::process::abort();
+    }
+    sync_parent(path)
+}
+
+fn finalized_state(journal: &FinalizationJournal) -> FinalizedState {
+    FinalizedState {
+        schema: 1,
+        outputs: journal
+            .outputs
+            .iter()
+            .map(|output| FinalizedOutput {
+                path: output.final_path.clone(),
+                len: output.len,
+                sha256: output.sha256.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn validate_file_identity(path: &Path, expected_len: u64, expected_sha256: &str) -> Result<()> {
+    use sha2::{Digest, Sha256};
+    let mut file = open_regular_file_nofollow(path)
+        .with_context(|| format!("missing finalized output {}", path.display()))?;
+    let actual_len = file.metadata()?.len();
+    if actual_len != expected_len {
+        bail!(
+            "finalized output {} has unexpected length: {actual_len} != {expected_len}",
+            path.display()
+        );
+    }
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let actual_sha256 = format!("{:x}", hasher.finalize());
+    if actual_sha256 != expected_sha256 {
+        bail!("finalized output {} has unexpected content hash", path.display());
+    }
+    Ok(())
+}
+
+fn complete_finalization(
+    output_path: &Path,
+    journal: &FinalizationJournal,
+    verify_staged: bool,
+) -> Result<()> {
+    for (index, output) in journal.outputs.iter().enumerate() {
+        match std::fs::symlink_metadata(&output.staged_path) {
+            Ok(metadata) if metadata.is_file() => {
+                if verify_staged {
+                    validate_file_identity(&output.staged_path, output.len, &output.sha256)?;
+                }
+                std::fs::rename(&output.staged_path, &output.final_path).with_context(|| {
+                    format!("failed to atomically replace {}", output.final_path.display())
+                })?;
+                sync_parent(&output.final_path)?;
+                if injected_fault(&format!("after_final_rename_{}", index + 1)) {
+                    std::process::abort();
+                }
+            }
+            Ok(_) => bail!("{} is not a regular file", output.staged_path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                validate_file_identity(&output.final_path, output.len, &output.sha256)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    write_json_atomic(&finalized_state_path(output_path), &finalized_state(journal))?;
+    for (index, temp) in journal.worker_temps.iter().enumerate() {
+        match std::fs::remove_file(temp) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        if injected_fault(&format!("after_worker_temp_delete_{}", index + 1)) {
+            std::process::abort();
+        }
+    }
+    sync_parent(output_path)?;
+    let journal_path = finalization_journal_path(output_path);
+    std::fs::remove_file(&journal_path)?;
+    sync_parent(&journal_path)
+}
+
+fn recover_pending_finalization(output_path: &Path) -> Result<()> {
+    let path = finalization_journal_path(output_path);
+    let tmp_path = atomic_temp_path(&path);
+    let bytes = match read_regular_file_nofollow(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if is_not_found(&error) => match read_regular_file_nofollow(&tmp_path) {
+            Ok(bytes) => {
+                match serde_json::from_slice::<FinalizationJournal>(&bytes) {
+                    Ok(journal) if journal.schema == 1 => {}
+                    Ok(journal) => {
+                        eprintln!(
+                            "warning: discarding finalization journal temporary file {} with unsupported schema {}",
+                            tmp_path.display(),
+                            journal.schema
+                        );
+                        std::fs::remove_file(&tmp_path)?;
+                        sync_parent(&tmp_path)?;
+                        return Ok(());
+                    }
+                    Err(parse_error) => {
+                        eprintln!(
+                            "warning: discarding invalid finalization journal temporary file {}: {parse_error}",
+                            tmp_path.display()
+                        );
+                        std::fs::remove_file(&tmp_path)?;
+                        sync_parent(&tmp_path)?;
+                        return Ok(());
+                    }
+                }
+                std::fs::rename(&tmp_path, &path)?;
+                sync_parent(&path)?;
+                bytes
+            }
+            Err(error) if is_not_found(&error) => {
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        },
+        Err(error) => return Err(error),
+    };
+    let journal: FinalizationJournal = serde_json::from_slice(&bytes)
+        .with_context(|| format!("invalid finalization journal {}", path.display()))?;
+    if journal.schema != 1 {
+        bail!("unsupported finalization journal schema {}", journal.schema);
+    }
+    let state_tmp = atomic_temp_path(&finalized_state_path(output_path));
+    match std::fs::symlink_metadata(&state_tmp) {
+        Ok(metadata) if metadata.is_file() => std::fs::remove_file(&state_tmp)?,
+        Ok(_) => bail!("{} is not a regular file", state_tmp.display()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    eprintln!("recovering interrupted gensfen finalization");
+    complete_finalization(output_path, &journal, true)
+}
+
+fn validate_finalized_outputs(
+    output_path: &Path,
+    required_paths: &[PathBuf],
+    training_path: Option<&Path>,
+    sidecar_path: Option<&Path>,
+    format: TrainingFormat,
+    has_results: bool,
+) -> Result<Option<FinalizedState>> {
+    let state_path = finalized_state_path(output_path);
+    let bytes = match read_regular_file_nofollow(&state_path) {
+        Ok(bytes) => bytes,
+        Err(error) if is_not_found(&error) && !has_results => {
+            for path in [training_path, sidecar_path].into_iter().flatten() {
+                if std::fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
+                    bail!("final output {} exists without finalized state", path.display());
+                }
+            }
+            return Ok(None);
+        }
+        Err(error) if is_not_found(&error) => {
+            bail!("resume results exist but {} is missing", state_path.display())
+        }
+        Err(error) => return Err(error),
+    };
+    let state: FinalizedState = serde_json::from_slice(&bytes)?;
+    if state.schema != 1 {
+        bail!("unsupported finalized state schema {}", state.schema);
+    }
+    for output in &state.outputs {
+        let actual = open_regular_file_nofollow(&output.path)
+            .with_context(|| format!("missing final output {}", output.path.display()))?
+            .metadata()?
+            .len();
+        if actual != output.len {
+            bail!(
+                "final output {} length differs from finalized state: {actual} != {}",
+                output.path.display(),
+                output.len
+            );
+        }
+    }
+    for required in required_paths {
+        if !state.outputs.iter().any(|output| output.path == required.as_path()) {
+            bail!("finalized state has no entry for {}", required.display());
+        }
+    }
+    if format == TrainingFormat::Psv {
+        let training_len = file_len_or_zero(training_path)?;
+        if !training_len.is_multiple_of(PackedSfenValue::SIZE as u64) {
+            bail!("final PSV is not on a {}-byte record boundary", PackedSfenValue::SIZE);
+        }
+        if let Some(sidecar_path) = sidecar_path {
+            let sidecar_len = file_len_or_zero(Some(sidecar_path))?;
+            if !sidecar_len.is_multiple_of(4) {
+                bail!("final game_id sidecar is not on a 4-byte record boundary");
+            }
+            if training_len / PackedSfenValue::SIZE as u64 != sidecar_len / 4 {
+                bail!("final PSV and game_id sidecar record counts differ");
+            }
+        }
+    }
+    Ok(Some(state))
+}
+
+/// worker temp を同一ディレクトリの一時ファイルへ連結し、rename 前の状態まで永続化する。
+fn stage_concatenated_file(
+    final_path: &Path,
+    temp_paths: &[PathBuf],
+    append: bool,
+    regenerate_existing: bool,
+    expected_prefix: Option<&FinalizedOutput>,
+) -> Result<FinalizationOutput> {
+    use sha2::{Digest, Sha256};
+    let merge_path = merge_temp_path(final_path);
+    if regenerate_existing {
+        match std::fs::symlink_metadata(&merge_path) {
+            Ok(metadata) if metadata.is_file() => std::fs::remove_file(&merge_path)?,
+            Ok(_) => bail!("{} is not a regular file", merge_path.display()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    let mut out = create_new_file_nofollow(&merge_path)
+        .with_context(|| format!("failed to create merge temp {}", merge_path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut len = 0u64;
+    if append {
+        match std::fs::symlink_metadata(final_path) {
+            Ok(_) => {
+                append_file_to_stage(final_path, &mut out, &mut hasher, &mut len)?;
+                if let Some(expected) = expected_prefix
+                    && (len != expected.len
+                        || format!("{:x}", hasher.clone().finalize()) != expected.sha256)
+                {
+                    bail!(
+                        "final output {} content differs from finalized state while staging",
+                        final_path.display()
+                    );
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    for tmp in temp_paths {
+        match std::fs::symlink_metadata(tmp) {
+            Ok(_) => append_file_to_stage(tmp, &mut out, &mut hasher, &mut len)?,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e.into()),
         }
+    }
+    out.sync_all()?;
+    drop(out);
+    sync_parent(&merge_path)?;
+    Ok(FinalizationOutput {
+        final_path: final_path.to_path_buf(),
+        staged_path: merge_path,
+        len,
+        sha256: format!("{:x}", hasher.finalize()),
+    })
+}
+
+fn finalized_output_for<'a>(
+    state: Option<&'a FinalizedState>,
+    path: &Path,
+) -> Option<&'a FinalizedOutput> {
+    state?.outputs.iter().find(|output| output.path == path)
+}
+
+fn validate_worker_outputs_exist(paths: &[(&str, &Path)]) -> Result<()> {
+    for (label, path) in paths {
+        let metadata = std::fs::symlink_metadata(path)
+            .with_context(|| format!("worker {label} output {} is missing", path.display()))?;
+        if !metadata.is_file() {
+            bail!("worker {label} output {} is not a regular file", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn validate_completed_worker_outputs(
+    jsonl_path: &Path,
+    training_path: &Path,
+    sidecar_path: Option<&Path>,
+    info_path: Option<&Path>,
+    eval_path: Option<&Path>,
+    metrics_path: Option<&Path>,
+    format: TrainingFormat,
+    worker_id: usize,
+    max_game_id: u32,
+) -> Result<()> {
+    let mut required = vec![("JSONL", jsonl_path), ("training data", training_path)];
+    required.extend(
+        [
+            sidecar_path.map(|path| ("game_id sidecar", path)),
+            info_path.map(|path| ("info log", path)),
+            eval_path.map(|path| ("eval file", path)),
+            metrics_path.map(|path| ("metrics", path)),
+        ]
+        .into_iter()
+        .flatten(),
+    );
+    validate_worker_outputs_exist(&required)?;
+
+    let mut lengths = CheckpointLengths {
+        sidecar: sidecar_path.map(|_| 0),
+        info: info_path.map(|_| 0),
+        eval: eval_path.map(|_| 0),
+        metrics: metrics_path.map(|_| 0),
+        ..CheckpointLengths::default()
+    };
+    let mut reader = BufReader::new(open_regular_file_nofollow(jsonl_path)?);
+    let mut line = Vec::new();
+    let mut line_index = 0usize;
+    loop {
+        line.clear();
+        let read = reader.read_until(b'\n', &mut line)?;
+        if read == 0 {
+            break;
+        }
+        line_index += 1;
+        if !line.ends_with(b"\n") {
+            bail!("incomplete JSON in {} at line {line_index}", jsonl_path.display());
+        }
+        let value: Value = serde_json::from_slice(&line[..line.len() - 1]).with_context(|| {
+            format!("invalid JSON in {} at line {line_index}", jsonl_path.display())
+        })?;
+        if value.get("type").and_then(Value::as_str) != Some("result") {
+            bail!("unexpected non-result line in worker checkpoint {}", jsonl_path.display());
+        }
+        if value.get("worker_id").and_then(Value::as_u64) != Some(worker_id as u64) {
+            bail!("worker_id mismatch in {}", jsonl_path.display());
+        }
+        let game_id = value
+            .get("game_id")
+            .and_then(Value::as_u64)
+            .context("worker result has no game_id")?;
+        if game_id == 0 || game_id > u64::from(max_game_id) {
+            bail!("worker game_id {game_id} is outside 1..={max_game_id}");
+        }
+        let read_offset =
+            |field: &str, enabled: bool| -> Result<Option<u64>> {
+                if enabled {
+                    Ok(Some(value.get(field).and_then(Value::as_u64).with_context(|| {
+                        format!("{} result has no {field}", jsonl_path.display())
+                    })?))
+                } else if value.get(field).is_some_and(|offset| !offset.is_null()) {
+                    bail!("{} unexpectedly has {field}", jsonl_path.display())
+                } else {
+                    Ok(None)
+                }
+            };
+        let next = CheckpointLengths {
+            training: value.get("training_bytes").and_then(Value::as_u64).with_context(|| {
+                format!("{} result has no training_bytes", jsonl_path.display())
+            })?,
+            sidecar: read_offset("sidecar_bytes", sidecar_path.is_some())?,
+            info: read_offset("info_bytes", info_path.is_some())?,
+            eval: read_offset("eval_bytes", eval_path.is_some())?,
+            metrics: read_offset("metrics_bytes", metrics_path.is_some())?,
+        };
+        validate_checkpoint_monotonic(lengths, next, jsonl_path)?;
+        validate_checkpoint_record_boundaries(next, format, jsonl_path)?;
+        lengths = next;
+    }
+
+    let actual = CheckpointLengths {
+        training: checkpoint_file_state(Some(training_path))?.len,
+        sidecar: sidecar_path
+            .map(|path| checkpoint_file_state(Some(path)).map(|file| file.len))
+            .transpose()?,
+        info: info_path
+            .map(|path| checkpoint_file_state(Some(path)).map(|file| file.len))
+            .transpose()?,
+        eval: eval_path
+            .map(|path| checkpoint_file_state(Some(path)).map(|file| file.len))
+            .transpose()?,
+        metrics: metrics_path
+            .map(|path| checkpoint_file_state(Some(path)).map(|file| file.len))
+            .transpose()?,
+    };
+    if lengths.training != actual.training
+        || lengths.sidecar != actual.sidecar
+        || lengths.info != actual.info
+        || lengths.eval != actual.eval
+        || lengths.metrics != actual.metrics
+    {
+        bail!(
+            "worker checkpoint {} output lengths do not match its final result",
+            jsonl_path.display()
+        );
+    }
+    Ok(())
+}
+
+fn merge_temp_path(final_path: &Path) -> PathBuf {
+    let file_name = final_path.file_name().and_then(|name| name.to_str()).unwrap_or("output");
+    final_path.with_file_name(format!(".{file_name}.merge.tmp"))
+}
+
+fn append_file_to_stage(
+    source: &Path,
+    out: &mut File,
+    hasher: &mut sha2::Sha256,
+    len: &mut u64,
+) -> Result<()> {
+    use sha2::Digest;
+    let mut input = open_regular_file_nofollow(source)?;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = input.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        out.write_all(&buffer[..read])?;
+        hasher.update(&buffer[..read]);
+        *len += read as u64;
     }
     Ok(())
 }
@@ -2487,12 +3914,7 @@ fn concatenate_temp_files(final_path: &Path, temp_paths: &[PathBuf], append: boo
 fn main() -> Result<()> {
     let mut cli = Cli::parse();
     validate_cli(&cli)?;
-
-    // 既存 run には sidecar が無い可能性があり、PSV だけへの追記は 1:1 対応を壊す。
-    // 既存 PSV/sidecar の全件検証を暗黙に行わず、安全側で併用を禁止する。
-    if cli.resume && cli.emit_game_id_sidecar.is_some() {
-        bail!("--emit-game-id-sidecar cannot be used with --resume");
-    }
+    let _ = fault_spec();
 
     // 時間制限のバリデーション: depth/nodes 指定がなく時間制御もない場合はデフォルト byoyomi を設定
     let has_limit = cli.depth.is_some() || cli.nodes.is_some();
@@ -2542,52 +3964,20 @@ fn main() -> Result<()> {
             "--engine-path* requires --native=false. NativeBackend does not spawn external USI engines."
         );
     }
+    if cli.native == Some(false)
+        && (!has_explicit_usi_model_option(&black_usi_opts_early)
+            || !has_explicit_usi_model_option(&white_usi_opts_early))
+    {
+        eprintln!(
+            "warning: USI engine model is not explicit for both sides; specify EvalFile/EvalDir/NNUE/ModelFile options so resume can fingerprint model contents"
+        );
+    }
 
     let (start_defs, start_commands) =
         load_start_positions(cli.startpos_file.as_deref(), cli.sfen.as_deref(), None, None)?;
     let timestamp = Local::now();
     let output_path = resolve_output_path(cli.out_dir.as_deref(), &timestamp);
     let info_path = output_path.with_extension("info.jsonl");
-
-    // --resume バリデーションと進捗読み取り
-    let resume_state = if cli.resume {
-        if cli.out_dir.is_none() {
-            bail!(
-                "--resume には --out-dir の指定が必要です（自動生成パスでは前回のディレクトリを特定できません）"
-            );
-        }
-        if !output_path.exists() {
-            bail!("--resume: 出力ファイルが見つかりません: {}", output_path.display());
-        }
-        let state = parse_resume_state(&output_path)?;
-        validate_resume_progress_file(
-            state.progress_file.as_deref(),
-            cli.progress_file.as_deref(),
-        )?;
-        if state.completed_games >= cli.games {
-            println!(
-                "全{}局が完了済みです（black {} / white {} / draw {}）。再開は不要です。",
-                state.completed_games, state.black_wins, state.white_wins, state.draws,
-            );
-            return Ok(());
-        }
-        println!(
-            "Resuming: {}/{}局完了済み（black {} / white {} / draw {}）",
-            state.completed_games, cli.games, state.black_wins, state.white_wins, state.draws,
-        );
-        Some(state)
-    } else {
-        None
-    };
-    let resume_offset = resume_state.as_ref().map_or(0, |s| s.completed_games);
-
-    if let Some(parent) = output_path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    // 学習データ出力形式のパース
     let training_format = match cli.training_data_format.as_str() {
         "psv" => TrainingFormat::Psv,
         "pack" => TrainingFormat::Pack,
@@ -2599,46 +3989,110 @@ fn main() -> Result<()> {
     if cli.emit_game_id_sidecar.is_some() && training_format != TrainingFormat::Psv {
         bail!("--emit-game-id-sidecar requires --training-data-format psv");
     }
-
     validate_hcpe3_opts(
         training_format,
         cli.skip_in_check,
         cli.hcpe3_policy_total,
         cli.hcpe3_policy_temp,
     )?;
-
-    // 学習データ出力の初期化（デフォルトで有効、--no-training-data で無効化）
     let training_data_ext = match training_format {
         TrainingFormat::Psv => "psv",
         TrainingFormat::Pack => "pack",
         TrainingFormat::Hcpe3 => "hcpe3",
     };
-    let training_data_path = Some(
-        cli.output_training_data
-            .clone()
-            .unwrap_or_else(|| default_training_data_path(&output_path, training_data_ext)),
-    );
-    let training_data_enabled = training_data_path.is_some();
+    let training_data_path = cli
+        .output_training_data
+        .clone()
+        .unwrap_or_else(|| default_training_data_path(&output_path, training_data_ext));
     let game_id_sidecar_path = cli.emit_game_id_sidecar.clone();
-    if let Some(sidecar_path) = game_id_sidecar_path.as_deref() {
-        validate_game_id_sidecar_path(
-            sidecar_path,
-            &output_path,
-            training_data_path.as_deref(),
-            training_data_ext,
-            cli.concurrency,
-            cli.log_info,
-            cli.emit_eval_file,
-            cli.emit_metrics,
-        )?;
+    validate_output_paths_unique(
+        &output_path,
+        &training_data_path,
+        game_id_sidecar_path.as_deref(),
+        training_data_ext,
+        cli.concurrency,
+        cli.log_info,
+        cli.emit_eval_file,
+        cli.emit_metrics,
+    )?;
+    let mut final_paths = vec![output_path.clone(), training_data_path.clone()];
+    if cli.log_info {
+        final_paths.push(info_path.clone());
     }
+    if cli.emit_eval_file {
+        final_paths.push(default_eval_path(&output_path));
+    }
+    if cli.emit_metrics {
+        final_paths.push(default_metrics_path(&output_path));
+    }
+    final_paths.extend(game_id_sidecar_path.iter().cloned());
+    validate_output_entry_types(
+        &output_path,
+        &final_paths,
+        training_data_ext,
+        cli.concurrency,
+        cli.log_info,
+        cli.emit_eval_file,
+        cli.emit_metrics,
+        game_id_sidecar_path.is_some(),
+        cli.resume,
+    )?;
+    if !cli.resume {
+        validate_fresh_output_paths(&final_paths)?;
+    }
+    if let Some(parent) = output_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let _run_dir_lock = RunDirLock::acquire(&output_path, cli.force_unlock)?;
+    recover_pending_finalization(&output_path)?;
+    // --resume バリデーションと進捗読み取り
+    let mut resume_state = if cli.resume {
+        if cli.out_dir.is_none() {
+            bail!(
+                "--resume には --out-dir の指定が必要です（自動生成パスでは前回のディレクトリを特定できません）"
+            );
+        }
+        if !output_path.exists() {
+            bail!("--resume: 出力ファイルが見つかりません: {}", output_path.display());
+        }
+        let state = parse_resume_state(&output_path, cli.games)?;
+        validate_resume_progress_file(
+            state.progress_file.as_deref(),
+            cli.progress_file.as_deref(),
+        )?;
+        println!(
+            "Resuming: {}/{}局完了済み（black {} / white {} / draw {}）",
+            state.completed_games.len(),
+            cli.games,
+            state.black_wins,
+            state.white_wins,
+            state.draws,
+        );
+        Some(state)
+    } else {
+        None
+    };
+    let prior_finalized_state = if cli.resume {
+        validate_finalized_outputs(
+            &output_path,
+            &final_paths,
+            Some(&training_data_path),
+            game_id_sidecar_path.as_deref(),
+            training_format,
+            resume_state.as_ref().is_some_and(|state| state.completed_games.len() > 0),
+        )?
+    } else {
+        None
+    };
     if let Some(parent) = game_id_sidecar_path.as_deref().and_then(Path::parent)
         && !parent.as_os_str().is_empty()
     {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-
     let engine_paths = resolve_engine_paths(&cli);
     let threads_black = cli.threads_black.unwrap_or(cli.threads);
     let threads_white = cli.threads_white.unwrap_or(cli.threads);
@@ -2737,9 +4191,8 @@ fn main() -> Result<()> {
         }
     }
 
-    // shuffle_seed の解決: CLI 指定 > meta から復元 > ランダム生成
-    // resume 時は meta の seed と CLI の seed が不一致ならエラー（順列が変わるため）
-    let shuffle_seed_resolved: Option<u64> = if startpos_no_repeat_resolved {
+    // seed は開始局面選択と各 game_id の乱択を再現するため、全モードで固定する。
+    let shuffle_seed_resolved: Option<u64> = {
         if let Some(ref state) = resume_state {
             // resume: meta から seed を復元
             let meta_seed = state.shuffle_seed;
@@ -2753,45 +4206,31 @@ fn main() -> Result<()> {
                     meta_seed
                 );
             }
-            if meta_seed.is_none() {
-                bail!(
-                    "Cannot resume with --startpos-no-repeat: \
-                     the original session did not save shuffle_seed in meta. \
-                     Re-run without --startpos-no-repeat or start a new session."
-                );
-            }
-            meta_seed
+            Some(meta_seed.context("resume meta has no shuffle_seed; start a new run")?)
         } else if let Some(seed) = cli.shuffle_seed {
             Some(seed)
         } else {
             Some(rand::random::<u64>())
         }
-    } else {
-        None
     };
+    let keep_tt_resolved = cli.keep_tt.unwrap_or(false);
+    let dedup_hash_size_resolved = cli.dedup_hash_size.unwrap_or(64 * 1024 * 1024);
+    let random_multi_pv_resolved = cli.random_multi_pv.unwrap_or(0);
+    let random_multi_pv_diff_resolved = cli.random_multi_pv_diff.unwrap_or(0);
 
-    // NativeBackend 使用時に NNUE 評価関数の初期化。
-    // meta 行の書き込みより前に行い、--progress-file の必須検証や係数ロードの失敗時に
-    // 出力 JSONL（progress_file を欠いた meta）が残って以後の --resume を壊さないようにする。
     let mut native_layer_stack_buckets = None;
+    let mut native_eval_file_sha256 = None;
     let mut native_progress_file_sha256 = None;
+    let mut native_eval_bytes = None;
+    let mut native_progress_bytes = None;
     if native_mode {
         let eval_file =
             cli.eval_file.as_ref().ok_or_else(|| anyhow!("--native requires --eval-file"))?;
-        rshogi_core::nnue::init_nnue(eval_file).map_err(|e| anyhow!("NNUE init failed: {e}"))?;
-        eprintln!("NativeBackend: NNUE loaded from {}", eval_file.display());
-        let layer_stack_buckets =
-            get_network().as_deref().and_then(|network| network.layer_stack_num_buckets());
-        native_layer_stack_buckets = layer_stack_buckets;
-        if native_progress_file_required(layer_stack_buckets) && cli.progress_file.is_none() {
-            bail!(
-                "--native LayerStacks NNUE with num_buckets={} requires --progress-file",
-                layer_stack_buckets.unwrap_or_default()
-            );
-        }
+        let eval_bytes = std::fs::read(eval_file)
+            .with_context(|| format!("failed to read --eval-file {}", eval_file.display()))?;
+        native_eval_file_sha256 = Some(sha256_hex(&eval_bytes));
+        native_eval_bytes = Some(eval_bytes);
         if let Some(path) = &cli.progress_file {
-            // 一度読んだバイト列からハッシュと重みの両方を作り、
-            // 検証したものと異なる内容がロードされる読み直しの隙を作らない
             let bytes = std::fs::read(path)
                 .with_context(|| format!("failed to read --progress-file {}", path.display()))?;
             let loaded_sha256 = sha256_hex(&bytes);
@@ -2801,22 +4240,150 @@ fn main() -> Result<()> {
                     &loaded_sha256,
                 )?;
             }
-            let weights = load_progress_coeff_kpabs_from_bytes(&bytes)
-                .map_err(|e| anyhow!("failed to load --progress-file {}: {e}", path.display()))?;
-            set_layer_stack_progress_kpabs_weights(weights)
-                .map_err(|e| anyhow!("failed to set --progress-file weights: {e}"))?;
             native_progress_file_sha256 = Some(loaded_sha256);
-            eprintln!("NativeBackend: progress file loaded from {}", path.display());
+            native_progress_bytes = Some(bytes);
         }
-        if let Some(num_buckets) = native_layer_stack_buckets {
-            eprintln!("NativeBackend: LayerStacks num_buckets={num_buckets}");
+        if !cli.resume {
+            // 新規 run は初期化失敗で不完全な meta を残さないよう、meta 永続化より先に検証する。
+            native_layer_stack_buckets = initialize_native_backend(
+                eval_file,
+                native_eval_bytes.as_deref().context("native eval bytes missing")?,
+                cli.progress_file.as_deref().zip(native_progress_bytes.as_deref()),
+            )?;
+        }
+    }
+
+    let eval_file_sha256 = if native_mode {
+        native_eval_file_sha256
+    } else {
+        cli.eval_file.as_deref().map(sha256_file).transpose()?
+    };
+    let startpos_file_sha256 = cli.startpos_file.as_deref().map(sha256_file).transpose()?;
+    let start_positions_sha256 = sha256_hex(&serde_json::to_vec(&start_commands)?);
+    let native_executable_sha256 = native_mode
+        .then(|| std::env::current_exe().context("failed to resolve current executable"))
+        .transpose()?
+        .map(|path| sha256_file(&path))
+        .transpose()?;
+    let engine_black_sha256 = if native_mode {
+        native_executable_sha256.clone()
+    } else {
+        Some(sha256_file(&engine_paths.black.path)?)
+    };
+    let engine_white_sha256 = if native_mode {
+        native_executable_sha256
+    } else {
+        Some(sha256_file(&engine_paths.white.path)?)
+    };
+    let usi_path_options_black = if native_mode {
+        Vec::new()
+    } else {
+        usi_option_path_fingerprints(&black_usi_opts)?
+    };
+    let usi_path_options_white = if native_mode {
+        Vec::new()
+    } else {
+        usi_option_path_fingerprints(&white_usi_opts)?
+    };
+    let generation_fingerprint = serde_json::json!({
+        "schema": 2,
+        "model": serde_json::json!({
+            "native": native_mode,
+            "eval_file": cli.eval_file.as_ref().map(|path| path.display().to_string()),
+            "eval_file_sha256": eval_file_sha256,
+            "progress_file": cli.progress_file.as_ref().map(|path| path.display().to_string()),
+            "progress_file_sha256": native_progress_file_sha256,
+        }),
+        "engine": serde_json::json!({
+            "path_black": engine_paths.black.path.display().to_string(),
+            "path_white": engine_paths.white.path.display().to_string(),
+            "sha256_black": engine_black_sha256,
+            "sha256_white": engine_white_sha256,
+            "args_black": black_args,
+            "args_white": white_args,
+            "usi_options_black": black_usi_opts,
+            "usi_options_white": white_usi_opts,
+            "usi_path_options_black": usi_path_options_black,
+            "usi_path_options_white": usi_path_options_white,
+            "threads_black": threads_black,
+            "threads_white": threads_white,
+            "hash_mb": cli.hash_mb,
+            "keep_tt": keep_tt_resolved,
+        }),
+        "search": serde_json::json!({
+            "max_moves": cli.max_moves,
+            "btime": cli.btime,
+            "wtime": cli.wtime,
+            "binc": cli.binc,
+            "winc": cli.winc,
+            "byoyomi": cli.byoyomi,
+            "depth": cli.depth,
+            "nodes": cli.nodes,
+            "timeout_margin_ms": cli.timeout_margin_ms,
+            "network_delay": cli.network_delay,
+            "network_delay2": cli.network_delay2,
+            "minimum_thinking_time": cli.minimum_thinking_time,
+            "slowmover": cli.slowmover,
+            "ponder": cli.ponder,
+            "concurrency": cli.concurrency,
+        }),
+        "start": serde_json::json!({
+            "file": cli.startpos_file.as_ref().map(|path| path.display().to_string()),
+            "file_sha256": startpos_file_sha256,
+            "sfen": cli.sfen,
+            "positions_sha256": start_positions_sha256,
+            "random_startpos": cli.random_startpos,
+            "no_repeat": startpos_no_repeat_resolved,
+            "seed": shuffle_seed_resolved,
+        }),
+        "training": serde_json::json!({
+            "skip_initial_ply": cli.skip_initial_ply,
+            "skip_in_check": cli.skip_in_check,
+            "format": cli.training_data_format,
+            "hcpe3_policy_total": cli.hcpe3_policy_total,
+            "hcpe3_policy_temp": cli.hcpe3_policy_temp,
+            "game_id_sidecar": game_id_sidecar_path.is_some(),
+            "dedup_hash_size": dedup_hash_size_resolved,
+        }),
+        "auxiliary_outputs": serde_json::json!({
+            "info": cli.log_info,
+            "eval": cli.emit_eval_file,
+            "metrics": cli.emit_metrics,
+        }),
+        "randomization": serde_json::json!({
+            "multi_pv": random_multi_pv_resolved,
+            "multi_pv_diff": random_multi_pv_diff_resolved,
+            "move_count": cli.random_move_count,
+            "move_min_ply": cli.random_move_min_ply,
+            "move_max_ply": cli.random_move_max_ply,
+        }),
+    });
+    if let Some(state) = &resume_state {
+        validate_resume_fingerprint(state.fingerprint.as_ref(), &generation_fingerprint)?;
+    }
+
+    if !cli.resume {
+        let output_stem =
+            output_path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("output");
+        let output_parent = output_path.parent().unwrap_or_else(|| Path::new("."));
+        let prefix = format!("{output_stem}.w");
+        for entry in std::fs::read_dir(output_parent)? {
+            let entry = entry?;
+            if entry.file_name().to_string_lossy().starts_with(&prefix)
+                && std::fs::symlink_metadata(entry.path())?.len() > 0
+            {
+                bail!(
+                    "worker temp {} already exists and is non-empty; use --resume or move it aside",
+                    entry.path().display()
+                );
+            }
         }
     }
 
     // Write meta line to final JSONL (resume時はスキップ: 既にメタ行が存在する)
     if !cli.resume {
         let mut writer = BufWriter::new(
-            File::create(&output_path)
+            create_new_file_nofollow(&output_path)
                 .with_context(|| format!("failed to open {}", output_path.display()))?,
         );
         let meta = MetaLog {
@@ -2848,7 +4415,7 @@ fn main() -> Result<()> {
                 startpos_file: cli.startpos_file.as_ref().map(|p| p.display().to_string()),
                 sfen: cli.sfen.clone(),
                 random_startpos: cli.random_startpos,
-                output_training_data: training_data_path.as_ref().map(|p| p.display().to_string()),
+                output_training_data: Some(training_data_path.display().to_string()),
                 game_id_sidecar: game_id_sidecar_path.as_ref().map(|p| p.display().to_string()),
                 skip_initial_ply: cli.skip_initial_ply,
                 skip_in_check: cli.skip_in_check,
@@ -2869,16 +4436,13 @@ fn main() -> Result<()> {
             start_positions: start_commands.clone(),
             output: output_path.display().to_string(),
             info_log: cli.log_info.then(|| info_path.display().to_string()),
+            fingerprint: generation_fingerprint,
         };
         serde_json::to_writer(&mut writer, &meta)?;
         writer.write_all(b"\n")?;
         writer.flush()?;
+        writer.get_ref().sync_all()?;
     }
-
-    let keep_tt_resolved = cli.keep_tt.unwrap_or(false);
-    let dedup_hash_size_resolved = cli.dedup_hash_size.unwrap_or(64 * 1024 * 1024);
-    let random_multi_pv_resolved = cli.random_multi_pv.unwrap_or(0);
-    let random_multi_pv_diff_resolved = cli.random_multi_pv_diff.unwrap_or(0);
 
     // gensfen: 共有ハッシュ重複検出テーブル（全ワーカーで1つ共有、tanuki-と同じ構成）
     let shared_dedup_hash = if dedup_hash_size_resolved > 0 {
@@ -2891,13 +4455,21 @@ fn main() -> Result<()> {
     } else {
         None
     };
+    if cli.resume && shared_dedup_hash.is_some() {
+        eprintln!(
+            "warning: --resume starts with an empty dedup table; duplicates against data committed before the restart are not detected"
+        );
+    }
 
     // dedup 警告の重複抑制フラグ（全ワーカー共有）
     let dedup_warn_emitted = Arc::new(AtomicBool::new(false));
 
     // ゲームチケットは逐次生成する。
     // `--games` が極端に大きい場合でも O(1) メモリで dispatch できるようにする。
-    let mut rng = rand::rng();
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(
+        shuffle_seed_resolved.context("run seed missing")? ^ 0x5354_4152_5450_4f53,
+    );
     let startpos_count = start_defs.len();
 
     // Compute temp file paths per worker
@@ -2954,11 +4526,8 @@ fn main() -> Result<()> {
         } else {
             None
         };
-        let w_training_path = if training_data_enabled {
-            Some(output_parent.join(format!("{output_stem}.w{w}.{training_data_ext}")))
-        } else {
-            None
-        };
+        let w_training_path =
+            Some(output_parent.join(format!("{output_stem}.w{w}.{training_data_ext}")));
         let w_game_id_path = game_id_sidecar_path
             .as_ref()
             .map(|_| output_parent.join(format!("{output_stem}.w{w}.game_ids.bin")));
@@ -2980,80 +4549,133 @@ fn main() -> Result<()> {
             temp_game_id_paths.push(p.clone());
         }
 
-        let cfg = WorkerConfig {
-            worker_id: w,
-            engine_path_black: engine_paths.black.path.clone(),
-            engine_path_white: engine_paths.white.path.clone(),
-            black_args: black_args.clone(),
-            white_args: white_args.clone(),
-            threads_black,
-            threads_white,
-            hash_mb: cli.hash_mb,
-            network_delay: cli.network_delay,
-            network_delay2: cli.network_delay2,
-            minimum_thinking_time: cli.minimum_thinking_time,
-            slowmover: cli.slowmover,
-            ponder: cli.ponder,
-            black_usi_opts: black_usi_opts.clone(),
-            white_usi_opts: white_usi_opts.clone(),
-            entering_king_rule_black,
-            entering_king_rule_white,
-            max_moves: cli.max_moves,
-            timeout_margin_ms: cli.timeout_margin_ms,
-            btime: cli.btime,
-            wtime: cli.wtime,
-            binc: cli.binc,
-            winc: cli.winc,
-            byoyomi: cli.byoyomi,
-            go_depth: cli.depth,
-            go_nodes: cli.nodes,
-            start_defs: Arc::clone(&shared_start_defs),
-            start_commands: Arc::clone(&shared_start_commands),
-            jsonl_path,
-            info_path: w_info_path,
-            eval_path: w_eval_path,
-            metrics_path: w_metrics_path,
-            training_data_path: w_training_path,
-            game_id_sidecar_path: w_game_id_path,
-            flush_each_move: cli.flush_each_move,
-            skip_initial_ply: cli.skip_initial_ply,
-            skip_in_check: cli.skip_in_check,
-            training_format,
-            hcpe3_policy_total: cli.hcpe3_policy_total,
-            hcpe3_policy_temp: cli.hcpe3_policy_temp,
-            native_mode,
-            usi_single,
-            eval_hash_size_mb: DEFAULT_EVAL_HASH_SIZE_MB,
-            layer_stack_num_buckets: native_layer_stack_buckets,
-            keep_tt: keep_tt_resolved,
-            dedup_hash: shared_dedup_hash.clone(),
-            random_multi_pv: random_multi_pv_resolved,
-            random_multi_pv_diff: random_multi_pv_diff_resolved,
-            random_move_count: cli.random_move_count,
-            random_move_min_ply: cli.random_move_min_ply,
-            random_move_max_ply: cli.random_move_max_ply,
-            dedup_warn_interval_per_worker: (cli.dedup_warn_interval / cli.concurrency as u32)
-                .max(1),
-            dedup_warn_rate: cli.dedup_warn_rate,
-            dedup_warn_emitted: Arc::clone(&dedup_warn_emitted),
-        };
+        if cli.resume {
+            let recovered = recover_worker_checkpoint(
+                &jsonl_path,
+                w_training_path.as_deref(),
+                w_game_id_path.as_deref(),
+                w_info_path.as_deref(),
+                w_eval_path.as_deref(),
+                w_metrics_path.as_deref(),
+                training_format,
+                w,
+                cli.games,
+            )?;
+            let state = resume_state.as_mut().context("resume state missing")?;
+            state.completed_games.merge(&recovered.completed_games)?;
+            state.black_wins += recovered.black_wins;
+            state.white_wins += recovered.white_wins;
+            state.draws += recovered.draws;
+        }
+    }
 
-        let rx = ticket_rx.clone();
-        let tx = result_tx.clone();
-        let sd = shutdown.clone();
-        if native_mode {
-            // NativeBackend は SearchWorker の再帰的 alpha-beta 探索で大きなスタックを使うため
-            // 64MB スタックが必要（rshogi-usi の SEARCH_STACK_SIZE と同じ値）
-            let builder = thread::Builder::new()
-                .name(format!("gensfen-worker-{w}"))
-                .stack_size(64 * 1024 * 1024);
-            handles.push(
-                builder
-                    .spawn(move || worker_main(cfg, rx, tx, sd))
-                    .expect("failed to spawn worker thread"),
-            );
-        } else {
-            handles.push(thread::spawn(move || worker_main(cfg, rx, tx, sd)));
+    let all_games_completed = resume_state.as_ref().is_some_and(|state| {
+        state.completed_games.len() >= cli.games
+            && (1..=cli.games).all(|game_id| state.completed_games.contains(game_id))
+    });
+    if let Some(state) = &resume_state {
+        if all_games_completed {
+            println!("全{}局が checkpoint 上で完了済みです。成果物を連結します。", cli.games);
+        }
+        println!(
+            "resume checkpoints restored: {}/{} games (black {} / white {} / draw {})",
+            state.completed_games.len(),
+            cli.games,
+            state.black_wins,
+            state.white_wins,
+            state.draws
+        );
+    }
+
+    if !all_games_completed {
+        if native_mode && cli.resume {
+            // checkpoint だけで完了できる resume では大きな NNUE をロードする必要がない。
+            native_layer_stack_buckets = initialize_native_backend(
+                cli.eval_file.as_deref().context("native eval path missing")?,
+                native_eval_bytes.as_deref().context("native eval bytes missing")?,
+                cli.progress_file.as_deref().zip(native_progress_bytes.as_deref()),
+            )?;
+        }
+        for w in 0..cli.concurrency {
+            let cfg = WorkerConfig {
+                worker_id: w,
+                engine_path_black: engine_paths.black.path.clone(),
+                engine_path_white: engine_paths.white.path.clone(),
+                black_args: black_args.clone(),
+                white_args: white_args.clone(),
+                threads_black,
+                threads_white,
+                hash_mb: cli.hash_mb,
+                network_delay: cli.network_delay,
+                network_delay2: cli.network_delay2,
+                minimum_thinking_time: cli.minimum_thinking_time,
+                slowmover: cli.slowmover,
+                ponder: cli.ponder,
+                black_usi_opts: black_usi_opts.clone(),
+                white_usi_opts: white_usi_opts.clone(),
+                entering_king_rule_black,
+                entering_king_rule_white,
+                max_moves: cli.max_moves,
+                timeout_margin_ms: cli.timeout_margin_ms,
+                btime: cli.btime,
+                wtime: cli.wtime,
+                binc: cli.binc,
+                winc: cli.winc,
+                byoyomi: cli.byoyomi,
+                go_depth: cli.depth,
+                go_nodes: cli.nodes,
+                start_defs: Arc::clone(&shared_start_defs),
+                start_commands: Arc::clone(&shared_start_commands),
+                jsonl_path: temp_jsonl_paths[w].clone(),
+                info_path: cli.log_info.then(|| temp_info_paths[w].clone()),
+                eval_path: cli.emit_eval_file.then(|| temp_eval_paths[w].clone()),
+                metrics_path: cli.emit_metrics.then(|| temp_metrics_paths[w].clone()),
+                training_data_path: Some(temp_pack_paths[w].clone()),
+                game_id_sidecar_path: game_id_sidecar_path
+                    .as_ref()
+                    .map(|_| temp_game_id_paths[w].clone()),
+                flush_each_move: cli.flush_each_move,
+                fsync_interval_games: cli.fsync_interval_games,
+                append_checkpoints: cli.resume,
+                run_seed: shuffle_seed_resolved.context("run seed missing")?,
+                skip_initial_ply: cli.skip_initial_ply,
+                skip_in_check: cli.skip_in_check,
+                training_format,
+                hcpe3_policy_total: cli.hcpe3_policy_total,
+                hcpe3_policy_temp: cli.hcpe3_policy_temp,
+                native_mode,
+                usi_single,
+                eval_hash_size_mb: DEFAULT_EVAL_HASH_SIZE_MB,
+                layer_stack_num_buckets: native_layer_stack_buckets,
+                keep_tt: keep_tt_resolved,
+                dedup_hash: shared_dedup_hash.clone(),
+                random_multi_pv: random_multi_pv_resolved,
+                random_multi_pv_diff: random_multi_pv_diff_resolved,
+                random_move_count: cli.random_move_count,
+                random_move_min_ply: cli.random_move_min_ply,
+                random_move_max_ply: cli.random_move_max_ply,
+                dedup_warn_interval_per_worker: (cli.dedup_warn_interval / cli.concurrency as u32)
+                    .max(1),
+                dedup_warn_rate: cli.dedup_warn_rate,
+                dedup_warn_emitted: Arc::clone(&dedup_warn_emitted),
+            };
+            let rx = ticket_rx.clone();
+            let tx = result_tx.clone();
+            let sd = shutdown.clone();
+            if native_mode {
+                // NativeBackend は SearchWorker の再帰的 alpha-beta 探索で大きなスタックを使うため
+                // 64MB スタックが必要（rshogi-usi の SEARCH_STACK_SIZE と同じ値）
+                let builder = thread::Builder::new()
+                    .name(format!("gensfen-worker-{w}"))
+                    .stack_size(64 * 1024 * 1024);
+                handles.push(
+                    builder
+                        .spawn(move || worker_main(cfg, rx, tx, sd))
+                        .expect("failed to spawn worker thread"),
+                );
+            } else {
+                handles.push(thread::spawn(move || worker_main(cfg, rx, tx, sd)));
+            }
         }
     }
     // Main thread doesn't send results
@@ -3061,9 +4683,7 @@ fn main() -> Result<()> {
 
     // Main loop: dispatch tickets and collect results
     //
-    // --startpos-no-repeat: seed 固定の StdRng でシャッフルし、resume 時は
-    // 同じ seed + completed_games 回の next() で順列位置を復元する。
-    // seed は meta 行に shuffle_seed として保存される。
+    // game_id ごとに開始局面を決定し、完了済み ID も乱数列だけは消費する。
     let mut shuffled_startpos = if startpos_no_repeat_resolved {
         let seed = if let Some(s) = shuffle_seed_resolved {
             s
@@ -3071,46 +4691,60 @@ fn main() -> Result<()> {
             // 新規セッションなのに seed が無い = バグ（上流で必ず設定される）
             bail!("internal error: shuffle_seed not set for --startpos-no-repeat");
         };
-        let mut s = ShuffledStartpos::new(startpos_count, seed);
-        // resume 時は完了済み対局分だけ消費して同一位置まで進める
-        for _ in 0..resume_offset {
-            s.next();
-        }
-        if resume_offset > 0 {
-            eprintln!(
-                "resume: restored startpos-no-repeat position (seed={}, skip={})",
-                seed, resume_offset
-            );
-        }
-        Some(s)
+        Some(ShuffledStartpos::new(startpos_count, seed))
     } else {
         None
     };
-    let mut next_game_idx = resume_offset;
-    let make_ticket = |game_idx: u32,
-                       rng: &mut rand::rngs::ThreadRng,
-                       shuffled: &mut Option<ShuffledStartpos>| {
-        if let Some(s) = shuffled.as_mut() {
-            GameTicket {
-                game_idx,
-                startpos_idx: s.next(),
+    let mut completed_games = resume_state
+        .as_ref()
+        .map_or_else(CompletedGames::default, |state| state.completed_games.clone());
+    if completed_games.max_id().is_some_and(|max_id| max_id > cli.games) {
+        bail!("--games is smaller than an already completed game_id");
+    }
+    let mut next_game_idx = 0u32;
+    let next_incomplete_ticket =
+        |next_game_idx: &mut u32,
+         rng: &mut rand::rngs::StdRng,
+         shuffled: &mut Option<ShuffledStartpos>,
+         completed_games: &CompletedGames| {
+            while *next_game_idx < cli.games {
+                let game_idx = *next_game_idx;
+                *next_game_idx += 1;
+                let ticket = if let Some(s) = shuffled.as_mut() {
+                    GameTicket {
+                        game_idx,
+                        startpos_idx: s.next(),
+                    }
+                } else {
+                    make_game_ticket(game_idx, cli.random_startpos, startpos_count, rng)
+                };
+                if !completed_games.contains(game_idx + 1) {
+                    return Some(ticket);
+                }
             }
-        } else {
-            make_game_ticket(game_idx, cli.random_startpos, startpos_count, rng)
-        }
-    };
-    let mut next_ticket = (next_game_idx < cli.games)
-        .then(|| make_ticket(next_game_idx, &mut rng, &mut shuffled_startpos));
-    let mut completed = resume_offset;
+            None
+        };
+    let mut next_ticket = next_incomplete_ticket(
+        &mut next_game_idx,
+        &mut rng,
+        &mut shuffled_startpos,
+        &completed_games,
+    );
+    let mut completed = completed_games.len();
     let mut black_wins = resume_state.as_ref().map_or(0, |s| s.black_wins);
     let mut white_wins = resume_state.as_ref().map_or(0, |s| s.white_wins);
     let mut draws = resume_state.as_ref().map_or(0, |s| s.draws);
 
     let handle_result = |result: WorkerGameResult,
+                         completed_games: &mut CompletedGames,
                          black_wins: &mut u32,
                          white_wins: &mut u32,
                          draws: &mut u32,
-                         completed: &mut u32| {
+                         completed: &mut u32|
+     -> Result<()> {
+        if !completed_games.insert(result.game_id) {
+            bail!("worker returned duplicate completed game_id {}", result.game_id);
+        }
         match result.outcome {
             GameOutcome::BlackWin => *black_wins += 1,
             GameOutcome::WhiteWin => *white_wins += 1,
@@ -3128,6 +4762,7 @@ fn main() -> Result<()> {
             white_wins,
             draws
         );
+        Ok(())
     };
 
     while completed < cli.games && !shutdown.load(Ordering::Relaxed) {
@@ -3138,11 +4773,12 @@ fn main() -> Result<()> {
                     Ok(result) => {
                         handle_result(
                             result,
+                            &mut completed_games,
                             &mut black_wins,
                             &mut white_wins,
                             &mut draws,
                             &mut completed,
-                        );
+                        )?;
                     }
                     Err(_) => break,
                 }
@@ -3151,17 +4787,19 @@ fn main() -> Result<()> {
                 chan::select! {
                     send(ticket_tx, Some(t.clone())) -> res => {
                         if res.is_ok() {
-                            next_game_idx += 1;
-                            next_ticket = (next_game_idx < cli.games).then(|| {
-                                make_ticket(next_game_idx, &mut rng, &mut shuffled_startpos)
-                            });
+                            next_ticket = next_incomplete_ticket(
+                                &mut next_game_idx,
+                                &mut rng,
+                                &mut shuffled_startpos,
+                                &completed_games,
+                            );
                         }
                     }
                     recv(result_rx) -> result => {
                         // Put the ticket back since we received a result instead of sending
                         next_ticket = Some(t);
                         if let Ok(result) = result {
-                            handle_result(result, &mut black_wins, &mut white_wins, &mut draws, &mut completed);
+                            handle_result(result, &mut completed_games, &mut black_wins, &mut white_wins, &mut draws, &mut completed)?;
                         }
                     }
                 }
@@ -3171,7 +4809,7 @@ fn main() -> Result<()> {
 
     // Signal workers to stop
     for _ in 0..cli.concurrency {
-        let _ = ticket_tx.send(None);
+        let _ = ticket_tx.try_send(None);
     }
     drop(ticket_tx); // チャネル閉鎖でワーカーの recv が終了する
 
@@ -3179,42 +4817,146 @@ fn main() -> Result<()> {
     // Ctrl-C 後もワーカーは進行中のゲームを完了させるため、
     // メインスレッドのカウンタがずれないようここで drain する。
     while let Ok(result) = result_rx.recv() {
-        handle_result(result, &mut black_wins, &mut white_wins, &mut draws, &mut completed);
+        handle_result(
+            result,
+            &mut completed_games,
+            &mut black_wins,
+            &mut white_wins,
+            &mut draws,
+            &mut completed,
+        )?;
     }
 
     // Join workers and collect training stats
     let mut training_stats = TrainingStats::default();
-    for h in handles {
-        if let Ok(output) = h.join() {
-            training_stats.merge(output.training_stats);
+    let mut worker_errors = Vec::new();
+    for (worker_id, handle) in handles.into_iter().enumerate() {
+        match handle.join() {
+            Ok(Ok(output)) => training_stats.merge(output.training_stats),
+            Ok(Err(error)) => worker_errors.push(format!("worker {worker_id}: {error:#}")),
+            Err(_) => worker_errors.push(format!("worker {worker_id}: thread panicked")),
         }
     }
 
-    // Concatenate temp files into final outputs
-    // resume時は既存ファイルに追記する
-    let append_mode = cli.resume;
-    concatenate_temp_files(&output_path, &temp_jsonl_paths, true)?;
+    if worker_errors.is_empty() && !all_games_completed {
+        for worker_id in 0..cli.concurrency {
+            validate_completed_worker_outputs(
+                &temp_jsonl_paths[worker_id],
+                &temp_pack_paths[worker_id],
+                game_id_sidecar_path.as_ref().map(|_| temp_game_id_paths[worker_id].as_path()),
+                cli.log_info.then(|| temp_info_paths[worker_id].as_path()),
+                cli.emit_eval_file.then(|| temp_eval_paths[worker_id].as_path()),
+                cli.emit_metrics.then(|| temp_metrics_paths[worker_id].as_path()),
+                training_format,
+                worker_id,
+                cli.games,
+            )?;
+        }
+    } else if !worker_errors.is_empty() {
+        for worker_id in 0..cli.concurrency {
+            recover_worker_checkpoint(
+                &temp_jsonl_paths[worker_id],
+                Some(temp_pack_paths[worker_id].as_path()),
+                game_id_sidecar_path.as_ref().map(|_| temp_game_id_paths[worker_id].as_path()),
+                cli.log_info.then(|| temp_info_paths[worker_id].as_path()),
+                cli.emit_eval_file.then(|| temp_eval_paths[worker_id].as_path()),
+                cli.emit_metrics.then(|| temp_metrics_paths[worker_id].as_path()),
+                training_format,
+                worker_id,
+                cli.games,
+            )?;
+        }
+    }
 
+    // worker checkpoint から全成果物を staging し、journal に固定してから置換する。
+    let append_mode = cli.resume;
+    let mut staged_outputs = Vec::new();
     if cli.log_info && !temp_info_paths.is_empty() {
-        concatenate_temp_files(&info_path, &temp_info_paths, append_mode)?;
+        let staged = stage_concatenated_file(
+            &info_path,
+            &temp_info_paths,
+            append_mode,
+            cli.resume,
+            finalized_output_for(prior_finalized_state.as_ref(), &info_path),
+        )?;
+        staged_outputs.push(staged);
     }
     if cli.emit_eval_file && !temp_eval_paths.is_empty() {
         let eval_path = default_eval_path(&output_path);
-        concatenate_temp_files(&eval_path, &temp_eval_paths, append_mode)?;
+        let staged = stage_concatenated_file(
+            &eval_path,
+            &temp_eval_paths,
+            append_mode,
+            cli.resume,
+            finalized_output_for(prior_finalized_state.as_ref(), &eval_path),
+        )?;
+        staged_outputs.push(staged);
     }
     if cli.emit_metrics && !temp_metrics_paths.is_empty() {
         let metrics_path = default_metrics_path(&output_path);
-        concatenate_temp_files(&metrics_path, &temp_metrics_paths, append_mode)?;
+        let staged = stage_concatenated_file(
+            &metrics_path,
+            &temp_metrics_paths,
+            append_mode,
+            cli.resume,
+            finalized_output_for(prior_finalized_state.as_ref(), &metrics_path),
+        )?;
+        staged_outputs.push(staged);
     }
-    if training_data_enabled && !temp_pack_paths.is_empty() {
-        let pack_path = training_data_path
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| default_training_data_path(&output_path, training_data_ext));
-        concatenate_temp_files(&pack_path, &temp_pack_paths, append_mode)?;
+    if !temp_pack_paths.is_empty() {
+        let staged = stage_concatenated_file(
+            &training_data_path,
+            &temp_pack_paths,
+            append_mode,
+            cli.resume,
+            finalized_output_for(prior_finalized_state.as_ref(), &training_data_path),
+        )?;
+        staged_outputs.push(staged);
     }
     if let Some(sidecar_path) = game_id_sidecar_path.as_deref() {
-        concatenate_temp_files(sidecar_path, &temp_game_id_paths, false)?;
+        let staged = stage_concatenated_file(
+            sidecar_path,
+            &temp_game_id_paths,
+            append_mode,
+            cli.resume,
+            finalized_output_for(prior_finalized_state.as_ref(), sidecar_path),
+        )?;
+        staged_outputs.push(staged);
+    }
+    let staged_jsonl = stage_concatenated_file(
+        &output_path,
+        &temp_jsonl_paths,
+        true,
+        cli.resume,
+        finalized_output_for(prior_finalized_state.as_ref(), &output_path),
+    )?;
+    staged_outputs.push(staged_jsonl);
+    let worker_temps = temp_jsonl_paths
+        .iter()
+        .chain(&temp_info_paths)
+        .chain(&temp_eval_paths)
+        .chain(&temp_metrics_paths)
+        .chain(&temp_pack_paths)
+        .chain(&temp_game_id_paths)
+        .cloned()
+        .collect();
+    let journal = FinalizationJournal {
+        schema: 1,
+        outputs: staged_outputs,
+        worker_temps,
+    };
+    if injected_fault("before_journal_write") {
+        bail!("injected failure before finalization journal write");
+    }
+    write_json_atomic(&finalization_journal_path(&output_path), &journal)?;
+    complete_finalization(&output_path, &journal, false)?;
+
+    if !worker_errors.is_empty() {
+        eprintln!("gensfen stopped because worker errors occurred:");
+        for error in &worker_errors {
+            eprintln!("  - {error}");
+        }
+        bail!("{} worker(s) failed; committed game data was preserved", worker_errors.len());
     }
 
     // 最終サマリー
@@ -3242,10 +4984,10 @@ fn main() -> Result<()> {
     println!();
 
     // 学習データサマリー出力
-    if training_data_enabled {
+    {
         println!();
         println!("--- Training Data ---");
-        println!("Total positions written: {}", training_stats.total_written);
+        println!("Positions written in this invocation: {}", training_stats.total_written);
         println!(
             "Skipped (initial ply 1-{}): {}",
             cli.skip_initial_ply, training_stats.skipped_initial
@@ -3271,10 +5013,7 @@ fn main() -> Result<()> {
                 training_stats.declaration_win_dedup_skipped_games
             );
         }
-        println!(
-            "Output: {}",
-            training_data_path.as_ref().map_or("-".to_string(), |p| p.display().to_string())
-        );
+        println!("Output: {}", training_data_path.display());
         if let Some(path) = game_id_sidecar_path.as_deref() {
             println!("Game ID sidecar: {}", path.display());
         }
@@ -3314,67 +5053,250 @@ fn default_training_data_path(jsonl: &Path, ext: &str) -> PathBuf {
     parent.join(format!("{stem}.{ext}"))
 }
 
-fn validate_game_id_sidecar_path(
-    sidecar: &Path,
+fn validate_fresh_output_paths(paths: &[PathBuf]) -> Result<()> {
+    for path in paths {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                let kind = if metadata.file_type().is_symlink() {
+                    "symbolic link"
+                } else if metadata.is_dir() {
+                    "directory"
+                } else if metadata.is_file() {
+                    "file"
+                } else {
+                    "filesystem entry"
+                };
+                bail!(
+                    "final output {} already exists as a {kind}; move it aside before starting a new run",
+                    path.display()
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to inspect final output {}", path.display()));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_output_entry_types(
     output_jsonl: &Path,
-    training_data: Option<&Path>,
+    final_paths: &[PathBuf],
+    training_data_ext: &str,
+    concurrency: usize,
+    log_info: bool,
+    emit_eval_file: bool,
+    emit_metrics: bool,
+    emit_sidecar: bool,
+    resume: bool,
+) -> Result<()> {
+    let journal = finalization_journal_path(output_jsonl);
+    let journal_tmp = atomic_temp_path(&journal);
+    let finalized = finalized_state_path(output_jsonl);
+    let finalized_tmp = atomic_temp_path(&finalized);
+    let journal_exists = std::fs::symlink_metadata(&journal).is_ok_and(|meta| meta.is_file());
+    for path in final_paths {
+        validate_existing_output_entry(path, resume, "final output")?;
+    }
+    for final_path in final_paths {
+        validate_existing_output_entry(
+            &merge_temp_path(final_path),
+            resume,
+            "merge temporary file",
+        )?;
+    }
+    for path in worker_checkpoint_paths(
+        output_jsonl,
+        training_data_ext,
+        concurrency,
+        log_info,
+        emit_eval_file,
+        emit_metrics,
+        emit_sidecar,
+    ) {
+        validate_existing_output_entry(&path, resume, "worker checkpoint")?;
+    }
+    validate_existing_output_entry(&journal, resume, "finalization journal")?;
+    validate_existing_output_entry(
+        &journal_tmp,
+        resume && !journal_exists,
+        "finalization journal temporary file",
+    )?;
+    validate_existing_output_entry(&finalized, resume, "finalized state")?;
+    validate_existing_output_entry(
+        &finalized_tmp,
+        resume && journal_exists,
+        "finalized state temporary file",
+    )?;
+    validate_existing_output_entry(
+        &output_jsonl.with_file_name(".gensfen.lock"),
+        true,
+        "run lock",
+    )?;
+    Ok(())
+}
+
+fn worker_checkpoint_paths(
+    output_jsonl: &Path,
+    training_data_ext: &str,
+    concurrency: usize,
+    log_info: bool,
+    emit_eval_file: bool,
+    emit_metrics: bool,
+    emit_sidecar: bool,
+) -> Vec<PathBuf> {
+    let parent = output_jsonl.parent().unwrap_or_else(|| Path::new("."));
+    let stem = output_jsonl.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
+    let mut paths = Vec::new();
+    for worker in 0..concurrency {
+        paths.push(parent.join(format!("{stem}.w{worker}.jsonl")));
+        paths.push(parent.join(format!("{stem}.w{worker}.{training_data_ext}")));
+        if emit_sidecar {
+            paths.push(parent.join(format!("{stem}.w{worker}.game_ids.bin")));
+        }
+        if log_info {
+            paths.push(parent.join(format!("{stem}.w{worker}.info.jsonl")));
+        }
+        if emit_eval_file {
+            paths.push(parent.join(format!("{stem}.w{worker}.eval.txt")));
+        }
+        if emit_metrics {
+            paths.push(parent.join(format!("{stem}.w{worker}.metrics.jsonl")));
+        }
+    }
+    paths
+}
+
+fn validate_existing_output_entry(path: &Path, allow_regular: bool, label: &str) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() && allow_regular => Ok(()),
+        Ok(metadata) => {
+            let kind = if metadata.file_type().is_symlink() {
+                "symbolic link"
+            } else if metadata.is_dir() {
+                "directory"
+            } else if metadata.is_file() {
+                "file"
+            } else {
+                "special filesystem entry"
+            };
+            bail!("{label} {} already exists as a {kind}", path.display())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to inspect {label} {}", path.display()))
+        }
+    }
+}
+
+fn validate_output_paths_unique(
+    output_jsonl: &Path,
+    training_data: &Path,
+    sidecar: Option<&Path>,
     training_data_ext: &str,
     concurrency: usize,
     log_info: bool,
     emit_eval_file: bool,
     emit_metrics: bool,
 ) -> Result<()> {
-    let normalized_sidecar = normalize_output_path(sidecar)?;
-    let mut final_paths = vec![output_jsonl.to_path_buf()];
-    final_paths.extend(training_data.map(Path::to_path_buf));
+    let mut paths = vec![("final JSONL".to_string(), output_jsonl.to_path_buf())];
+    paths.push(("final training data".to_string(), training_data.to_path_buf()));
     if log_info {
-        final_paths.push(output_jsonl.with_extension("info.jsonl"));
+        paths.push(("final info log".to_string(), output_jsonl.with_extension("info.jsonl")));
     }
     if emit_eval_file {
-        final_paths.push(default_eval_path(output_jsonl));
+        paths.push(("final eval file".to_string(), default_eval_path(output_jsonl)));
     }
     if emit_metrics {
-        final_paths.push(default_metrics_path(output_jsonl));
+        paths.push(("final metrics".to_string(), default_metrics_path(output_jsonl)));
     }
-    if final_paths
-        .iter()
-        .map(|path| normalize_output_path(path))
-        .collect::<Result<Vec<_>>>()?
-        .contains(&normalized_sidecar)
-    {
-        bail!(
-            "--emit-game-id-sidecar path conflicts with a final output path: {}",
-            sidecar.display()
-        );
+    if let Some(sidecar) = sidecar {
+        paths.push(("final game_id sidecar".to_string(), sidecar.to_path_buf()));
     }
 
     let parent = output_jsonl.parent().unwrap_or_else(|| Path::new("."));
     let stem = output_jsonl.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
     for worker in 0..concurrency {
-        let mut internal_paths = vec![
+        paths.push((
+            format!("worker {worker} JSONL"),
             parent.join(format!("{stem}.w{worker}.jsonl")),
+        ));
+        paths.push((
+            format!("worker {worker} training data"),
             parent.join(format!("{stem}.w{worker}.{training_data_ext}")),
-            parent.join(format!("{stem}.w{worker}.game_ids.bin")),
-        ];
+        ));
+        if sidecar.is_some() {
+            paths.push((
+                format!("worker {worker} game_id sidecar"),
+                parent.join(format!("{stem}.w{worker}.game_ids.bin")),
+            ));
+        }
         if log_info {
-            internal_paths.push(parent.join(format!("{stem}.w{worker}.info.jsonl")));
+            paths.push((
+                format!("worker {worker} info log"),
+                parent.join(format!("{stem}.w{worker}.info.jsonl")),
+            ));
         }
         if emit_eval_file {
-            internal_paths.push(parent.join(format!("{stem}.w{worker}.eval.txt")));
+            paths.push((
+                format!("worker {worker} eval file"),
+                parent.join(format!("{stem}.w{worker}.eval.txt")),
+            ));
         }
         if emit_metrics {
-            internal_paths.push(parent.join(format!("{stem}.w{worker}.metrics.jsonl")));
+            paths.push((
+                format!("worker {worker} metrics"),
+                parent.join(format!("{stem}.w{worker}.metrics.jsonl")),
+            ));
         }
-        if internal_paths
-            .iter()
-            .map(|path| normalize_output_path(path))
-            .collect::<Result<Vec<_>>>()?
-            .contains(&normalized_sidecar)
+    }
+
+    let final_paths: Vec<PathBuf> = paths
+        .iter()
+        .filter(|(label, _)| label.starts_with("final "))
+        .map(|(_, path)| path.clone())
+        .collect();
+    for (index, path) in final_paths.iter().enumerate() {
+        paths.push((format!("staging file {index}"), merge_temp_path(path)));
+    }
+    let journal = finalization_journal_path(output_jsonl);
+    let finalized = finalized_state_path(output_jsonl);
+    paths.extend([
+        ("finalization journal".to_string(), journal.clone()),
+        ("finalization journal temporary file".to_string(), atomic_temp_path(&journal)),
+        ("finalized state".to_string(), finalized.clone()),
+        ("finalized state temporary file".to_string(), atomic_temp_path(&finalized)),
+        ("run lock".to_string(), output_jsonl.with_file_name(".gensfen.lock")),
+    ]);
+
+    let mut normalized = std::collections::HashMap::<PathBuf, (String, PathBuf)>::new();
+    #[cfg(unix)]
+    let mut file_ids = std::collections::HashMap::<(u64, u64), (String, PathBuf)>::new();
+    for (label, path) in paths {
+        let identity = normalize_output_path(&path)?;
+        if let Some((other_label, other_path)) =
+            normalized.insert(identity, (label.clone(), path.clone()))
         {
             bail!(
-                "--emit-game-id-sidecar path conflicts with an internal worker path: {}",
-                sidecar.display()
+                "output path collision: {label} {} conflicts with {other_label} {}",
+                path.display(),
+                other_path.display()
             );
+        }
+        #[cfg(unix)]
+        if let Ok(metadata) = std::fs::metadata(&path) {
+            use std::os::unix::fs::MetadataExt;
+            if let Some((other_label, other_path)) =
+                file_ids.insert((metadata.dev(), metadata.ino()), (label.clone(), path.clone()))
+            {
+                bail!(
+                    "output file collision: {label} {} is the same file as {other_label} {}",
+                    path.display(),
+                    other_path.display()
+                );
+            }
         }
     }
     Ok(())
@@ -3383,7 +5305,15 @@ fn validate_game_id_sidecar_path(
 /// 未生成の出力ファイル同士を比較できるよう、存在する最深の祖先を canonicalize し、
 /// 残りの未生成コンポーネントを実体パスに対して正規化する。
 fn normalize_output_path(path: &Path) -> Result<PathBuf> {
+    normalize_output_path_inner(path, 0)
+}
+
+fn normalize_output_path_inner(path: &Path, symlink_depth: usize) -> Result<PathBuf> {
     use std::path::Component;
+
+    if symlink_depth > 40 {
+        bail!("too many symlinks while normalizing output path {}", path.display());
+    }
 
     let absolute = if path.is_absolute() {
         path.to_path_buf()
@@ -3395,8 +5325,19 @@ fn normalize_output_path(path: &Path) -> Result<PathBuf> {
     let mut ancestor_len = components.len();
     let ancestor = loop {
         let candidate: PathBuf = components[..ancestor_len].iter().collect();
-        if candidate.try_exists()? {
-            break candidate.canonicalize()?;
+        match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let target = std::fs::read_link(&candidate)?;
+                let target = if target.is_absolute() {
+                    target
+                } else {
+                    candidate.parent().unwrap_or_else(|| Path::new(".")).join(target)
+                };
+                break normalize_output_path_inner(&target, symlink_depth + 1)?;
+            }
+            Ok(_) => break candidate.canonicalize()?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
         }
         ancestor_len -= 1;
     };
@@ -3418,6 +5359,34 @@ fn normalize_output_path(path: &Path) -> Result<PathBuf> {
 
 fn native_progress_file_required(layer_stack_num_buckets: Option<usize>) -> bool {
     layer_stack_num_buckets.is_some_and(|n| n > 1)
+}
+
+fn initialize_native_backend(
+    eval_path: &Path,
+    eval_bytes: &[u8],
+    progress: Option<(&Path, &[u8])>,
+) -> Result<Option<usize>> {
+    init_nnue_from_bytes(eval_bytes).map_err(|e| anyhow!("NNUE init failed: {e}"))?;
+    eprintln!("NativeBackend: NNUE loaded from {}", eval_path.display());
+    let layer_stack_buckets =
+        get_network().as_deref().and_then(|network| network.layer_stack_num_buckets());
+    if native_progress_file_required(layer_stack_buckets) && progress.is_none() {
+        bail!(
+            "--native LayerStacks NNUE with num_buckets={} requires --progress-file",
+            layer_stack_buckets.unwrap_or_default()
+        );
+    }
+    if let Some((path, bytes)) = progress {
+        let weights = load_progress_coeff_kpabs_from_bytes(bytes)
+            .map_err(|e| anyhow!("failed to load --progress-file {}: {e}", path.display()))?;
+        set_layer_stack_progress_kpabs_weights(weights)
+            .map_err(|e| anyhow!("failed to set --progress-file weights: {e}"))?;
+        eprintln!("NativeBackend: progress file loaded from {}", path.display());
+    }
+    if let Some(num_buckets) = layer_stack_buckets {
+        eprintln!("NativeBackend: LayerStacks num_buckets={num_buckets}");
+    }
+    Ok(layer_stack_buckets)
 }
 
 fn resolve_engine_paths(cli: &Cli) -> ResolvedEnginePaths {
@@ -4170,17 +6139,328 @@ mod tests {
         )
         .expect("write resume jsonl");
 
-        let state = parse_resume_state(&path).expect("parse resume state");
-        assert_eq!(state.completed_games, 3);
+        let state = parse_resume_state(&path, 10).expect("parse resume state");
+        assert_eq!(state.completed_games.len(), 1);
+        assert!(state.completed_games.contains(3));
         assert_eq!(state.shuffle_seed, Some(7));
         assert_eq!(state.progress_file.as_deref(), Some("/tmp/progress.bin"));
         assert_eq!(state.progress_file_sha256.as_deref(), Some("abcd"));
     }
 
     #[test]
+    fn resume_completed_games_preserves_gaps() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gaps.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"type":"meta","settings":{}}"#,
+                "\n",
+                r#"{"type":"result","game_id":1,"outcome":"draw"}"#,
+                "\n",
+                r#"{"type":"result","game_id":3,"outcome":"draw"}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        let state = parse_resume_state(&path, 10).unwrap();
+        assert!(state.completed_games.contains(1));
+        assert!(!state.completed_games.contains(2));
+        assert!(state.completed_games.contains(3));
+        assert_eq!(state.completed_games.len(), 2);
+    }
+
+    #[test]
+    fn final_resume_rejects_invalid_outcome_before_completing_game() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalid-outcome.jsonl");
+        std::fs::write(
+            &path,
+            "{\"type\":\"meta\",\"settings\":{}}\n{\"type\":\"result\",\"game_id\":1,\"outcome\":\"unknown\"}\n",
+        )
+        .unwrap();
+        assert!(parse_resume_state(&path, 1).unwrap_err().to_string().contains("outcome"));
+    }
+
+    #[test]
+    fn final_resume_rejects_out_of_range_game_id_before_bitset_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge-id.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                "{{\"type\":\"meta\",\"settings\":{{}}}}\n{{\"type\":\"result\",\"game_id\":{},\"outcome\":\"draw\"}}\n",
+                u32::MAX
+            ),
+        )
+        .unwrap();
+        let error = parse_resume_state(&path, 10).unwrap_err().to_string();
+        assert!(error.contains("outside 1..=10"));
+    }
+
+    #[test]
+    fn resume_gap_keeps_start_position_bound_to_original_game_id() {
+        let expected: Vec<usize> = {
+            let mut shuffled = ShuffledStartpos::new(8, 99);
+            (0..4).map(|_| shuffled.next()).collect()
+        };
+        let mut completed = CompletedGames::default();
+        completed.insert(1);
+        completed.insert(3);
+        let mut resumed = ShuffledStartpos::new(8, 99);
+        let missing: Vec<(u32, usize)> = (1..=4)
+            .filter_map(|game_id| {
+                let startpos = resumed.next();
+                (!completed.contains(game_id)).then_some((game_id, startpos))
+            })
+            .collect();
+        assert_eq!(missing, vec![(2, expected[1]), (4, expected[3])]);
+    }
+
+    #[test]
+    fn worker_checkpoint_truncates_uncommitted_psv_sidecar_and_json_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        let sidecar = dir.path().join("gensfen.w0.game_ids.bin");
+        let committed = serde_json::json!({
+            "type": "result",
+            "worker_id": 0,
+            "game_id": 2,
+            "outcome": "draw",
+            "training_bytes": 40,
+            "sidecar_bytes": 4,
+            "fsync_boundary": true,
+        });
+        std::fs::write(&jsonl, format!("{committed}\n{{\"type\":\"res")).unwrap();
+        std::fs::write(&psv, vec![0u8; 47]).unwrap();
+        std::fs::write(&sidecar, vec![0u8; 7]).unwrap();
+
+        let state = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            Some(&sidecar),
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            10,
+        )
+        .unwrap();
+        assert!(state.completed_games.contains(2));
+        assert_eq!(std::fs::metadata(psv).unwrap().len(), 40);
+        assert_eq!(std::fs::metadata(sidecar).unwrap().len(), 4);
+        assert!(std::fs::read_to_string(jsonl).unwrap().ends_with('\n'));
+    }
+
+    #[test]
+    fn worker_checkpoint_without_commit_discards_only_uncommitted_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        std::fs::write(&jsonl, b"").unwrap();
+        std::fs::write(&psv, vec![0u8; 40]).unwrap();
+        let state = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            None,
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            10,
+        )
+        .unwrap();
+        assert_eq!(state.completed_games.len(), 0);
+        assert_eq!(std::fs::metadata(psv).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn worker_checkpoint_discards_results_ahead_of_durable_teacher_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        let sidecar = dir.path().join("gensfen.w0.game_ids.bin");
+        let first = "{\"type\":\"result\",\"worker_id\":0,\"game_id\":1,\"outcome\":\"draw\",\"training_bytes\":40,\"sidecar_bytes\":4,\"fsync_boundary\":true}\n";
+        let second = "{\"type\":\"result\",\"worker_id\":0,\"game_id\":2,\"outcome\":\"black_win\",\"training_bytes\":80,\"sidecar_bytes\":8,\"fsync_boundary\":true}\n";
+        std::fs::write(&jsonl, format!("{first}{second}")).unwrap();
+        std::fs::write(&psv, vec![0u8; PackedSfenValue::SIZE]).unwrap();
+        std::fs::write(&sidecar, vec![0u8; 8]).unwrap();
+
+        let state = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            Some(&sidecar),
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            2,
+        )
+        .unwrap();
+
+        assert!(state.completed_games.contains(1));
+        assert!(!state.completed_games.contains(2));
+        assert_eq!(state.draws, 1);
+        assert_eq!(state.black_wins, 0);
+        assert_eq!(std::fs::read_to_string(jsonl).unwrap(), first);
+        assert_eq!(std::fs::metadata(psv).unwrap().len(), PackedSfenValue::SIZE as u64);
+        assert_eq!(std::fs::metadata(sidecar).unwrap().len(), 4);
+    }
+
+    #[test]
+    fn worker_checkpoint_rejects_invalid_result_record_boundary_before_truncating() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        let row = "{\"type\":\"result\",\"worker_id\":0,\"game_id\":1,\"outcome\":\"draw\",\"training_bytes\":41,\"fsync_boundary\":true}\n";
+        std::fs::write(&jsonl, row).unwrap();
+        std::fs::write(&psv, vec![0u8; PackedSfenValue::SIZE]).unwrap();
+
+        let error = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            None,
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("record boundary"));
+        assert_eq!(std::fs::read_to_string(jsonl).unwrap(), row);
+        assert_eq!(std::fs::metadata(psv).unwrap().len(), PackedSfenValue::SIZE as u64);
+    }
+
+    #[test]
+    fn legacy_worker_checkpoint_fails_closed_without_truncating() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        std::fs::write(
+            &jsonl,
+            b"{\"type\":\"result\",\"worker_id\":0,\"game_id\":1,\"outcome\":\"draw\"}\n",
+        )
+        .unwrap();
+        std::fs::write(&psv, vec![0u8; 40]).unwrap();
+        let error = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            None,
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            10,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("move temp files aside"));
+        assert_eq!(std::fs::metadata(psv).unwrap().len(), 40);
+    }
+
+    #[test]
+    fn worker_checkpoint_validates_all_offsets_before_truncating() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("gensfen.w0.jsonl");
+        let psv = dir.path().join("gensfen.w0.psv");
+        let rows = concat!(
+            "{\"type\":\"result\",\"worker_id\":0,\"game_id\":1,\"outcome\":\"draw\",\"training_bytes\":80,\"fsync_boundary\":true}\n",
+            "{\"type\":\"result\",\"worker_id\":0,\"game_id\":2,\"outcome\":\"draw\",\"training_bytes\":40,\"fsync_boundary\":true}\n"
+        );
+        std::fs::write(&jsonl, rows).unwrap();
+        std::fs::write(&psv, vec![0u8; 120]).unwrap();
+        let error = recover_worker_checkpoint(
+            &jsonl,
+            Some(&psv),
+            None,
+            None,
+            None,
+            None,
+            TrainingFormat::Psv,
+            0,
+            2,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("non-monotonic training_bytes"));
+        assert_eq!(std::fs::metadata(&psv).unwrap().len(), 120);
+    }
+
+    #[test]
+    fn path_valued_usi_option_hashes_file_and_directory_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let eval_file = dir.path().join("eval.bin");
+        let eval_dir = dir.path().join("eval-dir");
+        std::fs::create_dir(&eval_dir).unwrap();
+        std::fs::write(&eval_file, b"first").unwrap();
+        std::fs::write(eval_dir.join("model.bin"), b"model-a").unwrap();
+        let options = vec![
+            format!("EvalFile={}", eval_file.display()),
+            format!("EvalDir={}", eval_dir.display()),
+            "Hash=16".to_string(),
+        ];
+        let first = usi_option_path_fingerprints(&options).unwrap();
+        assert_eq!(first.len(), 2);
+        std::fs::write(&eval_file, b"second").unwrap();
+        std::fs::write(eval_dir.join("model.bin"), b"model-b").unwrap();
+        let second = usi_option_path_fingerprints(&options).unwrap();
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn fingerprint_reports_each_changed_field() {
+        let meta = serde_json::json!({"search": {"nodes": 10}, "training": {"format": "psv"}});
+        let current = serde_json::json!({"search": {"nodes": 20}, "training": {"format": "pack"}});
+        let error = validate_resume_fingerprint(Some(&meta), &current).unwrap_err().to_string();
+        assert!(error.contains("search.nodes"));
+        assert!(error.contains("training.format"));
+    }
+
+    #[test]
+    fn failed_training_commit_does_not_write_result() {
+        let result = ResultLog {
+            kind: "result",
+            worker_id: 0,
+            game_id: 1,
+            start_pos_index: 1,
+            start_sfen: "startpos",
+            outcome: "draw",
+            reason: OutcomeReason::MaxMoves,
+            adopted: true,
+            plies: 0,
+            final_points_black: 0,
+            final_points_white: 0,
+            king_in_enemy_black: false,
+            king_in_enemy_white: false,
+            enemy_zone_pieces_black: 0,
+            enemy_zone_pieces_white: 0,
+            diversions: &[],
+            training_bytes: 0,
+            sidecar_bytes: None,
+            info_bytes: None,
+            eval_bytes: None,
+            metrics_bytes: None,
+            fsync_boundary: false,
+        };
+        let mut jsonl = Vec::new();
+        assert!(write_committed_result(&mut jsonl, result, false, || bail!("disk full")).is_err());
+        assert!(jsonl.is_empty());
+    }
+
+    #[test]
     fn result_log_serializes_empty_diversions() {
         let result = ResultLog {
             kind: "result",
+            worker_id: 0,
             game_id: 1,
             start_pos_index: 1,
             start_sfen: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p7/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 1",
@@ -4195,6 +6475,12 @@ mod tests {
             enemy_zone_pieces_black: 0,
             enemy_zone_pieces_white: 0,
             diversions: &[],
+            training_bytes: 0,
+            sidecar_bytes: None,
+            info_bytes: None,
+            eval_bytes: None,
+            metrics_bytes: None,
+            fsync_boundary: false,
         };
         let value = serde_json::to_value(result).unwrap();
         assert_eq!(value["diversions"], serde_json::json!([]));
@@ -4347,10 +6633,10 @@ mod tests {
             "run/./gensfen.psv",
             "run/nested/../gensfen.psv",
         ] {
-            let error = validate_game_id_sidecar_path(
-                Path::new(collision),
+            let error = validate_output_paths_unique(
                 output,
-                Some(training),
+                training,
+                Some(Path::new(collision)),
                 "psv",
                 2,
                 true,
@@ -4358,12 +6644,12 @@ mod tests {
                 true,
             )
             .unwrap_err();
-            assert!(error.to_string().contains("conflicts"), "{error:#}");
+            assert!(error.to_string().contains("collision"), "{error:#}");
         }
-        validate_game_id_sidecar_path(
-            Path::new("run/ids.bin"),
+        validate_output_paths_unique(
             output,
-            Some(training),
+            training,
+            Some(Path::new("run/ids.bin")),
             "psv",
             2,
             true,
@@ -5058,5 +7344,57 @@ mod tests {
         // 破棄により書き出されるのは欠落後の 1 手だけで、起点 HCP は局面C（取り直し局面）
         assert_eq!(u16::from_le_bytes([bytes[32], bytes[33]]), 1);
         assert_eq!(&bytes[0..32], &expected_hcp);
+    }
+
+    #[test]
+    fn run_dir_lock_rejects_second_owner_and_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("gensfen.jsonl");
+        let lock = RunDirLock::acquire(&output, false).unwrap();
+        let error = RunDirLock::acquire(&output, false).unwrap_err().to_string();
+        assert!(error.contains("out-dir is locked"));
+        assert!(error.contains(&std::process::id().to_string()));
+        drop(lock);
+        assert!(!dir.path().join(".gensfen.lock").exists());
+    }
+
+    #[test]
+    fn run_dir_lock_force_unlock_replaces_stale_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("gensfen.jsonl");
+        std::fs::write(dir.path().join(".gensfen.lock"), b"{\"pid\":999999}\n").unwrap();
+        let _lock = RunDirLock::acquire(&output, true).unwrap();
+        let body = std::fs::read_to_string(dir.path().join(".gensfen.lock")).unwrap();
+        assert!(body.contains(&std::process::id().to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worker_checkpoint_open_after_type_check_does_not_follow_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let checkpoint = dir.path().join("checkpoint");
+        std::fs::write(&target, b"preserve").unwrap();
+        symlink(&target, &checkpoint).unwrap();
+
+        assert!(open_worker_checkpoint_after_type_check(&checkpoint, true).is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"preserve");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worker_checkpoint_truncate_does_not_follow_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let checkpoint = dir.path().join("checkpoint");
+        std::fs::write(&target, b"preserve").unwrap();
+        symlink(&target, &checkpoint).unwrap();
+
+        assert!(truncate_file(&checkpoint, 0).is_err());
+        assert_eq!(std::fs::read(&target).unwrap(), b"preserve");
     }
 }

--- a/crates/tools/tests/gensfen_resume_integration.rs
+++ b/crates/tools/tests/gensfen_resume_integration.rs
@@ -1,0 +1,921 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_gensfen");
+
+fn write_engine(dir: &Path, crash_on_go: bool) -> PathBuf {
+    let path = dir.join("mock-engine.sh");
+    let go_action = if crash_on_go {
+        "exit 42"
+    } else {
+        "sleep 0.05; printf 'info score cp 0 nodes 1\\nbestmove 7g7f\\n'"
+    };
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nif [ -n \"$GENSFEN_ENGINE_MARKER\" ]; then : > \"$GENSFEN_ENGINE_MARKER\"; fi\nwhile IFS= read -r line; do\n  case \"$line\" in\n    usi) printf 'id name resume-test\\nusiok\\n' ;;\n    isready) printf 'readyok\\n' ;;\n    go*) {go_action} ;;\n    quit) break ;;\n  esac\ndone\nif [ -n \"$GENSFEN_REMOVE_ON_EXIT\" ]; then rm -f -- \"$GENSFEN_REMOVE_ON_EXIT\"; fi\n"
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+fn base_command(engine: &Path, out_dir: &Path) -> Command {
+    command_with_concurrency(engine, out_dir, 2)
+}
+
+fn command_with_concurrency(engine: &Path, out_dir: &Path, concurrency: usize) -> Command {
+    let mut command = Command::new(BIN);
+    command.args([
+        "--native=false",
+        "--engine-path",
+        engine.to_str().unwrap(),
+        "--out-dir",
+        out_dir.to_str().unwrap(),
+        "--games",
+        "4",
+        "--nodes",
+        "1",
+        "--max-moves",
+        "1",
+        "--concurrency",
+        &concurrency.to_string(),
+        "--dedup-hash-size",
+        "0",
+        "--shuffle-seed",
+        "42",
+        "--emit-game-id-sidecar",
+        out_dir.join("gensfen.game_ids.bin").to_str().unwrap(),
+        "--log-info",
+        "--emit-eval-file",
+        "--emit-metrics",
+    ]);
+    command
+}
+
+fn wait_for_nonempty_checkpoint(child: &mut Child, out_dir: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        for worker in 0..2 {
+            let path = out_dir.join(format!("gensfen.w{worker}.jsonl"));
+            if fs::metadata(path).is_ok_and(|meta| meta.len() > 0) {
+                return;
+            }
+        }
+        assert!(child.try_wait().unwrap().is_none(), "gensfen exited before checkpoint creation");
+        assert!(Instant::now() < deadline, "timed out waiting for worker checkpoint");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_result_count(child: &mut Child, out_dir: &Path, count: usize) {
+    let checkpoint = out_dir.join("gensfen.w0.jsonl");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if checkpoint.exists() && result_ids(&checkpoint).len() >= count {
+            return;
+        }
+        assert!(child.try_wait().unwrap().is_none(), "gensfen exited before result checkpoint");
+        assert!(Instant::now() < deadline, "timed out waiting for result checkpoint");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn result_ids(path: &Path) -> Vec<u32> {
+    let mut ids: Vec<u32> = fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .filter_map(|line| {
+            let value: serde_json::Value = serde_json::from_str(line).unwrap();
+            (value["type"] == "result").then(|| value["game_id"].as_u64().unwrap() as u32)
+        })
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+fn result_values(path: &Path) -> Vec<serde_json::Value> {
+    let mut values: Vec<_> = fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .filter(|value| value["type"] == "result")
+        .collect();
+    values.sort_by_key(|value| value["game_id"].as_u64().unwrap());
+    values
+}
+
+fn sidecar_ids(path: &Path) -> Vec<u32> {
+    let bytes = fs::read(path).unwrap();
+    assert_eq!(bytes.len() % 4, 0);
+    let mut ids: Vec<u32> = bytes
+        .chunks_exact(4)
+        .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+fn assert_exact_outputs(out_dir: &Path) {
+    assert_eq!(result_ids(&out_dir.join("gensfen.jsonl")), vec![1, 2, 3, 4]);
+    assert_eq!(fs::metadata(out_dir.join("gensfen.psv")).unwrap().len(), 4 * 40);
+    assert_eq!(sidecar_ids(&out_dir.join("gensfen.game_ids.bin")), vec![1, 2, 3, 4]);
+    for (path, expected_lines) in [
+        ("gensfen.info.jsonl", 4),
+        ("gensfen.eval.txt", 12),
+        ("gensfen.metrics.jsonl", 4),
+    ] {
+        assert_eq!(
+            fs::read_to_string(out_dir.join(path)).unwrap().lines().count(),
+            expected_lines,
+            "unexpected line count in {path}"
+        );
+    }
+}
+
+#[test]
+fn hard_kill_resume_preserves_worker_checkpoints_and_completes_missing_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("run");
+    let engine = write_engine(dir.path(), false);
+    let mut child = base_command(&engine, &out_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_nonempty_checkpoint(&mut child, &out_dir);
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    let checkpoint_bytes: u64 = (0..2)
+        .map(|worker| out_dir.join(format!("gensfen.w{worker}.psv")))
+        .filter_map(|path| fs::metadata(path).ok().map(|meta| meta.len()))
+        .sum();
+    assert!(checkpoint_bytes > 0);
+
+    let status = base_command(&engine, &out_dir)
+        .args(["--resume", "--force-unlock"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert_exact_outputs(&out_dir);
+    for worker in 0..2 {
+        assert!(!out_dir.join(format!("gensfen.w{worker}.jsonl")).exists());
+        assert!(!out_dir.join(format!("gensfen.w{worker}.psv")).exists());
+    }
+}
+
+#[test]
+fn resume_rejects_each_missing_referenced_worker_output_without_truncating_psv() {
+    for missing_suffix in [
+        "psv",
+        "game_ids.bin",
+        "info.jsonl",
+        "eval.txt",
+        "metrics.jsonl",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(format!("missing-{missing_suffix}"));
+        let engine = write_engine(dir.path(), false);
+        let mut child = command_with_concurrency(&engine, &out_dir, 1)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        wait_for_result_count(&mut child, &out_dir, 1);
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        let psv = out_dir.join("gensfen.w0.psv");
+        let psv_before = fs::read(&psv).unwrap();
+        fs::remove_file(out_dir.join(format!("gensfen.w0.{missing_suffix}"))).unwrap();
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .args(["--resume", "--force-unlock"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "missing {missing_suffix} was accepted");
+        if missing_suffix != "psv" {
+            assert_eq!(
+                fs::read(&psv).unwrap(),
+                psv_before,
+                "PSV was modified for {missing_suffix}"
+            );
+        }
+    }
+}
+
+#[test]
+fn successful_worker_exit_rejects_each_missing_output_before_staging() {
+    for suffix in [
+        "jsonl",
+        "psv",
+        "game_ids.bin",
+        "info.jsonl",
+        "eval.txt",
+        "metrics.jsonl",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(format!("missing-after-success-{suffix}"));
+        let engine = write_engine(dir.path(), false);
+        let missing = out_dir.join(format!("gensfen.w0.{suffix}"));
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .env("GENSFEN_REMOVE_ON_EXIT", &missing)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "missing {suffix} was accepted");
+        assert!(!out_dir.join(".gensfen.finalization.json").exists());
+        assert!(!out_dir.join("gensfen.finalized.json").exists());
+    }
+}
+
+#[test]
+fn output_training_data_rejects_staging_and_worker_path_collisions_before_creation() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = write_engine(dir.path(), false);
+    for relative in [".gensfen.jsonl.merge.tmp", "gensfen.w0.psv"] {
+        let out_dir = dir.path().join(relative.replace('.', "_"));
+        let training = out_dir.join(relative);
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .args(["--output-training-data", training.to_str().unwrap()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "collision {relative} was accepted");
+        assert!(!out_dir.exists(), "collision validation created output directory");
+    }
+}
+
+#[test]
+fn output_collision_detection_resolves_symlinks() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("symlink-collision");
+    fs::create_dir(&out_dir).unwrap();
+    let worker_path = out_dir.join("gensfen.w0.psv");
+    fs::write(&worker_path, b"preserve").unwrap();
+    let training_alias = out_dir.join("training-alias.psv");
+    symlink(&worker_path, &training_alias).unwrap();
+    let engine = write_engine(dir.path(), false);
+
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .args(["--output-training-data", training_alias.to_str().unwrap()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert_eq!(fs::read(&worker_path).unwrap(), b"preserve");
+    assert!(!out_dir.join(".gensfen.lock").exists());
+}
+
+#[test]
+fn resume_rolls_back_to_last_fsync_interval_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("fsync-boundary");
+    let engine = write_engine(dir.path(), false);
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .args(["--fsync-interval-games", "2"])
+        .env("RSHOGI_GENSFEN_FAULT", "before_result:4")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert_eq!(result_ids(&out_dir.join("gensfen.jsonl")), vec![1, 2]);
+    assert_eq!(fs::metadata(out_dir.join("gensfen.psv")).unwrap().len(), 2 * 40);
+
+    assert!(
+        command_with_concurrency(&engine, &out_dir, 1)
+            .args(["--resume", "--fsync-interval-games", "2"])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_exact_outputs(&out_dir);
+    for relative in [
+        "gensfen.w0.jsonl",
+        "gensfen.w0.psv",
+        "gensfen.w0.game_ids.bin",
+        "gensfen.w0.info.jsonl",
+        "gensfen.w0.eval.txt",
+        "gensfen.w0.metrics.jsonl",
+        ".gensfen.finalization.json",
+        ".gensfen.finalization.json.tmp",
+        ".gensfen.lock",
+    ] {
+        assert!(!out_dir.join(relative).exists(), "{relative} remains after resume");
+    }
+}
+
+#[test]
+fn worker_crash_returns_nonzero_exit_status() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("run");
+    let engine = write_engine(dir.path(), true);
+    let status: ExitStatus = base_command(&engine, &out_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+}
+
+#[test]
+fn non_resume_rejects_existing_training_output_and_merge_temp() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = write_engine(dir.path(), false);
+
+    let training_dir = dir.path().join("existing-training");
+    fs::create_dir(&training_dir).unwrap();
+    let training_path = training_dir.join("gensfen.psv");
+    fs::write(&training_path, b"keep").unwrap();
+    assert!(!base_command(&engine, &training_dir).status().unwrap().success());
+    assert_eq!(fs::read(&training_path).unwrap(), b"keep");
+
+    let merge_dir = dir.path().join("existing-merge");
+    fs::create_dir(&merge_dir).unwrap();
+    let merge_path = merge_dir.join(".gensfen.jsonl.merge.tmp");
+    fs::write(&merge_path, b"incomplete").unwrap();
+    assert!(!base_command(&engine, &merge_dir).status().unwrap().success());
+    assert_eq!(fs::read(&merge_path).unwrap(), b"incomplete");
+}
+
+#[test]
+fn non_resume_rejects_dangling_worker_temp_with_actionable_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("dangling-worker-temp");
+    fs::create_dir(&out_dir).unwrap();
+    let worker_temp = out_dir.join("gensfen.w99.psv");
+    symlink(dir.path().join("missing-worker-temp"), &worker_temp).unwrap();
+    let engine = write_engine(dir.path(), false);
+    let engine_marker = dir.path().join("engine-started");
+
+    let output = command_with_concurrency(&engine, &out_dir, 1)
+        .env("GENSFEN_ENGINE_MARKER", &engine_marker)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("already exists and is non-empty; use --resume or move it aside")
+    );
+    assert!(!engine_marker.exists());
+    assert!(fs::symlink_metadata(&worker_temp).unwrap().file_type().is_symlink());
+}
+
+fn internal_paths() -> [&'static str; 17] {
+    [
+        "gensfen.w0.jsonl",
+        "gensfen.w0.psv",
+        "gensfen.w0.game_ids.bin",
+        "gensfen.w0.info.jsonl",
+        "gensfen.w0.eval.txt",
+        "gensfen.w0.metrics.jsonl",
+        ".gensfen.jsonl.merge.tmp",
+        ".gensfen.psv.merge.tmp",
+        ".gensfen.game_ids.bin.merge.tmp",
+        ".gensfen.info.jsonl.merge.tmp",
+        ".gensfen.eval.txt.merge.tmp",
+        ".gensfen.metrics.jsonl.merge.tmp",
+        ".gensfen.finalization.json",
+        ".gensfen.finalization.json.tmp",
+        "gensfen.finalized.json",
+        "gensfen.finalized.json.tmp",
+        ".gensfen.lock",
+    ]
+}
+
+#[test]
+fn every_internal_path_rejects_symlink_without_touching_target() {
+    for relative in internal_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("run");
+        fs::create_dir(&out_dir).unwrap();
+        let victim = dir.path().join("victim");
+        fs::write(&victim, b"preserve").unwrap();
+        symlink(&victim, out_dir.join(relative)).unwrap();
+        let engine = write_engine(dir.path(), false);
+        let engine_marker = dir.path().join("engine-started");
+
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .env("GENSFEN_ENGINE_MARKER", &engine_marker)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+
+        assert!(!status.success(), "accepted symlink at {relative}");
+        assert_eq!(fs::read(&victim).unwrap(), b"preserve", "modified target of {relative}");
+        assert!(!engine_marker.exists(), "started engine before rejecting {relative}");
+        assert!(fs::symlink_metadata(out_dir.join(relative)).unwrap().file_type().is_symlink());
+    }
+}
+
+#[test]
+fn every_internal_path_detects_dangling_symlink() {
+    for relative in internal_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("run");
+        fs::create_dir(&out_dir).unwrap();
+        let internal = out_dir.join(relative);
+        let missing_target = dir.path().join("missing-target");
+        symlink(&missing_target, &internal).unwrap();
+        let engine = write_engine(dir.path(), false);
+
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+
+        assert!(!status.success(), "accepted dangling symlink at {relative}");
+        assert!(fs::symlink_metadata(&internal).unwrap().file_type().is_symlink());
+        assert!(!missing_target.exists(), "created target of dangling symlink at {relative}");
+    }
+}
+
+#[test]
+fn resume_rejects_dangling_worker_jsonl_without_creating_its_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("run");
+    let engine = write_engine(dir.path(), false);
+    let mut child = command_with_concurrency(&engine, &out_dir, 1)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_nonempty_checkpoint(&mut child, &out_dir);
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    let worker_jsonl = out_dir.join("gensfen.w0.jsonl");
+    fs::remove_file(&worker_jsonl).unwrap();
+    let missing_target = dir.path().join("missing-worker-jsonl");
+    symlink(&missing_target, &worker_jsonl).unwrap();
+
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .args(["--resume", "--force-unlock"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert!(!missing_target.exists());
+    assert!(fs::symlink_metadata(&worker_jsonl).unwrap().file_type().is_symlink());
+}
+
+#[test]
+fn every_internal_path_rejects_directories_and_special_files() {
+    for relative in internal_paths() {
+        for kind in ["directory", "special file"] {
+            let dir = tempfile::tempdir().unwrap();
+            let out_dir = dir.path().join("run");
+            fs::create_dir(&out_dir).unwrap();
+            let internal = out_dir.join(relative);
+            if kind == "directory" {
+                fs::create_dir(&internal).unwrap();
+            } else {
+                rustix::fs::mkfifoat(
+                    rustix::fs::CWD,
+                    &internal,
+                    rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR,
+                )
+                .unwrap();
+            }
+            let engine = write_engine(dir.path(), false);
+
+            let status = command_with_concurrency(&engine, &out_dir, 1)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap();
+
+            assert!(!status.success(), "accepted {kind} at {relative}");
+            assert!(fs::symlink_metadata(&internal).is_ok(), "removed {kind} at {relative}");
+        }
+    }
+}
+
+#[test]
+fn non_resume_rejects_every_existing_final_path_before_side_effects() {
+    for relative in [
+        "gensfen.jsonl",
+        "gensfen.psv",
+        "gensfen.game_ids.bin",
+        "gensfen.info.jsonl",
+        "gensfen.eval.txt",
+        "gensfen.metrics.jsonl",
+    ] {
+        for existing_kind in ["file", "directory", "symlink"] {
+            let dir = tempfile::tempdir().unwrap();
+            let out_dir = dir.path().join("run");
+            fs::create_dir(&out_dir).unwrap();
+            let existing = out_dir.join(relative);
+            if existing_kind == "file" {
+                fs::write(&existing, b"preserve").unwrap();
+            } else if existing_kind == "directory" {
+                fs::create_dir(&existing).unwrap();
+            } else {
+                symlink(out_dir.join("missing-target"), &existing).unwrap();
+            }
+            let engine = write_engine(dir.path(), false);
+            let status = command_with_concurrency(&engine, &out_dir, 1)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap();
+            assert!(!status.success(), "accepted existing {existing_kind} at {relative}");
+            if existing_kind == "file" {
+                assert_eq!(fs::read(&existing).unwrap(), b"preserve");
+            } else if existing_kind == "directory" {
+                assert!(existing.is_dir());
+            } else {
+                assert!(fs::symlink_metadata(&existing).unwrap().file_type().is_symlink());
+            }
+            assert!(!out_dir.join(".gensfen.lock").exists());
+            assert!(!out_dir.join("gensfen.finalized.json").exists());
+        }
+    }
+}
+
+#[test]
+fn uncommitted_worker_tails_are_not_finalized() {
+    for fault in ["before_result", "result_partial", "sidecar_partial"] {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(fault);
+        let engine = write_engine(dir.path(), false);
+        let status = base_command(&engine, &out_dir)
+            .env("RSHOGI_GENSFEN_FAULT", fault)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "fault {fault} unexpectedly succeeded");
+        assert!(result_ids(&out_dir.join("gensfen.jsonl")).is_empty());
+        assert_eq!(fs::metadata(out_dir.join("gensfen.psv")).unwrap().len(), 0);
+        assert_eq!(fs::metadata(out_dir.join("gensfen.game_ids.bin")).unwrap().len(), 0);
+        assert_eq!(fs::metadata(out_dir.join("gensfen.info.jsonl")).unwrap().len(), 0);
+        assert_eq!(fs::metadata(out_dir.join("gensfen.eval.txt")).unwrap().len(), 0);
+        assert_eq!(fs::metadata(out_dir.join("gensfen.metrics.jsonl")).unwrap().len(), 0);
+
+        assert!(base_command(&engine, &out_dir).arg("--resume").status().unwrap().success());
+        assert_exact_outputs(&out_dir);
+    }
+}
+
+#[test]
+fn every_finalization_rename_is_idempotent_after_abort() {
+    let baseline_dir = tempfile::tempdir().unwrap();
+    let baseline_out = baseline_dir.path().join("baseline");
+    let baseline_engine = write_engine(baseline_dir.path(), false);
+    assert!(
+        command_with_concurrency(&baseline_engine, &baseline_out, 1)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let expected_aux: Vec<Vec<u8>> = [
+        "gensfen.info.jsonl",
+        "gensfen.eval.txt",
+        "gensfen.metrics.jsonl",
+    ]
+    .map(|path| fs::read(baseline_out.join(path)).unwrap())
+    .into();
+
+    for rename_index in 1..=6 {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(format!("rename-{rename_index}"));
+        let engine = write_engine(dir.path(), false);
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .env("RSHOGI_GENSFEN_FAULT", format!("after_final_rename_{rename_index}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "rename fault {rename_index} unexpectedly succeeded");
+        assert!(out_dir.join(".gensfen.finalization.json").exists());
+
+        assert!(
+            command_with_concurrency(&engine, &out_dir, 1)
+                .args(["--resume", "--force-unlock"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert_exact_outputs(&out_dir);
+        for (path, expected) in [
+            "gensfen.info.jsonl",
+            "gensfen.eval.txt",
+            "gensfen.metrics.jsonl",
+        ]
+        .into_iter()
+        .zip(&expected_aux)
+        {
+            assert_eq!(
+                &fs::read(out_dir.join(path)).unwrap(),
+                expected,
+                "content mismatch in {path}"
+            );
+        }
+        assert!(!out_dir.join(".gensfen.finalization.json").exists());
+    }
+}
+
+#[test]
+fn finalization_journal_atomic_rename_faults_are_recoverable() {
+    for fault in ["before_journal_rename", "after_journal_rename"] {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(fault);
+        let engine = write_engine(dir.path(), false);
+        let status = command_with_concurrency(&engine, &out_dir, 1)
+            .env("RSHOGI_GENSFEN_FAULT", fault)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!status.success(), "journal fault {fault} unexpectedly succeeded");
+
+        assert!(
+            command_with_concurrency(&engine, &out_dir, 1)
+                .args(["--resume", "--force-unlock"])
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert_exact_outputs(&out_dir);
+        assert!(!out_dir.join(".gensfen.finalization.json").exists());
+        assert!(!out_dir.join(".gensfen.finalization.json.tmp").exists());
+    }
+}
+
+#[test]
+fn partial_finalization_journal_temporary_file_is_regenerated_on_resume() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("partial-journal");
+    let engine = write_engine(dir.path(), false);
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .env("RSHOGI_GENSFEN_FAULT", "before_journal_rename")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+
+    let journal_tmp = out_dir.join(".gensfen.finalization.json.tmp");
+    fs::write(&journal_tmp, b"{\"schema\":1,\"outputs\":[").unwrap();
+    assert!(!out_dir.join(".gensfen.finalization.json").exists());
+
+    assert!(
+        command_with_concurrency(&engine, &out_dir, 1)
+            .arg("--resume")
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_exact_outputs(&out_dir);
+    assert!(!journal_tmp.exists());
+}
+
+#[test]
+fn merge_staging_without_journal_is_regenerated_on_resume() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("before-journal");
+    let engine = write_engine(dir.path(), false);
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .env("RSHOGI_GENSFEN_FAULT", "before_journal_write")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert!(out_dir.join(".gensfen.jsonl.merge.tmp").exists());
+    assert!(!out_dir.join(".gensfen.finalization.json").exists());
+    assert!(!out_dir.join(".gensfen.finalization.json.tmp").exists());
+
+    assert!(
+        command_with_concurrency(&engine, &out_dir, 1)
+            .arg("--resume")
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_exact_outputs(&out_dir);
+    assert!(!out_dir.join(".gensfen.jsonl.merge.tmp").exists());
+}
+
+#[test]
+fn finalization_cleanup_crash_discards_already_committed_worker_temps() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("cleanup");
+    let engine = write_engine(dir.path(), false);
+    let status = base_command(&engine, &out_dir)
+        .env("RSHOGI_GENSFEN_FAULT", "after_worker_temp_delete_1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert!(out_dir.join(".gensfen.finalization.json").exists());
+    assert!(out_dir.join("gensfen.jsonl").exists());
+    assert!((0..2).any(|worker| out_dir.join(format!("gensfen.w{worker}.jsonl")).exists()));
+
+    assert!(
+        base_command(&engine, &out_dir)
+            .args(["--resume", "--force-unlock"])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_exact_outputs(&out_dir);
+    assert!(!out_dir.join(".gensfen.finalization.json").exists());
+    for worker in 0..2 {
+        assert!(!out_dir.join(format!("gensfen.w{worker}.jsonl")).exists());
+    }
+}
+
+#[test]
+fn fully_completed_resume_does_not_start_engine_workers() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("complete");
+    let engine = write_engine(dir.path(), false);
+    assert!(base_command(&engine, &out_dir).status().unwrap().success());
+    let marker = dir.path().join("engine-started");
+
+    assert!(
+        base_command(&engine, &out_dir)
+            .arg("--resume")
+            .env("GENSFEN_ENGINE_MARKER", &marker)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(!marker.exists());
+    assert_exact_outputs(&out_dir);
+}
+
+#[test]
+fn resume_rejects_shortened_or_mismatched_final_teacher_outputs() {
+    for damaged in ["psv", "sidecar"] {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join(damaged);
+        let engine = write_engine(dir.path(), false);
+        assert!(base_command(&engine, &out_dir).status().unwrap().success());
+        let path = if damaged == "psv" {
+            out_dir.join("gensfen.psv")
+        } else {
+            out_dir.join("gensfen.game_ids.bin")
+        };
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_len(file.metadata().unwrap().len() - 1).unwrap();
+        assert!(!base_command(&engine, &out_dir).arg("--resume").status().unwrap().success());
+    }
+}
+
+#[test]
+fn resume_rejects_same_length_final_content_corruption_without_rebaselining_hash() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("same-length-corruption");
+    let engine = write_engine(dir.path(), false);
+    assert!(base_command(&engine, &out_dir).status().unwrap().success());
+    let state_path = out_dir.join("gensfen.finalized.json");
+    let state_before = fs::read(&state_path).unwrap();
+    let psv_path = out_dir.join("gensfen.psv");
+    let mut psv = fs::read(&psv_path).unwrap();
+    psv[0] ^= 0x80;
+    fs::write(&psv_path, &psv).unwrap();
+
+    let status = base_command(&engine, &out_dir)
+        .arg("--resume")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert_eq!(fs::read(&state_path).unwrap(), state_before);
+    assert_eq!(fs::read(&psv_path).unwrap(), psv);
+    assert!(!out_dir.join(".gensfen.finalization.json").exists());
+}
+
+#[test]
+fn resume_rejects_replaced_path_valued_usi_option_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("option-model");
+    let engine = write_engine(dir.path(), false);
+    let model = dir.path().join("eval.bin");
+    fs::write(&model, b"model-a").unwrap();
+    let option = format!("EvalFile={}", model.display());
+    assert!(
+        base_command(&engine, &out_dir)
+            .args(["--usi-option", &option])
+            .status()
+            .unwrap()
+            .success()
+    );
+    fs::write(&model, b"model-b").unwrap();
+    assert!(
+        !base_command(&engine, &out_dir)
+            .args(["--usi-option", &option, "--resume"])
+            .status()
+            .unwrap()
+            .success()
+    );
+}
+
+#[test]
+fn nonexistent_path_valued_usi_option_runs_and_value_change_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("book-sentinel");
+    let engine = write_engine(dir.path(), false);
+    assert!(
+        base_command(&engine, &out_dir)
+            .args(["--usi-option", "BookFile=no_book"])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        !base_command(&engine, &out_dir)
+            .args(["--usi-option", "BookFile=other_sentinel", "--resume"])
+            .status()
+            .unwrap()
+            .success()
+    );
+}
+
+#[test]
+fn nth_fault_preserves_committed_prefix_and_resume_continues_from_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let out_dir = dir.path().join("nth-fault");
+    let engine = write_engine(dir.path(), false);
+    let status = command_with_concurrency(&engine, &out_dir, 1)
+        .env("RSHOGI_GENSFEN_FAULT", "before_result:2")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+    assert!(!status.success());
+    assert_eq!(result_ids(&out_dir.join("gensfen.jsonl")), vec![1]);
+    assert_eq!(fs::metadata(out_dir.join("gensfen.psv")).unwrap().len(), 40);
+
+    assert!(
+        command_with_concurrency(&engine, &out_dir, 1)
+            .arg("--resume")
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert_exact_outputs(&out_dir);
+}
+
+#[test]
+fn uninterrupted_and_hard_kill_resume_outputs_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let engine = write_engine(dir.path(), false);
+    let full_dir = dir.path().join("full");
+    let resumed_dir = dir.path().join("resumed");
+    assert!(command_with_concurrency(&engine, &full_dir, 1).status().unwrap().success());
+
+    let mut child = command_with_concurrency(&engine, &resumed_dir, 1)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_nonempty_checkpoint(&mut child, &resumed_dir);
+    child.kill().unwrap();
+    child.wait().unwrap();
+    assert!(
+        command_with_concurrency(&engine, &resumed_dir, 1)
+            .args(["--resume", "--force-unlock"])
+            .status()
+            .unwrap()
+            .success()
+    );
+
+    assert_eq!(
+        fs::read(full_dir.join("gensfen.psv")).unwrap(),
+        fs::read(resumed_dir.join("gensfen.psv")).unwrap()
+    );
+    assert_eq!(
+        fs::read(full_dir.join("gensfen.game_ids.bin")).unwrap(),
+        fs::read(resumed_dir.join("gensfen.game_ids.bin")).unwrap()
+    );
+    assert_eq!(
+        result_values(&full_dir.join("gensfen.jsonl")),
+        result_values(&resumed_dir.join("gensfen.jsonl"))
+    );
+}

--- a/crates/tools/tests/gensfen_sidecar_integration.rs
+++ b/crates/tools/tests/gensfen_sidecar_integration.rs
@@ -144,6 +144,18 @@ fn real_native_gensfen_concatenates_psv_and_game_id_sidecar_in_lockstep() {
     assert_eq!(result_ids, HashSet::from([1, 2]));
     assert!(game_ids.iter().all(|game_id| result_ids.contains(game_id)));
 
+    let meta: Value = serde_json::from_str(
+        std::fs::read_to_string(out_dir.join("gensfen.jsonl"))
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap();
+    let native_sha = meta["fingerprint"]["engine"]["sha256_black"].as_str().unwrap();
+    assert_eq!(native_sha.len(), 64);
+    assert_eq!(native_sha, meta["fingerprint"]["engine"]["sha256_white"].as_str().unwrap());
+
     for worker in 0..2 {
         assert!(!out_dir.join(format!("gensfen.w{worker}.jsonl")).exists());
         assert!(!out_dir.join(format!("gensfen.w{worker}.psv")).exists());


### PR DESCRIPTION
## 概要

入玉教師データの本番生成は **開始局面 163,802 / 数千万〜億局面 / 数日間の無人実行** になる。gensfen 全体レビュー (2 独立レビュアー) で、resume と最終化に **電源断・SIGKILL・worker 異常のいずれでも成果物を失うか黙って壊す経路**が複数見つかったため修正する。教師ラベルの正当性は #935 で対応済み。

## データ損失

- **hard kill 後の resume が worker temp を truncate して全損** — 最終ファイルへの連結は正常終了時にしか走らず、実行中のデータは worker temp にしかない。この状態で `--resume` すると worker が同じ temp を `File::create` で truncate し、**数日分が無言で消えていた**。temp を追記型 checkpoint として扱う
- **完了判定が「最大 game_id」** — 並列中断で歯抜けが出ると未完了局が永久にスキップされた。完了集合を bitset で保持し欠番だけ再実行。game_id ごとに開始局面と乱数列を固定し、再実行でも同じ開始局面を使う

## データ破壊

- **最終化が非原子的で教師レコードが二重化する** — 複数ファイルを個別に rename していたため、PSV rename 後に落ちると次の resume が「既存 final + 同じ temp」を連結する。**finalization journal** (merge の長さと SHA-256 を fsync してから rename 開始) を導入し、どのクラッシュ点でも冪等に復旧する
- **worker エラー時に未コミットの末尾を最終成果物へ取り込み、復旧に必要な checkpoint まで削除していた** — エラー時は最終 result 境界へ復旧してから連結する
- **正常終了時に worker 成果物が欠落しても黙って成功終了する** — staging が欠落を空ファイル相当とみなすため、教師データが欠落したまま exit 0 になり、resume でも「完了済み」で再生成されなかった。worker を起動した経路では全成果物を journal 作成前に検証する
- **出力先・内部一時ファイルが symlink でも辿って開いていた** — リンク先の外部ファイルを truncate し得た (実機再現済み: exit 0 のまま外部ファイルが上書きされ、dangling symlink では最終 JSONL 自体が symlink になった)。全 final / internal path を副作用の前に `symlink_metadata` で検査し、`O_NOFOLLOW` と `create_new` で開く
- **finalized state の同一長破損が「新しい正解」として上書きされる** — staging が既存 final を読む際に (追加 read なしで) prefix SHA-256 を旧 state と照合する

## 永続性

- `flush` は fsync ではなく、電源断で result と教師データの世代がずれ得た。**教師データ・sidecar・補助出力を書いて fsync してから result 行を書き**、result に各ファイルの絶対コミット長と fsync 世代 (`fsync_boundary`) を記録する。復旧は **fsync 済みと確認できる最後の世代まで**採用し、それ以降は全成果物を同一境界へ切り戻す
- `--fsync-interval-games` で間隔を制御 (既定 1)。実測: mock USI・200 局・NVMe/ext4 で interval 1 は +0.15 秒 ≈ 0.75 ms/局。本番は 1 局が秒〜分オーダーなので相対コストは無視できる

## 条件の同一性

別のモデル・探索条件・開始局面・出力形式で resume しても境界情報なしに同一ファイルへ追記できた。**native 実行ファイルと USI option 配下のモデル内容 (`*File`/`*Dir`/`*Path`/`LS_PROGRESS_COEFF`) の SHA-256 まで含めた fingerprint** を fail-closed で照合する。

## 運用

- worker エラーが親に伝播せず **exit 0** になっていた (監視側が全件完了と誤認する)。非ゼロ終了し、どの worker が何で落ちたかを出す
- out_dir を `O_EXCL` の lock で保護し二重起動を防ぐ (stale lock は PID 生存確認後に `--force-unlock`。supervisor 構成の手順を doc 化)
- 人手介入が必要な停止も事故として扱い、self-heal できるケース (末尾の不完全 JSON、未 fsync の result suffix、未確定 staging、不正な journal tmp) は自動復旧する。データを黙って壊しかねないケース (参照先の欠落、offset 後退、レコード境界不正、件数不一致) のみ fail-closed

## テスト

`cargo test -p tools` が **debug / release 両方** green。resume 統合テスト **27 本** + gensfen unit 78 本。

fault injection で全 rename 点 (6 箇所) の abort、temp 削除中の abort、journal rename 前後、result 書き込み前/途中の失敗、sidecar 部分書き込み、worker 成果物の個別欠落 (6 種)、同一長の final 破損、全 internal path の symlink / dangling symlink / directory / FIFO、不完全な journal tmp、N 局目での失敗、fsync 境界 (`interval 2` + `before_result:4`) を検証。

**ミューテーション検証** (レビュー中に実施): `fsync_boundary` のチェックを外すと `resume_rolls_back_to_last_fsync_interval_boundary` が、`O_NOFOLLOW` を外すと `worker_checkpoint_open_after_type_check_does_not_follow_symlink` が、それぞれ確実に FAILED することを確認済み。

## レビュー

Codex + Claude (Fable) の 2 レビュアーで独立レビュー。**10 ラウンド**にわたり、レビューのたびに実バグが出続けた。主なもの:

- (両者 Critical) 最終化の非原子性による教師レコードの二重化
- (Codex Critical) 正常終了時の worker 成果物欠落が exit 0 で成功扱いになる
- (Codex Critical) self-heal 強化が生んだ新経路 — 補助ファイル 1 個の欠落で正常な教師データを 0 バイトに truncate
- (Codex Critical) `--output-training-data` のパス衝突で最終成果物そのものが削除される
- (Fable High) CI が release ビルドで赤 — Critical を守る fault-injection テストが `#[cfg(debug_assertions)]` のため CI (`cargo test --release`) で発火せず落ちていた
- (両者) symlink 経由の外部ファイル破壊 (Fable が実機再現)

最終的に**両者 APPROVE (指摘ゼロ)**。

## チェック

- `cargo fmt --check` green
- `cargo clippy -p tools --tests -- -D warnings` 警告 0
- `cargo test -p tools` debug / release とも green
- `bash scripts/check-tracked-abs-paths.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4HZgkNw1y1WD9Ur3kyK9M