### PR TITLE
feat(gensfen): --omit-diversions で result 行の乱択来歴を件数に縮約

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定（[詳細](docs/analyze_selfplay.md)） |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録、FV_SCALE override、control.json 動的制御・drain） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換・`live-mirror --push` MONITOR2 着手通知付きリアルタイムミラー（[詳細](docs/floodgate_pipeline.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と出典 TSV を生成（[詳細](docs/nyugyoku_gensfen.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -61,7 +61,7 @@ KIF が必要な場合は `tournament` バイナリで対局を回し、その�
 | `king_in_enemy_black` / `king_in_enemy_white` | 自玉が敵陣三段内にいるか |
 | `enemy_zone_pieces_black` / `enemy_zone_pieces_white` | 敵陣三段内の自駒数（玉除く） |
 | `adopted` | 終局理由が教師データ採用対象か。異常終局では `false`。`true` でも dedup や出力形式の制約により書き出し局面数が 0 の場合がある |
-| `diversions` | `--random-multi-pv` / `--random-move-count` で PV1 以外を選んだ来歴配列。`--omit-diversions` 時はこのキー自体が省かれ、代わりに件数 (`multipv_diversions` / `random_moves`) が出る |
+| `diversions` | `--random-multi-pv` / `--random-move-count` で PV1 以外を選んだ来歴配列。`--omit-diversions` 時はこのキー自体が省かれ、代わりに件数 (`multipv_diversions` / `random_moves` / `diversions_total`) が出る |
 
 `diversions` の各要素は次の形:
 
@@ -191,7 +191,7 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `--log-info` | false | エンジンの info 出力を `gensfen.info.jsonl` に記録 |
-| `--omit-diversions` | false | result 行の `diversions` 配列を省き件数のみ記録（乱択が多いレシピで jsonl を約 9 割削減）。**`relabel_psv --deblunder` は diversions の ply 位置を必要とするため、deblunder を掛ける可能性のある run では使わない**。fingerprint 対象で、resume での全量/省略の混在は拒否される |
+| `--omit-diversions` | false | result 行の `diversions` 配列を省き件数のみ記録（実測: multipv 8-100 + random 4 / depth 9 のレシピで 5.0KB/局 → 0.7KB/局）。**`relabel_psv --deblunder` は diversions の ply 位置を必要とするため、deblunder を掛ける可能性のある run では使わない**。fingerprint 対象で、resume での全量/省略の混在は拒否される |
 | `--emit-eval-file` | false | 評価値推移を `gensfen.eval.txt` に出力 |
 | `--emit-metrics` | false | 対局メトリクス JSONL を出力 |
 | `--flush-each-move` | false | 毎手フラッシュ（安全だが低速） |

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -61,7 +61,7 @@ KIF が必要な場合は `tournament` バイナリで対局を回し、その�
 | `king_in_enemy_black` / `king_in_enemy_white` | 自玉が敵陣三段内にいるか |
 | `enemy_zone_pieces_black` / `enemy_zone_pieces_white` | 敵陣三段内の自駒数（玉除く） |
 | `adopted` | 終局理由が教師データ採用対象か。異常終局では `false`。`true` でも dedup や出力形式の制約により書き出し局面数が 0 の場合がある |
-| `diversions` | `--random-multi-pv` / `--random-move-count` で PV1 以外を選んだ来歴配列 |
+| `diversions` | `--random-multi-pv` / `--random-move-count` で PV1 以外を選んだ来歴配列。`--omit-diversions` 時はこのキー自体が省かれ、代わりに件数 (`multipv_diversions` / `random_moves`) が出る |
 
 `diversions` の各要素は次の形:
 
@@ -191,6 +191,7 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `--log-info` | false | エンジンの info 出力を `gensfen.info.jsonl` に記録 |
+| `--omit-diversions` | false | result 行の `diversions` 配列を省き件数のみ記録（乱択が多いレシピで jsonl を約 9 割削減）。**`relabel_psv --deblunder` は diversions の ply 位置を必要とするため、deblunder を掛ける可能性のある run では使わない**。fingerprint 対象で、resume での全量/省略の混在は拒否される |
 | `--emit-eval-file` | false | 評価値推移を `gensfen.eval.txt` に出力 |
 | `--emit-metrics` | false | 対局メトリクス JSONL を出力 |
 | `--flush-each-move` | false | 毎手フラッシュ（安全だが低速） |

--- a/crates/tools/docs/relabel_psv.md
+++ b/crates/tools/docs/relabel_psv.md
@@ -34,6 +34,10 @@ cargo run -p tools --release --bin relabel_psv -- \
 
 ## diversions による deblunder
 
+> **注意**: `gensfen --omit-diversions` で生成した run の jsonl には `diversions` が
+> 無いため deblunder には使えない (明示エラーになる)。deblunder を掛ける可能性の
+> ある run は全量記録 (gensfen の既定) で生成すること。
+
 `gensfen --emit-game-id-sidecar` で作った sidecar と result JSONL を指定する。
 result JSONL の diversion `ply` は開始局面からの相対手数であり、`start_sfen` の開始手数を使って
 PSV の絶対 `game_ply` へ `start_ply + ply - 1` で変換する。PSV と sidecar は lockstep で読み、

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。JSONL 出力 |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録、FV_SCALE override、control.json 動的制御・drain。[詳細](gensfen.md)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示（[詳細](analyze_selfplay.md)） |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -495,6 +495,10 @@ struct ResultLog<'a> {
     /// --omit-diversions 時のみ: 省いたランダムムーブの件数
     #[serde(skip_serializing_if = "Option::is_none")]
     random_moves: Option<u64>,
+    /// --omit-diversions 時のみ: 省いた diversion の総数。kind 別件数の合計と
+    /// 突き合わせることで、将来 kind が増えた際の集計漏れを検知できる
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diversions_total: Option<u64>,
     /// この result より先にコミット済みの worker 教師ファイル長。
     training_bytes: u64,
     /// この result より先にコミット済みの worker sidecar 長。
@@ -2417,6 +2421,7 @@ fn worker_main(
                 random_moves: cfg
                     .omit_diversions
                     .then(|| diversions.iter().filter(|d| d.kind == "random").count() as u64),
+                diversions_total: cfg.omit_diversions.then_some(diversions.len() as u64),
                 training_bytes: 0,
                 sidecar_bytes: None,
                 info_bytes: None,
@@ -6994,6 +6999,7 @@ mod tests {
             diversions: Some(&[]),
             multipv_diversions: None,
             random_moves: None,
+            diversions_total: None,
             training_bytes: 0,
             sidecar_bytes: None,
             info_bytes: None,
@@ -7027,6 +7033,7 @@ mod tests {
             diversions: Some(&[]),
             multipv_diversions: None,
             random_moves: None,
+            diversions_total: None,
             training_bytes: 0,
             sidecar_bytes: None,
             info_bytes: None,
@@ -7064,6 +7071,7 @@ mod tests {
             diversions: None,
             multipv_diversions: Some(12),
             random_moves: Some(4),
+            diversions_total: Some(16),
             training_bytes: 0,
             sidecar_bytes: None,
             info_bytes: None,
@@ -7075,6 +7083,7 @@ mod tests {
         assert!(value.get("diversions").is_none());
         assert_eq!(value["multipv_diversions"], 12);
         assert_eq!(value["random_moves"], 4);
+        assert_eq!(value["diversions_total"], 16);
     }
 
     #[test]

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -204,6 +204,12 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     log_info: bool,
 
+    /// result 行の diversions 配列を省き、件数のみ記録する (jsonl を大幅削減)。
+    /// relabel_psv --deblunder は diversions の ply 位置を必要とするため、
+    /// deblunder を掛ける可能性のある run では使わないこと
+    #[arg(long, default_value_t = false)]
+    omit_diversions: bool,
+
     /// Flush game log on every move (safer, but slower)
     #[arg(long, default_value_t = false)]
     flush_each_move: bool,
@@ -422,6 +428,9 @@ struct MetaSettings {
     /// FV_SCALE オーバーライド（未指定 = arch 文字列から自動判定）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     fv_scale: Option<i32>,
+    /// result 行の diversions 配列を省略したか（未指定 = 全量記録）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    omit_diversions: Option<bool>,
 }
 
 fn default_skip_in_check() -> bool {
@@ -476,7 +485,16 @@ struct ResultLog<'a> {
     king_in_enemy_white: bool,
     enemy_zone_pieces_black: u32,
     enemy_zone_pieces_white: u32,
-    diversions: &'a [DiversionLog],
+    /// 乱択来歴。--omit-diversions 時は None (キー自体を省く)。relabel_psv --deblunder が
+    /// ply 境界として消費するため、省略の有無は run 内で一貫している必要がある
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diversions: Option<&'a [DiversionLog]>,
+    /// --omit-diversions 時のみ: 省いた multipv 乱択の件数
+    #[serde(skip_serializing_if = "Option::is_none")]
+    multipv_diversions: Option<u64>,
+    /// --omit-diversions 時のみ: 省いたランダムムーブの件数
+    #[serde(skip_serializing_if = "Option::is_none")]
+    random_moves: Option<u64>,
     /// この result より先にコミット済みの worker 教師ファイル長。
     training_bytes: u64,
     /// この result より先にコミット済みの worker sidecar 長。
@@ -1884,6 +1902,7 @@ struct WorkerConfig {
     /// 直近 interval で既に警告済みかを示すフラグ（全ワーカー共有）。
     /// 同一タイミングで複数ワーカーが重複警告を出すのを抑制する。
     dedup_warn_emitted: Arc<AtomicBool>,
+    omit_diversions: bool,
 }
 
 fn worker_main(
@@ -2391,7 +2410,13 @@ fn worker_main(
                 king_in_enemy_white: final_meta.white.king_in_enemy,
                 enemy_zone_pieces_black: final_meta.black.enemy_zone_pieces,
                 enemy_zone_pieces_white: final_meta.white.enemy_zone_pieces,
-                diversions: &diversions,
+                diversions: (!cfg.omit_diversions).then_some(diversions.as_slice()),
+                multipv_diversions: cfg
+                    .omit_diversions
+                    .then(|| diversions.iter().filter(|d| d.kind == "multipv").count() as u64),
+                random_moves: cfg
+                    .omit_diversions
+                    .then(|| diversions.iter().filter(|d| d.kind == "random").count() as u64),
                 training_bytes: 0,
                 sidecar_bytes: None,
                 info_bytes: None,
@@ -4510,7 +4535,7 @@ fn main() -> Result<()> {
         native_progress_file_sha256.clone(),
         cli.fv_scale,
     );
-    let generation_fingerprint = serde_json::json!({
+    let mut generation_fingerprint = serde_json::json!({
         "schema": 2,
         "model": model_fingerprint,
         "engine": serde_json::json!({
@@ -4577,6 +4602,11 @@ fn main() -> Result<()> {
             "move_max_ply": cli.random_move_max_ply,
         }),
     });
+    if cli.omit_diversions {
+        // 未指定時はキーを出さない (既存 run の fingerprint 互換)。full/slim の混在は
+        // relabel_psv --deblunder の境界判定を silent に壊すため resume で拒否する。
+        generation_fingerprint["auxiliary_outputs"]["omit_diversions"] = serde_json::json!(true);
+    }
     if let Some(state) = &resume_state {
         validate_resume_fingerprint(state.fingerprint.as_ref(), &generation_fingerprint)?;
     }
@@ -4642,6 +4672,7 @@ fn main() -> Result<()> {
                 progress_file: cli.progress_file.as_ref().map(|p| p.display().to_string()),
                 progress_file_sha256: native_progress_file_sha256.clone(),
                 fv_scale: (cli.fv_scale > 0).then_some(cli.fv_scale),
+                omit_diversions: cli.omit_diversions.then_some(true),
             },
             engine_cmd: EngineCommandMeta {
                 path_black: engine_paths.black.path.display().to_string(),
@@ -4878,6 +4909,7 @@ fn main() -> Result<()> {
                     .max(1),
                 dedup_warn_rate: cli.dedup_warn_rate,
                 dedup_warn_emitted: Arc::clone(&dedup_warn_emitted),
+                omit_diversions: cli.omit_diversions,
             };
             let rx = ticket_rx.clone();
             let tx = result_tx.clone();
@@ -6959,7 +6991,9 @@ mod tests {
             king_in_enemy_white: false,
             enemy_zone_pieces_black: 0,
             enemy_zone_pieces_white: 0,
-            diversions: &[],
+            diversions: Some(&[]),
+            multipv_diversions: None,
+            random_moves: None,
             training_bytes: 0,
             sidecar_bytes: None,
             info_bytes: None,
@@ -6990,7 +7024,9 @@ mod tests {
             king_in_enemy_white: false,
             enemy_zone_pieces_black: 0,
             enemy_zone_pieces_white: 0,
-            diversions: &[],
+            diversions: Some(&[]),
+            multipv_diversions: None,
+            random_moves: None,
             training_bytes: 0,
             sidecar_bytes: None,
             info_bytes: None,
@@ -7002,6 +7038,43 @@ mod tests {
         assert_eq!(value["diversions"], serde_json::json!([]));
         assert_eq!(value["adopted"], true);
         assert_eq!(value["reason"], "max_moves");
+        // 全量記録モードでは件数フィールドを出さない
+        assert!(value.get("multipv_diversions").is_none());
+        assert!(value.get("random_moves").is_none());
+    }
+
+    #[test]
+    fn result_log_omits_diversions_and_keeps_counts() {
+        let result = ResultLog {
+            kind: "result",
+            worker_id: 0,
+            game_id: 1,
+            start_pos_index: 1,
+            start_sfen: "lnsgkgsnl/1r5b1/p1ppppppp/9/1p7/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 1",
+            outcome: "draw",
+            reason: OutcomeReason::MaxMoves,
+            adopted: true,
+            plies: 1,
+            final_points_black: 0,
+            final_points_white: 0,
+            king_in_enemy_black: false,
+            king_in_enemy_white: false,
+            enemy_zone_pieces_black: 0,
+            enemy_zone_pieces_white: 0,
+            diversions: None,
+            multipv_diversions: Some(12),
+            random_moves: Some(4),
+            training_bytes: 0,
+            sidecar_bytes: None,
+            info_bytes: None,
+            eval_bytes: None,
+            metrics_bytes: None,
+            fsync_boundary: false,
+        };
+        let value = serde_json::to_value(result).unwrap();
+        assert!(value.get("diversions").is_none());
+        assert_eq!(value["multipv_diversions"], 12);
+        assert_eq!(value["random_moves"], 4);
     }
 
     #[test]

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -7048,6 +7048,7 @@ mod tests {
         // 全量記録モードでは件数フィールドを出さない
         assert!(value.get("multipv_diversions").is_none());
         assert!(value.get("random_moves").is_none());
+        assert!(value.get("diversions_total").is_none());
     }
 
     #[test]

--- a/crates/tools/src/bin/relabel_psv.rs
+++ b/crates/tools/src/bin/relabel_psv.rs
@@ -830,7 +830,12 @@ fn load_diversion_bounds(paths: &[PathBuf]) -> Result<HashMap<u32, DiversionBoun
             let start_ply = parse_start_ply(&value, path, line_index)?;
             let diversions =
                 value.get("diversions").and_then(Value::as_array).with_context(|| {
-                    format!("missing diversions in {} line {}", path.display(), line_index + 1)
+                    format!(
+                        "missing diversions in {} line {} (gensfen --omit-diversions で生成した \
+                     jsonl には diversions が無い。deblunder には全量記録の run が必要)",
+                        path.display(),
+                        line_index + 1
+                    )
                 })?;
             for diversion in diversions {
                 let relative_ply = parse_relative_ply(diversion, path, line_index)?;
@@ -879,7 +884,12 @@ fn load_game_info(paths: &[PathBuf]) -> Result<HashMap<u32, GameInfo>> {
                 _ => GameEndReason::Other,
             };
             let values = value.get("diversions").and_then(Value::as_array).with_context(|| {
-                format!("missing diversions in {} line {}", path.display(), line_index + 1)
+                format!(
+                    "missing diversions in {} line {} (gensfen --omit-diversions で生成した \
+                     jsonl には diversions が無い。deblunder には全量記録の run が必要)",
+                    path.display(),
+                    line_index + 1
+                )
             })?;
             let mut diversions = Vec::with_capacity(values.len());
             for diversion in values {


### PR DESCRIPTION
## 概要

乱択の多いレシピ (multipv 8-100 + random 4 等) では gensfen.jsonl の大半を result 行の \`diversions\` 配列が占め、教師 PSV と同等以上の容量になる (実測 5.0KB/局 vs PSV 3.9KB/局)。\`--omit-diversions\` (opt-in) で配列をキーごと省き、件数 (\`multipv_diversions\` / \`random_moves\` / \`diversions_total\`) のみ記録する。実測 5.0KB/局 → 0.7KB/局。

## 設計判断

- **既定は従来どおり全量記録**: \`relabel_psv --deblunder\` が diversions の ply 位置を除外境界として消費するため、デフォルトで落とすと後から deblunder を掛ける選択肢を失う (jsonl は事後再生成できない)
- **fingerprint (\`auxiliary_outputs.omit_diversions\`) に含め、resume での全量/省略の混在を拒否**: 混在すると deblunder の境界判定が silent に壊れる。キーは指定時のみ追加し、既存 run の fingerprint 互換を維持
- relabel_psv 側は diversions 欠落を明示エラー (fail-closed) にしており、エラーメッセージに --omit-diversions 由来の可能性と対処を追記

## テスト / レビュー

- unit 84 pass (省略時のキー有無・件数の serialization テスト追加)、resume/sidecar/teacher_labels/relabel_psv integration 全 pass
- E2E: 実ネットで 20 局生成し 0.7KB/局・diversions キー無し・件数出力を確認。全量 run への \`--omit-diversions --resume\` は \`auxiliary_outputs.omit_diversions\` mismatch で拒否されることを確認
- local dual review 済み: Codex APPROVE / Claude reviewer APPROVE (P3 nit 2 件対応済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToEo4i3e2ovcVmQeSe7Nbc