### PR TITLE
fix(release): rshogi-core 0.5.2でlibc下限を明示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ core 変更を公開する PR では `crates/rshogi-core/Cargo.toml` のバー�
 
 ## Unreleased
 
+- **rshogi-core 0.5.2 (crates.io)**: Linux で使用する `libc::NAME_MAX` が公開された
+  `libc 0.2.186` を最小依存バージョンとして明示。既存の lockfile が古い `libc` を選択した
+  consumer で 0.5.1 がコンパイルできない問題を修正。
 - **rshogi-core 0.5.1 (crates.io)**: default の `edition-universal` をモデルヘッダー駆動の
   runtime-dimension構成へ変更。HalfKXの5 FT・3活性化と、LayerStacksの5 FT・任意次元・
   PSQT・full Threatを、次元ごとの固定editionを列挙せず読み込めるようにした。動的

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "rshogi-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "getrandom 0.3.4",

--- a/crates/rshogi-core/Cargo.toml
+++ b/crates/rshogi-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rshogi-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 authors = ["SH11235"]
 description = "A high-performance shogi engine core library with NNUE evaluation"
@@ -20,7 +20,7 @@ rand_xoshiro.workspace = true
 serde.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.186"
 
 [target.'cfg(windows)'.dependencies]
 # Keep in sync with clap's transitive windows-sys (0.60.x) to avoid duplicate versions on Windows.


### PR DESCRIPTION
## 概要

`rshogi-core` 0.5.1 の公開直後、既存の lockfile が `libc 0.2.177` を保持する consumer（ramu-shogi）でLinuxビルドが失敗することを検出しました。`libc::NAME_MAX` がLinux向けに公開された 0.2.186 を最小依存バージョンとして明示し、0.5.2としてパッチリリースします。

## 原因

0.5.1は `libc = "0.2"` のまま `libc::NAME_MAX` を使用していました。rshogiの現行lockfileは0.2.186を選ぶためCIとpublish dry-runは成功しましたが、semver上許容される0.2.177を保持したconsumerではシンボルがなくコンパイルできません。

## 変更

- `rshogi-core` 0.5.2
- Unix向け `libc` の最小バージョンを0.2.186へ更新
- CHANGELOGとworkspace lockを更新

## 検証

- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `bash scripts/check-tracked-abs-paths.sh`
- `cargo publish -p rshogi-core --dry-run --allow-dirty`
- ramu-shogiの旧lock条件でpath patchを適用
  - `libc 0.2.177 -> 0.2.186`へ自動更新
  - `cargo check --workspace`成功

マージ後はタグを作らず、このPRのマージコミットから`rshogi-core 0.5.2`をpublishします。
