### PR TITLE
workers.dev / preview URL を無効化 (無料枠保護、到達経路を Custom Domain に一本化)

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -360,7 +360,7 @@ jobs:
         run: |
           if [ -z "$DRAIN_URL" ]; then
             echo "::error::WORKERS_DRAIN_URL not set on rshogi-csa-server-workers-production Environment"
-            echo "::error::Configure the variable to the live API full URL (e.g. https://...workers.dev/api/v1/games/live)"
+            echo "::error::Configure the variable to the live API full URL (e.g. https://rshogi-csa-server.sh11235.com/api/v1/games/live)"
             echo "::error::See docs/csa-server/deployment.md §12 for the configuration procedure"
             exit 1
           fi

--- a/.github/workflows/synthetic-csa-staging.yml
+++ b/.github/workflows/synthetic-csa-staging.yml
@@ -67,7 +67,8 @@ jobs:
             --description "CSA Worker synthetic check failure detected by synthetic-csa-*.yml" \
             --color B60205 \
             || true
-      # `WORKERS_STAGING_BASE_URL` は staging の `https://...workers.dev` (path なし)。
+      # `WORKERS_STAGING_BASE_URL` は staging の Custom Domain
+      # `https://stg.rshogi-csa-server.sh11235.com` (path なし)。
       # 未設定時は warning + skip でジョブを green に倒す (drift-check 等の他 workflow
       # と揃えた fail-safe; 環境セットアップ未完で merge を block しない)。
       - name: Check Environment variables
@@ -142,7 +143,7 @@ jobs:
           OPTS="MaterialLevel=9,USI_Hash=16,Threads=1,NetworkDelay=0,NetworkDelay2=0,MinimumThinkingTime=100,PvInterval=0"
 
           # `--target staging` を渡しているので host / Origin は csa_client 内蔵
-          # プリセット (sh11235.workers.dev + Origin csa-client-local) が適用される。
+          # プリセット (stg.rshogi-csa-server.sh11235.com + Origin csa-client-local) が適用される。
           # 利用 account が異なる場合は別途 `--host` / `--ws-origin` を渡す経路を
           # 用意する必要があるが、本リポ標準 deploy 先のみ想定。
 

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -13,6 +13,10 @@ name = "rshogi-csa-server-workers"
 main = "build/worker/shim.mjs"
 # Custom Domain binding。DNS record (AAAA 100:: proxied) は iac repo (Pulumi) が正典
 routes = [{ pattern = "rshogi-csa-server.sh11235.com", custom_domain = true }]
+# workers.dev 直 URL / preview URL は zone (sh11235.com) の WAF・Rate Limiting を
+# 経由しないため公開しない。到達経路は Custom Domain (proxied) のみに限定する
+workers_dev = false
+preview_urls = false
 # 2026-04-21 時点の最新 compatibility flag 日付に追従する。
 # 主要 opt-in 機能:
 # - `web_socket_auto_reply_to_close` (2026-04-07): WS が close フレームに自動応答

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -14,6 +14,10 @@ name = "rshogi-csa-server-workers-staging"
 main = "build/worker/shim.mjs"
 # Custom Domain binding。DNS record (AAAA 100:: proxied) は iac repo (Pulumi) が正典
 routes = [{ pattern = "stg.rshogi-csa-server.sh11235.com", custom_domain = true }]
+# workers.dev 直 URL / preview URL は zone (sh11235.com) の WAF・Rate Limiting を
+# 経由しないため公開しない。到達経路は Custom Domain (proxied) のみに限定する
+workers_dev = false
+preview_urls = false
 # 通常は production と日付を揃え、新フラグ採用は両環境同時に bump する運用で
 # 挙動差を最小化する。staging で先に新 flag の挙動を観察してから production に
 # 反映したい場合に限り、本値を意図的に production より先行させて良い（その場合

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -13,6 +13,12 @@ main = "build/worker/shim.mjs"
 # https://developers.cloudflare.com/workers/configuration/compatibility-flags/ 参照。
 compatibility_date = "2026-04-21"
 
+# workers.dev 直 URL / preview URL は zone の WAF・Rate Limiting を経由しないため
+# 既定で公開しない (`wrangler dev` でのローカル開発には影響しない)。
+# 個人環境で workers.dev 公開したい場合はコピー後に true へ変更する
+workers_dev = false
+preview_urls = false
+
 [build]
 # worker-build が cdylib を wasm32 向けにビルドし、`build/worker/shim.mjs` を生成する。
 command = "cargo install -q worker-build@^0.8 && worker-build --release"

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -355,12 +355,10 @@ credential から旧 ID を導出できず、過去結果を統合できない�
 
 | Name | 値（例） |
 |---|---|
-| `WORKERS_HEALTH_URL` | staging: `https://rshogi-csa-server-workers-staging.<your-subdomain>.workers.dev/health`<br>production: `https://rshogi-csa-server-workers.<your-subdomain>.workers.dev/health` |
+| `WORKERS_HEALTH_URL` | staging: `https://stg.rshogi-csa-server.sh11235.com/health`<br>production: `https://rshogi-csa-server.sh11235.com/health` |
 
-`<your-subdomain>` は Cloudflare アカウント固有の workers.dev サブドメイン
-（例: `your-name`）。**§3.1 / §3.2 の `wrangler deploy` 実行ログ末尾に
-`Published ... https://...workers.dev` という形で完全な URL が出力される**ので、
-その値を流用する。
+URL は各環境の wrangler toml が `routes` で宣言する Custom Domain
+(`workers_dev = false` のため workers.dev 直 URL は公開されない)。
 [Cloudflare Dashboard → Workers & Pages → 各 worker → Triggers → Routes] でも
 確認できる。
 
@@ -415,14 +413,13 @@ vp run deploy:staging
 `wrangler.staging.toml` の `[build] command = "worker-build --release"` が
 `wrangler deploy` の前段で自動実行される。
 
-成功すると `https://rshogi-csa-server-workers-staging.<your-subdomain>.workers.dev/`
-にデプロイされ、URL が標準出力に表示される。
+成功すると Custom Domain `https://stg.rshogi-csa-server.sh11235.com/`
+(wrangler.staging.toml の `routes` 宣言) にデプロイされる。
 
 #### Smoke check
 
 ```bash
-SUBDOMAIN=<your-subdomain>
-curl "https://rshogi-csa-server-workers-staging.${SUBDOMAIN}.workers.dev/health"
+curl "https://stg.rshogi-csa-server.sh11235.com/health"
 # → "rshogi-csa-server-workers v0.1.0"
 ```
 
@@ -432,11 +429,11 @@ WebSocket 疎通は別途 ws client で確認:
 # `websocat` が無い場合は `cargo install websocat` か `brew install websocat` で入れる
 
 # (a) ネイティブ CSA クライアント経路（Origin ヘッダなし）の確認:
-websocat "wss://rshogi-csa-server-workers-staging.${SUBDOMAIN}.workers.dev/ws/test-room-1"
+websocat "wss://stg.rshogi-csa-server.sh11235.com/ws/test-room-1"
 # 接続が確立すれば OK。Origin が無いリクエストは allowlist に関係なく素通しする。
 
 # (b) ブラウザ経路（Origin 付き）の allowlist 確認:
-websocat "wss://rshogi-csa-server-workers-staging.${SUBDOMAIN}.workers.dev/ws/test-room-1" \
+websocat "wss://stg.rshogi-csa-server.sh11235.com/ws/test-room-1" \
   -H "Origin: https://csa-client-local"
 # `wrangler.staging.toml` の `WS_ALLOWED_ORIGINS` に含まれている Origin を指定する。
 # 含まれない値を渡すと `403 Forbidden Origin` で拒否される（allowlist の挙動確認）。
@@ -458,7 +455,7 @@ cd crates/rshogi-csa-server-workers
 vp run deploy:prod    # Vite+ 非使用時は `pnpm run deploy:prod`（§1 末尾参照）
 ```
 
-`https://rshogi-csa-server-workers.<your-subdomain>.workers.dev/` にデプロイされる。
+`https://rshogi-csa-server.sh11235.com/` にデプロイされる。
 同様に smoke check し、`/health` URL を `rshogi-csa-server-workers-production`
 Environment の variable に登録する。
 
@@ -470,7 +467,7 @@ deploy 後、環境ごとに既存の `ADMIN_API_TOKEN` を Authorization header
 bounded warmup を実行する（token を query string や log に載せない）:
 
 ```bash
-WORKER_URL="https://rshogi-csa-server-workers-staging.<your-subdomain>.workers.dev"
+WORKER_URL="https://stg.rshogi-csa-server.sh11235.com"
 curl --fail-with-body -X POST \
   -H "Authorization: Bearer ${ADMIN_API_TOKEN}" \
   "${WORKER_URL}/api/v1/admin/player-ratings/warmup"
@@ -1258,7 +1255,7 @@ admission gate (案 A: Worker 全体 maintenance flag / 案 B: cron で
 ### 12.2 ローカル手動 deploy 経路
 
 ```bash
-LIVE_URL="https://rshogi-csa-server-workers.sh11235.workers.dev/api/v1/games/live"
+LIVE_URL="https://rshogi-csa-server.sh11235.com/api/v1/games/live"
 bash scripts/check-csa-drain.sh \
   --live-url "$LIVE_URL" \
   --max-wait-sec 3900 \
@@ -1288,7 +1285,7 @@ job が `actions/checkout@v5` 後に `Drain in-flight games (production)` step
 #### 必須 environment variable
 
 GitHub Environment `rshogi-csa-server-workers-production` の variables に
-`WORKERS_DRAIN_URL` を登録 (例: `https://rshogi-csa-server-workers.sh11235.workers.dev/api/v1/games/live`)。
+`WORKERS_DRAIN_URL` を登録 (例: `https://rshogi-csa-server.sh11235.com/api/v1/games/live`)。
 未設定で production deploy を起動すると drain step が `::error::` で fail する
 (staging job は drain step を持たないため変数も不要)。
 
@@ -1400,11 +1397,11 @@ DO storage を喪失したシナリオでの運用方針を本節で確定する
 3. **DO instance の状態確認**:
    ```bash
    # 進行中対局が API 上見えるか
-   curl -s "https://rshogi-csa-server-workers.sh11235.workers.dev/api/v1/games/live" | jq
+   curl -s "https://rshogi-csa-server.sh11235.com/api/v1/games/live" | jq
    # DO 側が応答しているか (room_id を 1 件試す)
    # ※ websocat 未インストールなら `cargo install websocat` で入れる。
    #   本コマンドは WS 到達性の確認のみで、DO state (対局データ) の健全性は判定不可
-   websocat "wss://rshogi-csa-server-workers.sh11235.workers.dev/ws/<room_id>"
+   websocat "wss://rshogi-csa-server.sh11235.com/ws/<room_id>"
    ```
 4. **復旧**:
    - 部分的喪失 (一部 DO instance のみ): 該当 instance に `start_match` してきた
@@ -1420,7 +1417,7 @@ DO storage を喪失したシナリオでの運用方針を本節で確定する
      ```bash
      # 影響 game_id を抽出: cutoff_ms = DO 喪失発生時刻 (epoch ms)、それ以前に
      # 開始 (started_at_ms < cutoff_ms) した対局が abort 対象 (= 喪失時に進行中)
-     curl -s "https://rshogi-csa-server-workers.sh11235.workers.dev/api/v1/games/live" \
+     curl -s "https://rshogi-csa-server.sh11235.com/api/v1/games/live" \
        | jq -r '.live_games[] | select(.started_at_ms < <cutoff_ms>) | .game_id'
      # 各 game_id に対応する live-games-index key を計算 (started_at_ms から prefix 構築)
      # 詳細は live_games_index::live_games_index_key を参照

--- a/docs/csa-server/lobby_e2e_runbook.md
+++ b/docs/csa-server/lobby_e2e_runbook.md
@@ -12,7 +12,7 @@
 
 ## 1. 前提条件
 
-- staging Worker が `https://rshogi-csa-server-workers-staging.<account>.workers.dev/`
+- staging Worker が `https://stg.rshogi-csa-server.sh11235.com/`
   に deploy 済み (LobbyDO バインディング含む)。`/health` が `rshogi-csa-server-workers v0.1.0`
   を返すこと。
 - `target/release/rshogi-csa-client` と `target/release/rshogi-usi` がローカルに
@@ -67,7 +67,7 @@ cd /tmp/lobby-run-white && \
 
 ```text
 [INFO] CSA対局クライアント起動
-[INFO] サーバー: wss://...workers.dev/ws/lobby:0 (ID: alice+lobby+black)        ← apply_target_preset 後
+[INFO] サーバー: wss://stg.rshogi-csa-server.sh11235.com/ws/lobby:0 (ID: alice+lobby+black) ← apply_target_preset 後
 [INFO] エンジン: /path/to/rshogi-usi
 [INFO] [USI] エンジン準備完了: Shogi Engine 0.1.0                                 ← USI handshake OK
 [INFO] [CSA/WS] 接続中: wss://.../ws/lobby

--- a/docs/csa-server/observability.md
+++ b/docs/csa-server/observability.md
@@ -281,7 +281,7 @@ pulumi up
 
 **設計概要 (詳細は別 PR で起票・実装):**
 
-1. Pulumi で `cloudflare.HealthCheck` resource を declare (HTTP probe で `https://rshogi-csa-server-workers.sh11235.workers.dev/health` 等を 1 分間隔で probe)
+1. Pulumi で `cloudflare.HealthCheck` resource を declare (HTTP probe で `https://rshogi-csa-server.sh11235.com/health` 等を 1 分間隔で probe)
 2. Pulumi で `cloudflare.NotificationPolicy` (alertType=`health_check_status_notification`) を declare、`filters.healthCheckId` に上記 Health Check の id を指定、`mechanisms.webhooks` で既存 `alertWebhook` (rshogi-{stg,prod}-alerts) へ routing
 3. これで Worker `/health` endpoint が DOWN を検知 → Slack 通知 が完成
 

--- a/docs/csa-server/viewer_access_control.md
+++ b/docs/csa-server/viewer_access_control.md
@@ -70,7 +70,7 @@ production 中に viewer / spectate を即時無効化する必要が生じた�
 
 ## 5. smoke 確認 curl コマンド例
 
-`<host>` は `rshogi-csa-server-workers.<account>.workers.dev`、
+`<host>` は `rshogi-csa-server.sh11235.com` (Custom Domain)、
 `<allowed-origin>` は `WS_ALLOWED_ORIGINS` に登録した Origin、
 `<other-origin>` は登録していない Origin に置き換える。
 


### PR DESCRIPTION
workers.dev 直 URL / preview URL は zone (sh11235.com) の WAF・Rate Limiting を経由しないため、DDoS 様のアクセスによる Workers 無料枠の焼き潰し経路になる。到達経路を Custom Domain (proxied) に一本化するため `workers_dev = false` / `preview_urls = false` を宣言する。

runtime 側は 2026-07-20 に Cloudflare API で全 Worker の subdomain を無効化済み (workers.dev 直 URL は 404、Custom Domain は 200 を確認)。本 PR は次回 deploy での再有効化を防ぐ宣言の恒久化。調査ログ: iac docs/operation-log/2026-07-20-waf-free-plan-survey.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF8uygMzncnuMf5V17RztU