### PR TITLE
feat(nnue): make universal edition runtime-dimensional

### DIFF
--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -44,7 +44,7 @@ rayon = { version = "1.10", optional = true }
 web-time = "1"
 
 [features]
-# default は universal edition (HalfKX 全 variant + LS 全 size + 全 ext を dispatch)。
+# default は universal edition (NNUE の次元と variant をモデル header から runtime 構成)。
 # 探索経路では pass_rights / PASS NMP を無効化。
 # Web/WASM で pass ルールを使う場合は default-features=false で個別指定する。
 default = ["search-no-pass-rules", "edition-universal"]
@@ -90,7 +90,7 @@ threat-profile-cross-side = []               # profile 10: 同 side / 同種を�
 # Architecture 経路 slot (include-only 意味論)。
 # - layerstack-arch:     LayerStack network 経路を含める
 # - halfkx-arch: HalfKX family (HalfKP / HalfKa*) 経路を含める
-# 両者を同時に立てることも可 (= universal dispatch build)。
+# 固定/family edition では両者を同時に立てることも可。
 layerstack-arch     = []
 halfkx-arch = []
 
@@ -121,7 +121,8 @@ effect-bucket-3x3-kingbucketed = []
 
 # FT (Feature Transformer) 種別 slot (5 variant)。
 # LS / HalfKX どちらの family でも 5 variant 全対応。mode-specific では 1 個固定、
-# family / universal では複数 OR を許容して runtime dispatch。
+# family では複数 OR を許容して const-generic variant を runtime dispatch。
+# universal はこれらの slot を立てず、nnue-runtime-dimensions を使う。
 ft-halfkp           = []
 ft-halfka_split     = []
 ft-halfka_merged    = []
@@ -135,7 +136,7 @@ halfkx-activation-pairwise = []
 
 # Build mode sentinel (preset edition がセット、build.rs 整合性チェック用)。
 # user が直接指定するものではなく、preset edition 経由でのみ有効化される想定。
-# - mode-universal: 全 architecture × 構成 dispatch、check 緩和
+# - mode-universal: header 駆動の runtime-dimension 構成、static slot check 緩和
 # - mode-family:    family dispatch、check 部分緩和
 # - mode-specific:  単一構成 build、check 厳格 (size/activation/ft 1 個固定)
 mode-universal = []
@@ -156,15 +157,13 @@ nnue-progress-diff = []
 # 参照。各 preset は mode sentinel + 必要な atomic feature 群を bundle する。
 # 主要な build target をここで整備し、残りは需要に応じて追加する。
 
-# 全 architecture × 全構成 dispatch (default)
+# 全 architecture × 任意次元を header から runtime 構成 (default)。
+# 固定 edition の const-generic / SIMD 経路は変更しない。
 edition-universal = [
   "mode-universal",
   "nnue-runtime-dimensions",
-  "layerstack-arch", "halfkx-arch",
-  "ft-halfkp", "ft-halfka_split", "ft-halfka_merged", "ft-halfka_hm_split", "ft-halfka_hm_merged",
-  "layerstacks-1536x16x32", "layerstacks-1536x32x32", "layerstacks-768x16x32", "layerstacks-768x8x32", "layerstacks-512x16x32", "layerstacks-1024x16x32", "layerstacks-3072x16x32",
+  "halfkx-arch",
   "nnue-psqt", "nnue-threat",
-  "halfkx-activation-crelu", "halfkx-activation-screlu", "halfkx-activation-pairwise",
 ]
 
 # HalfKX family (全 FT / activation dispatch)。

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -110,6 +110,9 @@ layerstacks-3072x16x32 = []
 nnue-psqt   = []
 nnue-threat = []
 nnue-effect-bucket = []
+# universal edition 用の runtime 次元 NNUE 実装。
+# 固定 edition は const-generic 実装を使い続ける。
+nnue-runtime-dimensions = []
 
 effect-bucket-2x2-kingfixed = []
 effect-bucket-2x2-kingbucketed = []
@@ -156,6 +159,7 @@ nnue-progress-diff = []
 # 全 architecture × 全構成 dispatch (default)
 edition-universal = [
   "mode-universal",
+  "nnue-runtime-dimensions",
   "layerstack-arch", "halfkx-arch",
   "ft-halfkp", "ft-halfka_split", "ft-halfka_merged", "ft-halfka_hm_split", "ft-halfka_hm_merged",
   "layerstacks-1536x16x32", "layerstacks-1536x32x32", "layerstacks-768x16x32", "layerstacks-768x8x32", "layerstacks-512x16x32", "layerstacks-1024x16x32", "layerstacks-3072x16x32",

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -310,9 +310,11 @@ name = "rshogi_core"
 path = "src/lib.rs"
 
 # PSQT 統計ダンプツール。
-# `NetworkLayerStacks1536x16x32` のロードに `nnue-psqt` と `layerstacks-1536x16x32`
-# の両方が必要なため、`required-features` で明示する。
+# static `NetworkLayerStacks1536x16x32` のロードに必要な architecture / FT / PSQT を
+# `required-features` で明示する。default universal の dynamic 経路には依存しない。
 [[bin]]
 name = "dump_psqt_stats"
 path = "src/bin/dump_psqt_stats.rs"
-required-features = ["nnue-psqt", "layerstacks-1536x16x32"]
+required-features = [
+  "layerstack-arch", "nnue-psqt", "layerstacks-1536x16x32", "ft-halfka_hm_merged",
+]

--- a/crates/rshogi-core/build/checks.rs
+++ b/crates/rshogi-core/build/checks.rs
@@ -9,6 +9,7 @@ fn validate_feature_combination(
     has_feature: &dyn Fn(&str) -> bool,
 ) -> Result<(), String> {
     let layerstack_arch = has_feature("layerstack-arch");
+    let runtime_dimensions = has_feature("nnue-runtime-dimensions");
 
     let mode_universal = has_feature("mode-universal");
     let mode_family = has_feature("mode-family");
@@ -101,13 +102,13 @@ fn validate_feature_combination(
         ));
     }
 
-    if layerstack_arch && layerstacks_count == 0 {
+    if layerstack_arch && layerstacks_count == 0 && !runtime_dimensions {
         return Err(
             "layerstack-arch を有効化するには layerstacks-* を 1 個以上必要です。".to_string(),
         );
     }
 
-    if layerstack_arch && ft_count == 0 {
+    if layerstack_arch && ft_count == 0 && !runtime_dimensions {
         return Err("layerstack-arch を有効化するには ft-* を 1 個以上必要です。".to_string());
     }
 

--- a/crates/rshogi-core/src/bin/dump_psqt_stats.rs
+++ b/crates/rshogi-core/src/bin/dump_psqt_stats.rs
@@ -6,7 +6,8 @@
 //!
 //! 使用例:
 //! ```bash
-//! cargo run --release --bin dump_psqt_stats --features nnue-psqt -- \
+//! cargo run --release --bin dump_psqt_stats --no-default-features \
+//!   --features layerstack-arch,nnue-psqt,layerstacks-1536x16x32,ft-halfka_hm_merged -- \
 //!   /path/to/v101-100/quantised.bin \
 //!   /path/to/v101-200/quantised.bin \
 //!   /path/to/v101-380/quantised.bin

--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -15,6 +15,8 @@
 use super::accumulator::DirtyPiece;
 #[cfg(feature = "layerstack-arch")]
 use super::accumulator_layer_stacks::LayerStacksAccStack;
+#[cfg(feature = "nnue-runtime-dimensions")]
+use super::dynamic_halfkx::DynamicHalfKxStack;
 use super::halfka_hm_merged::HalfKaHmMergedStack;
 use super::halfka_hm_split::HalfKaHmSplitStack;
 use super::halfka_merged::HalfKaMergedStack;
@@ -36,6 +38,9 @@ use super::network::NNUENetwork;
 /// - **LayerStacks**: 1536次元 + 9バケット
 #[non_exhaustive]
 pub enum AccumulatorStackVariant {
+    /// Runtime-dimension HalfKX（universal edition 専用）
+    #[cfg(feature = "nnue-runtime-dimensions")]
+    DynamicHalfKx(Box<DynamicHalfKxStack>),
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitStack),
     /// HalfKaHmMerged 特徴量セット（L256/L512/L1024）
@@ -57,6 +62,10 @@ impl AccumulatorStackVariant {
     /// 指定されたネットワークのアーキテクチャに対応するスタックバリアントを生成する。
     pub fn from_network(network: &NNUENetwork) -> Self {
         match network {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            NNUENetwork::DynamicHalfKx(net) => {
+                Self::DynamicHalfKx(Box::new(DynamicHalfKxStack::new(net)))
+            }
             NNUENetwork::HalfKaSplit(net) => Self::HalfKaSplit(HalfKaSplitStack::from_network(net)),
             NNUENetwork::HalfKaHmMerged(net) => {
                 Self::HalfKaHmMerged(HalfKaHmMergedStack::from_network(net))
@@ -85,6 +94,10 @@ impl AccumulatorStackVariant {
     /// 一致しない場合は `from_network` で再作成が必要。
     pub fn matches_network(&self, network: &NNUENetwork) -> bool {
         match (self, network) {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (Self::DynamicHalfKx(stack), NNUENetwork::DynamicHalfKx(net)) => {
+                stack.l1_size() == net.l1_size()
+            }
             (Self::HalfKaSplit(stack), NNUENetwork::HalfKaSplit(net)) => {
                 stack.l1_size() == net.l1_size()
             }
@@ -115,6 +128,8 @@ impl AccumulatorStackVariant {
     #[inline]
     pub fn reset(&mut self) {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(stack) => stack.reset(),
             Self::HalfKaSplit(stack) => stack.reset(),
             Self::HalfKaHmMerged(stack) => stack.reset(),
             Self::HalfKaMerged(stack) => stack.reset(),
@@ -129,6 +144,8 @@ impl AccumulatorStackVariant {
     #[inline]
     pub fn push(&mut self, dirty_piece: DirtyPiece) {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(stack) => stack.push(dirty_piece),
             Self::HalfKaSplit(stack) => stack.push(dirty_piece),
             Self::HalfKaHmMerged(stack) => stack.push(dirty_piece),
             Self::HalfKaMerged(stack) => stack.push(dirty_piece),
@@ -146,6 +163,8 @@ impl AccumulatorStackVariant {
     #[inline]
     pub fn pop(&mut self) {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(stack) => stack.pop(),
             Self::HalfKaSplit(stack) => stack.pop(),
             Self::HalfKaHmMerged(stack) => stack.pop(),
             Self::HalfKaMerged(stack) => stack.pop(),

--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -4,19 +4,19 @@
 //!
 //! # 設計
 //!
-//! **「Accumulator は L1 だけで決まる」** を活用し、4バリアントに集約:
-//! - HalfKaSplit(HalfKaSplitStack): L256/L512/L1024 を内包
-//! - HalfKaHmMerged(HalfKaHmMergedStack): L256/L512/L1024 を内包
-//! - HalfKP(HalfKPStack): L256/L512 を内包
-//! - LayerStacks: 1536次元 + 9バケット
-//!
-//! L2/L3/活性化の追加時にこのファイルの変更は不要。
+//! 固定 edition の const-generic stack と、universal edition の runtime-dimension
+//! stack を同じ探索 API で扱う。
+
+#[cfg(feature = "nnue-runtime-dimensions")]
+use std::cell::RefCell;
 
 use super::accumulator::DirtyPiece;
 #[cfg(feature = "layerstack-arch")]
 use super::accumulator_layer_stacks::LayerStacksAccStack;
 #[cfg(feature = "nnue-runtime-dimensions")]
 use super::dynamic_halfkx::DynamicHalfKxStack;
+#[cfg(feature = "nnue-runtime-dimensions")]
+use super::dynamic_layer_stacks::DynamicLayerStacksStack;
 use super::halfka_hm_merged::HalfKaHmMergedStack;
 use super::halfka_hm_split::HalfKaHmSplitStack;
 use super::halfka_merged::HalfKaMergedStack;
@@ -29,18 +29,14 @@ use super::network::NNUENetwork;
 /// NNUEアーキテクチャに応じた適切なスタックを1つだけ保持する。
 /// これにより、メモリ使用量を削減し、do_move/undo_moveの効率を向上させる。
 ///
-/// # 4バリアント構造
-///
-/// L1 サイズのみで分類し、L2/L3/活性化は内部で処理:
-/// - **HalfKaSplit**: L256/L512/L1024 を HalfKaSplitStack で管理
-/// - **HalfKaHmMerged**: L256/L512/L1024 を HalfKaHmMergedStack で管理
-/// - **HalfKP**: L256/L512 を HalfKPStack で管理
-/// - **LayerStacks**: 1536次元 + 9バケット
 #[non_exhaustive]
 pub enum AccumulatorStackVariant {
     /// Runtime-dimension HalfKX（universal edition 専用）
     #[cfg(feature = "nnue-runtime-dimensions")]
-    DynamicHalfKx(Box<DynamicHalfKxStack>),
+    DynamicHalfKx(Box<RefCell<DynamicHalfKxStack>>),
+    /// Runtime-dimension LayerStacks（universal edition 専用）
+    #[cfg(feature = "nnue-runtime-dimensions")]
+    DynamicLayerStacks(Box<RefCell<DynamicLayerStacksStack>>),
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitStack),
     /// HalfKaHmMerged 特徴量セット（L256/L512/L1024）
@@ -64,7 +60,11 @@ impl AccumulatorStackVariant {
         match network {
             #[cfg(feature = "nnue-runtime-dimensions")]
             NNUENetwork::DynamicHalfKx(net) => {
-                Self::DynamicHalfKx(Box::new(DynamicHalfKxStack::new(net)))
+                Self::DynamicHalfKx(Box::new(RefCell::new(DynamicHalfKxStack::new(net))))
+            }
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            NNUENetwork::DynamicLayerStacks(net) => {
+                Self::DynamicLayerStacks(Box::new(RefCell::new(net.new_stack())))
             }
             NNUENetwork::HalfKaSplit(net) => Self::HalfKaSplit(HalfKaSplitStack::from_network(net)),
             NNUENetwork::HalfKaHmMerged(net) => {
@@ -96,8 +96,10 @@ impl AccumulatorStackVariant {
         match (self, network) {
             #[cfg(feature = "nnue-runtime-dimensions")]
             (Self::DynamicHalfKx(stack), NNUENetwork::DynamicHalfKx(net)) => {
-                stack.l1_size() == net.l1_size()
+                stack.borrow().l1_size() == net.l1_size()
             }
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (Self::DynamicLayerStacks(_), NNUENetwork::DynamicLayerStacks(_)) => true,
             (Self::HalfKaSplit(stack), NNUENetwork::HalfKaSplit(net)) => {
                 stack.l1_size() == net.l1_size()
             }
@@ -129,7 +131,9 @@ impl AccumulatorStackVariant {
     pub fn reset(&mut self) {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
-            Self::DynamicHalfKx(stack) => stack.reset(),
+            Self::DynamicHalfKx(stack) => stack.get_mut().reset(),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(stack) => stack.get_mut().reset(),
             Self::HalfKaSplit(stack) => stack.reset(),
             Self::HalfKaHmMerged(stack) => stack.reset(),
             Self::HalfKaMerged(stack) => stack.reset(),
@@ -145,7 +149,9 @@ impl AccumulatorStackVariant {
     pub fn push(&mut self, dirty_piece: DirtyPiece) {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
-            Self::DynamicHalfKx(stack) => stack.push(dirty_piece),
+            Self::DynamicHalfKx(stack) => stack.get_mut().push(dirty_piece),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(stack) => stack.get_mut().push(dirty_piece),
             Self::HalfKaSplit(stack) => stack.push(dirty_piece),
             Self::HalfKaHmMerged(stack) => stack.push(dirty_piece),
             Self::HalfKaMerged(stack) => stack.push(dirty_piece),
@@ -164,7 +170,9 @@ impl AccumulatorStackVariant {
     pub fn pop(&mut self) {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
-            Self::DynamicHalfKx(stack) => stack.pop(),
+            Self::DynamicHalfKx(stack) => stack.get_mut().pop(),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(stack) => stack.get_mut().pop(),
             Self::HalfKaSplit(stack) => stack.pop(),
             Self::HalfKaHmMerged(stack) => stack.pop(),
             Self::HalfKaMerged(stack) => stack.pop(),
@@ -178,7 +186,17 @@ impl AccumulatorStackVariant {
     /// 現在のバリアントがHalfKPかどうか
     #[inline]
     pub fn is_halfkp(&self) -> bool {
-        matches!(self, Self::HalfKP(_))
+        if matches!(self, Self::HalfKP(_)) {
+            return true;
+        }
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        {
+            matches!(self, Self::DynamicHalfKx(stack) if stack.borrow().is_halfkp())
+        }
+        #[cfg(not(feature = "nnue-runtime-dimensions"))]
+        {
+            false
+        }
     }
 }
 

--- a/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_stack_variant.rs
@@ -96,10 +96,12 @@ impl AccumulatorStackVariant {
         match (self, network) {
             #[cfg(feature = "nnue-runtime-dimensions")]
             (Self::DynamicHalfKx(stack), NNUENetwork::DynamicHalfKx(net)) => {
-                stack.borrow().l1_size() == net.l1_size()
+                stack.borrow().matches_network(net)
             }
             #[cfg(feature = "nnue-runtime-dimensions")]
-            (Self::DynamicLayerStacks(_), NNUENetwork::DynamicLayerStacks(_)) => true,
+            (Self::DynamicLayerStacks(stack), NNUENetwork::DynamicLayerStacks(net)) => {
+                stack.borrow().matches_network(net)
+            }
             (Self::HalfKaSplit(stack), NNUENetwork::HalfKaSplit(net)) => {
                 stack.l1_size() == net.l1_size()
             }

--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -562,6 +562,22 @@ fn activate_i32(kind: Activation, input: &[i32], output: &mut [u8]) {
 
 #[inline]
 fn add_row(acc: &mut [i16], row: &[i16]) {
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    unsafe {
+        use std::arch::wasm32::*;
+        let chunks = acc.len().min(row.len()) / 8;
+        for i in 0..chunks {
+            let offset = i * 8;
+            let a = v128_load(acc.as_ptr().add(offset).cast::<v128>());
+            let b = v128_load(row.as_ptr().add(offset).cast::<v128>());
+            v128_store(acc.as_mut_ptr().add(offset).cast::<v128>(), i16x8_add(a, b));
+        }
+        for (a, &w) in acc[chunks * 8..].iter_mut().zip(&row[chunks * 8..]) {
+            *a = a.wrapping_add(w);
+        }
+        return;
+    }
+    #[allow(unreachable_code)]
     for (a, &w) in acc.iter_mut().zip(row) {
         *a = a.wrapping_add(w);
     }
@@ -569,6 +585,22 @@ fn add_row(acc: &mut [i16], row: &[i16]) {
 
 #[inline]
 fn sub_row(acc: &mut [i16], row: &[i16]) {
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    unsafe {
+        use std::arch::wasm32::*;
+        let chunks = acc.len().min(row.len()) / 8;
+        for i in 0..chunks {
+            let offset = i * 8;
+            let a = v128_load(acc.as_ptr().add(offset).cast::<v128>());
+            let b = v128_load(row.as_ptr().add(offset).cast::<v128>());
+            v128_store(acc.as_mut_ptr().add(offset).cast::<v128>(), i16x8_sub(a, b));
+        }
+        for (a, &w) in acc[chunks * 8..].iter_mut().zip(&row[chunks * 8..]) {
+            *a = a.wrapping_sub(w);
+        }
+        return;
+    }
+    #[allow(unreachable_code)]
     for (a, &w) in acc.iter_mut().zip(row) {
         *a = a.wrapping_sub(w);
     }

--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -151,6 +151,8 @@ impl DynamicAffine {
         debug_assert!(output.len() >= self.output_dim);
 
         #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        // SAFETY: `input` covers `padded_input`, every weight row has exactly that padded
+        // length, and the four-row/output loops only load or store complete 16-byte groups.
         unsafe {
             use std::arch::wasm32::*;
 
@@ -484,6 +486,7 @@ impl DynamicHalfKxNetwork {
 
 /// Per-search runtime accumulator and preallocated inference scratch.
 pub struct DynamicHalfKxStack {
+    spec: ArchitectureSpec,
     l1: usize,
     halfkp: bool,
     current: usize,
@@ -501,6 +504,7 @@ pub struct DynamicHalfKxStack {
 impl DynamicHalfKxStack {
     pub(crate) fn new(net: &DynamicHalfKxNetwork) -> Self {
         Self {
+            spec: net.spec,
             l1: net.spec.l1,
             halfkp: net.is_halfkp(),
             current: 0,
@@ -516,8 +520,8 @@ impl DynamicHalfKxStack {
         }
     }
 
-    pub(crate) fn l1_size(&self) -> usize {
-        self.l1
+    pub(crate) fn matches_network(&self, net: &DynamicHalfKxNetwork) -> bool {
+        self.spec == net.spec
     }
     pub(crate) fn is_halfkp(&self) -> bool {
         self.halfkp
@@ -563,6 +567,8 @@ fn activate_i32(kind: Activation, input: &[i32], output: &mut [u8]) {
 #[inline]
 fn add_row(acc: &mut [i16], row: &[i16]) {
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    // SAFETY: `chunks` is bounded by both slices; each v128 access covers eight in-range
+    // i16 elements and the scalar tail starts immediately after the last vector.
     unsafe {
         use std::arch::wasm32::*;
         let chunks = acc.len().min(row.len()) / 8;
@@ -586,6 +592,8 @@ fn add_row(acc: &mut [i16], row: &[i16]) {
 #[inline]
 fn sub_row(acc: &mut [i16], row: &[i16]) {
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    // SAFETY: `chunks` is bounded by both slices; each v128 access covers eight in-range
+    // i16 elements and the scalar tail starts immediately after the last vector.
     unsafe {
         use std::arch::wasm32::*;
         let chunks = acc.len().min(row.len()) / 8;
@@ -628,8 +636,62 @@ mod tests {
     use std::io::BufReader;
 
     use super::*;
+    use crate::nnue::accumulator_stack_variant::AccumulatorStackVariant;
     use crate::nnue::halfkp::{HalfKPNetwork, HalfKPStack};
+    use crate::nnue::network::NNUENetwork;
     use crate::position::SFEN_HIRATE;
+
+    fn zero_affine(input_dim: usize, output_dim: usize) -> DynamicAffine {
+        DynamicAffine {
+            input_dim,
+            padded_input: padded_input(input_dim),
+            output_dim,
+            biases: AlignedBox::new_zeroed(output_dim),
+            weights: AlignedBox::new_zeroed(output_dim * padded_input(input_dim)),
+        }
+    }
+
+    fn test_network(spec: ArchitectureSpec) -> DynamicHalfKxNetwork {
+        let feature_set = RuntimeFeatureSet::from_spec(spec.feature_set).unwrap();
+        let dense_input = 2 * spec.l1 / spec.activation.output_dim_divisor();
+        DynamicHalfKxNetwork {
+            spec,
+            feature_set,
+            input_dimensions: feature_set.dimensions(),
+            activation: spec.activation,
+            ft_biases: AlignedBox::new_zeroed(spec.l1),
+            ft_weights: AlignedBox::new_zeroed(0),
+            l1: zero_affine(dense_input, spec.l2),
+            l2: zero_affine(spec.l2, spec.l3),
+            output: zero_affine(spec.l3, 1),
+            fv_scale: FV_SCALE,
+            qa: 127,
+        }
+    }
+
+    #[test]
+    fn stack_is_rebuilt_for_every_runtime_architecture_identity_change() {
+        let base_spec = ArchitectureSpec::new(FeatureSet::HalfKP, 8, 4, 3, Activation::CReLU);
+        let base = NNUENetwork::DynamicHalfKx(Box::new(test_network(base_spec)));
+        let stack = AccumulatorStackVariant::from_network(&base);
+        assert!(stack.matches_network(&base));
+
+        for switched_spec in [
+            ArchitectureSpec::new(FeatureSet::HalfKP, 10, 4, 3, Activation::CReLU),
+            ArchitectureSpec::new(FeatureSet::HalfKP, 8, 5, 3, Activation::CReLU),
+            ArchitectureSpec::new(FeatureSet::HalfKP, 8, 4, 5, Activation::CReLU),
+            ArchitectureSpec::new(FeatureSet::HalfKP, 8, 4, 3, Activation::SCReLU),
+            ArchitectureSpec::new(FeatureSet::HalfKP, 8, 4, 3, Activation::PairwiseCReLU),
+            ArchitectureSpec::new(FeatureSet::HalfKaHmMerged, 8, 4, 3, Activation::CReLU),
+        ] {
+            let switched = NNUENetwork::DynamicHalfKx(Box::new(test_network(switched_spec)));
+            assert!(!stack.matches_network(&switched), "switch to {switched_spec:?}");
+            assert!(
+                AccumulatorStackVariant::from_network(&switched).matches_network(&switched),
+                "replacement stack for {switched_spec:?}"
+            );
+        }
+    }
 
     /// 実ファイルを dynamic / const-generic の両方で読み、評価値を比較する。
     ///

--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -1,0 +1,534 @@
+//! Runtime-dimension HalfKX inference used by `edition-universal`.
+//!
+//! Fixed editions deliberately keep using the const-generic implementations.
+
+use std::io::{self, Read, Seek, SeekFrom};
+
+use super::accumulator::{
+    AlignedBox, DirtyPiece, IndexList, MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES,
+};
+use super::activation::{CReLU, FtActivation, PairwiseCReLU, SCReLU, default_qa_for_arch};
+use super::constants::{
+    FV_SCALE, FV_SCALE_HALFKA, MAX_ARCH_LEN, NNUE_VERSION, NNUE_VERSION_HALFKA,
+};
+use super::features::{
+    FeatureSet as FeatureSetTrait, HalfKPFeatureSet, HalfKaHmMergedFeatureSet,
+    HalfKaHmSplitFeatureSet, HalfKaMergedFeatureSet, HalfKaSplitFeatureSet,
+};
+use super::layers::padded_input;
+use super::network::{get_fv_scale_override, parse_fv_scale_from_arch};
+use super::spec::{
+    Activation, ArchitectureSpec, FeatureSet, parse_architecture, parse_feature_input_dimensions,
+};
+use crate::position::Position;
+use crate::types::{Color, Value};
+
+const STACK_CAPACITY: usize = 256;
+const MAX_RUNTIME_DIMENSION: usize = 16_384;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeFeatureSet {
+    HalfKP,
+    HalfKaHmMerged,
+    HalfKaSplit,
+    HalfKaMerged,
+    HalfKaHmSplit,
+}
+
+impl RuntimeFeatureSet {
+    fn from_spec(feature_set: FeatureSet) -> io::Result<Self> {
+        match feature_set {
+            FeatureSet::HalfKP => Ok(Self::HalfKP),
+            FeatureSet::HalfKaHmMerged => Ok(Self::HalfKaHmMerged),
+            FeatureSet::HalfKaSplit => Ok(Self::HalfKaSplit),
+            FeatureSet::HalfKaMerged => Ok(Self::HalfKaMerged),
+            FeatureSet::HalfKaHmSplit => Ok(Self::HalfKaHmSplit),
+            _ => Err(invalid_data(format!("{feature_set} is not a HalfKX feature set"))),
+        }
+    }
+
+    fn dimensions(self) -> usize {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::DIMENSIONS,
+            Self::HalfKaHmMerged => HalfKaHmMergedFeatureSet::DIMENSIONS,
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::DIMENSIONS,
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::DIMENSIONS,
+            Self::HalfKaHmSplit => HalfKaHmSplitFeatureSet::DIMENSIONS,
+        }
+    }
+
+    fn active(self, pos: &Position, perspective: Color) -> IndexList<MAX_ACTIVE_FEATURES> {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaHmMerged => {
+                HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective)
+            }
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaHmSplit => {
+                HalfKaHmSplitFeatureSet::collect_active_indices(pos, perspective)
+            }
+        }
+    }
+
+    fn changed(
+        self,
+        dirty: &DirtyPiece,
+        perspective: Color,
+        pos: &Position,
+    ) -> (IndexList<MAX_CHANGED_FEATURES>, IndexList<MAX_CHANGED_FEATURES>) {
+        let king_sq = pos.king_square(perspective);
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::collect_changed_indices(dirty, perspective, king_sq),
+            Self::HalfKaHmMerged => {
+                HalfKaHmMergedFeatureSet::collect_changed_indices(dirty, perspective, king_sq)
+            }
+            Self::HalfKaSplit => {
+                HalfKaSplitFeatureSet::collect_changed_indices(dirty, perspective, king_sq)
+            }
+            Self::HalfKaMerged => {
+                HalfKaMergedFeatureSet::collect_changed_indices(dirty, perspective, king_sq)
+            }
+            Self::HalfKaHmSplit => {
+                HalfKaHmSplitFeatureSet::collect_changed_indices(dirty, perspective, king_sq)
+            }
+        }
+    }
+
+    fn needs_refresh(self, dirty: &DirtyPiece, perspective: Color) -> bool {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaHmMerged => HalfKaHmMergedFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaHmSplit => HalfKaHmSplitFeatureSet::needs_refresh(dirty, perspective),
+        }
+    }
+}
+
+struct DynamicAffine {
+    input_dim: usize,
+    padded_input: usize,
+    output_dim: usize,
+    biases: AlignedBox<i32>,
+    weights: AlignedBox<i8>,
+}
+
+impl DynamicAffine {
+    fn read<R: Read>(reader: &mut R, input_dim: usize, output_dim: usize) -> io::Result<Self> {
+        let padded_input = padded_input(input_dim);
+        let mut biases = AlignedBox::new_zeroed(output_dim);
+        let mut buf4 = [0; 4];
+        for bias in biases.iter_mut() {
+            reader.read_exact(&mut buf4)?;
+            *bias = i32::from_le_bytes(buf4);
+        }
+        let weight_len = output_dim
+            .checked_mul(padded_input)
+            .ok_or_else(|| invalid_data("affine weight dimensions overflow"))?;
+        let mut weights = AlignedBox::new_zeroed(weight_len);
+        let mut byte = [0];
+        for weight in weights.iter_mut() {
+            reader.read_exact(&mut byte)?;
+            *weight = byte[0] as i8;
+        }
+        Ok(Self {
+            input_dim,
+            padded_input,
+            output_dim,
+            biases,
+            weights,
+        })
+    }
+
+    #[inline]
+    fn propagate(&self, input: &[u8], output: &mut [i32]) {
+        debug_assert!(input.len() >= self.padded_input);
+        debug_assert!(output.len() >= self.output_dim);
+        for (o, out) in output[..self.output_dim].iter_mut().enumerate() {
+            let row = &self.weights[o * self.padded_input..(o + 1) * self.padded_input];
+            let mut sum = self.biases[o];
+            for (&x, &w) in input[..self.input_dim].iter().zip(row) {
+                sum = sum.wrapping_add(i32::from(x) * i32::from(w));
+            }
+            *out = sum;
+        }
+    }
+}
+
+/// Runtime-dimension HalfKX network.
+pub struct DynamicHalfKxNetwork {
+    spec: ArchitectureSpec,
+    feature_set: RuntimeFeatureSet,
+    input_dimensions: usize,
+    activation: Activation,
+    ft_biases: AlignedBox<i16>,
+    ft_weights: AlignedBox<i16>,
+    l1: DynamicAffine,
+    l2: DynamicAffine,
+    output: DynamicAffine,
+    fv_scale: i32,
+    qa: i16,
+}
+
+impl DynamicHalfKxNetwork {
+    pub(crate) fn read<R: Read + Seek>(reader: &mut R) -> io::Result<Self> {
+        let file_size = reader.seek(SeekFrom::End(0))?;
+        reader.seek(SeekFrom::Start(0))?;
+
+        let mut buf4 = [0; 4];
+        reader.read_exact(&mut buf4)?;
+        let version = u32::from_le_bytes(buf4);
+        if version != NNUE_VERSION && version != NNUE_VERSION_HALFKA {
+            return Err(invalid_data(format!("unsupported HalfKX NNUE version: {version:#x}")));
+        }
+        reader.read_exact(&mut buf4)?; // structure hash
+        reader.read_exact(&mut buf4)?;
+        let arch_len = u32::from_le_bytes(buf4) as usize;
+        if arch_len == 0 || arch_len > MAX_ARCH_LEN {
+            return Err(invalid_data(format!("invalid architecture string length: {arch_len}")));
+        }
+        let mut arch = vec![0; arch_len];
+        reader.read_exact(&mut arch)?;
+        let arch = std::str::from_utf8(&arch)
+            .map_err(|_| invalid_data("architecture string is not valid UTF-8"))?;
+        if arch.contains("Factorizer") {
+            return Err(invalid_data(
+                "factorized training models must be coalesced before inference",
+            ));
+        }
+
+        let parsed = parse_architecture(arch).map_err(invalid_data)?;
+        let feature_set = RuntimeFeatureSet::from_spec(parsed.feature_set)?;
+        validate_dimension("l1", parsed.l1)?;
+        validate_dimension("l2", parsed.l2)?;
+        validate_dimension("l3", parsed.l3)?;
+        let input_dimensions = parse_feature_input_dimensions(arch)
+            .ok_or_else(|| invalid_data("HalfKX architecture is missing FT input dimensions"))?;
+        if input_dimensions != feature_set.dimensions() {
+            return Err(invalid_data(format!(
+                "FT input dimension mismatch: header={input_dimensions}, feature_set={} expects {}",
+                parsed.feature_set,
+                feature_set.dimensions()
+            )));
+        }
+        let activation = if arch.contains("PairwiseCReLU") || arch.contains("-Pairwise") {
+            Activation::PairwiseCReLU
+        } else if arch.contains("SCReLU") {
+            Activation::SCReLU
+        } else {
+            Activation::CReLU
+        };
+        let dense_input = parsed
+            .l1
+            .checked_mul(2)
+            .and_then(|v| v.checked_div(activation.output_dim_divisor()))
+            .ok_or_else(|| invalid_data("invalid FT output dimensions"))?;
+
+        reader.read_exact(&mut buf4)?; // feature transformer hash
+        let mut ft_biases = AlignedBox::new_zeroed(parsed.l1);
+        let mut buf2 = [0; 2];
+        for bias in ft_biases.iter_mut() {
+            reader.read_exact(&mut buf2)?;
+            *bias = i16::from_le_bytes(buf2);
+        }
+        let ft_weight_len = input_dimensions
+            .checked_mul(parsed.l1)
+            .ok_or_else(|| invalid_data("FT weight dimensions overflow"))?;
+        let mut ft_weights = AlignedBox::new_zeroed(ft_weight_len);
+        for weight in ft_weights.iter_mut() {
+            reader.read_exact(&mut buf2)?;
+            *weight = i16::from_le_bytes(buf2);
+        }
+
+        reader.read_exact(&mut buf4)?; // dense network hash
+        let l1 = DynamicAffine::read(reader, dense_input, parsed.l2)?;
+        let l2 = DynamicAffine::read(reader, parsed.l2, parsed.l3)?;
+        let output = DynamicAffine::read(reader, parsed.l3, 1)?;
+        let consumed = reader.stream_position()?;
+        if consumed != file_size {
+            return Err(invalid_data(format!(
+                "NNUE payload size mismatch: consumed={consumed}, file_size={file_size}"
+            )));
+        }
+
+        let fv_scale =
+            parse_fv_scale_from_arch(arch).unwrap_or(if parsed.feature_set == FeatureSet::HalfKP {
+                FV_SCALE
+            } else {
+                FV_SCALE_HALFKA
+            });
+        let qa = parse_qa(arch).unwrap_or_else(|| default_qa_for_arch(arch));
+        Ok(Self {
+            spec: ArchitectureSpec::new(
+                parsed.feature_set,
+                parsed.l1,
+                parsed.l2,
+                parsed.l3,
+                activation,
+            ),
+            feature_set,
+            input_dimensions,
+            activation,
+            ft_biases,
+            ft_weights,
+            l1,
+            l2,
+            output,
+            fv_scale,
+            qa,
+        })
+    }
+
+    pub(crate) fn spec(&self) -> ArchitectureSpec {
+        self.spec
+    }
+    pub(crate) fn l1_size(&self) -> usize {
+        self.spec.l1
+    }
+    pub(crate) fn is_halfkp(&self) -> bool {
+        self.spec.feature_set == FeatureSet::HalfKP
+    }
+
+    pub(crate) fn refresh(&self, pos: &Position, stack: &mut DynamicHalfKxStack) {
+        for perspective in [Color::Black, Color::White] {
+            self.refresh_perspective(pos, perspective, stack.current_accumulation_mut(perspective));
+        }
+        stack.computed[stack.current] = true;
+    }
+
+    fn refresh_perspective(&self, pos: &Position, perspective: Color, accumulation: &mut [i16]) {
+        accumulation.copy_from_slice(&self.ft_biases);
+        for index in self.feature_set.active(pos, perspective).iter() {
+            add_row(accumulation, self.ft_row(index));
+        }
+    }
+
+    pub(crate) fn ensure(&self, pos: &Position, stack: &mut DynamicHalfKxStack) {
+        if stack.computed[stack.current] {
+            return;
+        }
+        if stack.current == 0 || !stack.computed[stack.current - 1] {
+            self.refresh(pos, stack);
+            return;
+        }
+        let current = stack.current;
+        let dirty = stack.dirty[current];
+        for perspective in [Color::Black, Color::White] {
+            let p = perspective.index();
+            if self.feature_set.needs_refresh(&dirty, perspective) {
+                self.refresh_perspective(
+                    pos,
+                    perspective,
+                    stack.current_accumulation_mut(perspective),
+                );
+                continue;
+            }
+            let (removed, added) = self.feature_set.changed(&dirty, perspective, pos);
+            let l1 = self.spec.l1;
+            let prev_start = ((current - 1) * 2 + p) * l1;
+            let curr_start = (current * 2 + p) * l1;
+            let (before, after) = stack.accumulations.split_at_mut(curr_start);
+            let prev = &before[prev_start..prev_start + l1];
+            let curr = &mut after[..l1];
+            curr.copy_from_slice(prev);
+            for index in removed.iter() {
+                sub_row(curr, self.ft_row(index));
+            }
+            for index in added.iter() {
+                add_row(curr, self.ft_row(index));
+            }
+        }
+        stack.computed[current] = true;
+    }
+
+    pub(crate) fn evaluate(&self, pos: &Position, stack: &mut DynamicHalfKxStack) -> Value {
+        let l1 = self.spec.l1;
+        let stm = pos.side_to_move().index();
+        let opp = (!pos.side_to_move()).index();
+        let base = stack.current * 2 * l1;
+        stack.ft_raw[..l1]
+            .copy_from_slice(&stack.accumulations[base + stm * l1..base + (stm + 1) * l1]);
+        stack.ft_raw[l1..2 * l1]
+            .copy_from_slice(&stack.accumulations[base + opp * l1..base + (opp + 1) * l1]);
+        stack.ft_activated.fill(0);
+        activate_i16(
+            self.activation,
+            &stack.ft_raw[..2 * l1],
+            &mut stack.ft_activated[..self.l1.input_dim],
+            self.qa,
+        );
+        self.l1.propagate(&stack.ft_activated, &mut stack.layer_i32);
+        stack.layer_u8.fill(0);
+        activate_i32(
+            self.activation,
+            &stack.layer_i32[..self.spec.l2],
+            &mut stack.layer_u8[..self.spec.l2],
+        );
+        self.l2.propagate(&stack.layer_u8, &mut stack.layer2_i32);
+        stack.layer2_u8.fill(0);
+        activate_i32(
+            self.activation,
+            &stack.layer2_i32[..self.spec.l3],
+            &mut stack.layer2_u8[..self.spec.l3],
+        );
+        let mut output = [0];
+        self.output.propagate(&stack.layer2_u8, &mut output);
+        Value::new(output[0] / get_fv_scale_override().unwrap_or(self.fv_scale))
+    }
+
+    #[inline]
+    fn ft_row(&self, index: usize) -> &[i16] {
+        debug_assert!(index < self.input_dimensions);
+        let start = index * self.spec.l1;
+        &self.ft_weights[start..start + self.spec.l1]
+    }
+}
+
+/// Per-search runtime accumulator and preallocated inference scratch.
+pub struct DynamicHalfKxStack {
+    l1: usize,
+    current: usize,
+    accumulations: AlignedBox<i16>,
+    computed: Vec<bool>,
+    dirty: Vec<DirtyPiece>,
+    ft_raw: AlignedBox<i16>,
+    ft_activated: AlignedBox<u8>,
+    layer_i32: AlignedBox<i32>,
+    layer_u8: AlignedBox<u8>,
+    layer2_i32: AlignedBox<i32>,
+    layer2_u8: AlignedBox<u8>,
+}
+
+impl DynamicHalfKxStack {
+    pub(crate) fn new(net: &DynamicHalfKxNetwork) -> Self {
+        Self {
+            l1: net.spec.l1,
+            current: 0,
+            accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
+            computed: vec![false; STACK_CAPACITY],
+            dirty: (0..STACK_CAPACITY).map(|_| DirtyPiece::default()).collect(),
+            ft_raw: AlignedBox::new_zeroed(2 * net.spec.l1),
+            ft_activated: AlignedBox::new_zeroed(net.l1.padded_input),
+            layer_i32: AlignedBox::new_zeroed(net.spec.l2),
+            layer_u8: AlignedBox::new_zeroed(padded_input(net.spec.l2)),
+            layer2_i32: AlignedBox::new_zeroed(net.spec.l3),
+            layer2_u8: AlignedBox::new_zeroed(padded_input(net.spec.l3)),
+        }
+    }
+
+    pub(crate) fn l1_size(&self) -> usize {
+        self.l1
+    }
+    pub(crate) fn reset(&mut self) {
+        self.current = 0;
+        self.computed[0] = false;
+        self.dirty[0].clear();
+    }
+    pub(crate) fn push(&mut self, dirty: DirtyPiece) {
+        assert!(self.current + 1 < STACK_CAPACITY, "dynamic NNUE accumulator stack overflow");
+        self.current += 1;
+        self.computed[self.current] = false;
+        self.dirty[self.current] = dirty;
+    }
+    pub(crate) fn pop(&mut self) {
+        if self.current > 0 {
+            self.current -= 1;
+        }
+    }
+    fn current_accumulation_mut(&mut self, perspective: Color) -> &mut [i16] {
+        let start = (self.current * 2 + perspective.index()) * self.l1;
+        &mut self.accumulations[start..start + self.l1]
+    }
+}
+
+fn activate_i16(kind: Activation, input: &[i16], output: &mut [u8], qa: i16) {
+    match kind {
+        Activation::CReLU => CReLU::activate_i16_to_u8(input, output, qa),
+        Activation::SCReLU => SCReLU::activate_i16_to_u8(input, output, qa),
+        Activation::PairwiseCReLU => PairwiseCReLU::activate_i16_to_u8(input, output, qa),
+    }
+}
+
+fn activate_i32(kind: Activation, input: &[i32], output: &mut [u8]) {
+    match kind {
+        Activation::CReLU => CReLU::activate_i32_to_u8(input, output),
+        Activation::SCReLU => SCReLU::activate_i32_to_u8(input, output),
+        Activation::PairwiseCReLU => PairwiseCReLU::activate_i32_to_u8(input, output),
+    }
+}
+
+#[inline]
+fn add_row(acc: &mut [i16], row: &[i16]) {
+    for (a, &w) in acc.iter_mut().zip(row) {
+        *a = a.wrapping_add(w);
+    }
+}
+
+#[inline]
+fn sub_row(acc: &mut [i16], row: &[i16]) {
+    for (a, &w) in acc.iter_mut().zip(row) {
+        *a = a.wrapping_sub(w);
+    }
+}
+
+fn parse_qa(arch: &str) -> Option<i16> {
+    arch.split(',').find_map(|part| part.strip_prefix("qa=")?.parse().ok())
+}
+
+fn validate_dimension(name: &str, value: usize) -> io::Result<()> {
+    if value == 0 || value > MAX_RUNTIME_DIMENSION {
+        Err(invalid_data(format!("invalid runtime {name} dimension: {value}")))
+    } else {
+        Ok(())
+    }
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use super::*;
+    use crate::nnue::halfkp::{HalfKPNetwork, HalfKPStack};
+    use crate::position::SFEN_HIRATE;
+
+    /// 実ファイルを dynamic / const-generic の両方で読み、評価値を比較する。
+    ///
+    /// `NNUE_DYNAMIC_COMPARE_FILE` に既知形状の HalfKP net を指定して実行する。
+    #[test]
+    #[ignore]
+    fn real_halfkp_matches_const_generic() {
+        let path = std::env::var("NNUE_DYNAMIC_COMPARE_FILE")
+            .expect("set NNUE_DYNAMIC_COMPARE_FILE to a HalfKP NNUE file");
+
+        let mut dynamic_reader = BufReader::new(File::open(&path).unwrap());
+        let dynamic = DynamicHalfKxNetwork::read(&mut dynamic_reader).unwrap();
+        assert_eq!(dynamic.spec.feature_set, FeatureSet::HalfKP);
+
+        let mut static_reader = BufReader::new(File::open(&path).unwrap());
+        let static_net = HalfKPNetwork::read(
+            &mut static_reader,
+            dynamic.spec.l1,
+            dynamic.spec.l2,
+            dynamic.spec.l3,
+            dynamic.spec.activation,
+        )
+        .unwrap();
+
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).unwrap();
+        let mut dynamic_stack = DynamicHalfKxStack::new(&dynamic);
+        dynamic.refresh(&pos, &mut dynamic_stack);
+        let dynamic_value = dynamic.evaluate(&pos, &mut dynamic_stack);
+
+        let mut static_stack = HalfKPStack::from_network(&static_net);
+        static_net.refresh_accumulator(&pos, &mut static_stack);
+        let static_value = static_net.evaluate(&pos, &static_stack);
+        assert_eq!(dynamic_value, static_value);
+    }
+}

--- a/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_halfkx.rs
@@ -106,7 +106,7 @@ impl RuntimeFeatureSet {
     }
 }
 
-struct DynamicAffine {
+pub(crate) struct DynamicAffine {
     input_dim: usize,
     padded_input: usize,
     output_dim: usize,
@@ -115,7 +115,11 @@ struct DynamicAffine {
 }
 
 impl DynamicAffine {
-    fn read<R: Read>(reader: &mut R, input_dim: usize, output_dim: usize) -> io::Result<Self> {
+    pub(crate) fn read<R: Read>(
+        reader: &mut R,
+        input_dim: usize,
+        output_dim: usize,
+    ) -> io::Result<Self> {
         let padded_input = padded_input(input_dim);
         let mut biases = AlignedBox::new_zeroed(output_dim);
         let mut buf4 = [0; 4];
@@ -142,9 +146,93 @@ impl DynamicAffine {
     }
 
     #[inline]
-    fn propagate(&self, input: &[u8], output: &mut [i32]) {
+    pub(crate) fn propagate(&self, input: &[u8], output: &mut [i32]) {
         debug_assert!(input.len() >= self.padded_input);
         debug_assert!(output.len() >= self.output_dim);
+
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        unsafe {
+            use std::arch::wasm32::*;
+
+            use super::layers::{dot_i8x16_u8i8_preexpanded, haddx4, hsum_i32x4};
+
+            let chunks = self.padded_input / 16;
+            let input_ptr = input.as_ptr();
+            let weights_ptr = self.weights.as_ptr();
+            let mut output_index = 0;
+
+            while output_index + 4 <= self.output_dim {
+                let mut acc0 = i32x4_splat(0);
+                let mut acc1 = i32x4_splat(0);
+                let mut acc2 = i32x4_splat(0);
+                let mut acc3 = i32x4_splat(0);
+                let row0 = weights_ptr.add(output_index * self.padded_input);
+                let row1 = row0.add(self.padded_input);
+                let row2 = row1.add(self.padded_input);
+                let row3 = row2.add(self.padded_input);
+                for chunk in 0..chunks {
+                    let offset = chunk * 16;
+                    let input_vec = v128_load(input_ptr.add(offset).cast::<v128>());
+                    let input_lo = i16x8_extend_low_u8x16(input_vec);
+                    let input_hi = i16x8_extend_high_u8x16(input_vec);
+                    acc0 = i32x4_add(
+                        acc0,
+                        dot_i8x16_u8i8_preexpanded(
+                            input_lo,
+                            input_hi,
+                            v128_load(row0.add(offset).cast::<v128>()),
+                        ),
+                    );
+                    acc1 = i32x4_add(
+                        acc1,
+                        dot_i8x16_u8i8_preexpanded(
+                            input_lo,
+                            input_hi,
+                            v128_load(row1.add(offset).cast::<v128>()),
+                        ),
+                    );
+                    acc2 = i32x4_add(
+                        acc2,
+                        dot_i8x16_u8i8_preexpanded(
+                            input_lo,
+                            input_hi,
+                            v128_load(row2.add(offset).cast::<v128>()),
+                        ),
+                    );
+                    acc3 = i32x4_add(
+                        acc3,
+                        dot_i8x16_u8i8_preexpanded(
+                            input_lo,
+                            input_hi,
+                            v128_load(row3.add(offset).cast::<v128>()),
+                        ),
+                    );
+                }
+                let sums = haddx4(acc0, acc1, acc2, acc3);
+                let biases = v128_load(self.biases.as_ptr().add(output_index).cast::<v128>());
+                v128_store(
+                    output.as_mut_ptr().add(output_index).cast::<v128>(),
+                    i32x4_add(sums, biases),
+                );
+                output_index += 4;
+            }
+
+            while output_index < self.output_dim {
+                let mut acc = i32x4_splat(0);
+                let row = weights_ptr.add(output_index * self.padded_input);
+                for chunk in 0..chunks {
+                    let offset = chunk * 16;
+                    let input_vec = v128_load(input_ptr.add(offset).cast::<v128>());
+                    let weights_vec = v128_load(row.add(offset).cast::<v128>());
+                    acc = i32x4_add(acc, super::layers::dot_i8x16_u8i8(input_vec, weights_vec));
+                }
+                output[output_index] = self.biases[output_index] + hsum_i32x4(acc);
+                output_index += 1;
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
         for (o, out) in output[..self.output_dim].iter_mut().enumerate() {
             let row = &self.weights[o * self.padded_input..(o + 1) * self.padded_input];
             let mut sum = self.biases[o];
@@ -200,9 +288,17 @@ impl DynamicHalfKxNetwork {
 
         let parsed = parse_architecture(arch).map_err(invalid_data)?;
         let feature_set = RuntimeFeatureSet::from_spec(parsed.feature_set)?;
-        validate_dimension("l1", parsed.l1)?;
-        validate_dimension("l2", parsed.l2)?;
-        validate_dimension("l3", parsed.l3)?;
+        let detected = super::spec::detect_architecture_from_size(
+            file_size,
+            arch_len,
+            Some(parsed.feature_set),
+        );
+        let (l1_dim, l2_dim, l3_dim) = detected
+            .map(|d| (d.spec.l1, d.spec.l2, d.spec.l3))
+            .unwrap_or((parsed.l1, parsed.l2, parsed.l3));
+        validate_dimension("l1", l1_dim)?;
+        validate_dimension("l2", l2_dim)?;
+        validate_dimension("l3", l3_dim)?;
         let input_dimensions = parse_feature_input_dimensions(arch)
             .ok_or_else(|| invalid_data("HalfKX architecture is missing FT input dimensions"))?;
         if input_dimensions != feature_set.dimensions() {
@@ -219,21 +315,20 @@ impl DynamicHalfKxNetwork {
         } else {
             Activation::CReLU
         };
-        let dense_input = parsed
-            .l1
+        let dense_input = l1_dim
             .checked_mul(2)
             .and_then(|v| v.checked_div(activation.output_dim_divisor()))
             .ok_or_else(|| invalid_data("invalid FT output dimensions"))?;
 
         reader.read_exact(&mut buf4)?; // feature transformer hash
-        let mut ft_biases = AlignedBox::new_zeroed(parsed.l1);
+        let mut ft_biases = AlignedBox::new_zeroed(l1_dim);
         let mut buf2 = [0; 2];
         for bias in ft_biases.iter_mut() {
             reader.read_exact(&mut buf2)?;
             *bias = i16::from_le_bytes(buf2);
         }
         let ft_weight_len = input_dimensions
-            .checked_mul(parsed.l1)
+            .checked_mul(l1_dim)
             .ok_or_else(|| invalid_data("FT weight dimensions overflow"))?;
         let mut ft_weights = AlignedBox::new_zeroed(ft_weight_len);
         for weight in ft_weights.iter_mut() {
@@ -242,14 +337,22 @@ impl DynamicHalfKxNetwork {
         }
 
         reader.read_exact(&mut buf4)?; // dense network hash
-        let l1 = DynamicAffine::read(reader, dense_input, parsed.l2)?;
-        let l2 = DynamicAffine::read(reader, parsed.l2, parsed.l3)?;
-        let output = DynamicAffine::read(reader, parsed.l3, 1)?;
+        let l1 = DynamicAffine::read(reader, dense_input, l2_dim)?;
+        let l2 = DynamicAffine::read(reader, l2_dim, l3_dim)?;
+        let output = DynamicAffine::read(reader, l3_dim, 1)?;
         let consumed = reader.stream_position()?;
         if consumed != file_size {
-            return Err(invalid_data(format!(
-                "NNUE payload size mismatch: consumed={consumed}, file_size={file_size}"
-            )));
+            let trailing_len = (file_size - consumed) as usize;
+            let mut trailing = vec![0; trailing_len];
+            reader.read_exact(&mut trailing)?;
+            let marker = b"bullet";
+            let is_bullet_marker = trailing_len <= 64
+                && trailing.iter().enumerate().all(|(i, &b)| b == marker[i % marker.len()]);
+            if !is_bullet_marker {
+                return Err(invalid_data(format!(
+                    "NNUE payload size mismatch: consumed={consumed}, file_size={file_size}"
+                )));
+            }
         }
 
         let fv_scale =
@@ -260,13 +363,7 @@ impl DynamicHalfKxNetwork {
             });
         let qa = parse_qa(arch).unwrap_or_else(|| default_qa_for_arch(arch));
         Ok(Self {
-            spec: ArchitectureSpec::new(
-                parsed.feature_set,
-                parsed.l1,
-                parsed.l2,
-                parsed.l3,
-                activation,
-            ),
+            spec: ArchitectureSpec::new(parsed.feature_set, l1_dim, l2_dim, l3_dim, activation),
             feature_set,
             input_dimensions,
             activation,
@@ -388,6 +485,7 @@ impl DynamicHalfKxNetwork {
 /// Per-search runtime accumulator and preallocated inference scratch.
 pub struct DynamicHalfKxStack {
     l1: usize,
+    halfkp: bool,
     current: usize,
     accumulations: AlignedBox<i16>,
     computed: Vec<bool>,
@@ -404,6 +502,7 @@ impl DynamicHalfKxStack {
     pub(crate) fn new(net: &DynamicHalfKxNetwork) -> Self {
         Self {
             l1: net.spec.l1,
+            halfkp: net.is_halfkp(),
             current: 0,
             accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
             computed: vec![false; STACK_CAPACITY],
@@ -419,6 +518,9 @@ impl DynamicHalfKxStack {
 
     pub(crate) fn l1_size(&self) -> usize {
         self.l1
+    }
+    pub(crate) fn is_halfkp(&self) -> bool {
+        self.halfkp
     }
     pub(crate) fn reset(&mut self) {
         self.current = 0;
@@ -476,7 +578,7 @@ fn parse_qa(arch: &str) -> Option<i16> {
     arch.split(',').find_map(|part| part.strip_prefix("qa=")?.parse().ok())
 }
 
-fn validate_dimension(name: &str, value: usize) -> io::Result<()> {
+pub(crate) fn validate_dimension(name: &str, value: usize) -> io::Result<()> {
     if value == 0 || value > MAX_RUNTIME_DIMENSION {
         Err(invalid_data(format!("invalid runtime {name} dimension: {value}")))
     } else {

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -1,0 +1,701 @@
+//! Runtime-dimension LayerStacks inference for `edition-universal`.
+
+use std::io::{self, Read, Seek, SeekFrom};
+
+use super::accumulator::{
+    AlignedBox, DirtyPiece, IndexList, MAX_ACTIVE_FEATURES, MAX_CHANGED_FEATURES,
+};
+use super::bona_piece_effect_bucket::EffectBucketConfig;
+use super::constants::{
+    DEFAULT_NUM_BUCKETS, FV_SCALE_HALFKA, MAX_ARCH_LEN, MAX_LAYER_STACK_BUCKETS,
+    NNUE_VERSION_HALFKA, NNUE_VERSION_LAYERSTACK_NUM_BUCKETS,
+};
+use super::dynamic_halfkx::{DynamicAffine, validate_dimension};
+use super::effect_bucket_features::append_active_effect_bucket;
+use super::features::{
+    FeatureSet as FeatureSetTrait, HalfKPFeatureSet, HalfKaHmMergedFeatureSet,
+    HalfKaHmSplitFeatureSet, HalfKaMergedFeatureSet, HalfKaSplitFeatureSet,
+};
+use super::layers::padded_input;
+use super::leb128::read_compressed_tensor_i16_all;
+use super::network::{
+    LayerStackBucketMode, compute_layer_stack_progress8kpabs_bucket_index, get_fv_scale_override,
+    get_layer_stack_bucket_mode, get_layer_stack_progress_kpabs_weights, parse_fv_scale_from_arch,
+};
+use super::network_layer_stacks::compute_layer_stack_kingrank9_bucket_index;
+use super::spec::{
+    Activation, ArchitectureSpec, FeatureSet, parse_arch_dimensions,
+    parse_feature_input_dimensions, parse_feature_set_from_arch,
+};
+use crate::position::Position;
+use crate::types::{Color, Value};
+
+const STACK_CAPACITY: usize = 256;
+
+#[derive(Clone, Copy)]
+enum RuntimeLsFeature {
+    HalfKP,
+    HalfKaHmMerged,
+    HalfKaSplit,
+    HalfKaMerged,
+    HalfKaHmSplit,
+    EffectBucket(EffectBucketConfig),
+}
+
+impl RuntimeLsFeature {
+    fn dimensions(self) -> usize {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::DIMENSIONS,
+            Self::HalfKaHmMerged => HalfKaHmMergedFeatureSet::DIMENSIONS,
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::DIMENSIONS,
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::DIMENSIONS,
+            Self::HalfKaHmSplit => HalfKaHmSplitFeatureSet::DIMENSIONS,
+            Self::EffectBucket(config) => config.dimensions(),
+        }
+    }
+
+    fn active(self, pos: &Position, perspective: Color) -> IndexList<MAX_ACTIVE_FEATURES> {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaHmMerged => {
+                HalfKaHmMergedFeatureSet::collect_active_indices(pos, perspective)
+            }
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::collect_active_indices(pos, perspective),
+            Self::HalfKaHmSplit => {
+                HalfKaHmSplitFeatureSet::collect_active_indices(pos, perspective)
+            }
+            Self::EffectBucket(config) => {
+                let mut active = IndexList::new();
+                append_active_effect_bucket(pos, config, perspective, &mut active);
+                active
+            }
+        }
+    }
+
+    fn changed(
+        self,
+        dirty: &DirtyPiece,
+        perspective: Color,
+        pos: &Position,
+    ) -> Option<(IndexList<MAX_CHANGED_FEATURES>, IndexList<MAX_CHANGED_FEATURES>)> {
+        let king_sq = pos.king_square(perspective);
+        match self {
+            Self::HalfKP => {
+                Some(HalfKPFeatureSet::collect_changed_indices(dirty, perspective, king_sq))
+            }
+            Self::HalfKaHmMerged => {
+                Some(HalfKaHmMergedFeatureSet::collect_changed_indices(dirty, perspective, king_sq))
+            }
+            Self::HalfKaSplit => {
+                Some(HalfKaSplitFeatureSet::collect_changed_indices(dirty, perspective, king_sq))
+            }
+            Self::HalfKaMerged => {
+                Some(HalfKaMergedFeatureSet::collect_changed_indices(dirty, perspective, king_sq))
+            }
+            Self::HalfKaHmSplit => {
+                Some(HalfKaHmSplitFeatureSet::collect_changed_indices(dirty, perspective, king_sq))
+            }
+            Self::EffectBucket(_) => None,
+        }
+    }
+
+    fn needs_refresh(self, dirty: &DirtyPiece, perspective: Color) -> bool {
+        match self {
+            Self::HalfKP => HalfKPFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaHmMerged => HalfKaHmMergedFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaSplit => HalfKaSplitFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaMerged => HalfKaMergedFeatureSet::needs_refresh(dirty, perspective),
+            Self::HalfKaHmSplit => HalfKaHmSplitFeatureSet::needs_refresh(dirty, perspective),
+            Self::EffectBucket(_) => true,
+        }
+    }
+}
+
+struct DynamicLsBucket {
+    l1: DynamicAffine,
+    l2: DynamicAffine,
+    output: DynamicAffine,
+}
+
+/// Runtime-dimension LayerStacks network.
+pub struct DynamicLayerStacksNetwork {
+    spec: ArchitectureSpec,
+    feature: RuntimeLsFeature,
+    input_dimensions: usize,
+    num_buckets: usize,
+    ft_biases: AlignedBox<i16>,
+    ft_weights: AlignedBox<i16>,
+    psqt_biases: AlignedBox<i32>,
+    psqt_weights: AlignedBox<i32>,
+    threat_dimensions: usize,
+    threat_weights: AlignedBox<i8>,
+    buckets: Vec<DynamicLsBucket>,
+    fv_scale: i32,
+}
+
+impl DynamicLayerStacksNetwork {
+    pub(crate) fn read<R: Read + Seek>(
+        reader: &mut R,
+        psqt_override: Option<bool>,
+    ) -> io::Result<Self> {
+        let file_size = reader.seek(SeekFrom::End(0))?;
+        reader.seek(SeekFrom::Start(0))?;
+        let mut buf4 = [0; 4];
+        reader.read_exact(&mut buf4)?;
+        let version = u32::from_le_bytes(buf4);
+        if version != NNUE_VERSION_HALFKA && version != NNUE_VERSION_LAYERSTACK_NUM_BUCKETS {
+            return Err(invalid("invalid LayerStacks NNUE version"));
+        }
+        reader.read_exact(&mut buf4)?;
+        reader.read_exact(&mut buf4)?;
+        let arch_len = u32::from_le_bytes(buf4) as usize;
+        if arch_len == 0 || arch_len > MAX_ARCH_LEN {
+            return Err(invalid("invalid architecture string length"));
+        }
+        let mut arch = vec![0; arch_len];
+        reader.read_exact(&mut arch)?;
+        let arch =
+            std::str::from_utf8(&arch).map_err(|_| invalid("architecture string is not UTF-8"))?;
+        let num_buckets = if version == NNUE_VERSION_LAYERSTACK_NUM_BUCKETS {
+            reader.read_exact(&mut buf4)?;
+            u32::from_le_bytes(buf4) as usize
+        } else {
+            DEFAULT_NUM_BUCKETS
+        };
+        if !(1..=MAX_LAYER_STACK_BUCKETS).contains(&num_buckets) {
+            return Err(invalid("invalid LayerStacks bucket count"));
+        }
+
+        let (l1, l2, l3) = parse_arch_dimensions(arch);
+        if l1 == 0 || l1 % 2 != 0 || l2 < 2 || l3 == 0 {
+            return Err(invalid("invalid LayerStacks dimensions"));
+        }
+        validate_dimension("LayerStacks l1", l1)?;
+        validate_dimension("LayerStacks l2", l2)?;
+        validate_dimension("LayerStacks l3", l3)?;
+        let reported_input_dimensions = parse_feature_input_dimensions(arch)
+            .ok_or_else(|| invalid("missing FT input dimensions"))?;
+        let threat_dimensions = parse_token_usize(arch, "Threat=").unwrap_or(0);
+        if arch.contains("Threat=") && threat_dimensions == 0 {
+            return Err(invalid("malformed Threat token"));
+        }
+        #[cfg(feature = "nnue-threat")]
+        if threat_dimensions != 0 && threat_dimensions != super::threat_features::THREAT_DIMENSIONS
+        {
+            return Err(invalid(format!(
+                "Threat dimensions mismatch: model={threat_dimensions}, runtime={}",
+                super::threat_features::THREAT_DIMENSIONS
+            )));
+        }
+        #[cfg(not(feature = "nnue-threat"))]
+        if threat_dimensions != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Threat model requires nnue-threat",
+            ));
+        }
+        let input_dimensions = reported_input_dimensions
+            .checked_sub(threat_dimensions)
+            .ok_or_else(|| invalid("Threat dimensions exceed reported FT input dimensions"))?;
+        let parsed_feature = detect_feature(arch)?;
+        let feature = match parsed_feature {
+            FeatureSet::HalfKP => RuntimeLsFeature::HalfKP,
+            FeatureSet::HalfKaHmMerged => RuntimeLsFeature::HalfKaHmMerged,
+            FeatureSet::HalfKaSplit => RuntimeLsFeature::HalfKaSplit,
+            FeatureSet::HalfKaMerged => RuntimeLsFeature::HalfKaMerged,
+            FeatureSet::HalfKaHmSplit => RuntimeLsFeature::HalfKaHmSplit,
+            FeatureSet::HalfKaHmMergedEffectBucket => {
+                let config = parse_effect_config(arch)
+                    .ok_or_else(|| invalid("malformed EffectBucket token"))?;
+                RuntimeLsFeature::EffectBucket(config)
+            }
+            FeatureSet::LayerStacks => {
+                return Err(invalid("LayerStacks header does not identify its FT feature set"));
+            }
+        };
+        if input_dimensions != feature.dimensions() {
+            return Err(invalid(format!(
+                "FT input dimension mismatch: header={input_dimensions}, runtime={}",
+                feature.dimensions()
+            )));
+        }
+
+        reader.read_exact(&mut buf4)?;
+        let first = read_compressed_tensor_i16_all(reader)?;
+        let weight_len = input_dimensions
+            .checked_mul(l1)
+            .ok_or_else(|| invalid("FT dimensions overflow"))?;
+        let (bias_vec, weight_vec) = if first.len() == l1 + weight_len {
+            (first[..l1].to_vec(), first[l1..].to_vec())
+        } else if first.len() == l1 {
+            let weights = read_compressed_tensor_i16_all(reader)?;
+            if weights.len() != weight_len {
+                return Err(invalid("FT weight block size mismatch"));
+            }
+            (first, weights)
+        } else {
+            return Err(invalid("FT LEB128 block size mismatch"));
+        };
+        let mut ft_biases = AlignedBox::new_zeroed(l1);
+        ft_biases.copy_from_slice(&bias_vec);
+        let mut ft_weights = AlignedBox::new_zeroed(weight_len);
+        ft_weights.copy_from_slice(&weight_vec);
+
+        let has_psqt = psqt_override.unwrap_or_else(|| arch.contains("PSQT="));
+        let mut psqt_biases = AlignedBox::new_zeroed(if has_psqt { num_buckets } else { 0 });
+        let mut psqt_weights = AlignedBox::new_zeroed(if has_psqt {
+            input_dimensions * num_buckets
+        } else {
+            0
+        });
+        if has_psqt {
+            read_i32s(reader, &mut psqt_biases)?;
+            read_i32s(reader, &mut psqt_weights)?;
+        }
+
+        if arch.contains("ThreatProfile=") {
+            reader.read_exact(&mut buf4)?;
+            if u32::from_le_bytes(buf4) != 0 {
+                return Err(invalid(
+                    "runtime threat profiles other than profile 0 are not yet supported",
+                ));
+            }
+        }
+        let mut threat_weights: AlignedBox<i8> = AlignedBox::new_zeroed(
+            threat_dimensions
+                .checked_mul(l1)
+                .ok_or_else(|| invalid("Threat dimensions overflow"))?,
+        );
+        if !threat_weights.is_empty() {
+            let bytes = unsafe {
+                std::slice::from_raw_parts_mut(
+                    threat_weights.as_mut_ptr().cast::<u8>(),
+                    threat_weights.len(),
+                )
+            };
+            reader.read_exact(bytes)?;
+        }
+
+        let mut buckets = Vec::with_capacity(num_buckets);
+        for _ in 0..num_buckets {
+            reader.read_exact(&mut buf4)?; // per-bucket FC hash
+            buckets.push(DynamicLsBucket {
+                l1: DynamicAffine::read(reader, l1, l2)?,
+                l2: DynamicAffine::read(reader, 2 * (l2 - 1), l3)?,
+                output: DynamicAffine::read(reader, l3, 1)?,
+            });
+        }
+        let consumed = reader.stream_position()?;
+        if consumed != file_size {
+            return Err(invalid(format!(
+                "unexpected trailing LayerStacks data: consumed={consumed}, file_size={file_size}"
+            )));
+        }
+        Ok(Self {
+            spec: ArchitectureSpec::new(parsed_feature, l1, l2, l3, Activation::CReLU),
+            feature,
+            input_dimensions,
+            num_buckets,
+            ft_biases,
+            ft_weights,
+            psqt_biases,
+            psqt_weights,
+            threat_dimensions,
+            threat_weights,
+            buckets,
+            fv_scale: parse_fv_scale_from_arch(arch).unwrap_or(FV_SCALE_HALFKA),
+        })
+    }
+
+    pub(crate) fn spec(&self) -> ArchitectureSpec {
+        self.spec
+    }
+    pub(crate) fn num_buckets(&self) -> usize {
+        self.num_buckets
+    }
+    pub(crate) fn requires_board_effects(&self) -> bool {
+        matches!(self.feature, RuntimeLsFeature::EffectBucket(_))
+    }
+    pub(crate) fn new_stack(&self) -> DynamicLayerStacksStack {
+        DynamicLayerStacksStack::new(self)
+    }
+
+    pub(crate) fn refresh(&self, pos: &Position, stack: &mut DynamicLayerStacksStack) {
+        let current = stack.current;
+        for perspective in [Color::Black, Color::White] {
+            self.refresh_perspective(pos, perspective, stack);
+        }
+        stack.computed[current] = true;
+    }
+
+    fn refresh_perspective(
+        &self,
+        pos: &Position,
+        perspective: Color,
+        stack: &mut DynamicLayerStacksStack,
+    ) {
+        let current = stack.current;
+        let p = perspective.index();
+        let start = (current * 2 + p) * self.spec.l1;
+        let acc = &mut stack.accumulations[start..start + self.spec.l1];
+        acc.copy_from_slice(&self.ft_biases);
+        let psqt_start = (current * 2 + p) * self.num_buckets;
+        let psqt = &mut stack.psqt[psqt_start..psqt_start + self.num_buckets];
+        if self.psqt_biases.is_empty() {
+            psqt.fill(0);
+        } else {
+            psqt.copy_from_slice(&self.psqt_biases);
+        }
+        for index in self.feature.active(pos, perspective).iter() {
+            add_i16(acc, self.ft_row(index));
+            if !self.psqt_weights.is_empty() {
+                add_i32(
+                    psqt,
+                    &self.psqt_weights[index * self.num_buckets..(index + 1) * self.num_buckets],
+                );
+            }
+        }
+        self.refresh_threat(pos, perspective, stack);
+    }
+
+    fn refresh_threat(
+        &self,
+        pos: &Position,
+        perspective: Color,
+        stack: &mut DynamicLayerStacksStack,
+    ) {
+        let start = (stack.current * 2 + perspective.index()) * self.spec.l1;
+        let threat = &mut stack.threat_accumulations[start..start + self.spec.l1];
+        threat.fill(0);
+        if self.threat_dimensions != 0 {
+            #[cfg(feature = "nnue-threat")]
+            super::threat_features::for_each_active_threat_index(
+                pos,
+                perspective,
+                pos.king_square(perspective),
+                |idx| {
+                    let row = &self.threat_weights[idx * self.spec.l1..(idx + 1) * self.spec.l1];
+                    for (a, &w) in threat.iter_mut().zip(row) {
+                        *a = a.wrapping_add(i16::from(w));
+                    }
+                },
+            );
+        }
+    }
+
+    pub(crate) fn ensure(&self, pos: &Position, stack: &mut DynamicLayerStacksStack) {
+        if stack.computed[stack.current] {
+            return;
+        }
+        if stack.current == 0 || !stack.computed[stack.current - 1] {
+            self.refresh(pos, stack);
+            return;
+        }
+        let current = stack.current;
+        let dirty = stack.dirty[current];
+        for perspective in [Color::Black, Color::White] {
+            if self.feature.needs_refresh(&dirty, perspective) {
+                self.refresh_perspective(pos, perspective, stack);
+                continue;
+            }
+            let Some((removed, added)) = self.feature.changed(&dirty, perspective, pos) else {
+                self.refresh_perspective(pos, perspective, stack);
+                continue;
+            };
+            let p = perspective.index();
+            let l1 = self.spec.l1;
+            let prev_start = ((current - 1) * 2 + p) * l1;
+            let curr_start = (current * 2 + p) * l1;
+            let (before, after) = stack.accumulations.split_at_mut(curr_start);
+            let prev = &before[prev_start..prev_start + l1];
+            let curr = &mut after[..l1];
+            curr.copy_from_slice(prev);
+            for index in removed.iter() {
+                sub_i16(curr, self.ft_row(index));
+            }
+            for index in added.iter() {
+                add_i16(curr, self.ft_row(index));
+            }
+
+            let prev_psqt_start = ((current - 1) * 2 + p) * self.num_buckets;
+            let curr_psqt_start = (current * 2 + p) * self.num_buckets;
+            let (before, after) = stack.psqt.split_at_mut(curr_psqt_start);
+            let prev = &before[prev_psqt_start..prev_psqt_start + self.num_buckets];
+            let curr = &mut after[..self.num_buckets];
+            curr.copy_from_slice(prev);
+            if !self.psqt_weights.is_empty() {
+                for index in removed.iter() {
+                    sub_i32(
+                        curr,
+                        &self.psqt_weights
+                            [index * self.num_buckets..(index + 1) * self.num_buckets],
+                    );
+                }
+                for index in added.iter() {
+                    add_i32(
+                        curr,
+                        &self.psqt_weights
+                            [index * self.num_buckets..(index + 1) * self.num_buckets],
+                    );
+                }
+            }
+            self.refresh_threat(pos, perspective, stack);
+        }
+        stack.computed[current] = true;
+    }
+
+    pub(crate) fn evaluate(&self, pos: &Position, stack: &mut DynamicLayerStacksStack) -> Value {
+        let l1 = self.spec.l1;
+        let base = stack.current * 2 * l1;
+        let us = &stack.accumulations
+            [base + pos.side_to_move().index() * l1..base + (pos.side_to_move().index() + 1) * l1];
+        let them = &stack.accumulations[base + (!pos.side_to_move()).index() * l1
+            ..base + ((!pos.side_to_move()).index() + 1) * l1];
+        let us_threat = &stack.threat_accumulations
+            [base + pos.side_to_move().index() * l1..base + (pos.side_to_move().index() + 1) * l1];
+        let them_threat = &stack.threat_accumulations[base + (!pos.side_to_move()).index() * l1
+            ..base + ((!pos.side_to_move()).index() + 1) * l1];
+        let half = l1 / 2;
+        for i in 0..half {
+            let us0 = us[i].wrapping_add(us_threat[i]);
+            let us1 = us[half + i].wrapping_add(us_threat[half + i]);
+            let them0 = them[i].wrapping_add(them_threat[i]);
+            let them1 = them[half + i].wrapping_add(them_threat[half + i]);
+            stack.transformed[i] = ((u32::from(us0.clamp(0, 127) as u16)
+                * u32::from(us1.clamp(0, 127) as u16))
+                >> 7) as u8;
+            stack.transformed[half + i] = ((u32::from(them0.clamp(0, 127) as u16)
+                * u32::from(them1.clamp(0, 127) as u16))
+                >> 7) as u8;
+        }
+        let bucket_index = match get_layer_stack_bucket_mode() {
+            LayerStackBucketMode::KingRank9 => compute_layer_stack_kingrank9_bucket_index(
+                pos,
+                pos.side_to_move(),
+                self.num_buckets,
+            ),
+            LayerStackBucketMode::Progress8KPAbs => {
+                compute_layer_stack_progress8kpabs_bucket_index(
+                    pos,
+                    pos.side_to_move(),
+                    get_layer_stack_progress_kpabs_weights(),
+                    self.num_buckets,
+                )
+            }
+        };
+        let bucket = &self.buckets[bucket_index];
+        bucket.l1.propagate(&stack.transformed, &mut stack.l1_out);
+        let main_dim = self.spec.l2 - 1;
+        let skip = stack.l1_out[main_dim];
+        stack.l2_input.fill(0);
+        for i in 0..main_dim {
+            let v = stack.l1_out[i];
+            stack.l2_input[i] = (((i64::from(v) * i64::from(v)) >> 19).clamp(0, 127)) as u8;
+            stack.l2_input[main_dim + i] = (v >> 6).clamp(0, 127) as u8;
+        }
+        bucket.l2.propagate(&stack.l2_input, &mut stack.l2_out);
+        stack.l3_input.fill(0);
+        for (dst, &v) in stack.l3_input.iter_mut().zip(stack.l2_out.iter()) {
+            *dst = (v >> 6).clamp(0, 127) as u8;
+        }
+        let mut output = [0];
+        bucket.output.propagate(&stack.l3_input, &mut output);
+        let psqt_base = stack.current * 2 * self.num_buckets;
+        let psqt = if self.psqt_weights.is_empty() {
+            0
+        } else {
+            (stack.psqt[psqt_base + pos.side_to_move().index() * self.num_buckets + bucket_index]
+                - stack.psqt
+                    [psqt_base + (!pos.side_to_move()).index() * self.num_buckets + bucket_index])
+                / 2
+        };
+        Value::new(
+            (output[0] + skip).saturating_add(psqt)
+                / get_fv_scale_override().unwrap_or(self.fv_scale),
+        )
+    }
+
+    fn ft_row(&self, index: usize) -> &[i16] {
+        debug_assert!(index < self.input_dimensions);
+        &self.ft_weights[index * self.spec.l1..(index + 1) * self.spec.l1]
+    }
+}
+
+pub struct DynamicLayerStacksStack {
+    current: usize,
+    accumulations: AlignedBox<i16>,
+    threat_accumulations: AlignedBox<i16>,
+    psqt: AlignedBox<i32>,
+    computed: Vec<bool>,
+    dirty: Vec<DirtyPiece>,
+    transformed: AlignedBox<u8>,
+    l1_out: AlignedBox<i32>,
+    l2_input: AlignedBox<u8>,
+    l2_out: AlignedBox<i32>,
+    l3_input: AlignedBox<u8>,
+}
+
+impl DynamicLayerStacksStack {
+    fn new(net: &DynamicLayerStacksNetwork) -> Self {
+        Self {
+            current: 0,
+            accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
+            threat_accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
+            psqt: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.num_buckets),
+            computed: vec![false; STACK_CAPACITY],
+            dirty: (0..STACK_CAPACITY).map(|_| DirtyPiece::default()).collect(),
+            transformed: AlignedBox::new_zeroed(padded_input(net.spec.l1)),
+            l1_out: AlignedBox::new_zeroed(net.spec.l2),
+            l2_input: AlignedBox::new_zeroed(padded_input(2 * (net.spec.l2 - 1))),
+            l2_out: AlignedBox::new_zeroed(net.spec.l3),
+            l3_input: AlignedBox::new_zeroed(padded_input(net.spec.l3)),
+        }
+    }
+    pub(crate) fn reset(&mut self) {
+        self.current = 0;
+        self.computed[0] = false;
+        self.dirty[0].clear();
+    }
+    pub(crate) fn push(&mut self, dirty: DirtyPiece) {
+        assert!(self.current + 1 < STACK_CAPACITY, "dynamic NNUE accumulator stack overflow");
+        self.current += 1;
+        self.computed[self.current] = false;
+        self.dirty[self.current] = dirty;
+    }
+    pub(crate) fn pop(&mut self) {
+        if self.current > 0 {
+            self.current -= 1;
+        }
+    }
+}
+
+fn detect_feature(arch: &str) -> io::Result<FeatureSet> {
+    if arch.contains("EffectBucket=") || arch.contains("E4=") {
+        return Ok(FeatureSet::HalfKaHmMergedEffectBucket);
+    }
+    if let Ok(feature) = parse_feature_set_from_arch(arch)
+        && feature != FeatureSet::LayerStacks
+    {
+        return Ok(feature);
+    }
+    for (token, feature) in [
+        ("HalfKP", FeatureSet::HalfKP),
+        ("HalfKaSplit", FeatureSet::HalfKaSplit),
+        ("HalfKaMerged", FeatureSet::HalfKaMerged),
+        ("HalfKaHmSplit", FeatureSet::HalfKaHmSplit),
+        ("HalfKaHmMerged", FeatureSet::HalfKaHmMerged),
+    ] {
+        if arch.contains(token) {
+            return Ok(feature);
+        }
+    }
+    Err(invalid("unknown LayerStacks FT"))
+}
+fn parse_effect_config(arch: &str) -> Option<EffectBucketConfig> {
+    let token = arch
+        .split(',')
+        .find_map(|p| p.strip_prefix("EffectBucket=").or_else(|| p.strip_prefix("E4=")))?;
+    match token {
+        "2x2fixed" => Some(EffectBucketConfig::KINGFIXED_2X2),
+        "2x2bucketed" => Some(EffectBucketConfig::KINGBUCKETED_2X2),
+        "3x3fixed" => Some(EffectBucketConfig::KINGFIXED_3X3),
+        "3x3bucketed" => Some(EffectBucketConfig::KINGBUCKETED_3X3),
+        "4xfixed" => Some(EffectBucketConfig::KINGFIXED_2X2),
+        "4xbucketed" => Some(EffectBucketConfig::KINGBUCKETED_2X2),
+        "9xfixed" => Some(EffectBucketConfig::KINGFIXED_3X3),
+        "9xbucketed" => Some(EffectBucketConfig::KINGBUCKETED_3X3),
+        _ => None,
+    }
+}
+fn parse_token_usize(arch: &str, token: &str) -> Option<usize> {
+    arch.split(',').find_map(|p| p.strip_prefix(token))?.parse().ok()
+}
+fn read_i32s<R: Read>(reader: &mut R, dst: &mut [i32]) -> io::Result<()> {
+    let mut b = [0; 4];
+    for v in dst {
+        reader.read_exact(&mut b)?;
+        *v = i32::from_le_bytes(b);
+    }
+    Ok(())
+}
+fn add_i16(a: &mut [i16], b: &[i16]) {
+    for (a, &b) in a.iter_mut().zip(b) {
+        *a = a.wrapping_add(b);
+    }
+}
+fn sub_i16(a: &mut [i16], b: &[i16]) {
+    for (a, &b) in a.iter_mut().zip(b) {
+        *a = a.wrapping_sub(b);
+    }
+}
+fn add_i32(a: &mut [i32], b: &[i32]) {
+    for (a, &b) in a.iter_mut().zip(b) {
+        *a = a.wrapping_add(b);
+    }
+}
+fn sub_i32(a: &mut [i32], b: &[i32]) {
+    for (a, &b) in a.iter_mut().zip(b) {
+        *a = a.wrapping_sub(b);
+    }
+}
+fn invalid(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg.into())
+}
+
+#[cfg(all(test, feature = "layerstack-arch"))]
+mod tests {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use super::*;
+    use crate::nnue::network::set_layer_stack_bucket_mode;
+    use crate::nnue::network_layer_stacks::LayerStacksNetwork;
+    use crate::position::SFEN_HIRATE;
+    use crate::types::Move;
+
+    #[test]
+    #[ignore]
+    fn real_model_matches_const_generic() {
+        let path = std::env::var("NNUE_DYNAMIC_LS_COMPARE_FILE")
+            .expect("set NNUE_DYNAMIC_LS_COMPARE_FILE to a LayerStacks NNUE file");
+        let mut dynamic_reader = BufReader::new(File::open(&path).unwrap());
+        let dynamic = DynamicLayerStacksNetwork::read(&mut dynamic_reader, None).unwrap();
+
+        let mut static_reader = BufReader::new(File::open(&path).unwrap());
+        let static_net = LayerStacksNetwork::read_with_options(
+            &mut static_reader,
+            dynamic.spec.l1,
+            dynamic.spec.l2,
+            dynamic.spec.l3,
+            None,
+        )
+        .unwrap();
+
+        set_layer_stack_bucket_mode(LayerStackBucketMode::KingRank9);
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).unwrap();
+        let mut dynamic_stack = dynamic.new_stack();
+        dynamic.refresh(&pos, &mut dynamic_stack);
+        let dynamic_value = dynamic.evaluate(&pos, &mut dynamic_stack);
+
+        let mut static_stack = static_net.new_acc_stack();
+        static_net.update_accumulator(&pos, &mut static_stack, &mut None);
+        let static_value = static_net.evaluate(&pos, &static_stack);
+        assert_eq!(dynamic_value, static_value);
+
+        for move_text in ["7g7f", "3c3d", "2g2f", "8c8d", "6i7h", "4a3b"] {
+            let mv = Move::from_usi(move_text).unwrap();
+            let gives_check = pos.gives_check(mv);
+            let dirty = pos.do_move(mv, gives_check);
+            dynamic_stack.push(dirty);
+            dynamic.ensure(&pos, &mut dynamic_stack);
+            let incremental = dynamic.evaluate(&pos, &mut dynamic_stack);
+
+            let mut refreshed_stack = dynamic.new_stack();
+            dynamic.refresh(&pos, &mut refreshed_stack);
+            let refreshed = dynamic.evaluate(&pos, &mut refreshed_stack);
+            assert_eq!(incremental, refreshed, "dynamic update mismatch after {move_text}");
+        }
+    }
+}

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -32,7 +32,7 @@ use crate::types::{Color, Value};
 
 const STACK_CAPACITY: usize = 256;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RuntimeLsFeature {
     HalfKP,
     HalfKaHmMerged,
@@ -116,6 +116,17 @@ struct DynamicLsBucket {
     l1: DynamicAffine,
     l2: DynamicAffine,
     output: DynamicAffine,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DynamicLayerStacksSignature {
+    feature: RuntimeLsFeature,
+    l1: usize,
+    l2: usize,
+    l3: usize,
+    num_buckets: usize,
+    has_psqt: bool,
+    threat_dimensions: usize,
 }
 
 /// Runtime-dimension LayerStacks network.
@@ -270,6 +281,8 @@ impl DynamicLayerStacksNetwork {
                 .ok_or_else(|| invalid("Threat dimensions overflow"))?,
         );
         if !threat_weights.is_empty() {
+            // SAFETY: `i8` and `u8` have identical size/alignment, and the slice retains the
+            // exact allocation length while only its byte signedness changes for `Read`.
             let bytes = unsafe {
                 std::slice::from_raw_parts_mut(
                     threat_weights.as_mut_ptr().cast::<u8>(),
@@ -323,6 +336,17 @@ impl DynamicLayerStacksNetwork {
     }
     pub(crate) fn new_stack(&self) -> DynamicLayerStacksStack {
         DynamicLayerStacksStack::new(self)
+    }
+    fn stack_signature(&self) -> DynamicLayerStacksSignature {
+        DynamicLayerStacksSignature {
+            feature: self.feature,
+            l1: self.spec.l1,
+            l2: self.spec.l2,
+            l3: self.spec.l3,
+            num_buckets: self.num_buckets,
+            has_psqt: !self.psqt_weights.is_empty(),
+            threat_dimensions: self.threat_dimensions,
+        }
     }
 
     pub(crate) fn refresh(&self, pos: &Position, stack: &mut DynamicLayerStacksStack) {
@@ -515,6 +539,7 @@ impl DynamicLayerStacksNetwork {
 }
 
 pub struct DynamicLayerStacksStack {
+    signature: DynamicLayerStacksSignature,
     current: usize,
     accumulations: AlignedBox<i16>,
     threat_accumulations: AlignedBox<i16>,
@@ -531,6 +556,7 @@ pub struct DynamicLayerStacksStack {
 impl DynamicLayerStacksStack {
     fn new(net: &DynamicLayerStacksNetwork) -> Self {
         Self {
+            signature: net.stack_signature(),
             current: 0,
             accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
             threat_accumulations: AlignedBox::new_zeroed(STACK_CAPACITY * 2 * net.spec.l1),
@@ -543,6 +569,9 @@ impl DynamicLayerStacksStack {
             l2_out: AlignedBox::new_zeroed(net.spec.l3),
             l3_input: AlignedBox::new_zeroed(padded_input(net.spec.l3)),
         }
+    }
+    pub(crate) fn matches_network(&self, net: &DynamicLayerStacksNetwork) -> bool {
+        self.signature == net.stack_signature()
     }
     pub(crate) fn reset(&mut self) {
         self.current = 0;
@@ -613,6 +642,8 @@ fn read_i32s<R: Read>(reader: &mut R, dst: &mut [i32]) -> io::Result<()> {
 }
 fn add_i16(a: &mut [i16], b: &[i16]) {
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    // SAFETY: `chunks` is bounded by both slices; each v128 access covers eight in-range
+    // i16 elements and the scalar tail starts immediately after the last vector.
     unsafe {
         use std::arch::wasm32::*;
         let chunks = a.len().min(b.len()) / 8;
@@ -634,6 +665,8 @@ fn add_i16(a: &mut [i16], b: &[i16]) {
 }
 fn sub_i16(a: &mut [i16], b: &[i16]) {
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    // SAFETY: `chunks` is bounded by both slices; each v128 access covers eight in-range
+    // i16 elements and the scalar tail starts immediately after the last vector.
     unsafe {
         use std::arch::wasm32::*;
         let chunks = a.len().min(b.len()) / 8;
@@ -678,6 +711,8 @@ fn sqr_transform_with_threat(
     let processed = 0;
 
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    // SAFETY: all four accumulator slices have the same even L1 length and `output` has L1
+    // elements. The loop condition reserves 16 elements in each half before every load/store.
     unsafe {
         use std::arch::wasm32::*;
         let zero = i16x8_splat(0);
@@ -741,17 +776,118 @@ fn invalid(msg: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, msg.into())
 }
 
-#[cfg(all(test, feature = "layerstack-arch"))]
+#[cfg(test)]
 mod tests {
+    #[cfg(feature = "layerstack-arch")]
     use std::fs::File;
+    #[cfg(feature = "layerstack-arch")]
     use std::io::BufReader;
+    use std::io::Cursor;
+    use std::sync::Arc;
 
     use super::*;
+    use crate::nnue::accumulator_stack_variant::AccumulatorStackVariant;
+    use crate::nnue::evaluator::NNUEEvaluator;
+    use crate::nnue::network::NNUENetwork;
+    #[cfg(feature = "layerstack-arch")]
     use crate::nnue::network::set_layer_stack_bucket_mode;
+    #[cfg(feature = "layerstack-arch")]
     use crate::nnue::network_layer_stacks::LayerStacksNetwork;
     use crate::position::SFEN_HIRATE;
     use crate::types::Move;
 
+    fn zero_affine(input_dim: usize, output_dim: usize) -> DynamicAffine {
+        let bytes = vec![0; output_dim * 4 + output_dim * padded_input(input_dim)];
+        DynamicAffine::read(&mut Cursor::new(bytes), input_dim, output_dim).unwrap()
+    }
+
+    fn test_network(
+        feature: RuntimeLsFeature,
+        l1: usize,
+        l2: usize,
+        l3: usize,
+        num_buckets: usize,
+        has_psqt: bool,
+        threat_dimensions: usize,
+    ) -> DynamicLayerStacksNetwork {
+        DynamicLayerStacksNetwork {
+            spec: ArchitectureSpec::new(FeatureSet::LayerStacks, l1, l2, l3, Activation::CReLU),
+            feature,
+            input_dimensions: feature.dimensions(),
+            num_buckets,
+            ft_biases: AlignedBox::new_zeroed(l1),
+            ft_weights: AlignedBox::new_zeroed(0),
+            psqt_biases: AlignedBox::new_zeroed(usize::from(has_psqt)),
+            psqt_weights: AlignedBox::new_zeroed(usize::from(has_psqt)),
+            threat_dimensions,
+            threat_weights: AlignedBox::new_zeroed(0),
+            buckets: Vec::new(),
+            fv_scale: FV_SCALE_HALFKA,
+        }
+    }
+
+    #[test]
+    fn stack_is_rebuilt_for_every_runtime_layer_stacks_identity_change() {
+        let base = NNUENetwork::DynamicLayerStacks(Box::new(test_network(
+            RuntimeLsFeature::HalfKaHmMerged,
+            8,
+            4,
+            3,
+            9,
+            false,
+            0,
+        )));
+        let stack = AccumulatorStackVariant::from_network(&base);
+        assert!(stack.matches_network(&base));
+
+        let switches = [
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 10, 4, 3, 9, false, 0),
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 8, 5, 3, 9, false, 0),
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 8, 4, 5, 9, false, 0),
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 8, 4, 3, 4, false, 0),
+            test_network(RuntimeLsFeature::HalfKP, 8, 4, 3, 9, false, 0),
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 8, 4, 3, 9, true, 0),
+            test_network(RuntimeLsFeature::HalfKaHmMerged, 8, 4, 3, 9, false, 1),
+        ];
+        for switched_net in switches {
+            let switched = NNUENetwork::DynamicLayerStacks(Box::new(switched_net));
+            assert!(!stack.matches_network(&switched));
+            assert!(AccumulatorStackVariant::from_network(&switched).matches_network(&switched));
+        }
+    }
+
+    #[test]
+    fn public_evaluator_keeps_board_effects_for_runtime_effect_bucket() {
+        let feature = RuntimeLsFeature::EffectBucket(EffectBucketConfig::KINGFIXED_2X2);
+        let l1 = 2;
+        let l2 = 2;
+        let l3 = 1;
+        let num_buckets = DEFAULT_NUM_BUCKETS;
+        let mut net = test_network(feature, l1, l2, l3, num_buckets, false, 0);
+        net.ft_weights = AlignedBox::new_zeroed(feature.dimensions() * l1);
+        net.buckets = (0..num_buckets)
+            .map(|_| DynamicLsBucket {
+                l1: zero_affine(l1, l2),
+                l2: zero_affine(2 * (l2 - 1), l3),
+                output: zero_affine(l3, 1),
+            })
+            .collect();
+
+        let mut pos = Position::new();
+        pos.set_sfen(SFEN_HIRATE).unwrap();
+        let mut evaluator = NNUEEvaluator::new_with_position(
+            Arc::new(NNUENetwork::DynamicLayerStacks(Box::new(net))),
+            &pos,
+        );
+        assert_eq!(evaluator.evaluate(&pos), Value::ZERO);
+
+        let mv = Move::from_usi("7g7f").unwrap();
+        let dirty = pos.do_move(mv, pos.gives_check(mv));
+        evaluator.push(dirty);
+        assert_eq!(evaluator.evaluate(&pos), Value::ZERO);
+    }
+
+    #[cfg(feature = "layerstack-arch")]
     #[test]
     #[ignore]
     fn real_model_matches_const_generic() {

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -164,7 +164,9 @@ impl DynamicLayerStacksNetwork {
             DEFAULT_NUM_BUCKETS
         };
         if !(1..=MAX_LAYER_STACK_BUCKETS).contains(&num_buckets) {
-            return Err(invalid("invalid LayerStacks bucket count"));
+            return Err(invalid(format!(
+                "invalid LayerStacks num_buckets={num_buckets}; expected 1..={MAX_LAYER_STACK_BUCKETS}"
+            )));
         }
 
         let (l1, l2, l3) = parse_arch_dimensions(arch);

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -295,7 +295,9 @@ impl DynamicLayerStacksNetwork {
             )));
         }
         Ok(Self {
-            spec: ArchitectureSpec::new(parsed_feature, l1, l2, l3, Activation::CReLU),
+            // Keep public introspection compatible with the const-generic LayerStacks path;
+            // the concrete FT remains in `feature` for runtime dispatch.
+            spec: ArchitectureSpec::new(FeatureSet::LayerStacks, l1, l2, l3, Activation::CReLU),
             feature,
             input_dimensions,
             num_buckets,

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -187,8 +187,6 @@ impl DynamicLayerStacksNetwork {
         validate_dimension("LayerStacks l1", l1)?;
         validate_dimension("LayerStacks l2", l2)?;
         validate_dimension("LayerStacks l3", l3)?;
-        let reported_input_dimensions = parse_feature_input_dimensions(arch)
-            .ok_or_else(|| invalid("missing FT input dimensions"))?;
         let threat_dimensions = parse_token_usize(arch, "Threat=").unwrap_or(0);
         if arch.contains("Threat=") && threat_dimensions == 0 {
             return Err(invalid("malformed Threat token"));
@@ -208,9 +206,6 @@ impl DynamicLayerStacksNetwork {
                 "Threat model requires nnue-threat",
             ));
         }
-        let input_dimensions = reported_input_dimensions
-            .checked_sub(threat_dimensions)
-            .ok_or_else(|| invalid("Threat dimensions exceed reported FT input dimensions"))?;
         let parsed_feature = detect_feature(arch)?;
         let feature = match parsed_feature {
             FeatureSet::HalfKP => RuntimeLsFeature::HalfKP,
@@ -227,12 +222,7 @@ impl DynamicLayerStacksNetwork {
                 return Err(invalid("LayerStacks header does not identify its FT feature set"));
             }
         };
-        if input_dimensions != feature.dimensions() {
-            return Err(invalid(format!(
-                "FT input dimension mismatch: header={input_dimensions}, runtime={}",
-                feature.dimensions()
-            )));
-        }
+        let input_dimensions = parse_ft_input_dimensions(arch, feature, threat_dimensions)?;
 
         reader.read_exact(&mut buf4)?;
         let first = read_compressed_tensor_i16_all(reader)?;
@@ -776,6 +766,30 @@ fn invalid(msg: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, msg.into())
 }
 
+fn parse_ft_input_dimensions(
+    arch: &str,
+    feature: RuntimeLsFeature,
+    threat_dimensions: usize,
+) -> io::Result<usize> {
+    let reported = parse_feature_input_dimensions(arch)
+        .ok_or_else(|| invalid("missing FT input dimensions"))?;
+    let input_dimensions = feature.dimensions();
+
+    // Threat weights are stored in a separate block after the FT (and optional PSQT) data. Some
+    // exporters report only the FT dimension in `Features=...`, while older tatara models report
+    // FT + Threat there. Normalize both header conventions to the actual FT row count.
+    if reported == input_dimensions {
+        return Ok(input_dimensions);
+    }
+    if threat_dimensions != 0 && input_dimensions.checked_add(threat_dimensions) == Some(reported) {
+        return Ok(input_dimensions);
+    }
+
+    Err(invalid(format!(
+        "FT input dimension mismatch: header={reported}, runtime={input_dimensions}, threat={threat_dimensions}"
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "layerstack-arch")]
@@ -799,6 +813,28 @@ mod tests {
     fn zero_affine(input_dim: usize, output_dim: usize) -> DynamicAffine {
         let bytes = vec![0; output_dim * 4 + output_dim * padded_input(input_dim)];
         DynamicAffine::read(&mut Cursor::new(bytes), input_dim, output_dim).unwrap()
+    }
+
+    #[test]
+    fn threat_headers_accept_separate_and_combined_reported_dimensions() {
+        let feature = RuntimeLsFeature::HalfKaHmMerged;
+        let separate = format!(
+            "Features=HalfKaHmMerged(Friend)[{}->1024x2],Threat=216720,Network=...",
+            feature.dimensions()
+        );
+        let combined = format!(
+            "Features=HalfKaHmMerged(Friend)[{}->1024x2],Threat=216720,Network=...",
+            feature.dimensions() + 216_720
+        );
+
+        assert_eq!(
+            parse_ft_input_dimensions(&separate, feature, 216_720).unwrap(),
+            feature.dimensions()
+        );
+        assert_eq!(
+            parse_ft_input_dimensions(&combined, feature, 216_720).unwrap(),
+            feature.dimensions()
+        );
     }
 
     fn test_network(

--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -458,19 +458,7 @@ impl DynamicLayerStacksNetwork {
             [base + pos.side_to_move().index() * l1..base + (pos.side_to_move().index() + 1) * l1];
         let them_threat = &stack.threat_accumulations[base + (!pos.side_to_move()).index() * l1
             ..base + ((!pos.side_to_move()).index() + 1) * l1];
-        let half = l1 / 2;
-        for i in 0..half {
-            let us0 = us[i].wrapping_add(us_threat[i]);
-            let us1 = us[half + i].wrapping_add(us_threat[half + i]);
-            let them0 = them[i].wrapping_add(them_threat[i]);
-            let them1 = them[half + i].wrapping_add(them_threat[half + i]);
-            stack.transformed[i] = ((u32::from(us0.clamp(0, 127) as u16)
-                * u32::from(us1.clamp(0, 127) as u16))
-                >> 7) as u8;
-            stack.transformed[half + i] = ((u32::from(them0.clamp(0, 127) as u16)
-                * u32::from(them1.clamp(0, 127) as u16))
-                >> 7) as u8;
-        }
+        sqr_transform_with_threat(us, us_threat, them, them_threat, &mut stack.transformed[..l1]);
         let bucket_index = match get_layer_stack_bucket_mode() {
             LayerStackBucketMode::KingRank9 => compute_layer_stack_kingrank9_bucket_index(
                 pos,
@@ -622,11 +610,43 @@ fn read_i32s<R: Read>(reader: &mut R, dst: &mut [i32]) -> io::Result<()> {
     Ok(())
 }
 fn add_i16(a: &mut [i16], b: &[i16]) {
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    unsafe {
+        use std::arch::wasm32::*;
+        let chunks = a.len().min(b.len()) / 8;
+        for i in 0..chunks {
+            let offset = i * 8;
+            let va = v128_load(a.as_ptr().add(offset).cast::<v128>());
+            let vb = v128_load(b.as_ptr().add(offset).cast::<v128>());
+            v128_store(a.as_mut_ptr().add(offset).cast::<v128>(), i16x8_add(va, vb));
+        }
+        for (a, &b) in a[chunks * 8..].iter_mut().zip(&b[chunks * 8..]) {
+            *a = a.wrapping_add(b);
+        }
+        return;
+    }
+    #[allow(unreachable_code)]
     for (a, &b) in a.iter_mut().zip(b) {
         *a = a.wrapping_add(b);
     }
 }
 fn sub_i16(a: &mut [i16], b: &[i16]) {
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    unsafe {
+        use std::arch::wasm32::*;
+        let chunks = a.len().min(b.len()) / 8;
+        for i in 0..chunks {
+            let offset = i * 8;
+            let va = v128_load(a.as_ptr().add(offset).cast::<v128>());
+            let vb = v128_load(b.as_ptr().add(offset).cast::<v128>());
+            v128_store(a.as_mut_ptr().add(offset).cast::<v128>(), i16x8_sub(va, vb));
+        }
+        for (a, &b) in a[chunks * 8..].iter_mut().zip(&b[chunks * 8..]) {
+            *a = a.wrapping_sub(b);
+        }
+        return;
+    }
+    #[allow(unreachable_code)]
     for (a, &b) in a.iter_mut().zip(b) {
         *a = a.wrapping_sub(b);
     }
@@ -639,6 +659,80 @@ fn add_i32(a: &mut [i32], b: &[i32]) {
 fn sub_i32(a: &mut [i32], b: &[i32]) {
     for (a, &b) in a.iter_mut().zip(b) {
         *a = a.wrapping_sub(b);
+    }
+}
+
+fn sqr_transform_with_threat(
+    us: &[i16],
+    us_threat: &[i16],
+    them: &[i16],
+    them_threat: &[i16],
+    output: &mut [u8],
+) {
+    let half = us.len() / 2;
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    let mut processed = 0;
+    #[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+    let processed = 0;
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    unsafe {
+        use std::arch::wasm32::*;
+        let zero = i16x8_splat(0);
+        let max127 = i16x8_splat(127);
+        for (acc, threat, out_offset) in [(us, us_threat, 0usize), (them, them_threat, half)] {
+            let mut offset = 0;
+            while offset + 16 <= half {
+                let a0 = i16x8_add(
+                    v128_load(acc.as_ptr().add(offset).cast::<v128>()),
+                    v128_load(threat.as_ptr().add(offset).cast::<v128>()),
+                );
+                let b0 = i16x8_add(
+                    v128_load(acc.as_ptr().add(half + offset).cast::<v128>()),
+                    v128_load(threat.as_ptr().add(half + offset).cast::<v128>()),
+                );
+                let a1 = i16x8_add(
+                    v128_load(acc.as_ptr().add(offset + 8).cast::<v128>()),
+                    v128_load(threat.as_ptr().add(offset + 8).cast::<v128>()),
+                );
+                let b1 = i16x8_add(
+                    v128_load(acc.as_ptr().add(half + offset + 8).cast::<v128>()),
+                    v128_load(threat.as_ptr().add(half + offset + 8).cast::<v128>()),
+                );
+                let product0 = u16x8_shr(
+                    i16x8_mul(
+                        i16x8_min(i16x8_max(a0, zero), max127),
+                        i16x8_min(i16x8_max(b0, zero), max127),
+                    ),
+                    7,
+                );
+                let product1 = u16x8_shr(
+                    i16x8_mul(
+                        i16x8_min(i16x8_max(a1, zero), max127),
+                        i16x8_min(i16x8_max(b1, zero), max127),
+                    ),
+                    7,
+                );
+                v128_store(
+                    output.as_mut_ptr().add(out_offset + offset).cast::<v128>(),
+                    u8x16_narrow_i16x8(product0, product1),
+                );
+                offset += 16;
+            }
+            processed = offset;
+        }
+    }
+
+    for i in processed..half {
+        let us0 = us[i].wrapping_add(us_threat[i]);
+        let us1 = us[half + i].wrapping_add(us_threat[half + i]);
+        let them0 = them[i].wrapping_add(them_threat[i]);
+        let them1 = them[half + i].wrapping_add(them_threat[half + i]);
+        output[i] = ((u32::from(us0.clamp(0, 127) as u16) * u32::from(us1.clamp(0, 127) as u16))
+            >> 7) as u8;
+        output[half + i] = ((u32::from(them0.clamp(0, 127) as u16)
+            * u32::from(them1.clamp(0, 127) as u16))
+            >> 7) as u8;
     }
 }
 fn invalid(msg: impl Into<String>) -> io::Error {

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -87,11 +87,7 @@ impl NNUEEvaluator {
         } else {
             None
         };
-        let acc_cache_generic = if !net.is_layer_stacks() {
-            Some(AccumulatorCacheGeneric::new(net.l1_size()))
-        } else {
-            None
-        };
+        let acc_cache_generic = Self::new_generic_cache(&net);
         let mut evaluator = Self {
             net,
             stack,
@@ -119,11 +115,7 @@ impl NNUEEvaluator {
         } else {
             None
         };
-        let acc_cache_generic = if !self.net.is_layer_stacks() {
-            Some(AccumulatorCacheGeneric::new(self.net.l1_size()))
-        } else {
-            None
-        };
+        let acc_cache_generic = Self::new_generic_cache(&self.net);
         let mut evaluator = Self {
             net: Arc::clone(&self.net),
             stack: AccumulatorStackVariant::from_network(&self.net),
@@ -221,11 +213,16 @@ impl NNUEEvaluator {
     /// アキュムレータが未計算の場合、不正な評価値が返る。
     /// 通常は `evaluate()` を使用すること。
     #[inline(always)]
-    pub fn evaluate_only(&mut self, pos: &Position) -> Value {
-        match (&*self.net, &mut self.stack) {
+    pub fn evaluate_only(&self, pos: &Position) -> Value {
+        match (&*self.net, &self.stack) {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (
+                NNUENetwork::DynamicLayerStacks(net),
+                AccumulatorStackVariant::DynamicLayerStacks(st),
+            ) => net.evaluate(pos, &mut st.borrow_mut()),
             #[cfg(feature = "nnue-runtime-dimensions")]
             (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
-                net.evaluate(pos, st)
+                net.evaluate(pos, &mut st.borrow_mut())
             }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 net.evaluate(pos, st)
@@ -278,12 +275,29 @@ impl NNUEEvaluator {
     // 内部実装
     // =========================================================================
 
+    fn new_generic_cache(net: &NNUENetwork) -> Option<AccumulatorCacheGeneric> {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if matches!(net, NNUENetwork::DynamicHalfKx(_)) {
+            return None;
+        }
+        if net.is_layer_stacks() {
+            None
+        } else {
+            Some(AccumulatorCacheGeneric::new(net.l1_size()))
+        }
+    }
+
     /// アキュムレータをフル再計算
     fn refresh_accumulator(&mut self, pos: &Position) {
         match (&*self.net, &mut self.stack) {
             #[cfg(feature = "nnue-runtime-dimensions")]
+            (
+                NNUENetwork::DynamicLayerStacks(net),
+                AccumulatorStackVariant::DynamicLayerStacks(st),
+            ) => net.refresh(pos, st.get_mut()),
+            #[cfg(feature = "nnue-runtime-dimensions")]
             (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
-                net.refresh(pos, st);
+                net.refresh(pos, st.get_mut());
             }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 if let Some(cache) = &mut self.acc_cache_generic {
@@ -332,8 +346,13 @@ impl NNUEEvaluator {
     fn ensure_accumulator_computed(&mut self, pos: &Position) {
         match (&*self.net, &mut self.stack) {
             #[cfg(feature = "nnue-runtime-dimensions")]
+            (
+                NNUENetwork::DynamicLayerStacks(net),
+                AccumulatorStackVariant::DynamicLayerStacks(st),
+            ) => net.ensure(pos, st.get_mut()),
+            #[cfg(feature = "nnue-runtime-dimensions")]
             (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
-                net.ensure(pos, st);
+                net.ensure(pos, st.get_mut());
             }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 Self::update_halfka_accumulator(net, pos, st, &mut self.acc_cache_generic);

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -727,14 +727,17 @@ mod tests {
         // LayerStacks 各 L1 バリアント（有効 feature のみ検証）。
         // 外側の `any(...)` でいずれかの variant が有効なときだけ import が使われる
         // ようにして unused-import 警告を抑える。
-        #[cfg(any(
-            feature = "layerstacks-1536x16x32",
-            feature = "layerstacks-1536x32x32",
-            feature = "layerstacks-768x16x32",
-            feature = "layerstacks-768x8x32",
-            feature = "layerstacks-512x16x32",
-            feature = "layerstacks-1024x16x32",
-            feature = "layerstacks-3072x16x32"
+        #[cfg(all(
+            feature = "layerstack-arch",
+            any(
+                feature = "layerstacks-1536x16x32",
+                feature = "layerstacks-1536x32x32",
+                feature = "layerstacks-768x16x32",
+                feature = "layerstacks-768x8x32",
+                feature = "layerstacks-512x16x32",
+                feature = "layerstacks-1024x16x32",
+                feature = "layerstacks-3072x16x32"
+            )
         ))]
         {
             use crate::nnue::accumulator_layer_stacks::{

--- a/crates/rshogi-core/src/nnue/evaluator.rs
+++ b/crates/rshogi-core/src/nnue/evaluator.rs
@@ -221,8 +221,12 @@ impl NNUEEvaluator {
     /// アキュムレータが未計算の場合、不正な評価値が返る。
     /// 通常は `evaluate()` を使用すること。
     #[inline(always)]
-    pub fn evaluate_only(&self, pos: &Position) -> Value {
-        match (&*self.net, &self.stack) {
+    pub fn evaluate_only(&mut self, pos: &Position) -> Value {
+        match (&*self.net, &mut self.stack) {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
+                net.evaluate(pos, st)
+            }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 net.evaluate(pos, st)
             }
@@ -277,6 +281,10 @@ impl NNUEEvaluator {
     /// アキュムレータをフル再計算
     fn refresh_accumulator(&mut self, pos: &Position) {
         match (&*self.net, &mut self.stack) {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
+                net.refresh(pos, st);
+            }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 if let Some(cache) = &mut self.acc_cache_generic {
                     net.refresh_accumulator_with_cache(pos, st, cache);
@@ -323,6 +331,10 @@ impl NNUEEvaluator {
     /// アキュムレータが計算済みか確認し、必要に応じて更新
     fn ensure_accumulator_computed(&mut self, pos: &Position) {
         match (&*self.net, &mut self.stack) {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            (NNUENetwork::DynamicHalfKx(net), AccumulatorStackVariant::DynamicHalfKx(st)) => {
+                net.ensure(pos, st);
+            }
             (NNUENetwork::HalfKaSplit(net), AccumulatorStackVariant::HalfKaSplit(st)) => {
                 Self::update_halfka_accumulator(net, pos, st, &mut self.acc_cache_generic);
             }

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -35,6 +35,8 @@ mod bona_piece_halfka_merged;
 mod bona_piece_halfka_split;
 mod constants;
 mod diff;
+#[cfg(feature = "nnue-runtime-dimensions")]
+mod dynamic_halfkx;
 mod effect_bucket_features;
 mod evaluator;
 mod feature_transformer;

--- a/crates/rshogi-core/src/nnue/mod.rs
+++ b/crates/rshogi-core/src/nnue/mod.rs
@@ -37,6 +37,8 @@ mod constants;
 mod diff;
 #[cfg(feature = "nnue-runtime-dimensions")]
 mod dynamic_halfkx;
+#[cfg(feature = "nnue-runtime-dimensions")]
+mod dynamic_layer_stacks;
 mod effect_bucket_features;
 mod evaluator;
 mod feature_transformer;
@@ -111,6 +113,7 @@ pub use ls_feature_spec::{
 };
 #[cfg(feature = "layerstack-arch")]
 pub use network::evaluate_layer_stacks;
+pub(crate) use network::nnue_requires_board_effects;
 #[cfg(feature = "layerstack-arch")]
 pub(crate) use network::update_and_evaluate_layer_stacks_cached;
 pub use network::{

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -463,7 +463,10 @@ impl NNUENetwork {
                 };
 
                 // LayerStacks は特殊処理（FT が LEB128 圧縮のためファイルサイズ検出の対象外）
-                if effective_feature_set == FeatureSet::LayerStacks {
+                if matches!(
+                    effective_feature_set,
+                    FeatureSet::LayerStacks | FeatureSet::HalfKaHmMergedEffectBucket
+                ) {
                     if cfg!(feature = "nnue-runtime-dimensions") {
                         #[cfg(feature = "nnue-runtime-dimensions")]
                         {
@@ -2429,6 +2432,25 @@ mod tests {
         bytes.extend_from_slice(arch);
         bytes.extend_from_slice(&num_buckets.to_le_bytes());
         bytes
+    }
+
+    #[cfg(feature = "nnue-runtime-dimensions")]
+    #[test]
+    fn legacy_effect_bucket_auto_dispatches_to_dynamic_layer_stacks() {
+        let arch = b"Features=HalfKaHmMerged(Friend)[293220->2x2],EffectBucket=2x2fixed,l2=2,l3=1";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&NNUE_VERSION_HALFKA.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&(arch.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(arch);
+
+        // The truncated payload must get as far as the LayerStacks reader. Before the dispatch
+        // fix it was rejected earlier by DynamicHalfKx as an unsupported feature set.
+        let err = match NNUENetwork::from_bytes(&bytes) {
+            Ok(_) => panic!("truncated legacy EffectBucket model must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof, "{err}");
     }
 
     /// num_buckets-header layout で `num_buckets = 0` / 上限超過の値は

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -29,6 +29,8 @@ use super::constants::{
     MAX_ARCH_LEN, MAX_LAYER_STACK_BUCKETS, NNUE_VERSION, NNUE_VERSION_HALFKA,
     NNUE_VERSION_LAYERSTACK_NUM_BUCKETS,
 };
+#[cfg(feature = "nnue-runtime-dimensions")]
+use super::dynamic_halfkx::DynamicHalfKxNetwork;
 use super::halfka_hm_merged::{HalfKaHmMergedNetwork, HalfKaHmMergedStack};
 use super::halfka_hm_split::{HalfKaHmSplitNetwork, HalfKaHmSplitStack};
 use super::halfka_merged::{HalfKaMergedNetwork, HalfKaMergedStack};
@@ -324,6 +326,9 @@ pub fn reset_layer_stack_progress_kpabs_weights() {
 /// 詳細は `halfka_split/` や `halfkp/` のモジュールで管理される。
 #[non_exhaustive]
 pub enum NNUENetwork {
+    /// Runtime-dimension HalfKX（universal edition 専用）
+    #[cfg(feature = "nnue-runtime-dimensions")]
+    DynamicHalfKx(Box<DynamicHalfKxNetwork>),
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitNetwork),
     /// HalfKaHmMerged 特徴量セット（L256/L512/L1024）
@@ -493,6 +498,18 @@ impl NNUENetwork {
                     }
                 }
 
+                // universal edition は HalfKX の次元をヘッダーから動的に構成する。
+                // 固定/family edition は従来どおり既知サイズの const-generic 経路を使う。
+                if cfg!(feature = "nnue-runtime-dimensions") {
+                    #[cfg(feature = "nnue-runtime-dimensions")]
+                    {
+                        reader.seek(SeekFrom::Start(0))?;
+                        return Ok(Self::DynamicHalfKx(Box::new(DynamicHalfKxNetwork::read(
+                            reader,
+                        )?)));
+                    }
+                }
+
                 // 4. ファイルサイズからアーキテクチャを検出
                 let detection = super::spec::detect_architecture_from_size(
                     file_size,
@@ -608,22 +625,36 @@ impl NNUENetwork {
 
     /// HalfKaSplit アーキテクチャかどうか
     pub fn is_halfka(&self) -> bool {
-        matches!(self, Self::HalfKaSplit(_))
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        let dynamic = matches!(self, Self::DynamicHalfKx(net) if net.spec().feature_set == FeatureSet::HalfKaSplit);
+        #[cfg(not(feature = "nnue-runtime-dimensions"))]
+        let dynamic = false;
+        matches!(self, Self::HalfKaSplit(_)) || dynamic
     }
 
     /// HalfKaHmMerged アーキテクチャかどうか
     pub fn is_halfka_hm(&self) -> bool {
-        matches!(self, Self::HalfKaHmMerged(_))
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        let dynamic = matches!(self, Self::DynamicHalfKx(net) if net.spec().feature_set == FeatureSet::HalfKaHmMerged);
+        #[cfg(not(feature = "nnue-runtime-dimensions"))]
+        let dynamic = false;
+        matches!(self, Self::HalfKaHmMerged(_)) || dynamic
     }
 
     /// HalfKP アーキテクチャかどうか
     pub fn is_halfkp(&self) -> bool {
-        matches!(self, Self::HalfKP(_))
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        let dynamic = matches!(self, Self::DynamicHalfKx(net) if net.is_halfkp());
+        #[cfg(not(feature = "nnue-runtime-dimensions"))]
+        let dynamic = false;
+        matches!(self, Self::HalfKP(_)) || dynamic
     }
 
     /// L1 サイズを取得
     pub fn l1_size(&self) -> usize {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(net) => net.l1_size(),
             Self::HalfKaSplit(net) => net.l1_size(),
             Self::HalfKaHmMerged(net) => net.l1_size(),
             Self::HalfKaMerged(net) => net.l1_size(),
@@ -637,6 +668,8 @@ impl NNUENetwork {
     /// アーキテクチャ名を取得
     pub fn architecture_name(&self) -> String {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(net) => net.spec().name(),
             Self::HalfKaSplit(net) => net.architecture_name(),
             Self::HalfKaHmMerged(net) => net.architecture_name(),
             Self::HalfKaMerged(net) => net.architecture_name(),
@@ -650,6 +683,8 @@ impl NNUENetwork {
     /// アーキテクチャ仕様を取得
     pub fn architecture_spec(&self) -> super::spec::ArchitectureSpec {
         match self {
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicHalfKx(net) => net.spec(),
             Self::HalfKaSplit(net) => net.architecture_spec(),
             Self::HalfKaHmMerged(net) => net.architecture_spec(),
             Self::HalfKaMerged(net) => net.architecture_spec(),
@@ -1669,6 +1704,14 @@ pub fn evaluate_dispatch(
 
     // バリアントに応じて適切な評価関数を呼び出し
     match stack {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        AccumulatorStackVariant::DynamicHalfKx(s) => {
+            let NNUENetwork::DynamicHalfKx(net) = &*network else {
+                unreachable!("Network/Stack type mismatch")
+            };
+            net.ensure(pos, s);
+            net.evaluate(pos, s)
+        }
         #[cfg(feature = "layerstack-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {
             let net = network.as_layer_stacks();
@@ -1724,6 +1767,13 @@ pub fn ensure_accumulator_computed(
 
     // バリアントに応じてアキュムレータを更新（評価はしない）
     match stack {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        AccumulatorStackVariant::DynamicHalfKx(s) => {
+            let NNUENetwork::DynamicHalfKx(net) = &*network else {
+                unreachable!("Network/Stack type mismatch")
+            };
+            net.ensure(pos, s);
+        }
         #[cfg(feature = "layerstack-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {
             let net = network.as_layer_stacks();

--- a/crates/rshogi-core/src/nnue/network.rs
+++ b/crates/rshogi-core/src/nnue/network.rs
@@ -31,6 +31,8 @@ use super::constants::{
 };
 #[cfg(feature = "nnue-runtime-dimensions")]
 use super::dynamic_halfkx::DynamicHalfKxNetwork;
+#[cfg(feature = "nnue-runtime-dimensions")]
+use super::dynamic_layer_stacks::DynamicLayerStacksNetwork;
 use super::halfka_hm_merged::{HalfKaHmMergedNetwork, HalfKaHmMergedStack};
 use super::halfka_hm_split::{HalfKaHmSplitNetwork, HalfKaHmSplitStack};
 use super::halfka_merged::{HalfKaMergedNetwork, HalfKaMergedStack};
@@ -60,6 +62,7 @@ static NETWORK: LazyLock<RwLock<Option<Arc<NNUENetwork>>>> = LazyLock::new(|| Rw
 /// NNUE ロード時に true、クリア時に false に設定する。
 /// `should_update_board_effects()` 等のホットパスから RwLock::read を回避するため。
 static NNUE_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static NNUE_REQUIRES_BOARD_EFFECTS: AtomicBool = AtomicBool::new(false);
 
 /// FV_SCALE のグローバルオーバーライド設定
 ///
@@ -314,21 +317,18 @@ pub fn reset_layer_stack_progress_kpabs_weights() {
 // NNUENetwork - アーキテクチャを抽象化するenum
 // =============================================================================
 
-/// NNUEネットワーク（4バリアント階層構造）
+/// NNUEネットワークの runtime dispatch。
 ///
-/// **「Accumulator は L1 だけで決まる」** を活用した設計:
-/// - HalfKaSplit(HalfKaSplitNetwork): L256/L512/L1024 を内包
-/// - HalfKaHmMerged(HalfKaHmMergedNetwork): L256/L512/L1024 を内包
-/// - HalfKP(HalfKPNetwork): L256/L512 を内包
-/// - LayerStacks: 1536次元 + 9バケット
-///
-/// L2/L3/活性化の追加時、このenumの変更は不要。
-/// 詳細は `halfka_split/` や `halfkp/` のモジュールで管理される。
+/// 固定 edition は既存の const-generic variant、universal edition は header 駆動の
+/// `DynamicHalfKx` / `DynamicLayerStacks` を使う。
 #[non_exhaustive]
 pub enum NNUENetwork {
     /// Runtime-dimension HalfKX（universal edition 専用）
     #[cfg(feature = "nnue-runtime-dimensions")]
     DynamicHalfKx(Box<DynamicHalfKxNetwork>),
+    /// Runtime-dimension LayerStacks（universal edition 専用）
+    #[cfg(feature = "nnue-runtime-dimensions")]
+    DynamicLayerStacks(Box<DynamicLayerStacksNetwork>),
     /// HalfKaSplit 特徴量セット（L256/L512/L1024）
     HalfKaSplit(HalfKaSplitNetwork),
     /// HalfKaHmMerged 特徴量セット（L256/L512/L1024）
@@ -345,6 +345,14 @@ pub enum NNUENetwork {
 }
 
 impl NNUENetwork {
+    fn requires_board_effects(&self) -> bool {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if let Self::DynamicLayerStacks(net) = self {
+            return net.requires_board_effects();
+        }
+        cfg!(feature = "nnue-effect-bucket")
+    }
+
     /// HalfKP でサポートされているアーキテクチャ一覧
     pub fn supported_halfkp_specs() -> Vec<super::spec::ArchitectureSpec> {
         HalfKPNetwork::supported_specs()
@@ -456,6 +464,20 @@ impl NNUENetwork {
 
                 // LayerStacks は特殊処理（FT が LEB128 圧縮のためファイルサイズ検出の対象外）
                 if effective_feature_set == FeatureSet::LayerStacks {
+                    if cfg!(feature = "nnue-runtime-dimensions") {
+                        #[cfg(feature = "nnue-runtime-dimensions")]
+                        {
+                            let psqt_override = match arch_override {
+                                NNUEArchitectureOverride::LayerStacks => Some(false),
+                                NNUEArchitectureOverride::LayerStacksPSQT => Some(true),
+                                _ => None,
+                            };
+                            reader.seek(SeekFrom::Start(0))?;
+                            return Ok(Self::DynamicLayerStacks(Box::new(
+                                DynamicLayerStacksNetwork::read(reader, psqt_override)?,
+                            )));
+                        }
+                    }
                     #[cfg(feature = "layerstack-arch")]
                     {
                         // PSQT オーバーライド:
@@ -596,6 +618,10 @@ impl NNUENetwork {
 
     /// LayerStacks アーキテクチャかどうか
     pub fn is_layer_stacks(&self) -> bool {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if matches!(self, Self::DynamicLayerStacks(_)) {
+            return true;
+        }
         #[cfg(feature = "layerstack-arch")]
         {
             matches!(self, Self::LayerStacks(_))
@@ -610,6 +636,10 @@ impl NNUENetwork {
     ///
     /// LayerStacks 以外、または LayerStacks feature 無効ビルドでは `None` を返す。
     pub fn layer_stack_num_buckets(&self) -> Option<usize> {
+        #[cfg(feature = "nnue-runtime-dimensions")]
+        if let Self::DynamicLayerStacks(network) = self {
+            return Some(network.num_buckets());
+        }
         #[cfg(feature = "layerstack-arch")]
         {
             match self {
@@ -655,6 +685,8 @@ impl NNUENetwork {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
             Self::DynamicHalfKx(net) => net.l1_size(),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(net) => net.spec().l1,
             Self::HalfKaSplit(net) => net.l1_size(),
             Self::HalfKaHmMerged(net) => net.l1_size(),
             Self::HalfKaMerged(net) => net.l1_size(),
@@ -670,6 +702,8 @@ impl NNUENetwork {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
             Self::DynamicHalfKx(net) => net.spec().name(),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(net) => net.spec().name(),
             Self::HalfKaSplit(net) => net.architecture_name(),
             Self::HalfKaHmMerged(net) => net.architecture_name(),
             Self::HalfKaMerged(net) => net.architecture_name(),
@@ -685,6 +719,8 @@ impl NNUENetwork {
         match self {
             #[cfg(feature = "nnue-runtime-dimensions")]
             Self::DynamicHalfKx(net) => net.spec(),
+            #[cfg(feature = "nnue-runtime-dimensions")]
+            Self::DynamicLayerStacks(net) => net.spec(),
             Self::HalfKaSplit(net) => net.architecture_spec(),
             Self::HalfKaHmMerged(net) => net.architecture_spec(),
             Self::HalfKaMerged(net) => net.architecture_spec(),
@@ -1131,6 +1167,7 @@ pub fn progress_sum_to_bucket(sum: f32, num_buckets: usize) -> usize {
 /// NNUEを初期化（バージョン自動判別）
 pub fn init_nnue<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let network = Arc::new(NNUENetwork::load(path)?);
+    NNUE_REQUIRES_BOARD_EFFECTS.store(network.requires_board_effects(), Ordering::Release);
     *NETWORK.write().expect("NNUE lock poisoned") = Some(network);
     NNUE_INITIALIZED.store(true, Ordering::Release);
     Ok(())
@@ -1139,6 +1176,7 @@ pub fn init_nnue<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// バイト列からNNUEを初期化（バージョン自動判別）
 pub fn init_nnue_from_bytes(bytes: &[u8]) -> io::Result<()> {
     let network = Arc::new(NNUENetwork::from_bytes(bytes)?);
+    NNUE_REQUIRES_BOARD_EFFECTS.store(network.requires_board_effects(), Ordering::Release);
     *NETWORK.write().expect("NNUE lock poisoned") = Some(network);
     NNUE_INITIALIZED.store(true, Ordering::Release);
     Ok(())
@@ -1150,6 +1188,7 @@ pub fn clear_nnue() {
     // 逆順にすると is_nnue_initialized() == true の直後に get_network() が None を返す
     // 短い窓が生じる。false-negative（ロード済みなのに false に見える瞬間）は安全。
     NNUE_INITIALIZED.store(false, Ordering::Release);
+    NNUE_REQUIRES_BOARD_EFFECTS.store(false, Ordering::Release);
     *NETWORK.write().expect("NNUE lock poisoned") = None;
 }
 
@@ -1160,6 +1199,11 @@ pub fn clear_nnue() {
 #[inline]
 pub fn is_nnue_initialized() -> bool {
     NNUE_INITIALIZED.load(Ordering::Acquire)
+}
+
+#[inline]
+pub(crate) fn nnue_requires_board_effects() -> bool {
+    NNUE_REQUIRES_BOARD_EFFECTS.load(Ordering::Acquire)
 }
 
 // =============================================================================
@@ -1705,12 +1749,22 @@ pub fn evaluate_dispatch(
     // バリアントに応じて適切な評価関数を呼び出し
     match stack {
         #[cfg(feature = "nnue-runtime-dimensions")]
+        AccumulatorStackVariant::DynamicLayerStacks(s) => {
+            let NNUENetwork::DynamicLayerStacks(net) = &*network else {
+                unreachable!("Network/Stack type mismatch")
+            };
+            let stack = s.get_mut();
+            net.ensure(pos, stack);
+            net.evaluate(pos, stack)
+        }
+        #[cfg(feature = "nnue-runtime-dimensions")]
         AccumulatorStackVariant::DynamicHalfKx(s) => {
             let NNUENetwork::DynamicHalfKx(net) = &*network else {
                 unreachable!("Network/Stack type mismatch")
             };
-            net.ensure(pos, s);
-            net.evaluate(pos, s)
+            let stack = s.get_mut();
+            net.ensure(pos, stack);
+            net.evaluate(pos, stack)
         }
         #[cfg(feature = "layerstack-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {
@@ -1768,11 +1822,18 @@ pub fn ensure_accumulator_computed(
     // バリアントに応じてアキュムレータを更新（評価はしない）
     match stack {
         #[cfg(feature = "nnue-runtime-dimensions")]
+        AccumulatorStackVariant::DynamicLayerStacks(s) => {
+            let NNUENetwork::DynamicLayerStacks(net) = &*network else {
+                unreachable!("Network/Stack type mismatch")
+            };
+            net.ensure(pos, s.get_mut());
+        }
+        #[cfg(feature = "nnue-runtime-dimensions")]
         AccumulatorStackVariant::DynamicHalfKx(s) => {
             let NNUENetwork::DynamicHalfKx(net) = &*network else {
                 unreachable!("Network/Stack type mismatch")
             };
-            net.ensure(pos, s);
+            net.ensure(pos, s.get_mut());
         }
         #[cfg(feature = "layerstack-arch")]
         AccumulatorStackVariant::LayerStacks(s) => {

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -2092,7 +2092,11 @@ mod tests {
     #[cfg(feature = "layerstack-arch")]
     use super::*;
     use crate::nnue::constants::{FV_SCALE_HALFKA, NNUE_PYTORCH_L1};
-    #[cfg(all(feature = "layerstacks-1536x16x32", feature = "ft-halfka_hm_merged"))]
+    #[cfg(all(
+        feature = "layerstack-arch",
+        feature = "layerstacks-1536x16x32",
+        feature = "ft-halfka_hm_merged"
+    ))]
     use crate::position::{Position, SFEN_HIRATE};
 
     const TEST_L1: usize = NNUE_PYTORCH_L1;
@@ -2184,7 +2188,11 @@ mod tests {
     /// - FT weight nonzero: 2,143,627
     /// - L1 bias (bucket 0): [-15, 57, -182, -97, -202, -55, 120, 1, 87, -133, -16, 44, -27, -37, -201, -186]
     /// - Initial position score: 0 (epoch82は学習初期のため)
-    #[cfg(all(feature = "layerstacks-1536x16x32", feature = "ft-halfka_hm_merged"))]
+    #[cfg(all(
+        feature = "layerstack-arch",
+        feature = "layerstacks-1536x16x32",
+        feature = "ft-halfka_hm_merged"
+    ))]
     #[test]
     #[ignore]
     fn test_load_layer_stacks_file() {

--- a/crates/rshogi-core/src/nnue/spec.rs
+++ b/crates/rshogi-core/src/nnue/spec.rs
@@ -302,11 +302,15 @@ pub fn parse_arch_dimensions(arch_str: &str) -> (usize, usize, usize) {
     // 例: AffineTransform[8<-1024] → L2=8
     //     AffineTransform[96<-8] → L3=96
     let mut layers: Vec<(usize, usize)> = Vec::new();
-    let pattern = "AffineTransform[";
+    let pattern = "AffineTransform";
 
     let mut search_start = 0;
     while let Some(start) = arch_str[search_start..].find(pattern) {
-        let abs_start = search_start + start + pattern.len();
+        let after_name = search_start + start + pattern.len();
+        let Some(open_offset) = arch_str[after_name..].find('[') else {
+            break;
+        };
+        let abs_start = after_name + open_offset + 1;
         if let Some(end) = arch_str[abs_start..].find(']') {
             let content = &arch_str[abs_start..abs_start + end];
             if let Some(arrow_idx) = content.find("<-") {
@@ -1404,6 +1408,10 @@ mod tests {
         // nnue-pytorch 形式 (1024次元)
         let arch = "Features=HalfKA_hm[73305->1024x2],Network=AffineTransform[1<-96](ClippedReLU[96](AffineTransform[96<-8](ClippedReLU[8](AffineTransform[8<-2048](InputSlice[2048(0:2048)])))))";
         assert_eq!(parse_arch_dimensions(arch), (1024, 8, 96));
+
+        // sparse-input dense layer も AffineTransform と同じ次元表記を持つ
+        let arch = "Features=HalfKA_hm[73305->512x2],Network=AffineTransform[1<-96](ClippedReLU[96](AffineTransform[96<-8](ClippedReLU[8](AffineTransformSparseInput[8<-1024](InputSlice[1024(0:1024)])))))";
+        assert_eq!(parse_arch_dimensions(arch), (512, 8, 96));
 
         // bullet-shogi 形式 (l2=, l3= パターン)
         let arch = "Features=HalfKA_hm^[73305->512x2]-SCReLU,fv_scale=13,l2=8,l3=96,qa=127,qb=64";

--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -448,7 +448,7 @@ impl Position {
 
     #[inline]
     fn should_update_board_effects() -> bool {
-        if cfg!(feature = "nnue-effect-bucket") {
+        if cfg!(feature = "nnue-effect-bucket") || crate::nnue::nnue_requires_board_effects() {
             return true;
         }
         // halfkx-arch が無効な build は NNUE 経路のみで評価するため material fallback が

--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -448,7 +448,13 @@ impl Position {
 
     #[inline]
     fn should_update_board_effects() -> bool {
-        if cfg!(feature = "nnue-effect-bucket") || crate::nnue::nnue_requires_board_effects() {
+        // Runtime editions can receive an EffectBucket network through a local NNUEEvaluator or
+        // after the Position has already advanced, without touching the global NNUE state.
+        // Maintaining effects unconditionally makes both paths safe and keeps model reload atomic.
+        if cfg!(feature = "nnue-effect-bucket")
+            || cfg!(feature = "nnue-runtime-dimensions")
+            || crate::nnue::nnue_requires_board_effects()
+        {
             return true;
         }
         // halfkx-arch が無効な build は NNUE 経路のみで評価するため material fallback が

--- a/crates/rshogi-core/tests/build_rs_checks.rs
+++ b/crates/rshogi-core/tests/build_rs_checks.rs
@@ -54,6 +54,19 @@ fn universal_alone_ok() {
 }
 
 #[test]
+fn runtime_dimension_universal_needs_no_static_slots() {
+    let has = lookup(&[
+        "mode-universal",
+        "layerstack-arch",
+        "halfkx-arch",
+        "nnue-runtime-dimensions",
+        "nnue-psqt",
+        "nnue-threat",
+    ]);
+    assert!(validate_feature_combination(&has).is_ok());
+}
+
+#[test]
 fn universal_plus_family_rejected() {
     let has = lookup(&["mode-universal", "mode-family"]);
     let err = validate_feature_combination(&has).unwrap_err();

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -17,6 +17,7 @@ default = ["nnue-arch", "dlshogi-onnx", "kifu-player"]
 
 # 解析対象 NNUE アーキテクチャ (LayerStack L1 サイズ + FT variant 5 種) の既定集合。
 nnue-arch = [
+    "rshogi-core/layerstack-arch",
     "layerstacks-1536x16x32",
     "ft-halfkp",
     "ft-halfka_split",
@@ -35,8 +36,8 @@ threat-profile-cross-side = ["rshogi-core/threat-profile-cross-side"]
 
 # === Edition 軸 atomic feature 群 (本 crate で必要なものだけ forward) ===
 # 設計は docs/decisions/2026-05-24-build-edition-flavor-design.md を参照。
-# tools は LS network 上の解析ユーティリティ前提なので architecture 経路 (layerstack-arch /
-# halfkx-arch) や FT slot は forward しない。必要になったら追加する。
+# tools は静的 LS network の内部を解析するため、nnue-arch から layerstack-arch と
+# size / FT slot を明示的に forward する。rshogi-core の default universal には依存しない。
 # LS L1 サイズ slot
 layerstacks-1536x16x32 = ["rshogi-core/layerstacks-1536x16x32"]
 layerstacks-1536x32x32 = ["rshogi-core/layerstacks-1536x32x32"]
@@ -112,7 +113,7 @@ env_logger.workspace = true
 log.workspace = true
 
 # Local dependencies
-rshogi-core = { path = "../rshogi-core" }
+rshogi-core = { path = "../rshogi-core", default-features = false }
 rshogi-csa = { path = "../rshogi-csa" }
 # 定跡リーダ(book_from_csa の roundtrip テストで生成 .db を読み戻すのに使う)。
 # edition(NNUE)軸には触れないため default-features=false とし、rshogi-core の feature は

--- a/docs/build.md
+++ b/docs/build.md
@@ -83,7 +83,7 @@ build target で、5 カテゴリ × 複数 concrete preset の構造を持つ�
 
 | カテゴリ | 用途 | preset 名の例 | 含まれる arch |
 |---|---|---|---|
-| **universal** | 開発 / debug、全 arch runtime dispatch | `edition-universal` | 全 5 FT × 全 size × 全 ext |
+| **universal** | アプリ / 開発、header 駆動の動的推論 | `edition-universal` | HalfKX / LS、全 5 FT、任意次元 |
 | **HalfKX family** | 旧 NNUE 系統 (HalfKP / HalfKa\*) を dispatch | `edition-halfkx`, `edition-halfkx-any` | HalfKX 全 variant |
 | **HalfKX specific** | HalfKX 単一 architecture 専用 | `edition-halfkp-crelu`, `edition-halfka_hm_merged-screlu` | 1 architecture 固定 |
 | **LayerStack family** | LS 全 FT / size / ext を dispatch | `edition-layerstacks`, `edition-layerstacks-any-any-any` | LS 全構成 |
@@ -97,7 +97,19 @@ build target で、5 カテゴリ × 複数 concrete preset の構造を持つ�
 | 同じ NNUE モデルで SPRT / selfplay を回したい | specific preset (例 `edition-layerstacks-halfka_hm_merged-1536x16x32-psqt`) | dispatch 除去で最大 perf、再現性高い |
 | HalfKX 系モデル数本を切替えながら触りたい | `edition-halfkx-any` | activation 含む全 HalfKX を 1 binary でカバー |
 | LS 系を size 違いで切替えたい | `edition-layerstacks-any-any-any` | size / ext を runtime dispatch |
-| 全 arch / 全 size をまとめて動作確認したい | `edition-universal` | runtime dispatch で 1 binary が全 NNUE モデルを読み込める |
+| 全 arch / 任意 size をまとめて動作確認したい | `edition-universal` | header 駆動で対応 family を 1 binary に集約できる |
+
+`edition-universal` は NNUE header にある L1/L2/L3 を実行時に読み、HalfKX と
+LayerStacks のバッファおよび dense layer を動的に構成する。従って、新しい次元を
+追加するたびに Cargo feature とバイナリを増やす必要はない。HalfKP / HalfKaSplit /
+HalfKaMerged / HalfKaHmSplit / HalfKaHmMerged、HalfKX の CReLU / SCReLU /
+PairwiseCReLU、LayerStacks の PSQT / Threat profile 0 / EffectBucket、および
+KingRank9 / Progress8KPAbs bucket mode を扱う。
+
+一方、family / specific preset は従来どおり const-generic 実装を使う。大会、selfplay、
+SPRT など同じモデルを長時間使う用途では、SIMD 最適化と dispatch 除去を得られる
+specific preset を選ぶ。universal の目的はモデル互換性と配布サイズであり、固定
+edition の置き換えではない。
 
 ### 命名規則
 

--- a/docs/decisions/2026-05-24-build-edition-flavor-design.md
+++ b/docs/decisions/2026-05-24-build-edition-flavor-design.md
@@ -1,8 +1,22 @@
 # ビルド設定の Edition 軸設計 (Flavor 軸は非採用、Supplement 参照)
 
-- **Status**: Accepted (Edition 軸) / Flavor 軸は 2026-05-25 supplement で非採用に確定
-- **Date**: 2026-05-24 (本体) / 2026-05-25 (Flavor 軸 retire supplement)
+- **Status**: Accepted (Edition 軸) / Universal 実装は 2026-07-19 supplement で更新
+- **Date**: 2026-05-24 (本体) / 2026-05-25 (Flavor 軸 retire) / 2026-07-19 (dynamic universal)
 - **設計レビュー**: local Codex (REQUEST CHANGES → 反映済) / local Claude (APPROVE WITH SUGGESTIONS → 反映済) / GitHub Codex bot + Claude bot (PR #733 で auto-review、Critical 1 + Major 2 + Minor 2 + 事実誤り 1 を全て反映)
+
+## Supplement (2026-07-19): Universal を runtime-dimension 実装へ変更
+
+本 ADR の `edition-universal` に関する「全 const-generic variant / size をバイナリへ
+列挙し runtime dispatch する」という実装は廃止した。現在の universal は NNUE
+header から L1/L2/L3、FT、activation、拡張を読み、HalfKX / LayerStacks の推論器を
+実行時に構成する。この supplement は、以下に残る universal の内部展開例や
+「全 size feature を bundle」という記述を supersede する。
+
+- HalfKX / LayerStacks と 5 FT を runtime 構成し、次元追加ごとの再ビルドを不要にする。
+- LayerStacks は PSQT、Threat profile 0、EffectBucket、KingRank9 / Progress8KPAbs に対応する。
+- family / specific edition は const-generic 実装を維持する。固定モデルの大会・selfplay
+  では引き続き specific edition を性能基準とする。
+- `edition-universal` はアプリ配布サイズとモデル互換性を優先し、固定 edition を置換しない。
 
 ## Context
 


### PR DESCRIPTION
## 概要

- 既定の `edition-universal` を、固定次元variantの列挙からNNUEヘッダー駆動の動的次元推論へ変更
- HalfKX / LayerStacksの全5種類のFeature Transformerを実行時に判別
- HalfKXのCReLU / SCReLU / PairwiseCReLUに対応
- LayerStacksのKingRank9 / Progress8KPAbs、PSQT、EffectBucket、Threat profile 0に対応
- fixed / family editionは従来のconst-generic実装を維持
- compile-time dispatchが必要なLayerStacksツールは明示的なstatic editionを使用

## 背景

アプリでは、対応する任意次元のモデルを、次元ごとのWASMコードパスを同梱せずに読み込む必要がある。universal editionをヘッダー駆動にすることで、モデル互換性を維持しつつ配布バンドルを小さくする。

固定モデルを長時間使う大会・selfplay・SPRTでは、引き続きspecific editionを性能優先の選択肢とする。

## 対応範囲と互換性

- 動的Accumulator stackのidentityに次元、activation、bucket、PSQT、Threat構成を含め、EvalFile切替時に必要なら再構築
- universal buildではglobal NNUE初期化と独立して盤面effectを維持し、local `NNUEEvaluator` と遅延EffectBucket loadを安全化
- legacy EffectBucket headerをLayerStacks readerへdispatch
- `architecture_spec()` はstatic LayerStacks APIとの互換性を維持
- Threat profile 0に対応し、それ以外の除外profileは意図的に未対応
- Threatモデルの `Features=` 次元は、FTのみを記録する形式とFT+Threat合計を記録する既存tatara形式の両方を受理

## WASMサイズ

ramu-shogi production build。

### 1 thread

| Build | Raw | gzip -9 |
| --- | ---: | ---: |
| 従来static universal | 3,295,066 B | 362,283 B |
| 動的次元universal | 2,021,731 B | 278,753 B |
| 削減率 | 38.64% | 23.06% |

### threaded

| Build | Raw | gzip -9 |
| --- | ---: | ---: |
| 従来static universal | 3,321,562 B | 371,472 B |
| 動的次元universal | 2,112,228 B | 300,787 B |
| 削減率 | 36.41% | 19.03% |

## 推論性能

### 動的universal

LayerStacks 1536x16x32のstartpos探索では、最終動的buildが平均243,775 NPS、従来の固定variant群を内包したstatic universal baselineが310,717 NPSで、-21.54%。

この比較対象はLayerStacks specific editionではない。fixed / specific editionは引き続きconst-generic経路を使う。

### fixed LayerStacks editionの退行確認

PR直前 `59d4fcae` とPR実装 `9ee48fa0` を、production build、CPU 0固定、Threads=1、Hash=256 MiB、4局面、10秒探索、ABBA、3 rounds（各版24探索）で比較した。後続の `6532612c` はuniversal専用readerだけの変更で、fixed editionのbuild対象外。

| specific edition | 旧NPS | 新NPS | NPS差 | cycles/node差 | instructions/node差 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `layerstacks-halfka_hm_merged-1024x16x32-none` | 816,150 | 817,773 | +0.20% | -0.21% | -0.02% |
| `layerstacks-halfka_hm_merged-1024x16x32-threat` | 420,011 | 425,303 | +1.26% | -1.21% | +0.02% |

threat OFF / ONとも固定specific editionのNPS退行なし。

## レビュー対応

GitHub reviewで、Threat blockがFTとは別に格納される一方、`Features=` の報告次元に2種類の慣例がある点を確認した。

`6532612c` で以下を実施。

- `Features=` がFT次元のみの形式（例: 73305）を受理
- 既存tataraモデルのFT+Threat合計形式（290025 = 73305 + 216720）も維持
- 内部のFT行数へ正規化する回帰テストを追加
- 実Threatモデルでdynamic/static評価一致を確認

## 検証

- 独立レビュー: REQUEST CHANGESへの修正後にAPPROVE
- GitHub reviewのP1指摘へ修正・返信・スレッド解決
- `cargo test --workspace`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo check -p rshogi-core --target wasm32-unknown-unknown`
- fixed HalfKP CReLU / LayerStacks 1536x16x32 build
- production single-thread / threaded ramu-shogi WASM build
- HalfKP / LayerStacks（plain、PSQT、Threat）の実モデルdynamic/static評価一致
- LayerStacks全5 FT、HalfKX各activation、EffectBucket、KingRank9の実モデルload/search smoke test
- fixed LayerStacks threat OFF / ONのNPS A/B計測
- tracked absolute path check
