### PR TITLE
feat(csa-server): 入玉宣言ルールを設定駆動化 (env/CLI) + マッチ単位で永続化

### DIFF
--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -106,8 +106,8 @@ struct Cli {
     /// 最大手数。
     #[arg(long, default_value_t = 256)]
     max_moves: u32,
-    /// `%KACHI` 判定の入玉ルール。`csarule27` (27点法・既定) / `csarule24` (24点法) 等。
-    /// 電竜戦・従来 WCSC・floodgate は 27点法、WCSC 2028 は 24点法。
+    /// `%KACHI` 判定の入玉ルール (USI トークン)。`CSARule27` (27点法・既定) /
+    /// `CSARule24` (24点法) 等。電竜戦・従来 WCSC・floodgate は 27点法、WCSC 2028 は 24点法。
     #[arg(long, value_enum, default_value_t = EnteringKingRuleArg::CsaRule27)]
     entering_king_rule: EnteringKingRuleArg,
     /// AGREE 受信の最大待機時間（秒）。GUI/エンジンの起動待ちを許容するため長めの既定値。
@@ -153,19 +153,27 @@ enum ClockKindArg {
 }
 
 /// `--entering-king-rule` の CLI バリアント。`EnteringKingRule` の core enum へ写す。
+/// value 名は Workers の `ENTERING_KING_RULE` env と同じ USI トークンに揃える
+/// (両配備で綴りを 1 つにし、`EnteringKingRule::to_usi`/`from_usi` と一致させる)。
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
 enum EnteringKingRuleArg {
     /// 27点法 (先手28点/後手27点、電竜戦・従来 WCSC・floodgate 標準)。
+    #[value(name = "CSARule27")]
     CsaRule27,
     /// 24点法 (先後共 31点、WCSC 2028)。
+    #[value(name = "CSARule24")]
     CsaRule24,
     /// 27点法 (駒落ち対応)。
+    #[value(name = "CSARule27H")]
     CsaRule27H,
     /// 24点法 (駒落ち対応)。
+    #[value(name = "CSARule24H")]
     CsaRule24H,
     /// 宣言勝ち無効。
+    #[value(name = "NoEnteringKing")]
     NoEnteringKing,
     /// トライルール。
+    #[value(name = "TryRule")]
     TryRule,
 }
 
@@ -807,6 +815,19 @@ mod tests {
     fn entering_king_rule_defaults_to_point27() {
         let cli = Cli::parse_from(["prog", "--players", "players.yaml"]);
         assert_eq!(cli.entering_king_rule.to_rule(), rshogi_core::types::EnteringKingRule::Point27);
+    }
+
+    /// CLI の value 名が USI トークンと同じ綴りで受理される (Workers env と統一)。
+    #[test]
+    fn entering_king_rule_accepts_usi_token_spelling() {
+        let cli = Cli::parse_from([
+            "prog",
+            "--players",
+            "players.yaml",
+            "--entering-king-rule",
+            "CSARule24",
+        ]);
+        assert_eq!(cli.entering_king_rule.to_rule(), rshogi_core::types::EnteringKingRule::Point24);
     }
 
     /// `validate_handicap_sfen` がフィールド数不足を弾く契約。

--- a/crates/rshogi-csa-server-tcp/src/bin/main.rs
+++ b/crates/rshogi-csa-server-tcp/src/bin/main.rs
@@ -106,6 +106,10 @@ struct Cli {
     /// 最大手数。
     #[arg(long, default_value_t = 256)]
     max_moves: u32,
+    /// `%KACHI` 判定の入玉ルール。`csarule27` (27点法・既定) / `csarule24` (24点法) 等。
+    /// 電竜戦・従来 WCSC・floodgate は 27点法、WCSC 2028 は 24点法。
+    #[arg(long, value_enum, default_value_t = EnteringKingRuleArg::CsaRule27)]
+    entering_king_rule: EnteringKingRuleArg,
     /// AGREE 受信の最大待機時間（秒）。GUI/エンジンの起動待ちを許容するため長めの既定値。
     #[arg(long, default_value_t = 300)]
     agree_timeout_sec: u64,
@@ -146,6 +150,37 @@ enum ClockKindArg {
     Countdown,
     Fischer,
     Stopwatch,
+}
+
+/// `--entering-king-rule` の CLI バリアント。`EnteringKingRule` の core enum へ写す。
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+enum EnteringKingRuleArg {
+    /// 27点法 (先手28点/後手27点、電竜戦・従来 WCSC・floodgate 標準)。
+    CsaRule27,
+    /// 24点法 (先後共 31点、WCSC 2028)。
+    CsaRule24,
+    /// 27点法 (駒落ち対応)。
+    CsaRule27H,
+    /// 24点法 (駒落ち対応)。
+    CsaRule24H,
+    /// 宣言勝ち無効。
+    NoEnteringKing,
+    /// トライルール。
+    TryRule,
+}
+
+impl EnteringKingRuleArg {
+    fn to_rule(self) -> rshogi_core::types::EnteringKingRule {
+        use rshogi_core::types::EnteringKingRule as R;
+        match self {
+            Self::CsaRule27 => R::Point27,
+            Self::CsaRule24 => R::Point24,
+            Self::CsaRule27H => R::Point27H,
+            Self::CsaRule24H => R::Point24H,
+            Self::NoEnteringKing => R::None,
+            Self::TryRule => R::TryRule,
+        }
+    }
 }
 
 impl ClockKindArg {
@@ -256,7 +291,7 @@ fn main() -> anyhow::Result<()> {
         login_timeout: std::time::Duration::from_secs(30),
         agree_timeout: std::time::Duration::from_secs(cli.agree_timeout_sec),
         x1_reply_write_timeout: std::time::Duration::from_secs(5),
-        entering_king_rule: rshogi_core::types::EnteringKingRule::Point27,
+        entering_king_rule: cli.entering_king_rule.to_rule(),
         initial_sfen: None,
         admin_handles: cli.admin_handle.clone(),
         allow_floodgate_features: cli.allow_floodgate_features,
@@ -753,6 +788,25 @@ mod tests {
             ALLOW_FLOODGATE_FEATURES_FLAG,
             "ALLOW_FLOODGATE_FEATURES_FLAG must stay in sync with clap-generated flag",
         );
+    }
+
+    /// `--entering-king-rule` の各バリアントが core enum に正しく写ることを固定する。
+    #[test]
+    fn entering_king_rule_arg_maps_to_core_enum() {
+        use rshogi_core::types::EnteringKingRule as R;
+        assert_eq!(EnteringKingRuleArg::CsaRule27.to_rule(), R::Point27);
+        assert_eq!(EnteringKingRuleArg::CsaRule24.to_rule(), R::Point24);
+        assert_eq!(EnteringKingRuleArg::CsaRule27H.to_rule(), R::Point27H);
+        assert_eq!(EnteringKingRuleArg::CsaRule24H.to_rule(), R::Point24H);
+        assert_eq!(EnteringKingRuleArg::NoEnteringKing.to_rule(), R::None);
+        assert_eq!(EnteringKingRuleArg::TryRule.to_rule(), R::TryRule);
+    }
+
+    /// `--entering-king-rule` 未指定時の既定は 27点法。
+    #[test]
+    fn entering_king_rule_defaults_to_point27() {
+        let cli = Cli::parse_from(["prog", "--players", "players.yaml"]);
+        assert_eq!(cli.entering_king_rule.to_rule(), rshogi_core::types::EnteringKingRule::Point27);
     }
 
     /// `validate_handicap_sfen` がフィールド数不足を弾く契約。

--- a/crates/rshogi-csa-server-workers/src/config.rs
+++ b/crates/rshogi-csa-server-workers/src/config.rs
@@ -15,12 +15,12 @@ use rshogi_csa_server::config::{
 
 use crate::origin;
 
-/// Workers 配備の `%KACHI` 判定に使う入玉ルール。CoreRoom (判定側) と
-/// Game_Summary の広告 (`Declaration:` / `Entering_King_Rule:` 行) の両方が
-/// この値を参照する。別々の literal にすると判定と広告がずれ、client が
-/// 誤ったルールをエンジンへ自動注入してしまう。
-/// 27 点法は電竜戦・世界コンピュータ将棋選手権・wdoor floodgate と同じ標準宣言ルール。
-pub const ENTERING_KING_RULE: rshogi_core::types::EnteringKingRule =
+/// `%KACHI` 判定に使う入玉ルールの既定値。`ENTERING_KING_RULE` env 未設定・空・
+/// 不正トークン時のフォールバックに使う。27 点法は電竜戦・従来の世界コンピュータ将棋
+/// 選手権・wdoor floodgate と同じ標準宣言ルールで、エンジン USI 既定 `CSARule27` とも
+/// 一致する。実際に使う値は対局開始時に env から解決して `PersistedConfig` に焼き込む
+/// ため、判定 (CoreRoom) と広告 (Game_Summary) は常に同じ永続値を参照する。
+pub const DEFAULT_ENTERING_KING_RULE: rshogi_core::types::EnteringKingRule =
     rshogi_core::types::EnteringKingRule::Point27;
 
 /// 起動時にバインディング名として参照する環境変数キー群。
@@ -188,6 +188,11 @@ impl ConfigKeys {
     /// 構成は `--allow-floodgate-features` (Workers では `ALLOW_FLOODGATE_FEATURES`)
     /// を要求する Floodgate features の opt-in 経路に乗る。
     pub const RECONNECT_GRACE_SECONDS: &'static str = "RECONNECT_GRACE_SECONDS";
+    /// `%KACHI` 判定に使う入玉ルールを USI トークンで指定する (`CSARule27` /
+    /// `CSARule24` 等、`EnteringKingRule::from_usi` が受理する値)。未設定・空・
+    /// 不正トークンは [`DEFAULT_ENTERING_KING_RULE`] にフォールバックする。
+    /// 配備インスタンス単位でルールを切替える (電竜戦=27点法 / WCSC 2028=24点法) 用途。
+    pub const ENTERING_KING_RULE: &'static str = "ENTERING_KING_RULE";
     /// LOGIN OK 後の AGREE 待ち TTL (秒)。`start_match` で Game_Summary を送信した
     /// 直後に予約し、両者 AGREE 受領 (`HandleOutcome::GameStarted`) で cancel する。
     /// 発火時は対局が成立する前に部屋を解放する (https://github.com/SH11235/rshogi/issues/600)。
@@ -293,6 +298,7 @@ impl ConfigKeys {
         Self::TOTAL_TIME_MIN,
         Self::BYOYOMI_MIN,
         Self::CLOCK_PRESETS,
+        Self::ENTERING_KING_RULE,
         Self::RECONNECT_GRACE_SECONDS,
         Self::AGREE_TIMEOUT_SECONDS,
         Self::ALLOW_FLOODGATE_FEATURES,
@@ -459,6 +465,28 @@ pub(crate) fn resolve_reconnect_grace_from_strings(
     };
     validate_floodgate_feature_gate(allow, intent)?;
     Ok(grace)
+}
+
+/// `ENTERING_KING_RULE` env 文字列から `%KACHI` 判定ルールを解決する pure helper。
+///
+/// - `None` / 空文字 → `Ok(default)` (env 未設定は既定運用)
+/// - `EnteringKingRule::from_usi` が受理するトークン → `Ok(その値)`
+/// - 未知トークン → `Err(トークン)` (呼び出し側でログして default にフォールバックする。
+///   1 台の typo で全対局を落とすより、標準ルールで走らせて運用者に気付かせる方が安全)
+///
+/// `default` を引数に取るのは host テストで既定非依存に検証するため。実運用の
+/// フォールバック先は [`DEFAULT_ENTERING_KING_RULE`]。
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn resolve_entering_king_rule_from_string(
+    raw: Option<&str>,
+    default: rshogi_core::types::EnteringKingRule,
+) -> Result<rshogi_core::types::EnteringKingRule, String> {
+    match raw.map(str::trim) {
+        None | Some("") => Ok(default),
+        Some(token) => {
+            rshogi_core::types::EnteringKingRule::from_usi(token).ok_or_else(|| token.to_owned())
+        }
+    }
 }
 
 /// Workers `[vars]` 文字列群から時計設定を解決する。
@@ -862,6 +890,37 @@ mod tests {
             err.contains("allow_floodgate_features") || err.contains("reconnect_protocol"),
             "err must mention gate mismatch: {err}"
         );
+    }
+
+    #[test]
+    fn resolve_entering_king_rule_defaults_when_unset_or_blank() {
+        use rshogi_core::types::EnteringKingRule;
+        let d = EnteringKingRule::Point27;
+        assert_eq!(resolve_entering_king_rule_from_string(None, d), Ok(d));
+        assert_eq!(resolve_entering_king_rule_from_string(Some(""), d), Ok(d));
+        assert_eq!(resolve_entering_king_rule_from_string(Some("  "), d), Ok(d));
+    }
+
+    #[test]
+    fn resolve_entering_king_rule_parses_usi_tokens() {
+        use rshogi_core::types::EnteringKingRule;
+        let d = EnteringKingRule::Point27;
+        assert_eq!(
+            resolve_entering_king_rule_from_string(Some("CSARule24"), d),
+            Ok(EnteringKingRule::Point24)
+        );
+        assert_eq!(
+            resolve_entering_king_rule_from_string(Some("CSARule27"), d),
+            Ok(EnteringKingRule::Point27)
+        );
+    }
+
+    #[test]
+    fn resolve_entering_king_rule_rejects_unknown_token() {
+        use rshogi_core::types::EnteringKingRule;
+        let err = resolve_entering_king_rule_from_string(Some("Bogus"), EnteringKingRule::Point27)
+            .unwrap_err();
+        assert_eq!(err, "Bogus");
     }
 
     /// `CHALLENGE_TTL_SEC` が未設定 / 空文字なら既定 3600 秒。

--- a/crates/rshogi-csa-server-workers/src/game_room.rs
+++ b/crates/rshogi-csa-server-workers/src/game_room.rs
@@ -66,8 +66,8 @@ use crate::attachment::{
     parse_login_handle,
 };
 use crate::config::{
-    ConfigKeys, parse_agree_timeout_duration, parse_clock_presets, parse_clock_spec,
-    resolve_reconnect_grace_from_strings,
+    ConfigKeys, DEFAULT_ENTERING_KING_RULE, parse_agree_timeout_duration, parse_clock_presets,
+    parse_clock_spec, resolve_entering_king_rule_from_string, resolve_reconnect_grace_from_strings,
 };
 use crate::datetime::{format_csa_datetime, format_date_path, format_rfc3339_utc};
 use crate::export_retry::{is_exhausted, next_retry_delay_ms};
@@ -923,6 +923,9 @@ impl GameRoom {
         // で参照するために `PersistedConfig` に保存する。`grace == 0` の構成では
         // `(None, None)` を返し token 配布も `PersistedConfig` への保存もスキップする。
         let (black_reconnect_token, white_reconnect_token) = issue_tokens_if_enabled(grace);
+        // 入玉ルールを env から解決してマッチ単位で固定する。対局中に env を
+        // 変えても進行中の局は開始時ルールで判定する ([`PersistedConfig::entering_king_rule`])。
+        let entering_king_rule = resolve_entering_king_rule(&self.env);
         let clock_spec = preset.clock;
         let cfg = PersistedConfig {
             game_id: game_id.clone(),
@@ -942,6 +945,7 @@ impl GameRoom {
             })?),
             black_reconnect_token: black_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
             white_reconnect_token: white_reconnect_token.as_ref().map(|t| t.as_str().to_owned()),
+            entering_king_rule: Some(entering_king_rule.to_usi().to_owned()),
         };
         self.state.storage().put(KEY_CONFIG, &cfg).await?;
 
@@ -968,7 +972,7 @@ impl GameRoom {
                 white: PlayerName::new(cfg.white_handle.clone()),
                 max_moves: cfg.max_moves,
                 time_margin_ms: cfg.time_margin_ms,
-                entering_king_rule: crate::config::ENTERING_KING_RULE,
+                entering_king_rule,
                 initial_sfen: cfg.initial_sfen.clone(),
             },
             clock,
@@ -991,7 +995,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move,
-            entering_king_rule: crate::config::ENTERING_KING_RULE,
+            entering_king_rule,
             black_reconnect_token,
             white_reconnect_token,
         };
@@ -3411,7 +3415,7 @@ impl GameRoom {
             position_section,
             rematch_on_draw: false,
             to_move: core.current_turn(),
-            entering_king_rule: crate::config::ENTERING_KING_RULE,
+            entering_king_rule: cfg.entering_king_rule(),
             black_reconnect_token: cfg.black_reconnect_token.as_deref().map(ReconnectToken::new),
             white_reconnect_token: cfg.white_reconnect_token.as_deref().map(ReconnectToken::new),
         };
@@ -3998,6 +4002,26 @@ fn resolve_reconnect_grace(env: &Env) -> std::result::Result<Duration, String> {
     let grace_raw = env.var(ConfigKeys::RECONNECT_GRACE_SECONDS).ok().map(|v| v.to_string());
     let allow_raw = env.var(ConfigKeys::ALLOW_FLOODGATE_FEATURES).ok().map(|v| v.to_string());
     resolve_reconnect_grace_from_strings(grace_raw.as_deref(), allow_raw.as_deref())
+}
+
+/// `ENTERING_KING_RULE` env を読み、`%KACHI` 判定ルールを解決する。
+///
+/// 不正トークンは grace と違って対局を abort せず、ログを出して
+/// [`crate::config::DEFAULT_ENTERING_KING_RULE`] にフォールバックする (1 台の typo で
+/// 全対局を落とさず、標準ルールで走らせて運用者に気付かせる)。
+fn resolve_entering_king_rule(env: &Env) -> rshogi_core::types::EnteringKingRule {
+    let raw = env.var(ConfigKeys::ENTERING_KING_RULE).ok().map(|v| v.to_string());
+    match resolve_entering_king_rule_from_string(raw.as_deref(), DEFAULT_ENTERING_KING_RULE) {
+        Ok(rule) => rule,
+        Err(token) => {
+            crate::structured_log!(
+                event: "entering_king_rule_config_error",
+                component: "game_room",
+                token: token,
+            );
+            DEFAULT_ENTERING_KING_RULE
+        }
+    }
 }
 
 /// `ALLOW_FLOODGATE_FEATURES` env と `FLOODGATE_HISTORY_BUCKET` binding を読み、

--- a/crates/rshogi-csa-server-workers/src/persistence.rs
+++ b/crates/rshogi-csa-server-workers/src/persistence.rs
@@ -73,6 +73,26 @@ pub struct PersistedConfig {
     /// 後手向けの再接続トークン。挙動・契約は [`Self::black_reconnect_token`] と同様。
     #[serde(default)]
     pub(crate) white_reconnect_token: Option<String>,
+    /// 対局開始時に確定した `%KACHI` 判定の入玉ルール (USI トークン、例 `CSARule27`)。
+    ///
+    /// env `ENTERING_KING_RULE` を対局中に変えても進行中の局が別ルールで判定されない
+    /// よう、マッチ単位で固定した値を保存する ([`Self::reconnect_grace_ms`] と同じ理由)。
+    /// 旧 schema には存在しないため `#[serde(default)]` で `None` として読み、
+    /// [`Self::entering_king_rule`] が [`crate::config::DEFAULT_ENTERING_KING_RULE`] に
+    /// フォールバックする。
+    #[serde(default)]
+    pub(crate) entering_king_rule: Option<String>,
+}
+
+impl PersistedConfig {
+    /// 保存した USI トークンから `%KACHI` 判定ルールを復元する。`None` / 不正
+    /// トークン (旧 schema・手書き改変) は [`crate::config::DEFAULT_ENTERING_KING_RULE`]。
+    pub(crate) fn entering_king_rule(&self) -> rshogi_core::types::EnteringKingRule {
+        self.entering_king_rule
+            .as_deref()
+            .and_then(rshogi_core::types::EnteringKingRule::from_usi)
+            .unwrap_or(crate::config::DEFAULT_ENTERING_KING_RULE)
+    }
 }
 
 /// 終局フラグ。一度 `Some` になったらその DO は同じ対局を二度開始しない。
@@ -234,7 +254,7 @@ pub fn replay_core_room(cfg: &PersistedConfig, moves: &[MoveRow]) -> ReplaySumma
             white: PlayerName::new(cfg.white_handle.clone()),
             max_moves: cfg.max_moves,
             time_margin_ms: cfg.time_margin_ms,
-            entering_king_rule: crate::config::ENTERING_KING_RULE,
+            entering_king_rule: cfg.entering_king_rule(),
             initial_sfen: cfg.initial_sfen.clone(),
         },
         clock,
@@ -324,6 +344,7 @@ mod tests {
             reconnect_grace_ms: Some(0),
             black_reconnect_token: None,
             white_reconnect_token: None,
+            entering_king_rule: None,
         }
     }
 
@@ -348,7 +369,7 @@ mod tests {
                 white: PlayerName::new(cfg.white_handle.clone()),
                 max_moves: cfg.max_moves,
                 time_margin_ms: cfg.time_margin_ms,
-                entering_king_rule: crate::config::ENTERING_KING_RULE,
+                entering_king_rule: cfg.entering_king_rule(),
                 initial_sfen: cfg.initial_sfen.clone(),
             },
             cfg.clock.build_clock(),
@@ -376,6 +397,40 @@ mod tests {
                 .expect("move in directly_played");
         }
         core
+    }
+
+    #[test]
+    fn entering_king_rule_accessor_maps_token_and_falls_back() {
+        use rshogi_core::types::EnteringKingRule;
+        let mut cfg = baseline_config();
+        // 既定 (None) はフォールバック値。
+        assert_eq!(cfg.entering_king_rule(), crate::config::DEFAULT_ENTERING_KING_RULE);
+        cfg.entering_king_rule = Some("CSARule24".to_owned());
+        assert_eq!(cfg.entering_king_rule(), EnteringKingRule::Point24);
+        cfg.entering_king_rule = Some("bogus".to_owned());
+        assert_eq!(cfg.entering_king_rule(), crate::config::DEFAULT_ENTERING_KING_RULE);
+    }
+
+    #[test]
+    fn old_snapshot_without_rule_field_deserializes_to_default() {
+        // 本フィールド導入前に永続化された snapshot (entering_king_rule 欠落) を
+        // deserialize しても失敗せず、accessor は既定へフォールバックする。
+        let mut cfg = baseline_config();
+        cfg.entering_king_rule = Some("CSARule24".to_owned());
+        let mut json: serde_json::Value = serde_json::to_value(&cfg).unwrap();
+        json.as_object_mut().unwrap().remove("entering_king_rule");
+        let restored: PersistedConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.entering_king_rule, None);
+        assert_eq!(restored.entering_king_rule(), crate::config::DEFAULT_ENTERING_KING_RULE);
+    }
+
+    #[test]
+    fn persisted_rule_survives_serde_round_trip() {
+        let mut cfg = baseline_config();
+        cfg.entering_king_rule = Some("CSARule24".to_owned());
+        let round: PersistedConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(round.entering_king_rule(), rshogi_core::types::EnteringKingRule::Point24);
     }
 
     #[test]

--- a/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
+++ b/crates/rshogi-csa-server-workers/src/spectator_snapshot.rs
@@ -128,7 +128,7 @@ pub fn build_spectator_snapshot(input: SpectatorSnapshotInput<'_>) -> Vec<String
         position_section,
         rematch_on_draw: false,
         to_move,
-        entering_king_rule: crate::config::ENTERING_KING_RULE,
+        entering_king_rule: input.config.entering_king_rule(),
         // 観戦者向け builder は token を出力しないため、`None` 固定で渡す
         // (関数内部でも player 経路と異なり token 行は出さない契約)。
         black_reconnect_token: None,
@@ -324,6 +324,7 @@ mod tests {
             reconnect_grace_ms: Some(30_000),
             black_reconnect_token: Some("blk-token".to_owned()),
             white_reconnect_token: Some("wht-token".to_owned()),
+            entering_king_rule: None,
         }
     }
 
@@ -621,7 +622,7 @@ PI
             max_moves: 256,
             // margin を課金へ持ち込まないことを確認するため 0 でなく 1000ms を設定する。
             time_margin_ms: 1_000,
-            entering_king_rule: crate::config::ENTERING_KING_RULE,
+            entering_king_rule: crate::config::DEFAULT_ENTERING_KING_RULE,
             initial_sfen: None,
         };
         let clock = Box::new(FischerClock::new(60, 5));

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/harness.ts
@@ -67,6 +67,9 @@ export interface HarnessOptions {
   /// 切って必ず指定する契約。`makeTempPersistRoot()` のヘルパで作るのが基本経路。
   persistRoot: string;
   reconnectGraceSeconds?: number;
+  /// `%KACHI` 判定の入玉ルール (USI トークン、例 `CSARule24`)。未指定時は binding を
+  /// 出さず server 側 fallback (= 27点法) を使う。
+  enteringKingRule?: string;
   /// AGREE 待ち TTL (秒)。`start_match` 直後に予約され、両者 AGREE で cancel
   /// される (Issue #600)。テストで stuck 経路を再現する際は短めの値 (例: 1) を
   /// 渡し、`alarm()` 発火で部屋解放されることを assert する。未指定時は server
@@ -178,6 +181,9 @@ export async function createMiniflare(opts: HarnessOptions): Promise<Miniflare> 
       // 出て reconnect 経路が有効化される。Issue #591 hotfix 後は server 側 token
       // 配布も grace に応じた gate を通る。
       RECONNECT_GRACE_SECONDS: String(opts.reconnectGraceSeconds ?? 0),
+      // 未指定時は空文字を渡して server 側 fallback (= DEFAULT_ENTERING_KING_RULE
+      // = 27点法) を使う。24点法インスタンスの検証時のみ `CSARule24` を明示する。
+      ENTERING_KING_RULE: opts.enteringKingRule ?? "",
       // 未指定時は空文字を渡して server 側 fallback (= 60 秒既定) を使う。
       // 数値を指定したテストでは start_match 直後に AGREE 待ち alarm が予約される。
       AGREE_TIMEOUT_SECONDS:

--- a/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
+++ b/crates/rshogi-csa-server-workers/tests/miniflare_smoke/smoke.test.ts
@@ -84,4 +84,37 @@ describe("miniflare smoke: 1 対局 E2E", () => {
     await black.close();
     await white.close();
   });
+
+  it("ENTERING_KING_RULE=CSARule24 で 24 点法を広告する (Declaration 行なし)", async () => {
+    // 既定 mf を破棄し、24 点法 env の専用インスタンスを立てる。
+    await mf.dispose();
+    await cleanupPersist();
+    const persist = await makeTempPersistRoot();
+    cleanupPersist = persist.cleanup;
+    mf = await createMiniflare({
+      persistRoot: persist.path,
+      totalTimeSec: 60,
+      byoyomiSec: 1,
+      enteringKingRule: "CSARule24",
+    });
+
+    const roomId = "smoke-room-ekr24";
+    const gameName = "floodgate-60-1";
+    const black = await CsaClient.connect(mf, roomId);
+    const blackName = `alice+${gameName}+black`;
+    black.send(`LOGIN ${blackName} pw`);
+    expect(await black.recvLine()).toBe(`LOGIN:${blackName} OK`);
+    const white = await CsaClient.connect(mf, roomId);
+    const whiteName = `bob+${gameName}+white`;
+    white.send(`LOGIN ${whiteName} pw`);
+    expect(await white.recvLine()).toBe(`LOGIN:${whiteName} OK`);
+
+    const blackSummary = await black.drainGameSummary();
+    // 24 点法は拡張行のみ。CSA 標準 Declaration には 24 点法トークンが無いため出さない。
+    expect(blackSummary.some((l) => l === "Entering_King_Rule:CSARule24")).toBe(true);
+    expect(blackSummary.some((l) => l.startsWith("Declaration:"))).toBe(false);
+
+    await black.close();
+    await white.close();
+  });
 });

--- a/crates/rshogi-csa-server-workers/wrangler.production.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.production.toml
@@ -215,6 +215,12 @@ CLOCK_PRESETS = '''[
   {"game_name":"floodgate-600-10-moves512","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":512}
 ]'''
 
+# `%KACHI` 判定の入玉ルール (USI トークン)。未設定 / 空 / 不正トークンは 27点法
+# (`CSARule27`、電竜戦・従来 WCSC・floodgate 標準) にフォールバック。WCSC 2028 の
+# 24点法インスタンスを立てるときのみ `CSARule24` を明示する。対局開始時に確定して
+# PersistedConfig に固定されるため、途中で変更しても進行中の局は開始時ルールで判定。
+ENTERING_KING_RULE = "CSARule27"
+
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 RECONNECT_GRACE_SECONDS = "30"

--- a/crates/rshogi-csa-server-workers/wrangler.staging.toml
+++ b/crates/rshogi-csa-server-workers/wrangler.staging.toml
@@ -208,6 +208,11 @@ CLOCK_PRESETS = '''[
   {"game_name":"floodgate-600-10-moves512","kind":"countdown","total_time_sec":600,"byoyomi_sec":10,"max_moves":512}
 ]'''
 
+# `%KACHI` 判定の入玉ルール (USI トークン)。未設定 / 空 / 不正は 27点法にフォールバック。
+# WCSC 2028 の 24点法インスタンスでのみ `CSARule24` を明示する。意図は production toml の
+# 同等行を参照。
+ENTERING_KING_RULE = "CSARule27"
+
 # 切断時の再接続猶予秒数。`0` または未設定で再接続プロトコルを無効化（保守的既定）。
 # `> 0` を指定する構成は ALLOW_FLOODGATE_FEATURES=true との同時設定が必須。
 # staging では reconnect protocol / history bucket / rating 応答などの Floodgate 系

--- a/crates/rshogi-csa-server-workers/wrangler.toml.example
+++ b/crates/rshogi-csa-server-workers/wrangler.toml.example
@@ -152,6 +152,10 @@ BYOYOMI_MIN = "1"
 #   ]'''
 # 命名規則・各方式の field 名・strict mode 仕様は `docs/csa-server/clock_defaults.md` 参照。
 CLOCK_PRESETS = "[]"
+# `%KACHI` 判定の入玉ルール (USI トークン)。未設定 / 空 / 不正は 27点法
+# (`CSARule27`、電竜戦・従来 WCSC・floodgate 標準) にフォールバック。WCSC 2028 の
+# 24点法インスタンスでのみ `CSARule24` を明示する。
+ENTERING_KING_RULE = "CSARule27"
 # admin 認可基盤 (WS 内 `%%ADMIN <token>` / 将来の HTTP admin endpoint で共用
 # される static API token、https://github.com/SH11235/rshogi/issues/560 +
 # https://github.com/SH11235/rshogi/issues/621)。

--- a/docs/csa-server/deployment.md
+++ b/docs/csa-server/deployment.md
@@ -398,6 +398,9 @@ CI 自動 deploy 前に、ローカルから 1 度手動で deploy して動作�
   （未確定なら空のままで OK。空のままでもネイティブ CSA クライアントは Origin 欠落で
   素通し。web client 化したときだけ Origin の追加が必要）
 - 時計設定（`CLOCK_KIND` / `TOTAL_TIME_*` / `BYOYOMI_*`）を運用方針に合わせる
+- `ENTERING_KING_RULE`（`%KACHI` 入玉ルール、USI トークン）を大会方針に合わせる。既定
+  `CSARule27`（電竜戦・従来 WCSC・floodgate）。WCSC 2028 の 24点法インスタンスでは
+  `CSARule24` を明示。未設定 / 不正値は `CSARule27` にフォールバック
 - `ADMIN_API_TOKEN` と `PLAYER_ID_SECRET` を staging Cloudflare secret に登録済みか確認（§2.5 / [`admin_auth.md`](admin_auth.md)）。
   確認: `vp exec wrangler secret list --config wrangler.staging.toml`
 


### PR DESCRIPTION
## 背景

#956 で `%KACHI` 判定ルールを 27点法にコード直書きしたが、**WCSC 2028 が 24点法採用確定**のため、電竜戦/floodgate (27点法) と WCSC 2028 (24点法) を配備インスタンス単位で切替える必要が出た。ルールを運用者設定に変更する。

## 変更内容

### workers: env 駆動 + 永続化
- `ENTERING_KING_RULE` env (USI トークン `CSARule27` / `CSARule24` 等) から解決。旧 `const ENTERING_KING_RULE` は `DEFAULT_ENTERING_KING_RULE` (27点法) に改名しフォールバック専用化。
- 不正トークンは grace と違い**対局を落とさず**、ログ + 既定フォールバック (1 台の typo で全対局を止めない fail-open)。
- **永続化**: 解決値を対局開始時に `PersistedConfig.entering_king_rule` (USI トークン文字列) へ焼き込み、cold start / 再接続復元はこの固定値を読む。対局中に env を変えても進行中の局は開始時ルールで判定 (`reconnect_grace_ms` と同じマッチ単位固定パターン)。判定 (CoreRoom) と広告 (Game_Summary) が同一 cfg を参照するため乖離不能。旧 schema は `#[serde(default)]` で `None` → 既定へフォールバック。

### tcp: CLI フラグ
- `--entering-king-rule {csarule27,csarule24,csarule27h,csarule24h,no-entering-king,try-rule}` (既定 `csarule27`)。

### 設定・ドキュメント
- wrangler production / staging / example に `ENTERING_KING_RULE = "CSARule27"` を宣言、`ConfigKeys::SHARED_PUBLIC_VARS_KEYS` へ追加 (consistency test 準拠)、deployment.md の運用チェックリストに追記。

## テスト
- env resolver: 未設定/空/空白→既定、`CSARule24`/`CSARule27`→対応 enum、未知トークン→Err (単体 3 本)
- `PersistedConfig::entering_king_rule()` accessor + 旧 schema (フィールド欠落) デシリアライズ→既定 + serde round-trip (3 本)
- tcp: `EnteringKingRuleArg`→core enum マッピング全 6 バリアント + 既定 27点法 (2 本)
- miniflare E2E: `ENTERING_KING_RULE=CSARule24` で `Entering_King_Rule:CSARule24` 広告 + `Declaration:` 行なしを確認 (harness に `enteringKingRule` opt 追加)
- cargo fmt / clippy --tests 0 / cargo test 全 pass / miniflare smoke 52 pass / wasm build / abs-path check

## デプロイ
既定は 27点法据え置きなので #956 デプロイと同時でよい。WCSC 2028 用は 24点法インスタンスを `ENTERING_KING_RULE=CSARule24` で別途立てる (client はサーバー広告に追従するため無改修)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeVA9V36ojSNbcydM9Puz8