### PR TITLE
fix(gensfen): Windows で out-dir lock 取得直後に access denied で落ちる問題を修正

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定（[詳細](docs/analyze_selfplay.md)） |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換・`live-mirror --push` MONITOR2 着手通知付きリアルタイムミラー（[詳細](docs/floodgate_pipeline.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と出典 TSV を生成（[詳細](docs/nyugyoku_gensfen.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -556,6 +556,9 @@ checkpoint の新規作成後は親 directory も fsync するため、通常の
 ファイル長が短い状態は offset 検証で検出できるが、長さは正しく未永続ブロックだけがゼロ埋めされた状態は
 検出できない。既定の ext4 `data=ordered` では想定しない前提であり、異なる filesystem/mount option では
 耐障害性を別途確認する。
+Windows には directory fsync に相当する API が無いため親 directory の fsync はスキップされる。
+ファイル内容の `sync_all` は同一だが、電源断ではディレクトリエントリの変更 (新規作成・rename・削除)
+が失われ得る (プロセス crash のみなら影響しない)。
 
 `--flush-each-move` は、その時点までの result buffer と `--log-info` の info 行を OS buffer へ flush
 する。対局中の教師局面は勝敗確定までメモリ上にあるため、このフラグは進行中対局の教師データを保護せず、

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -556,6 +556,7 @@ checkpoint の新規作成後は親 directory も fsync するため、通常の
 ファイル長が短い状態は offset 検証で検出できるが、長さは正しく未永続ブロックだけがゼロ埋めされた状態は
 検出できない。既定の ext4 `data=ordered` では想定しない前提であり、異なる filesystem/mount option では
 耐障害性を別途確認する。
+
 Windows には directory fsync に相当する API が無いため親 directory の fsync はスキップされる。
 ファイル内容の `sync_all` は同一だが、電源断ではディレクトリエントリの変更 (新規作成・rename・削除)
 が失われ得る (プロセス crash のみなら影響しない)。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。JSONL 出力 |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain。[詳細](gensfen.md)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示（[詳細](analyze_selfplay.md)） |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -3607,9 +3607,17 @@ fn atomic_temp_path(path: &Path) -> PathBuf {
 }
 
 fn sync_parent(path: &Path) -> Result<()> {
+    // Windows は CreateFile でディレクトリを開けず access denied になり、
+    // directory fsync に相当する安全な std API も無いためスキップする
+    // (電源断時のディレクトリエントリ永続化保証が Unix より弱くなるのみ)。
+    #[cfg(unix)]
     if let Some(parent) = path.parent() {
-        File::open(parent)?.sync_all()?;
+        File::open(parent)
+            .and_then(|dir| dir.sync_all())
+            .with_context(|| format!("failed to fsync parent dir of {}", path.display()))?;
     }
+    #[cfg(not(unix))]
+    let _ = path;
     Ok(())
 }
 


### PR DESCRIPTION
## 問題

Windows で gensfen を実行すると、out-dir lock 作成直後に \`Error: アクセスが拒否されました。 (os error 5)\` で即死する (これまで gensfen は Windows で動かした実績が無かった)。

## 原因

\`sync_parent\` がディレクトリを \`File::open\` して \`sync_all\` する POSIX イディオムを使っており、Windows の \`CreateFileW\` は \`FILE_FLAG_BACKUP_SEMANTICS\` 無しにディレクトリを開けず ERROR_ACCESS_DENIED になる。

## 修正

- \`sync_parent\` の directory fsync を \`#[cfg(unix)]\` 限定にし、Windows では skip。失われるのは電源断時のディレクトリエントリ永続化保証のみで、ファイル内容の \`sync_all\` と resume の不変条件 (offset 単調性・fsync_boundary 順序) は全プラットフォームで不変
- Unix 側にエラー context を付与 (従来は裸の \`?\` で文脈ゼロ)
- gensfen.md の「flush / fsync 境界」節に Windows の耐障害性差を明記

## 検証

- Windows 実機 (sh11235-ws-win) で再現 → 修正後 smoke 成功 (EXIT 0、FV_SCALE override / bucket 分布正常)
- Linux: fmt / clippy 0 件、unit 84 + resume integration 27 pass (挙動不変)
- local dual review: Codex APPROVE (sync_parent 全 11 呼び出し箇所の用途確認、is_not_found 系との非干渉確認) / Claude reviewer APPROVE (not(unix) arm の -D warnings 通過を実測、P3 doc 提案は本 PR で対応済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToEo4i3e2ovcVmQeSe7Nbc