### PR TITLE
fix(jsonl_to_psv): 破損した対局ログで変換を中断しない

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -39,6 +39,7 @@
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
 | `psv_to_jsonl` | PSV 形式 → JSONL 変換（デバッグ・確認用） |
+| `jsonl_to_psv` | 自己対局 JSONL → PSV 変換（破損行は破棄して継続、件数を Summary に計上。[詳細](docs/pack_tools.md#jsonl_to_psv)） |
 | `psv_to_hcpe3` | PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応） |
 | `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行（[詳細](docs/migrate_psv_move16.md)） |
 | `pack_to_psv` | GenSfen .pack → PSV 変換（move16 は実 YaneuraOu 形式） |

--- a/crates/tools/docs/pack_tools.md
+++ b/crates/tools/docs/pack_tools.md
@@ -201,6 +201,21 @@ cargo run -p tools --release --bin jsonl_to_psv -- \
 | `--missing-score` | `eval` 欠損局面の扱い。`skip` または `zero` | `skip` |
 | `--max-games` | 変換する最大対局数（0=全件） | `0` |
 
+#### 破損ログの扱い
+
+対局中にプロセスが落ちたログは、最終行が改行なしで途中まで書かれていたり、
+行が NUL 埋め / 不正 UTF-8 になっていることがある。これらは変換を中断させず、
+該当行だけを破棄して健全な行から局面を取り出す。件数は Summary に出る:
+
+- `Truncated tail lines` — 改行なしで切れた最終行。検出時点でそのファイルの読み込みを終える
+- `Corrupt lines` — 不正 UTF-8 または JSON として解釈できない行。警告はファイルごと先頭 5 件まで
+- `Parse errors` — JSON としては妥当だが `move` / `result` として読めない行
+  （必須フィールドの欠落や型不一致。未知の `type` は無視され、ここには入らない）
+
+`result` 行を失った対局は `Orphan games` として局面ごと破棄される（勝敗が確定
+できないため）。破損が想定外に多い場合は Summary の件数で気付けるので、変換後に
+必ず確認すること。
+
 ### expand_psv_from_policy
 
 dlshogi 系 ONNX モデルのポリシー出力を使い、各局面の合法手のうち選択確率が閾値を超える手の

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -61,6 +61,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |
 | `fix_scores` | preprocess で上書きされたスコアを元ファイルから復元 |
 | `psv_to_jsonl` | PSV 形式を JSONL 形式に変換 |
+| `jsonl_to_psv` | tournament / analyze_selfplay 互換の自己対局 JSONL を PSV に変換。書き手のクラッシュで壊れた行は破棄して継続し、件数を Summary に計上（[詳細](pack_tools.md#jsonl_to_psv)） |
 | `psv_to_hcpe3` | PSV を dlshogi 学習用 hcpe3 / hcpe に変換（通常手は cshogi と byte 一致、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応） |
 | `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へストリーミング移行（[詳細](migrate_psv_move16.md)） |
 | `pack_to_psv` | GenSfen .pack を PackedSfenValue (PSV) 形式に展開し、move16 を実 YaneuraOu 形式へ変換 |

--- a/crates/tools/src/bin/jsonl_to_psv.rs
+++ b/crates/tools/src/bin/jsonl_to_psv.rs
@@ -258,7 +258,9 @@ fn process_file(
         // 健全な行として通ってしまうため trim_end() は使わない。
         let line = line.strip_suffix('\n').unwrap_or(line);
         let line = line.strip_suffix('\r').unwrap_or(line);
-        if line.trim().is_empty() {
+        // 空行のみ黙って読み飛ばす。空白だけが残った行は破損の疑いがあるので
+        // パースに回し、失敗すれば Corrupt lines に計上する。
+        if line.is_empty() {
             continue;
         }
 
@@ -555,6 +557,34 @@ mod tests {
         assert_eq!(stats.corrupt_lines, 0);
         assert_eq!(stats.games_written, 1);
         assert_eq!(stats.positions_written, 1);
+    }
+
+    /// 空白だけが残った行は「空行」として黙殺せず破損行に計上する。
+    #[test]
+    fn counts_whitespace_only_line_as_corrupt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("game.jsonl");
+        let output = dir.path().join("out.psv");
+        std::fs::write(
+            &input,
+            concat!(
+                "\n",         // 純粋な空行は黙って読み飛ばす
+                "\u{00a0}\n", // NBSP のみ
+                " \t\n",      // 半角空白とタブのみ
+                "{\"type\":\"result\",\"game_id\":1,\"outcome\":\"black_win\"}\n",
+            ),
+        )
+        .expect("write input");
+
+        let mut writer = BufWriter::new(File::create(&output).expect("create output"));
+        let mut games_written = 0;
+        let stats =
+            process_file(&input, &mut writer, MissingScoreMode::Skip, 0, &mut games_written)
+                .expect("process file");
+        writer.flush().expect("flush");
+
+        assert_eq!(stats.corrupt_lines, 2);
+        assert_eq!(stats.truncated_tail_lines, 0);
     }
 
     /// 全損した行が改行なしでファイル末尾にあっても「書き込み途中」ではなく破損行。

--- a/crates/tools/src/bin/jsonl_to_psv.rs
+++ b/crates/tools/src/bin/jsonl_to_psv.rs
@@ -123,6 +123,8 @@ struct Stats {
     skipped_error_game: u64,
     skipped_in_progress_game: u64,
     parse_errors: u64,
+    truncated_tail_lines: u64,
+    corrupt_lines: u64,
     move_errors: u64,
     orphan_games: u64,
 }
@@ -180,6 +182,8 @@ fn main() -> Result<()> {
     println!("Skipped in-progress:   {}", total.skipped_in_progress_game);
     println!("Move errors:           {}", total.move_errors);
     println!("Parse errors:          {}", total.parse_errors);
+    println!("Truncated tail lines:  {}", total.truncated_tail_lines);
+    println!("Corrupt lines:         {}", total.corrupt_lines);
     println!("Orphan games:          {}", total.orphan_games);
     println!("Output file:           {}", args.output.display());
     println!(
@@ -201,6 +205,8 @@ impl Stats {
         self.skipped_error_game += rhs.skipped_error_game;
         self.skipped_in_progress_game += rhs.skipped_in_progress_game;
         self.parse_errors += rhs.parse_errors;
+        self.truncated_tail_lines += rhs.truncated_tail_lines;
+        self.corrupt_lines += rhs.corrupt_lines;
         self.move_errors += rhs.move_errors;
         self.orphan_games += rhs.orphan_games;
     }
@@ -215,32 +221,74 @@ fn process_file(
 ) -> Result<Stats> {
     let file = File::open(path)
         .with_context(|| format!("入力ファイルを開けません: {}", path.display()))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut pending: HashMap<u32, Vec<PendingRecord>> = HashMap::new();
     let mut stats = Stats {
         files: 1,
         ..Stats::default()
     };
 
-    for (line_idx, line) in reader.lines().enumerate() {
+    let mut raw = Vec::new();
+    let mut line_idx = 0usize;
+    loop {
         if max_games > 0 && *games_written >= max_games {
             break;
         }
 
-        let line = line.with_context(|| format!("{}行目の読み込みに失敗", line_idx + 1))?;
+        raw.clear();
+        let read = reader
+            .read_until(b'\n', &mut raw)
+            .with_context(|| format!("{}行目の読み込みに失敗", line_idx + 1))?;
+        if read == 0 {
+            break;
+        }
+        line_idx += 1;
+        // 書き手のプロセスが落ちると、最終行が改行なしで途中まで書かれた状態で残る。
+        let complete = raw.ends_with(b"\n");
+
+        let line = match std::str::from_utf8(&raw) {
+            Ok(line) => line,
+            Err(_) => {
+                stats.corrupt_lines += 1;
+                warn_corrupt_line(path, line_idx, "不正なUTF-8", stats.corrupt_lines);
+                continue;
+            }
+        };
+        // 行区切りのみ落とす。JSON 文法上不正な空白 (NBSP 等) を削ると破損行が
+        // 健全な行として通ってしまうため trim_end() は使わない。
+        let line = line.strip_suffix('\n').unwrap_or(line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
         if line.trim().is_empty() {
             continue;
         }
 
-        let entry = match serde_json::from_str::<LogEntry>(&line) {
+        let entry = match serde_json::from_str::<LogEntry>(line) {
             Ok(entry) => entry,
-            Err(_) => match serde_json::from_str::<Value>(&line) {
+            Err(_) => match serde_json::from_str::<Value>(line) {
                 Ok(_) => {
                     stats.parse_errors += 1;
                     continue;
                 }
-                Err(e) => {
-                    return Err(e).with_context(|| format!("{}行目のJSONが不正", line_idx + 1));
+                Err(_) => {
+                    // 書き込み途中で切れた行は record の先頭 `{` だけが残る。
+                    // 全損して NUL 等で埋まった行はこれに当たらず破損行として数える。
+                    if !complete && line.trim_start().starts_with('{') {
+                        stats.truncated_tail_lines += 1;
+                        eprintln!(
+                            "  警告: {} の最終行({}行目)が書き込み途中のため破棄します",
+                            path.display(),
+                            line_idx
+                        );
+                        break;
+                    }
+                    stats.corrupt_lines += 1;
+                    warn_corrupt_line(
+                        path,
+                        line_idx,
+                        "JSONとして解釈できない",
+                        stats.corrupt_lines,
+                    );
+                    continue;
                 }
             },
         };
@@ -260,7 +308,7 @@ fn process_file(
                     eprintln!(
                         "  move変換エラー {}:{} game_id={} ply={}: {e}",
                         path.display(),
-                        line_idx + 1,
+                        line_idx,
                         mv.game_id,
                         mv.ply
                     );
@@ -402,6 +450,18 @@ fn color_label(color: Color) -> char {
     if color == Color::Black { 'b' } else { 'w' }
 }
 
+/// 破損行の警告。1 ファイルにつき先頭 5 件までに絞る（全損ファイルで数百万行の
+/// 警告を出さないため）。総数は Summary の `Corrupt lines` に出る。
+fn warn_corrupt_line(path: &Path, line_idx: usize, reason: &str, corrupt_so_far: u64) {
+    const MAX_WARNINGS: u64 = 5;
+    if corrupt_so_far <= MAX_WARNINGS {
+        eprintln!("  警告: {} の{}行目が{}ため破棄します", path.display(), line_idx, reason);
+        if corrupt_so_far == MAX_WARNINGS {
+            eprintln!("  警告: {} の破損行の警告は以降省略します", path.display());
+        }
+    }
+}
+
 fn is_terminal_move(move_usi: &str) -> bool {
     matches!(move_usi, "resign" | "win" | "timeout" | "illegal" | "none")
 }
@@ -435,6 +495,130 @@ mod tests {
         assert_eq!(game_result_for_side(Outcome::BlackWin, Color::White), -1);
         assert_eq!(game_result_for_side(Outcome::WhiteWin, Color::Black), -1);
         assert_eq!(game_result_for_side(Outcome::Draw, Color::White), 0);
+    }
+
+    #[test]
+    fn drops_truncated_last_line_without_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("game.jsonl");
+        let output = dir.path().join("out.psv");
+        std::fs::write(
+            &input,
+            concat!(
+                "{\"type\":\"move\",\"game_id\":1,\"ply\":1,\"side_to_move\":\"b\",",
+                "\"sfen_before\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\",",
+                "\"move_usi\":\"7g7f\",\"eval\":{\"score_cp\":23}}\n",
+                "{\"type\":\"result\",\"game_id\":1,\"outcome\":\"black_win\"}\n",
+                // 書き手が落ちて改行なしで切れた行
+                "{\"type\":\"move\",\"game_id\":2,\"ply\":1,\"side_to_move\":\"b\",\"sfen_bef",
+            ),
+        )
+        .expect("write input");
+
+        let mut writer = BufWriter::new(File::create(&output).expect("create output"));
+        let mut games_written = 0;
+        let stats =
+            process_file(&input, &mut writer, MissingScoreMode::Skip, 0, &mut games_written)
+                .expect("truncated tail must not fail the conversion");
+        writer.flush().expect("flush");
+
+        assert_eq!(stats.truncated_tail_lines, 1);
+        assert_eq!(stats.games_written, 1);
+        assert_eq!(stats.positions_written, 1);
+    }
+
+    /// 改行で終わっていない最終行でも、JSON として完結していれば取りこぼさない。
+    #[test]
+    fn keeps_complete_last_line_without_trailing_newline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("game.jsonl");
+        let output = dir.path().join("out.psv");
+        std::fs::write(
+            &input,
+            concat!(
+                "{\"type\":\"move\",\"game_id\":1,\"ply\":1,\"side_to_move\":\"b\",",
+                "\"sfen_before\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\",",
+                "\"move_usi\":\"7g7f\",\"eval\":{\"score_cp\":23}}\n",
+                "{\"type\":\"result\",\"game_id\":1,\"outcome\":\"black_win\"}",
+            ),
+        )
+        .expect("write input");
+
+        let mut writer = BufWriter::new(File::create(&output).expect("create output"));
+        let mut games_written = 0;
+        let stats =
+            process_file(&input, &mut writer, MissingScoreMode::Skip, 0, &mut games_written)
+                .expect("process file");
+        writer.flush().expect("flush");
+
+        assert_eq!(stats.truncated_tail_lines, 0);
+        assert_eq!(stats.corrupt_lines, 0);
+        assert_eq!(stats.games_written, 1);
+        assert_eq!(stats.positions_written, 1);
+    }
+
+    /// 全損した行が改行なしでファイル末尾にあっても「書き込み途中」ではなく破損行。
+    #[test]
+    fn counts_garbage_tail_as_corrupt_not_truncated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("game.jsonl");
+        let output = dir.path().join("out.psv");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(
+            concat!(
+                "{\"type\":\"move\",\"game_id\":1,\"ply\":1,\"side_to_move\":\"b\",",
+                "\"sfen_before\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\",",
+                "\"move_usi\":\"7g7f\",\"eval\":{\"score_cp\":23}}\n",
+                "{\"type\":\"result\",\"game_id\":1,\"outcome\":\"black_win\"}\n",
+            )
+            .as_bytes(),
+        );
+        bytes.extend_from_slice(&[0u8; 16]);
+        std::fs::write(&input, &bytes).expect("write input");
+
+        let mut writer = BufWriter::new(File::create(&output).expect("create output"));
+        let mut games_written = 0;
+        let stats =
+            process_file(&input, &mut writer, MissingScoreMode::Skip, 0, &mut games_written)
+                .expect("process file");
+        writer.flush().expect("flush");
+
+        assert_eq!(stats.truncated_tail_lines, 0);
+        assert_eq!(stats.corrupt_lines, 1);
+        assert_eq!(stats.games_written, 1);
+    }
+
+    /// 書き手のクラッシュで行の一部が NUL 埋め / 不正 UTF-8 になったログでも、
+    /// 健全な行から教師局面を取り出せること。
+    #[test]
+    fn skips_corrupt_lines_and_keeps_healthy_games() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("game.jsonl");
+        let output = dir.path().join("out.psv");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"\x00\x00\x00\x00\x00\x00\n");
+        bytes.extend_from_slice(&[0xff, 0xfe, 0xff, b'\n']);
+        bytes.extend_from_slice(
+            concat!(
+                "{\"type\":\"move\",\"game_id\":1,\"ply\":1,\"side_to_move\":\"b\",",
+                "\"sfen_before\":\"lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1\",",
+                "\"move_usi\":\"7g7f\",\"eval\":{\"score_cp\":23}}\n",
+                "{\"type\":\"result\",\"game_id\":1,\"outcome\":\"black_win\"}\n",
+            )
+            .as_bytes(),
+        );
+        std::fs::write(&input, &bytes).expect("write input");
+
+        let mut writer = BufWriter::new(File::create(&output).expect("create output"));
+        let mut games_written = 0;
+        let stats =
+            process_file(&input, &mut writer, MissingScoreMode::Skip, 0, &mut games_written)
+                .expect("corrupt lines must not fail the conversion");
+        writer.flush().expect("flush");
+
+        assert_eq!(stats.corrupt_lines, 2);
+        assert_eq!(stats.games_written, 1);
+        assert_eq!(stats.positions_written, 1);
     }
 
     #[test]


### PR DESCRIPTION
## 背景

自己対局ログを PSV 教師データへ変換する際、対局中に書き手のプロセスが落ちたログに当たると
`jsonl_to_psv` がそのファイルごと変換に失敗し、健全な数十万局面まで取り出せなくなっていた。

3 台のマシンの `runs/selfplay/` (654 ファイル / 29 GB / 7,600 万行) を変換したところ、
以下の 3 パターンで実際に停止した。

1. 最終行が改行なしで途中まで書かれている (`EOF while parsing a string`)
2. ファイル全体 (2.4 MB) が NUL バイトで埋まっている (`expected value at line 1 column 1`)
3. 行の途中に不正 UTF-8 が混ざっている (`stream did not contain valid UTF-8`)

## 変更

該当行だけを破棄して処理を継続し、破棄件数を Summary に出す。

- `Truncated tail lines` — 改行なしで `{` から始まる書き込み途中の最終行。検出時点でそのファイルを終える
- `Corrupt lines` — 不正 UTF-8 / JSON として解釈できない行。警告はファイルごと先頭 5 件まで

行区切りの除去は `\n` / `\r` のみとし、空行として黙って読み飛ばすのは行区切りを除いて
完全に空の行だけにした。`trim()` は NBSP 等の Unicode 空白も落とすため、空白が残った破損行が
健全な行として通ってしまう (どのカウンタにも出ない) のを避けている。

`result` 行を失った対局は従来どおり `Orphan games` として局面ごと破棄されるので、
`game_result` が信用できないレコードは出ない。

## 検証

- `cargo test -p tools --bin jsonl_to_psv` 8 件 pass / `cargo clippy -p tools --bin jsonl_to_psv --tests` 警告 0 / `cargo fmt` 済み
- 実データでの動作確認:
  - 末尾が切れた 673,819 行のログ → `Truncated tail lines: 1` で 664,819 局面。手作業で末尾行を削って変換した結果と **bit 一致**
  - NUL ファイルを含むディレクトリ → `Corrupt lines: 1` で 505,430 局面。破損ファイルを除外して変換した結果と **bit 一致**
  - 不正 UTF-8 を含むログ → 786 対局 98,258 局面を新たに回収 (従来はディレクトリごと失敗)

## doc

`crates/tools/docs/pack_tools.md` に破損ログの扱いと各カウンタの意味を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtuRnLHpx7a1C8J7Tpx4Kt