### PR TITLE
feat(csa-server): CLOCK_PRESETS に per-preset max_moves を追加 (floodgate-600-10-moves256/512)

### DIFF
--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -127,6 +127,9 @@ impl ConfigKeys {
     /// 等から導出する global clock を全 `game_name` に適用する後方互換動作にとどまる。
     /// 1 件以上登録された場合は strict mode となり、未登録 `game_name` の LOGIN は
     /// `LOGIN_LOBBY:incorrect unknown_game_name` で拒否される。
+    ///
+    /// 各 entry は時計仕様に加えて省略可能な `max_moves` (手数上限、到達で
+    /// `%MAX_MOVES` 引き分け) を持てる。省略時は `DEFAULT_MAX_MOVES` (256)。
     pub const CLOCK_PRESETS: &'static str = "CLOCK_PRESETS";
     /// 管理 API トークン (Floodgate audit https://github.com/SH11235/rshogi/issues/560
     /// 由来)。WS 内 admin command (`%%ADMIN <token>`,
@@ -485,7 +488,16 @@ pub fn parse_clock_spec(
     }
 }
 
-/// `CLOCK_PRESETS` 環境変数 (JSON 配列文字列) から `game_name → ClockSpec` の
+/// `CLOCK_PRESETS` の 1 entry を解決した結果。時計仕様に加えて、preset 単位の
+/// 対局ルール上書き (現状は `max_moves` のみ) を保持する。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GamePreset {
+    pub clock: ClockSpec,
+    /// 手数上限の上書き。`None` は既定 (`game_room` の `DEFAULT_MAX_MOVES`) を使う。
+    pub max_moves: Option<u32>,
+}
+
+/// `CLOCK_PRESETS` 環境変数 (JSON 配列文字列) から `game_name → GamePreset` の
 /// マップを構築する。
 ///
 /// `None` / 空文字 / `[]` は空 HashMap を返す（プリセット未宣言モード）。
@@ -497,9 +509,10 @@ pub fn parse_clock_spec(
 /// - 同一 `game_name` の重複は `Err`。
 /// - `total_time_*` が 0 の preset は `Err`（少なくとも 1 単位以上の本体時間を要求）。
 ///   `byoyomi_*` / `increment_sec` の 0 は sudden death として許容。
+/// - `max_moves` は省略可。指定時は 0 を `Err` (0 手上限は即引き分けで無意味)。
 pub fn parse_clock_presets(
     raw: Option<&str>,
-) -> Result<std::collections::HashMap<String, ClockSpec>, String> {
+) -> Result<std::collections::HashMap<String, GamePreset>, String> {
     use serde::Deserialize;
     let trimmed = raw.unwrap_or("").trim();
     if trimmed.is_empty() {
@@ -508,29 +521,43 @@ pub fn parse_clock_presets(
     #[derive(Deserialize)]
     struct Entry {
         game_name: String,
+        #[serde(default)]
+        max_moves: Option<u32>,
         #[serde(flatten)]
         spec: ClockSpec,
     }
     let entries: Vec<Entry> =
         serde_json::from_str(trimmed).map_err(|e| format!("CLOCK_PRESETS: invalid JSON: {e}"))?;
-    let mut out: std::collections::HashMap<String, ClockSpec> =
+    let mut out: std::collections::HashMap<String, GamePreset> =
         std::collections::HashMap::with_capacity(entries.len());
     for entry in entries {
         entry.spec.validate_total_time_nonzero().map_err(|field| {
             format!("CLOCK_PRESETS: clock preset {:?}: {field} must be > 0", entry.game_name)
         })?;
+        if entry.max_moves == Some(0) {
+            return Err(format!(
+                "CLOCK_PRESETS: clock preset {:?}: max_moves must be > 0",
+                entry.game_name
+            ));
+        }
         if out.contains_key(&entry.game_name) {
             return Err(format!(
                 "CLOCK_PRESETS: duplicate clock preset entry for game_name {:?}",
                 entry.game_name
             ));
         }
-        out.insert(entry.game_name, entry.spec);
+        out.insert(
+            entry.game_name,
+            GamePreset {
+                clock: entry.spec,
+                max_moves: entry.max_moves,
+            },
+        );
     }
     Ok(out)
 }
 
-/// `resolve_clock_spec_from_presets_map` の戻り値。
+/// `resolve_game_preset_from_presets_map` の戻り値。
 /// `parse_clock_presets` の結果から `game_name` の解決結果を 3 状態で表現する。
 #[derive(Debug, PartialEq, Eq)]
 pub enum PresetResolution {
@@ -538,22 +565,22 @@ pub enum PresetResolution {
     /// （後方互換モード）。
     Fallback,
     /// 該当 `game_name` の preset を返す。
-    Hit(ClockSpec),
+    Hit(GamePreset),
     /// presets 宣言済みかつ未登録 → strict mode で `Err` 化されるべき。
     Unknown,
 }
 
 /// `parse_clock_presets` で得たマップと `game_name` から `PresetResolution` を返す
 /// 純粋ロジック部。env-fetch を持たないため、host target テストから直接呼べる。
-pub fn resolve_clock_spec_from_presets_map(
-    presets: &std::collections::HashMap<String, ClockSpec>,
+pub fn resolve_game_preset_from_presets_map(
+    presets: &std::collections::HashMap<String, GamePreset>,
     game_name: &str,
 ) -> PresetResolution {
     if presets.is_empty() {
         return PresetResolution::Fallback;
     }
     match presets.get(game_name) {
-        Some(spec) => PresetResolution::Hit(spec.clone()),
+        Some(preset) => PresetResolution::Hit(preset.clone()),
         None => PresetResolution::Unknown,
     }
 }
@@ -901,18 +928,47 @@ mod tests {
         assert_eq!(map.len(), 3);
         assert!(matches!(
             map.get("byoyomi-600-10"),
-            Some(ClockSpec::Countdown {
-                total_time_sec: 600,
-                byoyomi_sec: 10
+            Some(GamePreset {
+                clock: ClockSpec::Countdown {
+                    total_time_sec: 600,
+                    byoyomi_sec: 10
+                },
+                max_moves: None
             })
         ));
         assert!(matches!(
             map.get("fischer-300-10F"),
-            Some(ClockSpec::Fischer {
-                total_time_sec: 300,
-                increment_sec: 10
+            Some(GamePreset {
+                clock: ClockSpec::Fischer {
+                    total_time_sec: 300,
+                    increment_sec: 10
+                },
+                max_moves: None
             })
         ));
+    }
+
+    /// `max_moves` は省略可能な per-preset 上書き。指定した preset のみ値を持ち、
+    /// 0 は拒否する。
+    #[test]
+    fn parse_clock_presets_accepts_optional_max_moves() {
+        let raw = r#"[
+            {"game_name":"floodgate-600-10-moves512","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":512},
+            {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10}
+        ]"#;
+        let map = parse_clock_presets(Some(raw)).unwrap();
+        assert_eq!(map.get("floodgate-600-10-moves512").unwrap().max_moves, Some(512));
+        assert_eq!(map.get("floodgate-600-10").unwrap().max_moves, None);
+    }
+
+    #[test]
+    fn parse_clock_presets_rejects_zero_max_moves() {
+        let raw = r#"[
+            {"game_name":"broken","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":0}
+        ]"#;
+        let err = parse_clock_presets(Some(raw)).unwrap_err();
+        assert!(err.contains("max_moves"), "error must mention field: {err}");
+        assert!(err.contains("broken"), "error must mention game_name: {err}");
     }
 
     #[test]
@@ -961,10 +1017,10 @@ mod tests {
     /// global clock 解決を委ねる。
     #[test]
     fn resolve_returns_fallback_when_presets_empty() {
-        let presets: std::collections::HashMap<String, ClockSpec> =
+        let presets: std::collections::HashMap<String, GamePreset> =
             std::collections::HashMap::new();
         assert_eq!(
-            resolve_clock_spec_from_presets_map(&presets, "anything"),
+            resolve_game_preset_from_presets_map(&presets, "anything"),
             PresetResolution::Fallback
         );
     }
@@ -975,16 +1031,22 @@ mod tests {
         let mut presets = std::collections::HashMap::new();
         presets.insert(
             "byoyomi-600-10".to_owned(),
-            ClockSpec::Countdown {
-                total_time_sec: 600,
-                byoyomi_sec: 10,
+            GamePreset {
+                clock: ClockSpec::Countdown {
+                    total_time_sec: 600,
+                    byoyomi_sec: 10,
+                },
+                max_moves: None,
             },
         );
         assert_eq!(
-            resolve_clock_spec_from_presets_map(&presets, "byoyomi-600-10"),
-            PresetResolution::Hit(ClockSpec::Countdown {
-                total_time_sec: 600,
-                byoyomi_sec: 10
+            resolve_game_preset_from_presets_map(&presets, "byoyomi-600-10"),
+            PresetResolution::Hit(GamePreset {
+                clock: ClockSpec::Countdown {
+                    total_time_sec: 600,
+                    byoyomi_sec: 10
+                },
+                max_moves: None
             })
         );
     }
@@ -996,13 +1058,16 @@ mod tests {
         let mut presets = std::collections::HashMap::new();
         presets.insert(
             "byoyomi-600-10".to_owned(),
-            ClockSpec::Countdown {
-                total_time_sec: 600,
-                byoyomi_sec: 10,
+            GamePreset {
+                clock: ClockSpec::Countdown {
+                    total_time_sec: 600,
+                    byoyomi_sec: 10,
+                },
+                max_moves: None,
             },
         );
         assert_eq!(
-            resolve_clock_spec_from_presets_map(&presets, "unregistered"),
+            resolve_game_preset_from_presets_map(&presets, "unregistered"),
             PresetResolution::Unknown
         );
     }

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -787,8 +787,8 @@ impl GameRoom {
         // Lobby 側の OnceCell キャッシュ廃止後は両 DO ともに env を毎回読み直す
         // ため deploy race による乖離は解消されたが、`CLOCK_PRESETS` 不正設定時の
         // fail-fast 経路は残す)。
-        let clock_spec = match resolve_clock_spec_for_game(&self.env, game_name) {
-            Ok(spec) => spec,
+        let preset = match resolve_game_preset_for_game(&self.env, game_name) {
+            Ok(preset) => preset,
             Err(e) => {
                 crate::structured_log!(
                     event: "clock_spec_resolution_failed",
@@ -873,13 +873,14 @@ impl GameRoom {
         // で参照するために `PersistedConfig` に保存する。`grace == 0` の構成では
         // `(None, None)` を返し token 配布も `PersistedConfig` への保存もスキップする。
         let (black_reconnect_token, white_reconnect_token) = issue_tokens_if_enabled(grace);
+        let clock_spec = preset.clock;
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
             black_handle: black_handle.to_owned(),
             white_handle: white_handle.to_owned(),
             game_name: game_name.to_owned(),
             clock: clock_spec.clone(),
-            max_moves: DEFAULT_MAX_MOVES,
+            max_moves: preset.max_moves.unwrap_or(DEFAULT_MAX_MOVES),
             time_margin_ms: DEFAULT_TIME_MARGIN_MS,
             matched_at_ms: started,
             play_started_at_ms: None,
@@ -3699,13 +3700,16 @@ fn load_clock_spec_from_env(env: &Env) -> Result<ClockSpec> {
 /// 発生していたため、両 DO とも env を毎回読み直す方針に統一した。GameRoom DO は
 /// 1 対局 = 1 インスタンスで `start_match` のたった 1 回しか評価しないため
 /// もともと re-parse コストは問題にならない。
-fn resolve_clock_spec_for_game(env: &Env, game_name: &str) -> Result<ClockSpec> {
-    use crate::config::{PresetResolution, resolve_clock_spec_from_presets_map};
+fn resolve_game_preset_for_game(env: &Env, game_name: &str) -> Result<crate::config::GamePreset> {
+    use crate::config::{GamePreset, PresetResolution, resolve_game_preset_from_presets_map};
     let raw = env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
     let presets = parse_clock_presets(raw.as_deref()).map_err(Error::RustError)?;
-    match resolve_clock_spec_from_presets_map(&presets, game_name) {
-        PresetResolution::Fallback => load_clock_spec_from_env(env),
-        PresetResolution::Hit(spec) => Ok(spec),
+    match resolve_game_preset_from_presets_map(&presets, game_name) {
+        PresetResolution::Fallback => Ok(GamePreset {
+            clock: load_clock_spec_from_env(env)?,
+            max_moves: None,
+        }),
+        PresetResolution::Hit(preset) => Ok(preset),
         PresetResolution::Unknown => Err(Error::RustError(format!(
             "CLOCK_PRESETS: unknown game_name {game_name:?}; configure preset or remove strict mode"
         ))),

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -340,7 +340,7 @@ impl Lobby {
     /// ブロックされる事態を避ける安全側挙動。`CLOCK_PRESETS` 値そのものは
     /// `parse_clock_presets` の起動時テストでカバーする）。
     /// 空 HashMap = preset 未宣言 = strict mode 無効。
-    fn clock_presets(&self) -> HashMap<String, ClockSpec> {
+    fn clock_presets(&self) -> HashMap<String, crate::config::GamePreset> {
         let raw = self.env.var(ConfigKeys::CLOCK_PRESETS).ok().map(|v| v.to_string());
         match parse_clock_presets(raw.as_deref()) {
             Ok(map) => map,
@@ -938,7 +938,7 @@ impl Lobby {
         //    `unknown_clock_preset` で拒否する (TCP 側は `state.config.clock_presets`
         //    が同じく必須で、未登録は拒否される)。
         let presets = self.clock_presets();
-        let Some(clock_spec) = presets.get(&req.clock_preset).cloned() else {
+        let Some(preset) = presets.get(&req.clock_preset).cloned() else {
             // 早期 return でも、purge した reg は永続化する (取りこぼし回避)。
             if purged {
                 self.save_challenge_registry(&reg).await?;
@@ -967,7 +967,7 @@ impl Lobby {
             PlayerName::new(&req.inviter),
             PlayerName::new(&req.opponent),
             req.inviter_color,
-            clock_spec,
+            preset.clock,
             req.initial_sfen.clone(),
             ttl,
             now_ms,

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -204,7 +204,9 @@ CLOCK_PRESETS = '''[
   {"game_name":"byoyomi-msec-10-100","kind":"countdown_msec","total_time_ms":10000,"byoyomi_ms":100},
   {"game_name":"byoyomi-120-5","kind":"countdown","total_time_sec":120,"byoyomi_sec":5},
   {"game_name":"fischer-60-5F","kind":"fischer","total_time_sec":60,"increment_sec":5},
-  {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10}
+  {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},
+  {"game_name":"floodgate-600-10-moves256","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":256},
+  {"game_name":"floodgate-600-10-moves512","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":512}
 ]'''
 
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化。

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -197,7 +197,9 @@ CLOCK_PRESETS = '''[
   {"game_name":"byoyomi-msec-10-100","kind":"countdown_msec","total_time_ms":10000,"byoyomi_ms":100},
   {"game_name":"byoyomi-120-5","kind":"countdown","total_time_sec":120,"byoyomi_sec":5},
   {"game_name":"fischer-60-5F","kind":"fischer","total_time_sec":60,"increment_sec":5},
-  {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10}
+  {"game_name":"floodgate-600-10","kind":"countdown","total_time_sec":600,"byoyomi_sec":10},
+  {"game_name":"floodgate-600-10-moves256","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":256},
+  {"game_name":"floodgate-600-10-moves512","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":512}
 ]'''
 
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。


### PR DESCRIPTION
## 概要

CLOCK_PRESETS の entry に省略可能な `max_moves` を追加し、game_name (= room の時計プリセット) 単位で手数上限を切り替えられるようにする。

- `config.rs`: `GamePreset { clock, max_moves }` を導入。`parse_clock_presets` は `game_name → GamePreset` を返す。`max_moves` は省略可・0 は Err。resolve 系は `resolve_game_preset_from_presets_map` に改名
- `game_room.rs`: `start_match` で preset の `max_moves` を採用 (省略時は従来どおり `DEFAULT_MAX_MOVES = 256`)
- `lobby.rs`: presets map の型変更追従 (strict mode の membership 判定と challenge 経路は `preset.clock` を使用、挙動不変)
- wrangler production/staging: `floodgate-600-10-moves256` / `floodgate-600-10-moves512` を宣言。**既存プリセットは全て無変更** (bare `floodgate-600-10` は 256 のまま)

## 動機

長手数の相入玉・宣言不能膠着のデータ採取 (moves512) を、既存 game_name の挙動を変えずに room 単位で opt-in したい。

## テスト

- `cargo test -p rshogi-csa-server-workers` 全 pass (max_moves の parse/省略/0拒否テスト追加)
- clippy --tests クリーン / fmt 済み / wasm32 build OK / check-tracked-abs-paths OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkZhYF4q21LWyaeg8UmTBb