### PR TITLE
skill(selfplay): enforce canonical persistent output root

### DIFF
--- a/.claude/skills/selfplay/SKILL.md
+++ b/.claude/skills/selfplay/SKILL.md
@@ -70,6 +70,43 @@ user-invocable: true
 はモデルごとに必要なものが異なる。デフォルト 1 つに固執せず、対象モデルから判断 +
 不明なら確認。
 
+## 永続出力先 gate（起動前に必ず実行）
+
+対局 JSONL は後で教師データに使う可能性があるため、出力先はユーザー相談で変える項目ではない。
+**本体 checkout の絶対パス `rshogi/runs/selfplay/` に固定**し、linked worktree には出さない。
+
+- 「本体 checkout」は branch 名では決めない。`main` branch 用でも `rshogi-main` 等は
+  disposable worktree であり、保存先として禁止。
+- `git worktree list --porcelain` の先頭 record（primary worktree）を canonical root とし、
+  directory 名が厳密に `rshogi` かつ実在する通常 directory であることを確認する。
+  条件を満たさなければ起動せず user に確認する。
+- run 名は実在日時の `YYYYMMDD-HHMMSS-PURPOSE`。`YYYYMMDD_HHMMSS` や不正日時は禁止。
+- `--out-dir` は必ず canonical root の直下
+  `<canonical-rshogi>/runs/selfplay/YYYYMMDD-HHMMSS-PURPOSE` を絶対パスで渡し、起動前には
+  run directory が存在しないことを確認する。
+- Windows の junction / symlink、Linux の symlink を永続 root に使わない。
+- engine の build は worktree でよいが、`xtask` が作る標準
+  `engines/rshogi-usi-<edition>` を使う。`sprt-runtime-*` 等の独自 runtime directory を作らない。
+- 起動 script では build repo と log root を同じ変数に畳み込まない。log root は上記 canonical
+  root からのみ組み立てる。
+
+出力 directory を作る前に OS に合う bundled checker を通す:
+
+```powershell
+# Windows native
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .claude/skills/selfplay/scripts/assert_output_root.ps1 `
+  -Repo $PWD -OutDir $OUT
+```
+
+```bash
+# Linux / WSL2
+bash .claude/skills/selfplay/scripts/assert_output_root.sh "$PWD" "$OUT"
+```
+
+checker が失敗したら **起動禁止**。起動後に違反へ気付いても user 承認なしに job を kill しない。
+状況を報告して指示を待つ。局数・並列数だけの変更は kill/restart せず `control.json` を使う。
+
 ## ビルドの注意 (pre-flight 必須 3 点)
 
 engine build / feature 構成 / format 互換性の詳細は
@@ -110,14 +147,18 @@ build / preset edition / feature 構成の詳細は
 
 ### 2. 出力ディレクトリの作成
 
-実験ごとに個別のディレクトリを作成し、ログファイルの混入を防ぐ。
+上記 gate で検証した絶対パスだけを作成し、実験ごとのログ混入を防ぐ。
 
-```
-mkdir -p runs/selfplay/{YYYYMMDD}-{HHMMSS}-{PURPOSE}
+```bash
+CANONICAL_RSHOGI=/absolute/path/to/rshogi
+OUT="$CANONICAL_RSHOGI/runs/selfplay/$(date +%Y%m%d-%H%M%S)-{PURPOSE}"
+mkdir -p "$CANONICAL_RSHOGI/runs/selfplay"
+bash .claude/skills/selfplay/scripts/assert_output_root.sh "$PWD" "$OUT"
+mkdir -p "$OUT"
 ```
 
 - `{PURPOSE}` はユーザーの実験目的を短く要約したもの（例: `tt-16bit`, `lmr-tuning`）
-- このディレクトリパスを以降の `--out-dir` オプションで使用する
+- 検証済みの絶対パス `$OUT` を以降の `--out-dir` オプションで使用する
 
 ### 3. tournament バイナリで総当たり自己対局を実行
 
@@ -130,7 +171,7 @@ cargo run -p tools --release --bin tournament -- \
   --games {GAMES} --byoyomi {BYOYOMI} --hash-mb {HASH} --threads {THREADS} \
   --concurrency {CONCURRENCY} \
   --usi-option {NNUE} \
-  --out-dir runs/selfplay/{DIR}
+  --out-dir "$OUT"
 ```
 
 - `--concurrency`: 並列対局数（デフォルト1）。CPUコア数に応じて調整。
@@ -158,7 +199,7 @@ cargo run -p tools --release --bin tournament -- \
 
 ```bash
 # <out-dir>/control.json （存在するフィールドだけ反映。両方任意）
-echo '{"target_games": 300, "concurrency": 8}' > runs/selfplay/{DIR}/control.json
+echo '{"target_games": 300, "concurrency": 8}' > "$OUT/control.json"
 ```
 
 - **`target_games`**: 各方向・各ペアあたりの目標対局数（CLI `--games` と同じ単位）。
@@ -189,7 +230,7 @@ cargo run -p tools --release --bin tournament -- \
   --engine-usi-option "1:EvalDir=/path/to/eval" \
   --engine-usi-option "1:BookFile=no_book" \
   --games 100 --byoyomi 3000 --concurrency 5 \
-  --out-dir runs/selfplay/{DIR}
+  --out-dir "$OUT"
 ```
 
 ### 4. 完了待ち・結果集計
@@ -198,7 +239,7 @@ Background task の完了を `TaskOutput` で検知する。
 完了後、`analyze_selfplay` ツールで対局ログを集計しサマリを生成する:
 
 ```
-cargo run -p tools --release --bin analyze_selfplay -- runs/selfplay/{DIR}/*.jsonl
+cargo run -p tools --release --bin analyze_selfplay -- "$OUT"/*.jsonl
 ```
 
 `analyze_selfplay` は JSONL ファイルを読み込み、勝率・Elo差・手数分布などを集計して標準出力に表示する。
@@ -235,7 +276,7 @@ cargo run -p tools --release --bin tournament -- \
   --base-label base \
   --sprt --sprt-base-label base --sprt-test-label test \
   --sprt-nelo0 0 --sprt-nelo1 5 --sprt-alpha 0.05 --sprt-beta 0.05 \
-  --out-dir runs/selfplay/$(date +%Y%m%d_%H%M%S)-sprt-base-vs-test
+  --out-dir "$OUT"
 ```
 
 ポイント:
@@ -277,7 +318,7 @@ final:       pairs=246, LLR=+3.002, decision=accept_h1
 
 ```
 cargo run -p tools --release --bin analyze_selfplay -- \
-  runs/selfplay/{DIR}/*.jsonl --sprt
+  "$OUT"/*.jsonl --sprt
 ```
 
 base/test のラベルは以下の順で自動推定され、推定時は根拠が stderr に表示される:

--- a/.claude/skills/selfplay/scripts/assert_output_root.ps1
+++ b/.claude/skills/selfplay/scripts/assert_output_root.ps1
@@ -1,0 +1,75 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repo,
+    [Parameter(Mandatory = $true)]
+    [string]$OutDir
+)
+
+$ErrorActionPreference = "Stop"
+$repoPath = [System.IO.Path]::GetFullPath($Repo)
+if ($OutDir -cnotmatch '^(?:[A-Za-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)') {
+    throw "selfplay output gate: --out-dir must be an absolute path; got $OutDir"
+}
+
+$worktreeOutput = & git -c "safe.directory=$repoPath" -C $repoPath worktree list --porcelain
+if ($LASTEXITCODE -ne 0) {
+    throw "selfplay output gate: git worktree list failed"
+}
+
+$worktrees = @(
+    $worktreeOutput |
+        Where-Object { $_.StartsWith("worktree ") } |
+        ForEach-Object { [System.IO.Path]::GetFullPath($_.Substring(9)) }
+)
+if ($worktrees.Count -lt 1) {
+    throw "selfplay output gate: git reported no worktrees"
+}
+$canonical = $worktrees[0]
+if ((Split-Path -Leaf $canonical) -cne "rshogi") {
+    throw "selfplay output gate: primary worktree must be named 'rshogi'; got $canonical"
+}
+if (-not (Test-Path -LiteralPath $canonical -PathType Container)) {
+    throw "selfplay output gate: primary worktree does not exist: $canonical"
+}
+
+$runsRoot = Join-Path $canonical "runs"
+$outputRoot = Join-Path $runsRoot "selfplay"
+foreach ($persistentPath in @($canonical, $runsRoot, $outputRoot)) {
+    if (-not (Test-Path -LiteralPath $persistentPath -PathType Container)) {
+        throw "selfplay output gate: persistent path does not exist: $persistentPath"
+    }
+    $item = Get-Item -LiteralPath $persistentPath -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "selfplay output gate: persistent path must not be a reparse point: $persistentPath"
+    }
+}
+
+$outputRoot = [System.IO.Path]::GetFullPath($outputRoot).TrimEnd("\", "/")
+$outPath = [System.IO.Path]::GetFullPath($OutDir).TrimEnd("\", "/")
+$outParent = [System.IO.Path]::GetDirectoryName($outPath).TrimEnd("\", "/")
+if (-not $outParent.Equals($outputRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "selfplay output gate: --out-dir must be a direct child of $outputRoot; got $outPath"
+}
+if (Test-Path -LiteralPath $outPath) {
+    throw "selfplay output gate: run directory must not exist before kick: $outPath"
+}
+
+$runName = [System.IO.Path]::GetFileName($outPath)
+if ($runName -cnotmatch '^\d{8}-\d{6}-[A-Za-z0-9][A-Za-z0-9._-]*$') {
+    throw "selfplay output gate: run directory must match YYYYMMDD-HHMMSS-PURPOSE; got '$runName'"
+}
+$timestamp = $runName.Substring(0, 15)
+try {
+    [void][datetime]::ParseExact(
+        $timestamp,
+        "yyyyMMdd-HHmmss",
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::None
+    )
+}
+catch {
+    throw "selfplay output gate: invalid timestamp '$timestamp'"
+}
+
+Write-Output "canonical_rshogi=$canonical"
+Write-Output "selfplay_out=$outPath"

--- a/.claude/skills/selfplay/scripts/assert_output_root.sh
+++ b/.claude/skills/selfplay/scripts/assert_output_root.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: assert_output_root.sh REPO OUT_DIR" >&2
+  exit 2
+fi
+
+repo="$(realpath -e "$1")"
+if [[ "$2" != /* ]]; then
+  echo "selfplay output gate: --out-dir must be an absolute path; got $2" >&2
+  exit 2
+fi
+out_dir="$2"
+mapfile -t worktrees < <(
+  git -c "safe.directory=$repo" -C "$repo" worktree list --porcelain |
+    sed -n 's/^worktree //p'
+)
+
+if [ "${#worktrees[@]}" -lt 1 ]; then
+  echo "selfplay output gate: git reported no worktrees" >&2
+  exit 2
+fi
+canonical_raw="${worktrees[0]}"
+if [ "$(basename "$canonical_raw")" != "rshogi" ]; then
+  echo "selfplay output gate: primary worktree must be named 'rshogi'; got $canonical_raw" >&2
+  exit 2
+fi
+if [ ! -d "$canonical_raw" ] || [ -L "$canonical_raw" ]; then
+  echo "selfplay output gate: primary worktree must be an existing real directory: $canonical_raw" >&2
+  exit 2
+fi
+canonical="$(realpath -e "$canonical_raw")"
+
+for persistent_path in "$canonical/runs" "$canonical/runs/selfplay"; do
+  if [ ! -d "$persistent_path" ] || [ -L "$persistent_path" ]; then
+    echo "selfplay output gate: persistent path must be an existing real directory: $persistent_path" >&2
+    exit 2
+  fi
+done
+output_root="$(realpath -e "$canonical/runs/selfplay")"
+out_parent="$(realpath -e "$(dirname "$out_dir")")"
+if [ "$out_parent" != "$output_root" ]; then
+  echo "selfplay output gate: --out-dir must be a direct child of $output_root; got $out_dir" >&2
+  exit 2
+fi
+if [ -e "$out_dir" ] || [ -L "$out_dir" ]; then
+  echo "selfplay output gate: run directory must not exist before kick: $out_dir" >&2
+  exit 2
+fi
+
+run_name="$(basename "$out_dir")"
+if [[ ! "$run_name" =~ ^[0-9]{8}-[0-9]{6}-[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "selfplay output gate: run directory must match YYYYMMDD-HHMMSS-PURPOSE; got '$run_name'" >&2
+  exit 2
+fi
+timestamp="${run_name:0:15}"
+date_input="${timestamp:0:4}-${timestamp:4:2}-${timestamp:6:2} ${timestamp:9:2}:${timestamp:11:2}:${timestamp:13:2}"
+normalized_timestamp="$(date -d "$date_input" +%Y%m%d-%H%M%S 2>/dev/null || true)"
+if [ "$normalized_timestamp" != "$timestamp" ]; then
+  echo "selfplay output gate: invalid timestamp '$timestamp'" >&2
+  exit 2
+fi
+
+echo "canonical_rshogi=$canonical"
+echo "selfplay_out=$out_dir"


### PR DESCRIPTION
## Summary
- require persistent selfplay output under the primary checkout's shogi/runs/selfplay`n- reject linked-worktree, relative, reparse-point, existing, and invalid timestamp destinations before kick
- require standard edition engine paths and forbid ad-hoc sprt-runtime-* directories
- add PowerShell and Bash preflight checkers

## Validation
- PowerShell checker: canonical positive case and relative/wrong-root/invalid-date/existing negative cases
- Bash checker under WSL: canonical positive case and relative/wrong-root/invalid-time negative cases
- git diff --check`n- independent Codex review: APPROVE