### PR TITLE
fix(csa-server): DO 再起動後の再接続を cold rejoin fallback で受理

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3397,22 +3397,38 @@ impl GameRoom {
                 return Ok(None);
             }
         }
+        let core_borrow = self.core.borrow();
+        let Some(core) = core_borrow.as_ref() else {
+            return Ok(None);
+        };
         // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぎ、
         // 再接続によって相手手番の wall-clock deadline が延びないようにする。
         // 取得エラー時は上限不明のまま受理せず reject に倒す (クライアントは
-        // LOGIN リトライで再試行する)。`Ok(None)` (alarm 消失) は受理するが、
-        // その場合の deadline は candidate B = 手番側の残時間 1 手分予算が上限で、
-        // replay 復元で経過思考時間が失われる既存 cold start 挙動と同等。
-        let original_turn_alarm_epoch_ms = self
+        // LOGIN リトライで再試行する)。alarm 消失 (`Ok(None)`) 時は、cold start
+        // 復元後も保持される計時起点 (`turn_started_at_ms`、rshogi#852) から
+        // `now + 現手番の残時間 + margin + 安全ゲタ` を上限として再構成する —
+        // candidate B (経過思考時間を差し引かない 1 手分全予算) をそのまま使うと
+        // 無応答時の TimeUp 確定が実際の残時間より遅れるため。
+        let original_turn_alarm_epoch_ms = match self
             .state
             .storage()
             .get_alarm()
             .await
             .map_err(|e| Error::RustError(format!("cold rejoin get_alarm: {e}")))?
-            .and_then(|ms| u64::try_from(ms).ok());
-        let core_borrow = self.core.borrow();
-        let Some(core) = core_borrow.as_ref() else {
-            return Ok(None);
+        {
+            Some(ms) => u64::try_from(ms).ok(),
+            None => {
+                let now = self.now_ms();
+                let Some(remaining) = core.current_turn_remaining_ms(now) else {
+                    // Playing 以外 (Finished への遷移途中等の異常系)。合成しない。
+                    return Ok(None);
+                };
+                Some(
+                    now.saturating_add(remaining)
+                        .saturating_add(cfg.time_margin_ms)
+                        .saturating_add(ALARM_SAFETY_MS),
+                )
+            }
         };
         let pending =
             self.build_pending_reconnect(core, &cfg, role, grace, original_turn_alarm_epoch_ms)?;

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3369,6 +3369,14 @@ impl GameRoom {
         let Some(cfg) = self.config.borrow().as_ref().cloned() else {
             return Ok(None);
         };
+        // AGREE 未成立 (対局未開始) の部屋は対象外。この段階で合成すると成功時の
+        // `delete_grace_alarm_state` が `AgreeTimeout` の alarm kind を消し、
+        // `AgreeWaiting` の core では TimeUp 経路が no-op のため部屋が永久残留する。
+        // 未開始クライアントは通常 LOGIN でやり直せばよく、放置は AgreeTimeout が
+        // 掃除する。
+        if cfg.play_started_at_ms.is_none() {
+            return Ok(None);
+        }
         // grace 設定は対局開始時に `PersistedConfig.reconnect_grace_ms` へ固定
         // されている。現在の `Env` を読み直すと「対局開始後に設定変更 + deploy →
         // DO 再起動」で開始時に token を発行済みの対局を拒否してしまうため、
@@ -3391,13 +3399,16 @@ impl GameRoom {
         }
         // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぎ、
         // 再接続によって相手手番の wall-clock deadline が延びないようにする。
+        // 取得エラー時は上限不明のまま受理せず reject に倒す (クライアントは
+        // LOGIN リトライで再試行する)。`Ok(None)` (alarm 消失) は受理するが、
+        // その場合の deadline は candidate B = 手番側の残時間 1 手分予算が上限で、
+        // replay 復元で経過思考時間が失われる既存 cold start 挙動と同等。
         let original_turn_alarm_epoch_ms = self
             .state
             .storage()
             .get_alarm()
             .await
-            .ok()
-            .flatten()
+            .map_err(|e| Error::RustError(format!("cold rejoin get_alarm: {e}")))?
             .and_then(|ms| u64::try_from(ms).ok());
         let core_borrow = self.core.borrow();
         let Some(core) = core_borrow.as_ref() else {

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3355,6 +3355,55 @@ impl GameRoom {
         Ok(())
     }
 
+    /// grace registry が無い再接続要求への fallback。DO instance が
+    /// `websocket_close` を経ずに破棄されると (deploy 移行やランタイム都合の退避で
+    /// 実行中 invocation が cancel される)、`enter_grace_window` が走らず pending
+    /// entry が残らない。一方 `PersistedConfig` の reconnect_token は storage に
+    /// 残っているため、対局が進行中 (`KEY_FINISHED` 未設定) かつ該当 role の
+    /// player socket が現存しなければ、「いま切断された」ものとして現在状態から
+    /// `PendingReconnect` を合成し、通常の照合経路 (token 一致検証込み) に乗せる。
+    async fn build_cold_rejoin_pending(&self, role: Role) -> Result<Option<PendingReconnect>> {
+        if self.load_finished().await?.is_some() {
+            return Ok(None);
+        }
+        // reconnect 機能が無効な構成 (grace 0 / 設定不正) では合成しない。
+        let grace = match resolve_reconnect_grace(&self.env) {
+            Ok(g) if !g.is_zero() => g,
+            _ => return Ok(None),
+        };
+        // 同 role の player socket が生きているなら切断ではない (二重接続要求)。
+        for ws in self.state.get_websockets() {
+            if let Ok(Some(WsAttachment::Player {
+                role: attached_role,
+                ..
+            })) = ws.deserialize_attachment::<WsAttachment>()
+                && attached_role == role
+            {
+                return Ok(None);
+            }
+        }
+        let Some(cfg) = self.config.borrow().as_ref().cloned() else {
+            return Ok(None);
+        };
+        // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぎ、
+        // 再接続によって相手手番の wall-clock deadline が延びないようにする。
+        let original_turn_alarm_epoch_ms = self
+            .state
+            .storage()
+            .get_alarm()
+            .await
+            .ok()
+            .flatten()
+            .and_then(|ms| u64::try_from(ms).ok());
+        let core_borrow = self.core.borrow();
+        let Some(core) = core_borrow.as_ref() else {
+            return Ok(None);
+        };
+        let pending =
+            self.build_pending_reconnect(core, &cfg, role, grace, original_turn_alarm_epoch_ms)?;
+        Ok(Some(pending))
+    }
+
     /// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
     /// grace 中対局へ再参加させる。
     ///
@@ -3378,15 +3427,29 @@ impl GameRoom {
         self.ensure_core_loaded().await?;
         let pending: Option<PendingReconnect> =
             self.state.storage().get(KEY_GRACE_REGISTRY).await.ok().flatten();
-        let Some(pending) = pending else {
-            crate::structured_log!(
-                event: "reconnect_rejected",
-                component: "game_room",
-                reason: "no_pending_entry",
-                game_id: req.game_id.as_str(),
-            );
-            send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
-            return Ok(());
+        let pending = match pending {
+            Some(pending) => pending,
+            None => match self.build_cold_rejoin_pending(role).await? {
+                Some(pending) => {
+                    crate::structured_log!(
+                        event: "reconnect_cold_rejoin",
+                        component: "game_room",
+                        game_id: req.game_id.as_str(),
+                        role: format!("{role:?}"),
+                    );
+                    pending
+                }
+                None => {
+                    crate::structured_log!(
+                        event: "reconnect_rejected",
+                        component: "game_room",
+                        reason: "no_pending_entry",
+                        game_id: req.game_id.as_str(),
+                    );
+                    send_line(ws, "LOGIN:incorrect reconnect_rejected")?;
+                    return Ok(());
+                }
+            },
         };
 
         // game_id 照合は registry 検索 (DO instance = 1 対局専属) で済むため、

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3366,9 +3366,16 @@ impl GameRoom {
         if self.load_finished().await?.is_some() {
             return Ok(None);
         }
-        // reconnect 機能が無効な構成 (grace 0 / 設定不正) では合成しない。
-        let grace = match resolve_reconnect_grace(&self.env) {
-            Ok(g) if !g.is_zero() => g,
+        let Some(cfg) = self.config.borrow().as_ref().cloned() else {
+            return Ok(None);
+        };
+        // grace 設定は対局開始時に `PersistedConfig.reconnect_grace_ms` へ固定
+        // されている。現在の `Env` を読み直すと「対局開始後に設定変更 + deploy →
+        // DO 再起動」で開始時に token を発行済みの対局を拒否してしまうため、
+        // `websocket_close` 経路と同じく永続化済みの値を使う。0 / 未設定 =
+        // reconnect 無効な対局なので合成しない。
+        let grace = match cfg.reconnect_grace_ms {
+            Some(ms) if ms > 0 => Duration::from_millis(ms),
             _ => return Ok(None),
         };
         // 同 role の player socket が生きているなら切断ではない (二重接続要求)。
@@ -3382,9 +3389,6 @@ impl GameRoom {
                 return Ok(None);
             }
         }
-        let Some(cfg) = self.config.borrow().as_ref().cloned() else {
-            return Ok(None);
-        };
         // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぎ、
         // 再接続によって相手手番の wall-clock deadline が延びないようにする。
         let original_turn_alarm_epoch_ms = self

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3423,11 +3423,17 @@ impl GameRoom {
                     // Playing 以外 (Finished への遷移途中等の異常系)。合成しない。
                     return Ok(None);
                 };
-                Some(
-                    now.saturating_add(remaining)
-                        .saturating_add(cfg.time_margin_ms)
-                        .saturating_add(ALARM_SAFETY_MS),
-                )
+                if remaining == 0 {
+                    // 既に予算超過。margin/safety を再付与すると元 deadline より
+                    // 遅くなるため、即時発火の epoch を渡して time_up 判定に進める。
+                    Some(now)
+                } else {
+                    Some(
+                        now.saturating_add(remaining)
+                            .saturating_add(cfg.time_margin_ms)
+                            .saturating_add(ALARM_SAFETY_MS),
+                    )
+                }
             }
         };
         let pending =

--- a/crates/rshogi-csa-server-workers/src/lobby.rs
+++ b/crates/rshogi-csa-server-workers/src/lobby.rs
@@ -56,7 +56,6 @@ use crate::rate_limit::{
     RateLimitDecision, RateLimitKind, build_challenge_lobby_rate_limited_line,
     build_login_lobby_rate_limited_line, check_and_consume_via_do, resolve_thresholds_from_env,
 };
-use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::matching::challenge::{
     ChallengeEntry, ChallengeRegistry, ChallengeToken, IssueError,
 };


### PR DESCRIPTION
## 問題

2026-07-18 の 6 プレイヤー評価シリーズで、対局が数分おきに Interrupted で失われる事象が多発 (第1陣 8 局中 7 局喪失)。wrangler tail の実測で次の連鎖を確認:

1. 対局 DO の WS invocation が **例外なし・limit 超過なしで `canceled`** (deploy 移行やランタイム都合の DO 退避。CF status 上のインシデントは無し = 正常挙動の範疇)
2. クライアントは数秒で再接続に来るが、DO は `websocket_close` を経ずに死んでいるため `enter_grace_window` が走っておらず grace registry が無い
3. 正規の `Reconnect_Token` を持つ両クライアントが **`reconnect_rejected reason=no_pending_entry` で一律拒否** → 対局喪失

## 修正

`handle_reconnect_request` に cold rejoin fallback を追加: grace registry が無い場合でも、**対局進行中 (`KEY_FINISHED` 未設定) かつ該当 role の player socket が現存しない**なら、`PersistedConfig` の reconnect_token を含む `PendingReconnect` を現在状態から合成し (`build_pending_reconnect` を再利用)、既存の照合経路 (token/handle/color 検証・resume 送出・alarm 再設定) にそのまま乗せる。

- token 検証は既存経路と同一 (合成した expected_token は storage の永続値)
- storage に残存する turn deadline alarm を `original_turn_alarm_epoch_ms` として引き継ぐため、再接続で相手手番の wall-clock deadline は延びない (既存の min 採用ロジック)
- 同 role の socket が生きている二重接続要求は合成しない (従来どおり拒否)
- 終局済み部屋・reconnect 無効構成 (grace 0) では従来どおり拒否

付随: lobby.rs の未使用 import (#942 の残り、wasm32 target のみ警告) を除去。

## テスト

- `cargo test -p rshogi-csa-server-workers` 402 件全パス / clippy 0 warning / fmt / wasm32 check OK
- DO の突然死自体はローカルで再現困難なため、fallback 経路の単体テストは未追加 (照合ロジック `PendingReconnect::match_request` は既存テストでカバー)。本番では `reconnect_cold_rejoin` structured log で発動を観測可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkZhYF4q21LWyaeg8UmTBb