### PR TITLE
search: 停止予算のない固定 depth 探索に動的 depth-liveness guard を導入

### DIFF
--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -368,6 +368,29 @@ pub struct SearchContext<'a> {
     pub draw_value_table: [Value; 2],
 }
 
+/// Path tracking used only when the dynamic depth-liveness guard is enabled.
+///
+/// Keep this out of [`Stack`] so the existing hot stack layout is unchanged when the guard is
+/// disabled. The state is allocated once per `go` only for a search without an interrupt budget
+/// and with both thresholds non-zero.
+struct DepthLivenessState {
+    root_search_start_nodes: u64,
+    active: bool,
+    search_entry_depth: [Depth; STACK_SIZE],
+    nondecreasing_depth_run: [i32; STACK_SIZE],
+}
+
+impl DepthLivenessState {
+    fn new() -> Self {
+        Self {
+            root_search_start_nodes: 0,
+            active: false,
+            search_entry_depth: [0; STACK_SIZE],
+            nondecreasing_depth_run: [0; STACK_SIZE],
+        }
+    }
+}
+
 /// 探索中に変化する状態
 ///
 /// 各探索スレッドが持つ可変状態。
@@ -384,10 +407,8 @@ pub struct SearchState {
     pub sel_depth: i32,
     /// ルート深さ
     pub root_depth: Depth,
-    /// 現在の root search（aspiration retry ごと）の開始ノード数
-    pub root_search_start_nodes: u64,
-    /// この go で depth liveness guard が発火済みか
-    pub depth_liveness_active: bool,
+    /// 動的depth-liveness guardのpath追跡。停止予算あり、または閾値0なら未確保。
+    depth_liveness: Option<Box<DepthLivenessState>>,
     /// 完了済み深さ
     pub completed_depth: Depth,
     /// 最善手
@@ -431,8 +452,7 @@ impl SearchState {
             abort: false,
             sel_depth: 0,
             root_depth: 0,
-            root_search_start_nodes: 0,
-            depth_liveness_active: false,
+            depth_liveness: None,
             completed_depth: 0,
             best_move: Move::NONE,
             best_move_changes: 0.0,
@@ -459,6 +479,27 @@ impl Default for SearchState {
 }
 
 impl SearchState {
+    pub(crate) fn begin_depth_liveness_attempt(&mut self) {
+        if let Some(liveness) = self.depth_liveness.as_mut() {
+            liveness.root_search_start_nodes = self.nodes;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn depth_liveness_is_enabled(&self) -> bool {
+        self.depth_liveness.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_depth_liveness_active_for_test(&mut self, active: bool) {
+        self.depth_liveness.as_mut().expect("depth liveness must be enabled").active = active;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn depth_liveness_is_active_for_test(&self) -> bool {
+        self.depth_liveness.as_ref().is_some_and(|liveness| liveness.active)
+    }
+
     #[inline]
     pub fn set_previous_pv(&mut self, pv: &[Move]) {
         self.previous_pv.clear();
@@ -756,12 +797,14 @@ impl SearchWorker {
     }
 
     /// goで呼び出し：探索状態のリセット（履歴はクリアしない）
-    pub fn prepare_search(&mut self) {
+    pub fn prepare_search(&mut self, limits: &LimitsType) {
         self.state.nodes = 0;
         self.state.sel_depth = 0;
         self.state.root_depth = 0;
-        self.state.root_search_start_nodes = 0;
-        self.state.depth_liveness_active = false;
+        self.state.depth_liveness = (!limits.has_interrupt_budget()
+            && self.search_tune_params.depth_liveness_node_threshold > 0
+            && self.search_tune_params.depth_liveness_run_threshold > 0)
+            .then(|| Box::new(DepthLivenessState::new()));
         self.state.root_delta = 1;
         self.state.completed_depth = 0;
         self.state.best_move = Move::NONE;
@@ -974,8 +1017,10 @@ impl SearchWorker {
         limits: &LimitsType,
         time_manager: &mut TimeManagement,
     ) -> Value {
-        self.state.stack[0].search_entry_depth = depth;
-        self.state.stack[0].nondecreasing_depth_run = 0;
+        if let Some(liveness) = self.state.depth_liveness.as_mut() {
+            liveness.search_entry_depth[0] = depth;
+            liveness.nondecreasing_depth_run[0] = 0;
+        }
 
         // 千日手評価値テーブルの初期化
         self.init_draw_value_table(pos.side_to_move());
@@ -1694,8 +1739,10 @@ impl SearchWorker {
         // rootNode && pvIdx の経路のみこの関数が担当する。
         // pv_idx == 0 は search_root() を使い、root TT save はそちらでのみ実行する。
         debug_assert!(pv_idx > 0);
-        self.state.stack[0].search_entry_depth = depth;
-        self.state.stack[0].nondecreasing_depth_run = 0;
+        if let Some(liveness) = self.state.depth_liveness.as_mut() {
+            liveness.search_entry_depth[0] = depth;
+            liveness.nondecreasing_depth_run[0] = 0;
+        }
 
         // 千日手評価値テーブルの初期化
         self.init_draw_value_table(pos.side_to_move());
@@ -2153,53 +2200,56 @@ impl SearchWorker {
             };
         }
 
-        // A legal move normally consumes one ply and therefore remaining depth must eventually
-        // decrease. Multi-extension, negative LMR and full-depth re-search can all produce a
-        // child depth >= its parent's depth. A long consecutive run of such edges is the common
-        // liveness failure observed in both rshogi and YaneuraOu fixed-depth searches.
-        //
-        // Singular verification recurses at the same ply without making a move. It is a separate
-        // search root for this purpose and must not be linked to the outer move path.
-        let raw_depth = depth;
-        let excluded_search = st.stack[ply as usize].excluded_move.is_some();
-        let real_child = ply > 0 && !excluded_search;
-        let parent_depth = if real_child {
-            st.stack[(ply - 1) as usize].search_entry_depth
-        } else {
-            raw_depth
-        };
-        let raw_nondecreasing_depth_run = if real_child && raw_depth >= parent_depth {
-            st.stack[(ply - 1) as usize].nondecreasing_depth_run + 1
-        } else {
-            0
-        };
+        let liveness_nodes = st.nodes;
+        if let Some(liveness) = st.depth_liveness.as_mut() {
+            // A legal move normally consumes one ply and therefore remaining depth must
+            // eventually decrease. Multi-extension, negative LMR and full-depth re-search can
+            // all produce a child depth >= its parent's depth. A long consecutive run of such
+            // edges is the common liveness failure observed in both rshogi and YaneuraOu.
+            //
+            // Singular verification recurses at the same ply without making a move. It is a
+            // separate search root for this purpose and must not be linked to the outer move path.
+            let raw_depth = depth;
+            let excluded_search = st.stack[ply as usize].excluded_move.is_some();
+            let real_child = ply > 0 && !excluded_search;
+            let parent_depth = if real_child {
+                liveness.search_entry_depth[(ply - 1) as usize]
+            } else {
+                raw_depth
+            };
+            let raw_nondecreasing_depth_run = if real_child && raw_depth >= parent_depth {
+                liveness.nondecreasing_depth_run[(ply - 1) as usize] + 1
+            } else {
+                0
+            };
 
-        if !st.depth_liveness_active
-            && should_activate_depth_liveness(
-                st.nodes,
-                st.root_search_start_nodes,
-                raw_nondecreasing_depth_run,
-                ctx.tune_params.depth_liveness_node_threshold,
-                ctx.tune_params.depth_liveness_run_threshold,
-            )
-        {
-            st.depth_liveness_active = true;
-        }
+            if !liveness.active
+                && should_activate_depth_liveness(
+                    liveness_nodes,
+                    liveness.root_search_start_nodes,
+                    raw_nondecreasing_depth_run,
+                    ctx.tune_params.depth_liveness_node_threshold,
+                    ctx.tune_params.depth_liveness_run_threshold,
+                )
+            {
+                liveness.active = true;
+            }
 
-        if real_child {
-            depth = enforce_decreasing_depth(depth, parent_depth, st.depth_liveness_active);
-        }
-        if depth <= DEPTH_QS {
-            return qsearch::<NT>(st, ctx, pos, alpha, beta, ply, limits, time_manager);
-        }
+            if real_child {
+                depth = enforce_decreasing_depth(depth, parent_depth, liveness.active);
+            }
+            if depth <= DEPTH_QS {
+                return qsearch::<NT>(st, ctx, pos, alpha, beta, ply, limits, time_manager);
+            }
 
-        let nondecreasing_depth_run = if real_child && depth >= parent_depth {
-            st.stack[(ply - 1) as usize].nondecreasing_depth_run + 1
-        } else {
-            0
-        };
-        st.stack[ply as usize].search_entry_depth = depth;
-        st.stack[ply as usize].nondecreasing_depth_run = nondecreasing_depth_run;
+            let nondecreasing_depth_run = if real_child && depth >= parent_depth {
+                liveness.nondecreasing_depth_run[(ply - 1) as usize] + 1
+            } else {
+                0
+            };
+            liveness.search_entry_depth[ply as usize] = depth;
+            liveness.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
+        }
 
         // 選択的深さを更新
         if pv_node && st.sel_depth < ply + 1 {
@@ -2745,8 +2795,12 @@ impl SearchWorker {
 
                 // verification search は同一 ply の追跡フィールドを上書きするため、
                 // 外側の move path に戻る際に復元する。
-                let outer_search_entry_depth = st.stack[ply as usize].search_entry_depth;
-                let outer_nondecreasing_depth_run = st.stack[ply as usize].nondecreasing_depth_run;
+                let outer_depth_liveness = st.depth_liveness.as_ref().map(|liveness| {
+                    (
+                        liveness.search_entry_depth[ply as usize],
+                        liveness.nondecreasing_depth_run[ply as usize],
+                    )
+                });
                 st.stack[ply as usize].excluded_move = mv;
                 let singular_value = Self::search_node::<{ NodeType::NonPV as u8 }>(
                     st,
@@ -2761,8 +2815,12 @@ impl SearchWorker {
                     time_manager,
                 );
                 st.stack[ply as usize].excluded_move = Move::NONE;
-                st.stack[ply as usize].search_entry_depth = outer_search_entry_depth;
-                st.stack[ply as usize].nondecreasing_depth_run = outer_nondecreasing_depth_run;
+                if let (Some(liveness), Some((search_entry_depth, nondecreasing_depth_run))) =
+                    (st.depth_liveness.as_mut(), outer_depth_liveness)
+                {
+                    liveness.search_entry_depth[ply as usize] = search_entry_depth;
+                    liveness.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
+                }
 
                 // SE再帰呼び出し内の上方伝播により
                 // st.stack[ply].tt_pvが変更される可能性がある。

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -574,6 +574,23 @@ impl SearchState {
         self.depth_liveness.is_some()
     }
 
+    /// search_node が node 入口で行う depth-liveness 追跡更新を、実手 child として
+    /// テストから再現する (verification search の production 配線を検証する用途)。
+    #[cfg(test)]
+    pub(crate) fn depth_liveness_update_for_test(
+        &mut self,
+        depth: Depth,
+        ply: i32,
+        node_threshold: i32,
+        run_threshold: i32,
+    ) -> Depth {
+        let nodes = self.nodes;
+        self.depth_liveness
+            .as_mut()
+            .expect("depth liveness must be enabled")
+            .update_depth(nodes, depth, ply, false, node_threshold, run_threshold)
+    }
+
     #[cfg(test)]
     pub(crate) fn set_depth_liveness_active_for_test(&mut self, active: bool) {
         self.depth_liveness.as_mut().expect("depth liveness must be enabled").active = active;

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -66,6 +66,36 @@ pub(super) fn draw_jitter(nodes: u64, tune_params: &SearchTuneParams) -> i32 {
     ((nodes & mask) as i32) + tune_params.draw_jitter_offset
 }
 
+/// 1回の root search 内で remaining depth が減らない edge が連鎖したとき、
+/// 探索の進行性を回復する guard を発火させるか判定する。
+#[inline]
+pub(crate) fn should_activate_depth_liveness(
+    nodes: u64,
+    root_search_start_nodes: u64,
+    nondecreasing_depth_run: i32,
+    node_threshold: i32,
+    run_threshold: i32,
+) -> bool {
+    node_threshold > 0
+        && run_threshold > 0
+        && nodes.saturating_sub(root_search_start_nodes) >= node_threshold as u64
+        && nondecreasing_depth_run >= run_threshold
+}
+
+/// guard 発火後は、実際に指し手を進めた子探索の remaining depth を必ず1以上減らす。
+#[inline]
+pub(crate) fn enforce_decreasing_depth(
+    depth: Depth,
+    parent_depth: Depth,
+    depth_liveness_active: bool,
+) -> Depth {
+    if depth_liveness_active {
+        depth.min(parent_depth - 1)
+    } else {
+        depth
+    }
+}
+
 #[inline]
 /// 補正履歴を適用した静的評価に変換（詰みスコア領域に入り込まないようにクリップ）
 pub(super) fn to_corrected_static_eval(unadjusted: Value, correction_value: i32) -> Value {
@@ -354,6 +384,10 @@ pub struct SearchState {
     pub sel_depth: i32,
     /// ルート深さ
     pub root_depth: Depth,
+    /// 現在の root search（aspiration retry ごと）の開始ノード数
+    pub root_search_start_nodes: u64,
+    /// この go で depth liveness guard が発火済みか
+    pub depth_liveness_active: bool,
     /// 完了済み深さ
     pub completed_depth: Depth,
     /// 最善手
@@ -397,6 +431,8 @@ impl SearchState {
             abort: false,
             sel_depth: 0,
             root_depth: 0,
+            root_search_start_nodes: 0,
+            depth_liveness_active: false,
             completed_depth: 0,
             best_move: Move::NONE,
             best_move_changes: 0.0,
@@ -724,6 +760,8 @@ impl SearchWorker {
         self.state.nodes = 0;
         self.state.sel_depth = 0;
         self.state.root_depth = 0;
+        self.state.root_search_start_nodes = 0;
+        self.state.depth_liveness_active = false;
         self.state.root_delta = 1;
         self.state.completed_depth = 0;
         self.state.best_move = Move::NONE;
@@ -936,6 +974,9 @@ impl SearchWorker {
         limits: &LimitsType,
         time_manager: &mut TimeManagement,
     ) -> Value {
+        self.state.stack[0].search_entry_depth = depth;
+        self.state.stack[0].nondecreasing_depth_run = 0;
+
         // 千日手評価値テーブルの初期化
         self.init_draw_value_table(pos.side_to_move());
 
@@ -1653,6 +1694,8 @@ impl SearchWorker {
         // rootNode && pvIdx の経路のみこの関数が担当する。
         // pv_idx == 0 は search_root() を使い、root TT save はそちらでのみ実行する。
         debug_assert!(pv_idx > 0);
+        self.state.stack[0].search_entry_depth = depth;
+        self.state.stack[0].nondecreasing_depth_run = 0;
 
         // 千日手評価値テーブルの初期化
         self.init_draw_value_table(pos.side_to_move());
@@ -2109,6 +2152,54 @@ impl SearchWorker {
                 nnue_evaluate(st, pos)
             };
         }
+
+        // A legal move normally consumes one ply and therefore remaining depth must eventually
+        // decrease. Multi-extension, negative LMR and full-depth re-search can all produce a
+        // child depth >= its parent's depth. A long consecutive run of such edges is the common
+        // liveness failure observed in both rshogi and YaneuraOu fixed-depth searches.
+        //
+        // Singular verification recurses at the same ply without making a move. It is a separate
+        // search root for this purpose and must not be linked to the outer move path.
+        let raw_depth = depth;
+        let excluded_search = st.stack[ply as usize].excluded_move.is_some();
+        let real_child = ply > 0 && !excluded_search;
+        let parent_depth = if real_child {
+            st.stack[(ply - 1) as usize].search_entry_depth
+        } else {
+            raw_depth
+        };
+        let raw_nondecreasing_depth_run = if real_child && raw_depth >= parent_depth {
+            st.stack[(ply - 1) as usize].nondecreasing_depth_run + 1
+        } else {
+            0
+        };
+
+        if !st.depth_liveness_active
+            && should_activate_depth_liveness(
+                st.nodes,
+                st.root_search_start_nodes,
+                raw_nondecreasing_depth_run,
+                ctx.tune_params.depth_liveness_node_threshold,
+                ctx.tune_params.depth_liveness_run_threshold,
+            )
+        {
+            st.depth_liveness_active = true;
+        }
+
+        if real_child {
+            depth = enforce_decreasing_depth(depth, parent_depth, st.depth_liveness_active);
+        }
+        if depth <= DEPTH_QS {
+            return qsearch::<NT>(st, ctx, pos, alpha, beta, ply, limits, time_manager);
+        }
+
+        let nondecreasing_depth_run = if real_child && depth >= parent_depth {
+            st.stack[(ply - 1) as usize].nondecreasing_depth_run + 1
+        } else {
+            0
+        };
+        st.stack[ply as usize].search_entry_depth = depth;
+        st.stack[ply as usize].nondecreasing_depth_run = nondecreasing_depth_run;
 
         // 選択的深さを更新
         if pv_node && st.sel_depth < ply + 1 {
@@ -2652,6 +2743,10 @@ impl SearchWorker {
                 // - move_count: ローカル変数で管理しているため影響なし
                 // - その他: ヒューリスティック用途のため多少の誤差は許容される
 
+                // verification search は同一 ply の追跡フィールドを上書きするため、
+                // 外側の move path に戻る際に復元する。
+                let outer_search_entry_depth = st.stack[ply as usize].search_entry_depth;
+                let outer_nondecreasing_depth_run = st.stack[ply as usize].nondecreasing_depth_run;
                 st.stack[ply as usize].excluded_move = mv;
                 let singular_value = Self::search_node::<{ NodeType::NonPV as u8 }>(
                     st,
@@ -2666,6 +2761,8 @@ impl SearchWorker {
                     time_manager,
                 );
                 st.stack[ply as usize].excluded_move = Move::NONE;
+                st.stack[ply as usize].search_entry_depth = outer_search_entry_depth;
+                st.stack[ply as usize].nondecreasing_depth_run = outer_nondecreasing_depth_run;
 
                 // SE再帰呼び出し内の上方伝播により
                 // st.stack[ply].tt_pvが変更される可能性がある。
@@ -2701,14 +2798,6 @@ impl SearchWorker {
                     extension = 1
                         + (singular_value < singular_beta - Value::new(double_margin)) as i32
                         + (singular_value < singular_beta - Value::new(triple_margin)) as i32;
-
-                    // engine 自身に打ち切り予算（時間・ノード・infinite）が無い深さ固定探索では、
-                    // double/triple 延長が child の探索深さを親より深くし続け、置換表飽和下で
-                    // 延長が連鎖して探索木が爆発し `go depth N` が事実上終了しなくなる。止める
-                    // 手段が無いため、この場合のみ単延長に制限して net の深さ成長を抑え終了を保証する。
-                    if !limits.has_interrupt_budget() {
-                        extension = extension.min(1);
-                    }
 
                     // singular確定時にdepthを+1
                     depth += 1;

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -389,6 +389,65 @@ impl DepthLivenessState {
             nondecreasing_depth_run: [0; STACK_SIZE],
         }
     }
+
+    /// Keep the tracking implementation out of the normal search hot path. Searches with an
+    /// interrupt budget never allocate this state, so their per-node cost remains a single
+    /// predictable `Option::None` branch in `search_node`.
+    #[inline(never)]
+    fn update_depth(
+        &mut self,
+        nodes: u64,
+        mut depth: Depth,
+        ply: i32,
+        excluded_search: bool,
+        node_threshold: i32,
+        run_threshold: i32,
+    ) -> Depth {
+        // A legal move normally consumes one ply and therefore remaining depth must eventually
+        // decrease. Multi-extension, negative LMR and full-depth re-search can all produce a
+        // child depth >= its parent's depth. A long consecutive run of such edges is the common
+        // liveness failure observed in both rshogi and YaneuraOu.
+        //
+        // Singular verification recurses at the same ply without making a move. It is a separate
+        // search root for this purpose and must not be linked to the outer move path.
+        let raw_depth = depth;
+        let real_child = ply > 0 && !excluded_search;
+        let parent_depth = if real_child {
+            self.search_entry_depth[(ply - 1) as usize]
+        } else {
+            raw_depth
+        };
+        let raw_nondecreasing_depth_run = if real_child && raw_depth >= parent_depth {
+            self.nondecreasing_depth_run[(ply - 1) as usize] + 1
+        } else {
+            0
+        };
+
+        if !self.active
+            && should_activate_depth_liveness(
+                nodes,
+                self.root_search_start_nodes,
+                raw_nondecreasing_depth_run,
+                node_threshold,
+                run_threshold,
+            )
+        {
+            self.active = true;
+        }
+
+        if real_child {
+            depth = enforce_decreasing_depth(depth, parent_depth, self.active);
+        }
+
+        let nondecreasing_depth_run = if real_child && depth >= parent_depth {
+            self.nondecreasing_depth_run[(ply - 1) as usize] + 1
+        } else {
+            0
+        };
+        self.search_entry_depth[ply as usize] = depth;
+        self.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
+        depth
+    }
 }
 
 /// 探索中に変化する状態
@@ -2202,53 +2261,18 @@ impl SearchWorker {
 
         let liveness_nodes = st.nodes;
         if let Some(liveness) = st.depth_liveness.as_mut() {
-            // A legal move normally consumes one ply and therefore remaining depth must
-            // eventually decrease. Multi-extension, negative LMR and full-depth re-search can
-            // all produce a child depth >= its parent's depth. A long consecutive run of such
-            // edges is the common liveness failure observed in both rshogi and YaneuraOu.
-            //
-            // Singular verification recurses at the same ply without making a move. It is a
-            // separate search root for this purpose and must not be linked to the outer move path.
-            let raw_depth = depth;
             let excluded_search = st.stack[ply as usize].excluded_move.is_some();
-            let real_child = ply > 0 && !excluded_search;
-            let parent_depth = if real_child {
-                liveness.search_entry_depth[(ply - 1) as usize]
-            } else {
-                raw_depth
-            };
-            let raw_nondecreasing_depth_run = if real_child && raw_depth >= parent_depth {
-                liveness.nondecreasing_depth_run[(ply - 1) as usize] + 1
-            } else {
-                0
-            };
-
-            if !liveness.active
-                && should_activate_depth_liveness(
-                    liveness_nodes,
-                    liveness.root_search_start_nodes,
-                    raw_nondecreasing_depth_run,
-                    ctx.tune_params.depth_liveness_node_threshold,
-                    ctx.tune_params.depth_liveness_run_threshold,
-                )
-            {
-                liveness.active = true;
-            }
-
-            if real_child {
-                depth = enforce_decreasing_depth(depth, parent_depth, liveness.active);
-            }
+            depth = liveness.update_depth(
+                liveness_nodes,
+                depth,
+                ply,
+                excluded_search,
+                ctx.tune_params.depth_liveness_node_threshold,
+                ctx.tune_params.depth_liveness_run_threshold,
+            );
             if depth <= DEPTH_QS {
                 return qsearch::<NT>(st, ctx, pos, alpha, beta, ply, limits, time_manager);
             }
-
-            let nondecreasing_depth_run = if real_child && depth >= parent_depth {
-                liveness.nondecreasing_depth_run[(ply - 1) as usize] + 1
-            } else {
-                0
-            };
-            liveness.search_entry_depth[ply as usize] = depth;
-            liveness.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
         }
 
         // 選択的深さを更新

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -376,6 +376,11 @@ pub struct SearchContext<'a> {
 pub(crate) struct DepthLivenessState {
     root_search_start_nodes: u64,
     active: bool,
+    /// 次に entry する node を same-ply verification root として扱い、run 判定と
+    /// enforcement から外す一回性マーク。NMP verification は excluded_move を
+    /// 立てずに同一 ply を再探索するため、このマークが無いと実手 child と誤認され、
+    /// 偽の非減少 edge カウントや verification depth への clamp が起きる。
+    same_ply_verification_root: bool,
     search_entry_depth: [Depth; STACK_SIZE],
     nondecreasing_depth_run: [i32; STACK_SIZE],
 }
@@ -385,6 +390,7 @@ impl DepthLivenessState {
         Self {
             root_search_start_nodes: 0,
             active: false,
+            same_ply_verification_root: false,
             search_entry_depth: [0; STACK_SIZE],
             nondecreasing_depth_run: [0; STACK_SIZE],
         }
@@ -409,9 +415,12 @@ impl DepthLivenessState {
         // liveness failure observed in both rshogi and YaneuraOu.
         //
         // Singular verification recurses at the same ply without making a move. It is a separate
-        // search root for this purpose and must not be linked to the outer move path.
+        // search root for this purpose and must not be linked to the outer move path. NMP
+        // verification does the same without setting excluded_move, so it is marked via
+        // `same_ply_verification_root` instead (consumed exactly by this entry).
+        let verification_root = std::mem::take(&mut self.same_ply_verification_root);
         let raw_depth = depth;
-        let real_child = ply > 0 && !excluded_search;
+        let real_child = ply > 0 && !excluded_search && !verification_root;
         let parent_depth = if real_child {
             self.search_entry_depth[(ply - 1) as usize]
         } else {
@@ -447,6 +456,11 @@ impl DepthLivenessState {
         self.search_entry_depth[ply as usize] = depth;
         self.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
         depth
+    }
+
+    /// 直後の update_depth 1回だけを same-ply verification root として扱わせる。
+    pub(crate) fn mark_same_ply_verification_root(&mut self) {
+        self.same_ply_verification_root = true;
     }
 
     /// 同一 ply で再帰する verification search (SE / NMP) は当該 ply の追跡フィールドを
@@ -561,6 +575,14 @@ impl SearchState {
 
     pub(crate) fn depth_liveness_snapshot(&self, ply: i32) -> Option<(Depth, i32)> {
         self.depth_liveness.as_ref().map(|liveness| liveness.snapshot_ply(ply))
+    }
+
+    /// 直後に entry する same-ply verification search (NMP) を depth-liveness の
+    /// run 判定・enforcement から外す。
+    pub(crate) fn depth_liveness_mark_verification_root(&mut self) {
+        if let Some(liveness) = self.depth_liveness.as_mut() {
+            liveness.mark_same_ply_verification_root();
+        }
     }
 
     pub(crate) fn depth_liveness_restore(&mut self, ply: i32, snapshot: Option<(Depth, i32)>) {

--- a/crates/rshogi-core/src/search/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/alpha_beta.rs
@@ -373,7 +373,7 @@ pub struct SearchContext<'a> {
 /// Keep this out of [`Stack`] so the existing hot stack layout is unchanged when the guard is
 /// disabled. The state is allocated once per `go` only for a search without an interrupt budget
 /// and with both thresholds non-zero.
-struct DepthLivenessState {
+pub(crate) struct DepthLivenessState {
     root_search_start_nodes: u64,
     active: bool,
     search_entry_depth: [Depth; STACK_SIZE],
@@ -381,7 +381,7 @@ struct DepthLivenessState {
 }
 
 impl DepthLivenessState {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             root_search_start_nodes: 0,
             active: false,
@@ -394,7 +394,7 @@ impl DepthLivenessState {
     /// interrupt budget never allocate this state, so their per-node cost remains a single
     /// predictable `Option::None` branch in `search_node`.
     #[inline(never)]
-    fn update_depth(
+    pub(crate) fn update_depth(
         &mut self,
         nodes: u64,
         mut depth: Depth,
@@ -447,6 +447,21 @@ impl DepthLivenessState {
         self.search_entry_depth[ply as usize] = depth;
         self.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
         depth
+    }
+
+    /// 同一 ply で再帰する verification search (SE / NMP) は当該 ply の追跡フィールドを
+    /// 上書きするため、外側の move path に戻る前に snapshot を取り復元する。
+    pub(crate) fn snapshot_ply(&self, ply: i32) -> (Depth, i32) {
+        (
+            self.search_entry_depth[ply as usize],
+            self.nondecreasing_depth_run[ply as usize],
+        )
+    }
+
+    pub(crate) fn restore_ply(&mut self, ply: i32, snapshot: (Depth, i32)) {
+        let (search_entry_depth, nondecreasing_depth_run) = snapshot;
+        self.search_entry_depth[ply as usize] = search_entry_depth;
+        self.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
     }
 }
 
@@ -541,6 +556,16 @@ impl SearchState {
     pub(crate) fn begin_depth_liveness_attempt(&mut self) {
         if let Some(liveness) = self.depth_liveness.as_mut() {
             liveness.root_search_start_nodes = self.nodes;
+        }
+    }
+
+    pub(crate) fn depth_liveness_snapshot(&self, ply: i32) -> Option<(Depth, i32)> {
+        self.depth_liveness.as_ref().map(|liveness| liveness.snapshot_ply(ply))
+    }
+
+    pub(crate) fn depth_liveness_restore(&mut self, ply: i32, snapshot: Option<(Depth, i32)>) {
+        if let (Some(liveness), Some(snapshot)) = (self.depth_liveness.as_mut(), snapshot) {
+            liveness.restore_ply(ply, snapshot);
         }
     }
 
@@ -2817,14 +2842,7 @@ impl SearchWorker {
                 // - move_count: ローカル変数で管理しているため影響なし
                 // - その他: ヒューリスティック用途のため多少の誤差は許容される
 
-                // verification search は同一 ply の追跡フィールドを上書きするため、
-                // 外側の move path に戻る際に復元する。
-                let outer_depth_liveness = st.depth_liveness.as_ref().map(|liveness| {
-                    (
-                        liveness.search_entry_depth[ply as usize],
-                        liveness.nondecreasing_depth_run[ply as usize],
-                    )
-                });
+                let outer_depth_liveness = st.depth_liveness_snapshot(ply);
                 st.stack[ply as usize].excluded_move = mv;
                 let singular_value = Self::search_node::<{ NodeType::NonPV as u8 }>(
                     st,
@@ -2839,12 +2857,7 @@ impl SearchWorker {
                     time_manager,
                 );
                 st.stack[ply as usize].excluded_move = Move::NONE;
-                if let (Some(liveness), Some((search_entry_depth, nondecreasing_depth_run))) =
-                    (st.depth_liveness.as_mut(), outer_depth_liveness)
-                {
-                    liveness.search_entry_depth[ply as usize] = search_entry_depth;
-                    liveness.nondecreasing_depth_run[ply as usize] = nondecreasing_depth_run;
-                }
+                st.depth_liveness_restore(ply, outer_depth_liveness);
 
                 // SE再帰呼び出し内の上方伝播により
                 // st.stack[ply].tt_pvが変更される可能性がある。

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1562,6 +1562,9 @@ where
                 let adjusted_depth =
                     (search_depth - failed_high_cnt - (3 * (search_again_counter + 1) / 4)).max(1);
 
+                // Aspiration retry ごとに node budget を測る。guard 自体は一度発火したら
+                // go の残り全体で有効にし、別 retry で同じ病的連鎖が再発するのを防ぐ。
+                worker.state.root_search_start_nodes = worker.state.nodes;
                 let score = if pv_idx == 0 {
                     worker.search_root(pos, adjusted_depth, alpha, beta, limits, time_manager)
                 } else {

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1033,7 +1033,7 @@ impl Search {
         worker.entering_king_rule = self.entering_king_rule;
 
         // 探索状態のリセット（履歴はクリアしない）
-        worker.prepare_search();
+        worker.prepare_search(&limits);
         worker.allow_tt_write = true;
 
         // 探索深さを決定
@@ -1564,7 +1564,7 @@ where
 
                 // Aspiration retry ごとに node budget を測る。guard 自体は一度発火したら
                 // go の残り全体で有効にし、別 retry で同じ病的連鎖が再発するのを防ぐ。
-                worker.state.root_search_start_nodes = worker.state.nodes;
+                worker.state.begin_depth_liveness_attempt();
                 let score = if pv_idx == 0 {
                     worker.search_root(pos, adjusted_depth, alpha, beta, limits, time_manager)
                 } else {

--- a/crates/rshogi-core/src/search/limits.rs
+++ b/crates/rshogi-core/src/search/limits.rs
@@ -163,13 +163,13 @@ impl LimitsType {
     /// 暴走探索を engine 自身が打ち切れる予算（時間・ノード・infinite）を持つか。
     ///
     /// `false`（深さ／詰み目標の完了のみで停止し、時間もノードも `stop` も効かない探索）の場合、
-    /// Singular Extension の double/triple 延長が置換表飽和下で連鎖して探索木が
+    /// remaining depth が減らない探索pathが置換表飽和下で連鎖して探索木が
     /// 深さ方向に成長し続けても止める手段が無く、`go depth N` が事実上終了しなくなる。
-    /// この判定が `false` のときだけ SE 延長を単延長に制限して終了を保証する。
+    /// この判定が `false` の探索だけ動的depth-liveness guardの追跡対象にする。
     ///
     /// 「実際に enforce される停止条件」のみを予算とみなす:
     /// - `use_time_management()`: 純粋な時間管理が有効で時間で停止する（`go depth N btime T` の
-    ///   ように depth 併用だと時間管理は無効化されるため `true` にならず、この場合は cap 対象）。
+    ///   ように depth 併用だと時間管理は無効化されるため `true` にならず、この場合は guard 対象）。
     ///   `rtime` は `time_manager.init` でこの判定が真のときだけ反映されるため（depth 併用時は
     ///   `!use_time_management()` の早期 return より後で処理され enforce されない）、ここでは
     ///   独立項を持たず `use_time_management()` に内包する。
@@ -178,7 +178,7 @@ impl LimitsType {
     /// - infinite: `stop` で打ち切り可能。
     ///
     /// なお `go perft N` は `use_time_management()` が `false` になり「予算なし」扱いだが、
-    /// perft は alpha-beta を通らず SE に到達しないため cap は発火しない（実害なし）。
+    /// perft は alpha-beta を通らず guard 追跡を行わない（実害なし）。
     #[inline]
     pub fn has_interrupt_budget(&self) -> bool {
         self.use_time_management() || self.movetime != 0 || self.nodes != 0 || self.infinite
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn test_has_interrupt_budget() {
-        // 純粋な depth 固定（go depth N）・詰み探索は engine 自身の打ち切り予算なし → cap 対象
+        // 純粋な depth 固定（go depth N）・詰み探索は engine 自身の打ち切り予算なし → guard 対象
         let mut l = LimitsType::new();
         l.depth = 15;
         assert!(!l.has_interrupt_budget());
@@ -298,14 +298,14 @@ mod tests {
         }
 
         // depth + rtime は time_manager.init で rtime 処理前に !use_time_management() で早期 return
-        // され rtime が enforce されない → 予算なし扱い（cap 対象）
+        // され rtime が enforce されない → 予算なし扱い（guard 対象）
         let mut l = LimitsType::new();
         l.depth = 15;
         l.rtime = 1000;
         assert!(!l.has_interrupt_budget());
 
         // depth と残り時間/秒読みの併用は時間管理が無効化される（time MAX/2 で実 enforce されない）
-        // ため予算なし扱い → cap 対象とし、この組合せでもハングしないようにする
+        // ため予算なし扱い → guard 対象とし、この組合せでもハングしないようにする
         let mut l = LimitsType::new();
         l.depth = 15;
         l.time[Color::Black.index()] = 60000;

--- a/crates/rshogi-core/src/search/pruning.rs
+++ b/crates/rshogi-core/src/search/pruning.rs
@@ -382,6 +382,9 @@ where
                 + ctx.tune_params.nmp_min_ply_update_num * (depth - r)
                     / ctx.tune_params.nmp_min_ply_update_den.max(1);
 
+            // NMP verification search は同一 ply の depth-liveness 追跡フィールドを
+            // 浅い depth で上書きするため、外側の move path に戻る際に復元する。
+            let outer_depth_liveness = st.depth_liveness_snapshot(ply);
             let v = search_node(
                 st,
                 ctx,
@@ -394,6 +397,7 @@ where
                 limits,
                 time_manager,
             );
+            st.depth_liveness_restore(ply, outer_depth_liveness);
 
             st.nmp_min_ply = 0;
 

--- a/crates/rshogi-core/src/search/pruning.rs
+++ b/crates/rshogi-core/src/search/pruning.rs
@@ -8,7 +8,7 @@
 
 use crate::nnue::DirtyPiece;
 use crate::position::Position;
-use crate::types::{Bound, Depth, Move, Value};
+use crate::types::{Bound, DEPTH_QS, Depth, Move, Value};
 
 use super::alpha_beta::{
     FutilityParams, SearchContext, SearchState, Step14Context, Step14Outcome, TTContext,
@@ -385,9 +385,13 @@ where
             // NMP verification search は同一 ply の depth-liveness 追跡フィールドを
             // 浅い depth で上書きするため、外側の move path に戻る際に復元する。
             // また verification 自体を実手 child と誤認させない (偽の非減少 edge
-            // カウントや verification depth への clamp を防ぐ)。
+            // カウントや verification depth への clamp を防ぐ)。マークは一回性なので、
+            // verification が qsearch へ直行して liveness 更新に到達しない depth では
+            // 立てない (残留すると次の実手 child が誤って追跡から外れる)。
             let outer_depth_liveness = st.depth_liveness_snapshot(ply);
-            st.depth_liveness_mark_verification_root();
+            if depth - r > DEPTH_QS {
+                st.depth_liveness_mark_verification_root();
+            }
             let v = search_node(
                 st,
                 ctx,

--- a/crates/rshogi-core/src/search/pruning.rs
+++ b/crates/rshogi-core/src/search/pruning.rs
@@ -384,7 +384,10 @@ where
 
             // NMP verification search は同一 ply の depth-liveness 追跡フィールドを
             // 浅い depth で上書きするため、外側の move path に戻る際に復元する。
+            // また verification 自体を実手 child と誤認させない (偽の非減少 edge
+            // カウントや verification depth への clamp を防ぐ)。
             let outer_depth_liveness = st.depth_liveness_snapshot(ply);
+            st.depth_liveness_mark_verification_root();
             let v = search_node(
                 st,
                 ctx,

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::eval::EvalHash;
 use crate::search::alpha_beta::{
-    SearchWorker, build_reductions, enforce_decreasing_depth, reduction,
+    DepthLivenessState, SearchWorker, build_reductions, enforce_decreasing_depth, reduction,
     should_activate_depth_liveness,
 };
 use crate::search::{LimitsType, SearchTuneParams};
@@ -113,6 +113,67 @@ fn test_depth_liveness_enforces_strict_progress_only_after_activation() {
     assert_eq!(enforce_decreasing_depth(4, 4, true), 3);
     assert_eq!(enforce_decreasing_depth(2, 4, true), 2);
     assert_eq!(enforce_decreasing_depth(1, 1, true), 0);
+}
+
+#[test]
+fn test_depth_liveness_update_depth_counts_runs_and_enforces_after_activation() {
+    let mut liveness = DepthLivenessState::new();
+    let (node_thr, run_thr) = (100, 3);
+
+    // root (ply=0) は real child ではないので run は増えない。
+    assert_eq!(liveness.update_depth(0, 5, 0, false, node_thr, run_thr), 5);
+    assert_eq!(liveness.snapshot_ply(0), (5, 0));
+
+    // 非減少 edge (child depth >= parent entry depth) が連続すると run が積み上がる。
+    assert_eq!(liveness.update_depth(200, 5, 1, false, node_thr, run_thr), 5);
+    assert_eq!(liveness.snapshot_ply(1), (5, 1));
+    assert_eq!(liveness.update_depth(200, 5, 2, false, node_thr, run_thr), 5);
+    assert_eq!(liveness.snapshot_ply(2), (5, 2));
+
+    // run が閾値に達すると発火し、以降の実手 child は parent entry depth - 1 に切り詰められる。
+    assert_eq!(liveness.update_depth(200, 5, 3, false, node_thr, run_thr), 4);
+    assert_eq!(liveness.snapshot_ply(3), (4, 0));
+    assert_eq!(liveness.update_depth(200, 5, 4, false, node_thr, run_thr), 3);
+
+    // depth が減る edge では run がリセットされる (発火前の状態で確認)。
+    let mut liveness = DepthLivenessState::new();
+    liveness.update_depth(0, 5, 0, false, node_thr, run_thr);
+    liveness.update_depth(200, 5, 1, false, node_thr, run_thr);
+    assert_eq!(liveness.update_depth(200, 4, 2, false, node_thr, run_thr), 4);
+    assert_eq!(liveness.snapshot_ply(2), (4, 0));
+
+    // excluded (SE verification) は別 root 扱いで、run にも enforcement にも関与しない。
+    let run_before = liveness.snapshot_ply(1);
+    assert_eq!(liveness.update_depth(200, 3, 1, true, node_thr, run_thr), 3);
+    assert_eq!(liveness.snapshot_ply(1), (3, 0));
+    liveness.restore_ply(1, run_before);
+    assert_eq!(liveness.snapshot_ply(1), run_before);
+}
+
+#[test]
+fn test_depth_liveness_verification_snapshot_restores_outer_path() {
+    let mut liveness = DepthLivenessState::new();
+    let (node_thr, run_thr) = (100, 8);
+
+    liveness.update_depth(0, 16, 0, false, node_thr, run_thr);
+    liveness.update_depth(200, 15, 1, false, node_thr, run_thr);
+    let outer = liveness.snapshot_ply(1);
+    assert_eq!(outer, (15, 0));
+
+    // NMP verification は excluded_move を立てずに同一 ply で浅い depth を再探索し、
+    // 追跡フィールドを上書きする。
+    liveness.update_depth(200, 4, 1, false, node_thr, run_thr);
+    assert_eq!(liveness.snapshot_ply(1), (4, 0));
+
+    // 復元しないと、外側の子 (ply=2, depth=14) が entry depth 4 と比較され
+    // 偽の非減少 edge として run を進めてしまう。
+    liveness.update_depth(200, 14, 2, false, node_thr, run_thr);
+    assert_eq!(liveness.snapshot_ply(2), (14, 1));
+
+    liveness.restore_ply(1, outer);
+    assert_eq!(liveness.snapshot_ply(1), (15, 0));
+    liveness.update_depth(200, 14, 2, false, node_thr, run_thr);
+    assert_eq!(liveness.snapshot_ply(2), (14, 0));
 }
 
 #[test]

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 
 use crate::eval::EvalHash;
-use crate::search::SearchTuneParams;
 use crate::search::alpha_beta::{
     SearchWorker, build_reductions, enforce_decreasing_depth, reduction,
     should_activate_depth_liveness,
 };
+use crate::search::{LimitsType, SearchTuneParams};
 use crate::tt::TranspositionTable;
 
 #[test]
@@ -120,13 +120,24 @@ fn test_depth_liveness_state_is_reset_for_each_go() {
     let tt = Arc::new(TranspositionTable::new(16));
     let eval_hash = Arc::new(EvalHash::new(1));
     let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+    let mut fixed_depth = LimitsType::new();
+    fixed_depth.depth = 15;
 
-    worker.state.root_search_start_nodes = 42;
-    worker.state.depth_liveness_active = true;
-    worker.prepare_search();
+    assert!(!worker.state.depth_liveness_is_enabled());
+    worker.prepare_search(&fixed_depth);
 
-    assert_eq!(worker.state.root_search_start_nodes, 0);
-    assert!(!worker.state.depth_liveness_active);
+    assert!(worker.state.depth_liveness_is_enabled());
+    worker.state.set_depth_liveness_active_for_test(true);
+    assert!(worker.state.depth_liveness_is_active_for_test());
+    worker.prepare_search(&fixed_depth);
+
+    assert!(worker.state.depth_liveness_is_enabled());
+    assert!(!worker.state.depth_liveness_is_active_for_test());
+
+    let mut node_limited = fixed_depth;
+    node_limited.nodes = 100_000;
+    worker.prepare_search(&node_limited);
+    assert!(!worker.state.depth_liveness_is_enabled());
 }
 
 #[test]

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -177,6 +177,37 @@ fn test_depth_liveness_verification_snapshot_restores_outer_path() {
 }
 
 #[test]
+fn test_depth_liveness_verification_root_mark_skips_run_and_enforcement() {
+    let mut liveness = DepthLivenessState::new();
+    let (node_thr, run_thr) = (100, 1);
+
+    // 発火前 (node 閾値未達) に multi-extension 相当の非減少 edge で entry 16 > parent 15 を作る。
+    liveness.update_depth(50, 15, 0, false, node_thr, run_thr);
+    assert_eq!(liveness.update_depth(50, 16, 1, false, node_thr, run_thr), 16);
+    assert_eq!(liveness.snapshot_ply(1), (16, 1));
+
+    // node 閾値超過後の same-ply verification entry (depth 15 >= parent entry 15)。
+    // mark が無いと非減少 edge と誤認され、ここが最初の発火点になって 14 へ clamp される。
+    liveness.mark_same_ply_verification_root();
+    assert_eq!(
+        liveness.update_depth(200, 15, 1, false, node_thr, run_thr),
+        15,
+        "mark 付き verification root は run 判定・enforcement の対象外"
+    );
+    assert_eq!(liveness.snapshot_ply(1), (15, 0));
+
+    // verification entry で guard が発火していないことを、node 閾値未達の非減少 edge が
+    // clamp されない (発火済みなら閾値によらず enforcement される) ことで確認する。
+    assert_eq!(
+        liveness.update_depth(50, 15, 2, false, node_thr, run_thr),
+        15,
+        "verification root では guard は発火しない"
+    );
+    // mark は一回性: 上の ply=2 entry は通常の実手 child として run が数えられている。
+    assert_eq!(liveness.snapshot_ply(2), (15, 1));
+}
+
+#[test]
 fn test_nmp_verification_restores_depth_liveness_in_production_path() {
     use std::cell::Cell;
     use std::sync::atomic::AtomicBool;
@@ -190,6 +221,16 @@ fn test_nmp_verification_restores_depth_liveness_in_production_path() {
     let tt = Arc::new(TranspositionTable::new(16));
     let eval_hash = Arc::new(EvalHash::new(1));
     let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+    // r = 1 + 16/32 = 1 にして verification depth 15 >= parent entry 15 の
+    // 非減少 same-ply entry を作る (verification root 除外が無いと clamp される設定)。
+    worker
+        .search_tune_params
+        .set_from_usi_name("SPSA_NMP_REDUCTION_BASE", 1)
+        .unwrap();
+    worker
+        .search_tune_params
+        .set_from_usi_name("SPSA_NMP_REDUCTION_DEPTH_DIV", 32)
+        .unwrap();
     let mut fixed_depth = LimitsType::new();
     fixed_depth.depth = 20;
     worker.prepare_search(&fixed_depth);
@@ -197,11 +238,16 @@ fn test_nmp_verification_restores_depth_liveness_in_production_path() {
     let mut pos = Position::new();
     pos.set_hirate();
 
-    // 外側 move path: root (ply=0) と NMP を試みるノード自身 (ply=1) の entry を記録。
-    let (node_thr, run_thr) = (100, 8);
-    worker.state.depth_liveness_update_for_test(16, 0, node_thr, run_thr);
+    // 外側 move path: root (ply=0) entry 15 と、multi-extension 相当で entry 16 になった
+    // NMP ノード自身 (ply=1) を、node 閾値未達 (guard 未発火) の時点で記録する。
+    let (node_thr, run_thr) = (100, 1);
+    worker.state.nodes = 50;
+    worker.state.depth_liveness_update_for_test(15, 0, node_thr, run_thr);
     worker.state.depth_liveness_update_for_test(16, 1, node_thr, run_thr);
     let outer = worker.state.depth_liveness_snapshot(1).unwrap();
+    assert_eq!(outer, (16, 1));
+    // null search 中に node 閾値を跨いだ状況を再現する。
+    worker.state.nodes = 200;
 
     let ctx = SearchContext {
         tt: &worker.tt,
@@ -244,8 +290,14 @@ fn test_nmp_verification_restores_depth_liveness_in_production_path() {
         |st, _ctx, _pos, child_depth, _alpha, _beta, ply, _cut_node, _limits, _tm| {
             calls.set(calls.get() + 1);
             if ply == 1 {
-                // verification search: 実際の search_node と同様に同一 ply の追跡を上書きする。
-                st.depth_liveness_update_for_test(child_depth, ply, node_thr, run_thr);
+                // verification search: 実際の search_node と同様に同一 ply の追跡を更新する。
+                assert_eq!(child_depth, 15, "r=1 で verification depth は 15 のはず");
+                let entered =
+                    st.depth_liveness_update_for_test(child_depth, ply, node_thr, run_thr);
+                assert_eq!(
+                    entered, child_depth,
+                    "verification root は非減少 same-ply entry でも clamp されないこと"
+                );
                 verification_snapshot.set(st.depth_liveness_snapshot(1));
                 beta
             } else {
@@ -262,6 +314,10 @@ fn test_nmp_verification_restores_depth_liveness_in_production_path() {
         worker.state.depth_liveness_snapshot(1).unwrap(),
         outer,
         "try_null_move_pruning は verification 後に外側 ply の追跡を復元すること"
+    );
+    assert!(
+        !worker.state.depth_liveness_is_active_for_test(),
+        "verification entry を発火点にしないこと"
     );
 }
 

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -322,6 +322,97 @@ fn test_nmp_verification_restores_depth_liveness_in_production_path() {
 }
 
 #[test]
+fn test_nmp_qsearch_verification_leaves_no_stale_mark() {
+    use std::cell::Cell;
+    use std::sync::atomic::AtomicBool;
+
+    use crate::position::Position;
+    use crate::search::alpha_beta::SearchContext;
+    use crate::search::pruning::try_null_move_pruning;
+    use crate::search::{NodeType, TimeManagement};
+    use crate::types::{Move, Value};
+
+    let tt = Arc::new(TranspositionTable::new(16));
+    let eval_hash = Arc::new(EvalHash::new(1));
+    let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+    // r = 32 で verification depth を負にし、search_node が liveness 更新前に
+    // qsearch へ早期 return する経路を作る (マークが消費されない状況)。
+    worker
+        .search_tune_params
+        .set_from_usi_name("SPSA_NMP_REDUCTION_BASE", 32)
+        .unwrap();
+    worker
+        .search_tune_params
+        .set_from_usi_name("SPSA_NMP_REDUCTION_DEPTH_DIV", 32)
+        .unwrap();
+    let mut fixed_depth = LimitsType::new();
+    fixed_depth.depth = 20;
+    worker.prepare_search(&fixed_depth);
+
+    let mut pos = Position::new();
+    pos.set_hirate();
+
+    let (node_thr, run_thr) = (100, 1);
+    worker.state.nodes = 50;
+    worker.state.depth_liveness_update_for_test(15, 0, node_thr, run_thr);
+    worker.state.depth_liveness_update_for_test(16, 1, node_thr, run_thr);
+    worker.state.nodes = 200;
+
+    let ctx = SearchContext {
+        tt: &worker.tt,
+        eval_hash: &worker.eval_hash,
+        history: &worker.history,
+        cont_history_sentinel: worker.cont_history_sentinel,
+        generate_all_legal_moves: worker.generate_all_legal_moves,
+        max_moves_to_draw: worker.max_moves_to_draw,
+        thread_id: worker.thread_id,
+        allow_tt_write: worker.allow_tt_write,
+        tune_params: &worker.search_tune_params,
+        reductions: &worker.reductions,
+        draw_value_table: worker.draw_value_table,
+    };
+    let mut time_manager =
+        TimeManagement::new(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
+
+    let beta = Value::new(100);
+    let static_eval = Value::new(1000);
+    let calls = Cell::new(0);
+    let (value, _improving) = try_null_move_pruning::<{ NodeType::NonPV as u8 }, _>(
+        &mut worker.state,
+        &ctx,
+        &mut pos,
+        16,
+        beta,
+        1,
+        true,
+        false,
+        static_eval,
+        false,
+        Move::NONE,
+        &fixed_depth,
+        &mut time_manager,
+        |_st, _ctx, _pos, child_depth, _alpha, _beta, ply, _cut_node, _limits, _tm| {
+            calls.set(calls.get() + 1);
+            // depth <= 0 の呼び出しは search_node なら liveness 更新前に qsearch へ
+            // 早期 return するため、ここでは追跡を触らない。
+            assert!(child_depth <= 0, "r=32 で null/verification とも depth は負のはず");
+            if ply == 1 { beta } else { -beta }
+        },
+    );
+
+    assert_eq!(calls.get(), 2);
+    assert!(value.is_some());
+
+    // マークが残留していると、次の実手 child が verification root と誤認され
+    // run 判定・enforcement から外れてしまう (発火せず 16 が素通しになる)。
+    assert_eq!(
+        worker.state.depth_liveness_update_for_test(16, 2, node_thr, run_thr),
+        15,
+        "verification 後の実手 child は通常どおり追跡され、発火・enforcement されること"
+    );
+}
+
+#[test]
 fn test_depth_liveness_state_is_reset_for_each_go() {
     let tt = Arc::new(TranspositionTable::new(16));
     let eval_hash = Arc::new(EvalHash::new(1));

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use crate::eval::EvalHash;
 use crate::search::SearchTuneParams;
-use crate::search::alpha_beta::{SearchWorker, build_reductions, reduction};
+use crate::search::alpha_beta::{
+    SearchWorker, build_reductions, enforce_decreasing_depth, reduction,
+    should_activate_depth_liveness,
+};
 use crate::tt::TranspositionTable;
 
 #[test]
@@ -85,6 +88,45 @@ fn test_reduction_zero_root_delta_clamped() {
     // root_delta=0 を渡しても内部で1にクランプされることを確認
     let r = reduction(&reductions, &tune, false, 10, 10, 0, 0) / 1024;
     assert!(r >= 0, "reduction should clamp root_delta to >=1 even when 0 is passed");
+}
+
+#[test]
+fn test_depth_liveness_activation_requires_node_and_run_thresholds() {
+    assert!(!should_activate_depth_liveness(99_999, 0, 8, 100_000, 8));
+    assert!(!should_activate_depth_liveness(100_000, 0, 7, 100_000, 8));
+    assert!(should_activate_depth_liveness(100_000, 0, 8, 100_000, 8));
+
+    // root search が go の途中から始まっても、試行内の消費 node だけを数える。
+    assert!(!should_activate_depth_liveness(149_999, 50_000, 8, 100_000, 8));
+    assert!(should_activate_depth_liveness(150_000, 50_000, 8, 100_000, 8));
+
+    // どちらかの閾値が0なら同一バイナリの無効化条件になる。
+    assert!(!should_activate_depth_liveness(u64::MAX, 0, 256, 0, 8));
+    assert!(!should_activate_depth_liveness(u64::MAX, 0, 256, 100_000, 0));
+}
+
+#[test]
+fn test_depth_liveness_enforces_strict_progress_only_after_activation() {
+    assert_eq!(enforce_decreasing_depth(5, 4, false), 5);
+    assert_eq!(enforce_decreasing_depth(4, 4, false), 4);
+    assert_eq!(enforce_decreasing_depth(5, 4, true), 3);
+    assert_eq!(enforce_decreasing_depth(4, 4, true), 3);
+    assert_eq!(enforce_decreasing_depth(2, 4, true), 2);
+    assert_eq!(enforce_decreasing_depth(1, 1, true), 0);
+}
+
+#[test]
+fn test_depth_liveness_state_is_reset_for_each_go() {
+    let tt = Arc::new(TranspositionTable::new(16));
+    let eval_hash = Arc::new(EvalHash::new(1));
+    let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+
+    worker.state.root_search_start_nodes = 42;
+    worker.state.depth_liveness_active = true;
+    worker.prepare_search();
+
+    assert_eq!(worker.state.root_search_start_nodes, 0);
+    assert!(!worker.state.depth_liveness_active);
 }
 
 #[test]

--- a/crates/rshogi-core/src/search/tests/alpha_beta.rs
+++ b/crates/rshogi-core/src/search/tests/alpha_beta.rs
@@ -177,6 +177,95 @@ fn test_depth_liveness_verification_snapshot_restores_outer_path() {
 }
 
 #[test]
+fn test_nmp_verification_restores_depth_liveness_in_production_path() {
+    use std::cell::Cell;
+    use std::sync::atomic::AtomicBool;
+
+    use crate::position::Position;
+    use crate::search::alpha_beta::SearchContext;
+    use crate::search::pruning::try_null_move_pruning;
+    use crate::search::{NodeType, TimeManagement};
+    use crate::types::{Move, Value};
+
+    let tt = Arc::new(TranspositionTable::new(16));
+    let eval_hash = Arc::new(EvalHash::new(1));
+    let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+    let mut fixed_depth = LimitsType::new();
+    fixed_depth.depth = 20;
+    worker.prepare_search(&fixed_depth);
+
+    let mut pos = Position::new();
+    pos.set_hirate();
+
+    // 外側 move path: root (ply=0) と NMP を試みるノード自身 (ply=1) の entry を記録。
+    let (node_thr, run_thr) = (100, 8);
+    worker.state.depth_liveness_update_for_test(16, 0, node_thr, run_thr);
+    worker.state.depth_liveness_update_for_test(16, 1, node_thr, run_thr);
+    let outer = worker.state.depth_liveness_snapshot(1).unwrap();
+
+    let ctx = SearchContext {
+        tt: &worker.tt,
+        eval_hash: &worker.eval_hash,
+        history: &worker.history,
+        cont_history_sentinel: worker.cont_history_sentinel,
+        generate_all_legal_moves: worker.generate_all_legal_moves,
+        max_moves_to_draw: worker.max_moves_to_draw,
+        thread_id: worker.thread_id,
+        allow_tt_write: worker.allow_tt_write,
+        tune_params: &worker.search_tune_params,
+        reductions: &worker.reductions,
+        draw_value_table: worker.draw_value_table,
+    };
+    let mut time_manager =
+        TimeManagement::new(Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
+
+    // depth >= nmp_verification_depth_threshold かつ null search が beta を上回る状況を作り、
+    // verification search (同一 ply の再帰) まで到達させる。margin は depth 16 の既定
+    // パラメータで負になるため、static_eval は beta より十分高くしておく。
+    let beta = Value::new(100);
+    let static_eval = Value::new(1000);
+    let depth = 16;
+    let calls = Cell::new(0);
+    let verification_snapshot = Cell::new(None);
+    let (value, _improving) = try_null_move_pruning::<{ NodeType::NonPV as u8 }, _>(
+        &mut worker.state,
+        &ctx,
+        &mut pos,
+        depth,
+        beta,
+        1,
+        true,
+        false,
+        static_eval,
+        false,
+        Move::NONE,
+        &fixed_depth,
+        &mut time_manager,
+        |st, _ctx, _pos, child_depth, _alpha, _beta, ply, _cut_node, _limits, _tm| {
+            calls.set(calls.get() + 1);
+            if ply == 1 {
+                // verification search: 実際の search_node と同様に同一 ply の追跡を上書きする。
+                st.depth_liveness_update_for_test(child_depth, ply, node_thr, run_thr);
+                verification_snapshot.set(st.depth_liveness_snapshot(1));
+                beta
+            } else {
+                -beta
+            }
+        },
+    );
+
+    assert_eq!(calls.get(), 2, "null search と verification search の両方を通ること");
+    assert!(value.is_some(), "verification が beta を上回れば NMP cutoff が成立すること");
+    let corrupted = verification_snapshot.get().unwrap();
+    assert_ne!(corrupted, outer, "verification search は同一 ply の追跡を実際に上書きすること");
+    assert_eq!(
+        worker.state.depth_liveness_snapshot(1).unwrap(),
+        outer,
+        "try_null_move_pruning は verification 後に外側 ply の追跡を復元すること"
+    );
+}
+
+#[test]
 fn test_depth_liveness_state_is_reset_for_each_go() {
     let tt = Arc::new(TranspositionTable::new(16));
     let eval_hash = Arc::new(EvalHash::new(1));

--- a/crates/rshogi-core/src/search/thread.rs
+++ b/crates/rshogi-core/src/search/thread.rs
@@ -339,7 +339,7 @@ mod imp {
                     worker.draw_value_black = task.draw_value_black;
                     worker.draw_value_white = task.draw_value_white;
                     worker.entering_king_rule = task.entering_king_rule;
-                    worker.prepare_search();
+                    worker.prepare_search(&task.limits);
 
                     let mut pos = task.pos;
                     let mut time_manager =
@@ -805,7 +805,7 @@ mod imp {
                         worker.draw_value_white = draw_value_white;
                         worker.entering_king_rule = entering_king_rule;
                         worker.search_tune_params = search_tune_params;
-                        worker.prepare_search();
+                        worker.prepare_search(&limits_clone);
 
                         let mut search_pos = pos_clone;
                         let mut time_manager =

--- a/crates/rshogi-core/src/search/tune_params.rs
+++ b/crates/rshogi-core/src/search/tune_params.rs
@@ -1292,13 +1292,13 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
     },
     SearchTuneOptionSpec {
         usi_name: "SPSA_DEPTH_LIVENESS_NODES",
-        default: 0,
+        default: 100000,
         min: 0,
         max: 100000000,
     },
     SearchTuneOptionSpec {
         usi_name: "SPSA_DEPTH_LIVENESS_RUN",
-        default: 0,
+        default: 8,
         min: 0,
         max: 256,
     },
@@ -1617,8 +1617,8 @@ impl Default for SearchTuneParams {
             // Group C
             aspiration_delta_base: 5,
             aspiration_mean_sq_div: 9000,
-            depth_liveness_node_threshold: 0,
-            depth_liveness_run_threshold: 0,
+            depth_liveness_node_threshold: 100_000,
+            depth_liveness_run_threshold: 8,
             // Group D
             lmr_table_coeff: 2809,
             // Group E
@@ -2102,15 +2102,15 @@ mod tests {
     }
 
     #[test]
-    fn depth_liveness_params_round_trip_and_disable_by_default() {
+    fn depth_liveness_params_default_and_disable_round_trip() {
         let mut params = SearchTuneParams::default();
-        assert_eq!(params.depth_liveness_node_threshold, 0);
-        assert_eq!(params.depth_liveness_run_threshold, 0);
-
-        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_NODES", 100_000).unwrap();
-        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_RUN", 8).unwrap();
         assert_eq!(params.depth_liveness_node_threshold, 100_000);
         assert_eq!(params.depth_liveness_run_threshold, 8);
+
+        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_NODES", 0).unwrap();
+        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_RUN", 0).unwrap();
+        assert_eq!(params.depth_liveness_node_threshold, 0);
+        assert_eq!(params.depth_liveness_run_threshold, 0);
     }
 
     #[test]

--- a/crates/rshogi-core/src/search/tune_params.rs
+++ b/crates/rshogi-core/src/search/tune_params.rs
@@ -1292,7 +1292,7 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
     },
     SearchTuneOptionSpec {
         usi_name: "SPSA_DEPTH_LIVENESS_NODES",
-        default: 100000,
+        default: 500000,
         min: 0,
         max: 100000000,
     },
@@ -1617,7 +1617,7 @@ impl Default for SearchTuneParams {
             // Group C
             aspiration_delta_base: 5,
             aspiration_mean_sq_div: 9000,
-            depth_liveness_node_threshold: 100_000,
+            depth_liveness_node_threshold: 500_000,
             depth_liveness_run_threshold: 8,
             // Group D
             lmr_table_coeff: 2809,
@@ -2104,7 +2104,7 @@ mod tests {
     #[test]
     fn depth_liveness_params_default_and_disable_round_trip() {
         let mut params = SearchTuneParams::default();
-        assert_eq!(params.depth_liveness_node_threshold, 100_000);
+        assert_eq!(params.depth_liveness_node_threshold, 500_000);
         assert_eq!(params.depth_liveness_run_threshold, 8);
 
         params.set_from_usi_name("SPSA_DEPTH_LIVENESS_NODES", 0).unwrap();

--- a/crates/rshogi-core/src/search/tune_params.rs
+++ b/crates/rshogi-core/src/search/tune_params.rs
@@ -340,6 +340,10 @@ pub struct SearchTuneParams {
     pub aspiration_delta_base: i32,
     /// aspiration window: mean squared score 除算値
     pub aspiration_mean_sq_div: i32,
+    /// 1回のroot searchでこのnode数を超えたらdepth livenessを監視（0=無効）
+    pub depth_liveness_node_threshold: i32,
+    /// remaining depthが減らない連続edge数の発火閾値（0=無効）
+    pub depth_liveness_run_threshold: i32,
 
     // =========================================================================
     // Group D: Reductions テーブル
@@ -1286,6 +1290,18 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
         min: 1,
         max: 100000,
     },
+    SearchTuneOptionSpec {
+        usi_name: "SPSA_DEPTH_LIVENESS_NODES",
+        default: 0,
+        min: 0,
+        max: 100000000,
+    },
+    SearchTuneOptionSpec {
+        usi_name: "SPSA_DEPTH_LIVENESS_RUN",
+        default: 0,
+        min: 0,
+        max: 256,
+    },
     // Group D: Reductions テーブル
     SearchTuneOptionSpec {
         usi_name: "SPSA_LMR_TABLE_COEFF",
@@ -1601,6 +1617,8 @@ impl Default for SearchTuneParams {
             // Group C
             aspiration_delta_base: 5,
             aspiration_mean_sq_div: 9000,
+            depth_liveness_node_threshold: 0,
+            depth_liveness_run_threshold: 0,
             // Group D
             lmr_table_coeff: 2809,
             // Group E
@@ -1994,6 +2012,8 @@ impl SearchTuneParams {
         // Group C
         try_apply!("SPSA_ASP_DELTA_BASE", aspiration_delta_base, 1, 64);
         try_apply!("SPSA_ASP_MEAN_SQ_DIV", aspiration_mean_sq_div, 1, 100000);
+        try_apply!("SPSA_DEPTH_LIVENESS_NODES", depth_liveness_node_threshold, 0, 100000000);
+        try_apply!("SPSA_DEPTH_LIVENESS_RUN", depth_liveness_run_threshold, 0, 256);
         // Group D
         try_apply!("SPSA_LMR_TABLE_COEFF", lmr_table_coeff, 1024, 8192);
         // Group E
@@ -2079,6 +2099,18 @@ mod tests {
         assert_eq!(params.update_all_stats_quiet_malus_decay_num, 955);
         assert_eq!(params.lmr_all_node_scale_num, 273);
         assert_eq!(params.lmr_all_node_scale_offset, 286);
+    }
+
+    #[test]
+    fn depth_liveness_params_round_trip_and_disable_by_default() {
+        let mut params = SearchTuneParams::default();
+        assert_eq!(params.depth_liveness_node_threshold, 0);
+        assert_eq!(params.depth_liveness_run_threshold, 0);
+
+        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_NODES", 100_000).unwrap();
+        params.set_from_usi_name("SPSA_DEPTH_LIVENESS_RUN", 8).unwrap();
+        assert_eq!(params.depth_liveness_node_threshold, 100_000);
+        assert_eq!(params.depth_liveness_run_threshold, 8);
     }
 
     #[test]

--- a/crates/rshogi-core/src/search/tune_params.rs
+++ b/crates/rshogi-core/src/search/tune_params.rs
@@ -2,6 +2,13 @@
 //!
 //! USI `setoption` で更新できる探索係数を集約する。
 
+use crate::types::MAX_PLY;
+
+/// depth-liveness の非減少 edge 連続数は ply が `MAX_PLY` で打ち切られるため
+/// `MAX_PLY - 1` を超えられない。これより大きい閾値を許すと「0のみ無効」の
+/// 契約に反して guard が黙って無効化されるので、上限をここで縛る。
+const DEPTH_LIVENESS_RUN_MAX: i32 = MAX_PLY - 1;
+
 /// 1つのチューニング項目のUSI定義。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SearchTuneOptionSpec {
@@ -1300,7 +1307,7 @@ const SPSA_OPTION_SPECS: &[SearchTuneOptionSpec] = &[
         usi_name: "SPSA_DEPTH_LIVENESS_RUN",
         default: 8,
         min: 0,
-        max: 256,
+        max: DEPTH_LIVENESS_RUN_MAX,
     },
     // Group D: Reductions テーブル
     SearchTuneOptionSpec {
@@ -2013,7 +2020,12 @@ impl SearchTuneParams {
         try_apply!("SPSA_ASP_DELTA_BASE", aspiration_delta_base, 1, 64);
         try_apply!("SPSA_ASP_MEAN_SQ_DIV", aspiration_mean_sq_div, 1, 100000);
         try_apply!("SPSA_DEPTH_LIVENESS_NODES", depth_liveness_node_threshold, 0, 100000000);
-        try_apply!("SPSA_DEPTH_LIVENESS_RUN", depth_liveness_run_threshold, 0, 256);
+        try_apply!(
+            "SPSA_DEPTH_LIVENESS_RUN",
+            depth_liveness_run_threshold,
+            0,
+            DEPTH_LIVENESS_RUN_MAX
+        );
         // Group D
         try_apply!("SPSA_LMR_TABLE_COEFF", lmr_table_coeff, 1024, 8192);
         // Group E

--- a/crates/rshogi-core/src/search/types.rs
+++ b/crates/rshogi-core/src/search/types.rs
@@ -10,7 +10,7 @@ use std::mem::MaybeUninit;
 
 use crate::movegen::{MoveList, generate_legal_with_pass};
 use crate::position::Position;
-use crate::types::{Depth, MAX_PLY, Move, Piece, RepetitionState, Square, Value};
+use crate::types::{MAX_PLY, Move, Piece, RepetitionState, Square, Value};
 
 use super::history::PieceToHistory;
 use std::ptr::NonNull;
@@ -189,12 +189,6 @@ pub struct Stack {
     /// ルートからの手数
     pub ply: i32,
 
-    /// このノードのsearch入口で実際に用いたremaining depth
-    pub search_entry_depth: Depth,
-
-    /// 親からremaining depthが減らなかった連続edge数
-    pub nondecreasing_depth_run: i32,
-
     /// このノードで選択されている手
     pub current_move: Move,
 
@@ -234,8 +228,6 @@ impl Default for Stack {
             cont_history_ptr: NonNull::dangling(),
             cont_hist_key: None,
             ply: 0,
-            search_entry_depth: 0,
-            nondecreasing_depth_run: 0,
             current_move: Move::NONE,
             excluded_move: Move::NONE,
             static_eval: Value::NONE,

--- a/crates/rshogi-core/src/search/types.rs
+++ b/crates/rshogi-core/src/search/types.rs
@@ -10,7 +10,7 @@ use std::mem::MaybeUninit;
 
 use crate::movegen::{MoveList, generate_legal_with_pass};
 use crate::position::Position;
-use crate::types::{MAX_PLY, Move, Piece, RepetitionState, Square, Value};
+use crate::types::{Depth, MAX_PLY, Move, Piece, RepetitionState, Square, Value};
 
 use super::history::PieceToHistory;
 use std::ptr::NonNull;
@@ -189,6 +189,12 @@ pub struct Stack {
     /// ルートからの手数
     pub ply: i32,
 
+    /// このノードのsearch入口で実際に用いたremaining depth
+    pub search_entry_depth: Depth,
+
+    /// 親からremaining depthが減らなかった連続edge数
+    pub nondecreasing_depth_run: i32,
+
     /// このノードで選択されている手
     pub current_move: Move,
 
@@ -228,6 +234,8 @@ impl Default for Stack {
             cont_history_ptr: NonNull::dangling(),
             cont_hist_key: None,
             ply: 0,
+            search_entry_depth: 0,
+            nondecreasing_depth_run: 0,
             current_move: Move::NONE,
             excluded_move: Move::NONE,
             static_eval: Value::NONE,


### PR DESCRIPTION
## 問題

TT 飽和時に「子の remaining depth が親より減らない edge」が連鎖すると、探索木が深さ方向に成長し続け、停止予算 (時間 / nodes / infinite) のない `go depth N` が事実上終了しなくなる。非減少 edge の発生源は Singular Extension 単体ではなく:

- negative LMR の初回探索
- LMR fail-high 後の深い再探索
- PV full-depth 再探索の depth 1→1

追跡した非減少 edge 自体はすべて extension=0 であり、旧修正 (`extension.min(1)`) は根因を直接直していなかったため撤去した。

## 修正

- 停止予算のない探索でのみ `DepthLivenessState` を確保 (`prepare_search`)。時間 / nodes / infinite 探索はコスト増なし (`Option::None` 分岐 1 個)
- root search 開始から 500k nodes 消費後、非減少 depth edge が 8 連続したら guard 発火 (`SPSA_DEPTH_LIVENESS_NODES` / `SPSA_DEPTH_LIVENESS_RUN`、0 で無効)
- 発火後は実手の子探索 depth を parent entry depth − 1 以下に制限し、有限終了を保証
- 同一 ply で再帰する verification search (SE / NMP) は snapshot/restore で外側 path の追跡状態を復元

## 検証

- 純 depth 15 固定コーパス: 151 探索すべて完走、最大 3.86M nodes
- kingrank9 追加 stress: 合計 152.30M nodes、最大 9.35M でも全件完走
- `depth 15 nodes 100000`: origin/main と 152/152 で time/nps 以外完全一致 (guard 無効経路の同一性)
- YO との depth 9・400 局: +18.26 ±34.10 nElo、guard 発火 0 回
- 通常探索 production A/B: NPS +0.38%、cycles/node −0.34%、instructions/node +0.11% (劣化なし)
- テスト 984 passed / 7 ignored、Clippy clean、abs-path 検査 OK
- NMP verification の restore 配線は mutation (restore 除去で当該テスト FAIL) で実効性確認済み

## レビュー

Claude (Fable) + Codex の 2 独立レビュー実施。Codex 初回 REQUEST_CHANGES (NMP verification の liveness state 破壊ほか 2 件) → 修正 → 両者 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EK891fnR6T9eRJSmN64stN