### PR TITLE
feat(csa-server): add player ratings API

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -226,6 +226,16 @@ jobs:
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "DEPLOY_TRIGGER_SHA=$sha"
+      # D1 migration は `wrangler deploy` では適用されない。additive migration を
+      # worker code より先に適用し、失敗時は deploy を止める。旧 worker は追加
+      # column を参照しないため、この順序でも staging の稼働を壊さない。
+      - name: Apply D1 migrations (staging)
+        if: steps.check.outputs.can_deploy == 'true'
+        working-directory: crates/rshogi-csa-server-workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 migrations apply GAMES_SEARCH_DB --remote --config wrangler.staging.toml
       - name: Deploy via wrangler-action
         if: steps.check.outputs.can_deploy == 'true'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -438,6 +448,15 @@ jobs:
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "DEPLOY_TRIGGER_SHA=$sha"
+      # staging と同じく D1 schema を code より先に additive 更新する。migration
+      # failure は deploy 前に fail-closed とし、schema 未適用の新 code を出さない。
+      - name: Apply D1 migrations (production)
+        if: steps.check.outputs.can_deploy == 'true'
+        working-directory: crates/rshogi-csa-server-workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 migrations apply GAMES_SEARCH_DB --remote --config wrangler.production.toml
       - name: Deploy via wrangler-action
         if: steps.check.outputs.can_deploy == 'true'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0

--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -160,13 +160,39 @@ jobs:
             echo "::error::ESC env top-level keys (debug): $(jq -c 'keys' "${esc_json}" 2>/dev/null || echo "[parse error]")"
             exit 1
           fi
-          # 必須 key の欠落チェック (本リポは ADMIN_API_TOKEN 1 件固定)。
+          # 必須 key の欠落チェック。PLAYER_ID_SECRET が無い状態でも対局自体は
+          # legacy ID fallback で継続するが、credential 単位の集約が失われるため
+          # release 用 secret sync は fail-closed とする。
           # 追加時は本 list を同時更新する運用契約。
-          required_keys=(ADMIN_API_TOKEN)
+          required_keys=(ADMIN_API_TOKEN PLAYER_ID_SECRET)
           missing=$(jq -r --argjson req "$(printf '%s\n' "${required_keys[@]}" | jq -R . | jq -s .)" \
             '($req - (.workerSecrets | keys)) | join(", ")' "${esc_json}")
           if [ -n "${missing}" ]; then
             echo "::error::ESC env '${ESC_ENV}' に必須 key 不足: ${missing}"
+            exit 1
+          fi
+          # 値を表示せず、旧単一 string または versioned keyring JSON string を検証。
+          if ! jq -e '
+            def valid_version:
+              type == "string" and test("^[a-z0-9]{1,16}$");
+            def valid_secret:
+              type == "string"
+              and . == (gsub("^\\s+|\\s+$"; ""))
+              and utf8bytelength >= 32;
+            def valid_keyring:
+              (try fromjson catch null) as $ring
+              | ($ring | type == "object")
+              and ($ring.active_version | valid_version)
+              and ($ring.keys | type == "object" and length > 0 and length <= 8)
+              and (($ring.keys | keys) | all(.[]; valid_version))
+              and (($ring.keys | to_entries) | all(.[]; .value | valid_secret))
+              and ($ring.keys | has($ring.active_version));
+            .workerSecrets.PLAYER_ID_SECRET
+            | type == "string"
+            and (if test("^\\s*\\{") then valid_keyring else valid_secret end)
+          ' "${esc_json}" > /dev/null; then
+            echo "::error::ESC env '${ESC_ENV}' の PLAYER_ID_SECRET が不正です（値は非表示）。"
+            echo "::error::32 bytes以上の単一string、またはactive_version + 1..8 keysを持つversioned keyring JSON stringを設定してください。"
             exit 1
           fi
           # wrangler secret bulk が要求する shape は flat {KEY: "value"}。

--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -115,11 +115,11 @@ jobs:
         working-directory: ${{ env.WORKERS_DIR }}
         run: pnpm install --frozen-lockfile
 
-      # ESC CLI 単独 install。`environment` / `keys` 入力を渡さなければ pure install
-      # モードとして動き、後続 step で `esc env open ...` を直接叩ける。env 変数の
-      # 自動 export は使わず、明示的に `esc env open --format json` で値を取得する
+      # Pulumi CLI install。`environment` / `keys` 入力を渡さなければ pure install
+      # モードとして動き、後続 step で `pulumi env open ...` を直接叩ける。env 変数の
+      # 自動 export は使わず、明示的に `pulumi env open --format json` で値を取得する
       # ことで「ESC のどのキーを wrangler に渡すか」を YAML 上で明示する。
-      - uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v1.5.0 (2025-10-07)
+      - uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3.0.0 (2026-06-15)
 
       # ESC environment から workerSecrets サブツリーを抽出。
       # ESC env 名規約: `sh11235/rshogi-csa-server-workers-<environment>`
@@ -146,10 +146,10 @@ jobs:
           tmpdir=$(mktemp -d -p "${RUNNER_TEMP}")
           esc_json="${tmpdir}/esc.json"
           secrets_json="${tmpdir}/secrets.json"
-          # `esc env open` は ESC environment を解決して values ツリーを JSON で出力する。
+          # `pulumi env open` は ESC environment を解決して values ツリーを JSON で出力する。
           # secret 値は plaintext で展開されるため runner 内のみで扱い、log には絶対に
           # 出さない (jq 後の値も echo しない)。
-          esc env open "${ESC_ENV}" --format json > "${esc_json}"
+          pulumi env open "${ESC_ENV}" --format json > "${esc_json}"
           # `.workerSecrets` の型 + 非空を厳格チェック (string / array / null すり抜け防止)。
           if ! jq -e '.workerSecrets | type == "object" and length > 0' "${esc_json}" > /dev/null; then
             echo "::error::ESC env '${ESC_ENV}' に非空 object の 'workerSecrets' が見つかりません。"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -981,6 +982,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -2533,6 +2543,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures-util",
+ "hmac",
  "rshogi-core",
  "rshogi-csa-server",
  "serde",

--- a/crates/rshogi-csa-server-workers/Cargo.toml
+++ b/crates/rshogi-csa-server-workers/Cargo.toml
@@ -32,6 +32,8 @@ subtle = { version = "2", default-features = false }
 # pure-Rust 実装で wasm32-unknown-unknown でも問題なく動く。LOGIN は人手駆動で
 # 頻度が低いため `default-features = false` (asm 無効化) で十分。
 sha2 = { version = "0.10", default-features = false }
+# LOGIN credential から公開用 player ID を導出する HMAC-SHA256。
+hmac = { version = "0.12", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # wasm32-unknown-unknown 以外では参照しない。worker-build / wrangler dev から

--- a/crates/rshogi-csa-server-workers/migrations/0003_games_search_index_player_ids.sql
+++ b/crates/rshogi-csa-server-workers/migrations/0003_games_search_index_player_ids.sql
@@ -1,0 +1,7 @@
+ALTER TABLE games_search_index ADD COLUMN black_player_id TEXT;
+ALTER TABLE games_search_index ADD COLUMN white_player_id TEXT;
+
+CREATE INDEX games_search_index_black_player_id_ended_at_ms
+    ON games_search_index (black_player_id, ended_at_ms DESC);
+CREATE INDEX games_search_index_white_player_id_ended_at_ms
+    ON games_search_index (white_player_id, ended_at_ms DESC);

--- a/crates/rshogi-csa-server-workers/migrations/0004_player_rating_materialization.sql
+++ b/crates/rshogi-csa-server-workers/migrations/0004_player_rating_materialization.sql
@@ -1,0 +1,37 @@
+CREATE TABLE player_rating_generations (
+    generation INTEGER NOT NULL,
+    player_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    rating REAL NOT NULL,
+    wins INTEGER NOT NULL,
+    losses INTEGER NOT NULL,
+    draws INTEGER NOT NULL,
+    games INTEGER NOT NULL,
+    last_played_at_ms INTEGER NOT NULL,
+    legacy INTEGER NOT NULL CHECK (legacy IN (0, 1)),
+    PRIMARY KEY (generation, player_id)
+);
+
+CREATE INDEX player_rating_generations_rating
+    ON player_rating_generations (generation, rating DESC, player_id ASC);
+
+CREATE TABLE player_rating_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    active_generation INTEGER,
+    building_generation INTEGER NOT NULL DEFAULT 0,
+    cursor_ended_at_ms INTEGER NOT NULL DEFAULT -1,
+    cursor_game_id TEXT NOT NULL DEFAULT '',
+    rebuild_required INTEGER NOT NULL DEFAULT 1 CHECK (rebuild_required IN (0, 1)),
+    lease_until_ms INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO player_rating_state (singleton) VALUES (1);
+
+CREATE TABLE player_id_aliases (
+    alias_id TEXT PRIMARY KEY,
+    canonical_id TEXT NOT NULL,
+    CHECK (alias_id <> canonical_id)
+);
+
+CREATE INDEX player_id_aliases_canonical_id
+    ON player_id_aliases (canonical_id, alias_id);

--- a/crates/rshogi-csa-server-workers/migrations/0004_player_rating_materialization.sql
+++ b/crates/rshogi-csa-server-workers/migrations/0004_player_rating_materialization.sql
@@ -22,7 +22,8 @@ CREATE TABLE player_rating_state (
     cursor_ended_at_ms INTEGER NOT NULL DEFAULT -1,
     cursor_game_id TEXT NOT NULL DEFAULT '',
     rebuild_required INTEGER NOT NULL DEFAULT 1 CHECK (rebuild_required IN (0, 1)),
-    lease_until_ms INTEGER NOT NULL DEFAULT 0
+    lease_until_ms INTEGER NOT NULL DEFAULT 0,
+    data_revision INTEGER NOT NULL DEFAULT 0
 );
 
 INSERT INTO player_rating_state (singleton) VALUES (1);

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -168,6 +168,13 @@ impl ConfigKeys {
     /// **local dev**: `wrangler.toml.example` の `[vars]` に空配列 placeholder
     /// (`"[]"`) を残し、friction なく `wrangler dev` を動かせるようにする。
     pub const WORKERS_HANDLE_AUTH: &'static str = "WORKERS_HANDLE_AUTH";
+    /// 公開用 player ID を LOGIN の handle + password から HMAC-SHA256 で導出する鍵。
+    /// 32 bytes 以上の単一 string、または `active_version` と version 別 `keys` を
+    /// 持つ JSON string を受ける。production / staging では
+    /// `wrangler secret put PLAYER_ID_SECRET` で配置し、API・R2・D1・ログへ値を
+    /// 出してはならない。未設定・不正時は対局を止めず、handle 由来の legacy
+    /// opaque ID にフォールバックして secret 値を含まない構造化警告を残す。
+    pub const PLAYER_ID_SECRET: &'static str = "PLAYER_ID_SECRET";
     /// 切断時の再接続猶予秒数。`0` または未設定なら再接続プロトコルを無効化し、
     /// WebSocket close を即時 `#ABNORMAL` に流す（保守的既定）。`> 0` を指定する
     /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
@@ -182,7 +189,8 @@ impl ConfigKeys {
     /// Floodgate 機能群を opt-in 有効化するブール変数。`true` / `1` / `yes` / `on`
     /// で有効。`reconnect_protocol` 等の Floodgate 系を要求する構成で必須。
     pub const ALLOW_FLOODGATE_FEATURES: &'static str = "ALLOW_FLOODGATE_FEATURES";
-    /// viewer 配信 API (`/api/v1/games*` HTTP, `/ws/<id>/spectate` WS) を opt-in
+    /// viewer 配信 API (`/api/v1/games*` / `/api/v1/players*` HTTP,
+    /// `/ws/<id>/spectate` WS) を opt-in
     /// 有効化するブール変数。`true` / `1` / `yes` / `on` で有効、`false` / `0`
     /// / `no` / `off` または未設定で無効（= 該当 endpoint は 404 で既存ルーティング
     /// にフォールスルー）。production rollout 時の kill-switch を兼ね、本値を
@@ -305,8 +313,11 @@ impl ConfigKeys {
     /// `wrangler.toml.example` には `SHARED_PUBLIC_VARS_KEYS ∪ LOCAL_DEV_ONLY_VARS_KEYS`
     /// 全件を `[vars]` として記載することで、新規メンバーが `cp wrangler.toml.example
     /// wrangler.toml && wrangler dev` で即動作確認できる friction レス運用を維持する。
-    pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] =
-        &[Self::ADMIN_API_TOKEN, Self::WORKERS_HANDLE_AUTH];
+    pub const LOCAL_DEV_ONLY_VARS_KEYS: &'static [&'static str] = &[
+        Self::ADMIN_API_TOKEN,
+        Self::WORKERS_HANDLE_AUTH,
+        Self::PLAYER_ID_SECRET,
+    ];
 
     /// **deploy 時に CI から runtime 注入される** `[vars]` キーの網羅列挙
     /// ([`Self::DEPLOYED_SHA`] 等)。`SHARED_PUBLIC_VARS_KEYS` / `LOCAL_DEV_ONLY_VARS_KEYS`

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -83,6 +83,7 @@ use crate::persistence::{
     ExportBodyKind, ExportPendingState, FailedExportObject, FinishedState, MoveRow,
     PersistedConfig, ReplaySummary, replay_core_room,
 };
+use crate::player_identity::{derive_player_identity, legacy_player_id};
 use crate::reconnect::{
     PendingAlarmKind, PendingReconnect, ReconnectMatchOutcome, ReconnectSnapshot, StartMatchGuard,
     build_resume_message, classify_alarm_after_enter_grace, classify_start_match_guard,
@@ -650,9 +651,28 @@ impl GameRoom {
         // 場合は永続化も attachment 差し替えも行わず、部屋を破壊しないよう拒否する
         // （game_name 不一致・重複 role・スロット超過の全てを一元的に弾く）。
         let mut next_slots = self.load_slots().await?;
+        let player_id_config =
+            self.env.var(ConfigKeys::PLAYER_ID_SECRET).ok().map(|value| value.to_string());
+        let identity =
+            match derive_player_identity(&handle, password.expose(), player_id_config.as_deref()) {
+                Ok(identity) => identity,
+                Err(error) => {
+                    crate::structured_log!(
+                        event: "player_id_secret_invalid",
+                        component: "game_room",
+                        reason: error.reason(),
+                        fallback: "legacy_handle_id",
+                    );
+                    crate::player_identity::PlayerIdentity {
+                        player_id: legacy_player_id(&handle),
+                        aliases: Vec::new(),
+                    }
+                }
+            };
         next_slots.push(Slot {
             role,
             handle: handle.clone(),
+            player_id: identity.player_id.clone(),
             game_name: game_name.clone(),
         });
         if let MatchResult::Conflict { reason } = evaluate_match(&next_slots) {
@@ -665,6 +685,20 @@ impl GameRoom {
             );
             send_line(ws, &LoginReply::Incorrect.to_line())?;
             return Ok(());
+        }
+
+        if let Err(error) = crate::games_search_index::register_player_aliases(
+            &self.env,
+            &identity.player_id,
+            &identity.aliases,
+        )
+        .await
+        {
+            crate::structured_log!(
+                event: "player_id_alias_registration_failed",
+                component: "game_room",
+                err: format!("{error:?}"),
+            );
         }
 
         // 検証を通ったので slots を書き戻し、attachment を Player に差し替える。
@@ -680,11 +714,21 @@ impl GameRoom {
 
         if let MatchResult::Match {
             black_handle,
+            black_player_id,
             white_handle,
+            white_player_id,
             game_name,
         } = evaluate_match(&next_slots)
         {
-            let _ = self.start_match(&black_handle, &white_handle, &game_name).await?;
+            let _ = self
+                .start_match(
+                    &black_handle,
+                    &black_player_id,
+                    &white_handle,
+                    &white_player_id,
+                    &game_name,
+                )
+                .await?;
         }
 
         Ok(())
@@ -694,7 +738,9 @@ impl GameRoom {
     async fn start_match(
         &self,
         black_handle: &str,
+        black_player_id: &str,
         white_handle: &str,
+        white_player_id: &str,
         game_name: &str,
     ) -> Result<bool> {
         // https://github.com/SH11235/rshogi/issues/626: `start_match` の呼び出し前に存在する重複起動防止ガード
@@ -882,7 +928,9 @@ impl GameRoom {
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
             black_handle: black_handle.to_owned(),
+            black_player_id: black_player_id.to_owned(),
             white_handle: white_handle.to_owned(),
+            white_player_id: white_player_id.to_owned(),
             game_name: game_name.to_owned(),
             clock: clock_spec.clone(),
             max_moves: preset.max_moves.unwrap_or(DEFAULT_MAX_MOVES),
@@ -1728,13 +1776,22 @@ impl GameRoom {
         let slots = self.load_slots().await?;
         let MatchResult::Match {
             black_handle,
+            black_player_id,
             white_handle,
+            white_player_id,
             game_name,
         } = evaluate_match(&slots)
         else {
             return Ok(false);
         };
-        self.start_match(&black_handle, &white_handle, &game_name).await
+        self.start_match(
+            &black_handle,
+            &black_player_id,
+            &white_handle,
+            &white_player_id,
+            &game_name,
+        )
+        .await
     }
 
     async fn load_kifu_by_game_id(&self, game_id: &GameId) -> Result<Option<String>> {
@@ -2439,12 +2496,24 @@ impl GameRoom {
         let source = resolve_index_source(&self.env);
 
         let (result_kind, end_reason) = classify_result(game_result);
+        let black_player_id = if cfg.black_player_id.is_empty() {
+            crate::player_identity::legacy_player_id(&cfg.black_handle)
+        } else {
+            cfg.black_player_id.clone()
+        };
+        let white_player_id = if cfg.white_player_id.is_empty() {
+            crate::player_identity::legacy_player_id(&cfg.white_handle)
+        } else {
+            cfg.white_player_id.clone()
+        };
         let entry = GamesIndexEntry {
             game_id: &cfg.game_id,
             started_at_ms: cfg.play_started_at_ms.unwrap_or(cfg.matched_at_ms),
             ended_at_ms,
             black_handle: &cfg.black_handle,
             white_handle: &cfg.white_handle,
+            black_player_id: Some(&black_player_id),
+            white_player_id: Some(&white_player_id),
             result_kind,
             end_reason,
             // CSA は理論上 0..=u32::MAX 手は到達しないが、API contract は

--- a/crates/rshogi-csa-server-workers/src/games_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_index.rs
@@ -83,6 +83,12 @@ pub struct GamesIndexEntry<'a> {
     pub ended_at_ms: u64,
     pub black_handle: &'a str,
     pub white_handle: &'a str,
+    /// LOGIN credential から導出した公開用 opaque ID。旧 meta では省略される。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub black_player_id: Option<&'a str>,
+    /// LOGIN credential から導出した公開用 opaque ID。旧 meta では省略される。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub white_player_id: Option<&'a str>,
     pub result_kind: &'static str,
     pub end_reason: &'static str,
     pub moves_count: u32,
@@ -518,6 +524,8 @@ mod tests {
             ended_at_ms: 1_777_392_877_244,
             black_handle: "alice",
             white_handle: "bob",
+            black_player_id: Some("p_alice"),
+            white_player_id: Some("p_bob"),
             result_kind: "WIN_BLACK",
             end_reason: "RESIGN",
             moves_count: 142,
@@ -537,6 +545,7 @@ mod tests {
         // result_kind / end_reason が独立 field として直列化されることを固定。
         assert!(json.contains("\"result_kind\":\"WIN_BLACK\""), "json={json}");
         assert!(json.contains("\"end_reason\":\"RESIGN\""), "json={json}");
+        assert!(json.contains("\"black_player_id\":\"p_alice\""), "json={json}");
         assert!(json.contains("\"source\":\"kifu\""), "json={json}");
         // 未使用 clock field は省略される。
         assert!(!json.contains("byoyomi_sec"), "json={json}");

--- a/crates/rshogi-csa-server-workers/src/games_search_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_search_index.rs
@@ -6,11 +6,53 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(any(target_arch = "wasm32", test))]
+use std::collections::{BTreeMap, BTreeSet};
+
 #[cfg(target_arch = "wasm32")]
 use crate::games_index::GamesIndexEntry;
 
 pub const DEFAULT_PAGE_SIZE: u32 = 20;
 pub const MAX_PAGE_SIZE: u32 = 100;
+
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AliasLink {
+    alias_id: String,
+    canonical_id: String,
+}
+
+/// A new canonical ID absorbs both the freshly derived aliases and every
+/// historical alias whose current target is one of those IDs. The canonical
+/// ID itself is never retained as an alias, preventing cycles.
+#[cfg(any(target_arch = "wasm32", test))]
+fn normalized_alias_links(
+    existing: &[AliasLink],
+    canonical_id: &str,
+    aliases: &[String],
+) -> BTreeMap<String, String> {
+    let targets: BTreeSet<&str> = std::iter::once(canonical_id)
+        .chain(aliases.iter().map(String::as_str))
+        .collect();
+    let mut normalized = BTreeMap::new();
+    for link in existing {
+        if link.alias_id == canonical_id {
+            continue;
+        }
+        let target = if targets.contains(link.canonical_id.as_str()) {
+            canonical_id.to_owned()
+        } else {
+            link.canonical_id.clone()
+        };
+        normalized.insert(link.alias_id.clone(), target);
+    }
+    for alias in aliases {
+        if alias != canonical_id {
+            normalized.insert(alias.clone(), canonical_id.to_owned());
+        }
+    }
+    normalized
+}
 
 pub fn validate_pagination(page: u32, page_size: u32) -> Result<(), String> {
     if page == 0 {
@@ -80,7 +122,7 @@ pub fn build_search_query(params: &SearchParams) -> SearchQuery {
     } else {
         format!(" WHERE {}", clauses.join(" AND "))
     };
-    let columns = "game_id, started_at_ms, ended_at_ms, sente_name, gote_name, wire_result_kind, end_reason, moves_count, clock_json, source";
+    let columns = "game_id, started_at_ms, ended_at_ms, sente_name, gote_name, black_player_id, white_player_id, wire_result_kind, end_reason, moves_count, clock_json, source";
     SearchQuery {
         count_sql: format!("SELECT COUNT(*) AS total_count FROM games_search_index{where_sql}"),
         rows_sql: format!(
@@ -114,6 +156,10 @@ pub struct OwnedGamesIndexEntry {
     pub ended_at_ms: u64,
     pub black_handle: String,
     pub white_handle: String,
+    #[serde(default)]
+    pub black_player_id: Option<String>,
+    #[serde(default)]
+    pub white_player_id: Option<String>,
     pub result_kind: String,
     pub end_reason: String,
     pub moves_count: u32,
@@ -128,6 +174,8 @@ pub struct SearchRow {
     ended_at_ms: u64,
     sente_name: String,
     gote_name: String,
+    black_player_id: Option<String>,
+    white_player_id: Option<String>,
     wire_result_kind: String,
     end_reason: String,
     moves_count: u32,
@@ -142,6 +190,8 @@ pub struct SearchGameSummary {
     ended_at_ms: u64,
     black_handle: String,
     white_handle: String,
+    black_player_id: String,
+    white_player_id: String,
     result_kind: String,
     end_reason: String,
     moves_count: u32,
@@ -150,6 +200,32 @@ pub struct SearchGameSummary {
 }
 
 impl SearchRow {
+    pub fn to_player_game(&self) -> crate::player_ratings::PlayerGame {
+        crate::player_ratings::PlayerGame {
+            game_id: self.game_id.clone(),
+            ended_at_ms: self.ended_at_ms,
+            black_handle: self.sente_name.clone(),
+            white_handle: self.gote_name.clone(),
+            black_player_id: self.black_player_id.clone(),
+            white_player_id: self.white_player_id.clone(),
+            result_kind: self.wire_result_kind.clone(),
+        }
+    }
+
+    pub fn resolved_player_ids(&self) -> (String, String) {
+        let black = self
+            .black_player_id
+            .clone()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| crate::player_identity::legacy_player_id(&self.sente_name));
+        let white = self
+            .white_player_id
+            .clone()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| crate::player_identity::legacy_player_id(&self.gote_name));
+        (black, white)
+    }
+
     /// R2 の正準 entry を D1 行と同じ表現へ変換する。
     pub fn from_owned(entry: &OwnedGamesIndexEntry) -> Result<Self, serde_json::Error> {
         Ok(Self {
@@ -158,6 +234,8 @@ impl SearchRow {
             ended_at_ms: entry.ended_at_ms,
             sente_name: entry.black_handle.clone(),
             gote_name: entry.white_handle.clone(),
+            black_player_id: entry.black_player_id.clone(),
+            white_player_id: entry.white_player_id.clone(),
             wire_result_kind: entry.result_kind.clone(),
             end_reason: entry.end_reason.clone(),
             moves_count: entry.moves_count,
@@ -167,12 +245,15 @@ impl SearchRow {
     }
 
     pub fn into_summary(self) -> Result<SearchGameSummary, serde_json::Error> {
+        let (black_player_id, white_player_id) = self.resolved_player_ids();
         Ok(SearchGameSummary {
             game_id: self.game_id,
             started_at_ms: self.started_at_ms,
             ended_at_ms: self.ended_at_ms,
             black_handle: self.sente_name,
             white_handle: self.gote_name,
+            black_player_id,
+            white_player_id,
             result_kind: self.wire_result_kind,
             end_reason: self.end_reason,
             moves_count: self.moves_count,
@@ -191,6 +272,8 @@ pub async fn upsert_entry(env: &worker::Env, entry: &GamesIndexEntry<'_>) -> wor
             game_id: entry.game_id,
             sente: entry.black_handle,
             gote: entry.white_handle,
+            black_player_id: entry.black_player_id,
+            white_player_id: entry.white_player_id,
             started_at_ms: entry.started_at_ms,
             ended_at_ms: entry.ended_at_ms,
             wire_result_kind: entry.result_kind,
@@ -212,6 +295,8 @@ pub async fn upsert_owned(env: &worker::Env, entry: &OwnedGamesIndexEntry) -> wo
             game_id: &entry.game_id,
             sente: &entry.black_handle,
             gote: &entry.white_handle,
+            black_player_id: entry.black_player_id.as_deref(),
+            white_player_id: entry.white_player_id.as_deref(),
             started_at_ms: entry.started_at_ms,
             ended_at_ms: entry.ended_at_ms,
             wire_result_kind: &entry.result_kind,
@@ -229,6 +314,8 @@ struct UpsertFields<'a> {
     game_id: &'a str,
     sente: &'a str,
     gote: &'a str,
+    black_player_id: Option<&'a str>,
+    white_player_id: Option<&'a str>,
     started_at_ms: u64,
     ended_at_ms: u64,
     wire_result_kind: &'a str,
@@ -242,10 +329,28 @@ struct UpsertFields<'a> {
 async fn upsert_fields(env: &worker::Env, fields: UpsertFields<'_>) -> worker::Result<()> {
     use worker::wasm_bindgen::JsValue;
     let db = env.d1(crate::config::ConfigKeys::GAMES_SEARCH_DB_BINDING)?;
+    let legacy_black;
+    let black_player_id = match fields.black_player_id {
+        Some(id) => id,
+        None => {
+            legacy_black = crate::player_identity::legacy_player_id(fields.sente);
+            &legacy_black
+        }
+    };
+    let legacy_white;
+    let white_player_id = match fields.white_player_id {
+        Some(id) => id,
+        None => {
+            legacy_white = crate::player_identity::legacy_player_id(fields.gote);
+            &legacy_white
+        }
+    };
     let values = [
         JsValue::from_str(fields.game_id),
         JsValue::from_str(fields.sente),
         JsValue::from_str(fields.gote),
+        JsValue::from_str(black_player_id),
+        JsValue::from_str(white_player_id),
         JsValue::from_f64(fields.started_at_ms as f64),
         JsValue::from_f64(fields.ended_at_ms as f64),
         JsValue::from_str(result_kind_for_search(fields.end_reason)),
@@ -255,8 +360,115 @@ async fn upsert_fields(env: &worker::Env, fields: UpsertFields<'_>) -> worker::R
         JsValue::from_str(fields.end_reason),
         JsValue::from_str(fields.clock_json),
     ];
-    db.prepare("INSERT INTO games_search_index (game_id, sente_name, gote_name, started_at_ms, ended_at_ms, result_kind, source, moves_count, wire_result_kind, end_reason, clock_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(game_id) DO UPDATE SET sente_name=excluded.sente_name, gote_name=excluded.gote_name, started_at_ms=excluded.started_at_ms, ended_at_ms=excluded.ended_at_ms, result_kind=excluded.result_kind, source=excluded.source, moves_count=excluded.moves_count, wire_result_kind=excluded.wire_result_kind, end_reason=excluded.end_reason, clock_json=excluded.clock_json")
-        .bind(&values)?.run().await?;
+    let dirty_values = vec![
+        JsValue::from_f64(fields.ended_at_ms as f64),
+        JsValue::from_f64(fields.ended_at_ms as f64),
+        JsValue::from_str(fields.game_id),
+        JsValue::from_str(fields.game_id),
+        JsValue::from_str(fields.game_id),
+        JsValue::from_str(fields.sente),
+        JsValue::from_str(fields.gote),
+        JsValue::from_str(black_player_id),
+        JsValue::from_str(white_player_id),
+        JsValue::from_f64(fields.started_at_ms as f64),
+        JsValue::from_f64(fields.ended_at_ms as f64),
+        JsValue::from_str(fields.wire_result_kind),
+        JsValue::from_str(fields.end_reason),
+        JsValue::from_str(fields.source),
+        JsValue::from_f64(f64::from(fields.moves_count)),
+        JsValue::from_str(fields.clock_json),
+    ];
+    // cursor 以前への late insert/update は Elo の後続順序を変える。変更判定を
+    // UPSERT 前に行い、dirty marker と UPSERT を同じ D1 transaction に入れる。
+    // これにより marker だけ失敗して同一 backfill retry が no-op になる穴を防ぐ。
+    let dirty = db
+        .prepare("UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1 AND (cursor_ended_at_ms > ? OR (cursor_ended_at_ms = ? AND cursor_game_id >= ?)) AND (NOT EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ?) OR EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ? AND (sente_name IS NOT ? OR gote_name IS NOT ? OR black_player_id IS NOT ? OR white_player_id IS NOT ? OR started_at_ms IS NOT ? OR ended_at_ms IS NOT ? OR wire_result_kind IS NOT ? OR end_reason IS NOT ? OR source IS NOT ? OR moves_count IS NOT ? OR clock_json IS NOT ?)))")
+        .bind(&dirty_values)?;
+    let upsert = db.prepare("INSERT INTO games_search_index (game_id, sente_name, gote_name, black_player_id, white_player_id, started_at_ms, ended_at_ms, result_kind, source, moves_count, wire_result_kind, end_reason, clock_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(game_id) DO UPDATE SET sente_name=excluded.sente_name, gote_name=excluded.gote_name, black_player_id=excluded.black_player_id, white_player_id=excluded.white_player_id, started_at_ms=excluded.started_at_ms, ended_at_ms=excluded.ended_at_ms, result_kind=excluded.result_kind, source=excluded.source, moves_count=excluded.moves_count, wire_result_kind=excluded.wire_result_kind, end_reason=excluded.end_reason, clock_json=excluded.clock_json WHERE sente_name IS NOT excluded.sente_name OR gote_name IS NOT excluded.gote_name OR black_player_id IS NOT excluded.black_player_id OR white_player_id IS NOT excluded.white_player_id OR ended_at_ms IS NOT excluded.ended_at_ms OR wire_result_kind IS NOT excluded.wire_result_kind OR end_reason IS NOT excluded.end_reason OR started_at_ms IS NOT excluded.started_at_ms OR source IS NOT excluded.source OR moves_count IS NOT excluded.moves_count OR clock_json IS NOT excluded.clock_json")
+        .bind(&values)?;
+    db.batch(vec![dirty, upsert]).await?;
+    Ok(())
+}
+
+/// keyring rotation で導出した旧 ID → active canonical ID alias を best-effort 登録する。
+#[cfg(target_arch = "wasm32")]
+pub async fn register_player_aliases(
+    env: &worker::Env,
+    canonical_id: &str,
+    aliases: &[String],
+) -> worker::Result<()> {
+    use worker::wasm_bindgen::JsValue;
+
+    if aliases.len() > crate::player_identity::MAX_KEYRING_KEYS {
+        return Err(worker::Error::RustError("player alias limit exceeded".into()));
+    }
+    let db = env.d1(crate::config::ConfigKeys::GAMES_SEARCH_DB_BINDING)?;
+    let targets: BTreeSet<_> = std::iter::once(canonical_id)
+        .chain(aliases.iter().map(String::as_str))
+        .collect();
+    let placeholders = std::iter::repeat_n("?", targets.len()).collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT alias_id, canonical_id FROM player_id_aliases WHERE alias_id IN ({placeholders}) OR canonical_id IN ({placeholders})"
+    );
+    let mut lookup_values: Vec<_> = targets.iter().map(|id| JsValue::from_str(id)).collect();
+    lookup_values.extend(targets.iter().map(|id| JsValue::from_str(id)));
+    #[derive(serde::Deserialize)]
+    struct ExistingAliasRow {
+        alias_id: String,
+        canonical_id: String,
+    }
+    let existing: Vec<AliasLink> = db
+        .prepare(&sql)
+        .bind(&lookup_values)?
+        .all()
+        .await?
+        .results::<ExistingAliasRow>()?
+        .into_iter()
+        .map(|row| AliasLink {
+            alias_id: row.alias_id,
+            canonical_id: row.canonical_id,
+        })
+        .collect();
+    let current: BTreeMap<_, _> = existing
+        .iter()
+        .map(|link| (link.alias_id.clone(), link.canonical_id.clone()))
+        .collect();
+    let normalized = normalized_alias_links(&existing, canonical_id, aliases);
+    if current == normalized {
+        return Ok(());
+    }
+
+    let mut statements = Vec::new();
+    let mut reparent_values = vec![JsValue::from_str(canonical_id)];
+    reparent_values.extend(targets.iter().map(|id| JsValue::from_str(id)));
+    reparent_values.push(JsValue::from_str(canonical_id));
+    statements.push(
+        db.prepare(&format!(
+            "UPDATE player_id_aliases SET canonical_id = ? WHERE canonical_id IN ({placeholders}) AND alias_id <> ?"
+        ))
+        .bind(&reparent_values)?,
+    );
+    let delete_values = [JsValue::from_str(canonical_id)];
+    statements.push(
+        db.prepare("DELETE FROM player_id_aliases WHERE alias_id = ?")
+            .bind(&delete_values)?,
+    );
+    for alias in aliases {
+        if alias == canonical_id {
+            continue;
+        }
+        let values = [JsValue::from_str(alias), JsValue::from_str(canonical_id)];
+        statements.push(
+            db.prepare("INSERT INTO player_id_aliases (alias_id, canonical_id) VALUES (?, ?) ON CONFLICT(alias_id) DO UPDATE SET canonical_id=excluded.canonical_id")
+                .bind(&values)?,
+        );
+    }
+    // Reparenting, cycle removal, fresh aliases and rebuild marker commit
+    // atomically. A transient failure cannot leave a half-rotated alias graph.
+    statements.push(
+        db.prepare("UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1"),
+    );
+    db.batch(statements).await?;
     Ok(())
 }
 
@@ -348,7 +560,12 @@ mod tests {
         });
         let entry: OwnedGamesIndexEntry = serde_json::from_value(original.clone()).unwrap();
         let summary = SearchRow::from_owned(&entry).unwrap().into_summary().unwrap();
-        assert_eq!(serde_json::to_value(summary).unwrap(), original);
+        let mut expected = original;
+        expected["black_player_id"] =
+            serde_json::Value::String(crate::player_identity::legacy_player_id("alice"));
+        expected["white_player_id"] =
+            serde_json::Value::String(crate::player_identity::legacy_player_id("bob"));
+        assert_eq!(serde_json::to_value(summary).unwrap(), expected);
     }
 
     #[test]
@@ -357,5 +574,39 @@ mod tests {
         assert!(validate_pagination(1, 0).is_err());
         assert!(validate_pagination(1, 101).is_err());
         assert!(validate_pagination(1, 100).is_ok());
+    }
+
+    #[test]
+    fn second_rotation_reparents_plain_v1_and_v2_urls_to_v3_without_v1_key() {
+        const V1: &str = "0123456789abcdef0123456789abcdef";
+        const V2: &str = "abcdef0123456789abcdef0123456789";
+        const V3: &str = "fedcba9876543210fedcba9876543210";
+        let plain_v1 =
+            crate::player_identity::derive_player_identity("alice", "pw", Some(V1)).unwrap();
+        let v2_ring = format!(r#"{{"active_version":"v2","keys":{{"v1":"{V1}","v2":"{V2}"}}}}"#);
+        let v2 =
+            crate::player_identity::derive_player_identity("alice", "pw", Some(&v2_ring)).unwrap();
+        let after_v2 = normalized_alias_links(&[], &v2.player_id, &v2.aliases);
+        assert_eq!(after_v2.get(&plain_v1.player_id), Some(&v2.player_id));
+
+        // v1 has deliberately been removed from the second rotated keyring.
+        let v3_ring = format!(r#"{{"active_version":"v3","keys":{{"v2":"{V2}","v3":"{V3}"}}}}"#);
+        let v3 =
+            crate::player_identity::derive_player_identity("alice", "pw", Some(&v3_ring)).unwrap();
+        let existing: Vec<_> = after_v2
+            .into_iter()
+            .map(|(alias_id, canonical_id)| AliasLink {
+                alias_id,
+                canonical_id,
+            })
+            .collect();
+        let after_v3 = normalized_alias_links(&existing, &v3.player_id, &v3.aliases);
+
+        // Old detail URLs and games carrying the v2 ID now resolve directly to
+        // v3; the materializer therefore rebuilds all ratings under v3 too.
+        assert_eq!(after_v3.get(&plain_v1.player_id), Some(&v3.player_id));
+        assert_eq!(after_v3.get(&v2.player_id), Some(&v3.player_id));
+        assert!(!after_v3.contains_key(&v3.player_id));
+        assert!(after_v3.values().all(|target| target == &v3.player_id));
     }
 }

--- a/crates/rshogi-csa-server-workers/src/games_search_index.rs
+++ b/crates/rshogi-csa-server-workers/src/games_search_index.rs
@@ -378,11 +378,12 @@ async fn upsert_fields(env: &worker::Env, fields: UpsertFields<'_>) -> worker::R
         JsValue::from_f64(f64::from(fields.moves_count)),
         JsValue::from_str(fields.clock_json),
     ];
-    // cursor 以前への late insert/update は Elo の後続順序を変える。変更判定を
-    // UPSERT 前に行い、dirty marker と UPSERT を同じ D1 transaction に入れる。
-    // これにより marker だけ失敗して同一 backfill retry が no-op になる穴を防ぐ。
+    // Every real change advances data_revision in the same transaction as the
+    // UPSERT. A materializer page loaded from an older revision can therefore
+    // discard all derived writes before advancing its cursor. Cursor以前の
+    // late insert/updateは同時に全履歴rebuildも要求する。
     let dirty = db
-        .prepare("UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1 AND (cursor_ended_at_ms > ? OR (cursor_ended_at_ms = ? AND cursor_game_id >= ?)) AND (NOT EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ?) OR EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ? AND (sente_name IS NOT ? OR gote_name IS NOT ? OR black_player_id IS NOT ? OR white_player_id IS NOT ? OR started_at_ms IS NOT ? OR ended_at_ms IS NOT ? OR wire_result_kind IS NOT ? OR end_reason IS NOT ? OR source IS NOT ? OR moves_count IS NOT ? OR clock_json IS NOT ?)))")
+        .prepare("UPDATE player_rating_state SET data_revision = data_revision + 1, rebuild_required = CASE WHEN cursor_ended_at_ms > ? OR (cursor_ended_at_ms = ? AND cursor_game_id >= ?) THEN 1 ELSE rebuild_required END WHERE singleton = 1 AND (NOT EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ?) OR EXISTS (SELECT 1 FROM games_search_index WHERE game_id = ? AND (sente_name IS NOT ? OR gote_name IS NOT ? OR black_player_id IS NOT ? OR white_player_id IS NOT ? OR started_at_ms IS NOT ? OR ended_at_ms IS NOT ? OR wire_result_kind IS NOT ? OR end_reason IS NOT ? OR source IS NOT ? OR moves_count IS NOT ? OR clock_json IS NOT ?)))")
         .bind(&dirty_values)?;
     let upsert = db.prepare("INSERT INTO games_search_index (game_id, sente_name, gote_name, black_player_id, white_player_id, started_at_ms, ended_at_ms, result_kind, source, moves_count, wire_result_kind, end_reason, clock_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(game_id) DO UPDATE SET sente_name=excluded.sente_name, gote_name=excluded.gote_name, black_player_id=excluded.black_player_id, white_player_id=excluded.white_player_id, started_at_ms=excluded.started_at_ms, ended_at_ms=excluded.ended_at_ms, result_kind=excluded.result_kind, source=excluded.source, moves_count=excluded.moves_count, wire_result_kind=excluded.wire_result_kind, end_reason=excluded.end_reason, clock_json=excluded.clock_json WHERE sente_name IS NOT excluded.sente_name OR gote_name IS NOT excluded.gote_name OR black_player_id IS NOT excluded.black_player_id OR white_player_id IS NOT excluded.white_player_id OR ended_at_ms IS NOT excluded.ended_at_ms OR wire_result_kind IS NOT excluded.wire_result_kind OR end_reason IS NOT excluded.end_reason OR started_at_ms IS NOT excluded.started_at_ms OR source IS NOT excluded.source OR moves_count IS NOT excluded.moves_count OR clock_json IS NOT excluded.clock_json")
         .bind(&values)?;
@@ -466,7 +467,7 @@ pub async fn register_player_aliases(
     // Reparenting, cycle removal, fresh aliases and rebuild marker commit
     // atomically. A transient failure cannot leave a half-rotated alias graph.
     statements.push(
-        db.prepare("UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1"),
+        db.prepare("UPDATE player_rating_state SET rebuild_required = 1, data_revision = data_revision + 1 WHERE singleton = 1"),
     );
     db.batch(statements).await?;
     Ok(())

--- a/crates/rshogi-csa-server-workers/src/lib.rs
+++ b/crates/rshogi-csa-server-workers/src/lib.rs
@@ -44,6 +44,9 @@ pub mod export_retry;
 pub mod floodgate_history;
 pub mod games_index;
 pub mod games_search_index;
+pub mod player_identity;
+pub mod player_rating_materialization;
+pub mod player_ratings;
 // `handle_auth` は `WORKERS_HANDLE_AUTH` whitelist の parse + password SHA256
 // 比較を担う。`HandleAuthRegistry` + `verify` は I/O 非依存の
 // pure helper でホスト target からテストできるよう `pub mod` で公開する。
@@ -162,9 +165,11 @@ fn minute_of_hour(epoch_ms: f64) -> i64 {
 /// ミリ秒なので、起動が数秒遅延しても分判定は予定どおり安定する:
 ///
 /// - 分が [`BACKFILL_MINUTE`] (0 分) のとき: `run_games_index_backfill` →
-///   `run_games_search_backfill` → `run_live_orphan_sweep` を順次実行する。3 者は
-///   cron 発火直後の時刻を共有し、3 ジョブ合わせて 25 秒以内に打ち切る。
-/// - それ以外 (15 / 30 / 45 分) のとき: `run_live_orphan_sweep` のみ。
+///   `run_games_search_backfill` → player rating materializer →
+///   `run_live_orphan_sweep` を順次実行する。全ジョブは cron 発火直後の時刻を
+///   共有し、合計25秒で新規page処理を打ち切る。
+/// - それ以外 (15 / 30 / 45 分) のとき: player rating materializer →
+///   `run_live_orphan_sweep` の順に同じ共有deadline内で実行する。
 ///   delete best-effort 失敗時の復旧遅延を 15 分以内に詰めるための高頻度経路
 ///   (https://github.com/SH11235/rshogi/issues/629)。
 ///
@@ -202,6 +207,27 @@ pub async fn scheduled(
                 err: format!("{e:?}"),
             );
         }
+    }
+    match player_rating_materialization::run_player_rating_materialization(
+        &env,
+        player_rating_materialization::MAX_PAGES_PER_RUN,
+        Some(started_at_ms.saturating_add(backfill::SCHEDULED_WORK_DEADLINE_MS)),
+    )
+    .await
+    {
+        Ok(outcome) if outcome.deadline_reached => crate::structured_log!(
+            event: "player_rating_materialization_deadline_reached",
+            component: "scheduled",
+            cron: cron,
+            processed_games: outcome.processed_games,
+        ),
+        Ok(_) => {}
+        Err(e) => crate::structured_log!(
+            event: "player_rating_materialization_failed",
+            component: "scheduled",
+            cron: cron,
+            err: format!("{e:?}"),
+        ),
     }
     if let Err(e) = backfill::run_live_orphan_sweep(&env, started_at_ms).await {
         crate::structured_log!(

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -29,8 +29,14 @@ pub struct PersistedConfig {
     pub(crate) game_id: String,
     /// 先手プレイヤのハンドル。
     pub(crate) black_handle: String,
+    /// 先手の公開用 opaque player ID。旧 snapshot は空文字から legacy ID に解決する。
+    #[serde(default)]
+    pub(crate) black_player_id: String,
     /// 後手プレイヤのハンドル。
     pub(crate) white_handle: String,
+    /// 後手の公開用 opaque player ID。旧 snapshot は空文字から legacy ID に解決する。
+    #[serde(default)]
+    pub(crate) white_player_id: String,
     /// LOGIN ハンドル末尾の `<game_name>`。マッチ確認・棋譜メタに使う。
     pub(crate) game_name: String,
     /// 時計設定（Countdown / Fischer / StopWatch）。
@@ -303,7 +309,9 @@ mod tests {
         PersistedConfig {
             game_id: "room-1-test".to_owned(),
             black_handle: "alice".to_owned(),
+            black_player_id: crate::player_identity::legacy_player_id("alice"),
             white_handle: "bob".to_owned(),
+            white_player_id: crate::player_identity::legacy_player_id("bob"),
             game_name: "g1".to_owned(),
             clock: ClockSpec::Countdown {
                 total_time_sec: 60,
@@ -920,6 +928,8 @@ mod tests {
         assert_eq!(cfg.reconnect_grace_ms, None);
         assert_eq!(cfg.black_reconnect_token, None);
         assert_eq!(cfg.white_reconnect_token, None);
+        assert!(cfg.black_player_id.is_empty());
+        assert!(cfg.white_player_id.is_empty());
     }
 
     /// 明示 `null` 値は `None` として読まれる (`#[serde(default)]` と同等の振る舞い)。

--- a/crates/rshogi-csa-server-workers/src/player_identity.rs
+++ b/crates/rshogi-csa-server-workers/src/player_identity.rs
@@ -1,0 +1,235 @@
+//! 公開用 player ID と versioned HMAC keyring の純粋ロジック。
+
+use std::collections::BTreeMap;
+
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+const ID_BYTES: usize = 20;
+pub const MIN_SECRET_BYTES: usize = 32;
+/// D1 alias lookup/batch の bind・statement 数を一定に保つ運用上限。
+pub const MAX_KEYRING_KEYS: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayerIdentity {
+    pub player_id: String,
+    pub aliases: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyringError {
+    Missing,
+    InvalidJson,
+    InvalidVersion,
+    ActiveVersionMissing,
+    SecretNotString,
+    SecretWhitespace,
+    SecretTooShort,
+    TooManyKeys,
+}
+
+impl KeyringError {
+    /// secret 値を含まない構造化ログ用 reason。
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::InvalidJson => "invalid_json",
+            Self::InvalidVersion => "invalid_version",
+            Self::ActiveVersionMissing => "active_version_missing",
+            Self::SecretNotString => "secret_not_string",
+            Self::SecretWhitespace => "secret_whitespace",
+            Self::SecretTooShort => "secret_too_short",
+            Self::TooManyKeys => "too_many_keys",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawKeyring {
+    active_version: String,
+    keys: BTreeMap<String, serde_json::Value>,
+}
+
+/// 単一 secret（旧形式）または versioned JSON keyring から ID と alias 群を導出する。
+///
+/// 旧 string 形式は既存 `p_<digest>` を canonical のまま維持する。JSON 形式は
+/// `p_<version>_<digest>` を canonical とし、keyring 内の全旧 version ID と、v1
+/// secret から導出できる旧 `p_<digest>` を alias として返す。
+pub fn derive_player_identity(
+    handle: &str,
+    password: &str,
+    raw: Option<&str>,
+) -> Result<PlayerIdentity, KeyringError> {
+    let raw = raw.ok_or(KeyringError::Missing)?;
+    if !raw.trim_start().starts_with('{') {
+        validate_secret(raw)?;
+        return Ok(PlayerIdentity {
+            player_id: credential_id(handle, password, raw, None),
+            aliases: Vec::new(),
+        });
+    }
+
+    let parsed: RawKeyring = serde_json::from_str(raw).map_err(|_| KeyringError::InvalidJson)?;
+    if !valid_version(&parsed.active_version) {
+        return Err(KeyringError::InvalidVersion);
+    }
+    if parsed.keys.len() > MAX_KEYRING_KEYS {
+        return Err(KeyringError::TooManyKeys);
+    }
+    let mut keys = BTreeMap::new();
+    for (version, value) in parsed.keys {
+        if !valid_version(&version) {
+            return Err(KeyringError::InvalidVersion);
+        }
+        let secret = value.as_str().ok_or(KeyringError::SecretNotString)?;
+        validate_secret(secret)?;
+        keys.insert(version, secret.to_owned());
+    }
+    let active_secret =
+        keys.get(&parsed.active_version).ok_or(KeyringError::ActiveVersionMissing)?;
+    let player_id = credential_id(handle, password, active_secret, Some(&parsed.active_version));
+    let mut aliases = Vec::new();
+    for (version, secret) in &keys {
+        let id = credential_id(handle, password, secret, Some(version));
+        if id != player_id {
+            aliases.push(id);
+        }
+        if version == "v1" {
+            // 旧単一 string secret が生成した unversioned ID の移行 alias。
+            let old = credential_id(handle, password, secret, None);
+            if old != player_id {
+                aliases.push(old);
+            }
+        }
+    }
+    aliases.sort();
+    aliases.dedup();
+    Ok(PlayerIdentity { player_id, aliases })
+}
+
+pub fn legacy_player_id(handle: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"rshogi-player-id:legacy:v1\0");
+    hasher.update(handle.as_bytes());
+    let digest = hasher.finalize();
+    format!("legacy_{}", hex_prefix(&digest, ID_BYTES))
+}
+
+fn validate_secret(secret: &str) -> Result<(), KeyringError> {
+    if secret.trim() != secret {
+        return Err(KeyringError::SecretWhitespace);
+    }
+    // `str::len` is the UTF-8 byte length, matching the workflow's
+    // `utf8bytelength` validation.
+    if secret.len() < MIN_SECRET_BYTES {
+        return Err(KeyringError::SecretTooShort);
+    }
+    Ok(())
+}
+
+fn valid_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 16
+        && version.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+fn credential_id(handle: &str, password: &str, secret: &str, version: Option<&str>) -> String {
+    // Stream credential segments into HMAC so password bytes are never copied
+    // into an intermediate heap allocation. Segment boundaries exactly match
+    // the original wire-ID message and therefore preserve existing IDs.
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts any key length");
+    mac.update(b"rshogi-player-id:v1\0");
+    mac.update(handle.as_bytes());
+    mac.update(&[0]);
+    mac.update(password.as_bytes());
+    let digest: [u8; 32] = mac.finalize().into_bytes().into();
+    match version {
+        Some(version) => format!("p_{version}_{}", hex_prefix(&digest, ID_BYTES)),
+        None => format!("p_{}", hex_prefix(&digest, ID_BYTES)),
+    }
+}
+
+#[cfg(test)]
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(message);
+    mac.finalize().into_bytes().into()
+}
+
+fn hex_prefix(bytes: &[u8], len: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(len * 2);
+    for byte in bytes.iter().take(len) {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const V1: &str = "0123456789abcdef0123456789abcdef";
+    const V2: &str = "abcdef0123456789abcdef0123456789";
+
+    #[test]
+    fn hmac_matches_rfc_4231_test_case_2() {
+        assert_eq!(
+            hex_prefix(&hmac_sha256(b"Jefe", b"what do ya want for nothing?"), 32),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn legacy_string_secret_keeps_unversioned_id() {
+        let id = derive_player_identity("alice", "password", Some(V1)).unwrap();
+        assert_eq!(id.player_id, "p_ec682f038394accea905a4f5863aba9b4295c08f");
+        assert_eq!(id.player_id.len(), 42);
+        assert!(id.aliases.is_empty());
+    }
+
+    #[test]
+    fn rotation_maps_versioned_and_old_unversioned_ids_to_active() {
+        let before = derive_player_identity("alice", "password", Some(V1)).unwrap();
+        let raw = format!(r#"{{"active_version":"v2","keys":{{"v1":"{V1}","v2":"{V2}"}}}}"#);
+        let after = derive_player_identity("alice", "password", Some(&raw)).unwrap();
+        assert!(after.player_id.starts_with("p_v2_"));
+        assert!(after.aliases.iter().any(|id| id == &before.player_id));
+        assert!(after.aliases.iter().any(|id| id.starts_with("p_v1_")));
+    }
+
+    #[test]
+    fn rejects_missing_short_whitespace_and_invalid_keyrings_without_exposing_values() {
+        assert_eq!(derive_player_identity("a", "p", None), Err(KeyringError::Missing));
+        assert_eq!(
+            derive_player_identity("a", "p", Some("short")),
+            Err(KeyringError::SecretTooShort)
+        );
+        let padded = format!(" {V1}");
+        assert_eq!(
+            derive_player_identity("a", "p", Some(&padded)),
+            Err(KeyringError::SecretWhitespace)
+        );
+        for raw in [
+            r#"{"active_version":"V1","keys":{}}"#,
+            r#"{"active_version":"v2","keys":{"v1":"0123456789abcdef0123456789abcdef"}}"#,
+            r#"{"active_version":"v1","keys":{"v1":123}}"#,
+            r#"{"active_version":"v1","keys":{"v1":"0123456789abcdef0123456789abcdef","v0":"short"}}"#,
+            r#"{"active_version":"v1","keys":{"v1":"0123456789abcdef0123456789abcdef "}}"#,
+        ] {
+            assert!(derive_player_identity("a", "p", Some(raw)).is_err());
+        }
+
+        let keys: BTreeMap<String, serde_json::Value> = (0..=MAX_KEYRING_KEYS)
+            .map(|index| (format!("v{index}"), serde_json::Value::String(V1.to_owned())))
+            .collect();
+        let too_many = serde_json::json!({"active_version": "v0", "keys": keys}).to_string();
+        assert_eq!(
+            derive_player_identity("a", "p", Some(&too_many)),
+            Err(KeyringError::TooManyKeys)
+        );
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/player_rating_materialization.rs
+++ b/crates/rshogi-csa-server-workers/src/player_rating_materialization.rs
@@ -31,6 +31,11 @@ fn row_requires_rebuild(
         || (cursor_ended_at_ms == row_ended_at_ms as i64 && cursor_game_id >= row_game_id)
 }
 
+#[cfg(test)]
+fn revision_allows_page_persist(expected_revision: i64, current_revision: i64) -> bool {
+    expected_revision == current_revision
+}
+
 #[cfg(any(target_arch = "wasm32", test))]
 fn snapshot_is_ready(
     active_generation: Option<i64>,
@@ -79,6 +84,7 @@ mod imp {
         cursor_ended_at_ms: i64,
         cursor_game_id: String,
         rebuild_required: i64,
+        data_revision: i64,
     }
 
     #[derive(Debug, Deserialize)]
@@ -204,7 +210,28 @@ mod imp {
                 load_existing_players(db, state.building_generation, &player_ids).await?;
             let updated = apply_player_games(existing, &games);
             let last = rows.last().expect("non-empty page").to_player_game();
-            persist_page(db, state.building_generation, &updated, &games, &last).await?;
+            let persisted = persist_page(
+                db,
+                state.building_generation,
+                state.data_revision,
+                &updated,
+                &games,
+                &last,
+            )
+            .await?;
+            if !persisted {
+                // The page was derived from a stale read. Every page mutation
+                // was revision-guarded and therefore discarded; the same D1
+                // batch marked the generation for a clean rebuild.
+                state.rebuild_required = 1;
+                return Ok(MaterializationOutcome {
+                    processed_games,
+                    active_generation: state.active_generation,
+                    rebuild_in_progress: true,
+                    lease_acquired: true,
+                    deadline_reached: false,
+                });
+            }
             processed_games = processed_games.saturating_add(rows.len() as u32);
             state.cursor_ended_at_ms = last.ended_at_ms as i64;
             state.cursor_game_id = last.game_id;
@@ -263,7 +290,7 @@ mod imp {
     }
 
     async fn load_state(db: &worker::D1Database) -> Result<StateRow> {
-        db.prepare("SELECT active_generation, building_generation, cursor_ended_at_ms, cursor_game_id, rebuild_required FROM player_rating_state WHERE singleton = 1")
+        db.prepare("SELECT active_generation, building_generation, cursor_ended_at_ms, cursor_game_id, rebuild_required, data_revision FROM player_rating_state WHERE singleton = 1")
             .first::<StateRow>(None)
             .await?
             .ok_or_else(|| worker::Error::RustError("player_rating_state missing".into()))
@@ -360,11 +387,12 @@ mod imp {
     async fn persist_page(
         db: &worker::D1Database,
         generation: i64,
+        expected_revision: i64,
         players: &[PlayerSummary],
         games: &[PlayerGame],
         last: &PlayerGame,
-    ) -> Result<()> {
-        let mut statements = Vec::with_capacity(players.len() + 1);
+    ) -> Result<bool> {
+        let mut statements = Vec::with_capacity(players.len() + games.len() + 2);
         for player in players {
             let values = [
                 JsValue::from_f64(generation as f64),
@@ -377,9 +405,10 @@ mod imp {
                 JsValue::from_f64(player.games as f64),
                 JsValue::from_f64(player.last_played_at_ms as f64),
                 JsValue::from_f64(if player.legacy { 1.0 } else { 0.0 }),
+                JsValue::from_f64(expected_revision as f64),
             ];
             statements.push(
-                db.prepare("INSERT INTO player_rating_generations (generation, player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(generation, player_id) DO UPDATE SET display_name=excluded.display_name, rating=excluded.rating, wins=excluded.wins, losses=excluded.losses, draws=excluded.draws, games=excluded.games, last_played_at_ms=excluded.last_played_at_ms, legacy=excluded.legacy")
+                db.prepare("INSERT INTO player_rating_generations (generation, player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE (SELECT data_revision FROM player_rating_state WHERE singleton = 1) = ? ON CONFLICT(generation, player_id) DO UPDATE SET display_name=excluded.display_name, rating=excluded.rating, wins=excluded.wins, losses=excluded.losses, draws=excluded.draws, games=excluded.games, last_played_at_ms=excluded.last_played_at_ms, legacy=excluded.legacy")
                     .bind(&values)?,
             );
         }
@@ -394,22 +423,32 @@ mod imp {
                     game.white_player_id.as_deref().expect("canonicalized before persist"),
                 ),
                 JsValue::from_str(&game.game_id),
+                JsValue::from_f64(expected_revision as f64),
             ];
             statements.push(
-                db.prepare("UPDATE games_search_index SET black_player_id = ?, white_player_id = ? WHERE game_id = ?")
+                db.prepare("UPDATE games_search_index SET black_player_id = ?, white_player_id = ? WHERE game_id = ? AND (SELECT data_revision FROM player_rating_state WHERE singleton = 1) = ?")
                     .bind(&values)?,
             );
         }
         let cursor_values = [
             JsValue::from_f64(last.ended_at_ms as f64),
             JsValue::from_str(&last.game_id),
+            JsValue::from_f64(expected_revision as f64),
         ];
         statements.push(
-            db.prepare("UPDATE player_rating_state SET cursor_ended_at_ms = ?, cursor_game_id = ? WHERE singleton = 1")
+            db.prepare("UPDATE player_rating_state SET cursor_ended_at_ms = ?, cursor_game_id = ? WHERE singleton = 1 AND data_revision = ?")
                 .bind(&cursor_values)?,
         );
-        db.batch(statements).await?;
-        Ok(())
+        let mismatch_values = [JsValue::from_f64(expected_revision as f64)];
+        statements.push(
+            db.prepare("UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1 AND data_revision <> ?")
+                .bind(&mismatch_values)?,
+        );
+        let results = db.batch(statements).await?;
+        let cursor_result = results.get(results.len().saturating_sub(2)).ok_or_else(|| {
+            worker::Error::RustError("player rating cursor result missing".into())
+        })?;
+        Ok(cursor_result.meta()?.and_then(|meta| meta.changes).unwrap_or(0) == 1)
     }
 }
 
@@ -474,5 +513,14 @@ mod tests {
         assert!(super::deadline_reached(Some(25_000), 25_000));
         assert!(super::deadline_reached(Some(25_000), 25_001));
         assert!(!super::deadline_reached(None, u64::MAX));
+    }
+
+    #[test]
+    fn page_loaded_before_concurrent_upsert_is_discarded() {
+        let revision_at_page_load = 7;
+        assert!(super::revision_allows_page_persist(revision_at_page_load, 7));
+        // A real game UPSERT increments data_revision atomically before the
+        // materializer's guarded batch can run.
+        assert!(!super::revision_allows_page_persist(revision_at_page_load, 8));
     }
 }

--- a/crates/rshogi-csa-server-workers/src/player_rating_materialization.rs
+++ b/crates/rshogi-csa-server-workers/src/player_rating_materialization.rs
@@ -1,0 +1,478 @@
+//! D1 上の Elo materialized snapshot を有界 batch で更新する。
+
+pub const PAGE_SIZE: u32 = 30;
+pub const MAX_PAGES_PER_RUN: u32 = 6;
+
+/// Only the lease holder may mutate a building generation. D1 reports one
+/// changed row for the winner and zero for concurrent cron/admin callers.
+#[cfg(any(target_arch = "wasm32", test))]
+fn lease_was_acquired(changes: usize) -> bool {
+    changes == 1
+}
+
+/// A page shorter than the query limit proves that the cursor reached the end
+/// of the snapshot observed by that query, so the generation can be activated
+/// without spending a seventh D1 page request.
+#[cfg(any(target_arch = "wasm32", test))]
+fn page_reached_end(row_count: usize) -> bool {
+    row_count < PAGE_SIZE as usize
+}
+
+/// Matches the late-write predicate used by `games_search_index`: a changed
+/// row at or before the persisted Elo cursor invalidates every later rating.
+#[cfg(test)]
+fn row_requires_rebuild(
+    cursor_ended_at_ms: i64,
+    cursor_game_id: &str,
+    row_ended_at_ms: u64,
+    row_game_id: &str,
+) -> bool {
+    cursor_ended_at_ms > row_ended_at_ms as i64
+        || (cursor_ended_at_ms == row_ended_at_ms as i64 && cursor_game_id >= row_game_id)
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn snapshot_is_ready(
+    active_generation: Option<i64>,
+    building_generation: i64,
+    rebuild_required: bool,
+) -> bool {
+    !rebuild_required && active_generation == Some(building_generation)
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn deadline_reached(deadline_at_ms: Option<u64>, now_ms: u64) -> bool {
+    deadline_at_ms.is_some_and(|deadline| now_ms >= deadline)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaterializationOutcome {
+    pub processed_games: u32,
+    pub active_generation: Option<i64>,
+    pub rebuild_in_progress: bool,
+    pub lease_acquired: bool,
+    pub deadline_reached: bool,
+}
+
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use serde::Deserialize;
+    use worker::wasm_bindgen::JsValue;
+    use worker::{Date, Env, Result};
+
+    use super::{
+        MAX_PAGES_PER_RUN, MaterializationOutcome, PAGE_SIZE, deadline_reached, lease_was_acquired,
+        page_reached_end, snapshot_is_ready,
+    };
+    use crate::config::ConfigKeys;
+    use crate::games_search_index::SearchRow;
+    use crate::player_ratings::{PlayerGame, PlayerSummary, apply_player_games};
+
+    const LEASE_MS: u64 = 60_000;
+
+    #[derive(Debug, Deserialize)]
+    struct StateRow {
+        active_generation: Option<i64>,
+        building_generation: i64,
+        cursor_ended_at_ms: i64,
+        cursor_game_id: String,
+        rebuild_required: i64,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct AliasRow {
+        alias_id: String,
+        canonical_id: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct RatingRow {
+        player_id: String,
+        display_name: String,
+        rating: f64,
+        wins: u64,
+        losses: u64,
+        draws: u64,
+        games: u64,
+        last_played_at_ms: u64,
+        legacy: i64,
+    }
+
+    impl From<RatingRow> for PlayerSummary {
+        fn from(row: RatingRow) -> Self {
+            Self {
+                player_id: row.player_id,
+                display_name: row.display_name,
+                rating: row.rating,
+                wins: row.wins,
+                losses: row.losses,
+                draws: row.draws,
+                games: row.games,
+                last_played_at_ms: row.last_played_at_ms,
+                legacy: row.legacy != 0,
+            }
+        }
+    }
+
+    /// cron / admin warmup の双方から呼ぶ bounded materializer。
+    pub async fn run_player_rating_materialization(
+        env: &Env,
+        requested_max_pages: u32,
+        deadline_at_ms: Option<u64>,
+    ) -> Result<MaterializationOutcome> {
+        if deadline_reached(deadline_at_ms, Date::now().as_millis()) {
+            return Ok(MaterializationOutcome {
+                processed_games: 0,
+                active_generation: None,
+                rebuild_in_progress: true,
+                lease_acquired: false,
+                deadline_reached: true,
+            });
+        }
+        let db = env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING)?;
+        let now = Date::now().as_millis();
+        let lease_values = [
+            JsValue::from_f64(now.saturating_add(LEASE_MS) as f64),
+            JsValue::from_f64(now as f64),
+        ];
+        let lease_result = db
+            .prepare("UPDATE player_rating_state SET lease_until_ms = ? WHERE singleton = 1 AND lease_until_ms <= ?")
+            .bind(&lease_values)?
+            .run()
+            .await?;
+        let acquired =
+            lease_was_acquired(lease_result.meta()?.and_then(|meta| meta.changes).unwrap_or(0));
+        if !acquired {
+            let state = load_state(&db).await?;
+            return Ok(MaterializationOutcome {
+                processed_games: 0,
+                active_generation: state.active_generation,
+                rebuild_in_progress: true,
+                lease_acquired: false,
+                deadline_reached: false,
+            });
+        }
+
+        let result =
+            run_with_lease(&db, requested_max_pages.clamp(1, MAX_PAGES_PER_RUN), deadline_at_ms)
+                .await;
+        // error 時も lease を早期解放する。失敗しても元の error を優先する。
+        let _ = db
+            .prepare("UPDATE player_rating_state SET lease_until_ms = 0 WHERE singleton = 1")
+            .run()
+            .await;
+        result
+    }
+
+    async fn run_with_lease(
+        db: &worker::D1Database,
+        max_pages: u32,
+        deadline_at_ms: Option<u64>,
+    ) -> Result<MaterializationOutcome> {
+        let mut state = load_state(db).await?;
+        if state.rebuild_required != 0 {
+            let next_generation = state.active_generation.unwrap_or(0).saturating_add(1);
+            let delete_values = [JsValue::from_f64(next_generation as f64)];
+            let reset_values = [JsValue::from_f64(next_generation as f64)];
+            db.batch(vec![
+                db.prepare("DELETE FROM player_rating_generations WHERE generation = ?")
+                    .bind(&delete_values)?,
+                db.prepare("UPDATE player_rating_state SET building_generation = ?, cursor_ended_at_ms = -1, cursor_game_id = '', rebuild_required = 0 WHERE singleton = 1")
+                    .bind(&reset_values)?,
+            ])
+            .await?;
+            state = load_state(db).await?;
+        }
+
+        let mut processed_games = 0_u32;
+        for _ in 0..max_pages {
+            if deadline_reached(deadline_at_ms, Date::now().as_millis()) {
+                return Ok(deadline_outcome(&state, processed_games));
+            }
+            let rows = load_game_page(db, &state).await?;
+            if deadline_reached(deadline_at_ms, Date::now().as_millis()) {
+                return Ok(deadline_outcome(&state, processed_games));
+            }
+            if rows.is_empty() {
+                return activate_if_clean(db, state.building_generation, processed_games).await;
+            }
+
+            let (games, player_ids) = canonicalize_page(db, &rows).await?;
+            let existing =
+                load_existing_players(db, state.building_generation, &player_ids).await?;
+            let updated = apply_player_games(existing, &games);
+            let last = rows.last().expect("non-empty page").to_player_game();
+            persist_page(db, state.building_generation, &updated, &games, &last).await?;
+            processed_games = processed_games.saturating_add(rows.len() as u32);
+            state.cursor_ended_at_ms = last.ended_at_ms as i64;
+            state.cursor_game_id = last.game_id;
+            if deadline_reached(deadline_at_ms, Date::now().as_millis()) {
+                return Ok(deadline_outcome(&state, processed_games));
+            }
+            if page_reached_end(rows.len()) {
+                return activate_if_clean(db, state.building_generation, processed_games).await;
+            }
+        }
+
+        let final_state = load_state(db).await?;
+        Ok(MaterializationOutcome {
+            processed_games,
+            active_generation: final_state.active_generation,
+            rebuild_in_progress: true,
+            lease_acquired: true,
+            deadline_reached: false,
+        })
+    }
+
+    fn deadline_outcome(state: &StateRow, processed_games: u32) -> MaterializationOutcome {
+        MaterializationOutcome {
+            processed_games,
+            active_generation: state.active_generation,
+            rebuild_in_progress: true,
+            lease_acquired: true,
+            deadline_reached: true,
+        }
+    }
+
+    async fn activate_if_clean(
+        db: &worker::D1Database,
+        building_generation: i64,
+        processed_games: u32,
+    ) -> Result<MaterializationOutcome> {
+        // A concurrent alias registration or late row marks the build dirty.
+        // The WHERE clause then leaves the prior active generation untouched.
+        let activation_values = [JsValue::from_f64(building_generation as f64)];
+        db.prepare("UPDATE player_rating_state SET active_generation = ?, lease_until_ms = 0 WHERE singleton = 1 AND rebuild_required = 0")
+            .bind(&activation_values)?
+            .run()
+            .await?;
+        let final_state = load_state(db).await?;
+        Ok(MaterializationOutcome {
+            processed_games,
+            active_generation: final_state.active_generation,
+            rebuild_in_progress: !snapshot_is_ready(
+                final_state.active_generation,
+                final_state.building_generation,
+                final_state.rebuild_required != 0,
+            ),
+            lease_acquired: true,
+            deadline_reached: false,
+        })
+    }
+
+    async fn load_state(db: &worker::D1Database) -> Result<StateRow> {
+        db.prepare("SELECT active_generation, building_generation, cursor_ended_at_ms, cursor_game_id, rebuild_required FROM player_rating_state WHERE singleton = 1")
+            .first::<StateRow>(None)
+            .await?
+            .ok_or_else(|| worker::Error::RustError("player_rating_state missing".into()))
+    }
+
+    async fn load_game_page(db: &worker::D1Database, state: &StateRow) -> Result<Vec<SearchRow>> {
+        let values = [
+            JsValue::from_f64(state.cursor_ended_at_ms as f64),
+            JsValue::from_f64(state.cursor_ended_at_ms as f64),
+            JsValue::from_str(&state.cursor_game_id),
+            JsValue::from_f64(f64::from(PAGE_SIZE)),
+        ];
+        db.prepare("SELECT game_id, started_at_ms, ended_at_ms, sente_name, gote_name, black_player_id, white_player_id, wire_result_kind, end_reason, moves_count, clock_json, source FROM games_search_index WHERE ended_at_ms > ? OR (ended_at_ms = ? AND game_id > ?) ORDER BY ended_at_ms ASC, game_id ASC LIMIT ?")
+            .bind(&values)?
+            .all()
+            .await?
+            .results::<SearchRow>()
+    }
+
+    async fn canonicalize_page(
+        db: &worker::D1Database,
+        rows: &[SearchRow],
+    ) -> Result<(Vec<PlayerGame>, BTreeSet<String>)> {
+        let raw_games: Vec<_> = rows.iter().map(SearchRow::to_player_game).collect();
+        let raw_ids: BTreeSet<_> = raw_games
+            .iter()
+            .flat_map(|game| {
+                [
+                    game.resolved_black_player_id(),
+                    game.resolved_white_player_id(),
+                ]
+            })
+            .collect();
+        let aliases = load_aliases(db, &raw_ids).await?;
+        let mut canonical_ids = BTreeSet::new();
+        let games = raw_games
+            .into_iter()
+            .map(|mut game| {
+                let black = game.resolved_black_player_id();
+                let white = game.resolved_white_player_id();
+                let black = aliases.get(&black).cloned().unwrap_or(black);
+                let white = aliases.get(&white).cloned().unwrap_or(white);
+                canonical_ids.insert(black.clone());
+                canonical_ids.insert(white.clone());
+                game.black_player_id = Some(black);
+                game.white_player_id = Some(white);
+                game
+            })
+            .collect();
+        Ok((games, canonical_ids))
+    }
+
+    async fn load_aliases(
+        db: &worker::D1Database,
+        ids: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, String>> {
+        if ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let placeholders = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT alias_id, canonical_id FROM player_id_aliases WHERE alias_id IN ({placeholders})"
+        );
+        let values: Vec<_> = ids.iter().map(|id| JsValue::from_str(id)).collect();
+        let rows = db.prepare(&sql).bind(&values)?.all().await?.results::<AliasRow>()?;
+        Ok(rows.into_iter().map(|row| (row.alias_id, row.canonical_id)).collect())
+    }
+
+    async fn load_existing_players(
+        db: &worker::D1Database,
+        generation: i64,
+        ids: &BTreeSet<String>,
+    ) -> Result<Vec<PlayerSummary>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat_n("?", ids.len()).collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? AND player_id IN ({placeholders})"
+        );
+        let mut values = vec![JsValue::from_f64(generation as f64)];
+        values.extend(ids.iter().map(|id| JsValue::from_str(id)));
+        Ok(db
+            .prepare(&sql)
+            .bind(&values)?
+            .all()
+            .await?
+            .results::<RatingRow>()?
+            .into_iter()
+            .map(PlayerSummary::from)
+            .collect())
+    }
+
+    async fn persist_page(
+        db: &worker::D1Database,
+        generation: i64,
+        players: &[PlayerSummary],
+        games: &[PlayerGame],
+        last: &PlayerGame,
+    ) -> Result<()> {
+        let mut statements = Vec::with_capacity(players.len() + 1);
+        for player in players {
+            let values = [
+                JsValue::from_f64(generation as f64),
+                JsValue::from_str(&player.player_id),
+                JsValue::from_str(&player.display_name),
+                JsValue::from_f64(player.rating),
+                JsValue::from_f64(player.wins as f64),
+                JsValue::from_f64(player.losses as f64),
+                JsValue::from_f64(player.draws as f64),
+                JsValue::from_f64(player.games as f64),
+                JsValue::from_f64(player.last_played_at_ms as f64),
+                JsValue::from_f64(if player.legacy { 1.0 } else { 0.0 }),
+            ];
+            statements.push(
+                db.prepare("INSERT INTO player_rating_generations (generation, player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(generation, player_id) DO UPDATE SET display_name=excluded.display_name, rating=excluded.rating, wins=excluded.wins, losses=excluded.losses, draws=excluded.draws, games=excluded.games, last_played_at_ms=excluded.last_played_at_ms, legacy=excluded.legacy")
+                    .bind(&values)?,
+            );
+        }
+        // 旧 NULL ID 行も同じ bounded pass で canonical ID に補完する。これにより
+        // detail API は name hash の逆引きをせず ID index だけで過去局を検索できる。
+        for game in games {
+            let values = [
+                JsValue::from_str(
+                    game.black_player_id.as_deref().expect("canonicalized before persist"),
+                ),
+                JsValue::from_str(
+                    game.white_player_id.as_deref().expect("canonicalized before persist"),
+                ),
+                JsValue::from_str(&game.game_id),
+            ];
+            statements.push(
+                db.prepare("UPDATE games_search_index SET black_player_id = ?, white_player_id = ? WHERE game_id = ?")
+                    .bind(&values)?,
+            );
+        }
+        let cursor_values = [
+            JsValue::from_f64(last.ended_at_ms as f64),
+            JsValue::from_str(&last.game_id),
+        ];
+        statements.push(
+            db.prepare("UPDATE player_rating_state SET cursor_ended_at_ms = ?, cursor_game_id = ? WHERE singleton = 1")
+                .bind(&cursor_values)?,
+        );
+        db.batch(statements).await?;
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use imp::run_player_rating_materialization;
+
+#[cfg(test)]
+mod tests {
+    use crate::player_ratings::{PlayerGame, PlayerSummary, apply_player_games};
+
+    #[test]
+    fn applying_same_page_from_same_snapshot_is_idempotent() {
+        let game = PlayerGame {
+            game_id: "g1".into(),
+            ended_at_ms: 1,
+            black_handle: "a".into(),
+            white_handle: "b".into(),
+            black_player_id: Some("p_a".into()),
+            white_player_id: Some("p_b".into()),
+            result_kind: "WIN_BLACK".into(),
+        };
+        let first = apply_player_games(Vec::<PlayerSummary>::new(), std::slice::from_ref(&game));
+        let retry = apply_player_games(Vec::<PlayerSummary>::new(), &[game]);
+        assert_eq!(first, retry);
+    }
+
+    #[test]
+    fn bounded_run_constants_cover_current_159_row_warmup() {
+        const {
+            assert!(super::PAGE_SIZE * super::MAX_PAGES_PER_RUN >= 159);
+            assert!(super::PAGE_SIZE * super::MAX_PAGES_PER_RUN <= 200);
+        }
+        assert!(super::page_reached_end(9));
+    }
+
+    #[test]
+    fn initial_generation_is_unavailable_until_clean_activation() {
+        assert!(!super::snapshot_is_ready(None, 1, false));
+        assert!(!super::snapshot_is_ready(Some(1), 2, false));
+        assert!(!super::snapshot_is_ready(Some(2), 2, true));
+        assert!(super::snapshot_is_ready(Some(2), 2, false));
+    }
+
+    #[test]
+    fn late_or_equal_cursor_upsert_requires_rebuild() {
+        assert!(super::row_requires_rebuild(100, "g2", 99, "later-time"));
+        assert!(super::row_requires_rebuild(100, "g2", 100, "g2"));
+        assert!(super::row_requires_rebuild(100, "g2", 100, "g1"));
+        assert!(!super::row_requires_rebuild(100, "g2", 100, "g3"));
+        assert!(!super::row_requires_rebuild(100, "g2", 101, "earlier-id"));
+    }
+
+    #[test]
+    fn concurrent_cron_callers_have_one_lease_winner() {
+        assert!(super::lease_was_acquired(1));
+        assert!(!super::lease_was_acquired(0));
+    }
+
+    #[test]
+    fn shared_deadline_stops_at_exact_boundary_but_admin_is_unlimited() {
+        assert!(!super::deadline_reached(Some(25_000), 24_999));
+        assert!(super::deadline_reached(Some(25_000), 25_000));
+        assert!(super::deadline_reached(Some(25_000), 25_001));
+        assert!(!super::deadline_reached(None, u64::MAX));
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/player_ratings.rs
+++ b/crates/rshogi-csa-server-workers/src/player_ratings.rs
@@ -1,0 +1,249 @@
+//! player ID 単位の Elo / 戦績集計純粋ロジック。
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::player_identity::legacy_player_id;
+
+pub const INITIAL_RATING: f64 = 1500.0;
+pub const ELO_K_FACTOR: f64 = 32.0;
+
+/// D1 の 1 対局行から集計に必要な値だけを切り出した表現。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayerGame {
+    pub game_id: String,
+    pub ended_at_ms: u64,
+    pub black_handle: String,
+    pub white_handle: String,
+    pub black_player_id: Option<String>,
+    pub white_player_id: Option<String>,
+    pub result_kind: String,
+}
+
+impl PlayerGame {
+    pub fn resolved_black_player_id(&self) -> String {
+        self.black_player_id
+            .clone()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| legacy_player_id(&self.black_handle))
+    }
+
+    pub fn resolved_white_player_id(&self) -> String {
+        self.white_player_id
+            .clone()
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| legacy_player_id(&self.white_handle))
+    }
+}
+
+/// Players API が返す 1 選手分の集計。
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PlayerSummary {
+    pub player_id: String,
+    pub display_name: String,
+    pub rating: f64,
+    pub wins: u64,
+    pub losses: u64,
+    pub draws: u64,
+    pub games: u64,
+    pub last_played_at_ms: u64,
+    pub legacy: bool,
+}
+
+/// 全履歴を終了時刻昇順（同時刻は game_id 昇順）で標準 Elo 集計する。
+///
+/// self-play（先後の解決済み ID が同一）は Elo / W-L-D から除外する。結果不確定の
+/// `ABORT` も同様に除外するが、選手の存在・表示名・最終対局時刻には反映する。
+pub fn aggregate_players(games: &[PlayerGame]) -> Vec<PlayerSummary> {
+    let mut ordered: Vec<&PlayerGame> = games.iter().collect();
+    ordered
+        .sort_by(|a, b| a.ended_at_ms.cmp(&b.ended_at_ms).then_with(|| a.game_id.cmp(&b.game_id)));
+
+    let mut players: BTreeMap<String, PlayerSummary> = BTreeMap::new();
+    apply_ordered_games(&mut players, ordered);
+
+    sorted_players(players)
+}
+
+/// materialized snapshot の既存 summary に、昇順 cursor page を増分適用する。
+pub fn apply_player_games(
+    existing: impl IntoIterator<Item = PlayerSummary>,
+    games: &[PlayerGame],
+) -> Vec<PlayerSummary> {
+    let mut players: BTreeMap<String, PlayerSummary> =
+        existing.into_iter().map(|player| (player.player_id.clone(), player)).collect();
+    let mut ordered: Vec<&PlayerGame> = games.iter().collect();
+    ordered
+        .sort_by(|a, b| a.ended_at_ms.cmp(&b.ended_at_ms).then_with(|| a.game_id.cmp(&b.game_id)));
+    apply_ordered_games(&mut players, ordered);
+    sorted_players(players)
+}
+
+fn apply_ordered_games<'a>(
+    players: &mut BTreeMap<String, PlayerSummary>,
+    ordered: impl IntoIterator<Item = &'a PlayerGame>,
+) {
+    for game in ordered {
+        let black_id = game.resolved_black_player_id();
+        let white_id = game.resolved_white_player_id();
+        observe_player(players, &black_id, &game.black_handle, game.ended_at_ms);
+        observe_player(players, &white_id, &game.white_handle, game.ended_at_ms);
+
+        if black_id == white_id {
+            continue;
+        }
+        let (black_score, white_score) = match game.result_kind.as_str() {
+            "WIN_BLACK" => (1.0, 0.0),
+            "WIN_WHITE" => (0.0, 1.0),
+            "DRAW" => (0.5, 0.5),
+            _ => continue,
+        };
+        let black_rating = players[&black_id].rating;
+        let white_rating = players[&white_id].rating;
+        let black_expected = expected_score(black_rating, white_rating);
+        let white_expected = 1.0 - black_expected;
+
+        let black = players.get_mut(&black_id).expect("observed above");
+        black.rating += ELO_K_FACTOR * (black_score - black_expected);
+        update_record(black, black_score);
+        let white = players.get_mut(&white_id).expect("observed above");
+        white.rating += ELO_K_FACTOR * (white_score - white_expected);
+        update_record(white, white_score);
+    }
+}
+
+fn sorted_players(players: BTreeMap<String, PlayerSummary>) -> Vec<PlayerSummary> {
+    let mut result: Vec<_> = players.into_values().collect();
+    result
+        .sort_by(|a, b| b.rating.total_cmp(&a.rating).then_with(|| a.player_id.cmp(&b.player_id)));
+    result
+}
+
+fn observe_player(
+    players: &mut BTreeMap<String, PlayerSummary>,
+    player_id: &str,
+    display_name: &str,
+    ended_at_ms: u64,
+) {
+    let player = players.entry(player_id.to_owned()).or_insert_with(|| PlayerSummary {
+        player_id: player_id.to_owned(),
+        display_name: display_name.to_owned(),
+        rating: INITIAL_RATING,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        games: 0,
+        last_played_at_ms: ended_at_ms,
+        legacy: player_id.starts_with("legacy_"),
+    });
+    player.display_name = display_name.to_owned();
+    player.last_played_at_ms = ended_at_ms;
+}
+
+fn expected_score(rating: f64, opponent_rating: f64) -> f64 {
+    1.0 / (1.0 + 10_f64.powf((opponent_rating - rating) / 400.0))
+}
+
+fn update_record(player: &mut PlayerSummary, score: f64) {
+    if score == 1.0 {
+        player.wins += 1;
+    } else if score == 0.0 {
+        player.losses += 1;
+    } else {
+        player.draws += 1;
+    }
+    player.games += 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn game(id: &str, ended: u64, black: &str, white: &str, result: &str) -> PlayerGame {
+        PlayerGame {
+            game_id: id.into(),
+            ended_at_ms: ended,
+            black_handle: black.into(),
+            white_handle: white.into(),
+            black_player_id: Some(format!("p_{black}")),
+            white_player_id: Some(format!("p_{white}")),
+            result_kind: result.into(),
+        }
+    }
+
+    #[test]
+    fn equal_ratings_move_sixteen_points_after_decisive_result() {
+        let players = aggregate_players(&[game("g1", 1, "alice", "bob", "WIN_BLACK")]);
+        let alice = players.iter().find(|p| p.player_id == "p_alice").unwrap();
+        let bob = players.iter().find(|p| p.player_id == "p_bob").unwrap();
+        assert_eq!((alice.rating, alice.wins, alice.games), (1516.0, 1, 1));
+        assert_eq!((bob.rating, bob.losses, bob.games), (1484.0, 1, 1));
+    }
+
+    #[test]
+    fn chronology_is_ended_at_then_game_id_not_input_order() {
+        let games = [
+            game("g3", 300, "alice", "bob", "WIN_BLACK"),
+            game("g2", 200, "alice", "bob", "WIN_WHITE"),
+            game("g1", 100, "alice", "bob", "WIN_BLACK"),
+        ];
+        let forward = aggregate_players(&games);
+        let reverse = aggregate_players(&games.iter().cloned().rev().collect::<Vec<_>>());
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn draw_counts_and_preserves_equal_ratings() {
+        let players = aggregate_players(&[game("g1", 1, "alice", "bob", "DRAW")]);
+        assert!(players.iter().all(|p| p.rating == INITIAL_RATING && p.draws == 1));
+    }
+
+    #[test]
+    fn self_play_and_abort_are_visible_but_not_rated() {
+        let mut self_game = game("g1", 10, "alice", "alice", "WIN_BLACK");
+        self_game.white_player_id = self_game.black_player_id.clone();
+        let abort = game("g2", 20, "alice", "bob", "ABORT");
+        let players = aggregate_players(&[self_game, abort]);
+        assert_eq!(players.len(), 2);
+        assert!(players.iter().all(|p| p.rating == INITIAL_RATING && p.games == 0));
+        assert_eq!(
+            players.iter().find(|p| p.player_id == "p_alice").unwrap().last_played_at_ms,
+            20
+        );
+    }
+
+    #[test]
+    fn missing_ids_resolve_to_name_derived_legacy_ids() {
+        let mut old = game("old", 1, "alice", "bob", "DRAW");
+        old.black_player_id = None;
+        old.white_player_id = None;
+        let players = aggregate_players(&[old]);
+        assert!(players.iter().any(|p| p.player_id == legacy_player_id("alice")));
+        assert!(players.iter().any(|p| p.player_id == legacy_player_id("bob")));
+        assert!(players.iter().all(|p| p.legacy));
+    }
+
+    #[test]
+    fn summary_wire_fields_match_viewer_contract() {
+        let players = aggregate_players(&[game("g1", 123, "alice", "bob", "WIN_BLACK")]);
+        let value = serde_json::to_value(&players[0]).unwrap();
+        let object = value.as_object().unwrap();
+        let mut keys: Vec<_> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "display_name",
+                "draws",
+                "games",
+                "last_played_at_ms",
+                "legacy",
+                "losses",
+                "player_id",
+                "rating",
+                "wins",
+            ]
+        );
+    }
+}

--- a/crates/rshogi-csa-server-workers/src/session_state.rs
+++ b/crates/rshogi-csa-server-workers/src/session_state.rs
@@ -16,6 +16,10 @@ pub struct Slot {
     pub role: Role,
     /// CSA LOGIN の `<handle>`。
     pub handle: String,
+    /// LOGIN credential から導出した公開用 opaque player ID。
+    /// 旧 snapshot では空文字となり、match 評価時に legacy ID へ解決する。
+    #[serde(default)]
+    pub player_id: String,
     /// CSA LOGIN の `<game_name>`。マッチ成立の同一性チェックに使う。
     pub game_name: String,
 }
@@ -29,8 +33,12 @@ pub enum MatchResult {
     Match {
         /// 先手プレイヤのハンドル。
         black_handle: String,
+        /// 先手プレイヤの公開 ID。
+        black_player_id: String,
         /// 後手プレイヤのハンドル。
         white_handle: String,
+        /// 後手プレイヤの公開 ID。
+        white_player_id: String,
         /// 共通の game_name。
         game_name: String,
     },
@@ -66,13 +74,23 @@ pub fn evaluate_match(slots: &[Slot]) -> MatchResult {
             }
             MatchResult::Match {
                 black_handle: black.handle.clone(),
+                black_player_id: resolved_player_id(black),
                 white_handle: white.handle.clone(),
+                white_player_id: resolved_player_id(white),
                 game_name: black.game_name.clone(),
             }
         }
         _ => MatchResult::Conflict {
             reason: "too many slots",
         },
+    }
+}
+
+fn resolved_player_id(slot: &Slot) -> String {
+    if slot.player_id.is_empty() {
+        crate::player_identity::legacy_player_id(&slot.handle)
+    } else {
+        slot.player_id.clone()
     }
 }
 
@@ -107,6 +125,7 @@ mod tests {
         Slot {
             role,
             handle: handle.to_owned(),
+            player_id: crate::player_identity::legacy_player_id(handle),
             game_name: game.to_owned(),
         }
     }
@@ -128,10 +147,22 @@ mod tests {
             evaluate_match(&slots),
             MatchResult::Match {
                 black_handle: "a".to_owned(),
+                black_player_id: crate::player_identity::legacy_player_id("a"),
                 white_handle: "b".to_owned(),
+                white_player_id: crate::player_identity::legacy_player_id("b"),
                 game_name: "g1".to_owned(),
             }
         );
+    }
+
+    #[test]
+    fn old_slot_without_player_id_resolves_to_legacy_id() {
+        let old: Slot = serde_json::from_value(serde_json::json!({
+            "role": "Black", "handle": "alice", "game_name": "g1"
+        }))
+        .unwrap();
+        assert!(old.player_id.is_empty());
+        assert_eq!(resolved_player_id(&old), crate::player_identity::legacy_player_id("alice"));
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -308,7 +308,9 @@ mod tests {
         PersistedConfig {
             game_id: "room-1-test".to_owned(),
             black_handle: "alice".to_owned(),
+            black_player_id: crate::player_identity::legacy_player_id("alice"),
             white_handle: "bob".to_owned(),
+            white_player_id: crate::player_identity::legacy_player_id("bob"),
             game_name: "g1".to_owned(),
             clock: ClockSpec::Countdown {
                 total_time_sec: 600,

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -21,7 +21,8 @@
 //!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
 //!   `kifu-by-id/<encoded_game_id>.meta.json` から取得した正準メタ (https://github.com/SH11235/rshogi/issues/551
 //!   設計 v3 §12) を合わせて返す。
-//! - `GET /api/v1/players` D1 の active Elo snapshot から返す選手一覧。
+//! - `GET /api/v1/players?page=<N>&pageSize=<N>` D1 の active Elo snapshot から
+//!   paginationして返す選手一覧（全体件数・対局数・global leader付き）。
 //! - `GET /api/v1/players/<player_id>` 選手 summary と最近の対局一覧。
 //!
 //! いずれも GameRoom DO を経由せず、Worker 直 fetch のみで完結する (R2 read
@@ -159,7 +160,7 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     let path = url.path().to_owned();
 
     if path == "/api/v1/players" {
-        return Ok(Some(handle_players(req, env).await?));
+        return Ok(Some(handle_players(req, env, &url).await?));
     }
     if let Some(player_id) = path.strip_prefix("/api/v1/players/") {
         if player_id.is_empty() || player_id.contains('/') {
@@ -285,6 +286,11 @@ struct SearchResponse {
 #[derive(Debug, Serialize)]
 struct PlayersResponse {
     players: Vec<PlayerSummary>,
+    page: u32,
+    page_size: u32,
+    total_count: u64,
+    total_games: u64,
+    leader: Option<PlayerSummary>,
 }
 
 #[derive(Debug, Serialize)]
@@ -357,10 +363,14 @@ async fn active_generation(db: &worker::D1Database) -> std::result::Result<Optio
         .map_err(|e| e.to_string())
 }
 
-async fn handle_players(req: &Request, env: &Env) -> Result<Response> {
+async fn handle_players(req: &Request, env: &Env, url: &Url) -> Result<Response> {
     if let Some(blocked) = check_origin(req, env)? {
         return Ok(blocked);
     }
+    let (page, page_size) = match parse_page_params(url) {
+        Ok(values) => values,
+        Err(message) => return with_cors(no_store_error(message, 400)?, req, env),
+    };
     let db = match env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING) {
         Ok(db) => db,
         Err(e) => {
@@ -376,9 +386,48 @@ async fn handle_players(req: &Request, env: &Env) -> Result<Response> {
             return with_cors(no_store_error("Storage error", 502)?, req, env);
         }
     };
-    let values = [worker::wasm_bindgen::JsValue::from_f64(generation as f64)];
+    #[derive(serde::Deserialize)]
+    struct PlayerTotalsRow {
+        total_count: u64,
+        total_games: u64,
+    }
+    let generation_values = [worker::wasm_bindgen::JsValue::from_f64(generation as f64)];
+    let totals = match db
+        .prepare("SELECT COUNT(*) AS total_count, CAST(COALESCE(SUM(games), 0) / 2 AS INTEGER) AS total_games FROM player_rating_generations WHERE generation = ?")
+        .bind(&generation_values)?
+        .first::<PlayerTotalsRow>(None)
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => PlayerTotalsRow {
+            total_count: 0,
+            total_games: 0,
+        },
+        Err(e) => {
+            log_viewer_api_failed("players_totals", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let leader = match db
+        .prepare("SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? ORDER BY rating DESC, player_id ASC LIMIT 1")
+        .bind(&generation_values)?
+        .first::<MaterializedPlayerRow>(None)
+        .await
+    {
+        Ok(row) => row.map(PlayerSummary::from),
+        Err(e) => {
+            log_viewer_api_failed("players_leader", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let offset = u64::from(page - 1) * u64::from(page_size);
+    let values = [
+        worker::wasm_bindgen::JsValue::from_f64(generation as f64),
+        worker::wasm_bindgen::JsValue::from_f64(f64::from(page_size)),
+        worker::wasm_bindgen::JsValue::from_f64(offset as f64),
+    ];
     let rows = match db
-        .prepare("SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? ORDER BY rating DESC, player_id ASC")
+        .prepare("SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? ORDER BY rating DESC, player_id ASC LIMIT ? OFFSET ?")
         .bind(&values)?
         .all()
         .await
@@ -392,6 +441,11 @@ async fn handle_players(req: &Request, env: &Env) -> Result<Response> {
     };
     let mut response = Response::from_json(&PlayersResponse {
         players: rows.into_iter().map(PlayerSummary::from).collect(),
+        page,
+        page_size,
+        total_count: totals.total_count,
+        total_games: totals.total_games,
+        leader,
     })?;
     set_cache_control(&mut response, CacheableKind::List.cache_control_header())?;
     with_cors(response, req, env)

--- a/crates/rshogi-csa-server-workers/src/viewer_api.rs
+++ b/crates/rshogi-csa-server-workers/src/viewer_api.rs
@@ -1,6 +1,7 @@
 //! viewer 配信 HTTP API (`/api/v1/games`) のルーティングと R2 アクセス。
 //!
-//! v3 設計 (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338088406) に準拠する 4 エンドポイント:
+//! v3 設計 (https://github.com/SH11235/rshogi/issues/542 issuecomment-4338088406) に準拠する games API に加え、
+//! player ID 単位の集計 API を提供する:
 //!
 //! - `GET /api/v1/games?cursor=<opaque>&limit=<N>` 一覧 (終局済)
 //!   `KIFU_BUCKET.list({prefix: "games-index/", cursor, limit})` を 1 回呼び、
@@ -20,6 +21,8 @@
 //!   `kifu-by-id/<encoded_game_id>.csa` を直接 get する。本文 (CSA V2) と
 //!   `kifu-by-id/<encoded_game_id>.meta.json` から取得した正準メタ (https://github.com/SH11235/rshogi/issues/551
 //!   設計 v3 §12) を合わせて返す。
+//! - `GET /api/v1/players` D1 の active Elo snapshot から返す選手一覧。
+//! - `GET /api/v1/players/<player_id>` 選手 summary と最近の対局一覧。
 //!
 //! いずれも GameRoom DO を経由せず、Worker 直 fetch のみで完結する (R2 read
 //! 1 ホップ)。CORS は staging では `WS_ALLOWED_ORIGINS` をそのまま流用して
@@ -104,13 +107,16 @@ use crate::games_search_index::{
 };
 use crate::live_games_index::LIVE_KEY_PREFIX;
 use crate::origin::{OriginDecision, evaluate};
+use crate::player_rating_materialization::{MAX_PAGES_PER_RUN, run_player_rating_materialization};
+use crate::player_ratings::PlayerSummary;
 use crate::x1_paths::{kifu_by_id_meta_key, kifu_by_id_object_key};
 
 const DEFAULT_LIMIT: u32 = 50;
 const MAX_LIMIT: u32 = 100;
 const MIN_LIMIT: u32 = 1;
+const PLAYER_GAMES_PREDICATE: &str = "((black_player_id = ? OR black_player_id IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)) OR (white_player_id = ? OR white_player_id IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)))";
 
-/// `/api/v1/games[/...]` 配下のリクエストを判定して該当ハンドラに振り分ける。
+/// `/api/v1/games[/...]` / `/api/v1/players[/...]` を判定してハンドラに振り分ける。
 ///
 /// 戻り値 `Some(_)` はマッチしたことを示す。`None` の場合は既存ルーティングに
 /// 引き継ぐ (404 までの fallthrough)。
@@ -132,6 +138,14 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
         return Ok(Some(handle_options(req, env)?));
     }
 
+    if method == Method::Post {
+        let url = req.url()?;
+        if url.path() == "/api/v1/admin/player-ratings/warmup" {
+            return Ok(Some(handle_player_ratings_warmup(req, env).await?));
+        }
+        return Ok(None);
+    }
+
     if method != Method::Get {
         return Ok(None);
     }
@@ -144,6 +158,16 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
     let url = req.url()?;
     let path = url.path().to_owned();
 
+    if path == "/api/v1/players" {
+        return Ok(Some(handle_players(req, env).await?));
+    }
+    if let Some(player_id) = path.strip_prefix("/api/v1/players/") {
+        if player_id.is_empty() || player_id.contains('/') {
+            let resp = no_store_error("Not Found", 404)?;
+            return Ok(Some(with_cors(resp, req, env)?));
+        }
+        return Ok(Some(handle_player_detail(req, env, &url, player_id).await?));
+    }
     if path == "/api/v1/games" {
         return Ok(Some(handle_list(req, env, &url).await?));
     }
@@ -174,11 +198,16 @@ pub async fn try_handle(req: &Request, env: &Env) -> Result<Option<Response>> {
 /// viewer 配信 API 配下のパスかどうかを判定する純粋ロジック。
 ///
 /// `OPTIONS` preflight 経路で対象パスをゲートするためにも使用する。
-/// `/api/v1/games` (一覧)、`/api/v1/games/live` (live 一覧)、検索、
-/// `/api/v1/games/<id>` (単局) のみを true とする。
+/// games 一覧 / live / 検索 / 単局、および players 一覧 / 詳細のみ true とする。
 fn is_viewer_api_path(path: &str) -> bool {
-    if matches!(path, "/api/v1/games" | "/api/v1/games/live" | "/api/v1/games/search") {
+    if matches!(
+        path,
+        "/api/v1/games" | "/api/v1/games/live" | "/api/v1/games/search" | "/api/v1/players"
+    ) {
         return true;
+    }
+    if let Some(rest) = path.strip_prefix("/api/v1/players/") {
+        return !rest.is_empty() && !rest.contains('/');
     }
     if let Some(rest) = path.strip_prefix("/api/v1/games/") {
         return !rest.is_empty() && !rest.contains('/');
@@ -251,6 +280,272 @@ struct SearchResponse {
     page: u32,
     page_size: u32,
     total_count: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct PlayersResponse {
+    players: Vec<PlayerSummary>,
+}
+
+#[derive(Debug, Serialize)]
+struct PlayerDetailResponse {
+    player: PlayerSummary,
+    games: Vec<SearchGameSummary>,
+    page: u32,
+    page_size: u32,
+    total_count: u64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ActiveGenerationRow {
+    active_generation: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MaterializedPlayerRow {
+    player_id: String,
+    display_name: String,
+    rating: f64,
+    wins: u64,
+    losses: u64,
+    draws: u64,
+    games: u64,
+    last_played_at_ms: u64,
+    legacy: i64,
+}
+
+impl From<MaterializedPlayerRow> for PlayerSummary {
+    fn from(row: MaterializedPlayerRow) -> Self {
+        Self {
+            player_id: row.player_id,
+            display_name: row.display_name,
+            rating: row.rating,
+            wins: row.wins,
+            losses: row.losses,
+            draws: row.draws,
+            games: row.games,
+            last_played_at_ms: row.last_played_at_ms,
+            legacy: row.legacy != 0,
+        }
+    }
+}
+
+fn parse_page_params(url: &Url) -> std::result::Result<(u32, u32), String> {
+    let mut page = 1;
+    let mut page_size = DEFAULT_PAGE_SIZE;
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "page" => {
+                page = value.parse().map_err(|_| "page must be a positive integer")?;
+            }
+            "pageSize" => {
+                page_size =
+                    value.parse().map_err(|_| format!("pageSize must be 1..={MAX_PAGE_SIZE}"))?;
+            }
+            _ => {}
+        }
+    }
+    validate_pagination(page, page_size)?;
+    Ok((page, page_size))
+}
+
+async fn active_generation(db: &worker::D1Database) -> std::result::Result<Option<i64>, String> {
+    db.prepare("SELECT active_generation FROM player_rating_state WHERE singleton = 1")
+        .first::<ActiveGenerationRow>(None)
+        .await
+        .map(|row| row.and_then(|row| row.active_generation))
+        .map_err(|e| e.to_string())
+}
+
+async fn handle_players(req: &Request, env: &Env) -> Result<Response> {
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+    let db = match env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING) {
+        Ok(db) => db,
+        Err(e) => {
+            log_viewer_api_failed("players_binding", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let generation = match active_generation(&db).await {
+        Ok(Some(generation)) => generation,
+        Ok(None) => return with_cors(no_store_error("Ratings warming up", 503)?, req, env),
+        Err(e) => {
+            log_viewer_api_failed("players_state", &extract_client_kind(req), &e);
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let values = [worker::wasm_bindgen::JsValue::from_f64(generation as f64)];
+    let rows = match db
+        .prepare("SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? ORDER BY rating DESC, player_id ASC")
+        .bind(&values)?
+        .all()
+        .await
+        .and_then(|result| result.results::<MaterializedPlayerRow>())
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            log_viewer_api_failed("players_query", &extract_client_kind(req), &e.to_string());
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let mut response = Response::from_json(&PlayersResponse {
+        players: rows.into_iter().map(PlayerSummary::from).collect(),
+    })?;
+    set_cache_control(&mut response, CacheableKind::List.cache_control_header())?;
+    with_cors(response, req, env)
+}
+
+async fn handle_player_detail(
+    req: &Request,
+    env: &Env,
+    url: &Url,
+    player_id: &str,
+) -> Result<Response> {
+    if let Some(blocked) = check_origin(req, env)? {
+        return Ok(blocked);
+    }
+    let (page, page_size) = match parse_page_params(url) {
+        Ok(values) => values,
+        Err(message) => return with_cors(no_store_error(message, 400)?, req, env),
+    };
+    let db = match env.d1(ConfigKeys::GAMES_SEARCH_DB_BINDING) {
+        Ok(db) => db,
+        Err(e) => {
+            log_viewer_api_failed(
+                "player_detail_binding",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let generation = match active_generation(&db).await {
+        Ok(Some(generation)) => generation,
+        Ok(None) => return with_cors(no_store_error("Ratings warming up", 503)?, req, env),
+        Err(e) => {
+            log_viewer_api_failed("player_detail_state", &extract_client_kind(req), &e);
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let canonical = resolve_canonical_player_id(&db, player_id).await?;
+    let player = match load_materialized_player(&db, generation, &canonical).await? {
+        Some(player) => player,
+        None => return with_cors(no_store_error("Not Found", 404)?, req, env),
+    };
+
+    // Keep bind count constant even after many rotations. The canonical alias
+    // index resolves the family inside D1 instead of loading every alias into
+    // Worker memory and binding it twice.
+    let predicate = PLAYER_GAMES_PREDICATE;
+    let family_values = [
+        worker::wasm_bindgen::JsValue::from_str(&canonical),
+        worker::wasm_bindgen::JsValue::from_str(&canonical),
+        worker::wasm_bindgen::JsValue::from_str(&canonical),
+        worker::wasm_bindgen::JsValue::from_str(&canonical),
+    ];
+    #[derive(serde::Deserialize)]
+    struct CountRow {
+        total_count: u64,
+    }
+    let count_sql =
+        format!("SELECT COUNT(*) AS total_count FROM games_search_index WHERE {predicate}");
+    let total_count = db
+        .prepare(&count_sql)
+        .bind(&family_values)?
+        .first::<CountRow>(None)
+        .await?
+        .map(|row| row.total_count)
+        .unwrap_or(0);
+    let offset = u64::from(page - 1) * u64::from(page_size);
+    let rows_sql = format!(
+        "SELECT game_id, started_at_ms, ended_at_ms, sente_name, gote_name, black_player_id, white_player_id, wire_result_kind, end_reason, moves_count, clock_json, source FROM games_search_index WHERE {predicate} ORDER BY ended_at_ms DESC, game_id ASC LIMIT ? OFFSET ?"
+    );
+    let mut row_values = family_values.to_vec();
+    row_values.push(worker::wasm_bindgen::JsValue::from_f64(f64::from(page_size)));
+    row_values.push(worker::wasm_bindgen::JsValue::from_f64(offset as f64));
+    let rows = db.prepare(&rows_sql).bind(&row_values)?.all().await?.results::<SearchRow>()?;
+    let games: std::result::Result<Vec<_>, _> =
+        rows.into_iter().map(SearchRow::into_summary).collect();
+    let games = match games {
+        Ok(games) => games,
+        Err(e) => {
+            log_viewer_api_failed(
+                "player_detail_clock_parse",
+                &extract_client_kind(req),
+                &e.to_string(),
+            );
+            return with_cors(no_store_error("Storage error", 502)?, req, env);
+        }
+    };
+    let mut response = Response::from_json(&PlayerDetailResponse {
+        player,
+        games,
+        page,
+        page_size,
+        total_count,
+    })?;
+    set_cache_control(&mut response, CacheableKind::List.cache_control_header())?;
+    with_cors(response, req, env)
+}
+
+async fn resolve_canonical_player_id(db: &worker::D1Database, player_id: &str) -> Result<String> {
+    #[derive(serde::Deserialize)]
+    struct AliasRow {
+        canonical_id: String,
+    }
+    let values = [worker::wasm_bindgen::JsValue::from_str(player_id)];
+    Ok(db
+        .prepare("SELECT canonical_id FROM player_id_aliases WHERE alias_id = ?")
+        .bind(&values)?
+        .first::<AliasRow>(None)
+        .await?
+        .map(|row| row.canonical_id)
+        .unwrap_or_else(|| player_id.to_owned()))
+}
+
+async fn load_materialized_player(
+    db: &worker::D1Database,
+    generation: i64,
+    canonical_id: &str,
+) -> Result<Option<PlayerSummary>> {
+    // rebuild 中は active snapshot が旧 canonical を持つ場合があるため、canonical
+    // または任意の旧 alias を固定 bind の subquery で選ぶ。partial building
+    // generation は読まない。
+    let values = [
+        worker::wasm_bindgen::JsValue::from_f64(generation as f64),
+        worker::wasm_bindgen::JsValue::from_str(canonical_id),
+        worker::wasm_bindgen::JsValue::from_str(canonical_id),
+        worker::wasm_bindgen::JsValue::from_str(canonical_id),
+    ];
+    Ok(db
+        .prepare("SELECT player_id, display_name, rating, wins, losses, draws, games, last_played_at_ms, legacy FROM player_rating_generations WHERE generation = ? AND (player_id = ? OR player_id IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)) ORDER BY CASE WHEN player_id = ? THEN 0 ELSE 1 END LIMIT 1")
+        .bind(&values)?
+        .first::<MaterializedPlayerRow>(None)
+        .await?
+        .map(PlayerSummary::from))
+}
+
+async fn handle_player_ratings_warmup(req: &Request, env: &Env) -> Result<Response> {
+    let authorization = req.headers().get("Authorization")?.unwrap_or_default();
+    let token = authorization.strip_prefix("Bearer ").unwrap_or("");
+    if crate::admin_auth::verify_admin_token_str(token, env).is_err() {
+        return no_store_error("Forbidden", 403);
+    }
+    // Admin warmup is an independent HTTP invocation and does not share the
+    // scheduled handler's 25-second budget.
+    let outcome = run_player_rating_materialization(env, MAX_PAGES_PER_RUN, None).await?;
+    let mut response = Response::from_json(&serde_json::json!({
+        "processed_games": outcome.processed_games,
+        "ready": outcome.active_generation.is_some() && !outcome.rebuild_in_progress,
+        "active_generation": outcome.active_generation,
+        "rebuild_in_progress": outcome.rebuild_in_progress,
+        "lease_acquired": outcome.lease_acquired,
+        "deadline_reached": outcome.deadline_reached,
+    }))?;
+    set_cache_control(&mut response, "no-store")?;
+    Ok(response)
 }
 
 fn parse_search_params(url: &Url) -> std::result::Result<SearchParams, String> {
@@ -1022,6 +1317,8 @@ mod tests {
         assert!(is_viewer_api_path("/api/v1/games/live"));
         assert!(is_viewer_api_path("/api/v1/games/search"));
         assert!(is_viewer_api_path("/api/v1/games/abc-123"));
+        assert!(is_viewer_api_path("/api/v1/players"));
+        assert!(is_viewer_api_path("/api/v1/players/p_v2_abc123"));
     }
 
     #[test]
@@ -1037,6 +1334,27 @@ mod tests {
     }
 
     #[test]
+    fn player_detail_pagination_uses_shared_bounds() {
+        for query in ["page=0", "pageSize=0", "pageSize=101"] {
+            let url =
+                Url::parse(&format!("https://example.com/api/v1/players/p_abc?{query}")).unwrap();
+            assert!(parse_page_params(&url).is_err(), "query={query}");
+        }
+        let url =
+            Url::parse("https://example.com/api/v1/players/p_abc?page=2&pageSize=100").unwrap();
+        assert_eq!(parse_page_params(&url), Ok((2, 100)));
+    }
+
+    #[test]
+    fn player_detail_alias_query_has_constant_bind_count() {
+        assert_eq!(PLAYER_GAMES_PREDICATE.matches('?').count(), 4);
+        assert!(
+            PLAYER_GAMES_PREDICATE
+                .contains("IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)")
+        );
+    }
+
+    #[test]
     fn parse_search_params_rejects_invalid_time_bounds() {
         for query in ["from=invalid", "to=-1", "to=1.5"] {
             let url =
@@ -1049,6 +1367,8 @@ mod tests {
     fn is_viewer_api_path_rejects_extra_segments_and_trailing_slash() {
         assert!(!is_viewer_api_path("/api/v1/games/"));
         assert!(!is_viewer_api_path("/api/v1/games/x/y"));
+        assert!(!is_viewer_api_path("/api/v1/players/"));
+        assert!(!is_viewer_api_path("/api/v1/players/x/y"));
         assert!(!is_viewer_api_path("/api/v2/games"));
     }
 }

--- a/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
+++ b/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
@@ -28,6 +28,7 @@ fn rating_materialization_uses_generation_swap_and_alias_index() {
         "CREATE TABLE player_rating_state",
         "active_generation INTEGER",
         "rebuild_required INTEGER NOT NULL DEFAULT 1",
+        "data_revision INTEGER NOT NULL DEFAULT 0",
         "CREATE TABLE player_id_aliases",
         "ON player_id_aliases (canonical_id, alias_id)",
     ] {
@@ -37,15 +38,21 @@ fn rating_materialization_uses_generation_swap_and_alias_index() {
     let source = repo_file("src/player_rating_materialization.rs");
     assert!(source.contains("WHERE singleton = 1 AND rebuild_required = 0"));
     assert!(source.contains("lease_until_ms <= ?"));
+    assert!(source.contains("data_revision = ?"));
+    assert!(source.contains("data_revision <> ?"));
 
     let search_index = repo_file("src/games_search_index.rs");
     assert!(search_index.contains("NOT EXISTS (SELECT 1 FROM games_search_index"));
     assert!(search_index.contains("db.batch(vec![dirty, upsert])"));
+    assert!(search_index.contains("data_revision = data_revision + 1"));
 
     let api = repo_file("src/viewer_api.rs");
     assert!(api.contains("WHERE generation = ?"));
     assert!(api.contains("COUNT(*) AS total_count FROM games_search_index"));
     assert!(api.contains("ORDER BY ended_at_ms DESC, game_id ASC LIMIT ? OFFSET ?"));
+    assert!(api.contains("COALESCE(SUM(games), 0) / 2"));
+    assert!(api.contains("players_leader"));
+    assert!(api.contains("ORDER BY rating DESC, player_id ASC LIMIT ? OFFSET ?"));
     assert!(api.contains("PLAYER_GAMES_PREDICATE"));
     assert!(api.contains("IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)"));
 

--- a/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
+++ b/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
@@ -84,6 +84,7 @@ fn deploy_workflow_applies_d1_migrations_before_each_worker_deploy() {
 fn secret_sync_validates_player_keyring_without_printing_value() {
     let workflow = repo_file("../../.github/workflows/secret-sync.yml");
     for required in [
+        "pulumi env open \"${ESC_ENV}\" --format json",
         "required_keys=(ADMIN_API_TOKEN PLAYER_ID_SECRET)",
         "utf8bytelength >= 32",
         "length <= 8",
@@ -92,5 +93,6 @@ fn secret_sync_validates_player_keyring_without_printing_value() {
     ] {
         assert!(workflow.contains(required), "secret strength gate missing {required}");
     }
+    assert!(!workflow.contains("esc env open \"${ESC_ENV}\""));
     assert!(workflow.contains("値は非表示"));
 }

--- a/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
+++ b/crates/rshogi-csa-server-workers/tests/d1_migrations_contract.rs
@@ -1,0 +1,89 @@
+//! viewer 検索 D1 migration の additive / 配線契約。
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_file(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+#[test]
+fn player_id_migration_is_additive_and_declares_both_columns() {
+    let sql = repo_file("migrations/0003_games_search_index_player_ids.sql");
+    assert!(sql.contains("ADD COLUMN black_player_id TEXT"));
+    assert!(sql.contains("ADD COLUMN white_player_id TEXT"));
+    let upper = sql.to_ascii_uppercase();
+    for forbidden in ["DROP ", "DELETE ", "TRUNCATE ", "RENAME "] {
+        assert!(!upper.contains(forbidden), "0003 must be additive; found {forbidden}");
+    }
+}
+
+#[test]
+fn rating_materialization_uses_generation_swap_and_alias_index() {
+    let sql = repo_file("migrations/0004_player_rating_materialization.sql");
+    for required in [
+        "CREATE TABLE player_rating_generations",
+        "PRIMARY KEY (generation, player_id)",
+        "CREATE TABLE player_rating_state",
+        "active_generation INTEGER",
+        "rebuild_required INTEGER NOT NULL DEFAULT 1",
+        "CREATE TABLE player_id_aliases",
+        "ON player_id_aliases (canonical_id, alias_id)",
+    ] {
+        assert!(sql.contains(required), "rating migration missing {required}");
+    }
+
+    let source = repo_file("src/player_rating_materialization.rs");
+    assert!(source.contains("WHERE singleton = 1 AND rebuild_required = 0"));
+    assert!(source.contains("lease_until_ms <= ?"));
+
+    let search_index = repo_file("src/games_search_index.rs");
+    assert!(search_index.contains("NOT EXISTS (SELECT 1 FROM games_search_index"));
+    assert!(search_index.contains("db.batch(vec![dirty, upsert])"));
+
+    let api = repo_file("src/viewer_api.rs");
+    assert!(api.contains("WHERE generation = ?"));
+    assert!(api.contains("COUNT(*) AS total_count FROM games_search_index"));
+    assert!(api.contains("ORDER BY ended_at_ms DESC, game_id ASC LIMIT ? OFFSET ?"));
+    assert!(api.contains("PLAYER_GAMES_PREDICATE"));
+    assert!(api.contains("IN (SELECT alias_id FROM player_id_aliases WHERE canonical_id = ?)"));
+
+    let scheduled = repo_file("src/lib.rs");
+    assert!(scheduled.contains("backfill::SCHEDULED_WORK_DEADLINE_MS"));
+    assert!(source.contains("deadline_reached(deadline_at_ms"));
+    assert!(api.contains("run_player_rating_materialization(env, MAX_PAGES_PER_RUN, None)"));
+}
+
+#[test]
+fn deploy_workflow_applies_d1_migrations_before_each_worker_deploy() {
+    let workflow = repo_file("../../.github/workflows/deploy-workers.yml");
+    for env in ["staging", "production"] {
+        let migration = format!(
+            "wrangler d1 migrations apply GAMES_SEARCH_DB --remote --config wrangler.{env}.toml"
+        );
+        let deploy = format!("command: deploy --config wrangler.{env}.toml");
+        let migration_pos = workflow
+            .find(&migration)
+            .unwrap_or_else(|| panic!("deploy workflow missing D1 migration command for {env}"));
+        let deploy_pos = workflow
+            .find(&deploy)
+            .unwrap_or_else(|| panic!("deploy workflow missing worker deploy for {env}"));
+        assert!(migration_pos < deploy_pos, "{env} migration must run before worker deploy");
+    }
+}
+
+#[test]
+fn secret_sync_validates_player_keyring_without_printing_value() {
+    let workflow = repo_file("../../.github/workflows/secret-sync.yml");
+    for required in [
+        "required_keys=(ADMIN_API_TOKEN PLAYER_ID_SECRET)",
+        "utf8bytelength >= 32",
+        "length <= 8",
+        "try fromjson catch null",
+        "^[a-z0-9]{1,16}$",
+    ] {
+        assert!(workflow.contains(required), "secret strength gate missing {required}");
+    }
+    assert!(workflow.contains("値は非表示"));
+}

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Miniflare, type WebSocket } from "miniflare";
@@ -83,6 +83,7 @@ export interface HarnessOptions {
   clockKind?: "countdown" | "countdown_msec" | "fischer" | "stopwatch";
   wsAllowedOrigins?: string;
   adminApiToken?: string;
+  playerIdSecret?: string;
   /// `WORKERS_HANDLE_AUTH` whitelist (issue #664) のオーバーライド。
   /// 既定は空配列 (`"[]"`) で「whitelist 未宣言」として self-claim 既定挙動を
   /// 維持する (一般 smoke は無影響)。検証時は
@@ -146,6 +147,7 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       RATE_LIMITER: { className: "RateLimiter", useSQLite: true },
     },
     r2Buckets: ["KIFU_BUCKET", "FLOODGATE_HISTORY_BUCKET"],
+    d1Databases: ["GAMES_SEARCH_DB"],
     bindings: {
       CLOCK_KIND: opts.clockKind ?? "countdown",
       TOTAL_TIME_SEC: String(opts.totalTimeSec ?? 600),
@@ -162,6 +164,8 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       // `adminApiToken: ""` を明示すること。`%%ADMIN <token>` 成功 E2E の場合は
       // 同 token を `adminApiToken` で揃えて binding する。
       ADMIN_API_TOKEN: opts.adminApiToken ?? "local-dev-admin-token-placeholder",
+      PLAYER_ID_SECRET:
+        opts.playerIdSecret ?? "local-dev-player-id-secret-placeholder",
       // `WORKERS_HANDLE_AUTH` 既定値は wrangler.toml.example と揃えた空配列で、
       // whitelist 未宣言モードとして self-claim 既定挙動を維持する。既存 smoke
       // が偶発的に handle_auth_failed に当たる経路を踏まないようにする。
@@ -212,7 +216,28 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
     defaultPersistRoot: opts.persistRoot,
   });
   await mf.ready;
+  await applyGamesSearchMigrations(mf);
   return mf;
+}
+
+async function applyGamesSearchMigrations(mf: Miniflare): Promise<void> {
+  const db = await mf.getD1Database("GAMES_SEARCH_DB");
+  const existing = await db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .bind("player_rating_state")
+    .first();
+  if (existing) return;
+  for (const name of [
+    "0001_games_search_index.sql",
+    "0002_games_index_backfill_state.sql",
+    "0003_games_search_index_player_ids.sql",
+    "0004_player_rating_materialization.sql",
+  ]) {
+    const sql = await readFile(resolve(WORKER_ROOT, "migrations", name), "utf8");
+    for (const statement of sql.split(";").map((part) => part.trim()).filter(Boolean)) {
+      await db.prepare(statement).run();
+    }
+  }
 }
 
 export async function makeTempPersistRoot(): Promise<{

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/player_ratings.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/player_ratings.test.ts
@@ -56,17 +56,24 @@ describe("miniflare smoke: materialized player ratings API", () => {
       lease_acquired: true,
     });
 
-    const list = await viewerFetch("/api/v1/players");
+    const list = await viewerFetch("/api/v1/players?page=2&pageSize=1");
     expect(list.status).toBe(200);
     const listBody = (await list.json()) as {
       players: Array<{ player_id: string; games: number; rating: number }>;
+      page: number;
+      page_size: number;
+      total_count: number;
+      total_games: number;
+      leader: { player_id: string; games: number } | null;
     };
-    expect(listBody.players.map((player) => player.player_id).sort()).toEqual([
-      "p_alice",
-      "p_bob",
-      "p_carol",
-    ]);
-    expect(listBody.players.find((player) => player.player_id === "p_alice")?.games).toBe(3);
+    expect(listBody).toMatchObject({
+      page: 2,
+      page_size: 1,
+      total_count: 3,
+      total_games: 3,
+      leader: { player_id: "p_alice", games: 3 },
+    });
+    expect(listBody.players).toHaveLength(1);
 
     // Resolve through one of 60 historical aliases. The API query uses four
     // fixed binds, so the family size cannot hit D1's parameter ceiling.
@@ -92,6 +99,72 @@ describe("miniflare smoke: materialized player ratings API", () => {
     expect(secondPage.status).toBe(200);
     const second = (await secondPage.json()) as { games: Array<{ game_id: string }> };
     expect(second.games[0]?.game_id).toBe("g2");
+  });
+
+  it("discards a page loaded before a same-game data revision change", async () => {
+    const db = await mf.getD1Database("GAMES_SEARCH_DB");
+    await db
+      .prepare(
+        "UPDATE player_rating_state SET rebuild_required = 0, building_generation = 1 WHERE singleton = 1",
+      )
+      .run();
+    const loaded = await db
+      .prepare("SELECT data_revision FROM player_rating_state WHERE singleton = 1")
+      .first<{ data_revision: number }>();
+    expect(loaded?.data_revision).toBe(0);
+
+    // This is the invariant used by every real changed game UPSERT: revision
+    // advancement and the row mutation commit atomically.
+    await db.batch([
+      db.prepare(
+        "UPDATE player_rating_state SET data_revision = data_revision + 1 WHERE singleton = 1",
+      ),
+      db.prepare("UPDATE games_search_index SET moves_count = moves_count + 1 WHERE game_id = ?").bind("g1"),
+    ]);
+
+    const expectedRevision = loaded!.data_revision;
+    await db.batch([
+      db
+        .prepare(
+          `INSERT INTO player_rating_generations
+           (generation, player_id, display_name, rating, wins, losses, draws, games,
+            last_played_at_ms, legacy)
+           SELECT 1, 'must_not_commit', 'stale', 1500, 0, 0, 0, 0, 20, 0
+           WHERE (SELECT data_revision FROM player_rating_state WHERE singleton = 1) = ?`,
+        )
+        .bind(expectedRevision),
+      db
+        .prepare(
+          "UPDATE player_rating_state SET cursor_ended_at_ms = 20, cursor_game_id = 'g1' WHERE singleton = 1 AND data_revision = ?",
+        )
+        .bind(expectedRevision),
+      db
+        .prepare(
+          "UPDATE player_rating_state SET rebuild_required = 1 WHERE singleton = 1 AND data_revision <> ?",
+        )
+        .bind(expectedRevision),
+    ]);
+
+    const stale = await db
+      .prepare("SELECT player_id FROM player_rating_generations WHERE player_id = 'must_not_commit'")
+      .first();
+    const state = await db
+      .prepare(
+        "SELECT cursor_ended_at_ms, cursor_game_id, rebuild_required, data_revision FROM player_rating_state WHERE singleton = 1",
+      )
+      .first<{
+        cursor_ended_at_ms: number;
+        cursor_game_id: string;
+        rebuild_required: number;
+        data_revision: number;
+      }>();
+    expect(stale).toBeNull();
+    expect(state).toEqual({
+      cursor_ended_at_ms: -1,
+      cursor_game_id: "",
+      rebuild_required: 1,
+      data_revision: 1,
+    });
   });
 
   async function warmup(token: string): Promise<Response> {

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/player_ratings.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/player_ratings.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Miniflare } from "miniflare";
+import { createMiniflare, makeTempPersistRoot } from "./harness.ts";
+
+describe("miniflare smoke: materialized player ratings API", () => {
+  let mf: Miniflare;
+  let cleanupPersist: () => Promise<void>;
+
+  beforeEach(async () => {
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      allowViewerApi: true,
+      adminApiToken: "ratings-admin-token",
+    });
+    const db = await mf.getD1Database("GAMES_SEARCH_DB");
+    const insert = db.prepare(
+      `INSERT INTO games_search_index
+       (game_id, sente_name, gote_name, black_player_id, white_player_id,
+        started_at_ms, ended_at_ms, result_kind, source, moves_count,
+        wire_result_kind, end_reason, clock_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const clock = JSON.stringify({ kind: "fischer", total_sec: 300, increment_sec: 5 });
+    await db.batch([
+      insert.bind("g1", "Alice", "Bob", "p_alice_old_59", "p_bob", 10, 20, "resignation", "kifu", 40, "WIN_BLACK", "RESIGN", clock),
+      insert.bind("g2", "Bob", "Alice", "p_bob", "p_alice", 30, 40, "resignation", "kifu", 42, "WIN_WHITE", "RESIGN", clock),
+      insert.bind("g3", "Alice", "Carol", "p_alice", "p_carol", 50, 60, "draw", "kifu", 60, "DRAW", "SENNICHITE", clock),
+    ]);
+    const aliasInsert = db.prepare(
+      "INSERT INTO player_id_aliases (alias_id, canonical_id) VALUES (?, ?)",
+    );
+    await db.batch(
+      Array.from({ length: 60 }, (_, index) =>
+        aliasInsert.bind(`p_alice_old_${index}`, "p_alice"),
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    if (mf) await mf.dispose();
+    if (cleanupPersist) await cleanupPersist();
+  });
+
+  it("authenticates warmup then serves list and paginated detail from active generation", async () => {
+    const denied = await warmup("wrong-token");
+    expect(denied.status).toBe(403);
+
+    const warmed = await warmup("ratings-admin-token");
+    expect(warmed.status).toBe(200);
+    expect(await warmed.json()).toMatchObject({
+      processed_games: 3,
+      ready: true,
+      rebuild_in_progress: false,
+      lease_acquired: true,
+    });
+
+    const list = await viewerFetch("/api/v1/players");
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as {
+      players: Array<{ player_id: string; games: number; rating: number }>;
+    };
+    expect(listBody.players.map((player) => player.player_id).sort()).toEqual([
+      "p_alice",
+      "p_bob",
+      "p_carol",
+    ]);
+    expect(listBody.players.find((player) => player.player_id === "p_alice")?.games).toBe(3);
+
+    // Resolve through one of 60 historical aliases. The API query uses four
+    // fixed binds, so the family size cannot hit D1's parameter ceiling.
+    const firstPage = await viewerFetch("/api/v1/players/p_alice_old_0?page=1&pageSize=1");
+    expect(firstPage.status).toBe(200);
+    const first = (await firstPage.json()) as {
+      player: { player_id: string };
+      games: Array<{ game_id: string }>;
+      page: number;
+      page_size: number;
+      total_count: number;
+    };
+    expect(first).toMatchObject({
+      player: { player_id: "p_alice" },
+      page: 1,
+      page_size: 1,
+      total_count: 3,
+    });
+    expect(first.games).toHaveLength(1);
+    expect(first.games[0]?.game_id).toBe("g3");
+
+    const secondPage = await viewerFetch("/api/v1/players/p_alice?page=2&pageSize=1");
+    expect(secondPage.status).toBe(200);
+    const second = (await secondPage.json()) as { games: Array<{ game_id: string }> };
+    expect(second.games[0]?.game_id).toBe("g2");
+  });
+
+  async function warmup(token: string): Promise<Response> {
+    return mf.dispatchFetch("https://example.com/api/v1/admin/player-ratings/warmup", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  async function viewerFetch(path: string): Promise<Response> {
+    return mf.dispatchFetch(`https://example.com${path}`, {
+      headers: { Origin: "https://example.com", "X-Client": "ratings-smoke/1" },
+    });
+  }
+});

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -167,6 +167,12 @@ ADMIN_API_TOKEN = "local-dev-admin-token-placeholder"
 # (password hash を含むため公開 toml には書かない)。本テンプレートには placeholder
 # のみを残す。詳細は `docs/csa-server/admin_auth.md` §LOGIN handle whitelist 節参照。
 WORKERS_HANDLE_AUTH = "[]"
+
+# 公開用 player ID の HMAC 鍵。production / staging では32 bytes以上の単一
+# string、または versioned keyring JSON string を `wrangler secret put
+# PLAYER_ID_SECRET` で配置する。local dev 専用 placeholder（実運用値を commit
+# しないこと）。rotation 手順は docs/csa-server/deployment.md §2.5 を参照。
+PLAYER_ID_SECRET = "local-dev-player-id-secret-placeholder"
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "0"

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -208,8 +208,8 @@ token 名は環境を識別できる文字列にする:
 > "Durable Objects" 行が無くても本構成の deploy は正常動作する。
 >
 > preset の権限内訳は Cloudflare 側仕様で更新されることがあるため、token 作成
-> 直前のサマリ画面で **`Workers スクリプト:編集`** と **`Workers R2 Storage:編集`**
-> の 2 つが含まれていることを確認してから "Create Token" を押す。preset から
+> 直前のサマリ画面で **`Workers スクリプト:編集`**、**`Workers R2 Storage:編集`**、
+> **`D1:編集`** が含まれていることを確認してから "Create Token" を押す。preset から
 > どちらかが脱落していた場合は "Custom token" に切り替えて下表を反映する。
 
 詳細を絞りたい場合は "Custom token" で以下を組み合わせる:
@@ -218,6 +218,7 @@ token 名は環境を識別できる文字列にする:
 |---|---|---|
 | Account | Workers Scripts | Edit （DO migration もここで covered）|
 | Account | Workers R2 Storage | Edit |
+| Account | D1 | Edit （deploy 前の `wrangler d1 migrations apply` で必要）|
 | Account | Workers Tail | Read （`vp run tail:*` で必要）|
 | Account | Account Settings | Read |
 | User | Memberships | Read |
@@ -315,10 +316,27 @@ Required reviewers の **作成時設定** 自体は §2.4.1 / §2.4.2 の通り
 | Secret | 用途 |
 |---|---|
 | `ADMIN_API_TOKEN` | WS 内 admin command (`%%ADMIN <token>`, [#621](https://github.com/SH11235/rshogi/issues/621)) や将来の HTTP admin endpoint の認可基盤として `crate::admin_auth` から参照する static API token (Floodgate audit [#560](https://github.com/SH11235/rshogi/issues/560))。生成 / rotation / admin client フロー / 旧 `ADMIN_HANDLE` 移行手順は [`docs/csa-server/admin_auth.md`](admin_auth.md) を参照。 |
+| `PLAYER_ID_SECRET` | LOGIN の handle + password から公開用 opaque player ID を HMAC-SHA256 で導出する鍵。32 bytes 以上かつ前後空白なしの旧単一 string、または下記 versioned keyring JSON string を設定する。値をログ・R2・D1・APIへ出さない。未設定・不正時は対局を継続し handle 由来 legacy ID にフォールバックするが、credential 単位の集約が失われるため release 前に secret-sync の validation を通す。 |
 
-設定 / rotation / admin client フローはすべて
+`ADMIN_API_TOKEN` の設定 / rotation / admin client フローは
 [`docs/csa-server/admin_auth.md`](admin_auth.md) に集約してある (token 生成、
 secret 登録、rotation、削除、確認、`%%ADMIN` 受信時の応答仕様までカバー)。
+
+`PLAYER_ID_SECRET` の新規環境では versioned keyring を推奨する（実値は例示しない）:
+
+```json
+{"active_version":"v1","keys":{"v1":"<32 bytes 以上のランダム値>"}}
+```
+
+`keys` は1〜8件に制限する。全keyは32 bytes以上で、versionは
+`[a-z0-9]{1,16}` とする。
+
+rotation は旧 key を残して `active_version` と新 key を追加する。例えば v1 から
+v2 へ移すときは `keys` に v1/v2 の両方を置く。接続した選手について Worker が
+旧 version ID（旧単一 string が作った `p_<digest>` を含む）を新 canonical ID の
+alias として登録し、rating rebuild を要求する。alias 登録前に旧 key を削除すると
+credential から旧 ID を導出できず、過去結果を統合できないため、対象選手の再接続と
+§3.2.1 の rebuild 完了を確認するまでは旧 key を削除しない。
 
 整合性 test (`tests/wrangler_environment_toml_consistency.rs`) が
 `wrangler.<env>.toml` の `[vars]` に `ADMIN_API_TOKEN` 等
@@ -382,7 +400,7 @@ CI 自動 deploy 前に、ローカルから 1 度手動で deploy して動作�
   （未確定なら空のままで OK。空のままでもネイティブ CSA クライアントは Origin 欠落で
   素通し。web client 化したときだけ Origin の追加が必要）
 - 時計設定（`CLOCK_KIND` / `TOTAL_TIME_*` / `BYOYOMI_*`）を運用方針に合わせる
-- `ADMIN_API_TOKEN` を staging Cloudflare secret に登録済みか確認（§2.5 / [`admin_auth.md`](admin_auth.md)）。
+- `ADMIN_API_TOKEN` と `PLAYER_ID_SECRET` を staging Cloudflare secret に登録済みか確認（§2.5 / [`admin_auth.md`](admin_auth.md)）。
   確認: `vp exec wrangler secret list --config wrangler.staging.toml`
 
 ```bash
@@ -433,7 +451,7 @@ websocat "wss://rshogi-csa-server-workers-staging.${SUBDOMAIN}.workers.dev/ws/te
 staging で動作確認できたら production も同様に立てる。
 
 `wrangler.production.toml` の値を §3.1 と同様に確認する（bucket 名は §2.1 の
-production bucket、`ADMIN_API_TOKEN` は production secret に登録済み）。
+production bucket、`ADMIN_API_TOKEN` / `PLAYER_ID_SECRET` は production secret に登録済み）。
 
 ```bash
 cd crates/rshogi-csa-server-workers
@@ -443,6 +461,29 @@ vp run deploy:prod    # Vite+ 非使用時は `pnpm run deploy:prod`（§1 末�
 `https://rshogi-csa-server-workers.<your-subdomain>.workers.dev/` にデプロイされる。
 同様に smoke check し、`/health` URL を `rshogi-csa-server-workers-production`
 Environment の variable に登録する。
+
+### 3.2.1 player rating snapshot を warmup する
+
+D1 migration 適用直後は `active_generation` が無いため、viewer の
+`GET /api/v1/players*` は partial result を返さず `503 Ratings warming up` を返す。
+deploy 後、環境ごとに既存の `ADMIN_API_TOKEN` を Authorization header にだけ載せ、
+bounded warmup を実行する（token を query string や log に載せない）:
+
+```bash
+WORKER_URL="https://rshogi-csa-server-workers-staging.<your-subdomain>.workers.dev"
+curl --fail-with-body -X POST \
+  -H "Authorization: Bearer ${ADMIN_API_TOKEN}" \
+  "${WORKER_URL}/api/v1/admin/player-ratings/warmup"
+```
+
+レスポンスの `ready` が `true` になるまで同じ操作を繰り返す。1 回は最大180局を
+処理し、現在の既存159局は最終の短い page を検出して同じ呼び出し内で公開できる。
+cron も15分ごとに同じ bounded job を実行するが、release gate は cron 待ちにせず
+この admin endpoint を使う。cron版は他のbackfill/sweepと発火時刻から25秒の
+共有deadlineを使い、到達時はcursorを保持して次回へ継続する。admin版は独立HTTP
+requestのため共有deadlineを持たず、レスポンスの `deadline_reached` は通常false。
+初回公開後の key rotation / late insert rebuild 中は
+旧 `active_generation` を返し続け、clean な次世代が完成した時点で切り替える。
 
 ### 3.3 DO migration 確認
 
@@ -596,6 +637,36 @@ contract を拡張する必要が出たら、test 側を更新するのと doc �
 blast radius は room 単位 (1 room = 1 GameRoom DO instance) だが、
 永続 storage / schema の消滅タイミングを rollback 手順の前提にしない
 こと。
+
+#### 3.4.6 D1 `games_search_index` migration
+
+viewer の検索・選手集計が使う `GAMES_SEARCH_DB` は DO 内 SQLite とは別の D1
+database である。`wrangler deploy` は `migrations/*.sql` を自動適用しないため、
+`.github/workflows/deploy-workers.yml` は各環境の Worker deploy 直前に次を実行する:
+
+```bash
+cd crates/rshogi-csa-server-workers
+pnpm exec wrangler d1 migrations apply GAMES_SEARCH_DB --remote \
+  --config wrangler.staging.toml
+pnpm exec wrangler d1 migrations apply GAMES_SEARCH_DB --remote \
+  --config wrangler.production.toml
+```
+
+migration は既存 row を保持する additive 変更 (`ADD COLUMN` / `CREATE INDEX`) のみ
+とし、旧 Worker が追加 column を無視できるため **migration → Worker deploy** の
+順に固定する。migration が失敗した場合 workflow はそこで停止し、新 schema を
+前提とする Worker を deploy しない。
+
+手動リリース時も同じ順序で実行する。適用状況は deploy 前に次で確認できる:
+
+```bash
+pnpm exec wrangler d1 migrations list GAMES_SEARCH_DB --remote \
+  --config wrangler.staging.toml
+```
+
+D1 migration 自体は rollback されない。Worker を rollback する場合も追加 column
+と index は残置し、修正が必要なら destructive rollback SQL ではなく次番号の
+forward migration を追加する。
 
 ### 3.5 web client 化時に `WS_ALLOWED_ORIGINS` を追加する
 

--- a/docs/csa-server/iac.md
+++ b/docs/csa-server/iac.md
@@ -318,7 +318,7 @@ historical 節として残す (旧手順を急遽踏みたい emergency rotation
 │   values.workerSecrets.ADMIN_API_TOKEN  (encrypted)          │
 │   values.workerSecrets.PLAYER_ID_SECRET (encrypted)          │
 └──────────────────────────────────┬──────────────────────────┘
-                                   │ (1) esc env open --format json
+                                   │ (1) pulumi env open --format json
                                    ▼
                         ┌──────────────────────────┐
                         │ secret-sync.yml          │
@@ -370,11 +370,11 @@ Worker code 側 `env.var("KEY")` で参照される名前と一致する必要�
 `workerSecrets` キーが空 / 不在のまま `secret-sync.yml` を起動すると
 fail-closed で abort する (空 push で既存 secret を消去 / 上書きしない既定)。
 
-`esc env open --format json` は decrypt 済の **flat** JSON を吐く (top-level に
+`pulumi env open --format json` は decrypt 済の **flat** JSON を吐く (top-level に
 `workerSecrets` object が現れる、`values` 等のネストは出ない)。デバッグ時の参考:
 
 ```bash
-$ esc env open sh11235/rshogi-csa-server-workers-staging --format json
+$ pulumi env open sh11235/rshogi-csa-server-workers-staging --format json
 {
   "workerSecrets": {
     "ADMIN_API_TOKEN": "<plaintext value>",
@@ -391,16 +391,14 @@ bulk` に渡す。`workerSecrets` が `values` ネスト下にある等の構造
 ### 9.3 通常の secret 追加 / rotation 手順
 
 ```bash
-# 1. ESC env を編集して新値を投入 (standalone esc CLI 経由)
-esc env edit sh11235/rshogi-csa-server-workers-staging
+# 1. ESC env を編集して新値を投入 (Pulumi CLI 経由)
+pulumi env edit sh11235/rshogi-csa-server-workers-staging
 #   → エディタが開くので values.workerSecrets.<KEY> を fn::secret で追加 / 更新
 #   (詳細は https://www.pulumi.com/docs/esc/cli/commands/esc_env_edit/ 参照)
-#   ※ Pulumi CLI を入れているなら `pulumi env edit ...` でも同等
 
 # 2. ESC 単体で値を確認 (workflow を流さずに dry-run したい場合)
-esc env open sh11235/rshogi-csa-server-workers-staging --format json | \
+pulumi env open sh11235/rshogi-csa-server-workers-staging --format json | \
     jq '.workerSecrets | keys'
-#   ※ workflow と同じ standalone `esc` CLI を使う。Pulumi CLI 経由なら `pulumi env open ...`
 
 # 3. workflow_dispatch で wrangler 同期を kick
 gh workflow run secret-sync.yml --repo SH11235/rshogi -f environment=staging
@@ -420,13 +418,13 @@ production も同手順で `staging` を `production` に置換するだけ。
 ### 9.4 secret-sync.yml の責務範囲
 
 - **やること**:
-  - 指定 `environment` の ESC env を `esc env open --format json` で読み出す
+  - 指定 `environment` の ESC env を `pulumi env open --format json` で読み出す
   - `.workerSecrets` を flat JSON object として書き出し、`wrangler secret bulk`
     で 1 回の API 呼び出しで投入
   - `Step Summary` に同期対象の ESC env 名 / wrangler config 名 / 反映確認コマンドを残す
 - **やらないこと**:
   - Worker script 本体の deploy (= `deploy-workers.yml` の責務)
-  - ESC 側の値変更 (= 運用者が `esc env edit` で行う)
+  - ESC 側の値変更 (= 運用者が `pulumi env edit` で行う)
   - 同期失敗時の自動 rollback (= ESC 値を戻して再 dispatch する手動 rollback 運用)
 
 ### 9.5 必要 GitHub secret / 権限
@@ -443,13 +441,13 @@ production も同手順で `staging` を `production` に置換するだけ。
 ### 9.6 トラブルシュート
 
 - **`ESC env '...' does not contain a non-empty 'workerSecrets' object`**: ESC env
-  の YAML 構造が §9.2 規約に合っていない。`esc env get <env>` で `values`
+  の YAML 構造が §9.2 規約に合っていない。`pulumi env get <env>` で `values`
   ツリーを確認し、`workerSecrets` 配下にキーがあるか見る。
 - **`wrangler secret bulk` が 401 / 403**: `CLOUDFLARE_API_TOKEN` の scope に
   `Workers Scripts: Edit` が含まれていない可能性。Cloudflare dashboard で token
   scope を確認 (deploy-workers.yml が動いていれば deploy 用 scope は満たすが、
   Cloudflare 側で scope を絞った別 token を使っている場合は要拡張)。
-- **`esc env open` が "no such environment"**: ESC env 名の typo か、
+- **`pulumi env open` が "no such environment"**: ESC env 名の typo か、
   `PULUMI_ACCESS_TOKEN` の発行 org が `sh11235` 以外。`pulumi whoami` で確認。
 
 ## 10. 参考

--- a/docs/csa-server/iac.md
+++ b/docs/csa-server/iac.md
@@ -313,8 +313,10 @@ historical 節として残す (旧手順を急遽踏みたい emergency rotation
 ┌─ Pulumi ESC (sh11235 org) ──────────────────────────────────┐
 │ env: sh11235/rshogi-csa-server-workers-staging              │
 │   values.workerSecrets.ADMIN_API_TOKEN  (encrypted)          │
+│   values.workerSecrets.PLAYER_ID_SECRET (encrypted)          │
 │ env: sh11235/rshogi-csa-server-workers-production           │
 │   values.workerSecrets.ADMIN_API_TOKEN  (encrypted)          │
+│   values.workerSecrets.PLAYER_ID_SECRET (encrypted)          │
 └──────────────────────────────────┬──────────────────────────┘
                                    │ (1) esc env open --format json
                                    ▼
@@ -353,11 +355,18 @@ values:
     ADMIN_API_TOKEN:
       fn::secret:
         ciphertext: <encrypted ciphertext>
+    PLAYER_ID_SECRET:
+      fn::secret:
+        ciphertext: <encrypted ciphertext>
     # 将来 Worker secret を追加するときは workerSecrets 配下にキーを足す
 ```
 
 `values.workerSecrets` 配下のキー名がそのまま `wrangler secret bulk` に渡され、
 Worker code 側 `env.var("KEY")` で参照される名前と一致する必要がある。
+`PLAYER_ID_SECRET` は32 bytes以上の単一 string、または
+`{"active_version":"v1","keys":{"v1":"<32 bytes以上>"}}` 形式の JSON を
+格納した secret string とする。`keys` は1〜8件。keyring 内の全 version/key を workflow が値を
+表示せず検証する。rotation 時は旧 key を残す（詳細は deployment.md §2.5）。
 `workerSecrets` キーが空 / 不在のまま `secret-sync.yml` を起動すると
 fail-closed で abort する (空 push で既存 secret を消去 / 上書きしない既定)。
 
@@ -368,7 +377,8 @@ fail-closed で abort する (空 push で既存 secret を消去 / 上書きし
 $ esc env open sh11235/rshogi-csa-server-workers-staging --format json
 {
   "workerSecrets": {
-    "ADMIN_API_TOKEN": "<plaintext value>"
+    "ADMIN_API_TOKEN": "<plaintext value>",
+    "PLAYER_ID_SECRET": "<plaintext value>"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- derive opaque player IDs from CSA LOGIN credentials with a versioned HMAC keyring and rotation aliases
- materialize chronological Elo ratings in bounded D1 generations and expose player list/detail APIs
- add indexed detail pagination, authenticated warmup, additive migrations, secret validation, and deployment runbooks

## Rating contract
- initial Elo 1500, K=32, draw score 0.5
- process games by `ended_at_ms`, then `game_id`
- exclude ABORT and same-player self-play from rated W/L/D
- retain pre-ID games as explicit name-derived `legacy_` players

## Scalability and operations
- viewer reads completed materialized generations instead of replaying full history
- cron materialization shares the existing 25-second deadline; admin warmup is bounded independently
- detail queries use fixed-parameter indexed alias subqueries
- D1 migrations run before staging/production worker deployment
- `PLAYER_ID_SECRET` accepts a >=32-byte legacy string or a versioned keyring (max 8 keys); values are never logged

## Verification
- `cargo test -p rshogi-csa-server-workers --tests` (384 unit tests + all integration/contract tests)
- `cargo clippy -p rshogi-csa-server-workers --tests -- -D warnings`
- `RUSTFLAGS='' cargo check -p rshogi-csa-server-workers --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
- Miniflare ratings, one-game, and restart smoke tests (3/3)
- independent agent review: APPROVE after three review rounds
