### PR TITLE
feat(tools): nyugyoku_metrics に探索読み切り詰み距離 concordance を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -61,7 +61,7 @@
 | `label_bench_dl` | `label_bench` jsonl の各局面を DL水匠 (標準 dlshogi ONNX) で静的評価し `eval_dl` を追記（`dlshogi-onnx` feature、default 有効） |
 | `yardstick_label` / `yardstick_score` | ラベル品質「物差し」。held-out hcpe を labeler でラベル付け（stage 1）→ engine ごとに勝率較正して per-class WDL logloss / 参照天井 / リファレンス一致を採点（stage 2） |
 | `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](docs/ek_testset.md)） |
-| `nyugyoku_metrics` | `%KACHI` 終局 CSA から宣言ルール距離ペアを抽出し、native NNUE 静的評価の順序一致率を条件別に採点（[詳細](docs/nyugyoku_metrics.md)） |
+| `nyugyoku_metrics` | 終局 CSA から宣言ルール距離ペア（`%KACHI`）と探索読み切り詰み距離（`%TORYO` + oracle 探索）を抽出し、native NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点（[詳細](docs/nyugyoku_metrics.md)） |
 | `nnue_saturation` | LayerStacks NNUE の活性飽和率（ClippedReLU 127 張り付き）を実局面で計測（[詳細](docs/nnue_saturation.md)） |
 
 ### NNUE 学習
@@ -109,7 +109,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [yardstick_label](docs/yardstick_label.md) - held-out hcpe を labeler の固定 depth 探索でラベル付け（物差し stage 1）
 - [yardstick_score](docs/yardstick_score.md) - labeler の WDL logloss / 参照天井 / リファレンス一致を採点（物差し stage 2）
 - [ek_testset](docs/ek_testset.md) - held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点
-- [nyugyoku_metrics](docs/nyugyoku_metrics.md) - `%KACHI` 終局 CSA から宣言ルール距離ペアを抽出し、NNUE 静的評価の順序一致率を採点
+- [nyugyoku_metrics](docs/nyugyoku_metrics.md) - 終局 CSA から宣言ルール距離ペアと探索読み切り詰み距離を抽出し、NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder

--- a/crates/tools/docs/nyugyoku_metrics.md
+++ b/crates/tools/docs/nyugyoku_metrics.md
@@ -1,20 +1,32 @@
 # nyugyoku_metrics
 
-`nyugyoku_metrics` は、「宣言ルール距離ペア順序一致」指標を測るツールです。評価関数が
-大差圏（入玉宣言に向かう終盤）で優劣の順序を正しく出せるか（大差圏分解能）を測ります。
-`%KACHI`（入玉宣言勝ち）で終局した対局の勝者手番局面から「宣言成立へのルール距離が確定的に
-縮んだ」前後 pair を抽出し（`build-pairs`）、NNUE 静的評価が後局面（距離小）を前局面（距離大）
-より高く評価するか＝順序一致率を条件別に測ります（`eval-pairs`）。
+`nyugyoku_metrics` は、評価関数が大差圏（勝ち切りに向かう終盤）で優劣の順序を正しく
+出せるか（大差圏分解能）を、宣言ルール距離と通常探索の読み切り結果から測るツールです。
+2 つの指標群を持ちます:
 
-既存の [ek_testset](ek_testset.md)（DT = 宣言真値 / OC = 勝敗較正）が測れない「大差圏内の順序分解能」を、ルール真値のみで
-（評価値を母集団選別・真値のどちらにも使わずに）測るのが目的です。
+- **宣言ルール距離ペア順序一致**（`build-pairs` / `eval-pairs`）:
+  `%KACHI`（入玉宣言勝ち）で終局した対局の勝者手番局面から「宣言成立へのルール距離が
+  確定的に縮んだ」前後 pair を抽出し、NNUE 静的評価が後局面（距離小）を前局面（距離大）
+  より高く評価するか＝順序一致率を条件別に測ります。
+- **探索読み切り詰み距離 concordance**（`build-mates` / `eval-mates`）:
+  `%TORYO`（投了）で終局した対局の終盤勝者手番局面を oracle 探索にかけ、詰みを
+  読み切れた局面（mate in N）だけを採用し、静的評価が詰み距離の順序と整合するか
+  （concordance）と、詰み手を全合法手中の最善候補に挙げられるか（詰み手 top-1 率）を
+  測ります。現行の NNUE 学習は詰み圏 score を drop しており「詰みに近い局面ほど高く
+  評価できるか」の物差しが無い、という欠落を埋める指標です。
+
+既存の [ek_testset](ek_testset.md)（DT = 宣言可否 (ルール判定) / OC = 勝敗較正）が測れない
+「大差圏内の順序分解能」を、評価対象の net の評価値を母集団選別や基準値に使わずに
+測るのが目的です。
 
 ## 用語
 
-- 本ツールが扱うのは**宣言勝ち（`%KACHI`）のみ**です。詰み（checkmate）は扱いません
-  （詰み距離の指標は別ツールの担当で、本ツールと混ぜません）。
-- 「勝者」= 宣言側 = 終端で手番だった側。pair の 2 局面はどちらも勝者手番なので、
-  評価値は同一 POV（手番相対）で直接比較できます。
+- **mate（詰み）と宣言勝ちは厳密に区別します**。`build-mates` / `eval-mates` の mate は
+  「詰み（checkmate）」のみで、入玉宣言勝ちを含みません。入玉宣言勝ちは宣言ルール距離
+  ペア（`build-pairs` / `eval-pairs`）の担当です。両指標の母集団は終局特殊手
+  （`%KACHI` / `%TORYO`）で排他に分かれます。
+- 「勝者」= `%KACHI` では宣言側（終端で手番だった側）、`%TORYO` では投了した側の相手。
+  抽出局面はいずれも勝者手番なので、評価値は同一 POV（手番相対）で直接比較できます。
 
 ## pair の定義と 4 条件
 
@@ -78,10 +90,14 @@ cargo run -p tools --release --bin nyugyoku_metrics -- eval-pairs \
 pair ごとに `sfen_before` / `sfen_after` を NNUE 静的評価（cp）し、順序一致
 `eval_after > eval_before` を 1、tie を 0.5、逆転を 0 として、全体と条件別に
 一致率・pair 数・対局数を集計します。標準出力と `--out` に同じ JSON を出します。
+NNUE は `init_nnue` がロードできる全アーキテクチャ（LayerStacks、HalfKP 系など）に
+対応します。
 
-- **bucket-mode**: `--bucket-mode progress8kpabs`（既定）は `--progress-file` が必須です。
-  `--bucket-mode kingrank9` は progress 係数を使わないため `--progress-file` 不要です
-  （指定するとエラーにします）。LayerStacks NNUE のみ対応です。
+- **bucket-mode（LayerStacks 専用）**: LayerStacks では `--bucket-mode` 省略時に
+  `progress8kpabs` を使い、`--progress-file` が必須です。`--bucket-mode kingrank9` は
+  progress 係数を使わないため `--progress-file` 不要です（指定するとエラーにします）。
+  LayerStacks 以外の NNUE で `--bucket-mode` または `--progress-file` を指定すると
+  エラーになります。
 - **95% CI**: 対局クラスタ bootstrap（`source_csa` 単位の復元抽出、既定 `--bootstrap 10000`、
   `--seed 20260726`）で出します。分位点は replicate 統計量を昇順ソートし、0 始まりの
   index `round((R-1)·q)`（R = replicate 数、q = 0.025 / 0.975、round は四捨五入）の要素を
@@ -116,3 +132,106 @@ pair ごとに `sfen_before` / `sfen_after` を NNUE 静的評価（cp）し、�
 ```
 
 モデル間の比較は、同一の pairs.jsonl（同一 pair 集合）の上で行ってください。
+
+## build-mates
+
+```bash
+cargo run -p tools --release --bin nyugyoku_metrics -- build-mates \
+  --input "$HOME/data/floodgate/extracted/toryo" \
+  --out-dir runs/nyugyoku_metrics/mates \
+  --tail-plies 16 --stride 2 --oracle-depth 15 \
+  --oracle-nodes 1000000 --threads 8
+```
+
+`%TORYO` 終局の対局（勝者 = 投了した側の相手）だけを対象に、終局側 tail の勝者手番局面を
+oracle 探索へかけ、**詰みを読み切れた局面のみ**を `mates.jsonl` に出力します。CSA の走査は
+`build-pairs` と同じファイル名ソートの決定的順序・streaming（対局単位処理）です。
+`--max-games N` は走査順の先頭 N 対局で打ち切ります（`meta.json` に params が残るので
+サブセット実行も再現可能）。
+
+候補局面の選び方: 最終手（`%TORYO` 対局では勝者の手）の局面を距離 0 とし、終局からの
+手数距離 `d` が `d < tail_plies` かつ `d % stride == 0` の勝者手番局面を候補にします
+（勝者手番局面は 2 手ごとにしか現れないため、既定 `--stride 2` で tail 内の全勝者手番局面
+= 既定 8 局面/対局が候補）。replay が完走しない対局（`Move::NONE` 混入等）と勝者の
+突き合わせに失敗した対局は警告して除外し、`meta.json` に計上します。
+
+### oracle 探索の設計
+
+- **入玉宣言判定は必ず無効化**（`EnteringKingRule::None`）して探索します。
+  EnteringKingRule 有効の探索は root の宣言可能局面を mate 帯スコア（`Value::MATE` +
+  `Move::WIN`）で返すため、無効化しないと「宣言勝ち」が「詰み」として混入します。
+  本指標の mate は詰みのみです（宣言は宣言ルール距離ペアの担当）。
+- 採用条件は「探索 score が**手番側（勝者）の mate 帯**」のみ。自玉が詰まされる側の
+  mate 帯（負側）や通常評価値の局面は採用しません。防御として、最善手が通常手でない
+  結果（`Move::WIN` 等）と `Value::MATE` ちょうど（mate_ply 0 = root 宣言スコアの形）も
+  採用しません。
+- **`mate_in` は「探索が発見した詰み手数」であり最短の保証はありません**。固定
+  `--oracle-depth` の探索は枝刈りを含むため、depth 内の詰みを見逃すこと
+  （completeness の欠け）も、最短でない詰みを報告することもあります。同一
+  mates.jsonl 上でモデル比較する限り、この限界は全モデルに共通で公平です。
+- mate 帯 score は通常探索の読み切り結果です。TT が 16-bit key のため、理論上は衝突由来の
+  偽 mate があり得ます。同一 mates.jsonl を使うことで oracle の差はモデル間に混入しない。
+  ただし、偽 mate や非最短距離を含む可能性による指標自体の偏りは排除できない。
+- oracle 探索は engine 既定の movegen（防御側の不成を生成しない）の上で読み切ります。
+  不成のみが受けになる局面では偽 mate になり得ます。
+- `--oracle-nodes N` は局面ごとの oracle 探索を最大 N nodes で打ち切ります（省略時は
+  無制限）。`--oracle-depth` と併用でき、どちらかへ先に達した時点で打ち切ります。
+  worst case の探索時間を抑えられる一方、上限を小さくするほど深い詰みの発見率が
+  下がります。打ち切り結果が mate 帯 score でなければ、その候補は単に不採用になります。
+- oracle は NNUE を要求せず、`MaterialLevel` Lv1 の駒得評価で探索します。このため
+  mates.jsonl は **net 非依存の固定 oracle データ**になります（探索での詰みの発見率には
+  使用する評価関数が影響し得ます）。
+- 決定性: 局面ごとに `Search` を作り直し 1 スレッド固定で探索します（`teacher_labeler`
+  と同じ不変条件）。`--threads` は局面単位の並列度で、出力はスレッド数に依存せず
+  同一入力で bit 一致します。
+
+出力:
+
+| ファイル | 内容 |
+|---|---|
+| `mates.jsonl` | 1 行 1 局面。`source_csa`, `winner` (`b`/`w`), `ply`, `sfen`, `mate_in`（勝者手番から数えた ply）, `oracle_bestmove`（USI）, `oracle_depth`, `oracle_nodes`（無制限は `null`） |
+| `meta.json` | params（`tail_plies` / `stride` / `max_games` / `oracle_depth` / `oracle_nodes`）、走査対局数、`%TORYO` 対局数、除外数（勝者不一致 / replay 未完走）、候補局面数、詰み読み切り数（採用数）、採用局面を持つ対局数 |
+
+## eval-mates
+
+```bash
+cargo run -p tools --release --bin nyugyoku_metrics -- eval-mates \
+  --mates runs/nyugyoku_metrics/mates/mates.jsonl \
+  --eval-file "$SHOGI_DATA/nnue/model.bin" \
+  --progress-file "$SHOGI_DATA/progress/progress.bin" \
+  --out runs/nyugyoku_metrics/mates/metrics.json
+```
+
+mates.jsonl を NNUE 静的評価で採点し、2 指標を出します。NNUE は `init_nnue` がロード
+できる全アーキテクチャに対応します。LayerStacks 専用の `--bucket-mode`・
+`--progress-file` の扱いと対局クラスタ bootstrap（95% CI、分位点規約、決定性）は
+eval-pairs と同一です。
+
+1. **concordance**: 同一対局の mate 局面の全 pair（`mate_in` が厳密に異なる組合せのみ）に
+   ついて、`mate_in` 小（詰みに近い）局面の静的評価が `mate_in` 大の局面より高ければ 1、
+   tie 0.5、逆転 0。全局面が勝者手番なので手番相対 cp をそのまま比較します。
+2. **詰み手 top-1 率**: 各 mate 局面で全合法手（`generate_legal_all`）を 1 手ずつ適用し、
+   子局面を静的評価（相手番になるので符号反転して指し手側視点に揃える）。
+   `oracle_bestmove` の値が全合法手中で厳密最大なら 1、最大タイに含まれるなら 0.5、
+   それ以外 0。詰み手の子局面（相手玉に王手）も除外せず同じ規約で評価します。
+
+bootstrap の対局クラスタは指標ごとに独立です（concordance = pair を 1 組以上持つ対局、
+top-1 = mate 局面を 1 つ以上持つ対局）。concordance の bootstrap seed は `--seed` その
+まま、top-1 は `seed ^ (1 · 0x9E3779B97F4A7C15)` で派生します。`n_games` が小さい層の
+CI は幅ではなく `n_games` を見て判断してください。
+
+`--dump <path>` で per-position / per-pair の明細 jsonl を出せます（行の `kind` が
+`"position"` / `"pair"`）。
+
+出力 `metrics.json` の形:
+
+```json
+{
+  "mates": "...", "eval_file": "...", "progress_file": "...",
+  "bucket_mode": "progress8kpabs", "bootstrap": 10000, "seed": 20260726,
+  "concordance": { "agreement": 0.8, "n_pairs": 210, "n_games": 60, "ci95_lo": 0.7, "ci95_hi": 0.9 },
+  "mate_top1":   { "rate": 0.4, "n_positions": 95, "n_games": 70, "ci95_lo": 0.3, "ci95_hi": 0.5 }
+}
+```
+
+モデル間の比較は、同一の mates.jsonl（同一 oracle・同一局面集合）の上で行ってください。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -27,7 +27,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `eval_sfens` | SFEN 局面を LayerStacks NNUE で静的評価（`score` は歩=90 の内部スケール、`score_cp` は cp） |
 | `nnue_saturation` | LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測（[詳細](nnue_saturation.md)） |
 | `ek_testset` | held-out CSA から入玉評価テストセットを構築し、native NNUE 評価で DT/OC 指標を採点（[詳細](ek_testset.md)） |
-| `nyugyoku_metrics` | `%KACHI` 終局 CSA から宣言ルール距離ペアを抽出し、native NNUE 静的評価の順序一致率を条件別 + 対局クラスタ bootstrap CI で採点（[詳細](nyugyoku_metrics.md)） |
+| `nyugyoku_metrics` | 終局 CSA から宣言ルール距離ペア（`%KACHI`）と探索読み切り詰み距離（`%TORYO` + oracle 探索）を抽出し、native NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を対局クラスタ bootstrap CI 付きで採点（[詳細](nyugyoku_metrics.md)） |
 | `compare_eval_nnue` | 教師 NNUE と生徒 NNUE の評価値一致度を検証（MAE・相関係数・スコア帯別誤差） |
 | `dump_effect_bucket_golden` | 形式一致 golden 用に effect bucket active index を config 別に dump（[詳細](dump_effect_bucket_golden.md)） |
 | `compare_nodes` | 2つの USI エンジン間で探索ノード数を深度別に比較。エンジン別の任意ノード上限を併用可能。alignment 調査用（[詳細](compare_nodes.md)） |

--- a/crates/tools/src/nyugyoku_metrics.rs
+++ b/crates/tools/src/nyugyoku_metrics.rs
@@ -1,12 +1,21 @@
-//! 宣言ルール距離ペア順序一致指標の構築・採点ツール。
+//! 入玉宣言・詰みの終盤 ground truth 指標の構築・採点ツール。
 //!
-//! `%KACHI`（入玉宣言勝ち）で終局した対局の勝者手番局面から、「宣言成立へのルール距離が
-//! 確定的に縮んだ」隣接局面 pair を抽出し（`build-pairs`）、NNUE 静的評価が後局面を
-//! 前局面より高く評価するか（順序一致率）を条件別に測る（`eval-pairs`）。
+//! 2 つの指標群を同じ bin に同居させる:
 //!
+//! - **宣言ルール距離ペア順序一致**（`build-pairs` / `eval-pairs`）: `%KACHI`（入玉宣言勝ち）
+//!   で終局した対局の勝者手番局面から、「宣言成立へのルール距離が確定的に縮んだ」隣接局面
+//!   pair を抽出し、NNUE 静的評価が後局面を前局面より高く評価するか（順序一致率）を
+//!   条件別に測る。ルール特徴は `Position::entering_king_point_info` / `Position::in_check`
+//!   のみを使い、評価値を母集団選別に使わない（循環の回避）。
+//! - **探索読み切り詰み距離 concordance**（`build-mates` / `eval-mates`）: `%TORYO` で終局した
+//!   対局の終盤勝者手番局面を oracle 探索（入玉宣言判定は無効化）にかけ、詰みを読み切れた
+//!   局面（mate in N の通常探索結果）だけを採用し、NNUE 静的評価が詰み距離の順序と整合するか
+//!   （concordance）と、詰み手を全合法手中の最善候補に挙げられるか（詰み手 top-1 率）を測る。
+//!
+//! 用語: 本ファイルの mate は「詰み（checkmate）」のみを指し、入玉宣言勝ちを含まない。
+//! 入玉宣言勝ちは宣言ルール距離ペア側の担当で、両指標の母集団は終局特殊手
+//! （`%KACHI` / `%TORYO`）で排他に分かれる。
 //! CSA replay と終局特殊手の取得は `replay::csa_source::CsaSource` に委譲する。
-//! ルール特徴は `Position::entering_king_point_info` / `Position::in_check` のみを使い、
-//! 評価値を母集団選別に使わない（循環の回避）。
 
 use std::collections::BTreeMap;
 use std::fs::{self, File};
@@ -18,13 +27,17 @@ use clap::{Parser, Subcommand, ValueEnum};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rand_distr::{Binomial, Distribution};
+use rayon::prelude::*;
+use rshogi_core::eval::{MaterialLevel, set_material_level};
+use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::nnue::{
     AccumulatorStackVariant, LayerStackBucketMode, LayerStacksAccCache, evaluate_dispatch,
     get_network, init_nnue, load_progress_coeff_kpabs, set_layer_stack_bucket_mode,
     set_layer_stack_progress_kpabs_weights,
 };
 use rshogi_core::position::Position;
-use rshogi_core::types::{Color, EnteringKingRule, Move};
+use rshogi_core::search::{LimitsType, Search, SearchInfo};
+use rshogi_core::types::{Color, EnteringKingRule, Move, Value};
 use rshogi_csa::SpecialMove;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
@@ -33,15 +46,19 @@ use crate::replay::csa_source::CsaSource;
 use crate::replay::model::{
     GameIndex, GameIndexEntry, GameOutcomeView, GameSource, GameSourceRef, MoveView,
 };
+use crate::teacher_labeler::SEARCH_STACK_SIZE;
 
 const DEFAULT_BOOTSTRAP: u32 = 10_000;
 const DEFAULT_SEED: u64 = 20_260_726;
+/// oracle 探索の worker ごとの置換表サイズ（MB）。局面ごとに `Search` を作り直すため
+/// 過大にしない（`label_bench_positions` と同じ指針）。
+const ORACLE_HASH_MB: usize = 64;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "nyugyoku_metrics",
     version,
-    about = "宣言ルール距離ペアを CSA から抽出し、NNUE 静的評価の順序一致率を採点する"
+    about = "宣言ルール距離ペアと探索読み切り詰み距離を CSA から抽出し、NNUE 静的評価を採点する"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -54,6 +71,10 @@ enum Command {
     BuildPairs(BuildArgs),
     /// pairs.jsonl を native NNUE 静的評価で採点し、順序一致率を条件別に集計する。
     EvalPairs(EvalArgs),
+    /// %TORYO 終局対局の終盤勝者手番局面を oracle 探索し、詰み読み切り局面を抽出する。
+    BuildMates(BuildMatesArgs),
+    /// mates.jsonl を native NNUE 静的評価で採点し、詰み距離 concordance と詰み手 top-1 率を集計する。
+    EvalMates(EvalMatesArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -77,9 +98,9 @@ struct EvalArgs {
     /// LayerStacks progress8kpabs 用 progress.bin（--bucket-mode progress8kpabs で必須）。
     #[arg(long)]
     progress_file: Option<PathBuf>,
-    /// LayerStacks の bucket 選択モード。
-    #[arg(long, value_enum, default_value_t = BucketModeArg::Progress8kpabs)]
-    bucket_mode: BucketModeArg,
+    /// LayerStacks の bucket 選択モード（省略時 progress8kpabs）。
+    #[arg(long, value_enum)]
+    bucket_mode: Option<BucketModeArg>,
     /// metrics.json の出力先。
     #[arg(long)]
     out: PathBuf,
@@ -92,6 +113,66 @@ struct EvalArgs {
     /// pair ごとの (eval_before, eval_after, agreement) を jsonl で出力する先。
     #[arg(long)]
     dump_pairs: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+struct BuildMatesArgs {
+    /// 入力 CSA ファイルまたは CSA ディレクトリ。
+    #[arg(long)]
+    input: PathBuf,
+    /// 出力ディレクトリ（mates.jsonl / meta.json を書く）。
+    #[arg(long)]
+    out_dir: PathBuf,
+    /// 終局（最終手 = 勝者の手の局面を距離 0 とする）からこの手数未満の勝者手番局面を
+    /// 候補にする。
+    #[arg(long, default_value_t = 16)]
+    tail_plies: u32,
+    /// 候補の間引き刻み。終局からの手数距離 d が d % stride == 0 の勝者手番局面のみ
+    /// 候補にする（勝者手番局面は 2 手ごとにしか現れないため、既定 2 で全候補）。
+    #[arg(long, default_value_t = 2)]
+    stride: u32,
+    /// 走査する対局数の上限（決定的な走査順の先頭 N 対局。0 = 無制限）。
+    #[arg(long, default_value_t = 0)]
+    max_games: usize,
+    /// oracle 探索の固定 depth。
+    #[arg(long, default_value_t = 15)]
+    oracle_depth: i32,
+    /// oracle 探索のノード数上限（省略時は無制限）。depth と併用し、先に達した方で
+    /// 打ち切る。
+    #[arg(long)]
+    oracle_nodes: Option<u64>,
+    /// oracle 探索の worker スレッド数（0 = 利用可能 CPU 数）。並列化は局面単位で、
+    /// 各局面の探索自体は 1 スレッド固定なので出力はスレッド数に依存しない。
+    #[arg(long, default_value_t = 0)]
+    threads: usize,
+}
+
+#[derive(Parser, Debug)]
+struct EvalMatesArgs {
+    /// `nyugyoku_metrics build-mates` が出した mates.jsonl。
+    #[arg(long)]
+    mates: PathBuf,
+    /// NNUE ファイル。
+    #[arg(long)]
+    eval_file: PathBuf,
+    /// LayerStacks progress8kpabs 用 progress.bin（--bucket-mode progress8kpabs で必須）。
+    #[arg(long)]
+    progress_file: Option<PathBuf>,
+    /// LayerStacks の bucket 選択モード（省略時 progress8kpabs）。
+    #[arg(long, value_enum)]
+    bucket_mode: Option<BucketModeArg>,
+    /// metrics.json の出力先。
+    #[arg(long)]
+    out: PathBuf,
+    /// 対局クラスタ bootstrap の replicate 数（0 で CI を出さない）。
+    #[arg(long, default_value_t = DEFAULT_BOOTSTRAP)]
+    bootstrap: u32,
+    /// bootstrap 乱数 seed（同 seed・同入力で CI は bit 一致する）。
+    #[arg(long, default_value_t = DEFAULT_SEED)]
+    seed: u64,
+    /// pair / 局面ごとの明細を jsonl で出力する先（行の `kind` で pair / position を区別）。
+    #[arg(long)]
+    dump: Option<PathBuf>,
 }
 
 /// LayerStacks bucket mode の CLI 表現。
@@ -202,7 +283,7 @@ struct EvalPairsMetrics {
     pairs: String,
     eval_file: String,
     progress_file: Option<String>,
-    bucket_mode: String,
+    bucket_mode: Option<String>,
     bootstrap: u32,
     seed: u64,
     overall: SliceMetrics,
@@ -238,6 +319,8 @@ pub fn run() -> Result<()> {
     match cli.command {
         Command::BuildPairs(args) => run_build(&args),
         Command::EvalPairs(args) => run_eval(&args),
+        Command::BuildMates(args) => run_build_mates(&args),
+        Command::EvalMates(args) => run_eval_mates(&args),
     }
 }
 
@@ -779,21 +862,22 @@ fn agreement_score(eval_before: i32, eval_after: i32) -> f64 {
     }
 }
 
-fn visit_pair_records(
+/// jsonl を streaming で読み、非空行ごとに `visit(record, 1 始まり行番号)` を呼ぶ。
+/// pairs.jsonl（`PairRecord`）と mates.jsonl（`MateRecord`）で共用する。
+fn visit_jsonl_records<T: serde::de::DeserializeOwned>(
     path: &Path,
-    mut visit: impl FnMut(PairRecord, usize) -> Result<()>,
+    mut visit: impl FnMut(T, usize) -> Result<()>,
 ) -> Result<()> {
-    let file =
-        File::open(path).with_context(|| format!("pairs を開けません: {}", path.display()))?;
+    let file = File::open(path).with_context(|| format!("入力を開けません: {}", path.display()))?;
     for (line_no, line) in BufReader::new(file).lines().enumerate() {
         let line = line?;
         if line.trim().is_empty() {
             continue;
         }
         let line_no = line_no + 1;
-        let pair: PairRecord = serde_json::from_str(&line)
+        let record: T = serde_json::from_str(&line)
             .with_context(|| format!("{}:{line_no}: JSON を読めません", path.display()))?;
-        visit(pair, line_no)?;
+        visit(record, line_no)?;
     }
     Ok(())
 }
@@ -805,7 +889,7 @@ fn count_game_clusters(path: &Path) -> Result<[usize; SLOTS]> {
     let mut current_source: Option<String> = None;
     let mut has_slot = [false; SLOTS];
 
-    visit_pair_records(path, |pair, line_no| {
+    visit_jsonl_records::<PairRecord>(path, |pair, line_no| {
         if current_source.as_deref() != Some(pair.source_csa.as_str()) {
             if let Some(previous) = &current_source {
                 if pair.source_csa < *previous {
@@ -836,11 +920,53 @@ fn count_game_clusters(path: &Path) -> Result<[usize; SLOTS]> {
     Ok(counts)
 }
 
-fn run_eval(args: &EvalArgs) -> Result<()> {
-    let cluster_counts = count_game_clusters(&args.pairs)?;
-    match args.bucket_mode {
-        BucketModeArg::Progress8kpabs => {
-            let progress_file = args.progress_file.as_ref().ok_or_else(|| {
+/// NNUE アーキテクチャと CLI 指定から、LayerStacks の実効 bucket mode を決める。
+fn resolve_bucket_mode(
+    is_layer_stacks: bool,
+    bucket_mode: Option<BucketModeArg>,
+    has_progress_file: bool,
+) -> Result<Option<BucketModeArg>> {
+    if !is_layer_stacks {
+        if bucket_mode.is_some() {
+            bail!("--bucket-mode は LayerStacks NNUE でのみ使用できます");
+        }
+        if has_progress_file {
+            bail!("--progress-file は LayerStacks NNUE でのみ使用できます");
+        }
+        return Ok(None);
+    }
+
+    let bucket_mode = bucket_mode.unwrap_or(BucketModeArg::Progress8kpabs);
+    match bucket_mode {
+        BucketModeArg::Progress8kpabs if !has_progress_file => {
+            bail!("--bucket-mode progress8kpabs では --progress-file が必須です");
+        }
+        BucketModeArg::Kingrank9 if has_progress_file => {
+            bail!("--bucket-mode kingrank9 では --progress-file は使いません");
+        }
+        _ => {}
+    }
+    Ok(Some(bucket_mode))
+}
+
+/// eval-pairs / eval-mates 共通の評価器初期化。
+///
+/// `init_nnue` が対応する全アーキテクチャを読み込み、LayerStacks の場合だけ bucket mode
+/// と progress 係数を設定して評価用 accumulator stack を返す。
+fn init_eval(
+    bucket_mode: Option<BucketModeArg>,
+    progress_file: Option<&Path>,
+    eval_file: &Path,
+) -> Result<(AccumulatorStackVariant, Option<BucketModeArg>)> {
+    init_nnue(eval_file)
+        .with_context(|| format!("NNUE を読み込めません: {}", eval_file.display()))?;
+    let network = get_network().ok_or_else(|| anyhow!("NNUE が初期化されていません"))?;
+    let bucket_mode =
+        resolve_bucket_mode(network.is_layer_stacks(), bucket_mode, progress_file.is_some())?;
+
+    match bucket_mode {
+        Some(BucketModeArg::Progress8kpabs) => {
+            let progress_file = progress_file.ok_or_else(|| {
                 anyhow!("--bucket-mode progress8kpabs では --progress-file が必須です")
             })?;
             let weights = load_progress_coeff_kpabs(progress_file)
@@ -849,23 +975,18 @@ fn run_eval(args: &EvalArgs) -> Result<()> {
                 .map_err(|e| anyhow!("progress 設定に失敗しました: {e}"))?;
             set_layer_stack_bucket_mode(LayerStackBucketMode::Progress8KPAbs);
         }
-        BucketModeArg::Kingrank9 => {
-            if args.progress_file.is_some() {
-                bail!("--bucket-mode kingrank9 では --progress-file は使いません");
-            }
+        Some(BucketModeArg::Kingrank9) => {
             set_layer_stack_bucket_mode(LayerStackBucketMode::KingRank9);
         }
+        None => {}
     }
-    init_nnue(&args.eval_file)
-        .with_context(|| format!("NNUE を読み込めません: {}", args.eval_file.display()))?;
-    let network = get_network().ok_or_else(|| anyhow!("NNUE が初期化されていません"))?;
-    if !network.is_layer_stacks() {
-        bail!(
-            "nyugyoku_metrics eval-pairs は LayerStacks NNUE のみ対応しています: {}",
-            network.architecture_name()
-        );
-    }
-    let mut stack = AccumulatorStackVariant::from_network(&network);
+    Ok((AccumulatorStackVariant::from_network(&network), bucket_mode))
+}
+
+fn run_eval(args: &EvalArgs) -> Result<()> {
+    let cluster_counts = count_game_clusters(&args.pairs)?;
+    let (mut stack, bucket_mode) =
+        init_eval(args.bucket_mode, args.progress_file.as_deref(), &args.eval_file)?;
     // acc_cache (Finny Tables) は静的 LayerStacks variant 専用の API で、
     // runtime-dimensions ビルドでは同じ net でも DynamicLayerStacks として load され
     // `as_layer_stacks()` が panic する (`is_layer_stacks()` は Dynamic でも true)。
@@ -885,7 +1006,7 @@ fn run_eval(args: &EvalArgs) -> Result<()> {
     let mut agg = PairAggregator::new(cluster_counts, args.bootstrap, args.seed);
     let mut current_source: Option<String> = None;
     let mut current_game = [GameAgg::default(); SLOTS];
-    visit_pair_records(&args.pairs, |pair, line_no| {
+    visit_jsonl_records::<PairRecord>(&args.pairs, |pair, line_no| {
         let at = || format!("{}:{line_no}", args.pairs.display());
         if current_source.as_deref() != Some(pair.source_csa.as_str()) {
             if let Some(previous) = &current_source {
@@ -948,15 +1069,739 @@ fn run_eval(args: &EvalArgs) -> Result<()> {
         pairs: args.pairs.display().to_string(),
         eval_file: args.eval_file.display().to_string(),
         progress_file: args.progress_file.as_ref().map(|p| p.display().to_string()),
-        bucket_mode: match args.bucket_mode {
-            BucketModeArg::Progress8kpabs => LayerStackBucketMode::Progress8KPAbs.as_str(),
-            BucketModeArg::Kingrank9 => LayerStackBucketMode::KingRank9.as_str(),
-        }
-        .to_string(),
+        bucket_mode: bucket_mode
+            .map(|mode| match mode {
+                BucketModeArg::Progress8kpabs => LayerStackBucketMode::Progress8KPAbs.as_str(),
+                BucketModeArg::Kingrank9 => LayerStackBucketMode::KingRank9.as_str(),
+            })
+            .map(str::to_string),
         bootstrap: args.bootstrap,
         seed: args.seed,
         overall,
         conditions,
+    };
+
+    let stdout = std::io::stdout();
+    let mut locked = stdout.lock();
+    serde_json::to_writer_pretty(&mut locked, &out)?;
+    writeln!(locked)?;
+    write_json_pretty(&args.out, &out)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// build-mates
+// ---------------------------------------------------------------------------
+
+/// mates.jsonl の 1 行（勝者手番の詰み読み切り局面）。
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct MateRecord {
+    source_csa: String,
+    /// 勝者（詰ます側）。'b' / 'w'。
+    winner: char,
+    ply: u32,
+    sfen: String,
+    /// oracle の通常探索が読み切った詰み手数（勝者手番から数えた ply）。
+    /// 最短および厳密な証明の保証はない。
+    mate_in: u32,
+    /// oracle 探索の最善手（USI）。
+    oracle_bestmove: String,
+    oracle_depth: i32,
+    oracle_nodes: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildMatesMeta {
+    input: String,
+    tail_plies: u32,
+    stride: u32,
+    max_games: usize,
+    oracle_depth: i32,
+    oracle_nodes: Option<u64>,
+    /// 走査した CSA ファイル数（1 ファイル = 1 対局）。
+    games_scanned: usize,
+    /// `%TORYO` 終局と確認できた対局数。
+    toryo_games: usize,
+    /// 勝者の突き合わせ（parse 由来の勝者 vs 最終通常手の手番）に失敗して除外した対局数。
+    games_skipped_winner_mismatch: usize,
+    /// replay 未完走（`Move::NONE` 混入等）で盤面列を信頼できず除外した対局数。
+    games_skipped_broken: usize,
+    /// oracle 探索にかけた候補局面数（tail_plies / stride による選別後）。
+    candidate_positions: usize,
+    /// oracle が詰みを読み切り mates.jsonl に採用した局面数。
+    mate_positions: usize,
+    /// 採用局面を 1 つ以上持つ対局数。
+    games_with_mates: usize,
+}
+
+/// oracle 探索が勝者の詰みを読み切ったときの結果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OracleMate {
+    mate_in: u32,
+    bestmove_usi: String,
+}
+
+/// mate 帯（手番側の勝ち）の探索 score から「探索が発見した詰み手数（ply）」を取り出す。
+///
+/// - `is_win()` 帯（`Value::MATE_IN_MAX_PLY` 以上）のみ採用する。`is_loss()`（自玉が
+///   詰まされる側）や通常評価値は `None`。
+/// - `mate_ply() == 0`（`Value::MATE` ちょうど）は「root で既に勝ち」を意味し、通常の
+///   詰み探索では現れない（EnteringKingRule 有効時の root 宣言勝ちスコアの形）。oracle は
+///   宣言判定を無効化して探索するため実際には出ないはずだが、混入すると「詰み距離 0」の
+///   偽ラベルになるため防御的に `None` にする。
+fn winner_mate_in(score: Value) -> Option<u32> {
+    if !score.is_win() {
+        return None;
+    }
+    let ply = score.mate_ply();
+    (ply >= 1).then_some(ply as u32)
+}
+
+/// 1 局面を固定 depth（必要ならノード数上限も併用）で探索し、score と最善手を返す
+/// （内部用。rule を差し替え可能にしてあるのは EnteringKingRule::None の効果をテストで
+/// 対照するため）。
+///
+/// 決定性の不変条件（`teacher_labeler` / `label_bench_positions` と同じ）:
+/// 局面ごとに `Search` を作り直し 1 スレッド固定で探索する。これにより 1 局面の結果は
+/// 他局面・処理順・worker スレッド数から独立し、同一入力なら出力が bit 一致する。
+/// ノード上限も探索スレッドの決定的な node counter だけで判定され、時間には依存しない。
+fn oracle_raw_search(
+    sfen: &str,
+    winner: Color,
+    depth: i32,
+    nodes: Option<u64>,
+    rule: EnteringKingRule,
+) -> Result<(Value, Move)> {
+    let mut pos = Position::new();
+    pos.set_sfen(sfen).with_context(|| format!("SFEN を復元できません: {sfen}"))?;
+    if pos.side_to_move() != winner {
+        bail!("勝者手番のはずの局面で手番が一致しません: {sfen}");
+    }
+    let mut search = Search::new(ORACLE_HASH_MB);
+    search.set_num_threads(1);
+    search.set_entering_king_rule(rule);
+    let mut limits = LimitsType::default();
+    limits.depth = depth;
+    if let Some(nodes) = nodes {
+        limits.nodes = nodes;
+    }
+    limits.set_start_time();
+    let result = search.go(&mut pos, limits, None::<fn(&SearchInfo)>);
+    Ok((result.score, result.best_move))
+}
+
+/// 1 候補局面を oracle 探索し、勝者の詰み読み切りなら `Some` を返す。
+///
+/// EnteringKingRule 有効の探索は root の宣言可能局面を mate 帯スコア（`Value::MATE` +
+/// `Move::WIN`）で返しうる。本指標の mate は「詰み（checkmate）」のみで入玉宣言勝ちを
+/// 含まないため、必ず `EnteringKingRule::None` で宣言判定を無効化して探索する。
+/// さらに防御として、最善手が通常手でない結果（`Move::WIN` 等）は採用しない。
+fn oracle_search_mate(
+    sfen: &str,
+    winner: Color,
+    depth: i32,
+    nodes: Option<u64>,
+) -> Result<Option<OracleMate>> {
+    let (score, best_move) = oracle_raw_search(sfen, winner, depth, nodes, EnteringKingRule::None)?;
+    let Some(mate_in) = winner_mate_in(score) else {
+        return Ok(None);
+    };
+    if !best_move.is_normal() {
+        return Ok(None);
+    }
+    Ok(Some(OracleMate {
+        mate_in,
+        bestmove_usi: best_move.to_usi(),
+    }))
+}
+
+/// 終局側 tail の勝者手番局面を候補として列挙する（`(ply, sfen_before)`、ply 昇順）。
+///
+/// 最終手（`%TORYO` 対局では勝者の手）の局面を距離 0 とし、距離 `d = last_ply - ply` が
+/// `d < tail_plies` かつ `d % stride == 0` の勝者手番局面を採る。呼び出し側で replay
+/// 完走（全手が通常手・ply 連番）を確認済みであること。
+fn mate_candidates(
+    moves: &[MoveView],
+    winner: Color,
+    tail_plies: u32,
+    stride: u32,
+) -> Vec<(u32, &str)> {
+    let Some(last) = moves.last() else {
+        return Vec::new();
+    };
+    let last_ply = last.ply;
+    moves
+        .iter()
+        .filter(|m| m.side == winner)
+        .filter(|m| {
+            let d = last_ply - m.ply;
+            d < tail_plies && d % stride == 0
+        })
+        .map(|m| (m.ply, m.sfen_before.as_str()))
+        .collect()
+}
+
+fn run_build_mates(args: &BuildMatesArgs) -> Result<()> {
+    if args.tail_plies == 0 {
+        bail!("--tail-plies は 1 以上を指定してください");
+    }
+    if args.stride == 0 {
+        bail!("--stride は 1 以上を指定してください");
+    }
+    // depth 0 以下は探索の停止条件が無くなる（時間管理探索へ落ちる）ため弾く。
+    if args.oracle_depth <= 0 {
+        bail!("--oracle-depth は 1 以上を指定してください");
+    }
+    if args.oracle_nodes == Some(0) {
+        bail!("--oracle-nodes は 1 以上を指定してください（無制限は省略）");
+    }
+    fs::create_dir_all(&args.out_dir)
+        .with_context(|| format!("出力ディレクトリを作成できません: {}", args.out_dir.display()))?;
+    let mates_path = args.out_dir.join("mates.jsonl");
+    let meta_path = args.out_dir.join("meta.json");
+    let mut mates_out = BufWriter::new(File::create(&mates_path)?);
+
+    // mate 帯 score は通常探索の読み切り結果として使う。TT は 16-bit key のため理論上は
+    // 衝突由来の偽 mate があり得る。同一 mates.jsonl を使うことで oracle の差はモデル間に
+    // 混入しない。ただし、偽 mate や非最短距離を含む可能性による指標自体の偏りは排除できない。
+    set_material_level(MaterialLevel::Lv1);
+
+    let num_threads = if args.threads > 0 {
+        args.threads
+    } else {
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+    };
+    // 並列化は局面単位（`par_iter` は順序保存 collect なので出力順も決定的）。
+    // 深い探索の再帰スタック用に worker へ main 同等の 64MB を確保する。
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .stack_size(SEARCH_STACK_SIZE)
+        .thread_name(|i| format!("oracle-worker-{i}"))
+        .build()
+        .context("rayon スレッドプールを構築できません")?;
+
+    let mut games_scanned = 0usize;
+    let mut toryo_games = 0usize;
+    let mut games_skipped_winner_mismatch = 0usize;
+    let mut games_skipped_broken = 0usize;
+    let mut candidate_positions = 0usize;
+    let mut mate_positions = 0usize;
+    let mut games_with_mates = 0usize;
+
+    // build-pairs と同じ決定的な遅延走査（ファイル名ソート、1 ファイル = 1 対局ずつ）。
+    for path in csa_paths(&args.input)? {
+        if args.max_games > 0 && games_scanned >= args.max_games {
+            break;
+        }
+        let path = path?;
+        games_scanned += 1;
+        if games_scanned.is_multiple_of(1000) {
+            eprintln!(
+                "progress: {games_scanned} games scanned, {candidate_positions} candidates, {mate_positions} mates"
+            );
+        }
+
+        let source = CsaSource::new(&path);
+        let index = source.build_index()?;
+        for warning in &index.warnings {
+            eprintln!("warning: {warning}");
+        }
+        for entry in &index.entries {
+            let game = source.load_game(&index, entry)?;
+            // 投了終局のみ対象。宣言勝ち（%KACHI）は宣言ルール距離ペア側の担当で、
+            // 本指標の mate（詰み）には含まない。
+            if game.termination != Some(SpecialMove::Resign) {
+                continue;
+            }
+            toryo_games += 1;
+            let prov = pair_provenance(&index, entry)?;
+            let source_csa = prov.source_csa.as_str();
+
+            // 勝者 = 投了した側の相手（derive_outcome の Win 側）。
+            let Some(GameOutcomeView::Win(winner)) = entry.outcome else {
+                games_skipped_winner_mismatch += 1;
+                eprintln!(
+                    "warning: {source_csa}: %TORYO 終局なのに勝者を導出できないため除外します"
+                );
+                continue;
+            };
+            // 候補局面の SFEN 列を信頼するには replay の完走（全手が通常手として盤面追跡
+            // できたこと）が必要。完走しなかった対局は除外する。
+            let replay_complete = game.moves.len() as u64 == u64::from(entry.ply_count)
+                && game.moves.iter().all(|m| m.mv.is_normal());
+            if !replay_complete {
+                games_skipped_broken += 1;
+                eprintln!(
+                    "warning: {source_csa}: replay が完走せず盤面列を信頼できないため除外します"
+                );
+                continue;
+            }
+            // 投了は手番側の行為なので、最終通常手は勝者の手のはず。不一致は除外する。
+            if let Some(last) = game.moves.last()
+                && last.side != winner
+            {
+                games_skipped_winner_mismatch += 1;
+                eprintln!("warning: {source_csa}: 勝者と最終手番が一致しないため除外します");
+                continue;
+            }
+
+            let candidates = mate_candidates(&game.moves, winner, args.tail_plies, args.stride);
+            if candidates.is_empty() {
+                continue;
+            }
+            candidate_positions += candidates.len();
+            let oracle_results: Result<Vec<Option<OracleMate>>> = pool.install(|| {
+                candidates
+                    .par_iter()
+                    .map(|(_, sfen)| {
+                        oracle_search_mate(sfen, winner, args.oracle_depth, args.oracle_nodes)
+                    })
+                    .collect()
+            });
+            let oracle_results = match oracle_results {
+                Ok(results) => results,
+                Err(e) => {
+                    games_skipped_broken += 1;
+                    eprintln!(
+                        "warning: {source_csa}: oracle 探索に失敗したため除外します（{e:#}）"
+                    );
+                    continue;
+                }
+            };
+
+            let mut game_mates = 0usize;
+            for ((ply, sfen), oracle) in candidates.iter().zip(oracle_results) {
+                let Some(oracle) = oracle else {
+                    continue;
+                };
+                let record = MateRecord {
+                    source_csa: prov.source_csa.clone(),
+                    winner: color_label(winner),
+                    ply: *ply,
+                    sfen: (*sfen).to_string(),
+                    mate_in: oracle.mate_in,
+                    oracle_bestmove: oracle.bestmove_usi,
+                    oracle_depth: args.oracle_depth,
+                    oracle_nodes: args.oracle_nodes,
+                };
+                serde_json::to_writer(&mut mates_out, &record)?;
+                writeln!(mates_out)?;
+                mate_positions += 1;
+                game_mates += 1;
+            }
+            if game_mates > 0 {
+                games_with_mates += 1;
+            }
+        }
+    }
+    mates_out.flush()?;
+
+    let meta = BuildMatesMeta {
+        input: args.input.display().to_string(),
+        tail_plies: args.tail_plies,
+        stride: args.stride,
+        max_games: args.max_games,
+        oracle_depth: args.oracle_depth,
+        oracle_nodes: args.oracle_nodes,
+        games_scanned,
+        toryo_games,
+        games_skipped_winner_mismatch,
+        games_skipped_broken,
+        candidate_positions,
+        mate_positions,
+        games_with_mates,
+    };
+    write_json_pretty(&meta_path, &meta)?;
+
+    eprintln!(
+        "wrote {mate_positions} mate positions from {games_with_mates} games (candidates={candidate_positions}, toryo={toryo_games}, scanned={games_scanned}) to {}",
+        mates_path.display()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// eval-mates
+// ---------------------------------------------------------------------------
+
+/// mates.jsonl の事前走査で数えた対局クラスタ数（bootstrap の母数）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MateClusterCounts {
+    /// mate_in が厳密に異なる局面 pair を 1 組以上持つ対局数。
+    concordance_games: usize,
+    /// mate 局面を 1 つ以上持つ対局数。
+    top1_games: usize,
+}
+
+/// `build-mates` が出す source_csa 順の並びを一度走査し、指標別の対局クラスタ数を数える。
+fn count_mate_clusters(path: &Path) -> Result<MateClusterCounts> {
+    let mut counts = MateClusterCounts {
+        concordance_games: 0,
+        top1_games: 0,
+    };
+    let mut current_source: Option<String> = None;
+    let mut mate_ins: Vec<u32> = Vec::new();
+    let mut flush = |mate_ins: &mut Vec<u32>| {
+        if mate_ins.is_empty() {
+            return;
+        }
+        counts.top1_games += 1;
+        if mate_ins.iter().any(|&m| m != mate_ins[0]) {
+            counts.concordance_games += 1;
+        }
+        mate_ins.clear();
+    };
+    visit_jsonl_records::<MateRecord>(path, |record, line_no| {
+        if current_source.as_deref() != Some(record.source_csa.as_str()) {
+            if let Some(previous) = &current_source {
+                if record.source_csa < *previous {
+                    bail!(
+                        "{}:{line_no}: source_csa は昇順かつ対局単位で連続している必要があります",
+                        path.display()
+                    );
+                }
+                flush(&mut mate_ins);
+            }
+            current_source = Some(record.source_csa.clone());
+        }
+        mate_ins.push(record.mate_in);
+        Ok(())
+    })?;
+    flush(&mut mate_ins);
+    Ok(counts)
+}
+
+/// 詰み手 top-1 の判定に使う 1 局面ぶんの子局面評価の要約。
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Top1Eval {
+    /// top-1 スコア（厳密最大 1 / 最大タイ 0.5 / それ以外 0）。
+    score: f64,
+    /// oracle 最善手の子局面評価（指し手側視点 cp）。
+    oracle_child_cp: i32,
+    /// 全合法手中の最大子局面評価（指し手側視点 cp）。
+    best_child_cp: i32,
+    /// 合法手数。
+    n_legal: usize,
+    /// 最大値タイの手数（oracle 手を含む）。
+    n_best: usize,
+}
+
+/// 詰み手 top-1 のスコア規約。`best_cp` は全合法手（oracle 手を含む）の最大値なので
+/// `oracle_cp > best_cp` はあり得ない。
+fn top1_score(oracle_cp: i32, best_cp: i32, n_best: usize) -> f64 {
+    if oracle_cp < best_cp {
+        0.0
+    } else if n_best == 1 {
+        1.0
+    } else {
+        0.5
+    }
+}
+
+/// 1 mate 局面の全合法手を 1 手ずつ適用し、子局面の静的評価（相手番になるので符号反転
+/// して指し手側視点 cp に揃える）で oracle 最善手が最大かを判定する。
+///
+/// 詰み手の子局面は相手玉が王手を受けた局面になるが、除外せず同じ規約で評価する
+/// （「詰みに向かう手を静的評価だけで選べるか」を測るのが目的のため）。
+fn mate_top1_eval(
+    pos: &mut Position,
+    oracle_bestmove: &str,
+    stack: &mut AccumulatorStackVariant,
+    acc_cache: &mut Option<LayerStacksAccCache>,
+) -> Result<Top1Eval> {
+    let mut list = MoveList::new();
+    // oracle の最善手が不成などの搦め手でも必ず候補に含まれるよう、全合法手を生成する。
+    generate_legal_all(pos, &mut list);
+    if list.is_empty() {
+        bail!("合法手がありません");
+    }
+    let mut best_cp = i32::MIN;
+    let mut n_best = 0usize;
+    let mut oracle_cp: Option<i32> = None;
+    for &mv in list.iter() {
+        let gives_check = pos.gives_check(mv);
+        pos.do_move(mv, gives_check);
+        stack.reset();
+        let cp = (-evaluate_dispatch(pos, stack, acc_cache)).to_cp();
+        pos.undo_move(mv);
+        match cp.cmp(&best_cp) {
+            std::cmp::Ordering::Greater => {
+                best_cp = cp;
+                n_best = 1;
+            }
+            std::cmp::Ordering::Equal => n_best += 1,
+            std::cmp::Ordering::Less => {}
+        }
+        if mv.to_usi() == oracle_bestmove {
+            oracle_cp = Some(cp);
+        }
+    }
+    let Some(oracle_cp) = oracle_cp else {
+        bail!("oracle_bestmove {oracle_bestmove} が合法手にありません");
+    };
+    Ok(Top1Eval {
+        score: top1_score(oracle_cp, best_cp, n_best),
+        oracle_child_cp: oracle_cp,
+        best_child_cp: best_cp,
+        n_legal: list.len(),
+        n_best,
+    })
+}
+
+/// 同一対局内の mate 局面から、mate_in が厳密に異なる全 pair の順序一致を列挙する。
+///
+/// `items[i] = (mate_in, eval)`（eval は勝者手番視点 cp）。返り値は
+/// `(near, far, agreement)` の列で、near = 詰みに近い側（mate_in 小）の index、
+/// far = 遠い側の index。agreement は near の eval が far より高ければ 1、tie 0.5、逆 0。
+fn concordance_pairs(items: &[(u32, i32)]) -> Vec<(usize, usize, f64)> {
+    let mut out = Vec::new();
+    for i in 0..items.len() {
+        for j in (i + 1)..items.len() {
+            if items[i].0 == items[j].0 {
+                continue;
+            }
+            let (near, far) = if items[i].0 < items[j].0 {
+                (i, j)
+            } else {
+                (j, i)
+            };
+            let agreement = agreement_score(items[far].1, items[near].1);
+            out.push((near, far, agreement));
+        }
+    }
+    out
+}
+
+/// eval-mates の集計出力。
+#[derive(Debug, Serialize)]
+struct EvalMatesMetrics {
+    mates: String,
+    eval_file: String,
+    progress_file: Option<String>,
+    bucket_mode: Option<String>,
+    bootstrap: u32,
+    seed: u64,
+    concordance: ConcordanceMetrics,
+    mate_top1: MateTop1Metrics,
+}
+
+/// 詰み距離 concordance（同一対局内 pair の順序一致率）と対局クラスタ bootstrap 95% CI。
+#[derive(Debug, Serialize, Clone, PartialEq)]
+struct ConcordanceMetrics {
+    /// 順序一致率（tie は 0.5）。pair が 1 組も無ければ `None`。
+    agreement: Option<f64>,
+    n_pairs: u64,
+    n_games: usize,
+    ci95_lo: Option<f64>,
+    ci95_hi: Option<f64>,
+}
+
+/// 詰み手 top-1 率（厳密最大 1 / 最大タイ 0.5）と対局クラスタ bootstrap 95% CI。
+#[derive(Debug, Serialize, Clone, PartialEq)]
+struct MateTop1Metrics {
+    /// top-1 率。局面が 1 つも無ければ `None`。
+    rate: Option<f64>,
+    n_positions: u64,
+    n_games: usize,
+    ci95_lo: Option<f64>,
+    ci95_hi: Option<f64>,
+}
+
+/// `--dump` の pair 行。
+#[derive(Debug, Serialize)]
+struct MateDumpPair<'a> {
+    kind: &'static str,
+    source_csa: &'a str,
+    /// 詰みに近い側（mate_in 小）。
+    ply_near: u32,
+    mate_in_near: u32,
+    eval_near: i32,
+    /// 詰みから遠い側（mate_in 大）。
+    ply_far: u32,
+    mate_in_far: u32,
+    eval_far: i32,
+    agreement: f64,
+}
+
+/// `--dump` の position 行。
+#[derive(Debug, Serialize)]
+struct MateDumpPosition<'a> {
+    kind: &'static str,
+    source_csa: &'a str,
+    ply: u32,
+    mate_in: u32,
+    oracle_bestmove: &'a str,
+    oracle_child_eval: i32,
+    best_child_eval: i32,
+    n_legal: usize,
+    n_best: usize,
+    score: f64,
+}
+
+/// 1 対局ぶんの mate 局面を評価し、concordance / top-1 の対局集計を返す。
+/// dump が指定されていれば per-position / per-pair の明細行も書く。
+fn process_mate_game(
+    records: &[MateRecord],
+    stack: &mut AccumulatorStackVariant,
+    acc_cache: &mut Option<LayerStacksAccCache>,
+    dump: &mut Option<BufWriter<File>>,
+) -> Result<(GameAgg, GameAgg)> {
+    let winner = color_from_label(records[0].winner)?;
+    let mut items: Vec<(u32, i32)> = Vec::with_capacity(records.len());
+    let mut top1_agg = GameAgg::default();
+    for record in records {
+        if record.winner != records[0].winner {
+            bail!("{}: 同一対局内で winner が一致しません", record.source_csa);
+        }
+        let mut pos = Position::new();
+        pos.set_sfen(&record.sfen)
+            .with_context(|| format!("SFEN を復元できません: {}", record.sfen))?;
+        if pos.side_to_move() != winner {
+            bail!("{}: 勝者手番でない局面が含まれています: {}", record.source_csa, record.sfen);
+        }
+        // concordance は勝者手番視点の静的評価同士を比較する（eval-pairs と同じ規約）。
+        stack.reset();
+        let eval = evaluate_dispatch(&pos, stack, acc_cache).to_cp();
+        let top1 = mate_top1_eval(&mut pos, &record.oracle_bestmove, stack, acc_cache)
+            .with_context(|| format!("{} ply {}", record.source_csa, record.ply))?;
+        top1_agg.sum += top1.score;
+        top1_agg.count += 1;
+        if let Some(dump) = dump {
+            let row = MateDumpPosition {
+                kind: "position",
+                source_csa: &record.source_csa,
+                ply: record.ply,
+                mate_in: record.mate_in,
+                oracle_bestmove: &record.oracle_bestmove,
+                oracle_child_eval: top1.oracle_child_cp,
+                best_child_eval: top1.best_child_cp,
+                n_legal: top1.n_legal,
+                n_best: top1.n_best,
+                score: top1.score,
+            };
+            serde_json::to_writer(&mut *dump, &row)?;
+            writeln!(dump)?;
+        }
+        items.push((record.mate_in, eval));
+    }
+
+    let mut concordance_agg = GameAgg::default();
+    for (near, far, agreement) in concordance_pairs(&items) {
+        concordance_agg.sum += agreement;
+        concordance_agg.count += 1;
+        if let Some(dump) = dump {
+            let row = MateDumpPair {
+                kind: "pair",
+                source_csa: &records[near].source_csa,
+                ply_near: records[near].ply,
+                mate_in_near: records[near].mate_in,
+                eval_near: items[near].1,
+                ply_far: records[far].ply,
+                mate_in_far: records[far].mate_in,
+                eval_far: items[far].1,
+                agreement,
+            };
+            serde_json::to_writer(&mut *dump, &row)?;
+            writeln!(dump)?;
+        }
+    }
+    Ok((concordance_agg, top1_agg))
+}
+
+fn run_eval_mates(args: &EvalMatesArgs) -> Result<()> {
+    let cluster_counts = count_mate_clusters(&args.mates)?;
+    let (mut stack, bucket_mode) =
+        init_eval(args.bucket_mode, args.progress_file.as_deref(), &args.eval_file)?;
+    // acc_cache を使わない理由は `init_eval` 呼び出し元の eval-pairs 側と同じ
+    // （runtime-dimensions ビルドで `as_layer_stacks()` が panic するため）。
+    let mut acc_cache: Option<LayerStacksAccCache> = None;
+
+    let mut dump = args
+        .dump
+        .as_ref()
+        .map(|path| {
+            File::create(path)
+                .map(BufWriter::new)
+                .with_context(|| format!("出力できません: {}", path.display()))
+        })
+        .transpose()?;
+
+    // 指標ごとに独立の対局クラスタ bootstrap を回す。concordance は seed そのまま、
+    // top-1 は slot_seed で派生（eval-pairs の条件 slot と同じ衝突回避方式）。
+    let mut concordance_agg =
+        SliceAggregator::new(cluster_counts.concordance_games, args.bootstrap, args.seed);
+    let mut top1_agg =
+        SliceAggregator::new(cluster_counts.top1_games, args.bootstrap, slot_seed(args.seed, 1));
+
+    // 対局単位で group 化して処理する。保持するのは現在処理中の対局の record 列だけ
+    // （tail_plies / stride で上限が決まる少数）で、完了済み対局の集計は保持しない。
+    let mut current_source: Option<String> = None;
+    let mut current_records: Vec<MateRecord> = Vec::new();
+    let mut flush_game = |records: &mut Vec<MateRecord>,
+                          stack: &mut AccumulatorStackVariant,
+                          acc_cache: &mut Option<LayerStacksAccCache>,
+                          dump: &mut Option<BufWriter<File>>|
+     -> Result<()> {
+        if records.is_empty() {
+            return Ok(());
+        }
+        let (concordance_game, top1_game) = process_mate_game(records, stack, acc_cache, dump)?;
+        if concordance_game.count > 0 {
+            concordance_agg.push(concordance_game)?;
+        }
+        top1_agg.push(top1_game)?;
+        records.clear();
+        Ok(())
+    };
+    visit_jsonl_records::<MateRecord>(&args.mates, |record, line_no| {
+        if current_source.as_deref() != Some(record.source_csa.as_str()) {
+            if let Some(previous) = &current_source {
+                if record.source_csa < *previous {
+                    bail!(
+                        "{}:{line_no}: source_csa は昇順かつ対局単位で連続している必要があります",
+                        args.mates.display()
+                    );
+                }
+                flush_game(&mut current_records, &mut stack, &mut acc_cache, &mut dump)?;
+            }
+            current_source = Some(record.source_csa.clone());
+        }
+        current_records.push(record);
+        Ok(())
+    })?;
+    flush_game(&mut current_records, &mut stack, &mut acc_cache, &mut dump)?;
+    if let Some(mut dump) = dump {
+        dump.flush()?;
+    }
+
+    let concordance = concordance_agg.finish()?;
+    let top1 = top1_agg.finish()?;
+    let out = EvalMatesMetrics {
+        mates: args.mates.display().to_string(),
+        eval_file: args.eval_file.display().to_string(),
+        progress_file: args.progress_file.as_ref().map(|p| p.display().to_string()),
+        bucket_mode: bucket_mode
+            .map(|mode| match mode {
+                BucketModeArg::Progress8kpabs => LayerStackBucketMode::Progress8KPAbs.as_str(),
+                BucketModeArg::Kingrank9 => LayerStackBucketMode::KingRank9.as_str(),
+            })
+            .map(str::to_string),
+        bootstrap: args.bootstrap,
+        seed: args.seed,
+        concordance: ConcordanceMetrics {
+            agreement: concordance.agreement,
+            n_pairs: concordance.n_pairs,
+            n_games: concordance.n_games,
+            ci95_lo: concordance.ci95_lo,
+            ci95_hi: concordance.ci95_hi,
+        },
+        mate_top1: MateTop1Metrics {
+            rate: top1.agreement,
+            n_positions: top1.n_pairs,
+            n_games: top1.n_games,
+            ci95_lo: top1.ci95_lo,
+            ci95_hi: top1.ci95_hi,
+        },
     };
 
     let stdout = std::io::stdout();
@@ -981,6 +1826,46 @@ fn write_json_pretty<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 mod tests {
     use super::*;
     use crate::replay::model::MoveAnnotation;
+
+    #[test]
+    fn layer_stacks_bucket_mode_defaults_and_validates_progress_file() {
+        assert_eq!(
+            resolve_bucket_mode(true, None, true).expect("既定 mode"),
+            Some(BucketModeArg::Progress8kpabs)
+        );
+        assert_eq!(
+            resolve_bucket_mode(true, Some(BucketModeArg::Progress8kpabs), true)
+                .expect("明示 progress8kpabs"),
+            Some(BucketModeArg::Progress8kpabs)
+        );
+        assert_eq!(
+            resolve_bucket_mode(true, Some(BucketModeArg::Kingrank9), false)
+                .expect("明示 kingrank9"),
+            Some(BucketModeArg::Kingrank9)
+        );
+
+        let missing_progress = resolve_bucket_mode(true, None, false)
+            .expect_err("既定 progress8kpabs には progress-file が必要");
+        assert!(missing_progress.to_string().contains("--progress-file が必須"));
+        let unused_progress = resolve_bucket_mode(true, Some(BucketModeArg::Kingrank9), true)
+            .expect_err("kingrank9 では progress-file を拒否");
+        assert!(unused_progress.to_string().contains("--progress-file は使いません"));
+    }
+
+    #[test]
+    fn non_layer_stacks_rejects_layer_stacks_options() {
+        assert_eq!(resolve_bucket_mode(false, None, false).expect("専用 option なし"), None);
+
+        let bucket_mode = resolve_bucket_mode(false, Some(BucketModeArg::Progress8kpabs), false)
+            .expect_err("bucket-mode を拒否");
+        assert!(bucket_mode.to_string().contains("--bucket-mode は LayerStacks"));
+        let progress_file =
+            resolve_bucket_mode(false, None, true).expect_err("progress-file を拒否");
+        assert!(progress_file.to_string().contains("--progress-file は LayerStacks"));
+        let both = resolve_bucket_mode(false, Some(BucketModeArg::Kingrank9), true)
+            .expect_err("両 option を拒否");
+        assert!(both.to_string().contains("--bucket-mode は LayerStacks"));
+    }
 
     fn write_csa(dir: &Path, name: &str, text: &str) {
         let mut f = File::create(dir.join(name)).expect("create");
@@ -1332,6 +2217,357 @@ mod tests {
         let (lo, hi) = streaming_ci(&per_game, 100, DEFAULT_SEED).expect("ci");
         assert_eq!(lo, 0.75);
         assert_eq!(hi, 0.75);
+    }
+
+    // -----------------------------------------------------------------------
+    // 探索読み切り詰み距離 concordance（build-mates / eval-mates）
+    // -----------------------------------------------------------------------
+
+    /// 先手番で先手が 1 手詰めの局面。5c の歩が 5b への金打ちを支え、G*5b が唯一の詰み。
+    const MATE_IN_ONE_SFEN: &str = "4k4/9/4P4/9/9/9/9/9/4K4 b G 1";
+
+    /// 先手番で先手が 3 手詰め（1 手詰めなし）の局面。
+    /// G*5c（5d の歩が支える）に対し後手玉は 1 段目へ逃げるしかなく、どこへ逃げても
+    /// もう 1 枚の金打ちで頭金の詰み。
+    const MATE_IN_THREE_SFEN: &str = "9/4k4/9/4P4/9/9/9/9/4K4 b 2G 1";
+
+    /// 先手番で Point27 宣言が成立する形だが、詰みは（浅い探索の範囲では）存在しない局面。
+    /// 宣言要件: 先手玉 5b が敵陣内・敵陣内の玉以外の駒 10 枚（飛2 角2 金4 銀2）・
+    /// 28 点（大駒 4x5 + 小駒 6 + 持ち歩 2）・王手なし。後手玉 1i は 7 段目の歩壁の
+    /// 向こうにあり、先手の飛角は g 段の歩を突破しない限り王手すら掛からない。
+    const DECLARATION_FORM_SFEN: &str = "R1GGG1G1R/B1S1K1S1B/9/9/9/9/ppppppppp/9/8k b 2P 1";
+
+    /// oracle 系テストの前提となる評価器（NNUE 不要の駒得評価）を有効化する。
+    /// `run_build_mates` が本番でやるのと同じ設定で、プロセスグローバルかつ冪等。
+    fn enable_material_eval() {
+        set_material_level(MaterialLevel::Lv1);
+    }
+
+    #[test]
+    fn winner_mate_in_accepts_only_positive_mate_band() {
+        // 通常の詰みスコア。
+        assert_eq!(winner_mate_in(Value::mate_in(1)), Some(1));
+        assert_eq!(winner_mate_in(Value::mate_in(15)), Some(15));
+        // mate 帯の下端（MATE_IN_MAX_PLY ちょうど）は win 扱い。
+        assert_eq!(
+            winner_mate_in(Value::MATE_IN_MAX_PLY),
+            Some(Value::MATE.raw() as u32 - Value::MATE_IN_MAX_PLY.raw() as u32)
+        );
+        // 下端より 1 小さいと mate 帯ではない。
+        assert_eq!(winner_mate_in(Value::new(Value::MATE_IN_MAX_PLY.raw() - 1)), None);
+        // Value::MATE ちょうど（mate_ply 0 = 宣言勝ちの root スコアの形）は不採用。
+        assert_eq!(winner_mate_in(Value::MATE), None);
+        // 詰まされ側（負の mate 帯）と通常評価値は不採用。
+        assert_eq!(winner_mate_in(Value::mated_in(3)), None);
+        assert_eq!(winner_mate_in(Value::new(300)), None);
+        assert_eq!(winner_mate_in(Value::new(-300)), None);
+    }
+
+    #[test]
+    fn mate_candidates_filters_by_tail_and_stride() {
+        let b = Color::Black;
+        let w = Color::White;
+        // ply 1..=9、先手が奇数 ply、最終手（ply 9）は先手 = 勝者。
+        let moves: Vec<MoveView> =
+            (1..=9).map(|ply| mv(ply, if ply % 2 == 1 { b } else { w }, true)).collect();
+
+        // tail 4: 距離 d = 9 - ply が {0, 2} の先手番局面（ply 9, 7）。
+        let plies: Vec<u32> =
+            mate_candidates(&moves, b, 4, 2).into_iter().map(|(ply, _)| ply).collect();
+        assert_eq!(plies, vec![7, 9]);
+
+        // tail 8, stride 4: d が {0, 4} の先手番局面（ply 9, 5）。
+        let plies: Vec<u32> =
+            mate_candidates(&moves, b, 8, 4).into_iter().map(|(ply, _)| ply).collect();
+        assert_eq!(plies, vec![5, 9]);
+
+        // tail が全体を覆う場合は全先手番局面。
+        let plies: Vec<u32> =
+            mate_candidates(&moves, b, 100, 2).into_iter().map(|(ply, _)| ply).collect();
+        assert_eq!(plies, vec![1, 3, 5, 7, 9]);
+
+        // 後手勝者なら後手番局面（d が奇数になるため stride 1 で全対象）。
+        let plies: Vec<u32> =
+            mate_candidates(&moves, w, 4, 1).into_iter().map(|(ply, _)| ply).collect();
+        assert_eq!(plies, vec![6, 8]);
+
+        assert!(mate_candidates(&[], b, 16, 2).is_empty());
+    }
+
+    #[test]
+    fn oracle_finds_mate_in_one() {
+        enable_material_eval();
+        let oracle = oracle_search_mate(MATE_IN_ONE_SFEN, Color::Black, 7, None)
+            .expect("oracle")
+            .expect("mate expected");
+        assert_eq!(oracle.mate_in, 1);
+        assert_eq!(oracle.bestmove_usi, "G*5b");
+    }
+
+    #[test]
+    fn oracle_finds_mate_in_three() {
+        enable_material_eval();
+        let oracle = oracle_search_mate(MATE_IN_THREE_SFEN, Color::Black, 9, None)
+            .expect("oracle")
+            .expect("mate expected");
+        assert_eq!(oracle.mate_in, 3);
+        assert_eq!(oracle.bestmove_usi, "G*5c");
+    }
+
+    #[test]
+    fn oracle_nodes_limit_can_leave_synthetic_mate_unselected() {
+        enable_material_eval();
+        // fresh Search・単一スレッドでは node counter の進み方も決定的。この合成 3 手詰めは
+        // 1 node では読み切れず不採用だが、同じ depth の無制限探索では採用される。
+        assert_eq!(
+            oracle_search_mate(MATE_IN_THREE_SFEN, Color::Black, 9, Some(1)).expect("limited"),
+            None
+        );
+        assert!(
+            oracle_search_mate(MATE_IN_THREE_SFEN, Color::Black, 9, None)
+                .expect("unlimited")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn declaration_form_is_not_mate_with_entering_king_rule_none() {
+        enable_material_eval();
+        // 前提: この局面は Point27 宣言が成立する形。
+        let mut pos = Position::new();
+        pos.set_sfen(DECLARATION_FORM_SFEN).expect("sfen");
+        assert_eq!(pos.declaration_win(EnteringKingRule::Point27), Move::WIN);
+
+        // EnteringKingRule 有効の探索は root 宣言勝ちを mate 帯（Value::MATE + Move::WIN）
+        // で返す＝これが oracle で宣言判定を無効化する理由。
+        let (score, best_move) = oracle_raw_search(
+            DECLARATION_FORM_SFEN,
+            Color::Black,
+            7,
+            None,
+            EnteringKingRule::Point27,
+        )
+        .expect("search");
+        assert_eq!(score, Value::MATE);
+        assert_eq!(best_move, Move::WIN);
+        // Value::MATE（mate_ply 0）は winner_mate_in の防御でも不採用になる。
+        assert_eq!(winner_mate_in(score), None);
+
+        // oracle（EnteringKingRule::None）では宣言が無効化され、mate 帯は出ない。
+        let (score, best_move) =
+            oracle_raw_search(DECLARATION_FORM_SFEN, Color::Black, 7, None, EnteringKingRule::None)
+                .expect("search");
+        assert!(!score.is_mate_score(), "宣言無効なら mate 帯は出ない: {}", score.raw());
+        assert!(best_move.is_normal());
+        assert_eq!(
+            oracle_search_mate(DECLARATION_FORM_SFEN, Color::Black, 7, None).expect("oracle"),
+            None
+        );
+    }
+
+    /// 先手が 1 手詰めの局面で後手が投了する合成対局（`MATE_IN_ONE_SFEN` と同じ配置）。
+    /// 最終手 G*5b（詰み）の局面 = 候補距離 0 が mate in 1。
+    const TORYO_MATE_CSA: &str = concat!(
+        "V2.2\n",
+        "N+B\nN-W\n",
+        "P+53FU59OU00KI\n",
+        "P-51OU\n",
+        "+\n",
+        "+0052KI\nT1\n",
+        "%TORYO\n",
+    );
+
+    /// 玉しかおらず詰みが存在しないまま後手が投了する合成対局（候補は出るが不採用）。
+    const TORYO_NO_MATE_CSA: &str = concat!(
+        "V2.2\n",
+        "N+B\nN-W\n",
+        "P+54OU\n",
+        "P-19OU\n",
+        "+\n",
+        "+5453OU\nT1\n",
+        "-1918OU\nT1\n",
+        "+5352OU\nT1\n",
+        "%TORYO\n",
+    );
+
+    /// %TORYO だが途中の相手手が不正（Move::NONE fallback + 打ち切り）の対局。
+    const TORYO_BROKEN_CSA: &str = concat!(
+        "V2.2\n",
+        "N+B\nN-W\n",
+        "P+54OU\n",
+        "P-19OU\n",
+        "+\n",
+        "+5453OU\nT1\n",
+        "-5556FU\nT1\n",
+        "+5352OU\nT1\n",
+        "%TORYO\n",
+    );
+
+    fn build_mates_args(input: &Path, out_dir: &Path) -> BuildMatesArgs {
+        BuildMatesArgs {
+            input: input.to_path_buf(),
+            out_dir: out_dir.to_path_buf(),
+            tail_plies: 16,
+            stride: 2,
+            max_games: 0,
+            oracle_depth: 7,
+            oracle_nodes: None,
+            threads: 1,
+        }
+    }
+
+    #[test]
+    fn run_build_mates_writes_mates_and_meta() {
+        let in_dir = tempfile::tempdir().expect("tempdir");
+        write_csa(in_dir.path(), "a_mate.csa", TORYO_MATE_CSA);
+        write_csa(in_dir.path(), "b_no_mate.csa", TORYO_NO_MATE_CSA);
+        write_csa(in_dir.path(), "c_broken.csa", TORYO_BROKEN_CSA);
+        // %KACHI 対局は toryo に数えず対象外。
+        write_csa(in_dir.path(), "d_kachi.csa", KACHI_ENTRY_CSA);
+        let out_dir = tempfile::tempdir().expect("tempdir");
+
+        run_build_mates(&build_mates_args(in_dir.path(), out_dir.path())).expect("run_build_mates");
+
+        let mates_text =
+            fs::read_to_string(out_dir.path().join("mates.jsonl")).expect("mates.jsonl");
+        let mates: Vec<MateRecord> = mates_text
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("mate json"))
+            .collect();
+        assert_eq!(mates.len(), 1);
+        let record = &mates[0];
+        assert_eq!(record.winner, 'b');
+        assert_eq!(record.ply, 1);
+        assert_eq!(record.mate_in, 1);
+        assert_eq!(record.oracle_bestmove, "G*5b");
+        assert_eq!(record.oracle_depth, 7);
+        assert_eq!(record.oracle_nodes, None);
+        assert_eq!(record.sfen, MATE_IN_ONE_SFEN);
+
+        let meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(out_dir.path().join("meta.json")).unwrap())
+                .expect("meta json");
+        assert_eq!(meta["games_scanned"], 4);
+        assert_eq!(meta["toryo_games"], 3);
+        assert_eq!(meta["games_skipped_broken"], 1);
+        assert_eq!(meta["games_skipped_winner_mismatch"], 0);
+        // 詰み対局の候補 1 + 玉のみ対局の候補 2（ply 1, 3）。
+        assert_eq!(meta["candidate_positions"], 3);
+        assert_eq!(meta["mate_positions"], 1);
+        assert_eq!(meta["games_with_mates"], 1);
+        assert_eq!(meta["oracle_nodes"], serde_json::Value::Null);
+
+        // 同一入力の再実行で mates.jsonl は byte 一致する（oracle の決定性）。
+        let out_dir2 = tempfile::tempdir().expect("tempdir");
+        run_build_mates(&build_mates_args(in_dir.path(), out_dir2.path()))
+            .expect("run_build_mates twice");
+        let mates_text2 =
+            fs::read_to_string(out_dir2.path().join("mates.jsonl")).expect("mates.jsonl");
+        assert_eq!(mates_text, mates_text2);
+    }
+
+    #[test]
+    fn run_build_mates_max_games_limits_scan_order_prefix() {
+        let in_dir = tempfile::tempdir().expect("tempdir");
+        write_csa(in_dir.path(), "a_no_mate.csa", TORYO_NO_MATE_CSA);
+        write_csa(in_dir.path(), "b_mate.csa", TORYO_MATE_CSA);
+        let out_dir = tempfile::tempdir().expect("tempdir");
+
+        let mut args = build_mates_args(in_dir.path(), out_dir.path());
+        args.max_games = 1;
+        run_build_mates(&args).expect("run_build_mates");
+
+        let meta: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(out_dir.path().join("meta.json")).unwrap())
+                .expect("meta json");
+        // 走査順（ファイル名ソート）の先頭 1 対局 = a_no_mate のみが走査される。
+        assert_eq!(meta["games_scanned"], 1);
+        assert_eq!(meta["toryo_games"], 1);
+        assert_eq!(meta["mate_positions"], 0);
+    }
+
+    #[test]
+    fn concordance_pairs_orders_by_mate_in_and_skips_equal() {
+        // (mate_in, eval): mate_in 1 と 3 は順序一致、1 と 5 は tie、3 と 5 は逆転。
+        let items = [(1, 500), (3, 300), (5, 500)];
+        let pairs = concordance_pairs(&items);
+        assert_eq!(pairs, vec![(0, 1, 1.0), (0, 2, 0.5), (1, 2, 0.0)]);
+
+        // mate_in が同じ pair は数えない。
+        let items = [(3, 100), (3, 200)];
+        assert!(concordance_pairs(&items).is_empty());
+
+        // near/far は mate_in の大小で決まる（並び順に依存しない）。
+        let items = [(5, 100), (1, 200)];
+        assert_eq!(concordance_pairs(&items), vec![(1, 0, 1.0)]);
+
+        assert!(concordance_pairs(&[]).is_empty());
+        assert!(concordance_pairs(&[(1, 100)]).is_empty());
+    }
+
+    #[test]
+    fn top1_score_classifies_strict_max_tie_and_loss() {
+        // 厳密最大。
+        assert_eq!(top1_score(300, 300, 1), 1.0);
+        // 最大タイに含まれる。
+        assert_eq!(top1_score(300, 300, 2), 0.5);
+        // 最大でない。
+        assert_eq!(top1_score(100, 300, 1), 0.0);
+        assert_eq!(top1_score(100, 300, 3), 0.0);
+    }
+
+    fn write_mate_jsonl(path: &Path, records: &[MateRecord]) {
+        let mut out = String::new();
+        for record in records {
+            out.push_str(&serde_json::to_string(record).expect("json"));
+            out.push('\n');
+        }
+        fs::write(path, out).expect("write");
+    }
+
+    fn mate_record(source_csa: &str, ply: u32, mate_in: u32) -> MateRecord {
+        MateRecord {
+            source_csa: source_csa.to_string(),
+            winner: 'b',
+            ply,
+            sfen: MATE_IN_ONE_SFEN.to_string(),
+            mate_in,
+            oracle_bestmove: "G*5b".to_string(),
+            oracle_depth: 7,
+            oracle_nodes: None,
+        }
+    }
+
+    #[test]
+    fn count_mate_clusters_distinguishes_concordance_and_top1() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("mates.jsonl");
+        write_mate_jsonl(
+            &path,
+            &[
+                // 対局 a: mate_in が異なる 2 局面 → concordance / top-1 両方のクラスタ。
+                mate_record("a.csa", 5, 3),
+                mate_record("a.csa", 7, 1),
+                // 対局 b: mate_in が同一 → top-1 のみ。
+                mate_record("b.csa", 5, 3),
+                mate_record("b.csa", 7, 3),
+                // 対局 c: 1 局面のみ → top-1 のみ。
+                mate_record("c.csa", 9, 1),
+            ],
+        );
+        let counts = count_mate_clusters(&path).expect("counts");
+        assert_eq!(
+            counts,
+            MateClusterCounts {
+                concordance_games: 1,
+                top1_games: 3,
+            }
+        );
+
+        // source_csa の順序違反はエラー。
+        let bad = dir.path().join("bad.jsonl");
+        write_mate_jsonl(&bad, &[mate_record("b.csa", 5, 3), mate_record("a.csa", 7, 1)]);
+        assert!(count_mate_clusters(&bad).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **build-mates**: `%TORYO` 終局対局の終局間際の勝者手番局面を、material 評価・固定 depth (`--oracle-depth`)・ノード上限 (`--oracle-nodes`)・`EnteringKingRule::None` (宣言勝ちの mate 帯混入を排除) の単一スレッド探索でスクリーニングし、詰みを読み切った局面のみ `mates.jsonl` に採用。局面単位 rayon 並列 (順序保存・出力は決定的)
- **eval-mates**: 同一対局内の mate_in 順序 pair の concordance + 全合法手静的評価による詰み手 top-1 率。対局クラスタ streaming bootstrap 95% CI
- **eval 系の非 LayerStacks 汎化**: `--bucket-mode` を Option 化し、init_nnue がロードできる全アーキテクチャ (HalfKP 系含む) を評価可能に。bucket/progress は LayerStacks 専用で、非 LayerStacks での明示指定はエラー
- mate 帯 score は探索の読み切り結果であり厳密な証明値ではない (16-bit TT key 衝突・防御側不成の非生成) 旨を doc・コメントに明記

## 実データ smoke (floodgate)

- toryo 475 局 (depth 15 / nodes 1M / 16 threads): 候補 3,800 → 詰み採用 1,905 局面 (378 局)、343 秒
- eval-mates を 3 net (LayerStacks kingrank9 ×2 + HalfKP-768-16-64) で完走。mate_top1 に net 間で 0.163 vs 0.269 (CI 非重複) の有意差を検出 — 指標の感度確認
- 非 LayerStacks 汎化は HalfKP-768-16-64 の実 net ロード・評価で end-to-end 確認

## Test plan

- [x] cargo fmt --check / clippy (tools lib+bin) warning 0 / cargo test -p tools --lib 253 pass (新規 13 テスト: mate 帯境界・宣言成立形の正負対照・nodes 上限対照・決定性 byte 一致・bucket-mode 分岐等)
- [x] scripts/check-tracked-abs-paths.sh OK
- [x] local dual review: reviewer #1 (Codex) 初巡 REQUEST CHANGES (mate score の soundness 表現) → 修正 → 解消確認 / reviewer #2 (Claude) APPROVE (oracle の枝刈り経路・決定性・後方互換をコードレベル検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)