### PR TITLE
fix(csa-client): preserve records across reconnects

### DIFF
--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 
 use crate::config::CsaClientConfig;
 use crate::protocol::GameResult;
-use crate::record::{GameRecord, JsonlMoveExtra, RecordedMove};
+use crate::record::{GameRecord, JsonlMoveExtra, RecordStatus, RecordedMove};
 
 /// CSA 経由対局で 1 局分の JSONL を書き出す。
 ///
@@ -39,11 +39,22 @@ pub fn write_game_jsonl(
     config: &CsaClientConfig,
     result: &GameResult,
 ) -> Result<PathBuf> {
+    write_game_jsonl_with_status(out_dir, record, config, result, &RecordStatus::Complete)
+}
+
+/// 棋譜種別を明示して CSA 経由対局の JSONL を書き出す。
+pub fn write_game_jsonl_with_status(
+    out_dir: &Path,
+    record: &GameRecord,
+    config: &CsaClientConfig,
+    result: &GameResult,
+    status: &RecordStatus,
+) -> Result<PathBuf> {
     fs::create_dir_all(out_dir).with_context(|| {
         format!("JSONL 出力ディレクトリを作成できません: {}", out_dir.display())
     })?;
 
-    let path = out_dir.join(jsonl_filename(record));
+    let path = out_dir.join(jsonl_filename(record, status));
     // live 追記 (`LiveJsonlWriter`) 有効時は同じパスを読者 (kifu_player --live 等) が
     // 開いていることがあるため、truncate 書き込みでなく tmp→rename で置き換え、
     // 読者が常に完全な内容だけを見るようにする。
@@ -102,10 +113,20 @@ impl LiveJsonlWriter {
     /// 対局開始時 (Game_Summary 確定後) に作る。record が既に持つ手 (途中局面開始・
     /// resume 済みの手) もすべて書き出してから追記を続ける。
     pub fn create(out_dir: &Path, record: &GameRecord, config: &CsaClientConfig) -> Result<Self> {
+        Self::create_with_status(out_dir, record, config, &RecordStatus::Complete)
+    }
+
+    /// 棋譜種別を明示して live JSONL を作る。
+    pub fn create_with_status(
+        out_dir: &Path,
+        record: &GameRecord,
+        config: &CsaClientConfig,
+        status: &RecordStatus,
+    ) -> Result<Self> {
         fs::create_dir_all(out_dir).with_context(|| {
             format!("JSONL 出力ディレクトリを作成できません: {}", out_dir.display())
         })?;
-        let path = out_dir.join(jsonl_filename(record));
+        let path = out_dir.join(jsonl_filename(record, status));
         let file = File::create(&path)
             .with_context(|| format!("live JSONL を作成できません: {}", path.display()))?;
         let mut writer = BufWriter::new(file);
@@ -135,11 +156,25 @@ impl LiveJsonlWriter {
 }
 
 /// `<datetime>_<sente>_vs_<gote>.jsonl` 形式のファイル名を生成する。
-fn jsonl_filename(record: &GameRecord) -> String {
+fn jsonl_filename(record: &GameRecord, status: &RecordStatus) -> String {
     let datetime = record.start_time.format("%Y%m%d_%H%M%S").to_string();
     let sente = sanitize_for_filename(&record.sente_name);
     let gote = sanitize_for_filename(&record.gote_name);
-    format!("{datetime}_{sente}_vs_{gote}{}.jsonl", record.filename_suffix())
+    format!("{datetime}_{sente}_vs_{gote}{}.jsonl", status.filename_suffix())
+}
+
+/// 切断前に作った通常名 live JSONL を削除する。
+///
+/// 局面不一致 fallback では以後 `_reconnect_fragment.jsonl` へ記録するため、通常名の
+/// 未完ファイルを残すと集計側が別対局として拾ってしまう。存在しない場合は成功扱い。
+pub(crate) fn remove_complete_live_jsonl(out_dir: &Path, record: &GameRecord) -> Result<()> {
+    let path = out_dir.join(jsonl_filename(record, &RecordStatus::Complete));
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err)
+            .with_context(|| format!("切断前 live JSONL を削除できません: {}", path.display())),
+    }
 }
 
 /// ファイル名・JSONL `engine` ラベルの名前正規化。英数字と `-` `_` 以外を `_` に置換する
@@ -539,7 +574,7 @@ mod tests {
         let mut record = GameRecord::new(&summary());
 
         let mut live = LiveJsonlWriter::create(&dir, &record, &config).unwrap();
-        let path = dir.join(jsonl_filename(&record));
+        let path = dir.join(jsonl_filename(&record, &RecordStatus::Complete));
         let text = std::fs::read_to_string(&path).unwrap();
         assert_eq!(text.lines().count(), 1, "作成直後は meta 行のみ");
         assert!(text.contains("\"type\":\"meta\""));
@@ -606,21 +641,47 @@ mod tests {
         push_move(&mut record, Color::White, "sfen2", "3c3d");
 
         let _live = LiveJsonlWriter::create(&dir, &record, &config).unwrap();
-        let path = dir.join(jsonl_filename(&record));
+        let path = dir.join(jsonl_filename(&record, &RecordStatus::Complete));
         assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 3);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn reconnect_fragment_filename_is_explicit() {
-        let mut record = GameRecord::new(&summary());
-        record.status = RecordStatus::ReconnectFragment {
+        let record = GameRecord::new(&summary());
+        let status = RecordStatus::ReconnectFragment {
             reason: "test mismatch".to_owned(),
         };
         assert!(
-            jsonl_filename(&record).ends_with("_reconnect_fragment.jsonl"),
+            jsonl_filename(&record, &status).ends_with("_reconnect_fragment.jsonl"),
             "filename={}",
-            jsonl_filename(&record)
+            jsonl_filename(&record, &status)
         );
+    }
+
+    #[test]
+    fn fragment_fallback_removes_complete_live_file_only() {
+        let dir = std::env::temp_dir().join("csa_live_jsonl_fragment_cleanup_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        let config = CsaClientConfig::default();
+        let record = GameRecord::new(&summary());
+        let complete = dir.join(jsonl_filename(&record, &RecordStatus::Complete));
+        let fragment_status = RecordStatus::ReconnectFragment {
+            reason: "mismatch".to_owned(),
+        };
+        let fragment = dir.join(jsonl_filename(&record, &fragment_status));
+
+        let _complete_live = LiveJsonlWriter::create(&dir, &record, &config).unwrap();
+        let _fragment_live =
+            LiveJsonlWriter::create_with_status(&dir, &record, &config, &fragment_status).unwrap();
+        assert!(complete.exists());
+        assert!(fragment.exists());
+
+        remove_complete_live_jsonl(&dir, &record).unwrap();
+        assert!(!complete.exists());
+        assert!(fragment.exists());
+        // 2 回目も NotFound を成功扱いにする。
+        remove_complete_live_jsonl(&dir, &record).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -139,7 +139,7 @@ fn jsonl_filename(record: &GameRecord) -> String {
     let datetime = record.start_time.format("%Y%m%d_%H%M%S").to_string();
     let sente = sanitize_for_filename(&record.sente_name);
     let gote = sanitize_for_filename(&record.gote_name);
-    format!("{datetime}_{sente}_vs_{gote}.jsonl")
+    format!("{datetime}_{sente}_vs_{gote}{}.jsonl", record.filename_suffix())
 }
 
 /// ファイル名・JSONL `engine` ラベルの名前正規化。英数字と `-` `_` 以外を `_` に置換する
@@ -499,6 +499,7 @@ fn winner_label(record: &GameRecord, result: &GameResult) -> Option<String> {
 mod tests {
     use super::*;
     use crate::protocol::{GameResult, GameSummary, TimeConfig};
+    use crate::record::RecordStatus;
     use rshogi_csa::{Color, initial_position};
 
     fn summary() -> GameSummary {
@@ -608,5 +609,18 @@ mod tests {
         let path = dir.join(jsonl_filename(&record));
         assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 3);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reconnect_fragment_filename_is_explicit() {
+        let mut record = GameRecord::new(&summary());
+        record.status = RecordStatus::ReconnectFragment {
+            reason: "test mismatch".to_owned(),
+        };
+        assert!(
+            jsonl_filename(&record).ends_with("_reconnect_fragment.jsonl"),
+            "filename={}",
+            jsonl_filename(&record)
+        );
     }
 }

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -96,7 +96,7 @@ pub use protocol::{
 };
 pub use record::{GameRecord, RecordStatus, RecordedMove};
 pub use session::{
-    run_game_session, run_game_session_with_events, run_resumed_session,
+    RecordedSessionOutcome, run_game_session, run_game_session_with_events, run_resumed_session,
     run_resumed_session_with_events, run_resumed_session_with_record,
 };
 pub use transport::{ConnectOpts, CsaTransport, TransportTarget};

--- a/crates/rshogi-csa-client/src/lib.rs
+++ b/crates/rshogi-csa-client/src/lib.rs
@@ -94,9 +94,9 @@ pub use events::{
 pub use protocol::{
     CsaConnection, GameResult, GameSummary, compute_effective_retry_delay, extract_retry_after_sec,
 };
-pub use record::{GameRecord, RecordedMove};
+pub use record::{GameRecord, RecordStatus, RecordedMove};
 pub use session::{
     run_game_session, run_game_session_with_events, run_resumed_session,
-    run_resumed_session_with_events,
+    run_resumed_session_with_events, run_resumed_session_with_record,
 };
 pub use transport::{ConnectOpts, CsaTransport, TransportTarget};

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -27,7 +27,7 @@ use rshogi_csa_client::events::SessionOutcome;
 use rshogi_csa_client::jsonl::write_game_jsonl;
 use rshogi_csa_client::protocol::{CsaConnection, GameResult, compute_effective_retry_delay};
 use rshogi_csa_client::record::save_record;
-use rshogi_csa_client::session::{run_game_session, run_resumed_session};
+use rshogi_csa_client::session::{run_game_session, run_resumed_session_with_record};
 use rshogi_csa_client::transport::{ConnectOpts, TransportTarget};
 
 /// `--target` プリセット。本リポ単一 Cloudflare アカウントの staging / production
@@ -467,11 +467,12 @@ fn run_one_game(
     // 場合は reconnect 試行自体を skip するため、https://github.com/SH11235/rshogi/issues/591 の
     // `LOGIN:incorrect reconnect_rejected` 経路に到達しない。
     let reconnect_request = match session_result.as_ref() {
-        Ok(outcome) => should_attempt_reconnect(outcome, shutdown.load(Ordering::SeqCst)),
+        Ok(outcome) => should_attempt_reconnect(outcome, shutdown.load(Ordering::SeqCst))
+            .map(|(game_id, token)| (game_id, token, outcome.record.clone())),
         Err(_) => None,
     };
 
-    if let Some((game_id, token)) = reconnect_request {
+    if let Some((game_id, token, retained_record)) = reconnect_request {
         log::warn!(
             "[CSA] サーバ切断を検出。Reconnect_Token を持つので grace 内に再接続を試みます: game_id={}",
             game_id
@@ -484,7 +485,15 @@ fn run_one_game(
             game_id: &game_id,
             token: &token,
         };
-        match attempt_reconnect(&target, &opts, &credentials, engine, config, shutdown) {
+        match attempt_reconnect(
+            &target,
+            &opts,
+            &credentials,
+            engine,
+            config,
+            shutdown,
+            retained_record,
+        ) {
             Ok((reconnect_result, reconnect_record)) => {
                 log::info!("[CSA] 再接続成功: 対局を継続して終局: {:?}", reconnect_result);
                 return Ok((reconnect_result, reconnect_record));
@@ -557,11 +566,13 @@ fn attempt_reconnect(
     engine: &mut UsiEngine,
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
+    retained_record: rshogi_csa_client::record::GameRecord,
 ) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
     let mut conn = CsaConnection::connect_with_target(target, opts)?;
     conn.login_reconnect(creds.id, creds.password, creds.game_id, creds.token)?;
-    let outcome = run_resumed_session(&mut conn, engine, config, shutdown)
-        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    let outcome =
+        run_resumed_session_with_record(&mut conn, engine, config, shutdown, retained_record)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
     let _ = conn.logout();
     Ok((outcome.result, outcome.record))
 }
@@ -1109,6 +1120,7 @@ mod tests {
                 start_time: chrono::Local::now(),
                 my_color: CsaColor::Black,
                 jsonl_moves: vec![],
+                status: rshogi_csa_client::record::RecordStatus::Complete,
             },
             summary: Some(summary),
         }

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -24,9 +24,9 @@ use clap::{ArgAction, Parser, ValueEnum};
 use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::{SpawnOptions, UsiEngine};
 use rshogi_csa_client::events::SessionOutcome;
-use rshogi_csa_client::jsonl::write_game_jsonl;
+use rshogi_csa_client::jsonl::write_game_jsonl_with_status;
 use rshogi_csa_client::protocol::{CsaConnection, GameResult, compute_effective_retry_delay};
-use rshogi_csa_client::record::save_record;
+use rshogi_csa_client::record::{RecordStatus, save_record_with_status};
 use rshogi_csa_client::session::{run_game_session, run_resumed_session_with_record};
 use rshogi_csa_client::transport::{ConnectOpts, TransportTarget};
 
@@ -357,15 +357,21 @@ fn main() -> Result<()> {
         };
 
         match run_one_game(&game_config, &mut engine, &shutdown, games_played) {
-            Ok((result, record)) => {
+            Ok((result, record, record_status)) => {
                 // 棋譜保存
-                if let Err(e) = save_record(&record, &config.record) {
+                if let Err(e) = save_record_with_status(&record, &config.record, &record_status) {
                     log::error!("棋譜保存エラー: {e}");
                 }
 
                 // analyze_selfplay 互換 JSONL（ON/OFF と出力先は RecordConfig::jsonl_dir）
                 if let Some(jsonl_dir) = config.record.jsonl_dir() {
-                    match write_game_jsonl(&jsonl_dir, &record, &config, &result) {
+                    match write_game_jsonl_with_status(
+                        &jsonl_dir,
+                        &record,
+                        &config,
+                        &result,
+                        &record_status,
+                    ) {
                         Ok(path) => log::info!("[REC] JSONL 保存: {}", path.display()),
                         Err(e) => log::error!("JSONL 保存エラー: {e}"),
                     }
@@ -440,7 +446,7 @@ fn run_one_game(
     engine: &mut UsiEngine,
     shutdown: &AtomicBool,
     games_played: u32,
-) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
+) -> Result<(GameResult, rshogi_csa_client::record::GameRecord, RecordStatus)> {
     let game_seq_str = games_played.to_string();
     let host = config.server.host.replace("{game_seq}", &game_seq_str);
     let id = config.server.id.replace("{game_seq}", &game_seq_str);
@@ -494,9 +500,9 @@ fn run_one_game(
             shutdown,
             retained_record,
         ) {
-            Ok((reconnect_result, reconnect_record)) => {
+            Ok((reconnect_result, reconnect_record, record_status)) => {
                 log::info!("[CSA] 再接続成功: 対局を継続して終局: {:?}", reconnect_result);
-                return Ok((reconnect_result, reconnect_record));
+                return Ok((reconnect_result, reconnect_record, record_status));
             }
             Err(e) => {
                 // engine は元 disconnect 経路で `gameover("lose")` 発射済み。
@@ -507,7 +513,7 @@ fn run_one_game(
                 log::warn!("[CSA] 再接続失敗: {e}。元の Interrupted 結果で終了します。");
                 let _ = engine.stop_and_wait();
                 return session_result
-                    .map(|outcome| (outcome.result, outcome.record))
+                    .map(|outcome| (outcome.result, outcome.record, RecordStatus::Complete))
                     .map_err(|e| anyhow::anyhow!("{}", e));
             }
         }
@@ -523,7 +529,7 @@ fn run_one_game(
 
     let _ = conn.logout();
     session_result
-        .map(|outcome| (outcome.result, outcome.record))
+        .map(|outcome| (outcome.result, outcome.record, RecordStatus::Complete))
         .map_err(|e| anyhow::anyhow!("{}", e))
 }
 
@@ -567,14 +573,14 @@ fn attempt_reconnect(
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
     retained_record: rshogi_csa_client::record::GameRecord,
-) -> Result<(GameResult, rshogi_csa_client::record::GameRecord)> {
+) -> Result<(GameResult, rshogi_csa_client::record::GameRecord, RecordStatus)> {
     let mut conn = CsaConnection::connect_with_target(target, opts)?;
     conn.login_reconnect(creds.id, creds.password, creds.game_id, creds.token)?;
     let outcome =
         run_resumed_session_with_record(&mut conn, engine, config, shutdown, retained_record)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
     let _ = conn.logout();
-    Ok((outcome.result, outcome.record))
+    Ok((outcome.outcome.result, outcome.outcome.record, outcome.status))
 }
 
 /// `--lobby` モードで成立したマッチ。`run_one_game` 直前に config を差し替えるための
@@ -1120,7 +1126,6 @@ mod tests {
                 start_time: chrono::Local::now(),
                 my_color: CsaColor::Black,
                 jsonl_moves: vec![],
-                status: rshogi_csa_client::record::RecordStatus::Complete,
             },
             summary: Some(summary),
         }

--- a/crates/rshogi-csa-client/src/record.rs
+++ b/crates/rshogi-csa-client/src/record.rs
@@ -5,7 +5,7 @@ use std::fmt::Write as _;
 use anyhow::Result;
 use chrono::Local;
 
-use rshogi_csa::{Color, Position, usi_move_to_csa};
+use rshogi_csa::{Color, Position, csa_move_to_usi, usi_move_to_csa};
 
 use crate::config::RecordConfig;
 use crate::engine::SearchInfo;
@@ -30,6 +30,35 @@ pub struct GameRecord {
     /// 各要素は `moves[i]` に対応する。投了 / 勝ち宣言など `apply_csa_move` を経由しない
     /// 手は含まれず、ply ベースで一致する。
     pub jsonl_moves: Vec<JsonlMoveExtra>,
+    /// 通常の通し棋譜か、再接続時の局面不一致により作成した断片か。
+    pub status: RecordStatus,
+}
+
+/// 棋譜が対局全体を表すか、再接続後だけの断片かを示す。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum RecordStatus {
+    /// 対局開始からの通し棋譜。
+    #[default]
+    Complete,
+    /// 再接続時に、切断前の保持局面とサーバーの resume 局面が一致しなかったため
+    /// resume 局面から記録し直した断片。
+    ReconnectFragment { reason: String },
+}
+
+/// 切断前の棋譜を resume セッションへ引き継げるかの判定結果。
+#[derive(Clone, Debug)]
+pub(crate) enum ResumeRecordDecision {
+    /// 局面が一致したため、切断前の棋譜・開始時刻・JSONL 情報を引き継ぐ。
+    Continued {
+        record: Box<GameRecord>,
+        position: Box<Position>,
+        usi_moves: Vec<String>,
+    },
+    /// 局面または対局 identity が一致しないため、resume 局面から断片記録を始める。
+    Fragment {
+        record: Box<GameRecord>,
+        reason: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -102,6 +131,119 @@ impl GameRecord {
             start_time: Local::now(),
             my_color: summary.my_color,
             jsonl_moves: Vec::new(),
+            status: RecordStatus::Complete,
+        }
+    }
+
+    /// 再接続前に保持していた棋譜を、サーバーから再送された現在局面と照合する。
+    ///
+    /// `Game_Summary` の Position block には手数番号が無いため、比較時は `ply` を
+    /// 除外し、盤面・持ち駒・手番を比較する。一致時は保持棋譜を初期局面から replay
+    /// して得た `position` / `usi_moves` も返し、resume 後の USI `position` コマンドを
+    /// 対局開始局面から通しで組み立てられるようにする。
+    pub(crate) fn continue_for_resume(
+        self,
+        summary: &GameSummary,
+        reconnect_turn: Option<Color>,
+    ) -> ResumeRecordDecision {
+        let mismatch = |reason: String| {
+            let mut record = GameRecord::new(summary);
+            record.status = RecordStatus::ReconnectFragment {
+                reason: reason.clone(),
+            };
+            ResumeRecordDecision::Fragment {
+                record: Box::new(record),
+                reason,
+            }
+        };
+
+        if self.game_id != summary.game_id {
+            return mismatch(format!(
+                "game_id 不一致: retained={} resume={}",
+                self.game_id, summary.game_id
+            ));
+        }
+        if self.sente_name != summary.sente_name || self.gote_name != summary.gote_name {
+            return mismatch(format!(
+                "対局者不一致: retained={} vs {} resume={} vs {}",
+                self.sente_name, self.gote_name, summary.sente_name, summary.gote_name
+            ));
+        }
+        if self.my_color != summary.my_color {
+            return mismatch(format!(
+                "自手番不一致: retained={:?} resume={:?}",
+                self.my_color, summary.my_color
+            ));
+        }
+
+        let mut retained_position = self.initial_position.clone();
+        let mut usi_moves = Vec::with_capacity(self.moves.len());
+        for (index, recorded) in self.moves.iter().enumerate() {
+            let usi = match csa_move_to_usi(&recorded.csa_move, &retained_position) {
+                Ok(usi) => usi,
+                Err(err) => {
+                    return mismatch(format!(
+                        "保持棋譜の {} 手目を USI 変換できません: {} ({err:#})",
+                        index + 1,
+                        recorded.csa_move
+                    ));
+                }
+            };
+            if let Err(err) = retained_position.apply_csa_move(&recorded.csa_move) {
+                return mismatch(format!(
+                    "保持棋譜の {} 手目を適用できません: {} ({err:#})",
+                    index + 1,
+                    recorded.csa_move
+                ));
+            }
+            usi_moves.push(usi);
+        }
+
+        // Position block 内に初期手順を持つ CSA サーバーにも対応する。Workers の
+        // reconnect summary は現在局面そのものを Position block に入れるため通常は空。
+        let mut resume_position = summary.position.clone();
+        for cm in &summary.initial_moves {
+            if let Err(err) = resume_position.apply_csa_move(&cm.mv) {
+                return mismatch(format!(
+                    "resume Game_Summary の指し手を適用できません: {} ({err:#})",
+                    cm.mv
+                ));
+            }
+        }
+
+        match reconnect_turn {
+            Some(turn) if turn == resume_position.side_to_move => {}
+            Some(turn) => {
+                return mismatch(format!(
+                    "Reconnect_State の手番不一致: summary={:?} reconnect_state={turn:?}",
+                    resume_position.side_to_move
+                ));
+            }
+            None => {
+                return mismatch("Reconnect_State に Current_Turn がありません".to_owned());
+            }
+        }
+
+        if retained_position.to_csa_board() != resume_position.to_csa_board() {
+            return mismatch(format!(
+                "局面不一致: retained={} resume={}",
+                retained_position.to_sfen(),
+                resume_position.to_sfen()
+            ));
+        }
+
+        ResumeRecordDecision::Continued {
+            record: Box::new(self),
+            position: Box::new(retained_position),
+            usi_moves,
+        }
+    }
+
+    /// 断片棋譜なら、全形式のファイル名に付ける suffix を返す。
+    pub fn filename_suffix(&self) -> &'static str {
+        match &self.status {
+            RecordStatus::Complete => "",
+            RecordStatus::ReconnectFragment { .. } => "_reconnect_fragment",
         }
     }
 
@@ -148,6 +290,9 @@ impl GameRecord {
     pub fn to_csa(&self) -> String {
         let mut out = String::new();
         writeln!(out, "V2.2").unwrap();
+        if let RecordStatus::ReconnectFragment { reason } = &self.status {
+            writeln!(out, "'RECONNECT_FRAGMENT: {reason}").unwrap();
+        }
         writeln!(out, "N+{}", self.sente_name).unwrap();
         writeln!(out, "N-{}", self.gote_name).unwrap();
         writeln!(out, "$EVENT:{}", self.game_id).unwrap();
@@ -251,12 +396,13 @@ pub fn save_record(record: &GameRecord, config: &RecordConfig) -> Result<()> {
     std::fs::create_dir_all(&config.dir)?;
 
     let datetime = record.start_time.format("%Y%m%d_%H%M%S").to_string();
-    let filename_base = config
+    let mut filename_base = config
         .filename_template
         .replace("{datetime}", &datetime)
         .replace("{game_id}", &record.game_id)
         .replace("{sente}", &sanitize_filename(&record.sente_name))
         .replace("{gote}", &sanitize_filename(&record.gote_name));
+    filename_base.push_str(record.filename_suffix());
 
     if config.save_csa {
         let path = config.dir.join(format!("{filename_base}.csa"));
@@ -292,6 +438,34 @@ fn sanitize_filename(name: &str) -> String {
 mod tests {
     use super::*;
 
+    fn summary(position: Position) -> GameSummary {
+        GameSummary {
+            game_id: "resume-game".to_owned(),
+            my_color: Color::Black,
+            sente_name: "alice".to_owned(),
+            gote_name: "bob".to_owned(),
+            position,
+            initial_moves: Vec::new(),
+            black_time: TimeConfig::default(),
+            white_time: TimeConfig::default(),
+            reconnect_token: Some("token".to_owned()),
+        }
+    }
+
+    fn add_jsonl_placeholder(record: &mut GameRecord, sfen_before: String, usi: &str) {
+        record.add_jsonl_move(JsonlMoveExtra {
+            sfen_before,
+            move_usi: usi.to_owned(),
+            engine_label: "alice".to_owned(),
+            elapsed_ms: 10,
+            think_limit_ms: 100,
+            seldepth: None,
+            nodes: None,
+            time_ms: None,
+            nps: None,
+        });
+    }
+
     #[test]
     fn effective_score_omits_unrepresentable_white_min_value() {
         let mv = RecordedMove {
@@ -304,5 +478,64 @@ mod tests {
             side_to_move: Color::White,
         };
         assert_eq!(mv.effective_score(), None);
+    }
+
+    #[test]
+    fn resume_keeps_complete_record_when_position_matches() {
+        let initial = rshogi_csa::initial_position();
+        let mut retained = GameRecord::new(&summary(initial.clone()));
+        let started_at = retained.start_time;
+
+        let mut current = initial;
+        let before = current.to_sfen();
+        retained.add_move("+2726FU", 1, None, Color::Black);
+        add_jsonl_placeholder(&mut retained, before, "2g2f");
+        current.apply_csa_move("+2726FU").unwrap();
+        let before = current.to_sfen();
+        retained.add_move("-8384FU", 2, None, Color::White);
+        add_jsonl_placeholder(&mut retained, before, "8c8d");
+        current.apply_csa_move("-8384FU").unwrap();
+
+        // Game_Summary の Position block は ply を運ばないため parse 後は 1 になる。
+        let mut resume_position = current.clone();
+        resume_position.ply = 1;
+        let decision = retained.continue_for_resume(&summary(resume_position), Some(Color::Black));
+
+        let ResumeRecordDecision::Continued {
+            record,
+            position,
+            usi_moves,
+        } = decision
+        else {
+            panic!("一致局面が fragment 扱いになりました");
+        };
+        assert_eq!(record.start_time, started_at);
+        assert_eq!(record.moves.len(), 2);
+        assert_eq!(record.jsonl_moves.len(), 2);
+        assert_eq!(record.status, RecordStatus::Complete);
+        assert_eq!(position.to_sfen(), current.to_sfen());
+        assert_eq!(usi_moves, ["2g2f", "8c8d"]);
+    }
+
+    #[test]
+    fn resume_falls_back_to_marked_fragment_when_position_mismatches() {
+        let initial = rshogi_csa::initial_position();
+        let mut retained = GameRecord::new(&summary(initial.clone()));
+        retained.add_move("+2726FU", 1, None, Color::Black);
+
+        let decision = retained.continue_for_resume(&summary(initial), Some(Color::Black));
+        let ResumeRecordDecision::Fragment { record, reason } = decision else {
+            panic!("不一致局面が通し棋譜として継続されました");
+        };
+
+        assert!(reason.contains("局面不一致"), "reason={reason}");
+        assert!(record.moves.is_empty());
+        assert_eq!(record.filename_suffix(), "_reconnect_fragment");
+        assert!(matches!(record.status, RecordStatus::ReconnectFragment { .. }));
+        let csa = record.to_csa();
+        assert!(
+            csa.lines().nth(1).is_some_and(|line| line.starts_with("'RECONNECT_FRAGMENT:")),
+            "CSA 先頭に断片コメントがありません:\n{csa}"
+        );
     }
 }

--- a/crates/rshogi-csa-client/src/record.rs
+++ b/crates/rshogi-csa-client/src/record.rs
@@ -30,8 +30,6 @@ pub struct GameRecord {
     /// 各要素は `moves[i]` に対応する。投了 / 勝ち宣言など `apply_csa_move` を経由しない
     /// 手は含まれず、ply ベースで一致する。
     pub jsonl_moves: Vec<JsonlMoveExtra>,
-    /// 通常の通し棋譜か、再接続時の局面不一致により作成した断片か。
-    pub status: RecordStatus,
 }
 
 /// 棋譜が対局全体を表すか、再接続後だけの断片かを示す。
@@ -57,6 +55,7 @@ pub(crate) enum ResumeRecordDecision {
     /// 局面または対局 identity が一致しないため、resume 局面から断片記録を始める。
     Fragment {
         record: Box<GameRecord>,
+        retained_record: Box<GameRecord>,
         reason: String,
     },
 }
@@ -131,7 +130,6 @@ impl GameRecord {
             start_time: Local::now(),
             my_color: summary.my_color,
             jsonl_moves: Vec::new(),
-            status: RecordStatus::Complete,
         }
     }
 
@@ -148,11 +146,14 @@ impl GameRecord {
     ) -> ResumeRecordDecision {
         let mismatch = |reason: String| {
             let mut record = GameRecord::new(summary);
-            record.status = RecordStatus::ReconnectFragment {
-                reason: reason.clone(),
-            };
+            // fallback でも対局開始時刻は維持する。ファイル名と $START_TIME が
+            // 再接続時刻へ巻き戻ると、元の欠損バグと同じ誤認を招くため。
+            record.start_time = self.start_time;
             ResumeRecordDecision::Fragment {
                 record: Box::new(record),
+                // live JSONL が有効だった場合、切断前の通常名ファイルを削除するため
+                // 元 record も返す（不一致時だけの clone）。
+                retained_record: Box::new(self.clone()),
                 reason,
             }
         };
@@ -239,14 +240,6 @@ impl GameRecord {
         }
     }
 
-    /// 断片棋譜なら、全形式のファイル名に付ける suffix を返す。
-    pub fn filename_suffix(&self) -> &'static str {
-        match &self.status {
-            RecordStatus::Complete => "",
-            RecordStatus::ReconnectFragment { .. } => "_reconnect_fragment",
-        }
-    }
-
     /// JSONL 出力モード向けの追加情報を 1 手分蓄積する。
     /// CSA 棋譜・SFEN 出力にはこのバッファは使われない。
     pub fn add_jsonl_move(&mut self, extra: JsonlMoveExtra) {
@@ -288,9 +281,14 @@ impl GameRecord {
 
     /// CSA形式の棋譜テキストを生成する
     pub fn to_csa(&self) -> String {
+        self.to_csa_with_status(&RecordStatus::Complete)
+    }
+
+    /// record の種別を明示して CSA 形式の棋譜テキストを生成する。
+    pub fn to_csa_with_status(&self, status: &RecordStatus) -> String {
         let mut out = String::new();
         writeln!(out, "V2.2").unwrap();
-        if let RecordStatus::ReconnectFragment { reason } = &self.status {
+        if let RecordStatus::ReconnectFragment { reason } = status {
             writeln!(out, "'RECONNECT_FRAGMENT: {reason}").unwrap();
         }
         writeln!(out, "N+{}", self.sente_name).unwrap();
@@ -389,6 +387,15 @@ impl GameRecord {
 
 /// 棋譜をファイルに保存する
 pub fn save_record(record: &GameRecord, config: &RecordConfig) -> Result<()> {
+    save_record_with_status(record, config, &RecordStatus::Complete)
+}
+
+/// 棋譜種別を明示してファイルへ保存する。
+pub fn save_record_with_status(
+    record: &GameRecord,
+    config: &RecordConfig,
+    status: &RecordStatus,
+) -> Result<()> {
     if !config.enabled {
         return Ok(());
     }
@@ -402,11 +409,11 @@ pub fn save_record(record: &GameRecord, config: &RecordConfig) -> Result<()> {
         .replace("{game_id}", &record.game_id)
         .replace("{sente}", &sanitize_filename(&record.sente_name))
         .replace("{gote}", &sanitize_filename(&record.gote_name));
-    filename_base.push_str(record.filename_suffix());
+    filename_base.push_str(status.filename_suffix());
 
     if config.save_csa {
         let path = config.dir.join(format!("{filename_base}.csa"));
-        std::fs::write(&path, record.to_csa())?;
+        std::fs::write(&path, record.to_csa_with_status(status))?;
         log::info!("[REC] 棋譜保存: {}", path.display());
     }
 
@@ -420,6 +427,16 @@ pub fn save_record(record: &GameRecord, config: &RecordConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+impl RecordStatus {
+    /// 断片棋譜なら、全形式のファイル名に付ける suffix を返す。
+    pub fn filename_suffix(&self) -> &'static str {
+        match self {
+            Self::Complete => "",
+            Self::ReconnectFragment { .. } => "_reconnect_fragment",
+        }
+    }
 }
 
 fn sanitize_filename(name: &str) -> String {
@@ -512,7 +529,6 @@ mod tests {
         assert_eq!(record.start_time, started_at);
         assert_eq!(record.moves.len(), 2);
         assert_eq!(record.jsonl_moves.len(), 2);
-        assert_eq!(record.status, RecordStatus::Complete);
         assert_eq!(position.to_sfen(), current.to_sfen());
         assert_eq!(usi_moves, ["2g2f", "8c8d"]);
     }
@@ -521,18 +537,26 @@ mod tests {
     fn resume_falls_back_to_marked_fragment_when_position_mismatches() {
         let initial = rshogi_csa::initial_position();
         let mut retained = GameRecord::new(&summary(initial.clone()));
+        let started_at = retained.start_time;
         retained.add_move("+2726FU", 1, None, Color::Black);
 
         let decision = retained.continue_for_resume(&summary(initial), Some(Color::Black));
-        let ResumeRecordDecision::Fragment { record, reason } = decision else {
+        let ResumeRecordDecision::Fragment {
+            record,
+            retained_record,
+            reason,
+        } = decision
+        else {
             panic!("不一致局面が通し棋譜として継続されました");
         };
 
         assert!(reason.contains("局面不一致"), "reason={reason}");
         assert!(record.moves.is_empty());
-        assert_eq!(record.filename_suffix(), "_reconnect_fragment");
-        assert!(matches!(record.status, RecordStatus::ReconnectFragment { .. }));
-        let csa = record.to_csa();
+        assert_eq!(record.start_time, started_at);
+        assert_eq!(retained_record.moves.len(), 1);
+        let status = RecordStatus::ReconnectFragment { reason };
+        assert_eq!(status.filename_suffix(), "_reconnect_fragment");
+        let csa = record.to_csa_with_status(&status);
         assert!(
             csa.lines().nth(1).is_some_and(|line| line.starts_with("'RECONNECT_FRAGMENT:")),
             "CSA 先頭に断片コメントがありません:\n{csa}"

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -39,7 +39,7 @@ use crate::protocol::{
     CsaConnection, GameResult, GameSummary, ReconnectState as ProtocolReconnectState,
     parse_game_result, parse_server_move,
 };
-use crate::record::{GameRecord, JsonlMoveExtra};
+use crate::record::{GameRecord, JsonlMoveExtra, ResumeRecordDecision};
 
 // ────────────────────────────────────────────
 // 公開エントリポイント
@@ -64,7 +64,7 @@ where
     E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
-    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Fresh)
+    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Fresh, None)
 }
 
 /// `LOGIN ... reconnect:<game_id>+<token>` 後の resume セッションを進捗通知付きで
@@ -84,7 +84,7 @@ where
     E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
-    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Resumed)
+    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Resumed, None)
 }
 
 /// 進捗通知不要な consumer 向けの薄いラッパー。内部で [`NoopSessionEventSink`] を渡す。
@@ -97,7 +97,7 @@ pub fn run_game_session(
     shutdown: &AtomicBool,
 ) -> Result<SessionOutcome, SessionError> {
     let mut sink = NoopSessionEventSink;
-    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Fresh)
+    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Fresh, None)
 }
 
 /// 進捗通知不要な consumer 向けの薄いラッパー (resume 経路)。
@@ -108,7 +108,30 @@ pub fn run_resumed_session(
     shutdown: &AtomicBool,
 ) -> Result<SessionOutcome, SessionError> {
     let mut sink = NoopSessionEventSink;
-    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Resumed)
+    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Resumed, None)
+}
+
+/// 進捗通知不要な CLI 等に向けた、切断前 record 引き継ぎ付き resume entry point。
+/// 再送 `Game_Summary` の現在局面と保持局面を照合し、一致すれば対局開始からの
+/// 通し record を返す。不一致なら警告を出し、resume 局面から
+/// [`crate::record::RecordStatus::ReconnectFragment`] として記録する。
+pub fn run_resumed_session_with_record(
+    conn: &mut CsaConnection,
+    engine: &mut UsiEngine,
+    config: &CsaClientConfig,
+    shutdown: &AtomicBool,
+    retained_record: GameRecord,
+) -> Result<SessionOutcome, SessionError> {
+    let mut sink = NoopSessionEventSink;
+    drive_session(
+        config,
+        conn,
+        engine,
+        shutdown,
+        &mut sink,
+        SessionMode::Resumed,
+        Some(retained_record),
+    )
 }
 
 // ────────────────────────────────────────────
@@ -128,6 +151,7 @@ fn drive_session<E, S>(
     shutdown: &AtomicBool,
     sink: &mut S,
     mode: SessionMode,
+    retained_record: Option<GameRecord>,
 ) -> Result<SessionOutcome, SessionError>
 where
     E: UsiEngineDriver + ?Sized,
@@ -207,6 +231,7 @@ where
         summary.clone(),
         reconnect_state_protocol,
         sink,
+        retained_record,
     );
 
     match loop_result {
@@ -321,6 +346,7 @@ fn run_session_loop<E, S>(
     summary: GameSummary,
     resume_state: Option<ProtocolReconnectState>,
     sink: &mut S,
+    retained_record: Option<GameRecord>,
 ) -> LoopOutcome
 where
     E: UsiEngineDriver + ?Sized,
@@ -336,12 +362,43 @@ where
         clock.apply_resume_remaining(state.black_remaining_ms, state.white_remaining_ms);
     }
 
+    let reconnect_turn = resume_state.as_ref().and_then(|state| state.current_turn);
+    let (record, pos, initial_sfen, usi_moves, apply_summary_initial_moves) = match retained_record
+        .map(|record| record.continue_for_resume(&summary, reconnect_turn))
+    {
+        Some(ResumeRecordDecision::Continued {
+            record,
+            position,
+            usi_moves,
+        }) => {
+            log::info!(
+                "[REC] resume 局面一致。切断前の棋譜を継続: game_id={} retained_moves={}",
+                record.game_id,
+                record.moves.len()
+            );
+            let initial_sfen = record.initial_position.to_sfen();
+            (*record, *position, initial_sfen, usi_moves, false)
+        }
+        Some(ResumeRecordDecision::Fragment { record, reason }) => {
+            log::warn!("[REC] resume 局面不一致。再接続以降を断片棋譜として保存します: {reason}");
+            let pos = summary.position.clone();
+            let initial_sfen = pos.to_sfen();
+            (*record, pos, initial_sfen, Vec::new(), true)
+        }
+        None => {
+            let record = GameRecord::new(&summary);
+            let pos = summary.position.clone();
+            let initial_sfen = pos.to_sfen();
+            (record, pos, initial_sfen, Vec::new(), true)
+        }
+    };
+
     let mut s = SessionState {
-        pos: summary.position.clone(),
-        initial_sfen: summary.position.to_sfen(),
-        usi_moves: Vec::new(),
+        pos,
+        initial_sfen,
+        usi_moves,
         clock,
-        record: GameRecord::new(&summary),
+        record,
         ponder_state: None,
         my_color: summary.my_color,
         conn,
@@ -360,7 +417,12 @@ where
     // 一部であり、この時点では既に局面に焼き込まれている扱いとして MoveConfirmed は
     // emit しない。ただし record / clock / usi_moves には反映する必要がある)。
     let mut move_color = summary.position.side_to_move;
-    for cm in &summary.initial_moves {
+    let summary_initial_moves = if apply_summary_initial_moves {
+        summary.initial_moves.as_slice()
+    } else {
+        &[]
+    };
+    for cm in summary_initial_moves {
         let usi = match csa_move_to_usi(&cm.mv, &s.pos) {
             Ok(u) => u,
             Err(err) => return LoopOutcome::Error(map_anyhow_to_session_error(err)),

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -34,12 +34,19 @@ use crate::events::{
     SearchInfoSnapshot, SearchOrigin, SessionError, SessionEventSink, SessionOutcome,
     SessionProgress, Side, SinkError,
 };
-use crate::jsonl::LiveJsonlWriter;
+use crate::jsonl::{LiveJsonlWriter, remove_complete_live_jsonl};
 use crate::protocol::{
     CsaConnection, GameResult, GameSummary, ReconnectState as ProtocolReconnectState,
     parse_game_result, parse_server_move,
 };
-use crate::record::{GameRecord, JsonlMoveExtra, ResumeRecordDecision};
+use crate::record::{GameRecord, JsonlMoveExtra, RecordStatus, ResumeRecordDecision};
+
+/// record 引き継ぎ付き resume API の戻り値。
+#[derive(Debug)]
+pub struct RecordedSessionOutcome {
+    pub outcome: SessionOutcome,
+    pub status: RecordStatus,
+}
 
 // ────────────────────────────────────────────
 // 公開エントリポイント
@@ -64,7 +71,17 @@ where
     E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
-    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Fresh, None)
+    let mut status = RecordStatus::Complete;
+    drive_session(
+        config,
+        conn,
+        engine,
+        shutdown.as_ref(),
+        sink,
+        SessionMode::Fresh,
+        None,
+        &mut status,
+    )
 }
 
 /// `LOGIN ... reconnect:<game_id>+<token>` 後の resume セッションを進捗通知付きで
@@ -84,7 +101,17 @@ where
     E: UsiEngineDriver + ?Sized,
     S: SessionEventSink + ?Sized,
 {
-    drive_session(config, conn, engine, shutdown.as_ref(), sink, SessionMode::Resumed, None)
+    let mut status = RecordStatus::Complete;
+    drive_session(
+        config,
+        conn,
+        engine,
+        shutdown.as_ref(),
+        sink,
+        SessionMode::Resumed,
+        None,
+        &mut status,
+    )
 }
 
 /// 進捗通知不要な consumer 向けの薄いラッパー。内部で [`NoopSessionEventSink`] を渡す。
@@ -97,7 +124,8 @@ pub fn run_game_session(
     shutdown: &AtomicBool,
 ) -> Result<SessionOutcome, SessionError> {
     let mut sink = NoopSessionEventSink;
-    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Fresh, None)
+    let mut status = RecordStatus::Complete;
+    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Fresh, None, &mut status)
 }
 
 /// 進捗通知不要な consumer 向けの薄いラッパー (resume 経路)。
@@ -108,7 +136,17 @@ pub fn run_resumed_session(
     shutdown: &AtomicBool,
 ) -> Result<SessionOutcome, SessionError> {
     let mut sink = NoopSessionEventSink;
-    drive_session(config, conn, engine, shutdown, &mut sink, SessionMode::Resumed, None)
+    let mut status = RecordStatus::Complete;
+    drive_session(
+        config,
+        conn,
+        engine,
+        shutdown,
+        &mut sink,
+        SessionMode::Resumed,
+        None,
+        &mut status,
+    )
 }
 
 /// 進捗通知不要な CLI 等に向けた、切断前 record 引き継ぎ付き resume entry point。
@@ -121,9 +159,10 @@ pub fn run_resumed_session_with_record(
     config: &CsaClientConfig,
     shutdown: &AtomicBool,
     retained_record: GameRecord,
-) -> Result<SessionOutcome, SessionError> {
+) -> Result<RecordedSessionOutcome, SessionError> {
     let mut sink = NoopSessionEventSink;
-    drive_session(
+    let mut status = RecordStatus::Complete;
+    let outcome = drive_session(
         config,
         conn,
         engine,
@@ -131,7 +170,9 @@ pub fn run_resumed_session_with_record(
         &mut sink,
         SessionMode::Resumed,
         Some(retained_record),
-    )
+        &mut status,
+    )?;
+    Ok(RecordedSessionOutcome { outcome, status })
 }
 
 // ────────────────────────────────────────────
@@ -152,6 +193,7 @@ fn drive_session<E, S>(
     sink: &mut S,
     mode: SessionMode,
     retained_record: Option<GameRecord>,
+    record_status: &mut RecordStatus,
 ) -> Result<SessionOutcome, SessionError>
 where
     E: UsiEngineDriver + ?Sized,
@@ -232,6 +274,7 @@ where
         reconnect_state_protocol,
         sink,
         retained_record,
+        record_status,
     );
 
     match loop_result {
@@ -347,6 +390,7 @@ fn run_session_loop<E, S>(
     resume_state: Option<ProtocolReconnectState>,
     sink: &mut S,
     retained_record: Option<GameRecord>,
+    record_status: &mut RecordStatus,
 ) -> LoopOutcome
 where
     E: UsiEngineDriver + ?Sized,
@@ -363,35 +407,54 @@ where
     }
 
     let reconnect_turn = resume_state.as_ref().and_then(|state| state.current_turn);
-    let (record, pos, initial_sfen, usi_moves, apply_summary_initial_moves) = match retained_record
-        .map(|record| record.continue_for_resume(&summary, reconnect_turn))
-    {
-        Some(ResumeRecordDecision::Continued {
-            record,
-            position,
-            usi_moves,
-        }) => {
-            log::info!(
-                "[REC] resume 局面一致。切断前の棋譜を継続: game_id={} retained_moves={}",
-                record.game_id,
-                record.moves.len()
-            );
-            let initial_sfen = record.initial_position.to_sfen();
-            (*record, *position, initial_sfen, usi_moves, false)
-        }
-        Some(ResumeRecordDecision::Fragment { record, reason }) => {
-            log::warn!("[REC] resume 局面不一致。再接続以降を断片棋譜として保存します: {reason}");
-            let pos = summary.position.clone();
-            let initial_sfen = pos.to_sfen();
-            (*record, pos, initial_sfen, Vec::new(), true)
-        }
-        None => {
-            let record = GameRecord::new(&summary);
-            let pos = summary.position.clone();
-            let initial_sfen = pos.to_sfen();
-            (record, pos, initial_sfen, Vec::new(), true)
-        }
-    };
+    let (record, pos, initial_sfen, usi_moves, apply_summary_initial_moves, status) =
+        match retained_record.map(|record| record.continue_for_resume(&summary, reconnect_turn)) {
+            Some(ResumeRecordDecision::Continued {
+                record,
+                position,
+                usi_moves,
+            }) => {
+                log::info!(
+                    "[REC] resume 局面一致。切断前の棋譜を継続: game_id={} retained_moves={}",
+                    record.game_id,
+                    record.moves.len()
+                );
+                let initial_sfen = record.initial_position.to_sfen();
+                (*record, *position, initial_sfen, usi_moves, false, RecordStatus::Complete)
+            }
+            Some(ResumeRecordDecision::Fragment {
+                record,
+                retained_record,
+                reason,
+            }) => {
+                log::warn!(
+                    "[REC] resume 局面不一致。再接続以降を断片棋譜として保存します: {reason}"
+                );
+                if config.record.live_jsonl
+                    && let Some(dir) = config.record.jsonl_dir()
+                    && let Err(err) = remove_complete_live_jsonl(&dir, &retained_record)
+                {
+                    log::warn!("[REC] 切断前 live JSONL の削除に失敗しました: {err:#}");
+                }
+                let pos = summary.position.clone();
+                let initial_sfen = pos.to_sfen();
+                (
+                    *record,
+                    pos,
+                    initial_sfen,
+                    Vec::new(),
+                    true,
+                    RecordStatus::ReconnectFragment { reason },
+                )
+            }
+            None => {
+                let record = GameRecord::new(&summary);
+                let pos = summary.position.clone();
+                let initial_sfen = pos.to_sfen();
+                (record, pos, initial_sfen, Vec::new(), true, RecordStatus::Complete)
+            }
+        };
+    *record_status = status.clone();
 
     let mut s = SessionState {
         pos,
@@ -443,7 +506,7 @@ where
 
     // initial_moves (途中局面開始) や resume 済みの手も含めて書き出すため、
     // 手順の反映が終わってから live ライターを作る。
-    s.live_jsonl = make_live_writer(config, &s.record);
+    s.live_jsonl = make_live_writer(config, &s.record, &status);
 
     loop {
         // 各イテレーション先頭で sink.should_continue() を確認
@@ -1635,12 +1698,16 @@ fn label_for_color(record: &GameRecord, color: Color) -> String {
 
 /// `[record] live_jsonl` 有効時に live ライターを作る。失敗は warn に留めて `None`
 /// (live 追記は補助機能で、対局の進行を妨げない)。`save_jsonl` 無効時も `None`。
-fn make_live_writer(config: &CsaClientConfig, record: &GameRecord) -> Option<LiveJsonlWriter> {
+fn make_live_writer(
+    config: &CsaClientConfig,
+    record: &GameRecord,
+    status: &RecordStatus,
+) -> Option<LiveJsonlWriter> {
     if !config.record.live_jsonl {
         return None;
     }
     let dir = config.record.jsonl_dir()?;
-    match LiveJsonlWriter::create(&dir, record, config) {
+    match LiveJsonlWriter::create_with_status(&dir, record, config, status) {
         Ok(w) => Some(w),
         Err(e) => {
             log::warn!("live JSONL の作成に失敗 (追記なしで続行): {e:#}");

--- a/crates/rshogi-csa-client/tests/jsonl_output.rs
+++ b/crates/rshogi-csa-client/tests/jsonl_output.rs
@@ -10,7 +10,7 @@ use rshogi_csa::{Color, initial_position};
 use rshogi_csa_client::config::{CsaClientConfig, EngineConfig, RecordConfig, TimeConfig};
 use rshogi_csa_client::jsonl::write_game_jsonl;
 use rshogi_csa_client::protocol::{GameResult, TimeConfig as ProtoTimeConfig};
-use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra};
+use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra, RecordStatus};
 use serde_json::Value;
 
 /// テスト用の minimal な `GameRecord` を作る。
@@ -36,6 +36,7 @@ fn build_record(my_color: Color) -> GameRecord {
         start_time: chrono::Local::now(),
         my_color,
         jsonl_moves: Vec::new(),
+        status: RecordStatus::Complete,
     }
 }
 

--- a/crates/rshogi-csa-client/tests/jsonl_output.rs
+++ b/crates/rshogi-csa-client/tests/jsonl_output.rs
@@ -10,7 +10,7 @@ use rshogi_csa::{Color, initial_position};
 use rshogi_csa_client::config::{CsaClientConfig, EngineConfig, RecordConfig, TimeConfig};
 use rshogi_csa_client::jsonl::write_game_jsonl;
 use rshogi_csa_client::protocol::{GameResult, TimeConfig as ProtoTimeConfig};
-use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra, RecordStatus};
+use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra};
 use serde_json::Value;
 
 /// テスト用の minimal な `GameRecord` を作る。
@@ -36,7 +36,6 @@ fn build_record(my_color: Color) -> GameRecord {
         start_time: chrono::Local::now(),
         my_color,
         jsonl_moves: Vec::new(),
-        status: RecordStatus::Complete,
     }
 }
 

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -26,13 +26,16 @@ use rshogi_csa_client::config::CsaClientConfig;
 use rshogi_csa_client::engine::SpawnOptions;
 
 mod common;
+use rshogi_csa::{Color, Position, initial_position};
 use rshogi_csa_client::events::{
     DisconnectReason, MovePlayer, ReconnectState, SearchInfoEmitPolicy, SessionError,
     SessionEventSink, SessionProgress, SinkError,
 };
-use rshogi_csa_client::protocol::CsaConnection;
+use rshogi_csa_client::protocol::{CsaConnection, GameSummary, TimeConfig};
+use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra, RecordStatus};
 use rshogi_csa_client::session::{
     run_game_session, run_game_session_with_events, run_resumed_session_with_events,
+    run_resumed_session_with_record,
 };
 
 // ────────────────────────────────────────────
@@ -194,32 +197,35 @@ fn mock_config(engine_path: PathBuf, search_info_emit: SearchInfoEmitPolicy) -> 
 
 /// 1 局分の `Game_Summary` 行群 (平手・自分先手)。`Reconnect_Token` 拡張あり。
 fn game_summary_lines(game_id: &str) -> Vec<String> {
-    vec![
+    game_summary_lines_for_position(game_id, &initial_position())
+}
+
+/// resume 用に、指定した現在局面を Position block に入れた `Game_Summary` を作る。
+fn game_summary_lines_for_position(game_id: &str, position: &Position) -> Vec<String> {
+    let turn = match position.side_to_move {
+        Color::Black => "+",
+        Color::White => "-",
+    };
+    let mut lines = vec![
         "BEGIN Game_Summary".to_owned(),
         "Protocol_Version:1.2".to_owned(),
         format!("Game_ID:{}", game_id),
         "Name+:alice".to_owned(),
         "Name-:bob".to_owned(),
         "Your_Turn:+".to_owned(),
-        "To_Move:+".to_owned(),
+        format!("To_Move:{turn}"),
         "Time_Unit:1sec".to_owned(),
         "Total_Time:600".to_owned(),
         "Byoyomi:10".to_owned(),
         "BEGIN Position".to_owned(),
-        "P1-KY-KE-GI-KI-OU-KI-GI-KE-KY".to_owned(),
-        "P2 * -HI *  *  *  *  * -KA *".to_owned(),
-        "P3-FU-FU-FU-FU-FU-FU-FU-FU-FU".to_owned(),
-        "P4 *  *  *  *  *  *  *  *  *".to_owned(),
-        "P5 *  *  *  *  *  *  *  *  *".to_owned(),
-        "P6 *  *  *  *  *  *  *  *  *".to_owned(),
-        "P7+FU+FU+FU+FU+FU+FU+FU+FU+FU".to_owned(),
-        "P8 * +KA *  *  *  *  * +HI *".to_owned(),
-        "P9+KY+KE+GI+KI+OU+KI+GI+KE+KY".to_owned(),
-        "+".to_owned(),
+    ];
+    lines.extend(position.to_csa_board().lines().map(str::to_owned));
+    lines.extend([
         "END Position".to_owned(),
         "Reconnect_Token:tok-xyz".to_owned(),
         "END Game_Summary".to_owned(),
-    ]
+    ]);
+    lines
 }
 
 /// 集計用に sink から取り出す Arc 観測 handle 一式。
@@ -526,6 +532,108 @@ fn resumed_session_emits_resumed_event_and_no_history_replay() {
         .filter(|e| **e == "MoveConfirmedSelf" || **e == "MoveConfirmedOpp")
         .count();
     assert_eq!(confirmed_count, 1, "履歴 replay が emit されています: {events:?}");
+}
+
+#[test]
+fn resumed_session_keeps_pre_disconnect_record_and_start_time() {
+    let initial = initial_position();
+    let retained_summary = GameSummary {
+        game_id: "g-resume-record".to_owned(),
+        my_color: Color::Black,
+        sente_name: "alice".to_owned(),
+        gote_name: "bob".to_owned(),
+        position: initial.clone(),
+        initial_moves: Vec::new(),
+        black_time: TimeConfig {
+            total_time_ms: 600_000,
+            byoyomi_ms: 10_000,
+            increment_ms: 0,
+        },
+        white_time: TimeConfig {
+            total_time_ms: 600_000,
+            byoyomi_ms: 10_000,
+            increment_ms: 0,
+        },
+        reconnect_token: Some("tok-xyz".to_owned()),
+    };
+    let mut retained = GameRecord::new(&retained_summary);
+    let original_start_time = retained.start_time;
+    let mut current = initial;
+    for (csa, usi, side) in [
+        ("+2726FU", "2g2f", Color::Black),
+        ("-8384FU", "8c8d", Color::White),
+    ] {
+        let sfen_before = current.to_sfen();
+        retained.add_move(csa, 1, None, side);
+        retained.add_jsonl_move(JsonlMoveExtra {
+            sfen_before,
+            move_usi: usi.to_owned(),
+            engine_label: if side == Color::Black { "alice" } else { "bob" }.to_owned(),
+            elapsed_ms: 10,
+            think_limit_ms: 1000,
+            seldepth: None,
+            nodes: None,
+            time_ms: None,
+            nps: None,
+        });
+        current.apply_csa_move(csa).unwrap();
+    }
+    let resume_lines = game_summary_lines_for_position("g-resume-record", &current);
+
+    let port = spawn_mock_tcp_server(move |reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let line_refs: Vec<&str> = resume_lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:+",
+                "Black_Time_Remaining_Ms:599500",
+                "White_Time_Remaining_Ms:599000",
+                "END Reconnect_State",
+            ],
+        );
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"), "expected +7776FU, got: {mv}");
+        write_lines(writer, &["+7776FU,T1", "#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login_reconnect("alice", "pw", "g-resume-record", "tok-xyz")
+        .expect("login_reconnect");
+    let mut engine = common::spawn_engine(
+        &config.engine.path,
+        &config.engine.options,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
+    )
+    .expect("spawn engine");
+    let outcome = run_resumed_session_with_record(
+        &mut conn,
+        &mut engine,
+        &config,
+        shutdown.as_ref(),
+        retained,
+    )
+    .expect("resumed session");
+    engine.quit();
+
+    assert_eq!(outcome.record.start_time, original_start_time);
+    assert_eq!(outcome.record.moves.len(), 3);
+    assert_eq!(outcome.record.jsonl_moves.len(), 3);
+    assert_eq!(outcome.record.moves[0].csa_move, "+2726FU");
+    assert_eq!(outcome.record.moves[1].csa_move, "-8384FU");
+    assert_eq!(outcome.record.moves[2].csa_move, "+7776FU");
+    assert_eq!(outcome.record.status, RecordStatus::Complete);
 }
 
 #[test]

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -31,6 +31,7 @@ use rshogi_csa_client::events::{
     DisconnectReason, MovePlayer, ReconnectState, SearchInfoEmitPolicy, SessionError,
     SessionEventSink, SessionProgress, SinkError,
 };
+use rshogi_csa_client::jsonl::LiveJsonlWriter;
 use rshogi_csa_client::protocol::{CsaConnection, GameSummary, TimeConfig};
 use rshogi_csa_client::record::{GameRecord, JsonlMoveExtra, RecordStatus};
 use rshogi_csa_client::session::{
@@ -627,13 +628,120 @@ fn resumed_session_keeps_pre_disconnect_record_and_start_time() {
     .expect("resumed session");
     engine.quit();
 
-    assert_eq!(outcome.record.start_time, original_start_time);
-    assert_eq!(outcome.record.moves.len(), 3);
-    assert_eq!(outcome.record.jsonl_moves.len(), 3);
-    assert_eq!(outcome.record.moves[0].csa_move, "+2726FU");
-    assert_eq!(outcome.record.moves[1].csa_move, "-8384FU");
-    assert_eq!(outcome.record.moves[2].csa_move, "+7776FU");
-    assert_eq!(outcome.record.status, RecordStatus::Complete);
+    assert_eq!(outcome.outcome.record.start_time, original_start_time);
+    assert_eq!(outcome.outcome.record.moves.len(), 3);
+    assert_eq!(outcome.outcome.record.jsonl_moves.len(), 3);
+    assert_eq!(outcome.outcome.record.moves[0].csa_move, "+2726FU");
+    assert_eq!(outcome.outcome.record.moves[1].csa_move, "-8384FU");
+    assert_eq!(outcome.outcome.record.moves[2].csa_move, "+7776FU");
+    assert_eq!(outcome.status, RecordStatus::Complete);
+}
+
+#[test]
+fn resumed_session_mismatch_keeps_start_time_and_removes_stale_live_jsonl() {
+    let initial = initial_position();
+    let retained_summary = GameSummary {
+        game_id: "g-resume-fragment".to_owned(),
+        my_color: Color::Black,
+        sente_name: "alice".to_owned(),
+        gote_name: "bob".to_owned(),
+        position: initial.clone(),
+        initial_moves: Vec::new(),
+        black_time: TimeConfig::default(),
+        white_time: TimeConfig::default(),
+        reconnect_token: Some("tok-xyz".to_owned()),
+    };
+    let mut retained = GameRecord::new(&retained_summary);
+    let original_start_time = retained.start_time;
+    retained.add_move("+2726FU", 1, None, Color::Black);
+    retained.add_jsonl_move(JsonlMoveExtra {
+        sfen_before: initial.to_sfen(),
+        move_usi: "2g2f".to_owned(),
+        engine_label: "alice".to_owned(),
+        elapsed_ms: 10,
+        think_limit_ms: 1000,
+        seldepth: None,
+        nodes: None,
+        time_ms: None,
+        nps: None,
+    });
+
+    let port = spawn_mock_tcp_server(|reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let resume_lines = game_summary_lines("g-resume-fragment");
+        let line_refs: Vec<&str> = resume_lines.iter().map(String::as_str).collect();
+        write_lines(writer, &line_refs);
+        write_lines(
+            writer,
+            &[
+                "BEGIN Reconnect_State",
+                "Current_Turn:+",
+                "Black_Time_Remaining_Ms:599500",
+                "White_Time_Remaining_Ms:599000",
+                "END Reconnect_State",
+            ],
+        );
+        let mv = read_line(reader);
+        assert!(mv.starts_with("+7776FU"), "expected +7776FU, got: {mv}");
+        write_lines(writer, &["+7776FU,T1", "#WIN"]);
+        let _ = read_line(reader);
+    });
+
+    let engine_path = mock_usi_engine_script();
+    let mut config = mock_config(engine_path, SearchInfoEmitPolicy::Disabled);
+    let jsonl_dir =
+        tempfile_root().join(format!("csa_resume_fragment_live_jsonl_e2e_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&jsonl_dir);
+    config.record.jsonl_out = Some(jsonl_dir.clone());
+    config.record.live_jsonl = true;
+    // 切断前 session が残した通常名 live JSONL を再現する。
+    let stale_writer = LiveJsonlWriter::create(&jsonl_dir, &retained, &config).unwrap();
+    drop(stale_writer);
+    assert_eq!(std::fs::read_dir(&jsonl_dir).unwrap().count(), 1);
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login_reconnect("alice", "pw", "g-resume-fragment", "tok-xyz")
+        .expect("login_reconnect");
+    let mut engine = common::spawn_engine(
+        &config.engine.path,
+        &config.engine.options,
+        SpawnOptions {
+            ponder: config.game.ponder,
+            startup_timeout: Duration::from_secs(5),
+            stderr_passthrough: false,
+        },
+    )
+    .expect("spawn engine");
+    let outcome = run_resumed_session_with_record(
+        &mut conn,
+        &mut engine,
+        &config,
+        shutdown.as_ref(),
+        retained,
+    )
+    .expect("resumed session");
+    engine.quit();
+
+    assert_eq!(outcome.outcome.record.start_time, original_start_time);
+    assert_eq!(outcome.outcome.record.moves.len(), 1);
+    let RecordStatus::ReconnectFragment { reason } = &outcome.status else {
+        panic!("局面不一致が fragment 扱いになっていません");
+    };
+    assert!(reason.contains("局面不一致"), "reason={reason}");
+    let paths: Vec<_> = std::fs::read_dir(&jsonl_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert_eq!(paths.len(), 1, "通常名 live JSONL が残っています: {paths:?}");
+    let filename = paths[0].file_name().unwrap().to_string_lossy();
+    assert!(filename.contains("_reconnect_fragment.jsonl"), "filename={filename}");
+    assert!(
+        filename.starts_with(&original_start_time.format("%Y%m%d_%H%M%S").to_string()),
+        "filename={filename}"
+    );
+    let _ = std::fs::remove_dir_all(&jsonl_dir);
 }
 
 #[test]

--- a/docs/csa-client.md
+++ b/docs/csa-client.md
@@ -141,6 +141,20 @@ live_jsonl = false # 対局中に JSONL を手単位で live 追記（下記）
 進行中対局（勝敗不明）として扱う。終局時は従来どおりの完全な内容（result 行込み）へ
 置き換わる。追記の失敗は警告のみで対局は続行する。`save_jsonl = false` なら効果なし。
 
+#### 再接続時の棋譜継続
+
+対局中の切断から `Reconnect_Token` で復帰した場合、`csa_client` は切断前にメモリへ
+蓄積した指し手を対局開始局面から replay し、再送された `Game_Summary` の現在局面
+（盤面・持ち駒・手番）および `Reconnect_State` の `Current_Turn` と照合する。
+一致すれば開始時刻と既存の指し手・探索情報を
+引き継ぎ、再接続を挟んでも `.csa` / `.sfen` / `.jsonl` を 1 局 1 ファイルの通し記録
+として保存する。ファイル名の `{datetime}` も最初の対局開始時刻のまま変わらない。
+
+局面または game ID・対局者・自手番が一致しない場合は `[REC] resume 局面不一致` の
+警告を出し、resume 局面以降だけを断片として保存する。この場合は全形式のファイル名に
+`_reconnect_fragment` が付き、CSA には `RECONNECT_FRAGMENT` コメントと不一致理由も
+記録される。
+
 ## 使い方の例
 
 ### floodgate で連続対局
@@ -374,5 +388,6 @@ floodgate = true
 ### 棋譜ファイル
 
 `records/` ディレクトリに対局ごとに保存:
+
 - `20260328_120030_rshogi_v1_vs_opponent.csa` — CSA形式（評価値コメント付き）
 - `20260328_120030_rshogi_v1_vs_opponent.sfen` — SFEN局面列（タブ区切り: SFEN, 指し手, 評価値）


### PR DESCRIPTION
## 概要

CSA 対局中の grace / cold rejoin 後も、切断前からの `.csa` / `.sfen` / `.jsonl` と対局開始時刻を維持します。

## 原因

初回セッションの `SessionOutcome.record` は切断時点までの指し手を保持していましたが、resume セッションが再送 `Game_Summary` から `GameRecord::new` を作り直し、`run_one_game` がその再接続後 record だけを返していました。そのため保存物が再接続以降の断片になっていました。

## 変更

- 切断前 record を resume セッションへ渡し、初期局面から replay した保持局面を再送 `Game_Summary` と `Reconnect_State.Current_Turn` に照合
- 一致時は指し手、探索情報、JSONL 情報、開始時刻を引き継いで通し記録を生成
- 不一致時だけ警告を出し、`_reconnect_fragment` suffix と CSA 先頭コメント付きの断片記録へ fallback
- record 層の一致・不一致 unit test と、TCP mock + USI mock による resume 統合テストを追加
- `docs/csa-client.md` に挙動を記載

## 実例確認

報告局 `r6-s7n4-1784307906-1784307914209` は、サーバー API 正本 128 手に対し旧 client 保存 CSA が 47 手であることと、`local.log` の切断→再接続→再接続側 record 保存を確認しました。

## 検証

- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo clippy --tests` (warning 0)
- `cargo test`
- `bash scripts/check-tracked-abs-paths.sh`
