### PR TITLE
feat(csa): Game_Summary で入玉ルールを広告し client がエンジンへ自動伝達

### DIFF
--- a/crates/rshogi-csa-client/src/engine.rs
+++ b/crates/rshogi-csa-client/src/engine.rs
@@ -154,6 +154,13 @@ pub trait UsiEngineDriver {
     /// USI `usinewgame` 相当を実装する。対局開始前に 1 度呼ばれる。
     fn new_game(&mut self) -> Result<()>;
 
+    /// USI `setoption name <name> value <value>` を送信する。
+    ///
+    /// session はサーバーが Game_Summary で広告した入玉ルールをエンジンへ伝える
+    /// ために [`UsiEngineDriver::new_game`] の直前に呼ぶ。同期は後続 `new_game`
+    /// (usinewgame + isready) の readyok 待ちに委ねてよい。
+    fn set_option(&mut self, name: &str, value: &str) -> Result<()>;
+
     /// `position` + `go` を送信し、bestmove または server interrupt まで block する。
     ///
     /// 実装の責任:
@@ -218,6 +225,10 @@ pub trait UsiEngineDriver {
 impl UsiEngineDriver for UsiEngine {
     fn new_game(&mut self) -> Result<()> {
         UsiEngine::new_game(self)
+    }
+
+    fn set_option(&mut self, name: &str, value: &str) -> Result<()> {
+        self.send(&format!("setoption name {name} value {value}"))
     }
 
     fn go_with_info(

--- a/crates/rshogi-csa-client/src/jsonl.rs
+++ b/crates/rshogi-csa-client/src/jsonl.rs
@@ -548,6 +548,7 @@ mod tests {
             black_time: TimeConfig::default(),
             white_time: TimeConfig::default(),
             reconnect_token: None,
+            entering_king_rule: None,
         }
     }
 

--- a/crates/rshogi-csa-client/src/main.rs
+++ b/crates/rshogi-csa-client/src/main.rs
@@ -1111,6 +1111,7 @@ mod tests {
                 increment_ms: 0,
             },
             reconnect_token,
+            entering_king_rule: None,
         };
         SessionOutcome {
             result,

--- a/crates/rshogi-csa-client/src/protocol.rs
+++ b/crates/rshogi-csa-client/src/protocol.rs
@@ -50,6 +50,11 @@ pub struct GameSummary {
     /// `Some(token)` の場合、WS 切断時に `LOGIN <id> <pw> reconnect:<game_id>+<token>`
     /// で同一対局へ復帰できる (Workers の `RECONNECT_GRACE_SECONDS` 以内)。
     pub reconnect_token: Option<String>,
+    /// サーバーが広告した `%KACHI` 判定の入玉ルール。`Entering_King_Rule:` 拡張行
+    /// (USI トークン、本リポサーバー) を優先し、無ければ CSA 標準の
+    /// `Declaration:Jishogi 1.1` (27 点法、wdoor 等) から導出する。どちらも
+    /// 無ければ `None` (サーバーのルール不明。エンジン設定は変更しない)。
+    pub entering_king_rule: Option<rshogi_core::types::EnteringKingRule>,
 }
 
 /// 再接続成立時にサーバから送られる `BEGIN Reconnect_State` ブロックの
@@ -242,6 +247,8 @@ impl CsaConnection {
         let mut position_lines = Vec::new();
         let mut in_position = false;
         let mut reconnect_token: Option<String> = None;
+        let mut entering_king_rule: Option<rshogi_core::types::EnteringKingRule> = None;
+        let mut declaration_jishogi = false;
 
         // 時間設定: 共通 / 先手別 / 後手別の3レイヤー
         // Time_Unit のデフォルトは秒 (1000ms)
@@ -340,6 +347,14 @@ impl CsaConnection {
             } else if let Some(val) = line.strip_prefix("Increment:") {
                 let v: i64 = val.trim().parse().unwrap_or(0);
                 common_time.increment_ms = v * header_time_unit_ms;
+            } else if let Some(val) = line.strip_prefix("Entering_King_Rule:") {
+                let val = val.trim();
+                entering_king_rule = rshogi_core::types::EnteringKingRule::from_usi(val);
+                if entering_king_rule.is_none() {
+                    log::warn!("[CSA] 未知の Entering_King_Rule '{val}' を無視します");
+                }
+            } else if let Some(val) = line.strip_prefix("Declaration:") {
+                declaration_jishogi = val.trim() == "Jishogi 1.1";
             } else if let Some(val) = line.strip_prefix("Reconnect_Token:") {
                 // 自色用 token は `END Game_Summary` 直前に 1 行だけ届く拡張行。
                 // 相手色 token は届かない（サーバ側 `build_for(my_color)` で除外）。
@@ -362,6 +377,12 @@ impl CsaConnection {
             })
             .collect();
 
+        // 拡張行が無いサーバー (wdoor 等) では CSA 標準 `Declaration:Jishogi 1.1`
+        // (= 27 点法) から導出する。
+        if entering_king_rule.is_none() && declaration_jishogi {
+            entering_king_rule = Some(rshogi_core::types::EnteringKingRule::Point27);
+        }
+
         let summary = GameSummary {
             game_id,
             my_color,
@@ -372,6 +393,7 @@ impl CsaConnection {
             black_time: final_black_time,
             white_time: final_white_time,
             reconnect_token,
+            entering_king_rule,
         };
         log::info!(
             "[CSA] 対局情報受信: {} ({}手目から) {}vs{} 先手:{}ms+{}ms+{}ms 後手:{}ms+{}ms+{}ms",

--- a/crates/rshogi-csa-client/src/record.rs
+++ b/crates/rshogi-csa-client/src/record.rs
@@ -466,6 +466,7 @@ mod tests {
             black_time: TimeConfig::default(),
             white_time: TimeConfig::default(),
             reconnect_token: Some("token".to_owned()),
+            entering_king_rule: None,
         }
     }
 

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -252,6 +252,7 @@ where
     {
         return Err(map_anyhow_to_session_error(err));
     }
+    apply_advertised_entering_king_rule(config, engine, &summary)?;
     if let Err(err) = engine.new_game() {
         return Err(SessionError::Engine(format!("{err}")));
     }
@@ -380,6 +381,42 @@ enum MoveAction {
 // ────────────────────────────────────────────
 // メインループ
 // ────────────────────────────────────────────
+
+/// サーバーが Game_Summary で広告した入玉ルールをエンジンへ伝える。
+///
+/// config の `engine.options` に `EnteringKingRule` が明示されている場合は
+/// ユーザー設定を優先し、広告値と異なるときは warn のみ出す。未指定なら
+/// `setoption` で広告値を注入する。広告が無いサーバーでは何もしない
+/// (エンジン既定のまま)。
+fn apply_advertised_entering_king_rule<E>(
+    config: &CsaClientConfig,
+    engine: &mut E,
+    summary: &GameSummary,
+) -> Result<(), SessionError>
+where
+    E: UsiEngineDriver + ?Sized,
+{
+    let Some(rule) = summary.entering_king_rule else {
+        return Ok(());
+    };
+    let advertised = rule.to_usi();
+    if let Some(configured) = config.engine.options.get("EnteringKingRule") {
+        let configured = match configured {
+            toml::Value::String(v) => v.clone(),
+            other => other.to_string(),
+        };
+        if configured != advertised {
+            log::warn!(
+                "[CSA] EnteringKingRule 設定 ({configured}) がサーバー広告 ({advertised}) と一致しません。設定値を優先します"
+            );
+        }
+        return Ok(());
+    }
+    log::info!("[CSA] サーバー広告に従い EnteringKingRule={advertised} を設定します");
+    engine
+        .set_option("EnteringKingRule", advertised)
+        .map_err(|err| SessionError::Engine(format!("{err}")))
+}
 
 fn run_session_loop<E, S>(
     conn: &mut CsaConnection,
@@ -2185,6 +2222,7 @@ mod tests {
             black_time: crate::protocol::TimeConfig::default(),
             white_time: crate::protocol::TimeConfig::default(),
             reconnect_token: None,
+            entering_king_rule: None,
         };
         let proto_state = ProtocolReconnectState {
             current_turn: Some(Color::Black),
@@ -2197,6 +2235,105 @@ mod tests {
         assert_eq!(pub_state.side_to_move, Side::Black);
         assert_eq!(pub_state.remaining_time_sec_self, Some(10));
         assert_eq!(pub_state.remaining_time_sec_opp, Some(5));
+    }
+
+    /// set_option 呼び出しだけを記録する stub。他の driver method は
+    /// apply_advertised_entering_king_rule から呼ばれない契約なので panic でよい。
+    struct RecordingEngine {
+        set_options: Vec<(String, String)>,
+    }
+
+    impl UsiEngineDriver for RecordingEngine {
+        fn new_game(&mut self) -> anyhow::Result<()> {
+            unreachable!()
+        }
+        fn set_option(&mut self, name: &str, value: &str) -> anyhow::Result<()> {
+            self.set_options.push((name.to_owned(), value.to_owned()));
+            Ok(())
+        }
+        fn go_with_info(
+            &mut self,
+            _: &str,
+            _: &str,
+            _: &std::sync::atomic::AtomicBool,
+            _: &std::sync::mpsc::Receiver<Event>,
+            _: &mut crate::engine::InfoCallback<'_>,
+        ) -> anyhow::Result<SearchOutcome> {
+            unreachable!()
+        }
+        fn go_ponder(&mut self, _: &str, _: &str) -> anyhow::Result<()> {
+            unreachable!()
+        }
+        fn ponderhit_with_info(
+            &mut self,
+            _: &std::sync::atomic::AtomicBool,
+            _: &std::sync::mpsc::Receiver<Event>,
+            _: &mut crate::engine::InfoCallback<'_>,
+        ) -> anyhow::Result<SearchOutcome> {
+            unreachable!()
+        }
+        fn stop_and_wait(&mut self) -> anyhow::Result<()> {
+            unreachable!()
+        }
+        fn gameover(&mut self, _: &str) -> anyhow::Result<()> {
+            unreachable!()
+        }
+    }
+
+    fn summary_with_rule(rule: Option<rshogi_core::types::EnteringKingRule>) -> GameSummary {
+        use rshogi_csa::{Color, initial_position};
+        GameSummary {
+            game_id: "g".to_owned(),
+            my_color: Color::Black,
+            sente_name: "b".to_owned(),
+            gote_name: "w".to_owned(),
+            position: initial_position(),
+            initial_moves: Vec::new(),
+            black_time: crate::protocol::TimeConfig::default(),
+            white_time: crate::protocol::TimeConfig::default(),
+            reconnect_token: None,
+            entering_king_rule: rule,
+        }
+    }
+
+    #[test]
+    fn advertised_rule_is_injected_when_config_unset() {
+        let config = CsaClientConfig::default();
+        let mut engine = RecordingEngine {
+            set_options: Vec::new(),
+        };
+        let summary = summary_with_rule(Some(rshogi_core::types::EnteringKingRule::Point24));
+        apply_advertised_entering_king_rule(&config, &mut engine, &summary).unwrap();
+        assert_eq!(
+            engine.set_options,
+            vec![("EnteringKingRule".to_owned(), "CSARule24".to_owned())]
+        );
+    }
+
+    #[test]
+    fn configured_rule_wins_over_advertised() {
+        let mut config = CsaClientConfig::default();
+        config
+            .engine
+            .options
+            .insert("EnteringKingRule".to_owned(), toml::Value::String("CSARule27".to_owned()));
+        let mut engine = RecordingEngine {
+            set_options: Vec::new(),
+        };
+        let summary = summary_with_rule(Some(rshogi_core::types::EnteringKingRule::Point24));
+        apply_advertised_entering_king_rule(&config, &mut engine, &summary).unwrap();
+        assert!(engine.set_options.is_empty());
+    }
+
+    #[test]
+    fn no_advertisement_leaves_engine_untouched() {
+        let config = CsaClientConfig::default();
+        let mut engine = RecordingEngine {
+            set_options: Vec::new(),
+        };
+        let summary = summary_with_rule(None);
+        apply_advertised_entering_king_rule(&config, &mut engine, &summary).unwrap();
+        assert!(engine.set_options.is_empty());
     }
 
     #[test]
@@ -2212,6 +2349,7 @@ mod tests {
             black_time: crate::protocol::TimeConfig::default(),
             white_time: crate::protocol::TimeConfig::default(),
             reconnect_token: None,
+            entering_king_rule: None,
         };
         let proto_state = ProtocolReconnectState {
             current_turn: Some(Color::White),
@@ -2243,6 +2381,7 @@ mod tests {
             black_time: time.clone(),
             white_time: time,
             reconnect_token: None,
+            entering_king_rule: None,
         }
     }
 
@@ -2263,6 +2402,7 @@ mod tests {
             black_time: time.clone(),
             white_time: time,
             reconnect_token: None,
+            entering_king_rule: None,
         }
     }
 

--- a/crates/rshogi-csa-client/src/session.rs
+++ b/crates/rshogi-csa-client/src/session.rs
@@ -387,7 +387,7 @@ enum MoveAction {
 /// config の `engine.options` に `EnteringKingRule` が明示されている場合は
 /// ユーザー設定を優先し、広告値と異なるときは warn のみ出す。未指定なら
 /// `setoption` で広告値を注入する。広告が無いサーバーでは何もしない
-/// (エンジン既定のまま)。
+/// (エンジンは既定値、または同一プロセスで前局に注入された値のまま)。
 fn apply_advertised_entering_king_rule<E>(
     config: &CsaClientConfig,
     engine: &mut E,

--- a/crates/rshogi-csa-client/tests/csa_entering_king_rule.rs
+++ b/crates/rshogi-csa-client/tests/csa_entering_king_rule.rs
@@ -1,0 +1,106 @@
+//! Game_Summary の入玉ルール広告 (`Entering_King_Rule:` 拡張行 / CSA 標準
+//! `Declaration:Jishogi 1.1`) を client が正しく解釈するか TCP loopback で確認する。
+//! transport 種別非依存の parse 経路のため TCP / WS 共通の挙動として妥当に確認できる。
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use rshogi_core::types::EnteringKingRule;
+use rshogi_csa_client::protocol::CsaConnection;
+
+/// 1 接続を受け取り、与えた `handler` を別スレッドで実行する mock CSA TCP サーバ。
+fn spawn_mock_tcp_server<F>(handler: F) -> u16
+where
+    F: FnOnce(&mut dyn BufRead, &mut dyn Write) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+        let mut writer = stream;
+        handler(&mut reader, &mut writer);
+    });
+    port
+}
+
+fn read_line(reader: &mut dyn BufRead) -> String {
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read_line");
+    line.trim_end().to_owned()
+}
+
+fn write_lines(writer: &mut dyn Write, lines: &[&str]) {
+    for line in lines {
+        writer.write_all(line.as_bytes()).expect("write");
+        writer.write_all(b"\n").expect("write");
+    }
+    writer.flush().expect("flush");
+}
+
+/// `extra` をヘッダフィールド部に挿入した最小 Game_Summary を送出する mock を立て、
+/// login + recv_game_summary した結果を返す。
+fn recv_summary_with(extra: &'static [&'static str]) -> rshogi_csa_client::GameSummary {
+    let port = spawn_mock_tcp_server(move |reader, writer| {
+        let _ = read_line(reader);
+        write_lines(writer, &["LOGIN:alice OK"]);
+        let mut lines = vec![
+            "BEGIN Game_Summary",
+            "Protocol_Version:1.2",
+            "Game_ID:game-ekr",
+            "Name+:black",
+            "Name-:white",
+            "Your_Turn:+",
+            "To_Move:+",
+            "Time_Unit:1sec",
+            "Total_Time:600",
+            "Byoyomi:10",
+        ];
+        lines.extend_from_slice(extra);
+        lines.extend_from_slice(&[
+            "BEGIN Position",
+            "PI",
+            "+",
+            "END Position",
+            "END Game_Summary",
+        ]);
+        write_lines(writer, &lines);
+    });
+
+    let mut conn = CsaConnection::connect("127.0.0.1", port, false).expect("connect");
+    conn.login("alice", "pw").expect("login");
+    conn.recv_game_summary(0).expect("recv_game_summary")
+}
+
+#[test]
+fn extension_line_maps_usi_token() {
+    let summary = recv_summary_with(&["Entering_King_Rule:CSARule24"]);
+    assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point24));
+}
+
+#[test]
+fn declaration_jishogi_maps_to_point27() {
+    let summary = recv_summary_with(&["Declaration:Jishogi 1.1"]);
+    assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point27));
+}
+
+#[test]
+fn extension_line_wins_over_declaration() {
+    // 本リポサーバーが将来 Point24 のまま `Declaration:` も出すような構成でも
+    // 拡張行 (正確なルール) を優先する。
+    let summary = recv_summary_with(&["Declaration:Jishogi 1.1", "Entering_King_Rule:CSARule24"]);
+    assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point24));
+}
+
+#[test]
+fn absent_advertisement_yields_none() {
+    let summary = recv_summary_with(&[]);
+    assert_eq!(summary.entering_king_rule, None);
+}
+
+#[test]
+fn unknown_token_yields_none() {
+    let summary = recv_summary_with(&["Entering_King_Rule:BogusRule"]);
+    assert_eq!(summary.entering_king_rule, None);
+}

--- a/crates/rshogi-csa-client/tests/csa_entering_king_rule.rs
+++ b/crates/rshogi-csa-client/tests/csa_entering_king_rule.rs
@@ -39,15 +39,19 @@ fn write_lines(writer: &mut dyn Write, lines: &[&str]) {
     writer.flush().expect("flush");
 }
 
-/// `extra` をヘッダフィールド部に挿入した最小 Game_Summary を送出する mock を立て、
-/// login + recv_game_summary した結果を返す。
-fn recv_summary_with(extra: &'static [&'static str]) -> rshogi_csa_client::GameSummary {
+/// 最小 Game_Summary を送出する mock を立て、login + recv_game_summary した結果を
+/// 返す。`header_extra` はヘッダフィールド部 (rshogi サーバーの `Declaration:` 位置)、
+/// `tail_extra` は `END Position` 後 (同 `Entering_King_Rule:` 拡張行の位置) に挿入する。
+fn recv_summary_with(
+    header_extra: &'static [&'static str],
+    tail_extra: &'static [&'static str],
+) -> rshogi_csa_client::GameSummary {
     let port = spawn_mock_tcp_server(move |reader, writer| {
         let _ = read_line(reader);
         write_lines(writer, &["LOGIN:alice OK"]);
-        let mut lines = vec![
-            "BEGIN Game_Summary",
-            "Protocol_Version:1.2",
+        let mut lines = vec!["BEGIN Game_Summary", "Protocol_Version:1.2"];
+        lines.extend_from_slice(header_extra);
+        lines.extend_from_slice(&[
             "Game_ID:game-ekr",
             "Name+:black",
             "Name-:white",
@@ -56,15 +60,13 @@ fn recv_summary_with(extra: &'static [&'static str]) -> rshogi_csa_client::GameS
             "Time_Unit:1sec",
             "Total_Time:600",
             "Byoyomi:10",
-        ];
-        lines.extend_from_slice(extra);
-        lines.extend_from_slice(&[
             "BEGIN Position",
             "PI",
             "+",
             "END Position",
-            "END Game_Summary",
         ]);
+        lines.extend_from_slice(tail_extra);
+        lines.push("END Game_Summary");
         write_lines(writer, &lines);
     });
 
@@ -75,13 +77,13 @@ fn recv_summary_with(extra: &'static [&'static str]) -> rshogi_csa_client::GameS
 
 #[test]
 fn extension_line_maps_usi_token() {
-    let summary = recv_summary_with(&["Entering_King_Rule:CSARule24"]);
+    let summary = recv_summary_with(&[], &["Entering_King_Rule:CSARule24"]);
     assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point24));
 }
 
 #[test]
 fn declaration_jishogi_maps_to_point27() {
-    let summary = recv_summary_with(&["Declaration:Jishogi 1.1"]);
+    let summary = recv_summary_with(&["Declaration:Jishogi 1.1"], &[]);
     assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point27));
 }
 
@@ -89,18 +91,19 @@ fn declaration_jishogi_maps_to_point27() {
 fn extension_line_wins_over_declaration() {
     // 本リポサーバーが将来 Point24 のまま `Declaration:` も出すような構成でも
     // 拡張行 (正確なルール) を優先する。
-    let summary = recv_summary_with(&["Declaration:Jishogi 1.1", "Entering_King_Rule:CSARule24"]);
+    let summary =
+        recv_summary_with(&["Declaration:Jishogi 1.1"], &["Entering_King_Rule:CSARule24"]);
     assert_eq!(summary.entering_king_rule, Some(EnteringKingRule::Point24));
 }
 
 #[test]
 fn absent_advertisement_yields_none() {
-    let summary = recv_summary_with(&[]);
+    let summary = recv_summary_with(&[], &[]);
     assert_eq!(summary.entering_king_rule, None);
 }
 
 #[test]
 fn unknown_token_yields_none() {
-    let summary = recv_summary_with(&["Entering_King_Rule:BogusRule"]);
+    let summary = recv_summary_with(&[], &["Entering_King_Rule:BogusRule"]);
     assert_eq!(summary.entering_king_rule, None);
 }

--- a/crates/rshogi-csa-client/tests/session_events_integration.rs
+++ b/crates/rshogi-csa-client/tests/session_events_integration.rs
@@ -556,6 +556,7 @@ fn resumed_session_keeps_pre_disconnect_record_and_start_time() {
             increment_ms: 0,
         },
         reconnect_token: Some("tok-xyz".to_owned()),
+        entering_king_rule: None,
     };
     let mut retained = GameRecord::new(&retained_summary);
     let original_start_time = retained.start_time;
@@ -650,6 +651,7 @@ fn resumed_session_mismatch_keeps_start_time_and_removes_stale_live_jsonl() {
         black_time: TimeConfig::default(),
         white_time: TimeConfig::default(),
         reconnect_token: Some("tok-xyz".to_owned()),
+        entering_king_rule: None,
     };
     let mut retained = GameRecord::new(&retained_summary);
     let original_start_time = retained.start_time;

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -256,7 +256,7 @@ fn main() -> anyhow::Result<()> {
         login_timeout: std::time::Duration::from_secs(30),
         agree_timeout: std::time::Duration::from_secs(cli.agree_timeout_sec),
         x1_reply_write_timeout: std::time::Duration::from_secs(5),
-        entering_king_rule: rshogi_core::types::EnteringKingRule::Point24,
+        entering_king_rule: rshogi_core::types::EnteringKingRule::Point27,
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
         allow_floodgate_features: cli.allow_floodgate_features,

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -226,7 +226,7 @@ pub struct ServerConfig {
     /// 超過時は切断扱いにする。5 秒は「localhost / LAN の健常クライアント
     /// では十分、stall した client を抱え込み続けるには長すぎる」レンジ。
     pub x1_reply_write_timeout: Duration,
-    /// 入玉ルール。既定は 24 点法。
+    /// 入玉ルール。既定は 27 点法 (電竜戦・WCSC・floodgate と同じ標準宣言ルール)。
     pub entering_king_rule: EnteringKingRule,
     /// 既定の対局開始局面 SFEN。`None` なら平手。
     ///
@@ -326,7 +326,7 @@ impl ServerConfig {
             login_timeout: Duration::from_secs(30),
             agree_timeout: Duration::from_secs(5 * 60),
             x1_reply_write_timeout: Duration::from_secs(5),
-            entering_king_rule: EnteringKingRule::Point24,
+            entering_king_rule: EnteringKingRule::Point27,
             initial_sfen: None,
             admin_handles: Vec::new(),
             allow_floodgate_features: false,

--- a/crates/rshogi-csa-server-tcp/src/server.rs
+++ b/crates/rshogi-csa-server-tcp/src/server.rs
@@ -2441,7 +2441,7 @@ where
         position_section,
         rematch_on_draw: false,
         to_move,
-        declaration: "Jishogi 1.1".to_owned(),
+        entering_king_rule: state.config.entering_king_rule,
         black_reconnect_token: black_reconnect_token.clone(),
         white_reconnect_token: white_reconnect_token.clone(),
     };

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -15,6 +15,14 @@ use rshogi_csa_server::config::{
 
 use crate::origin;
 
+/// Workers 配備の `%KACHI` 判定に使う入玉ルール。CoreRoom (判定側) と
+/// Game_Summary の広告 (`Declaration:` / `Entering_King_Rule:` 行) の両方が
+/// この値を参照する。別々の literal にすると判定と広告がずれ、client が
+/// 誤ったルールをエンジンへ自動注入してしまう。
+/// 27 点法は電竜戦・世界コンピュータ将棋選手権・wdoor floodgate と同じ標準宣言ルール。
+pub const ENTERING_KING_RULE: rshogi_core::types::EnteringKingRule =
+    rshogi_core::types::EnteringKingRule::Point27;
+
 /// 起動時にバインディング名として参照する環境変数キー群。
 ///
 /// # 新規定数を追加するときは

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -992,7 +992,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move,
-            declaration: String::new(),
+            entering_king_rule: EnteringKingRule::Point24,
             black_reconnect_token,
             white_reconnect_token,
         };
@@ -3412,7 +3412,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move: core.current_turn(),
-            declaration: String::new(),
+            entering_king_rule: EnteringKingRule::Point24,
             black_reconnect_token: cfg.black_reconnect_token.as_deref().map(ReconnectToken::new),
             white_reconnect_token: cfg.white_reconnect_token.as_deref().map(ReconnectToken::new),
         };

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -38,7 +38,6 @@ use worker::{
     WebSocket, WebSocketIncomingMessage, WebSocketPair, durable_object, wasm_bindgen,
 };
 
-use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::config::{
     FloodgateFeatureIntent, parse_allow_floodgate_features, validate_floodgate_feature_gate,
@@ -969,7 +968,7 @@ impl GameRoom {
                 white: PlayerName::new(cfg.white_handle.clone()),
                 max_moves: cfg.max_moves,
                 time_margin_ms: cfg.time_margin_ms,
-                entering_king_rule: EnteringKingRule::Point24,
+                entering_king_rule: crate::config::ENTERING_KING_RULE,
                 initial_sfen: cfg.initial_sfen.clone(),
             },
             clock,
@@ -992,7 +991,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move,
-            entering_king_rule: EnteringKingRule::Point24,
+            entering_king_rule: crate::config::ENTERING_KING_RULE,
             black_reconnect_token,
             white_reconnect_token,
         };
@@ -3412,7 +3411,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move: core.current_turn(),
-            entering_king_rule: EnteringKingRule::Point24,
+            entering_king_rule: crate::config::ENTERING_KING_RULE,
             black_reconnect_token: cfg.black_reconnect_token.as_deref().map(ReconnectToken::new),
             white_reconnect_token: cfg.white_reconnect_token.as_deref().map(ReconnectToken::new),
         };

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -17,7 +17,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::ClockSpec;
 use rshogi_csa_server::game::room::{GameRoom as CoreRoom, GameRoomConfig};
 use rshogi_csa_server::types::{Color, CsaLine, GameId, PlayerName};
@@ -235,7 +234,7 @@ pub fn replay_core_room(cfg: &PersistedConfig, moves: &[MoveRow]) -> ReplaySumma
             white: PlayerName::new(cfg.white_handle.clone()),
             max_moves: cfg.max_moves,
             time_margin_ms: cfg.time_margin_ms,
-            entering_king_rule: EnteringKingRule::Point24,
+            entering_king_rule: crate::config::ENTERING_KING_RULE,
             initial_sfen: cfg.initial_sfen.clone(),
         },
         clock,
@@ -349,7 +348,7 @@ mod tests {
                 white: PlayerName::new(cfg.white_handle.clone()),
                 max_moves: cfg.max_moves,
                 time_margin_ms: cfg.time_margin_ms,
-                entering_king_rule: EnteringKingRule::Point24,
+                entering_king_rule: crate::config::ENTERING_KING_RULE,
                 initial_sfen: cfg.initial_sfen.clone(),
             },
             cfg.clock.build_clock(),

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -21,6 +21,7 @@
 //! クライアント側は `##[MONITOR2] BEGIN <id>` と `##[MONITOR2] END` の間で本関数の
 //! 戻り値を順次受信し、`END` 受信を hard delimiter として state を全置換する。
 
+use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
@@ -128,7 +129,7 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
         position_section,
         rematch_on_draw: false,
         to_move,
-        declaration: String::new(),
+        entering_king_rule: EnteringKingRule::Point24,
         // 観戦者向け builder は token を出力しないため、`None` 固定で渡す
         // (関数内部でも player 経路と異なり token 行は出さない契約)。
         black_reconnect_token: None,

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -21,7 +21,6 @@
 //! クライアント側は `##[MONITOR2] BEGIN <id>` と `##[MONITOR2] END` の間で本関数の
 //! 戻り値を順次受信し、`END` 受信を hard delimiter として state を全置換する。
 
-use rshogi_core::types::EnteringKingRule;
 use rshogi_csa_server::protocol::summary::{
     GameSummaryBuilder, position_section_from_sfen, side_to_move_from_sfen,
     standard_initial_position_block,
@@ -129,7 +128,7 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
         position_section,
         rematch_on_draw: false,
         to_move,
-        entering_king_rule: EnteringKingRule::Point24,
+        entering_king_rule: crate::config::ENTERING_KING_RULE,
         // 観戦者向け builder は token を出力しないため、`None` 固定で渡す
         // (関数内部でも player 経路と異なり token 行は出さない契約)。
         black_reconnect_token: None,
@@ -612,7 +611,6 @@ PI
         //   が同一手で一致すること。通信マージンを課金から差し引かなくなったため、両者とも
         //   「(到着 at_ms − 直前手 at_ms) を秒切り捨て」した同じ値になる (旧実装ではライブ側が
         //   margin を引いて 1 秒/手ずれていた)。
-        use rshogi_core::types::EnteringKingRule;
         use rshogi_csa_server::{CsaLine, FischerClock, GameRoom, GameRoomConfig, HandleOutcome};
 
         let play_started_ms: u64 = 1_000_000;
@@ -623,7 +621,7 @@ PI
             max_moves: 256,
             // margin を課金へ持ち込まないことを確認するため 0 でなく 1000ms を設定する。
             time_margin_ms: 1_000,
-            entering_king_rule: EnteringKingRule::Point24,
+            entering_king_rule: crate::config::ENTERING_KING_RULE,
             initial_sfen: None,
         };
         let clock = Box::new(FischerClock::new(60, 5));

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -45,6 +45,9 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     const whiteSummary = await white.drainGameSummary();
     expect(blackSummary.some((l) => l === "Your_Turn:+")).toBe(true);
     expect(whiteSummary.some((l) => l === "Your_Turn:-")).toBe(true);
+    // 入玉ルール広告の拡張行 (24 点法固定の本番構成)
+    expect(blackSummary.some((l) => l === "Entering_King_Rule:CSARule24")).toBe(true);
+    expect(whiteSummary.some((l) => l === "Entering_King_Rule:CSARule24")).toBe(true);
 
     black.send("AGREE");
     white.send("AGREE");

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -45,9 +45,10 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     const whiteSummary = await white.drainGameSummary();
     expect(blackSummary.some((l) => l === "Your_Turn:+")).toBe(true);
     expect(whiteSummary.some((l) => l === "Your_Turn:-")).toBe(true);
-    // 入玉ルール広告の拡張行 (24 点法固定の本番構成)
-    expect(blackSummary.some((l) => l === "Entering_King_Rule:CSARule24")).toBe(true);
-    expect(whiteSummary.some((l) => l === "Entering_King_Rule:CSARule24")).toBe(true);
+    // 入玉ルール広告 (本番構成 = 27 点法): 標準 Declaration 行と拡張行の両方
+    expect(blackSummary.some((l) => l === "Declaration:Jishogi 1.1")).toBe(true);
+    expect(blackSummary.some((l) => l === "Entering_King_Rule:CSARule27")).toBe(true);
+    expect(whiteSummary.some((l) => l === "Entering_King_Rule:CSARule27")).toBe(true);
 
     black.send("AGREE");
     white.send("AGREE");

--- a/crates/rshogi-csa-server/src/game/result.rs
+++ b/crates/rshogi-csa-server/src/game/result.rs
@@ -11,7 +11,7 @@ pub enum IllegalReason {
     Generic,
     /// 打ち歩詰。
     Uchifuzume,
-    /// `%KACHI` 宣言が 24 点法で不成立。
+    /// `%KACHI` 宣言が入玉宣言ルールで不成立。
     IllegalKachi,
 }
 
@@ -35,7 +35,7 @@ pub enum GameResult {
         /// 反則の種別。
         reason: IllegalReason,
     },
-    /// `%KACHI` → `#JISHOGI`（24 点法成立）。
+    /// `%KACHI` → `#JISHOGI`（入玉宣言成立）。
     Kachi {
         /// 入玉宣言が成立した側（勝者）。
         winner: Color,

--- a/crates/rshogi-csa-server/src/game/room.rs
+++ b/crates/rshogi-csa-server/src/game/room.rs
@@ -122,7 +122,7 @@ pub struct GameRoomConfig {
     /// `compute_deadline` / turn alarm の予約で加算し、`consume`（課金）からは
     /// 差し引かない。
     pub time_margin_ms: u64,
-    /// `%KACHI` 判定に使う入玉ルール（既定は 24 点法 = `Point24`）。
+    /// `%KACHI` 判定に使う入玉ルール（本番配備は 27 点法 = `Point27`）。
     pub entering_king_rule: EnteringKingRule,
     /// 対局の開始局面を表す SFEN。`None` なら平手（`SFEN_HIRATE`）を使う。
     ///

--- a/crates/rshogi-csa-server/src/game/validator.rs
+++ b/crates/rshogi-csa-server/src/game/validator.rs
@@ -62,8 +62,8 @@ pub enum KachiOutcome {
 
 /// 合法性・千日手・入玉宣言を判定するサービス。
 ///
-/// `entering_king_rule` で `%KACHI` 判定方式を切替可能にしている（既定は
-/// CSA 24 点法 = `Point24`。27 点法やトライルールも選択可能）。
+/// `entering_king_rule` で `%KACHI` 判定方式を切替可能にしている
+/// （27 点法 / 24 点法 / トライルール等を選択可能）。
 #[derive(Debug, Clone, Copy)]
 pub struct Validator {
     entering_king_rule: EnteringKingRule,
@@ -181,8 +181,8 @@ impl Validator {
 
     /// `%KACHI`（入玉宣言）が `pos` の手番側で成立するか判定する。
     ///
-    /// 内部は `rshogi_core::Position::declaration_win` に委譲する。CSA 24 点法
-    /// （`Point24`）を既定とし、`Point27`/`Point24H`/`Point27H` も同 API で扱える。
+    /// 内部は `rshogi_core::Position::declaration_win` に委譲する。27 点法
+    /// （`Point27`）/ 24 点法（`Point24`）/ 駒落ち variant を同 API で扱える。
     /// `TryRule` も API 契約上は宣言成立を示す任意の `Move` を Accepted として
     /// 受け付けるため、`entering_king_rule` を切替えても呼び出し側のコードは変更不要。
     pub fn evaluate_kachi(&self, pos: &Position) -> KachiOutcome {

--- a/crates/rshogi-csa-server/src/protocol/summary.rs
+++ b/crates/rshogi-csa-server/src/protocol/summary.rs
@@ -349,6 +349,8 @@ mod tests {
         let begin_time = pos("BEGIN Time");
         let begin_pos = pos("BEGIN Position");
         let end_pos = pos("END Position");
+        let ekr = pos("Entering_King_Rule:");
+        let end_summary = pos("END Game_Summary");
         assert!(pv < pm);
         assert!(pm < fmt);
         assert!(fmt < decl);
@@ -361,6 +363,8 @@ mod tests {
         assert!(to_move < begin_time);
         assert!(begin_time < begin_pos);
         assert!(begin_pos < end_pos);
+        assert!(end_pos < ekr);
+        assert!(ekr < end_summary);
     }
 
     #[test]
@@ -463,7 +467,11 @@ mod tests {
         let end_game = txt
             .find("END Game_Summary\n")
             .unwrap_or_else(|| panic!("missing END Game_Summary: {txt}"));
-        assert!(end_position < token_line, "token must follow END Position");
+        let ekr_line = txt
+            .find("\nEntering_King_Rule:")
+            .unwrap_or_else(|| panic!("missing Entering_King_Rule line: {txt}"));
+        assert!(end_position < ekr_line, "rule line must follow END Position");
+        assert!(ekr_line < token_line, "token must follow rule line");
         assert!(token_line < end_game, "token must precede END Game_Summary");
     }
 

--- a/crates/rshogi-csa-server/src/protocol/summary.rs
+++ b/crates/rshogi-csa-server/src/protocol/summary.rs
@@ -7,7 +7,7 @@
 use std::fmt::Write as _;
 
 use rshogi_core::position::Position;
-use rshogi_core::types::{Color as CoreColor, File, PieceType, Rank, Square};
+use rshogi_core::types::{Color as CoreColor, EnteringKingRule, File, PieceType, Rank, Square};
 
 use crate::types::{Color, GameId, PlayerName, ReconnectToken};
 
@@ -30,8 +30,9 @@ pub struct GameSummaryBuilder {
     pub rematch_on_draw: bool,
     /// 開始時の手番。CSA 仕様 `To_Move:` に直接書ける `+`/`-` 文字。
     pub to_move: Color,
-    /// 入玉宣言ルール表示（`Declaration:Jishogi 1.1` など）。空ならデフォルト省略。
-    pub declaration: String,
+    /// `%KACHI` 判定に使う入玉ルール。CSA 標準の `Declaration:` 行と本リポ拡張の
+    /// `Entering_King_Rule:` 行の両方をここから導出する（値の食い違いを構造的に防ぐ）。
+    pub entering_king_rule: EnteringKingRule,
     /// 先手向けの再接続トークン。`Some` の場合、`build_for(Color::Black)` 出力に
     /// 標準項目の後・`END Game_Summary` の直前で `Reconnect_Token:<token>` 拡張行
     /// として埋め込む。`None` なら拡張行を出さず CSA v1.2.1 標準互換の出力に戻る。
@@ -59,8 +60,8 @@ impl GameSummaryBuilder {
         out.push_str("Protocol_Version:1.2\n");
         out.push_str("Protocol_Mode:Server\n");
         out.push_str("Format:Shogi 1.0\n");
-        if !self.declaration.is_empty() {
-            let _ = writeln!(out, "Declaration:{}", self.declaration);
+        if let Some(decl) = declaration_of(self.entering_king_rule) {
+            let _ = writeln!(out, "Declaration:{decl}");
         }
         let _ = writeln!(out, "Game_ID:{}", self.game_id);
         let _ = writeln!(out, "Name+:{}", self.black);
@@ -78,6 +79,7 @@ impl GameSummaryBuilder {
         if !self.position_section.ends_with('\n') {
             out.push('\n');
         }
+        let _ = writeln!(out, "Entering_King_Rule:{}", self.entering_king_rule.to_usi());
         // 観戦者向け拡張行: 残時間 (ms 粒度)。Workers reconnect 経路の
         // `Black/White_Time_Remaining_Ms:` 行と同形式。
         let _ = writeln!(out, "Black_Time_Remaining_Ms:{black_remaining_ms}");
@@ -95,8 +97,8 @@ impl GameSummaryBuilder {
         out.push_str("Protocol_Version:1.2\n");
         out.push_str("Protocol_Mode:Server\n");
         out.push_str("Format:Shogi 1.0\n");
-        if !self.declaration.is_empty() {
-            let _ = writeln!(out, "Declaration:{}", self.declaration);
+        if let Some(decl) = declaration_of(self.entering_king_rule) {
+            let _ = writeln!(out, "Declaration:{decl}");
         }
         let _ = writeln!(out, "Game_ID:{}", self.game_id);
         let _ = writeln!(out, "Name+:{}", self.black);
@@ -115,8 +117,11 @@ impl GameSummaryBuilder {
         if !self.position_section.ends_with('\n') {
             out.push('\n');
         }
-        // CSA v1.2.1 標準項目の後に続く拡張行として再接続トークンを末尾追加する。
-        // 標準互換クライアントは未知キーを無視できるため、CSA v1.2.1 とは後方互換。
+        // CSA v1.2.1 標準項目の後に続く拡張行。標準互換クライアントは未知キーを
+        // 無視できるため、CSA v1.2.1 とは後方互換。
+        // 入玉ルールの広告: `Declaration:` は CSA 標準に 27 点法のトークンしか無い
+        // ため、24 点法等も含めた正確なルールは USI トークンの拡張行で伝える。
+        let _ = writeln!(out, "Entering_King_Rule:{}", self.entering_king_rule.to_usi());
         let token = match you {
             Color::Black => self.black_reconnect_token.as_ref(),
             Color::White => self.white_reconnect_token.as_ref(),
@@ -133,6 +138,15 @@ fn color_char(c: Color) -> char {
     match c {
         Color::Black => '+',
         Color::White => '-',
+    }
+}
+
+/// CSA 標準 `Declaration:` 行の値。標準仕様にトークンが存在するのは 27 点法
+/// (`Jishogi 1.1`) のみで、他ルールでは行自体を省略する。
+fn declaration_of(rule: EnteringKingRule) -> Option<&'static str> {
+    match rule {
+        EnteringKingRule::Point27 | EnteringKingRule::Point27H => Some("Jishogi 1.1"),
+        _ => None,
     }
 }
 
@@ -297,7 +311,7 @@ mod tests {
             position_section: standard_initial_position_block(),
             rematch_on_draw: false,
             to_move: Color::Black,
-            declaration: "Jishogi 1.1".to_owned(),
+            entering_king_rule: EnteringKingRule::Point27,
             black_reconnect_token: None,
             white_reconnect_token: None,
         }
@@ -350,11 +364,27 @@ mod tests {
     }
 
     #[test]
-    fn declaration_is_optional() {
+    fn declaration_line_only_for_point27() {
         let mut b = skeleton();
-        b.declaration = String::new();
+        b.entering_king_rule = EnteringKingRule::Point24;
         let txt = b.build_for(Color::Black);
         assert!(!txt.contains("Declaration:"));
+        assert!(txt.contains("\nEntering_King_Rule:CSARule24\n"));
+    }
+
+    #[test]
+    fn entering_king_rule_extension_line_for_point27() {
+        let txt = skeleton().build_for(Color::Black);
+        assert!(txt.contains("Declaration:Jishogi 1.1"));
+        assert!(txt.contains("\nEntering_King_Rule:CSARule27\n"));
+    }
+
+    #[test]
+    fn spectator_summary_includes_entering_king_rule() {
+        let mut b = skeleton();
+        b.entering_king_rule = EnteringKingRule::Point24;
+        let txt = b.build_for_spectator(1000, 2000);
+        assert!(txt.contains("\nEntering_King_Rule:CSARule24\n"));
     }
 
     #[test]

--- a/docs/csa-server/lobby_e2e_runbook.md
+++ b/docs/csa-server/lobby_e2e_runbook.md
@@ -279,7 +279,7 @@ Total_Time:600 / Byoyomi:10) ではこのレートで時間切れにはならな
 | 終局トークン | 意味 | history JSON `result_code` | broadcast 通知行 (各 client) | 記録経路 |
 |---|---|---|---|---|
 | `%TORYO` | 投了 | `#RESIGN` | `#RESIGN` + 勝者 `#WIN` / 敗者 `#LOSE` | client が `engine bestmove resign` で送出 |
-| `%KACHI` | 入玉宣言勝ち (24点法成立) | `#JISHOGI` | `#JISHOGI` + 勝者 `#WIN` / 敗者 `#LOSE` | client が `engine bestmove win` で送出 |
+| `%KACHI` | 入玉宣言勝ち (27点法成立) | `#JISHOGI` | `#JISHOGI` + 勝者 `#WIN` / 敗者 `#LOSE` | client が `engine bestmove win` で送出 |
 | `%CHUDAN` | 中断 (合意中断、winner 無し) | `#ABNORMAL` | `#ABNORMAL` 単独 | サーバ側で `force_abnormal(None)` 経由 |
 | (`force_abnormal` 切断経路) | 切断 grace 超過 / 運営権限による強制終了 | `#ABNORMAL` | `#ABNORMAL` + 残存側 `#WIN` / 切断側 `#LOSE` | サーバ側で `force_abnormal(Some(loser))` 経由 |
 | `%TIME_UP` | 時間切れ | `#TIME_UP` | `#TIME_UP` + 勝者 `#WIN` / 敗者 `#LOSE` | サーバ側 alarm 発火、`force_time_up` で確定 |

--- a/docs/csa-server/protocol-reference.md
+++ b/docs/csa-server/protocol-reference.md
@@ -186,11 +186,20 @@ CSA v1.2.1 標準 `BEGIN Game_Summary` / `END Game_Summary` の組み立ては
 | `summary.rs::position_section_from_sfen` | 任意 SFEN から Position ブロック |
 
 `build_for` は CSA v1.2.1 標準項目を以下の順で出す: `Protocol_Version` →
-`Protocol_Mode` → `Format` → `Declaration` (任意) → `Game_ID` → `Name+` → `Name-` →
+`Protocol_Mode` → `Format` → `Declaration` (27 点法のときのみ `Jishogi 1.1`) →
+`Game_ID` → `Name+` → `Name-` →
 `Your_Turn` → `Rematch_On_Draw` → `To_Move` → `BEGIN Time` ... `END Time` →
-`BEGIN Position` ... `END Position` → (本リポ拡張) `Reconnect_Token:` →
+`BEGIN Position` ... `END Position` → (本リポ拡張) `Entering_King_Rule:` →
+`Reconnect_Token:` →
 `END Game_Summary`。順序は `summary.rs::tests::build_for_includes_required_csa_fields_in_order`
 で固定されている。
+
+`Entering_King_Rule:` 拡張行は `%KACHI` 判定に使う入玉ルールを USI トークン
+(`CSARule24` / `CSARule27` 等、`EnteringKingRule::to_usi`) で広告する。CSA 標準の
+`Declaration:` には 27 点法のトークンしか存在しないため、24 点法等も正確に伝える
+目的で常に出力する。csa_client は本行 (無ければ `Declaration:Jishogi 1.1` → 27 点法)
+を解釈し、config で `EnteringKingRule` が明示されていない場合にエンジンへ
+`setoption` で注入する。
 
 ## 8. 終局メッセージ
 


### PR DESCRIPTION
## 背景

rating6 クロスマシンシリーズ (2026-07-18) で `ILLEGAL_KACHI` 反則負けが 3 局発生した (調査は #955)。原因はサーバーの `%KACHI` 判定ルールとエンジンの `EnteringKingRule` USI オプション (既定 `CSARule27`) の食い違いで、client 設定に依存する構成上の穴だった。本 PR は (1) ルール不一致をプロトコルで塞ぐ恒久対応と、(2) 判定ルール自体の標準化の 2 本立て。

## 変更内容

### 1. 入玉宣言ルールを 27 点法 (Point27) へ変更

電竜戦・世界コンピュータ将棋選手権・wdoor floodgate はいずれも 27 点法 (先手28/後手27点)。従来の Point24 (31点宣言) を使うコンピュータ将棋の大会は現存せず、選択の経緯にも根拠記載がなかった。エンジン USI 既定 (`CSARule27`) と一致するため、広告が届かない旧構成でも食い違いが起きない。workers は判定 (CoreRoom) と広告が別 literal で乖離し得たため共有 const `config::ENTERING_KING_RULE` に一元化。

### 2. サーバーが Game_Summary で入玉ルールを広告

`GameSummaryBuilder` の `declaration: String` を `entering_king_rule: EnteringKingRule` に置き換え、CSA 標準 `Declaration:` 行 (27点法のときのみ `Jishogi 1.1`) と本リポ拡張行 `Entering_King_Rule:<USIトークン>` (常時、`END Position` 後・`Reconnect_Token:` 前) を同一値から導出。拡張行は「標準クライアントは未知キー無視」で CSA v1.2.1 後方互換。副次修正: tcp server が Point24 判定なのに `Declaration:Jishogi 1.1` を広告していた既存不整合を解消。

### 3. csa_client が広告をエンジンへ自動伝達

`GameSummary.entering_king_rule` を追加 (`Entering_King_Rule:` 優先、無ければ `Declaration:Jishogi 1.1` → `CSARule27`)。`usinewgame` 直前に、config の `engine.options` に `EnteringKingRule` が無ければ広告値を `setoption` で注入。明示設定があればユーザー設定を優先し、不一致は warn。`UsiEngineDriver` trait に `set_option` を追加。

## テスト

- summary builder: Declaration 行の有無 (Point27/Point24)、拡張行の内容と順序 (END Position 後・Reconnect_Token 前) を単体で固定
- client parse: 拡張行 (実サーバーと同じ END Position 後配置) / Declaration フォールバック / 優先順位 / 広告なし / 未知トークン (TCP loopback 統合テスト 5 本新設)
- session: config 未設定→注入 / 明示設定優先 / 広告なし→無操作 (単体 3 本)
- miniflare smoke E2E: `Declaration:Jishogi 1.1` + `Entering_King_Rule:CSARule27` の存在アサート
- cargo fmt / clippy --tests warning 0 / cargo test 全 pass / abs-path check pass

## デプロイ注意

本番反映には CF Workers の deploy と各マシンの csa_client 再ビルドが必要。旧 client + 新サーバー / 新 client + 旧サーバーのどの組合せでも安全 (拡張行は無視される / 広告が無ければ何もしない / いずれのエンジン既定も新ルールと一致)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeVA9V36ojSNbcydM9Puz8