### PR TITLE
fix(nnue): LayerStacksのunderscore形式FTヘッダーに対応

### DIFF
--- a/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/dynamic_layer_stacks.rs
@@ -32,6 +32,7 @@ use super::piece_list::PieceNumber;
 use super::spec::{
     Activation, ArchitectureSpec, FeatureSet, parse_arch_dimensions,
     parse_feature_input_dimensions, parse_feature_set_from_arch,
+    parse_layer_stacks_feature_set_keyword,
 };
 use super::stats::{count_refresh, count_update};
 use crate::position::Position;
@@ -1019,6 +1020,9 @@ fn detect_feature(arch: &str) -> io::Result<FeatureSet> {
     if arch.contains("EffectBucket=") || arch.contains("E4=") {
         return Ok(FeatureSet::HalfKaHmMergedEffectBucket);
     }
+    if let Some(feature) = parse_layer_stacks_feature_set_keyword(arch).map_err(invalid)? {
+        return Ok(feature);
+    }
     if let Ok(feature) = parse_feature_set_from_arch(arch)
         && feature != FeatureSet::LayerStacks
     {
@@ -1359,6 +1363,29 @@ mod tests {
     use crate::nnue::network_layer_stacks::LayerStacksNetwork;
     use crate::position::SFEN_HIRATE;
     use crate::types::Move;
+
+    #[test]
+    fn layer_stacks_ft_detection_accepts_underscore_headers() {
+        let cases = [
+            ("HalfKP", 125_388, FeatureSet::HalfKP),
+            ("HalfKA", 138_510, FeatureSet::HalfKaSplit),
+            ("HalfKA_merged", 131_949, FeatureSet::HalfKaMerged),
+            ("HalfKA_hm_split", 76_950, FeatureSet::HalfKaHmSplit),
+            ("HalfKA_hm", 73_305, FeatureSet::HalfKaHmMerged),
+        ];
+        for (keyword, input_dim, expected) in cases {
+            let arch = format!(
+                "Features={keyword}(Friend)[{input_dim}->1536x2],Network=(ClippedReLU[32](SqrClippedReLU[30]))"
+            );
+            assert_eq!(detect_feature(&arch).unwrap(), expected, "keyword={keyword}");
+        }
+    }
+
+    #[test]
+    fn layer_stacks_ft_detection_rejects_unknown_keyword_substrings() {
+        let arch = "Features=UnknownHalfKaHmMerged(Friend)[73305->1536x2],Network=(ClippedReLU[32](SqrClippedReLU[30]))";
+        assert_eq!(detect_feature(arch).unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
 
     fn zero_affine(input_dim: usize, output_dim: usize) -> DynamicAffine {
         let bytes = vec![0; output_dim * 4 + output_dim * padded_input(input_dim)];

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -2035,7 +2035,8 @@ fn peek_layer_stacks_feature_set<R: Read + Seek>(
         let mut arch = vec![0u8; arch_len];
         reader.read_exact(&mut arch)?;
         let arch_str = String::from_utf8_lossy(&arch);
-        Ok(detect_layer_stacks_feature_set(&arch_str))
+        detect_layer_stacks_feature_set(&arch_str)
+            .map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))
     })();
     reader.seek(SeekFrom::Start(original))?;
     result
@@ -2043,23 +2044,15 @@ fn peek_layer_stacks_feature_set<R: Read + Seek>(
 
 /// arch_str から LS の FT を判別する pure helper (peek の純粋ロジック部分)。
 #[cfg(feature = "layerstack-arch")]
-fn detect_layer_stacks_feature_set(arch_str: &str) -> super::spec::FeatureSet {
+fn detect_layer_stacks_feature_set(arch_str: &str) -> Result<super::spec::FeatureSet, String> {
     use super::spec::FeatureSet as Fs;
     if arch_str.contains("EffectBucket=") {
-        return Fs::HalfKaHmMergedEffectBucket;
+        return Ok(Fs::HalfKaHmMergedEffectBucket);
     }
-    if let Some(name) = super::spec::parse_feature_set_keyword(arch_str) {
-        match name {
-            "HalfKP" => return Fs::HalfKP,
-            "HalfKaSplit" => return Fs::HalfKaSplit,
-            "HalfKaMerged" => return Fs::HalfKaMerged,
-            "HalfKaHmSplit" => return Fs::HalfKaHmSplit,
-            "HalfKaHmMergedEffectBucket" => return Fs::HalfKaHmMergedEffectBucket,
-            "HalfKaHmMerged" => return Fs::HalfKaHmMerged,
-            _ => {}
-        }
+    if let Some(feature) = super::spec::parse_layer_stacks_feature_set_keyword(arch_str)? {
+        return Ok(feature);
     }
-    super::spec::parse_feature_set_from_arch(arch_str).unwrap_or(Fs::LayerStacks)
+    Ok(super::spec::parse_feature_set_from_arch(arch_str).unwrap_or(Fs::LayerStacks))
 }
 
 #[cfg(feature = "nnue-effect-bucket")]
@@ -2365,7 +2358,7 @@ mod tests {
         }
     }
 
-    /// `detect_layer_stacks_feature_set` が tatara emit 形式の arch_str (PascalCase) を
+    /// `detect_layer_stacks_feature_set` が underscore / PascalCase の arch_str を
     /// 5 FT 全てで正しく分岐することを確認する。
     ///
     /// 実 NNUE の arch_str は `LayerStacks` キーワードを含まないため、`SqrClippedReLU`
@@ -2378,6 +2371,22 @@ mod tests {
         use crate::nnue::spec::FeatureSet as Fs;
 
         let cases: &[(&str, Fs)] = &[
+            (
+                "Features=HalfKA(Friend)[138510->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaSplit,
+            ),
+            (
+                "Features=HalfKA_merged(Friend)[131949->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaMerged,
+            ),
+            (
+                "Features=HalfKA_hm_split(Friend)[76950->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaHmSplit,
+            ),
+            (
+                "Features=HalfKA_hm(Friend)[73305->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
+                Fs::HalfKaHmMerged,
+            ),
             (
                 "Features=HalfKP(Friend)[125388->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-30](SqrClippedReLU[30](AffineTransform[16<-3072](InputSlice[3072(0:3072)]))))),fv_scale=28",
                 Fs::HalfKP,
@@ -2413,7 +2422,7 @@ mod tests {
         ];
 
         for (arch_str, expected) in cases {
-            let got = detect_layer_stacks_feature_set(arch_str);
+            let got = detect_layer_stacks_feature_set(arch_str).unwrap();
             assert_eq!(
                 got, *expected,
                 "arch_str={arch_str:?} → expected {expected:?}, got {got:?}"
@@ -2421,17 +2430,22 @@ mod tests {
         }
     }
 
-    /// `Features=` keyword が見つからない / 不明な FT のみ、`LayerStacks` fallback に
-    /// 落ちることを確認する。
+    /// `Features=` keyword が無い場合のみ `LayerStacks` fallback に落ち、明示された
+    /// 未知 keyword は拒否することを確認する。
     #[cfg(feature = "layerstack-arch")]
     #[test]
     fn test_detect_feature_set_fallback() {
         use crate::nnue::spec::FeatureSet as Fs;
         // Features= が無く LayerStacks キーワードがあるケース → fallback で LayerStacks
-        let got = detect_layer_stacks_feature_set("LayerStacks(...)");
+        let got = detect_layer_stacks_feature_set("LayerStacks(...)").unwrap();
         assert_eq!(got, Fs::LayerStacks);
         // 完全に未知 → fallback の unwrap_or で LayerStacks
-        let got = detect_layer_stacks_feature_set("unknown-arch-string");
+        let got = detect_layer_stacks_feature_set("unknown-arch-string").unwrap();
         assert_eq!(got, Fs::LayerStacks);
+        let err = detect_layer_stacks_feature_set(
+            "Features=UnknownHalfKaHmMerged(Friend)[73305->1536x2]",
+        )
+        .unwrap_err();
+        assert!(err.contains("Unknown feature set keyword"));
     }
 }

--- a/crates/rshogi-core/src/nnue/network_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/network_layer_stacks.rs
@@ -2006,11 +2006,11 @@ impl LayerStacksNetwork {
 /// reader の現在位置から LayerStacks ヘッダの arch_str を peek し、FT を判別する。
 ///
 /// tatara emit 形式の arch_str は `Features=<FT>(Friend)[<dim>->1536x2],...` で、
-/// `Features=` 直後のキーワード (HalfKaHmMerged / HalfKaHmSplit / HalfKaMerged /
-/// HalfKaSplit / HalfKP の PascalCase 5 種) を最優先で読み取る。無ければ汎用
-/// `parse_feature_set_from_arch` (LayerStacks fallback 含む) に委譲する。完全に
-/// 判別不能なモデルは `FeatureSet::LayerStacks` を返し、上位の `read_with_feature_set`
-/// で HalfKaHmMerged 互換扱いになる。
+/// `Features=` 直後のキーワードを最優先で読み取る。PascalCase 形式と underscore
+/// 形式を同じ 5 FT に解決し、キーワードが無ければ汎用 `parse_feature_set_from_arch`
+/// (LayerStacks fallback 含む) に委譲する。FT が明示されていないモデルは
+/// `FeatureSet::LayerStacks` を返し、上位の `read_with_feature_set` で
+/// HalfKaHmMerged 互換扱いになる。明示された未知キーワードはエラーにする。
 ///
 /// 読み取り後は `Seek::seek(SeekFrom::Start(original))` で reader 位置を巻き戻す。
 /// `BufReader<File>` 等の seekable reader では seek 時に内部 buffer が破棄・再同期される

--- a/crates/rshogi-core/src/nnue/spec.rs
+++ b/crates/rshogi-core/src/nnue/spec.rs
@@ -187,13 +187,57 @@ pub(crate) fn parse_feature_set_keyword(arch_str: &str) -> Option<&str> {
     Some(&after_key[..end])
 }
 
-/// アーキテクチャ文字列から FeatureSet を判定
-pub fn parse_feature_set_from_arch(arch_str: &str) -> Result<FeatureSet, String> {
+/// LayerStacks ヘッダーの `Features=` keyword から内部 FT を厳密に判定する。
+///
+/// family 判定では混在活性化や `Threat=` を優先して `LayerStacks` を返す必要があるが、
+/// 実際の入力特徴量はこの keyword から別途判定する。tatara の PascalCase 表記と
+/// bullet-shogi 系の underscore 表記を同じ FT に解決する。
+pub(crate) fn parse_layer_stacks_feature_set_keyword(
+    arch_str: &str,
+) -> Result<Option<FeatureSet>, String> {
     use super::constants::{
         HALFKA_DIMENSIONS, HALFKA_HM_DIMENSIONS, HALFKA_HM_SPLIT_DIMENSIONS,
         HALFKA_MERGED_DIMENSIONS,
     };
 
+    let Some(name) = parse_feature_set_keyword(arch_str) else {
+        return Ok(None);
+    };
+    let feature = match name {
+        "HalfKP" => FeatureSet::HalfKP,
+        "HalfKA_merged" | "HalfKaMerged" => FeatureSet::HalfKaMerged,
+        "HalfKA_hm_split" | "HalfKaHmSplit" => FeatureSet::HalfKaHmSplit,
+        "HalfKA_hm" | "HalfKaHmMerged" => FeatureSet::HalfKaHmMerged,
+        "HalfKaSplit" => FeatureSet::HalfKaSplit,
+        "HalfKaHmMergedEffectBucket" => FeatureSet::HalfKaHmMergedEffectBucket,
+        "HalfKA" => {
+            let reported_dim = parse_feature_input_dimensions(arch_str).ok_or_else(|| {
+                "HalfKA architecture is missing input dimensions in arch string.".to_string()
+            })?;
+            let threat_dim = arch_str
+                .split(',')
+                .find_map(|part| part.strip_prefix("Threat="))
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(0);
+            let resolve = |input_dim| match input_dim {
+                HALFKA_HM_DIMENSIONS => Some(FeatureSet::HalfKaHmMerged),
+                HALFKA_DIMENSIONS => Some(FeatureSet::HalfKaSplit),
+                HALFKA_MERGED_DIMENSIONS => Some(FeatureSet::HalfKaMerged),
+                HALFKA_HM_SPLIT_DIMENSIONS => Some(FeatureSet::HalfKaHmSplit),
+                _ => None,
+            };
+            resolve(reported_dim)
+                .or_else(|| reported_dim.checked_sub(threat_dim).and_then(resolve))
+                .ok_or_else(|| format!("Unknown HalfKA input dimensions: {reported_dim}"))?
+        }
+        "" => return Ok(None),
+        other => return Err(format!("Unknown feature set keyword: {other}")),
+    };
+    Ok(Some(feature))
+}
+
+/// アーキテクチャ文字列から FeatureSet を判定
+pub fn parse_feature_set_from_arch(arch_str: &str) -> Result<FeatureSet, String> {
     // 明示的な "LayerStacks" キーワードがあれば確定
     if arch_str.contains("LayerStacks") {
         return Ok(FeatureSet::LayerStacks);
@@ -227,40 +271,8 @@ pub fn parse_feature_set_from_arch(arch_str: &str) -> Result<FeatureSet, String>
     // Features= キーワードを切り出して `==` で完全一致判定する。
     // underscore 表記 (`HalfKA_hm` 等) と PascalCase 表記 (`HalfKaHmMerged` 等) の両方を
     // 同じ enum に解決して、両綴りで emit された .bin ヘッダを共通にロードできる。
-    if let Some(name) = parse_feature_set_keyword(arch_str) {
-        match name {
-            "HalfKP" => return Ok(FeatureSet::HalfKP),
-
-            // plane を明示する綴り (両表記)。
-            "HalfKA_merged" | "HalfKaMerged" => return Ok(FeatureSet::HalfKaMerged),
-            "HalfKA_hm_split" | "HalfKaHmSplit" => return Ok(FeatureSet::HalfKaHmSplit),
-            "HalfKaHmMergedEffectBucket" => return Ok(FeatureSet::HalfKaHmMergedEffectBucket),
-
-            // mirror + merged: underscore / PascalCase の同義綴り。
-            "HalfKA_hm" | "HalfKaHmMerged" => return Ok(FeatureSet::HalfKaHmMerged),
-            // 非ミラー + split: PascalCase 綴り (underscore 綴りは plane 暗黙の "HalfKA" 経由)。
-            "HalfKaSplit" => return Ok(FeatureSet::HalfKaSplit),
-
-            // "HalfKA" 単独は plane 暗黙: bullet-shogi 互換のため input_dim で
-            // disambiguate する (HALFKA_HM_DIMENSIONS なら HalfKA_hm、等)。
-            "HalfKA" => {
-                let input_dim = parse_feature_input_dimensions(arch_str).ok_or_else(|| {
-                    "HalfKA architecture is missing input dimensions in arch string.".to_string()
-                })?;
-                return match input_dim {
-                    HALFKA_HM_DIMENSIONS => Ok(FeatureSet::HalfKaHmMerged),
-                    HALFKA_DIMENSIONS => Ok(FeatureSet::HalfKaSplit),
-                    HALFKA_MERGED_DIMENSIONS => Ok(FeatureSet::HalfKaMerged),
-                    HALFKA_HM_SPLIT_DIMENSIONS => Ok(FeatureSet::HalfKaHmSplit),
-                    _ => Err(format!("Unknown HalfKA input dimensions: {input_dim}")),
-                };
-            }
-
-            // 空 keyword (`Features=,...` 形式) は LayerStacks フォールバックへ落とす。
-            "" => {}
-
-            other => return Err(format!("Unknown feature set keyword: {other}")),
-        }
+    if let Some(feature) = parse_layer_stacks_feature_set_keyword(arch_str)? {
+        return Ok(feature);
     }
 
     // HalfKX キーワードを持たないネスト形式 LayerStacks: FT_OUT パターンで補完判定
@@ -1268,6 +1280,48 @@ mod tests {
         assert_eq!(
             parse_feature_set_from_arch("Features=HalfKA[138510->512x2]").unwrap(),
             parse_feature_set_from_arch("Features=HalfKaSplit[138510->512x2]").unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_layer_stacks_internal_ft_accepts_both_header_styles() {
+        let cases: &[(&str, usize, FeatureSet)] = &[
+            ("HalfKP", 125_388, FeatureSet::HalfKP),
+            ("HalfKA", 138_510, FeatureSet::HalfKaSplit),
+            ("HalfKA_merged", 131_949, FeatureSet::HalfKaMerged),
+            ("HalfKA_hm_split", 76_950, FeatureSet::HalfKaHmSplit),
+            ("HalfKA_hm", 73_305, FeatureSet::HalfKaHmMerged),
+            ("HalfKaSplit", 138_510, FeatureSet::HalfKaSplit),
+            ("HalfKaMerged", 131_949, FeatureSet::HalfKaMerged),
+            ("HalfKaHmSplit", 76_950, FeatureSet::HalfKaHmSplit),
+            ("HalfKaHmMerged", 73_305, FeatureSet::HalfKaHmMerged),
+        ];
+        for &(keyword, input_dim, expected) in cases {
+            let arch = format!(
+                "Features={keyword}(Friend)[{input_dim}->1536x2],Network=AffineTransform[1<-32](ClippedReLU[32](SqrClippedReLU[30](AffineTransform[16<-3072])))"
+            );
+            assert_eq!(parse_feature_set_from_arch(&arch).unwrap(), FeatureSet::LayerStacks);
+            assert_eq!(
+                parse_layer_stacks_feature_set_keyword(&arch).unwrap(),
+                Some(expected),
+                "keyword={keyword}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_layer_stacks_internal_ft_rejects_unknown_keyword_substrings() {
+        let arch = "Features=UnknownHalfKaHmMerged(Friend)[73305->1536x2],Network=(ClippedReLU[32](SqrClippedReLU[30]))";
+        let err = parse_layer_stacks_feature_set_keyword(arch).unwrap_err();
+        assert!(err.contains("Unknown feature set keyword"));
+    }
+
+    #[test]
+    fn test_layer_stacks_implicit_halfka_accepts_combined_threat_dimensions() {
+        let arch = "Features=HalfKA(Friend)[355230->1536x2],Threat=216720,Network=(ClippedReLU[32](SqrClippedReLU[30]))";
+        assert_eq!(
+            parse_layer_stacks_feature_set_keyword(arch).unwrap(),
+            Some(FeatureSet::HalfKaSplit)
         );
     }
 


### PR DESCRIPTION
## 概要

LayerStacksモデルの一般的なunderscore形式FTヘッダーを、universal editionと固定次元LayerStacks editionの双方で読み込めるようにします。

対象例:

- `HalfKA_hm`
- `HalfKA_hm_split`
- `HalfKA_merged`
- plane暗黙の`HalfKA`
- 既存のPascalCase形式と`HalfKP`

## 原因

LayerStacksの混在活性化または`Threat=`を検出すると、top-levelのfamily parserは正しく`LayerStacks`を返します。一方、その後のLayerStacks内部FT判定はPascalCase形式だけを独自に判定していたため、`Features=HalfKA_hm(...)`などを`unknown LayerStacks FT`として拒否していました。

## 変更内容

- LayerStacks内部FT用の厳密なkeyword resolverを共通化
- underscore形式とPascalCase形式を同じ5 FTへ解決
- plane暗黙の`HalfKA`は入力次元で判定
- ThreatモデルがFT次元とThreat次元の合算値を報告する形式にも対応
- 動的universalローダーと固定次元LayerStacksローダーから共通resolverを使用
- 明示された未知keywordを部分文字列で誤認せず拒否
- top-level family parserの判定順と`LayerStacks`分類は変更しない

## 実モデル確認

universal editionで次のunderscore形式モデルを実際にロードし、`LS_BUCKET_MODE=kingrank9`で`readyok`と初期局面評価まで確認しました。

- 通常版 `Features=HalfKA_hm(Friend)[73305->1536x2]`: 評価 `-40`
- Threat版 `Features=HalfKA_hm(Friend)[290025->512x2],Threat=216720`: 評価 `-456`

固定次元`edition-layerstacks-halfka_hm_merged-1536x32x32-none`でも通常版をロードし、KingRank9で同じ評価`-40`を確認しています。

## tatara実出力との互換性確認

tatara `701eaf5` のヘッダー生成ロジックを確認し、100局面のサンプルPSVを1 superbatch・1 batch（16局面）だけ学習して、実際のNNUEファイルを55通り出力しました。

- Simple: 5 FT × 3活性化（CReLU / SCReLU / Pairwise）= 15ファイル
- LayerStacks: 5 FT × 8構成（plain / PSQT / Threat 6プロファイル）= 40ファイル
- PSQTとThreatはtatara側で排他のため、同時有効は有効な出力パターンに含めない
- EffectBucketは今回の対象外

全55ファイルの実ヘッダーを抽出して、FT名・入力次元・`PSQT=`・`Threat=`・`ThreatProfile=`・活性化表現を期待値と照合し、不一致0件でした。tataraの現在の正規出力は `HalfKP` / `HalfKaSplit` / `HalfKaMerged` / `HalfKaHmSplit` / `HalfKaHmMerged` のPascalCaseです。PRの共通resolverはこれらを維持したままunderscore形式も受理します。

同じ55ファイルをuniversal editionでロードし、`readyok`と初期局面の`eval`まで確認しました。

- 対応範囲30件: Simple 15件、LayerStacks plain 5件、PSQT 5件、Threat full 5件はすべて成功
- Threat非full 25件: 既知の未対応として `Threat dimensions mismatch` または「profile 0以外は未対応」で明示的に拒否
- 予期しないロード失敗: 0件

Threat非fullプロファイルの推論対応は本PRの対象外です。今回の結果では、現在サポート対象としているtatara出力に退行がないことと、未対応範囲がヘッダー表記の不整合ではなくThreat実装上の制限であることを分離して確認できました。

## 検証

- `cargo test`（workspace全体）
- `cargo test -p rshogi-core`
- `cargo test -p rshogi-core --no-default-features --features edition-layerstacks test_detect_feature_set -- --nocapture`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo fmt --all --check`
- `bash scripts/check-tracked-abs-paths.sh`
- universal editionで通常版・Threat版の実モデルUSIロードとKingRank9評価
- 固定次元editionで通常版の実モデルUSIロードとKingRank9評価
- tatara実学習出力55ファイルのヘッダー照合とuniversalロード・評価マトリクス

## 対象外

EffectBucket、Threat非fullプロファイルの推論サポート、推論性能には変更を加えていません。動的LayerStacksの性能改善PRとは独立した修正です。
