### PR TITLE
perf(nnue): defer changed-index collection on LayerStacks fast path

### DIFF
--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -758,23 +758,27 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                 // 差分更新
                 let mut removed = IndexList::new();
                 let mut added = IndexList::new();
-                append_changed_indices::<FT>(
-                    dirty_piece,
-                    perspective,
-                    pos.king_square(perspective),
-                    &mut removed,
-                    &mut added,
-                );
-
                 let prev = prev_acc.get(p);
                 let curr = acc.get_mut(p);
                 curr.copy_from_slice(prev);
-                if !self.try_apply_dirty_piece_fast(
+                let fast_applied = self.try_apply_dirty_piece_fast(
                     curr,
                     dirty_piece,
                     perspective,
                     pos.king_square(perspective),
-                ) {
+                );
+                // PSQT は main accumulator の fast path 成功時も changed indices を使う。
+                // PSQT なしでは slow path に落ちた場合だけ生成すればよい。
+                if !fast_applied || cfg!(feature = "nnue-psqt") {
+                    append_changed_indices::<FT>(
+                        dirty_piece,
+                        perspective,
+                        pos.king_square(perspective),
+                        &mut removed,
+                        &mut added,
+                    );
+                }
+                if !fast_applied {
                     for index in removed.iter() {
                         self.sub_weights(curr, index);
                     }
@@ -913,23 +917,27 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                 // 差分更新（キャッシュ不使用）
                 let mut removed = IndexList::new();
                 let mut added = IndexList::new();
-                append_changed_indices::<FT>(
-                    dirty_piece,
-                    perspective,
-                    pos.king_square(perspective),
-                    &mut removed,
-                    &mut added,
-                );
-
                 let prev = prev_acc.get(p);
                 let curr = acc.get_mut(p);
                 curr.copy_from_slice(prev);
-                if !self.try_apply_dirty_piece_fast(
+                let fast_applied = self.try_apply_dirty_piece_fast(
                     curr,
                     dirty_piece,
                     perspective,
                     pos.king_square(perspective),
-                ) {
+                );
+                // PSQT は main accumulator の fast path 成功時も changed indices を使う。
+                // PSQT なしでは slow path に落ちた場合だけ生成すればよい。
+                if !fast_applied || cfg!(feature = "nnue-psqt") {
+                    append_changed_indices::<FT>(
+                        dirty_piece,
+                        perspective,
+                        pos.king_square(perspective),
+                        &mut removed,
+                        &mut added,
+                    );
+                }
+                if !fast_applied {
                     for index in removed.iter() {
                         self.sub_weights(curr, index);
                     }


### PR DESCRIPTION
## 概要

LayerStacks NNUE の差分更新で、dirty-piece fast path が成功した場合に不要な changed-index 生成を省きます。

従来は fast path の成否を判定する前に常に `append_changed_indices()` を実行していました。このPRでは fast path を先に試し、slow pathへ落ちた場合、またはPSQT accumulator更新に必要な場合だけ removed/added indexを生成します。

accumulator cache使用経路と非使用経路の両方を変更します。

## 適用範囲

効果がある条件:

- LayerStacks
- `nnue-psqt` 無効
- `nnue-effect-bucket` 無効
- `try_apply_dirty_piece_fast()` が成功する通常の駒移動

挙動を維持する条件:

- PSQT版はmain accumulatorのfast path成功時もchanged indicesを生成する
- effect-bucket版はfast pathがfalseを返すため従来のslow pathを使う
- 駒打ち、手駒だけの変化、refreshが必要な玉移動なども従来のslow pathを使う

`effect-bucket` と `progress.bin` は別機能です。今回実測した `LS_BUCKET_MODE=kingrank9` は `progress.bin` を使用しません。

## 性能測定

Ryzen 9 5950X、Threads=1、HalfKaHmMerged LayerStacks 1536x16x32 none、kingrank9、4局面、5秒、ABBA x 3 rounds（各24 samples）:

- NPS: `651,299 -> 668,552`（`+2.649%`）
- cycles/node: `-2.407%`
- instructions/node: `-4.171%`

この改善量を実測したのは上記editionだけです。他editionの効果量は別途測定が必要です。

## 探索同一性

PR #938 merge後の最新mainと、このPRのproduction buildを同一KingRank9 NNUEで比較しました。

- depth 16、4局面
- depth 1〜16のnodes: 全局面・全depthで完全一致
- bestmove: 4 / 4一致
- production metadata: `commit_dirty=false`

## 検証

- `cargo test -p rshogi-core --quiet`
  - 986 passed / 7 ignored
  - build feature checks 39 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p rshogi-core --all-targets -- -D warnings`
- `bash scripts/check-tracked-abs-paths.sh`
- `git diff --check origin/main...HEAD`
- `cargo xtask build --edition layerstacks-halfka_hm_merged-1536x16x32-none`

すべて成功しました。
