### PR TITLE
chore(release): rshogi-core 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ core 変更を公開する PR では `crates/rshogi-core/Cargo.toml` のバー�
 
 ## Unreleased
 
+- **rshogi-core 0.5.1 (crates.io)**: default の `edition-universal` をモデルヘッダー駆動の
+  runtime-dimension構成へ変更。HalfKXの5 FT・3活性化と、LayerStacksの5 FT・任意次元・
+  PSQT・full Threatを、次元ごとの固定editionを列挙せず読み込めるようにした。動的
+  LayerStacksの差分更新性能を改善し、従来のPascalCase形式に加えて一般的なunderscore形式
+  (`HalfKA_hm`等) のFTヘッダーも受理する。EffectBucketとThreat非fullプロファイルは未対応。
 - **rshogi-core publish 規約の訂正**: v1.3.0 で追加した「engine の `vX.Y.Z` タグと同時に、
   そのタグから publish する」という規約を撤回。core 単独変更や engine 以外の変更だけを
   含む期間にも core を公開できるよう、core は engine release と独立して version bump・publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "rshogi-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "getrandom 0.3.4",

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rshogi-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["SH11235"]
 description = "A high-performance shogi engine core library with NNUE evaluation"


### PR DESCRIPTION
## 概要

`rshogi-core` 0.5.1 の crates.io 公開準備です。engine release とは独立した core-only release とし、タグは作成しません。マージ後、この PR のマージコミットから publish します。

## 変更内容

- `rshogi-core` を 0.5.1 に更新
- #950: default `edition-universal` をモデルヘッダー駆動の runtime-dimension 構成へ変更
- #951: 動的 LayerStacks の差分更新性能を改善
- #952: `HalfKA_hm` など一般的な underscore 形式の FT ヘッダーを受理
- `Cargo.lock` と `CHANGELOG.md` を更新

## 0.5.1 の universal 対応範囲

- HalfKX: 5 FT、3 activation
- LayerStacks: 5 FT、任意次元、PSQT、full Threat
- 未対応: EffectBucket、Threat 非 full プロファイル

## 検証

- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `bash scripts/check-tracked-abs-paths.sh`
- `cargo publish -p rshogi-core --dry-run --allow-dirty`
  - package: 154 files
  - 3.1 MiB raw / 613.0 KiB compressed
  - package verification compile 成功

## 公開手順

1. CI 成功後にこの PR をマージ
2. マージコミットを checkout
3. `cargo publish -p rshogi-core`
4. crates.io で 0.5.1 を確認

engine の `vX.Y.Z` タグおよび core 専用タグは作成しません。
