### PR TITLE
fix(csa-server): bound reconnect clock compensation

### DIFF
--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -3220,27 +3220,16 @@ impl GameRoom {
             .as_ref()
             .cloned()
             .ok_or_else(|| Error::RustError("enter_grace_window: config missing".into()))?;
-        // 既存 turn alarm の予定発火時刻を grace 経路前に取得しておき、
-        // `PendingReconnect` に保存する。再接続成功後に新規 alarm を貼り直すとき、
-        // この値に「今回実際に付与した bounded credit」だけを加えた時刻と、
-        // 補償後の実残時間から再計算した時刻のうち早い方を採用する。off-turn
-        // 再接続では credit=0 のため相手手番の deadline は一切延びない。
-        // 同じ値を後段の `classify_alarm_after_enter_grace` でも使うため、
-        // `get_alarm` は 1 回だけ呼んで使い回す。
+        // 既存 turn alarm の予定発火時刻を grace 経路前に取得する。grace deadline
+        // と比較して早い方を残すために使い、再接続成立後の turn alarm は core の
+        // 固定計時起点 + 現在予算 + 永続化済み累積 credit から再構成する。
         let existing_alarm = self.state.storage().get_alarm().await.ok().flatten();
-        let original_turn_alarm_epoch_ms = existing_alarm.map(|e| e as u64);
         let pending = {
             let borrow = self.core.borrow();
             let core = borrow.as_ref().ok_or_else(|| {
                 Error::RustError("enter_grace_window: core missing after ensure_core_loaded".into())
             })?;
-            self.build_pending_reconnect(
-                core,
-                &cfg,
-                role,
-                grace_duration,
-                original_turn_alarm_epoch_ms,
-            )?
+            self.build_pending_reconnect(core, &cfg, role, grace_duration)?
         };
         // 既存の turn alarm より grace deadline が早ければ上書き、遅ければ既存
         // alarm (時間切れ) を残す。`get_alarm` は次回発火時刻 (epoch ms) を返し、
@@ -3288,7 +3277,6 @@ impl GameRoom {
         cfg: &PersistedConfig,
         role: Role,
         grace_duration: Duration,
-        original_turn_alarm_epoch_ms: Option<u64>,
     ) -> Result<PendingReconnect> {
         let disconnected_color = role.to_core();
         let token = match disconnected_color {
@@ -3348,7 +3336,6 @@ impl GameRoom {
             deadline_ms,
             snapshot,
             game_summary_for_disconnected,
-            original_turn_alarm_epoch_ms,
         })
     }
 
@@ -3443,44 +3430,7 @@ impl GameRoom {
         let Some(core) = core_borrow.as_ref() else {
             return Ok(None);
         };
-        // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぐ。
-        // 成立後に延長できるのは「on-turn かつ同一手番累積で秒読み 1 回分まで」の
-        // bounded credit だけで、off-turn 再接続では元 deadline を保つ。
-        // 取得エラー時は上限不明のまま受理せず reject に倒す (クライアントは
-        // LOGIN リトライで再試行する)。alarm 消失 (`Ok(None)`) 時は、cold start
-        // 復元後も保持される計時起点 (`turn_started_at_ms`、rshogi#852) から
-        // `now + 現手番の残時間 + margin + 安全ゲタ` を上限として再構成する —
-        // candidate B (経過思考時間を差し引かない 1 手分全予算) をそのまま使うと
-        // 無応答時の TimeUp 確定が実際の残時間より遅れるため。
-        let original_turn_alarm_epoch_ms = match self
-            .state
-            .storage()
-            .get_alarm()
-            .await
-            .map_err(|e| Error::RustError(format!("cold rejoin get_alarm: {e}")))?
-        {
-            Some(ms) => u64::try_from(ms).ok(),
-            None => {
-                let now = self.now_ms();
-                let Some(remaining) = core.current_turn_remaining_ms(now) else {
-                    // Playing 以外 (Finished への遷移途中等の異常系)。合成しない。
-                    return Ok(None);
-                };
-                if remaining == 0 {
-                    // 既に予算超過。margin/safety を再付与すると元 deadline より
-                    // 遅くなるため、即時発火の epoch を渡して time_up 判定に進める。
-                    Some(now)
-                } else {
-                    Some(
-                        now.saturating_add(remaining)
-                            .saturating_add(cfg.time_margin_ms)
-                            .saturating_add(ALARM_SAFETY_MS),
-                    )
-                }
-            }
-        };
-        let pending =
-            self.build_pending_reconnect(core, &cfg, role, grace, original_turn_alarm_epoch_ms)?;
+        let pending = self.build_pending_reconnect(core, &cfg, role, grace)?;
         Ok(Some(pending))
     }
 
@@ -3647,7 +3597,7 @@ impl GameRoom {
 
         // token / handle / color / grace の全照合が通った再接続だけを補償対象にする。
         // LOGIN OK より先に永続化し、補償保存失敗時は成功応答を返さない。
-        let granted_credit_ms = self.compensate_reconnect_clock_if_needed(role, now_ms).await?;
+        self.compensate_reconnect_clock_if_needed(role, now_ms).await?;
 
         // 成功確定。LOGIN OK → resume 送出 → attachment を Player に差し替え →
         // grace registry / alarm tag を片付ける順で進める。
@@ -3669,32 +3619,26 @@ impl GameRoom {
 
         self.delete_grace_alarm_state().await?;
         // 再接続クライアントが指し手を送らず放置しても確実に turn deadline が
-        // 発火するよう、即時 alarm を貼り直す。決定方針:
-        // - 候補 A: 切断時に取り置いた元 turn alarm の発火時刻 + 今回付与した補償
-        // - 候補 B: 再接続処理完了時刻 + (補償反映後の実残時間 + 通信マージン +
-        //   安全側ゲタ)
-        // のうち**早い方**を採用する。A へ加えるのは今回の bounded credit だけで、
-        // off-turn は 0、on-turn も同一手番累積で秒読み 1 回分が上限となる。
+        // 発火するよう、即時 alarm を貼り直す。deadline は以前の alarm へ今回の
+        // 差分を足すのでなく、固定の手番開始時刻 + 現在予算 + 永続化済み累積
+        // credit + 通信マージン + safety から絶対時刻として再構成する。これにより
+        // credit 保存と alarm 更新の間で isolate が失われても、次の cold rejoin が
+        // 復元済み credit を反映できる。off-turn は credit を付与しないため延長なし。
         let now = self.now_ms();
-        let candidate_b_total_ms = {
+        let turn_alarm_epoch_ms = {
             let core_borrow = self.core.borrow();
-            core_borrow.as_ref().map(|core| {
-                let remaining = core.current_turn_remaining_ms(now).unwrap_or(0);
+            core_borrow.as_ref().and_then(|core| {
                 let margin = self
                     .config
                     .borrow()
                     .as_ref()
                     .map(|c| c.time_margin_ms)
                     .unwrap_or(DEFAULT_TIME_MARGIN_MS);
-                remaining.saturating_add(margin).saturating_add(ALARM_SAFETY_MS)
+                core.current_turn_deadline_ms()
+                    .map(|deadline| deadline.saturating_add(margin).saturating_add(ALARM_SAFETY_MS))
             })
         };
-        if let Some(total_b) = candidate_b_total_ms {
-            let candidate_b_epoch = now.saturating_add(total_b);
-            let final_epoch = pending
-                .original_turn_alarm_epoch_ms
-                .map(|orig| orig.saturating_add(granted_credit_ms).min(candidate_b_epoch))
-                .unwrap_or(candidate_b_epoch);
+        if let Some(final_epoch) = turn_alarm_epoch_ms {
             // `set_alarm(Duration)` は「now から N ms 後」に発火する API なので
             // delay = final_epoch - now で渡す。`saturating_sub` は now が final_epoch
             // を既に過ぎている場合に 0 を返し、即時発火させて time_up に進める。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -138,7 +138,7 @@ const _: () = assert!(
 
 /// Durable Object 初期化 SQL。
 ///
-/// moves のみ SQL で持つ（append と ply 順 replay の効率を理由に）。
+/// moves と ply ごとの時計補償を SQL で持つ（append と ply 順 replay の効率を理由に）。
 /// 他の構造化状態 (slots / config / finished) は `state.storage().put/get` で
 /// JSON として置き、スキーママイグレーションを軽くする。
 const SCHEMA_SQL: &str = r#"
@@ -147,6 +147,10 @@ CREATE TABLE IF NOT EXISTS moves (
     color TEXT NOT NULL,
     line TEXT NOT NULL,
     at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS reconnect_clock_credits (
+    ply INTEGER PRIMARY KEY CHECK (ply >= 1),
+    credited_ms INTEGER NOT NULL CHECK (credited_ms >= 0)
 );
 "#;
 
@@ -2287,8 +2291,9 @@ impl GameRoom {
         // MoveRow は client が送ってきた raw CSA 行 (`+7776FU,T3` や Floodgate
         // 形式 `+7776FU,'* 123 pv...`) を保持している。snapshot と同じ共有ヘルパ
         // (`parse_move_row_line` / `move_elapsed_secs`) で token / コメントを抽出し、
-        // 消費時間は at_ms 差分から秒に丸めて `KifuMove` に変換する。Floodgate の
-        // 評価値 PV コメントは `KifuMove::comment` に載せて棋譜 `'` 行として残す。
+        // 消費時間は at_ms 差分から再接続時計補償を引いて秒に丸め、`KifuMove` に
+        // 変換する。これでライブ `T` / snapshot / 終局棋譜が同じ実効経過時間に
+        // なる。Floodgate の評価値 PV コメントは `KifuMove::comment` に残す。
         let first_prev_ms = cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms);
         let elapsed = move_elapsed_secs(&moves_rows, first_prev_ms);
         let mut kifu_moves: Vec<KifuMove> = Vec::with_capacity(moves_rows.len());
@@ -2751,7 +2756,16 @@ impl GameRoom {
             Vec::new()
         };
         match replay_core_room(&cfg, &moves) {
-            ReplaySummary::Restored { core } => {
+            ReplaySummary::Restored { mut core } => {
+                // `replay_core_room` は確定済み各手の credit を適用済み。まだ着手
+                // されていない現手番にも先行保存済みの次 ply credit があれば戻す。
+                let next_ply = i64::from(core.moves_played()).saturating_add(1);
+                if let Some(credit) = self.load_reconnect_clock_credit(next_ply)? {
+                    core.restore_current_turn_reconnect_credit_ms(
+                        credit.max(0) as u64,
+                        cfg.clock.reconnect_compensation_limit_ms(),
+                    );
+                }
                 // `core` は `Box<CoreRoom>` で返るためここで unbox する
                 // (`ReplaySummary` の variant 間サイズ差対策、persistence.rs 参照)。
                 *self.core.borrow_mut() = Some(*core);
@@ -3094,16 +3108,37 @@ impl GameRoom {
         );
     }
 
-    /// `moves` テーブルを ply 昇順で読み出す。
+    /// `moves` テーブルを ply 昇順で読み出し、同じ ply の再接続時計補償を結合する。
     async fn load_moves(&self) -> Result<Vec<MoveRow>> {
         let sql = self.state.storage().sql();
-        let cursor =
-            sql.exec("SELECT ply, color, line, at_ms FROM moves ORDER BY ply ASC", None)?;
+        let cursor = sql.exec(
+            "SELECT m.ply, m.color, m.line, m.at_ms, \
+                    COALESCE(c.credited_ms, 0) AS reconnect_credit_ms \
+             FROM moves AS m \
+             LEFT JOIN reconnect_clock_credits AS c ON c.ply = m.ply \
+             ORDER BY m.ply ASC",
+            None,
+        )?;
         let rows: Vec<MoveRow> = cursor.to_array()?;
         Ok(rows)
     }
 
-    /// `moves` テーブルを空にする (https://github.com/SH11235/rshogi/issues/637)。
+    /// まだ `moves` に入っていない現手番を含め、指定 ply の再接続時計補償を読む。
+    fn load_reconnect_clock_credit(&self, ply: i64) -> Result<Option<i64>> {
+        #[derive(Deserialize)]
+        struct CreditRow {
+            credited_ms: i64,
+        }
+        let cursor = self.state.storage().sql().exec(
+            "SELECT credited_ms FROM reconnect_clock_credits WHERE ply = ?",
+            vec![ply.into()],
+        )?;
+        let rows: Vec<CreditRow> = cursor.to_array()?;
+        Ok(rows.into_iter().next().map(|row| row.credited_ms))
+    }
+
+    /// `moves` と `reconnect_clock_credits` テーブルを空にする
+    /// (https://github.com/SH11235/rshogi/issues/637)。
     ///
     /// 終局時に `finalize_if_ended` から呼び出され、同 room_id を再利用するリファクタ
     /// が将来入った場合でも `replay_core_room` が古い moves を再生して
@@ -3120,6 +3155,13 @@ impl GameRoom {
         if let Err(e) = sql.exec("DELETE FROM moves", None) {
             crate::structured_log!(
                 event: "clear_moves_failed",
+                component: "game_room",
+                err: format!("{e:?}"),
+            );
+        }
+        if let Err(e) = sql.exec("DELETE FROM reconnect_clock_credits", None) {
+            crate::structured_log!(
+                event: "clear_reconnect_clock_credits_failed",
                 component: "game_room",
                 err: format!("{e:?}"),
             );
@@ -3180,9 +3222,9 @@ impl GameRoom {
             .ok_or_else(|| Error::RustError("enter_grace_window: config missing".into()))?;
         // 既存 turn alarm の予定発火時刻を grace 経路前に取得しておき、
         // `PendingReconnect` に保存する。再接続成功後に新規 alarm を貼り直すとき、
-        // この値と「再接続時刻 + 残時間 budget」のうち早い方を採用することで、
-        // 悪意あるクライアントが切断 → grace 直前再接続を繰り返して相手手番の
-        // wall-clock 上の deadline を不当に延長する経路を防ぐ。
+        // この値に「今回実際に付与した bounded credit」だけを加えた時刻と、
+        // 補償後の実残時間から再計算した時刻のうち早い方を採用する。off-turn
+        // 再接続では credit=0 のため相手手番の deadline は一切延びない。
         // 同じ値を後段の `classify_alarm_after_enter_grace` でも使うため、
         // `get_alarm` は 1 回だけ呼んで使い回す。
         let existing_alarm = self.state.storage().get_alarm().await.ok().flatten();
@@ -3401,8 +3443,9 @@ impl GameRoom {
         let Some(core) = core_borrow.as_ref() else {
             return Ok(None);
         };
-        // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぎ、
-        // 再接続によって相手手番の wall-clock deadline が延びないようにする。
+        // 再起動を跨いで storage に残った turn deadline alarm を上限として引き継ぐ。
+        // 成立後に延長できるのは「on-turn かつ同一手番累積で秒読み 1 回分まで」の
+        // bounded credit だけで、off-turn 再接続では元 deadline を保つ。
         // 取得エラー時は上限不明のまま受理せず reject に倒す (クライアントは
         // LOGIN リトライで再試行する)。alarm 消失 (`Ok(None)`) 時は、cold start
         // 復元後も保持される計時起点 (`turn_started_at_ms`、rshogi#852) から
@@ -3439,6 +3482,75 @@ impl GameRoom {
         let pending =
             self.build_pending_reconnect(core, &cfg, role, grace, original_turn_alarm_epoch_ms)?;
         Ok(Some(pending))
+    }
+
+    /// 再接続した側が現手番で、残時間が秒読み 1 回分を下回っている場合だけ不足分を
+    /// 補償する。同一手番の累積補償も秒読み 1 回分を上限とし、意図的な連続切断で
+    /// 思考時間を無制限に増やせないようにする。
+    ///
+    /// 次の ply に対応する SQL 行へ累積値を書いてから in-memory core に反映する。
+    /// 書き込み後に isolate が失われても `ensure_core_loaded` が同じ credit を replay
+    /// 後の core へ戻す。着手後も行を残し、将来の replay で過去の補償を再適用する。
+    async fn compensate_reconnect_clock_if_needed(&self, role: Role, now_ms: u64) -> Result<u64> {
+        let cfg = self.config.borrow().as_ref().cloned().ok_or_else(|| {
+            Error::RustError("reconnect clock compensation: config missing".into())
+        })?;
+        let limit_ms = cfg.clock.reconnect_compensation_limit_ms();
+        if limit_ms == 0 {
+            return Ok(0);
+        }
+
+        let color = role.to_core();
+        let plan = {
+            let core_borrow = self.core.borrow();
+            let Some(core) = core_borrow.as_ref() else {
+                return Ok(0);
+            };
+            if core.current_turn() != color {
+                return Ok(0);
+            }
+            let remaining_before_ms = core.current_turn_remaining_ms(now_ms).unwrap_or(0);
+            let granted_ms =
+                core.additional_reconnect_credit_ms(now_ms, limit_ms, limit_ms).unwrap_or(0);
+            let total_credited_ms =
+                core.current_turn_reconnect_credit_ms().saturating_add(granted_ms).min(limit_ms);
+            (core.moves_played(), remaining_before_ms, granted_ms, total_credited_ms)
+        };
+        let (moves_played, remaining_before_ms, granted_ms, total_credited_ms) = plan;
+        if granted_ms == 0 {
+            return Ok(0);
+        }
+
+        let target_ply = i64::from(moves_played).saturating_add(1);
+        let total_credited_i64 = i64::try_from(total_credited_ms).map_err(|_| {
+            Error::RustError("reconnect clock compensation exceeds SQLite INTEGER".into())
+        })?;
+        self.state.storage().sql().exec(
+            "INSERT INTO reconnect_clock_credits(ply, credited_ms) VALUES (?, ?) \
+             ON CONFLICT(ply) DO UPDATE SET credited_ms = excluded.credited_ms",
+            vec![target_ply.into(), total_credited_i64.into()],
+        )?;
+
+        let remaining_after_ms = {
+            let mut core_borrow = self.core.borrow_mut();
+            let Some(core) = core_borrow.as_mut() else {
+                return Ok(0);
+            };
+            core.restore_current_turn_reconnect_credit_ms(total_credited_ms, limit_ms);
+            core.current_turn_remaining_ms(now_ms).unwrap_or(0)
+        };
+        crate::structured_log!(
+            event: "reconnect_clock_compensated",
+            component: "game_room",
+            game_id: cfg.game_id.as_str(),
+            role: format!("{role:?}"),
+            moves_played: moves_played,
+            granted_ms: granted_ms,
+            total_credited_ms: total_credited_ms,
+            remaining_before_ms: remaining_before_ms,
+            remaining_after_ms: remaining_after_ms,
+        );
+        Ok(granted_ms)
     }
 
     /// LOGIN 行で `reconnect:<game_id>+<token>` が指定されたクライアントを受理し、
@@ -3533,6 +3645,10 @@ impl GameRoom {
             }
         }
 
+        // token / handle / color / grace の全照合が通った再接続だけを補償対象にする。
+        // LOGIN OK より先に永続化し、補償保存失敗時は成功応答を返さない。
+        let granted_credit_ms = self.compensate_reconnect_clock_if_needed(role, now_ms).await?;
+
         // 成功確定。LOGIN OK → resume 送出 → attachment を Player に差し替え →
         // grace registry / alarm tag を片付ける順で進める。
         let game_name = self.current_game_name_or_empty().await?;
@@ -3554,33 +3670,30 @@ impl GameRoom {
         self.delete_grace_alarm_state().await?;
         // 再接続クライアントが指し手を送らず放置しても確実に turn deadline が
         // 発火するよう、即時 alarm を貼り直す。決定方針:
-        // - 候補 A: 切断時に取り置いた元 turn alarm の発火時刻 (`pending.original
-        //   _turn_alarm_epoch_ms`)
-        // - 候補 B: 再接続時刻 + (現在手番の本体時間 + 秒読み + 通信マージン +
+        // - 候補 A: 切断時に取り置いた元 turn alarm の発火時刻 + 今回付与した補償
+        // - 候補 B: 再接続処理完了時刻 + (補償反映後の実残時間 + 通信マージン +
         //   安全側ゲタ)
-        // のうち**早い方**を採用する。常に B にすると悪意あるクライアントが
-        // 切断 → grace 直前再接続を繰り返して相手手番の wall-clock 上の deadline
-        // を延長する経路が成立するため、A を上限としても利く形にする。
+        // のうち**早い方**を採用する。A へ加えるのは今回の bounded credit だけで、
+        // off-turn は 0、on-turn も同一手番累積で秒読み 1 回分が上限となる。
         let now = self.now_ms();
         let candidate_b_total_ms = {
             let core_borrow = self.core.borrow();
             core_borrow.as_ref().map(|core| {
-                let next_turn = core.current_turn();
-                let budget = core.clock_turn_budget_ms(next_turn).max(0) as u64;
+                let remaining = core.current_turn_remaining_ms(now).unwrap_or(0);
                 let margin = self
                     .config
                     .borrow()
                     .as_ref()
                     .map(|c| c.time_margin_ms)
                     .unwrap_or(DEFAULT_TIME_MARGIN_MS);
-                budget.saturating_add(margin).saturating_add(ALARM_SAFETY_MS)
+                remaining.saturating_add(margin).saturating_add(ALARM_SAFETY_MS)
             })
         };
         if let Some(total_b) = candidate_b_total_ms {
             let candidate_b_epoch = now.saturating_add(total_b);
             let final_epoch = pending
                 .original_turn_alarm_epoch_ms
-                .map(|orig| orig.min(candidate_b_epoch))
+                .map(|orig| orig.saturating_add(granted_credit_ms).min(candidate_b_epoch))
                 .unwrap_or(candidate_b_epoch);
             // `set_alarm(Duration)` は「now から N ms 後」に発火する API なので
             // delay = final_epoch - now で渡す。`saturating_sub` は now が final_epoch

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -10,6 +10,7 @@
 //! - `slots` (= [`crate::session_state::Slot`]): WebSocket 別の役割割当
 //! - [`PersistedConfig`]: マッチ成立時に確定する対局メタ + 開始局面 SFEN
 //! - `moves` テーブル ([`MoveRow`]): ply 順の指し手列（SQL）
+//! - `reconnect_clock_credits` テーブル: ply ごとの有界な再接続時計補償（SQL）
 //! - [`FinishedState`]: 終局確定後のフラグ（同 DO で再起動した場合の早期 return）
 //!
 //! cold start 復元の手順は [`replay_core_room`] のドキュメントを参照。
@@ -153,6 +154,11 @@ pub struct MoveRow {
     pub(crate) line: String,
     /// 手を受信した瞬間の wall-clock ミリ秒。replay の clock 復元に使う。
     pub(crate) at_ms: i64,
+    /// この手番で再接続により課金対象外とした累積時間（ミリ秒）。
+    /// `moves` と `reconnect_clock_credits` の LEFT JOIN で埋め、過去の補償手も
+    /// cold-start replay 時に同じ `T` / 時計消費へ復元する。
+    #[serde(default)]
+    pub(crate) reconnect_credit_ms: i64,
 }
 
 /// `replay_core_room` の戻り値。cold start 復元の各分岐をデータとして表現する。
@@ -206,9 +212,10 @@ pub enum ReplaySummary {
 ///    検証に失敗したら [`ReplaySummary::InvalidSfen`] を返す
 /// 3. `cfg.play_started_at_ms` が `Some(t)` のとき:
 ///    - 両側に AGREE を `t` のタイムスタンプで再送して `Playing` に遷移
-///    - `moves` を ply 順に逐次 `handle_line` で再生する。各手の wall-clock
-///      タイムスタンプは `at_ms.max(0).max(t)` に正規化（負値や AGREE より
-///      前の `at_ms` は clock を巻き戻すため）
+///    - `moves` を ply 順に逐次 `handle_line` で再生する。各手の直前にその ply の
+///      `reconnect_credit_ms` を戻し、wall-clock タイムスタンプは
+///      `at_ms.max(0).max(t)` に正規化（負値や AGREE より前の `at_ms` は clock を
+///      巻き戻すため）
 /// 4. `play_started_at_ms = None` の場合は `AgreeWaiting` のまま返す
 ///
 /// 設計上、本関数は I/O を持たないため、ホスト target で網羅的にテスト可能。
@@ -263,6 +270,10 @@ pub fn replay_core_room(cfg: &PersistedConfig, moves: &[MoveRow]) -> ReplaySumma
                 };
             }
         };
+        core.restore_current_turn_reconnect_credit_ms(
+            m.reconnect_credit_ms.max(0) as u64,
+            cfg.clock.reconnect_compensation_limit_ms(),
+        );
         let ts = (m.at_ms.max(0) as u64).max(play_started_at_ms);
         if let Err(e) = core.handle_line(color, &CsaLine::new(&m.line), ts) {
             return ReplaySummary::MoveReplayFailed {
@@ -315,6 +326,7 @@ mod tests {
             color: color.to_owned(),
             line: line.to_owned(),
             at_ms: (PLAY_STARTED_AT_MS + at_ms_offset_from_start) as i64,
+            reconnect_credit_ms: 0,
         }
     }
 
@@ -348,6 +360,10 @@ mod tests {
                 "white" => Color::White,
                 _ => unreachable!("test data must use black/white only"),
             };
+            core.restore_current_turn_reconnect_credit_ms(
+                m.reconnect_credit_ms.max(0) as u64,
+                cfg.clock.reconnect_compensation_limit_ms(),
+            );
             let ts = (m.at_ms.max(0) as u64).max(t0);
             core.handle_line(color, &CsaLine::new(&m.line), ts)
                 .expect("move in directly_played");
@@ -420,6 +436,37 @@ mod tests {
                 "turn_budget_ms mismatch for {color:?}"
             );
         }
+    }
+
+    #[test]
+    fn replay_reapplies_credit_for_past_reconnected_turns() {
+        let mut cfg = baseline_config();
+        cfg.play_started_at_ms = Some(PLAY_STARTED_AT_MS);
+        cfg.clock = ClockSpec::Countdown {
+            total_time_sec: 1,
+            byoyomi_sec: 1,
+        };
+        let mut first = move_row(1, "black", "+7776FU,T2", 3_500);
+        first.reconnect_credit_ms = 1_000;
+        let second = move_row(2, "white", "-3334FU,T0", 4_000);
+        let moves = vec![first.clone(), second.clone()];
+
+        let ReplaySummary::Restored { core } = replay_core_room(&cfg, &moves) else {
+            panic!("credit を含む過去手は replay できる必要がある");
+        };
+        assert_eq!(core.moves_played(), 2);
+        assert_eq!(core.current_turn(), Color::Black);
+        assert_eq!(core.clock_remaining_main_ms(Color::Black), 0);
+        assert_eq!(core.clock_remaining_main_ms(Color::White), 1_000);
+
+        // 同じ wall-clock 列で credit が無いと先手 1 手目が TimeUp になり、後手を
+        // replay できない。テストが credit 適用を実際に必要としていることを固定する。
+        let mut without_credit = moves;
+        without_credit[0].reconnect_credit_ms = 0;
+        assert!(matches!(
+            replay_core_room(&cfg, &without_credit),
+            ReplaySummary::MoveReplayFailed { ply: 2, .. }
+        ));
     }
 
     /// Fischer / StopWatch でも replay 後の `clock_turn_budget_ms` と本体残時間が
@@ -706,12 +753,14 @@ mod tests {
                 color: "black".to_owned(),
                 line: "+7776FU,T0".to_owned(),
                 at_ms: -42,
+                reconnect_credit_ms: 0,
             },
             MoveRow {
                 ply: 2,
                 color: "white".to_owned(),
                 line: "-3334FU,T0".to_owned(),
                 at_ms: (PLAY_STARTED_AT_MS - 10_000) as i64,
+                reconnect_credit_ms: 0,
             },
         ];
         let ReplaySummary::Restored {

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -74,11 +74,11 @@ pub struct PendingReconnect {
     /// `position_section` は切断時点の現在局面で再構築済み)。
     pub game_summary_for_disconnected: String,
     /// 切断時点で予約されていた turn alarm の発火時刻 (UNIX epoch ms)。
-    /// 再接続成功時に新しい turn alarm を貼り直す際、本値と「再接続時刻 + 残時間
-    /// budget」のうち**早い方**を採用することで、悪意あるクライアントが切断 →
-    /// grace 直前再接続を繰り返して相手手番の deadline を wall-clock 上で延長
-    /// する経路を防ぐ (元 deadline は壊さない)。`None` なら turn alarm 未予約
-    /// 時点での切断 (例: AGREE 直後の対局未開始) で、上書きせず素直に新規予約。
+    /// 再接続成功時に新しい turn alarm を貼り直す際、本値へ「今回付与した bounded
+    /// credit」だけを加えた時刻と、補償後の実残時間から再計算した時刻のうち
+    /// **早い方**を採用する。off-turn の credit は 0、on-turn も同一手番累積で
+    /// 秒読み 1 回分までなので、切断反復による無制限延長はできない。`None` なら
+    /// turn alarm 未予約時点での切断として、実残時間から新規予約する。
     /// `#[serde(default)]` で旧 schema からの cold-start 互換も維持する。
     #[serde(default)]
     pub original_turn_alarm_epoch_ms: Option<u64>,

--- a/crates/rshogi-csa-server-workers/src/reconnect.rs
+++ b/crates/rshogi-csa-server-workers/src/reconnect.rs
@@ -73,15 +73,6 @@ pub struct PendingReconnect {
     /// 切断側宛の Game_Summary 文字列 (`Reconnect_Token:` 拡張行を含む完全形、
     /// `position_section` は切断時点の現在局面で再構築済み)。
     pub game_summary_for_disconnected: String,
-    /// 切断時点で予約されていた turn alarm の発火時刻 (UNIX epoch ms)。
-    /// 再接続成功時に新しい turn alarm を貼り直す際、本値へ「今回付与した bounded
-    /// credit」だけを加えた時刻と、補償後の実残時間から再計算した時刻のうち
-    /// **早い方**を採用する。off-turn の credit は 0、on-turn も同一手番累積で
-    /// 秒読み 1 回分までなので、切断反復による無制限延長はできない。`None` なら
-    /// turn alarm 未予約時点での切断として、実残時間から新規予約する。
-    /// `#[serde(default)]` で旧 schema からの cold-start 互換も維持する。
-    #[serde(default)]
-    pub original_turn_alarm_epoch_ms: Option<u64>,
 }
 
 /// `PendingReconnect::match_request` の判定結果。
@@ -307,7 +298,6 @@ mod tests {
             game_summary_for_disconnected:
                 "BEGIN Game_Summary\nGame_ID:g1\nReconnect_Token:abcd\nEND Game_Summary\n"
                     .to_owned(),
-            original_turn_alarm_epoch_ms: None,
         }
     }
 

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -9,7 +9,8 @@
 //! 1. 観戦者向け `BEGIN Game_Summary` ブロック（`Black/White_Time_Remaining_Ms:`
 //!    末尾拡張行を含む、player 経路の `Your_Turn:` / `Reconnect_Token:` は含まない）
 //! 2. これまでの move 行 (1 手あたり 1〜2 行): まず `<token>,T<elapsed_sec>`
-//!    （broadcast の通常形式と一致。`elapsed_sec` は `at_ms` 差分から再計算する）、
+//!    （broadcast の通常形式と一致。`elapsed_sec` は `at_ms` 差分から再接続時計補償を
+//!    差し引いて再計算する）、
 //!    続いてコメントが付いていれば `'<comment>` 行（Floodgate 評価値 PV。ライブ
 //!    broadcast の観戦者専用コメント行と同一形式）
 //! 3. （終局済 DO の場合のみ）終局結果コード行 (`#RESIGN` / `#TIME_UP` 等)
@@ -123,8 +124,9 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
     // 既存の指し手を broadcast と同一 wire 形式に正規化して push する。
     // `MoveRow::line` は client が送ってきた raw 行 (`+7776FU,T3` や Floodgate
     // 形式 `+7776FU,'* 123 +7776FU...`) をそのまま保持しているため、
-    // - token 部を取り出し、消費時間は broadcast 同様 `at_ms` 差分から再計算した
-    //   `<token>,T<sec>` を出す (raw 行の `T` 値や `,T` 欠落に依存しない)
+    // - token 部を取り出し、消費時間は broadcast 同様 `at_ms` 差分から再接続時計
+    //   補償を差し引いて再計算した `<token>,T<sec>` を出す
+    //   (raw 行の `T` 値や `,T` 欠落に依存しない)
     // - コメントが付いていれば直後に `'<comment>` 行を 1 行足す (Floodgate
     //   評価値 PV。ライブ broadcast の観戦者専用コメント行と同じ形式で、観戦
     //   client は `'` 始まり行を無視する互換性がある)
@@ -175,17 +177,20 @@ pub(crate) fn parse_move_row_line(line: &str) -> (&str, Option<&str>) {
 /// 算出する共有ヘルパ。
 ///
 /// `first_prev_ms` は初手の計時起点 (= `play_started_at_ms`、無ければ
-/// `matched_at_ms`)。以降は 1 手前の `at_ms` を起点にする。負値 `at_ms` は
-/// `0` に丸め、起点より小さい `at_ms` は `saturating_sub` で `0` 秒にする。
-/// snapshot と export で同一の経過秒を出すためのロジック集約。
+/// `matched_at_ms`)。以降は 1 手前の raw `at_ms` を起点にし、各行の差分から
+/// `reconnect_credit_ms` を差し引く。これにより次手番の起点は実際の着手時刻の
+/// まま、補償対象手の `T` だけを core 課金と同じ実効経過時間へ揃える。負値
+/// `at_ms` / credit は 0 に丸める。snapshot と export で同じ値を使う。
 pub(crate) fn move_elapsed_secs(moves: &[MoveRow], first_prev_ms: u64) -> Vec<u32> {
     let mut prev_ts = first_prev_ms;
     moves
         .iter()
         .map(|m| {
             let at_ms = m.at_ms.max(0) as u64;
-            let elapsed_ms = at_ms.saturating_sub(prev_ts);
+            let raw_elapsed_ms = at_ms.saturating_sub(prev_ts);
             prev_ts = at_ms;
+            let credit_ms = m.reconnect_credit_ms.max(0) as u64;
+            let elapsed_ms = raw_elapsed_ms.saturating_sub(credit_ms);
             (elapsed_ms / 1000) as u32
         })
         .collect()
@@ -223,6 +228,7 @@ pub(crate) fn move_rows_from_exported_csa(csa_text: &str, first_prev_ms: u64) ->
                 .to_owned(),
                 line: line.to_owned(),
                 at_ms,
+                reconnect_credit_ms: 0,
             });
         } else if let Some(comment) = line.strip_prefix('\'')
             && let Some(last) = rows.last_mut()
@@ -281,6 +287,7 @@ mod tests {
             color: color.to_owned(),
             line: line.to_owned(),
             at_ms,
+            reconnect_credit_ms: 0,
         }
     }
 
@@ -533,6 +540,21 @@ PI
         assert_eq!(move_elapsed_secs(&moves, 1_000_000), vec![3, 2, 0]);
         // 空入力は空 Vec。
         assert_eq!(move_elapsed_secs(&[], 1_000_000), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn move_elapsed_secs_subtracts_credit_without_shifting_the_next_turn_origin() {
+        let mut moves = vec![
+            move_row_at(1, "black", "+7776FU", 1_005_000),
+            move_row_at(2, "white", "-3334FU", 1_007_000),
+            move_row_at(3, "black", "+2726FU", 1_010_000),
+        ];
+        moves[0].reconnect_credit_ms = 3_000;
+        moves[2].reconnect_credit_ms = 1_000;
+
+        // 1 手目は raw 5s - credit 3s = T2。2 手目の起点は補償後の仮想時刻でなく
+        // 1 手目の raw at_ms のままなので T2、3 手目は raw 3s - credit 1s = T2。
+        assert_eq!(move_elapsed_secs(&moves, 1_000_000), vec![2, 2, 2]);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect_clock.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/reconnect_clock.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  CsaClient,
+  createMiniflare,
+  getKifuBucket,
+  makeTempPersistRoot,
+  pollR2ForGameId,
+} from "./harness.ts";
+import type { Miniflare } from "miniflare";
+
+describe("miniflare smoke: 秒読み中の再接続時計補償", () => {
+  let mf: Miniflare;
+  let persistRoot: string;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    persistRoot = persist.path;
+    cleanupPersist = persist.cleanup;
+    mf = await spawnMiniflare();
+  });
+
+  afterEach(async () => {
+    await mf.dispose();
+    await cleanupPersist();
+  });
+
+  it("再接続後は秒読み 1 回分まで戻り、元 deadline 後の着手も継続する", async () => {
+    const roomId = "reconnect-clock-room-1";
+    const gameName = "fg-1-1";
+    const blackName = `alice+${gameName}+black`;
+    const whiteName = `bob+${gameName}+white`;
+
+    const black0 = await CsaClient.connect(mf, roomId);
+    black0.send(`LOGIN ${blackName} pw`);
+    expect(await black0.recvLine()).toBe(`LOGIN:${blackName} OK`);
+    const white = await CsaClient.connect(mf, roomId);
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    const blackSummary = await black0.drainGameSummary();
+    const whiteSummary = await white.drainGameSummary();
+    const blackToken = blackSummary
+      .find((line) => line.startsWith("Reconnect_Token:"))
+      ?.slice("Reconnect_Token:".length);
+    expect(blackToken).toBeDefined();
+    const whiteToken = whiteSummary
+      .find((line) => line.startsWith("Reconnect_Token:"))
+      ?.slice("Reconnect_Token:".length);
+    expect(whiteToken).toBeDefined();
+
+    black0.send("AGREE");
+    white.send("AGREE");
+    const start = await black0.recvLine();
+    await white.recvLine();
+    const gameId = start.slice("START:".length);
+
+    // 先手本体 1 秒を使い切り、後手着手後の先手を純粋な 1 秒秒読みにする。
+    await sleep(1_100);
+    black0.send("+7776FU");
+    await black0.recvUntil((line) => line.startsWith("+7776FU"));
+    await white.recvUntil((line) => line.startsWith("+7776FU"));
+    white.send("-3334FU");
+    await white.recvUntil((line) => line.startsWith("-3334FU"));
+    await black0.recvUntil((line) => line.startsWith("-3334FU"));
+
+    // 秒読み開始から 1.3 秒で切断する。秒粒度時計は 1,999ms まで受理するため、
+    // この時点ではまだ alarm 前だが残りは 1 秒未満。再接続で不足分を補償する。
+    await sleep(1_300);
+    // Miniflare は client close ack を返さず既定 2 秒 timeout まで待つ場合がある。
+    // grace 登録には十分な 100ms だけ待ち、元 turn alarm より前に再接続する。
+    await black0.close(100);
+    const black1 = await CsaClient.connect(mf, roomId);
+    black1.send(`LOGIN ${blackName} pw reconnect:${gameId}+${blackToken}`);
+    expect(await black1.recvLine()).toBe(`LOGIN:${blackName} OK`);
+    await black1.drainGameSummary();
+    expect(await black1.recvLine()).toBe("BEGIN Reconnect_State");
+    await black1.recvUntil((line) => line === "END Reconnect_State");
+
+    // さらに 0.9 秒後は raw 経過が 2 秒を超え、旧実装なら着手時に %TIME_UP。
+    // 補償後は実効経過が 2 秒未満なので着手を受理し、両側へ同じ T 行を送る。
+    await sleep(900);
+    black1.send("+2726FU");
+    const blackMove = await black1.recvUntil((line) => line.startsWith("+2726FU"));
+    const whiteMove = await white.recvUntil((line) => line.startsWith("+2726FU"));
+    expect(blackMove.at(-1)).toMatch(/^\+2726FU,T1$/);
+    expect(whiteMove.at(-1)).toBe(blackMove.at(-1));
+
+    // 補償済みの黒着手後に DO を再起動する。replay は ply ごとの credit を再適用
+    // できないと黒手を TimeUp にして失敗するため、両 token の再参加成功が永続化の
+    // E2E assertion になる（grace registry が消えた場合は cold rejoin fallback）。
+    await mf.dispose();
+    mf = await spawnMiniflare();
+    const black2 = await reconnect(mf, roomId, blackName, gameId, blackToken!);
+    const white2 = await reconnect(mf, roomId, whiteName, gameId, whiteToken!);
+
+    white2.send("%TORYO");
+    await white2.recvUntil((line) => line === "#LOSE");
+    await black2.recvUntil((line) => line === "#WIN");
+
+    // export も live wire と同じ補償後の T を使う。raw at_ms 差分のままなら
+    // ここが T2 になり、クライアント表示と棋譜が食い違う。
+    const r2 = await getKifuBucket(mf);
+    const list = await pollR2ForGameId(r2, gameId);
+    const obj = await r2.get(list[0]!.key);
+    expect(await obj!.text()).toContain("+2726FU,T1");
+
+    await black2.close();
+    await white2.close();
+  });
+
+  function spawnMiniflare(): Promise<Miniflare> {
+    return createMiniflare({
+      persistRoot,
+      reconnectGraceSeconds: 30,
+      allowFloodgateFeatures: true,
+      totalTimeSec: 1,
+      byoyomiSec: 1,
+    });
+  }
+});
+
+async function reconnect(
+  mf: Miniflare,
+  roomId: string,
+  playerName: string,
+  gameId: string,
+  token: string,
+): Promise<CsaClient> {
+  const client = await CsaClient.connect(mf, roomId);
+  client.send(`LOGIN ${playerName} pw reconnect:${gameId}+${token}`);
+  expect(await client.recvLine()).toBe(`LOGIN:${playerName} OK`);
+  await client.drainGameSummary();
+  expect(await client.recvLine()).toBe("BEGIN Reconnect_State");
+  await client.recvUntil((line) => line === "END Reconnect_State");
+  return client;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/crates/rshogi-csa-server/src/game/clock.rs
+++ b/crates/rshogi-csa-server/src/game/clock.rs
@@ -123,6 +123,21 @@ impl ClockSpec {
         self.build_clock().format_summary()
     }
 
+    /// 再接続時に同一手番へ付与できる時計補償の上限（ミリ秒）。
+    ///
+    /// 秒読み方式では 1 回分の秒読み時間を返す。Workers frontend はこの値を
+    /// 「再接続後に最低限保証する残時間」と「同一手番で累積付与できる上限」の
+    /// 両方に使い、切断を繰り返して思考時間を無制限に増やす悪用を防ぐ。
+    /// Fischer 方式には秒読みがないため補償しない。
+    pub fn reconnect_compensation_limit_ms(&self) -> u64 {
+        match self {
+            Self::Countdown { byoyomi_sec, .. } => u64::from(*byoyomi_sec) * 1_000,
+            Self::CountdownMsec { byoyomi_ms, .. } => u64::from(*byoyomi_ms),
+            Self::Fischer { .. } => 0,
+            Self::StopWatch { byoyomi_min, .. } => u64::from(*byoyomi_min) * 60_000,
+        }
+    }
+
     /// `total_time_*` が 0 の構成を弾く。`byoyomi_*` / `increment_sec` の 0 は
     /// sudden death として許容する。`Err` には違反フィールド名 (`"total_time_sec"`
     /// / `"total_time_ms"` / `"total_time_min"`) を返し、メッセージ組み立ては
@@ -904,6 +919,42 @@ mod tests {
             byoyomi_min: 1,
         };
         assert_eq!(spec.format_time_section(), StopWatchClock::new(15, 1).format_summary());
+    }
+
+    #[test]
+    fn reconnect_compensation_limit_is_one_byoyomi_and_zero_for_fischer() {
+        assert_eq!(
+            ClockSpec::Countdown {
+                total_time_sec: 600,
+                byoyomi_sec: 10,
+            }
+            .reconnect_compensation_limit_ms(),
+            10_000
+        );
+        assert_eq!(
+            ClockSpec::CountdownMsec {
+                total_time_ms: 10_000,
+                byoyomi_ms: 250,
+            }
+            .reconnect_compensation_limit_ms(),
+            250
+        );
+        assert_eq!(
+            ClockSpec::StopWatch {
+                total_time_min: 15,
+                byoyomi_min: 2,
+            }
+            .reconnect_compensation_limit_ms(),
+            120_000
+        );
+        assert_eq!(
+            ClockSpec::Fischer {
+                total_time_sec: 600,
+                increment_sec: 10,
+            }
+            .reconnect_compensation_limit_ms(),
+            0
+        );
     }
 
     /// 4 variant 全てで `total_time_*` 0 が該当フィールド名 `Err` を返す。

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -161,6 +161,13 @@ pub struct GameRoom {
     moves_played: u32,
     /// 現在の手番が開始した瞬間の単調時刻（ミリ秒）。`Playing` 中のみ意味を持つ。
     turn_started_at_ms: Option<u64>,
+    /// 現手番で再接続により課金対象外とした時間（ミリ秒）。
+    ///
+    /// raw elapsed から本値を差し引いた実効経過時間を時計消費・`T` 行・alarm
+    /// 残時間で共通利用する。frontend が同一手番の累積上限を管理し、cold-start
+    /// replay 時は永続化済みの値を [`Self::restore_current_turn_reconnect_credit_ms`]
+    /// で戻す。
+    turn_reconnect_credit_ms: u64,
 }
 
 impl fmt::Debug for GameRoom {
@@ -170,6 +177,7 @@ impl fmt::Debug for GameRoom {
             .field("status", &self.status)
             .field("moves_played", &self.moves_played)
             .field("turn_started_at_ms", &self.turn_started_at_ms)
+            .field("turn_reconnect_credit_ms", &self.turn_reconnect_credit_ms)
             .finish()
     }
 }
@@ -210,6 +218,7 @@ impl GameRoom {
             status: GameStatus::AgreeWaiting,
             moves_played: 0,
             turn_started_at_ms: None,
+            turn_reconnect_credit_ms: 0,
         })
     }
 
@@ -336,10 +345,49 @@ impl GameRoom {
         if !matches!(self.status, GameStatus::Playing) {
             return None;
         }
-        let started = self.turn_started_at_ms.unwrap_or(now_ms);
-        let elapsed = now_ms.saturating_sub(started);
+        let elapsed = self.current_turn_elapsed_ms(now_ms);
         let budget = self.clock.turn_budget_ms(self.current_turn()).max(0) as u64;
         Some(budget.saturating_sub(elapsed))
+    }
+
+    /// 現手番に既に付与済みの再接続時計補償（ミリ秒）。
+    pub fn current_turn_reconnect_credit_ms(&self) -> u64 {
+        self.turn_reconnect_credit_ms
+    }
+
+    /// `now_ms` 時点の残時間を `minimum_remaining_ms` まで戻すために必要な追加補償を
+    /// 返す。同一手番の累積補償は `maximum_total_credit_ms` を超えない。
+    ///
+    /// 本メソッドは状態を変更しない。frontend は戻り値を永続化してから
+    /// [`Self::restore_current_turn_reconnect_credit_ms`] で反映することで、storage
+    /// 書き込みと DO isolate 消失の間でも補償を失わないようにできる。
+    pub fn additional_reconnect_credit_ms(
+        &self,
+        now_ms: u64,
+        minimum_remaining_ms: u64,
+        maximum_total_credit_ms: u64,
+    ) -> Option<u64> {
+        let remaining = self.current_turn_remaining_ms(now_ms)?;
+        let needed = minimum_remaining_ms.saturating_sub(remaining);
+        let available = maximum_total_credit_ms.saturating_sub(self.turn_reconnect_credit_ms);
+        Some(needed.min(available))
+    }
+
+    /// cold-start replay または再接続成立時に、現手番の累積時計補償を復元する。
+    /// 呼び出し側が時計方式に応じた上限を渡し、過大な永続値はここでも clamp する。
+    pub fn restore_current_turn_reconnect_credit_ms(
+        &mut self,
+        total_credit_ms: u64,
+        maximum_total_credit_ms: u64,
+    ) {
+        if matches!(self.status, GameStatus::Playing) {
+            self.turn_reconnect_credit_ms = total_credit_ms.min(maximum_total_credit_ms);
+        }
+    }
+
+    fn current_turn_elapsed_ms(&self, now_ms: u64) -> u64 {
+        let started = self.turn_started_at_ms.unwrap_or(now_ms);
+        now_ms.saturating_sub(started).saturating_sub(self.turn_reconnect_credit_ms)
     }
 
     /// 切断を検出したときに呼ぶ。再接続猶予 0 秒で即時 `#ABNORMAL` 確定。
@@ -392,6 +440,7 @@ impl GameRoom {
                 self.status = GameStatus::Playing;
                 self.moves_played = 0;
                 self.turn_started_at_ms = Some(now_ms);
+                self.turn_reconnect_credit_ms = 0;
                 let line = CsaLine::new(format!("START:{}", self.config.game_id));
                 Ok(HandleResult {
                     outcome: HandleOutcome::GameStarted,
@@ -423,6 +472,7 @@ impl GameRoom {
             let result = GameResult::Abnormal { winner: None };
             self.status = GameStatus::Finished(result.clone());
             self.turn_started_at_ms = None;
+            self.turn_reconnect_credit_ms = 0;
             Ok(HandleResult {
                 outcome: HandleOutcome::GameEnded(result),
                 broadcasts: vec![BroadcastEntry {
@@ -500,8 +550,7 @@ impl GameRoom {
         //    fischer では実効予算が「total + (inc + margin)×手数」に膨張し、ライブ台帳
         //    と終局棋譜の T が 1 秒/手ずれる (#857)。秒単位への切り捨ては clock 実装
         //    (`SecondsCountdownClock` / `FischerClock`) 側で行われる。
-        let started = self.turn_started_at_ms.unwrap_or(now_ms);
-        let elapsed_ms = now_ms.saturating_sub(started);
+        let elapsed_ms = self.current_turn_elapsed_ms(now_ms);
         let clock_result = self.clock.consume(from, elapsed_ms);
 
         // 2. 時間切れなら盤面を進めず終局（手は受理しない）。
@@ -591,6 +640,7 @@ impl GameRoom {
 
         // 7. 続行 → 次手番開始時刻を更新。
         self.turn_started_at_ms = Some(now_ms);
+        self.turn_reconnect_credit_ms = 0;
         let next_turn = from.opposite();
         let core_next: rshogi_core::types::Color = next_turn.into();
         let remaining_main_ms = self.clock.remaining_main_ms(core_next.into());
@@ -674,6 +724,7 @@ impl GameRoom {
         }
         self.status = GameStatus::Finished(result.clone());
         self.turn_started_at_ms = None;
+        self.turn_reconnect_credit_ms = 0;
         HandleResult {
             outcome: HandleOutcome::GameEnded(result),
             broadcasts,
@@ -789,6 +840,45 @@ mod tests {
         // budget 到達/超過 → 0（実時間が予算を超えた時間切れ。alarm は force_time_up する）
         assert_eq!(room.current_turn_remaining_ms(budget), Some(0));
         assert_eq!(room.current_turn_remaining_ms(budget + 5_000), Some(0));
+    }
+
+    #[test]
+    fn reconnect_credit_restores_byoyomi_and_keeps_t_line_consistent() {
+        let mut room = room_with(0, 0, 10);
+        agree_both(&mut room);
+
+        // 秒読み 10 秒 + 秒粒度の端数 999ms のうち 6 秒が経過済み。
+        assert_eq!(room.current_turn_remaining_ms(6_000), Some(4_999));
+        let granted = room.additional_reconnect_credit_ms(6_000, 10_000, 10_000).unwrap();
+        assert_eq!(granted, 5_001);
+        room.restore_current_turn_reconnect_credit_ms(granted, 10_000);
+        assert_eq!(room.current_turn_remaining_ms(6_000), Some(10_000));
+
+        // 再接続後さらに 8 秒で着手しても受理される。T 行は raw 14 秒ではなく、
+        // 補償 5,001ms を除いた実効経過 8,999ms と同じ T8 を出す。
+        let result = room.handle_line(Color::Black, &line("+7776FU"), 14_000).unwrap();
+        assert!(matches!(result.outcome, HandleOutcome::MoveAccepted { .. }));
+        assert_eq!(result.broadcasts[0].line.as_str(), "+7776FU,T8");
+        assert_eq!(room.current_turn_reconnect_credit_ms(), 0, "次手番では補償を reset");
+    }
+
+    #[test]
+    fn reconnect_credit_is_capped_across_repeated_disconnects_in_same_turn() {
+        let mut room = room_with(0, 0, 10);
+        agree_both(&mut room);
+
+        let first = room.additional_reconnect_credit_ms(6_000, 10_000, 10_000).unwrap();
+        room.restore_current_turn_reconnect_credit_ms(first, 10_000);
+        assert_eq!(first, 5_001);
+
+        // さらに時間を使って再切断しても、同一手番の残枠 4,999ms までしか付与しない。
+        let second = room.additional_reconnect_credit_ms(12_000, 10_000, 10_000).unwrap();
+        assert_eq!(second, 4_999);
+        room.restore_current_turn_reconnect_credit_ms(first + second, 10_000);
+        assert_eq!(room.current_turn_reconnect_credit_ms(), 10_000);
+
+        // 累積上限到達後の再切断では追加補償 0。切断ループで時間は増えない。
+        assert_eq!(room.additional_reconnect_credit_ms(13_000, 10_000, 10_000), Some(0));
     }
 
     #[test]

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -350,6 +350,20 @@ impl GameRoom {
         Some(budget.saturating_sub(elapsed))
     }
 
+    /// 現手番の時計 deadline（通信マージンを含まない単調時刻、ミリ秒）。
+    ///
+    /// 再接続後の alarm は「以前の alarm + 今回の差分」ではなく、この絶対値から
+    /// 再構成する。これにより credit 永続化直後に frontend が再起動しても、復元
+    /// 済みの累積 credit が deadline に必ず反映される。
+    pub fn current_turn_deadline_ms(&self) -> Option<u64> {
+        if !matches!(self.status, GameStatus::Playing) {
+            return None;
+        }
+        let started = self.turn_started_at_ms?;
+        let budget = self.clock.turn_budget_ms(self.current_turn()).max(0) as u64;
+        Some(started.saturating_add(budget).saturating_add(self.turn_reconnect_credit_ms))
+    }
+
     /// 現手番に既に付与済みの再接続時計補償（ミリ秒）。
     pub fn current_turn_reconnect_credit_ms(&self) -> u64 {
         self.turn_reconnect_credit_ms
@@ -849,10 +863,12 @@ mod tests {
 
         // 秒読み 10 秒 + 秒粒度の端数 999ms のうち 6 秒が経過済み。
         assert_eq!(room.current_turn_remaining_ms(6_000), Some(4_999));
+        assert_eq!(room.current_turn_deadline_ms(), Some(10_999));
         let granted = room.additional_reconnect_credit_ms(6_000, 10_000, 10_000).unwrap();
         assert_eq!(granted, 5_001);
         room.restore_current_turn_reconnect_credit_ms(granted, 10_000);
         assert_eq!(room.current_turn_remaining_ms(6_000), Some(10_000));
+        assert_eq!(room.current_turn_deadline_ms(), Some(16_000));
 
         // 再接続後さらに 8 秒で着手しても受理される。T 行は raw 14 秒ではなく、
         // 補償 5,001ms を除いた実効経過 8,999ms と同じ T8 を出す。


### PR DESCRIPTION
## Summary

- restore the reconnecting side's current-turn remaining time up to one byoyomi interval
- cap cumulative reconnect credit to one byoyomi interval per turn, with no credit for off-turn reconnects or Fischer clocks
- persist credit per ply so normal grace reconnects, cold rejoin replay, live `T` lines, spectator snapshots, and R2 CSA exports use the same effective elapsed time

## Root cause

The turn origin intentionally remains the previous move's `at_ms`. Reconnect previously restored the socket/session but kept the original turn alarm unchanged, so disconnect, reconnect, and engine restart overhead continued consuming the active side's byoyomi and could cause a server-induced `%TIME_UP`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --fix --allow-dirty --tests -- -D warnings`
- `cargo test --workspace`
- `RUSTFLAGS='' cargo build -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- `pnpm test:smoke` (14 files / 49 tests)
- `scripts/check-tracked-abs-paths.sh`

The new Miniflare scenario covers byoyomi disconnect/reconnect, a move after the old deadline, DO restart/cold rejoin replay, and live/R2 `T` consistency.
