### PR TITLE
test(core): 入玉宣言 24点法/27点法の境界局面 regression test

### DIFF
--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -3011,6 +3011,56 @@ mod tests {
         assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::NONE);
     }
 
+    // 24点法(31点)と27点法(先手28/後手27点)の判定が分かれる境界局面。
+    // 実対局由来: 27点法設定のエンジンが宣言し、24点法のサーバーに拒否され得る帯
+    // (27〜30点) の局面で、ルールごとの結果が食い違うことを固定する。
+
+    #[test]
+    fn test_declaration_win_point24_rejects_29_points_black() {
+        // 先手29点(敵陣: 馬・角・飛5点×3 + 小駒7枚、持駒: 金1銀2歩4)、玉2段目、敵陣10枚
+        let sfen = "+B+N4R+Pl/KBG2g2l/P+P2P+N3/6p2/2p3s2/4S2L1/G8/7p+l/7+pk b G2S4Pr2n6p 1";
+        let pos = make_pos(sfen);
+        let info = pos.entering_king_point_info(Color::Black);
+        assert_eq!(info.points, 29);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point24), Move::NONE);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::WIN);
+    }
+
+    #[test]
+    fn test_declaration_win_point24_rejects_27_points_white() {
+        // 後手27点(敵陣: 龍・飛・馬5点×3 + 小駒7枚、持駒: 銀1香1歩3)、玉9段目、敵陣10枚
+        let sfen = "K+P7/L+N+P3P2/8+P/B8/9/4s1g2/p+ns3g1+n/2l5+p/1+r2r1+b1k w 2GSNL9Psl3p 1";
+        let pos = make_pos(sfen);
+        let info = pos.entering_king_point_info(Color::White);
+        assert_eq!(info.points, 27);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point24), Move::NONE);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::WIN);
+    }
+
+    #[test]
+    fn test_declaration_win_point24_rejects_27_points_white_dense_zone() {
+        // 後手27点だが敵陣15枚(小駒中心)の別パターン。持駒: 桂1歩3
+        let sfen =
+            "K+P7/+SP1+b1+B3/9/9/P+L2p4/5g+p2/1pg+lsn2+l/1+rp3+pPk/1+p1rgg1+l+s w S2N5Pn3p 1";
+        let pos = make_pos(sfen);
+        let info = pos.entering_king_point_info(Color::White);
+        assert_eq!(info.points, 27);
+        assert_eq!(info.enemy_zone_pieces, 15);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point24), Move::NONE);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::WIN);
+    }
+
+    #[test]
+    fn test_declaration_win_point24_accepts_31_points_white() {
+        // 後手31点(敵陣: 馬・龍5点×2 + 小駒8枚、持駒: 桂2香1歩10)ちょうどで宣言成立
+        let sfen = "1+R4+L1K/7PP/6g2/5P1sp/4b2g1/2P4n1/1g1P2Psg/1+bl2+r2l/3sP+n1sk w 2nl10p 1";
+        let pos = make_pos(sfen);
+        let info = pos.entering_king_point_info(Color::White);
+        assert_eq!(info.points, 31);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point24), Move::WIN);
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::WIN);
+    }
+
     #[test]
     fn test_count_total_piece_points_startpos() {
         let pos = make_pos("lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1");


### PR DESCRIPTION
## 背景

rating6 CSA クロスマシンシリーズ (2026-07-18) で、`%KACHI` 宣言がサーバーに拒否され
`ILLEGAL_KACHI` 反則負けとなる事象が 3 局発生した (game_id:
r6-s2n19-1784329453-1784329460915 / r6-s6n28-1784342585-1784342592124 /
r6-s7n29-1784339624-1784339632880)。

## 調査結果 (コードのバグではない)

- サーバー正本 CSA から宣言時局面を再構成し駒点を検算した結果、宣言側の点数は
  **29 / 27 / 27 点**。いずれも 27点法 (先手28/後手27) では成立、24点法 (31点) では
  不成立の境界帯だった。サーバー (Point24) の Rejected 判定は正しい。
- エンジンとサーバーは同一の `Position::declaration_win` を使っており、関数自体に
  バグはない。原因は**クライアント起動時の usi_options に `EnteringKingRule` が無く**、
  エンジンが USI 既定の `CSARule27` で宣言判定していたルール不一致 (両マシンの
  jsonl `engine_cmd` で確認)。shiba 側 100% 集中は偶然で、同シリーズ s3n17 では
  shiba が 31 点ちょうどで宣言し受理されている。
- 機種依存 (SIMD/丸め) 説・時間切迫での判定省略説は棄却: 判定は root で毎回無条件に
  呼ばれ、整数演算のみ。

## 変更内容

該当 3 局面 + 受理された 31 点局面を SFEN で固定し、`declaration_win` が
Point24 / Point27 で正しく判定を分けることを pin する regression test を 4 本追加。
コード変更なし (テストのみ)。

運用側の再発防止 (シリーズ起動テンプレへの `EnteringKingRule=CSARule24` 追加) は
skill 側で対応済み。サーバーが Game_Summary で入玉ルールを広告しクライアントが
自動 setoption する恒久策は別課題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeVA9V36ojSNbcydM9Puz8