### PR TITLE
fix(tools): bench_nnue_eval の --ls-progress-coeff を runtime-dimensions ビルドでも動くように修正

### DIFF
--- a/crates/tools/src/bench_nnue_eval_tool.rs
+++ b/crates/tools/src/bench_nnue_eval_tool.rs
@@ -710,12 +710,11 @@ pub fn run() -> Result<()> {
 
     // progress8kpabs bucket ベンチマーク (net 由来の num_buckets で駆動)
     if let Some(weights) = progress_weights.as_deref() {
-        let num_buckets = if network.is_layer_stacks() {
-            network.as_layer_stacks().num_buckets()
-        } else {
-            // 非 LayerStack net: 微小ベンチに net 由来 N が無いので default
-            DEFAULT_NUM_BUCKETS
-        };
+        // `as_layer_stacks()` は runtime-dimensions ビルドで DynamicLayerStacks として
+        // load された net に対して panic する (`is_layer_stacks()` は Dynamic でも true)。
+        // 両 variant を扱う `layer_stack_num_buckets()` で取得する。
+        // 非 LayerStack net: 微小ベンチに net 由来 N が無いので default
+        let num_buckets = network.layer_stack_num_buckets().unwrap_or(DEFAULT_NUM_BUCKETS);
         bench_progress_bucket(&positions, weights, num_buckets, cli.warmup, cli.iterations);
     }
     println!("Architecture: {arch_name}");


### PR DESCRIPTION
## Summary

- tools crate の default build (nnue-runtime-dimensions) では LayerStacks net が DynamicLayerStacks variant として load されるため、`is_layer_stacks()` ガード (Dynamic でも true) を通過した直後の `as_layer_stacks()` が panic していた (`bench_nnue_eval --ls-progress-coeff` 実行時)
- num_buckets 取得を両 variant 対応の `NNUENetwork::layer_stack_num_buckets()` + `unwrap_or(DEFAULT_NUM_BUCKETS)` に置換。非 LayerStack net のフォールバック挙動は従来と同一
- ek_testset.rs (#970 系 branch `fix/ek-testset-eval-dynamic-layer-stacks`) / nyugyoku_metrics.rs (#967) と同種修正の 3 件目。tools crate 内の残りの `as_layer_stacks()` は ek_testset.rs:531 のみで、別 branch で修正中のため本 PR では触っていない

## Test plan

- [x] cargo fmt --all -- --check / cargo clippy --workspace --tests (warning ゼロ) / cargo test --workspace / scripts/check-tracked-abs-paths.sh
- [x] 実地確認: origin/main のコードで LayerStacks net + --ls-progress-coeff の panic を再現 (\"This method is only for LayerStacks architecture.\") → 本修正で完走 (net 由来 N=9 で bucket bench 出力正常)
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)