### PR TITLE
chore(release): publish rshogi-core 0.5.0 independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ marker として `vX.Y.Z` を打つ。crates.io 上の `rshogi-core` は別系�
 運用しており、library API の互換性は core のバージョンで判断する
 (`crates/rshogi-core/Cargo.toml`)。
 
-crates.io への `rshogi-core` publish は (v1.3.0 リリース以降) `vX.Y.Z` リリース時に、
-そのタグの commit から行う。release PR では前回 publish 以降に core へ変更があれば必ず
-バージョンを bump する (publish される tarball とタグの内容を常に一致させ、「バージョン
-番号が動いていない = core 変更なし」という誤推定を防ぐため)。
+crates.io への `rshogi-core` publish は engine release とは独立して行う。前回 publish 以降の
+core 変更を公開する PR では `crates/rshogi-core/Cargo.toml` のバージョンを必ず bump し、
+その PR の merge commit から publish する。`vX.Y.Z` タグは engine 全体の release marker
+専用であり、core 単独 publish のためのタグは打たない。
 
 ## Unreleased
 
+- **rshogi-core publish 規約の訂正**: v1.3.0 で追加した「engine の `vX.Y.Z` タグと同時に、
+  そのタグから publish する」という規約を撤回。core 単独変更や engine 以外の変更だけを
+  含む期間にも core を公開できるよう、core は engine release と独立して version bump・publish
+  する。core 用の release tag は設けない。
+- **rshogi-core 0.5.0 (crates.io)**: v1.3.0 で公開した 0.4.0 以降の core 変更を公開。
+  `LayerStackBucketMode::KingRank9`、探索の修正・調整、NNUE changed-index 更新の高速化を含む。
+  将来の NNUE architecture 追加を互換な 0.5.x update で行えるよう、公開 NNUE enum を
+  `#[non_exhaustive]` に変更。
 - **gensfen resume の互換性変更**: worker temp を永続 checkpoint として扱い、完了 `game_id` の
   欠番再実行、全 worker 成果物の result 境界復旧、既定毎対局 fsync、journal による冪等な複数成果物
   finalization、正常終了 worker 成果物の fail-closed 検証、final 長・staging 中 SHA-256・PSV/sidecar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "rshogi-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "getrandom 0.3.4",

--- a/crates/rshogi-book/Cargo.toml
+++ b/crates/rshogi-book/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["games", "game-engines"]
 # default-features=false とし、standalone ビルド用の既定 edition のみ本 crate の default で足す。
 # rshogi-usi は本 crate を default-features=false で依存し、preset edition specific build 時に
 # edition-universal が unify されるのを防ぐ(rshogi-usi/Cargo.toml と同じ方針)。
-rshogi-core = { version = "0.4", path = "../rshogi-core", default-features = false }
+rshogi-core = { version = "0.5", path = "../rshogi-core", default-features = false }
 
 [features]
 # standalone(`cargo test -p rshogi-book`)時に rshogi-core を既定 edition で解決するための default。

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rshogi-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["SH11235"]
 description = "A high-performance shogi engine core library with NNUE evaluation"

--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -34,6 +34,7 @@ use super::network::NNUENetwork;
 /// - **HalfKaHmMerged**: L256/L512/L1024 を HalfKaHmMergedStack で管理
 /// - **HalfKP**: L256/L512 を HalfKPStack で管理
 /// - **LayerStacks**: 1536次元 + 9バケット
+#[non_exhaustive]
 pub enum AccumulatorStackVariant {
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitStack),

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -123,6 +123,7 @@ pub fn parse_nnue_architecture(value: &str) -> Option<NNUEArchitectureOverride> 
 
 /// LayerStacks の bucket 選択モード
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LayerStackBucketMode {
     /// 両玉の相対段で 9 バケットを選択する YaneuraOu 互換方式
     KingRank9 = 0,
@@ -321,6 +322,7 @@ pub fn reset_layer_stack_progress_kpabs_weights() {
 ///
 /// L2/L3/活性化の追加時、このenumの変更は不要。
 /// 詳細は `halfka_split/` や `halfkp/` のモジュールで管理される。
+#[non_exhaustive]
 pub enum NNUENetwork {
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitNetwork),

--- a/crates/rshogi-usi/Cargo.toml
+++ b/crates/rshogi-usi/Cargo.toml
@@ -23,7 +23,7 @@ env_logger.workspace = true
 # Local dependencies
 # rshogi-core の default features は本 crate の default で明示的に再構築する
 # (preset edition specific build 時に複数 edition が unify されるのを防ぐため)。
-rshogi-core = { version = "0.4", path = "../rshogi-core", default-features = false }
+rshogi-core = { version = "0.5", path = "../rshogi-core", default-features = false }
 # 定跡(opening book)リーダ + probe。edition を持ち込まないよう default-features=false。
 rshogi-book = { version = "0.1", path = "../rshogi-book", default-features = false }
 

--- a/crates/tools/src/bench_nnue_eval_tool.rs
+++ b/crates/tools/src/bench_nnue_eval_tool.rs
@@ -334,6 +334,7 @@ fn compute_layer_stack_bucket_index(
             get_layer_stack_progress_kpabs_weights(),
             num_buckets,
         ),
+        _ => unreachable!("unsupported LayerStack bucket mode"),
     }
 }
 


### PR DESCRIPTION
## Summary

- correct the publish policy: rshogi-core releases are independent from engine vX.Y.Z tags and do not get core-specific tags
- bump rshogi-core to 0.5.0 and update workspace dependency requirements and lockfile
- make public NNUE enums non-exhaustive so new runtime architectures can be added in compatible 0.5.x releases

## Why

The v1.3.0 policy incorrectly required core publication to coincide with an engine release tag. That fails for core-only release timing and conflicts with the repository history of independent crate version bumps.

## Validation

- cargo fmt
- cargo clippy --fix --allow-dirty --tests
- cargo test
- bash scripts/check-tracked-abs-paths.sh
- cargo publish -p rshogi-core --dry-run --allow-dirty

After merge, rshogi-core 0.5.0 will be published from the merge commit without creating a tag.