### PR TITLE
fix(tools): ek_testset eval が DynamicLayerStacks ロード時に panic する問題を修正

### DIFF
--- a/crates/tools/src/ek_testset.rs
+++ b/crates/tools/src/ek_testset.rs
@@ -527,8 +527,11 @@ fn run_eval(args: &EvalArgs) -> Result<()> {
         );
     }
     let mut stack = AccumulatorStackVariant::from_network(&network);
-    let mut acc_cache: Option<LayerStacksAccCache> =
-        Some(network.as_layer_stacks().new_acc_cache());
+    // acc_cache (Finny Tables) は静的 LayerStacks variant 専用の API で、
+    // runtime-dimensions ビルドでは同じ net でも DynamicLayerStacks として load され
+    // `as_layer_stacks()` が panic する (`is_layer_stacks()` は Dynamic でも true)。
+    // `evaluate_dispatch` は None でも全 variant を正しく評価するため cache は使わない。
+    let mut acc_cache: Option<LayerStacksAccCache> = None;
 
     let mut builder = EvalMetricBuilder::default();
     let file = File::open(&args.testset)


### PR DESCRIPTION
## Summary

- `ek_testset eval` は `network.is_layer_stacks()` チェック後に `network.as_layer_stacks().new_acc_cache()` を呼んでいたが、`is_layer_stacks()` は nnue-runtime-dimensions ビルドで net が `DynamicLayerStacks` として load された場合も true を返す一方、`as_layer_stacks()` は静的 `LayerStacks` variant しか受けず panic する (tools の default features ビルドで再現: `network.rs:744 This method is only for LayerStacks architecture.`)
- #967 の `nyugyoku_metrics` run_eval と同じパターンで acc_cache を常に `None` にして `evaluate_dispatch` に渡すよう修正 (rshogi-usi の eval コマンドと同様)

## 関連

- #967 (nyugyoku_metrics 開発時に同種問題を確認・同パターンで回避済み)

## Test plan

- [x] cargo fmt --all -- --check / cargo clippy -p tools --tests (warning ゼロ) / cargo test -p tools --lib (240 pass)
- [x] 修正前 HEAD で panic 再現、修正後 default features release build で full testset (103,799 局面) の eval が正常終了
- [x] 既存 baseline (ek_testset_band_s1_v4/metrics_baseline_s600.json) と records/dt/oc/scale が完全一致 — acc_cache=None による数値影響なし
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Fable) APPROVE
