### PR TITLE
feat(gensfen): hcpe3 policy 分布を dlshogi 参照実装の既定に合わせる

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -11,7 +11,7 @@
 | `tournament` | 複数エンジンの round-robin 並列トーナメント、SPRT 検定 |
 | `analyze_selfplay` | tournament 出力の集計・Elo/nElo 算出・SPRT post-hoc 判定（[詳細](docs/analyze_selfplay.md)） |
 | `floodgate_record` | csa_client の per-game JSONL から 1 エンジンの戦績を集計（先後別勝率・相手別・後手勝ち/負け/引分・実戦 NPS、`--config` で csa_client 設定から入力導出、`--fetch-ratings` で wdoor 現在レート併記・履歴記録。floodgate 連続対局向け、[詳細](docs/floodgate_record.md)） |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、USI engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)） |
 | `floodgate_pipeline` | Floodgate棋譜のダウンロード・変換・`live-mirror --push` MONITOR2 着手通知付きリアルタイムミラー（[詳細](docs/floodgate_pipeline.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と出典 TSV を生成（[詳細](docs/nyugyoku_gensfen.md)） |
 | `book_from_csa` | CSA 棋譜群から YANEURAOU-DB2016 テキスト定跡 `.db` を生成（消費時間による定跡手判定・レート/勝敗フィルタ、[詳細](docs/book_from_csa.md)） |

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -168,8 +168,9 @@ position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1
 | `--output-training-data PATH` | `<out-dir>/gensfen.psv` | 学習データ出力先 |
 | `--emit-game-id-sidecar PATH` | — | PSV 各レコードと 1:1・同順の `game_id` を u32 little-endian で出力（PSV 専用） |
 | `--training-data-format FORMAT` | psv | `psv`（40バイト固定）/ `pack`（32バイト + メタ）/ `hcpe3`（可変長棋譜 + policy） |
-| `--hcpe3-policy-total N` | 1000 | hcpe3 の policy 分布に割り当てる visit 総票数 |
-| `--hcpe3-policy-temp F` | 600.0 | hcpe3 の policy softmax 温度（centipawn 単位、大きいほど分布を均す） |
+| `--hcpe3-policy-total N` | 65535 | hcpe3 の policy 分布に割り当てる visit 総票数 |
+| `--hcpe3-policy-temp F` | 100.0 | hcpe3 の policy softmax 温度（centipawn 単位、大きいほど分布を均す。0 以下は最善候補へ全票） |
+| `--hcpe3-eval-drop-threshold N` | 500 | 最善候補から N cp を超えて劣る候補を除外（負値で無効、実着手は常に保持） |
 | `--skip-initial-ply N` | 0 | 序盤 1〜N 手目をスキップ（hcpe3 でも prefix 連続なので可） |
 | `--skip-in-check BOOL` | false | 王手局面をスキップ（**hcpe3 では不可** = 中間スキップが replay を壊す） |
 
@@ -399,8 +400,8 @@ selectedMove16 には実際に着手した手を記録するため、ランダ�
 |-----------|--------|------|
 | hcp | 32 | 開始局面 |
 | moveNum | 2 | 手数 |
-| result | 1 | 0=引き分け / 1=先手勝ち / 2=後手勝ち |
-| opponent | 1 | 予約（0） |
+| result | 1 | 下位2bit: 0=引き分け / 1=先手勝ち / 2=後手勝ち。bit2=千日手、bit3=入玉宣言、bit4=最大手数 |
+| gameInfo | 1 | bit0-1=opponent（自己対局は0）、bit2-3=max_moves code（256=1、320=2、512=3、その他=0） |
 | 以下を moveNum 回 | | |
 | selectedMove16 | 2 | 実着手（hcpe move16） |
 | eval | 2 | 手番側視点 cp。詰みは 32000-ply 符号化 |
@@ -409,9 +410,16 @@ selectedMove16 には実際に着手した手を記録するため、ランダ�
 | move16 | 2 | 候補手（hcpe move16） |
 | visitNum | 2 | softmax 量子化した票数 |
 
-policy の票数は各候補の eval を温度 `--hcpe3-policy-temp` の softmax で確率化し
-`--hcpe3-policy-total` 票へ量子化する（詰み候補は ±10000 にクリップ、PV1 は必ず 1 票以上）。
+policy 候補は量子化前に、最善候補から `--hcpe3-eval-drop-threshold` を超えて劣る候補を
+除外する（負値で無効）。実際に着手した手は閾値を超えていても保持する。残った全候補へ
+最低 1 票を与え、残りを各候補の eval と温度 `--hcpe3-policy-temp` の softmax で配分して
+`--hcpe3-policy-total` 票へ量子化する。総票数が候補数未満なら候補数まで引き上げる。
+詰み候補は eval と同じ `±(32000-ply)` を softmax にも使用する。
 `--random-multi-pv` 未指定（候補なし）のときは実着手の one-hot（visit=1）になる。
+
+gensfen が書く eval は rshogi の cp スケールである。一方、dlshogi の `score_to_value` は
+`sigmoid(score / 756.086)` 固定で、`train.py` は `--use_evalfix` を指定した場合だけデータから
+係数を推定して補正する。dlshogi で学習するときは `--use_evalfix` を指定すること。
 
 ## 中断・再開（Resume）
 

--- a/crates/tools/docs/gensfen.md
+++ b/crates/tools/docs/gensfen.md
@@ -393,6 +393,7 @@ NativeBackend でこの指定を検出した場合は stderr に警告する。�
 `--random-multi-pv N`（N>1）を指定したときに収集される。`--random-multi-pv-diff 0` を併用すると
 着手を PV1 と同評価の候補に限定できる（同評価が PV1 だけなら実着手は PV1 になる）。なお
 selectedMove16 には実際に着手した手を記録するため、ランダム着手を使っても replay は崩れない。
+dlshogi の hcpe3 読み込み側は `moveNum <= 513` を前提とするため、`--max-moves` は 513 以下にすること。
 
 レコード（局面は開始局面 hcp から `selectedMove16` を辿って復元する = 手列が連続している必要）:
 
@@ -411,7 +412,8 @@ selectedMove16 には実際に着手した手を記録するため、ランダ�
 | visitNum | 2 | softmax 量子化した票数 |
 
 policy 候補は量子化前に、最善候補から `--hcpe3-eval-drop-threshold` を超えて劣る候補を
-除外する（負値で無効）。実際に着手した手は閾値を超えていても保持する。残った全候補へ
+除外する（負値で無効）。実際に着手した手は閾値を超えていても保持する。
+policy 候補数は `--random-multi-pv` の MultiPV 幅を超えない。残った全候補へ
 最低 1 票を与え、残りを各候補の eval と温度 `--hcpe3-policy-temp` の softmax で配分して
 `--hcpe3-policy-total` 票へ量子化する。総票数が候補数未満なら候補数まで引き上げる。
 詰み候補は eval と同じ `±(32000-ply)` を softmax にも使用する。
@@ -420,6 +422,11 @@ policy 候補は量子化前に、最善候補から `--hcpe3-eval-drop-threshol
 gensfen が書く eval は rshogi の cp スケールである。一方、dlshogi の `score_to_value` は
 `sigmoid(score / 756.086)` 固定で、`train.py` は `--use_evalfix` を指定した場合だけデータから
 係数を推定して補正する。dlshogi で学習するときは `--use_evalfix` を指定すること。
+
+参照実装との差異として、`MoveInfo.eval` の非詰み cp は psv 出力と共有する経路の規約を
+踏襲して ±10000 に clip する（参照実装は ±32767）。この経路を変えると psv 出力も変わる一方、
+`sigmoid(score / 756.086)` は 10000cp でほぼ飽和するため、学習への影響は小さい。
+また、`MoveInfo.eval` には実着手のスコアではなく PV1 の評価値を書く。
 
 ## 中断・再開（Resume）
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -7,7 +7,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | ツール | 説明 |
 |--------|------|
 | `tournament` | 複数エンジンの round-robin 並列トーナメント。JSONL 出力 |
-| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
+| `gensfen` | NNUE 学習用 PSV/pack/hcpe3 教師局面の生成（PSV move16 は実 YaneuraOu 形式、hcpe3 policy は既定 65535 票・温度 100、`--hcpe3-eval-drop-threshold` による候補除外と終局理由/gameInfo 符号化、engine vs engine／NativeBackend、native LS progress 係数、千日手裁定、異常終局の全局破棄、宣言勝ち PSV 終端局面、乱択来歴 JSONL 記録 (--omit-diversions で件数のみに省略可、deblunder 非互換)、FV_SCALE override、control.json 動的制御・drain、Windows でも動作可 (親 dir fsync はスキップされ電源断耐性が Unix より弱い)。[詳細](gensfen.md)） |
 | `nyugyoku_gensfen` | CSA manifest から入玉アンカー局面を disk-partition exact dedup で抽出し、checkpoint/resume 付きで gensfen 用 `startpos.txt` と provenance を生成（[詳細](nyugyoku_gensfen.md)） |
 | `csa_client` | USI エンジンを floodgate 等の CSA サーバーに接続して連続対局 |
 | `analyze_selfplay` | 自己対局の JSONL ログを集計。勝率・Elo 差・NPS 等を表示（[詳細](analyze_selfplay.md)） |

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -37,7 +37,9 @@ use tools::selfplay::{
 
 const DEFAULT_EVAL_HASH_SIZE_MB: usize = 64;
 const DEFAULT_HCPE3_EVAL_DROP_THRESHOLD: i32 = 500;
-const HCPE3_POLICY_ALGO_VERSION: u32 = 2;
+const HCPE3_POLICY_ALGO_VERSION: u32 = 3;
+// 消費側の固定長 buffer と将棋の合法手数上限に合わせる。
+const MAX_HCPE3_POLICY_CANDIDATES: u32 = 593;
 #[cfg(test)]
 const TEST_HCPE3_MAX_MOVES_GAME_INFO_CODE_1: u32 = 256;
 
@@ -798,6 +800,15 @@ struct TrainingEntry {
     hcpe3: Option<Hcpe3EntryData>,
 }
 
+/// hcpe3 policy の生成設定。
+#[derive(Clone, Copy)]
+struct Hcpe3PolicyConfig {
+    total: u16,
+    temp: f64,
+    multi_pv: u32,
+    eval_drop_threshold: i32,
+}
+
 /// 学習データ収集器
 /// 対局中の局面データを収集し、対局終了後に勝敗を設定して書き出す
 struct TrainingDataCollector {
@@ -806,12 +817,8 @@ struct TrainingDataCollector {
     /// PSV と同じループで game_id を書く。PSV 以外では常に None。
     game_id_writer: Option<BufWriter<File>>,
     format: TrainingFormat,
-    /// hcpe3 policy 分布の visit 総票数（softmax 量子化に使用）
-    policy_total: u16,
-    /// hcpe3 policy softmax の温度
-    policy_temp: f64,
-    /// hcpe3 policy 候補を除外する最善評価値との差
-    eval_drop_threshold: i32,
+    /// hcpe3 policy の生成設定
+    policy: Hcpe3PolicyConfig,
     /// hcpe3 gameInfo に符号化する最大手数
     max_moves: u32,
     skip_initial_ply: u32,
@@ -846,9 +853,12 @@ impl TrainingDataCollector {
             skip_initial_ply,
             skip_in_check,
             format,
-            policy_total,
-            policy_temp,
-            DEFAULT_HCPE3_EVAL_DROP_THRESHOLD,
+            Hcpe3PolicyConfig {
+                total: policy_total,
+                temp: policy_temp,
+                multi_pv: u32::MAX,
+                eval_drop_threshold: DEFAULT_HCPE3_EVAL_DROP_THRESHOLD,
+            },
             TEST_HCPE3_MAX_MOVES_GAME_INFO_CODE_1,
             game_id_path,
             false,
@@ -860,9 +870,7 @@ impl TrainingDataCollector {
         skip_initial_ply: u32,
         skip_in_check: bool,
         format: TrainingFormat,
-        policy_total: u16,
-        policy_temp: f64,
-        eval_drop_threshold: i32,
+        policy: Hcpe3PolicyConfig,
         max_moves: u32,
         game_id_path: Option<&Path>,
         append: bool,
@@ -894,9 +902,7 @@ impl TrainingDataCollector {
             writer: BufWriter::new(file),
             game_id_writer,
             format,
-            policy_total,
-            policy_temp,
-            eval_drop_threshold,
+            policy,
             max_moves,
             skip_initial_ply,
             skip_in_check,
@@ -1006,10 +1012,11 @@ impl TrainingDataCollector {
             } else {
                 multipv_to_policy(
                     candidates,
-                    selected_move16,
-                    self.policy_total,
-                    self.policy_temp,
-                    self.eval_drop_threshold,
+                    played_move,
+                    self.policy.total,
+                    self.policy.temp,
+                    self.policy.multi_pv,
+                    self.policy.eval_drop_threshold,
                 )
             };
             Some(Hcpe3EntryData {
@@ -1653,6 +1660,8 @@ fn mate_to_eval(score_mate: i32) -> i16 {
 
 fn candidate_eval(candidate: &MultiPvCandidate) -> i32 {
     candidate.score_mate.map_or(candidate.score_cp, |mate| {
+        // native backend の mate_ply は負け詰みでも手数が非負になり得るため、
+        // 勝敗符号が残る score_cp も使って詰み評価値の符号を復元する。
         let signed_mate = if mate < 0 || candidate.score_cp < 0 {
             -mate.abs()
         } else {
@@ -1668,28 +1677,51 @@ fn candidate_eval(candidate: &MultiPvCandidate) -> i32 {
 /// 厳密配分する。決定性のため候補と同端数の配分順は multipv 昇順にする。
 fn multipv_to_policy(
     candidates: &[MultiPvCandidate],
-    selected_move16: u16,
+    played_move: Move,
     total: u16,
     temp: f64,
+    multi_pv: u32,
     eval_drop_threshold: i32,
 ) -> Vec<(u16, u16)> {
-    let mut sorted: Vec<&MultiPvCandidate> = candidates.iter().collect();
+    let mut sorted = candidates.to_vec();
     sorted.sort_by_key(|c| c.multipv);
 
-    let scalar = candidate_eval;
-    if eval_drop_threshold >= 0 && !sorted.is_empty() {
-        let best_score = sorted.iter().map(|c| scalar(c)).max().unwrap_or(i32::MIN);
-        let filtered: Vec<&MultiPvCandidate> = sorted
-            .iter()
-            .copied()
-            .filter(|c| {
-                best_score.saturating_sub(scalar(c)) <= eval_drop_threshold
-                    || move_to_psv_move16(c.first_move) == selected_move16
-            })
-            .collect();
-        if !filtered.is_empty() {
-            sorted = filtered;
+    let mut seen_move16 = Vec::with_capacity(sorted.len());
+    sorted.retain(|c| {
+        let move16 = move_to_psv_move16(c.first_move);
+        if seen_move16.contains(&move16) {
+            false
+        } else {
+            seen_move16.push(move16);
+            true
         }
+    });
+
+    let selected_move16 = move_to_psv_move16(played_move);
+    if !seen_move16.contains(&selected_move16) {
+        let (score_cp, score_mate) =
+            sorted.first().map_or((0, None), |c| (c.score_cp, c.score_mate));
+        sorted.insert(
+            0,
+            MultiPvCandidate {
+                // 通常の MultiPV は 1-indexed。0 なら合成候補を常に先頭に固定できる。
+                multipv: 0,
+                score_cp,
+                score_mate,
+                first_move: played_move,
+            },
+        );
+    }
+
+    // 合成候補は先頭に挿入済みなので、末尾を切っても実着手は必ず残る。
+    sorted.truncate(multi_pv.clamp(1, MAX_HCPE3_POLICY_CANDIDATES) as usize);
+
+    if eval_drop_threshold >= 0 && !sorted.is_empty() {
+        let best_score = sorted.iter().map(candidate_eval).max().unwrap_or(i32::MIN);
+        sorted.retain(|c| {
+            best_score.saturating_sub(candidate_eval(c)) <= eval_drop_threshold
+                || move_to_psv_move16(c.first_move) == selected_move16
+        });
     }
 
     let total = u32::from(total).max(sorted.len() as u32).min(u32::from(u16::MAX));
@@ -1700,8 +1732,8 @@ fn multipv_to_policy(
     }
 
     if temp <= 0.0 {
-        let best_score = sorted.iter().map(|c| scalar(c)).max().unwrap_or(i32::MIN);
-        let best = sorted.iter().position(|c| scalar(c) == best_score).unwrap_or(0);
+        let best_score = sorted.iter().map(candidate_eval).max().unwrap_or(i32::MIN);
+        let best = sorted.iter().position(|c| candidate_eval(c) == best_score).unwrap_or(0);
         visits[best] += remaining;
         return sorted
             .iter()
@@ -1710,10 +1742,13 @@ fn multipv_to_policy(
             .collect();
     }
 
-    let max_s = sorted.iter().map(|c| f64::from(scalar(c))).fold(f64::NEG_INFINITY, f64::max);
+    let max_s = sorted
+        .iter()
+        .map(|c| f64::from(candidate_eval(c)))
+        .fold(f64::NEG_INFINITY, f64::max);
     let weights: Vec<f64> = sorted
         .iter()
-        .map(|c| ((f64::from(scalar(c)) - max_s) / temp).clamp(-700.0, 700.0).exp())
+        .map(|c| ((f64::from(candidate_eval(c)) - max_s) / temp).clamp(-700.0, 700.0).exp())
         .collect();
     let sum: f64 = weights.iter().sum();
 
@@ -2094,9 +2129,12 @@ fn worker_main(
                 cfg.skip_initial_ply,
                 cfg.skip_in_check,
                 cfg.training_format,
-                cfg.hcpe3_policy_total,
-                cfg.hcpe3_policy_temp,
-                cfg.hcpe3_eval_drop_threshold,
+                Hcpe3PolicyConfig {
+                    total: cfg.hcpe3_policy_total,
+                    temp: cfg.hcpe3_policy_temp,
+                    multi_pv: cfg.random_multi_pv,
+                    eval_drop_threshold: cfg.hcpe3_eval_drop_threshold,
+                },
                 cfg.max_moves,
                 cfg.game_id_sidecar_path.as_deref(),
                 cfg.append_checkpoints,
@@ -7410,7 +7448,7 @@ mod tests {
                 first_move: m2,
             },
         ];
-        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
+        let policy = multipv_to_policy(&candidates, m1, 1000, 600.0, 3, -1);
         assert!(!policy.is_empty());
         // PV1 (m1) が先頭で 1 票以上
         assert_eq!(policy[0].0, move_to_psv_move16(m1));
@@ -7441,7 +7479,7 @@ mod tests {
                 first_move: m2,
             },
         ];
-        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
+        let policy = multipv_to_policy(&candidates, m1, 1000, 600.0, 2, -1);
         assert_eq!(policy.len(), 2);
         assert_eq!(policy[0].1, policy[1].1);
     }
@@ -7944,7 +7982,8 @@ mod tests {
             legal_candidate(5, -120, "5g5f"),
         ];
         for total in [1u16, 7, 1000, 1001, 65535] {
-            let policy = multipv_to_policy(&candidates, 0, total, 600.0, -1);
+            let policy =
+                multipv_to_policy(&candidates, candidates[0].first_move, total, 600.0, 5, -1);
             let sum: u32 = policy.iter().map(|(_, v)| *v as u32).sum();
             assert_eq!(sum, u32::from(total).max(candidates.len() as u32), "total={total}");
             assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
@@ -7961,8 +8000,9 @@ mod tests {
             legal_candidate(2, 499, "2g2f"),
             legal_candidate(3, 498, "3g3f"),
         ];
-        let selected = move_to_psv_move16(candidates[2].first_move);
-        let policy = multipv_to_policy(&candidates, selected, 100, 100.0, 500);
+        let selected_move = candidates[2].first_move;
+        let selected = move_to_psv_move16(selected_move);
+        let policy = multipv_to_policy(&candidates, selected_move, 100, 100.0, 3, 500);
 
         assert_eq!(policy.len(), 2);
         assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
@@ -7972,14 +8012,149 @@ mod tests {
     }
 
     #[test]
+    fn multipv_to_policy_inserts_missing_played_move_first() {
+        use rshogi_core::types::Move;
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(2, 80, "2g2f"),
+            legal_candidate(1, 100, "7g7f"),
+        ];
+        let played = Move::from_usi("3g3f").unwrap();
+        let policy = multipv_to_policy(&candidates, played, 100, 100.0, 2, 0);
+
+        assert_eq!(policy.len(), 2);
+        assert_eq!(policy[0].0, move_to_psv_move16(played));
+        assert!(policy[0].1 >= 1);
+        assert_eq!(policy.iter().map(|(_, visit)| u32::from(*visit)).sum::<u32>(), 100);
+    }
+
+    #[test]
+    fn multipv_to_policy_trims_synthetic_candidate_to_multi_pv_width() {
+        use rshogi_core::types::Move;
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(1, 100, "7g7f"),
+            legal_candidate(2, 80, "2g2f"),
+            legal_candidate(3, 60, "3g3f"),
+        ];
+        let played = Move::from_usi("6g6f").unwrap();
+        let policy = multipv_to_policy(&candidates, played, 100, 100.0, 3, -1);
+
+        assert_eq!(policy.len(), 3);
+        assert_eq!(policy[0].0, move_to_psv_move16(played));
+        assert_eq!(policy[1].0, move_to_psv_move16(candidates[0].first_move));
+        assert_eq!(policy[2].0, move_to_psv_move16(candidates[1].first_move));
+        assert!(
+            !policy
+                .iter()
+                .any(|(move16, _)| *move16 == move_to_psv_move16(candidates[2].first_move))
+        );
+        assert_eq!(policy.iter().map(|(_, visit)| u32::from(*visit)).sum::<u32>(), 100);
+    }
+
+    #[test]
+    fn multipv_to_policy_keeps_all_candidates_when_played_move_is_within_exact_width() {
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(1, 100, "7g7f"),
+            legal_candidate(2, 80, "2g2f"),
+            legal_candidate(3, 60, "3g3f"),
+        ];
+        let played = candidates[1].first_move;
+        let policy = multipv_to_policy(&candidates, played, 100, 100.0, 3, -1);
+
+        assert_eq!(policy.len(), candidates.len());
+        assert_eq!(
+            policy.iter().map(|(move16, _)| *move16).collect::<Vec<_>>(),
+            candidates
+                .iter()
+                .map(|candidate| move_to_psv_move16(candidate.first_move))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(policy.iter().map(|(_, visit)| u32::from(*visit)).sum::<u32>(), 100);
+    }
+
+    #[test]
+    fn multipv_to_policy_caps_width_at_hcpe3_candidate_limit() {
+        use rshogi_core::types::{Move, Square};
+
+        let candidates = (0..=MAX_HCPE3_POLICY_CANDIDATES)
+            .map(|index| MultiPvCandidate {
+                multipv: index + 1,
+                score_cp: 0,
+                score_mate: None,
+                first_move: Move::new_move(
+                    Square::from_u8((index / 81) as u8).unwrap(),
+                    Square::from_u8((index % 81) as u8).unwrap(),
+                    false,
+                ),
+            })
+            .collect::<Vec<_>>();
+        let policy = multipv_to_policy(
+            &candidates,
+            candidates[0].first_move,
+            1000,
+            100.0,
+            MAX_HCPE3_POLICY_CANDIDATES + 1,
+            -1,
+        );
+
+        assert_eq!(policy.len(), MAX_HCPE3_POLICY_CANDIDATES as usize);
+    }
+
+    #[test]
+    fn multipv_to_policy_clamps_multi_pv_width_to_one() {
+        use rshogi_core::types::Move;
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(1, 100, "7g7f"),
+            legal_candidate(2, 80, "2g2f"),
+        ];
+        let played = Move::from_usi("3g3f").unwrap();
+
+        for multi_pv in [0, 1] {
+            let policy = multipv_to_policy(&candidates, played, 100, 100.0, multi_pv, -1);
+            assert_eq!(policy, vec![(move_to_psv_move16(played), 100)]);
+        }
+    }
+
+    #[test]
+    fn multipv_to_policy_deduplicates_move16_by_lowest_multipv() {
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(3, -500, "7g7f"),
+            legal_candidate(2, 50, "2g2f"),
+            legal_candidate(1, 100, "7g7f"),
+        ];
+        let policy = multipv_to_policy(&candidates, candidates[0].first_move, 100, 100.0, 3, -1);
+
+        assert_eq!(policy.len(), 2);
+        assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
+        assert_eq!(policy.iter().map(|(_, visit)| u32::from(*visit)).sum::<u32>(), 100);
+        assert_eq!(
+            policy
+                .iter()
+                .filter(|(move16, _)| { *move16 == move_to_psv_move16(candidates[0].first_move) })
+                .count(),
+            1
+        );
+        assert!(policy[0].1 > policy[1].1);
+    }
+
+    #[test]
     fn multipv_to_policy_is_deterministic() {
         let candidates = vec![
             legal_candidate(3, 26, "3g3f"),
             legal_candidate(1, 100, "7g7f"),
             legal_candidate(2, 63, "2g2f"),
         ];
-        let a = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
-        let b = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
+        let a = multipv_to_policy(&candidates, candidates[1].first_move, 1000, 600.0, 3, -1);
+        let b = multipv_to_policy(&candidates, candidates[1].first_move, 1000, 600.0, 3, -1);
         assert_eq!(a, b);
     }
 
@@ -7994,7 +8169,7 @@ mod tests {
         ];
 
         for temp in [0.0, -1.0] {
-            let policy = multipv_to_policy(&candidates, 0, 100, temp, -1);
+            let policy = multipv_to_policy(&candidates, candidates[2].first_move, 100, temp, 3, -1);
             assert_eq!(policy[0], (move_to_psv_move16(candidates[2].first_move), 98));
             assert_eq!(policy[1], (move_to_psv_move16(candidates[1].first_move), 1));
             assert_eq!(policy[2], (move_to_psv_move16(candidates[0].first_move), 1));
@@ -8039,7 +8214,7 @@ mod tests {
             },
         ];
         assert_eq!(candidate_eval(&candidates[1]), -31995);
-        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
+        let policy = multipv_to_policy(&candidates, good, 1000, 600.0, 2, -1);
         let good_v = policy
             .iter()
             .find(|(m, _)| *m == move_to_psv_move16(good))
@@ -8105,8 +8280,10 @@ mod tests {
         let bytes = std::fs::read(&path).unwrap();
         let _ = std::fs::remove_file(&path);
 
-        // selectedMove16(36..38) は実着手、候補 move16(42..44) は PV1 = 最善手。両者は異なる
-        assert_ne!(bytes[36..38], bytes[42..44]);
+        // 実着手が MultiPV に無くても合成候補として先頭に入り、policy に 1 票以上を持つ
+        assert_eq!(u16::from_le_bytes([bytes[40], bytes[41]]), 2);
+        assert_eq!(bytes[36..38], bytes[42..44]);
+        assert!(u16::from_le_bytes([bytes[44], bytes[45]]) >= 1);
     }
 
     #[test]

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -36,6 +36,10 @@ use tools::selfplay::{
 };
 
 const DEFAULT_EVAL_HASH_SIZE_MB: usize = 64;
+const DEFAULT_HCPE3_EVAL_DROP_THRESHOLD: i32 = 500;
+const HCPE3_POLICY_ALGO_VERSION: u32 = 2;
+#[cfg(test)]
+const TEST_HCPE3_MAX_MOVES_GAME_INFO_CODE_1: u32 = 256;
 
 /// NNUE 学習用の教師局面（PSV/pack）を生成する gensfen ツール。
 /// NativeBackend で `--eval-file` 指定の評価関数を使い、対局を回しながら
@@ -261,12 +265,16 @@ struct Cli {
     training_data_format: String,
 
     /// hcpe3 形式の policy 分布に割り当てる visit の総票数
-    #[arg(long, default_value_t = 1000)]
+    #[arg(long, default_value_t = 65535)]
     hcpe3_policy_total: u16,
 
     /// hcpe3 形式の policy softmax の温度（centipawn 単位、大きいほど分布を均す）
-    #[arg(long, default_value_t = 600.0)]
+    #[arg(long, default_value_t = 100.0)]
     hcpe3_policy_temp: f64,
+
+    /// hcpe3 policy から最善候補との差がこの値を超える候補を除外する（負値で無効）
+    #[arg(long, default_value_t = DEFAULT_HCPE3_EVAL_DROP_THRESHOLD)]
+    hcpe3_eval_drop_threshold: i32,
 
     /// Number of concurrent worker threads
     #[arg(long, default_value_t = 1)]
@@ -802,6 +810,10 @@ struct TrainingDataCollector {
     policy_total: u16,
     /// hcpe3 policy softmax の温度
     policy_temp: f64,
+    /// hcpe3 policy 候補を除外する最善評価値との差
+    eval_drop_threshold: i32,
+    /// hcpe3 gameInfo に符号化する最大手数
+    max_moves: u32,
     skip_initial_ply: u32,
     skip_in_check: bool,
     total_written: u64,
@@ -836,6 +848,8 @@ impl TrainingDataCollector {
             format,
             policy_total,
             policy_temp,
+            DEFAULT_HCPE3_EVAL_DROP_THRESHOLD,
+            TEST_HCPE3_MAX_MOVES_GAME_INFO_CODE_1,
             game_id_path,
             false,
         )
@@ -848,6 +862,8 @@ impl TrainingDataCollector {
         format: TrainingFormat,
         policy_total: u16,
         policy_temp: f64,
+        eval_drop_threshold: i32,
+        max_moves: u32,
         game_id_path: Option<&Path>,
         append: bool,
     ) -> Result<Self> {
@@ -880,6 +896,8 @@ impl TrainingDataCollector {
             format,
             policy_total,
             policy_temp,
+            eval_drop_threshold,
+            max_moves,
             skip_initial_ply,
             skip_in_check,
             total_written: 0,
@@ -986,7 +1004,13 @@ impl TrainingDataCollector {
             let policy = if candidates.is_empty() {
                 vec![(selected_move16, 1u16)]
             } else {
-                multipv_to_policy(candidates, self.policy_total, self.policy_temp)
+                multipv_to_policy(
+                    candidates,
+                    selected_move16,
+                    self.policy_total,
+                    self.policy_temp,
+                    self.eval_drop_threshold,
+                )
             };
             Some(Hcpe3EntryData {
                 selected_move16,
@@ -1031,9 +1055,20 @@ impl TrainingDataCollector {
     }
 
     /// 対局終了時に勝敗を設定して書き出す
+    #[cfg(test)]
     fn finish_game(
         &mut self,
         outcome: GameOutcome,
+        disposition: TrainingDisposition,
+        game_id: u32,
+    ) -> Result<()> {
+        self.finish_game_with_reason(outcome, OutcomeReason::Mate, disposition, game_id)
+    }
+
+    fn finish_game_with_reason(
+        &mut self,
+        outcome: GameOutcome,
+        outcome_reason: OutcomeReason,
         disposition: TrainingDisposition,
         game_id: u32,
     ) -> Result<()> {
@@ -1059,7 +1094,7 @@ impl TrainingDataCollector {
         match self.format {
             TrainingFormat::Psv => self.finish_game_psv(outcome, game_id)?,
             TrainingFormat::Pack => self.finish_game_pack(outcome)?,
-            TrainingFormat::Hcpe3 => self.finish_game_hcpe3(outcome)?,
+            TrainingFormat::Hcpe3 => self.finish_game_hcpe3(outcome, outcome_reason)?,
         }
 
         self.entries.clear();
@@ -1149,27 +1184,27 @@ impl TrainingDataCollector {
     /// hcpe3 形式で書き出す（可変長対局棋譜 + 各手の policy 分布）。
     ///
     /// レイアウト:
-    ///   [hcp: 32byte][moveNum: u16 LE][result: u8][opponent: u8]
+    ///   [hcp: 32byte][moveNum: u16 LE][result: u8][gameInfo: u8]
     ///   moveNum 回: [selectedMove16: u16 LE][eval: i16 LE][candidateNum: u16 LE]
     ///               candidateNum 回: [move16: u16 LE][visitNum: u16 LE]
     /// result は 0=draw / 1=black_win / 2=white_win。move16 は hcpe 形式。
     /// 局面は hcp から selectedMove16 を順に辿って再構成するため手列が連続している必要がある。
-    fn finish_game_hcpe3(&mut self, outcome: GameOutcome) -> Result<()> {
+    fn finish_game_hcpe3(
+        &mut self,
+        outcome: GameOutcome,
+        outcome_reason: OutcomeReason,
+    ) -> Result<()> {
         let (hcp, _start_ply, _is_hirate) =
             self.start_hcp.ok_or_else(|| anyhow!("hcpe3 format: start_hcp not set"))?;
         let move_num: u16 = self.entries.len().try_into().map_err(|_| {
             anyhow!("hcpe3 format: too many moves in one game ({})", self.entries.len())
         })?;
-        let result: u8 = match outcome {
-            GameOutcome::BlackWin => 1,
-            GameOutcome::WhiteWin => 2,
-            GameOutcome::Draw => 0,
-            GameOutcome::InProgress => unreachable!(),
-        };
+        let result = hcpe3_result(outcome, outcome_reason);
+        let game_info = hcpe3_game_info(self.max_moves);
 
         self.writer.write_all(&hcp)?;
         self.writer.write_all(&move_num.to_le_bytes())?;
-        self.writer.write_all(&[result, 0u8])?;
+        self.writer.write_all(&[result, game_info])?;
 
         for entry in &self.entries {
             let h = entry
@@ -1233,6 +1268,31 @@ impl TrainingDataCollector {
             discarded_no_bestmove_games: self.discarded_no_bestmove_games,
             declaration_win_dedup_skipped_games: self.declaration_win_dedup_skipped_games,
         }
+    }
+}
+
+fn hcpe3_result(outcome: GameOutcome, outcome_reason: OutcomeReason) -> u8 {
+    let result = match outcome {
+        GameOutcome::BlackWin => 1,
+        GameOutcome::WhiteWin => 2,
+        GameOutcome::Draw => 0,
+        GameOutcome::InProgress => unreachable!(),
+    };
+    result
+        | match outcome_reason {
+            OutcomeReason::Sennichite | OutcomeReason::PerpetualCheck => 4,
+            OutcomeReason::Win => 8,
+            OutcomeReason::MaxMoves => 16,
+            _ => 0,
+        }
+}
+
+fn hcpe3_game_info(max_moves: u32) -> u8 {
+    match max_moves {
+        256 => 1 << 2,
+        320 => 2 << 2,
+        512 => 3 << 2,
+        _ => 0,
     }
 }
 
@@ -1427,8 +1487,8 @@ fn validate_hcpe3_opts(
     if policy_total == 0 {
         bail!("--hcpe3-policy-total must be >= 1");
     }
-    if !(policy_temp.is_finite() && policy_temp > 0.0) {
-        bail!("--hcpe3-policy-temp must be a finite value > 0");
+    if !policy_temp.is_finite() {
+        bail!("--hcpe3-policy-temp must be finite");
     }
     Ok(())
 }
@@ -1591,27 +1651,77 @@ fn mate_to_eval(score_mate: i32) -> i16 {
     }
 }
 
+fn candidate_eval(candidate: &MultiPvCandidate) -> i32 {
+    candidate.score_mate.map_or(candidate.score_cp, |mate| {
+        let signed_mate = if mate < 0 || candidate.score_cp < 0 {
+            -mate.abs()
+        } else {
+            mate.abs()
+        };
+        i32::from(mate_to_eval(signed_mate))
+    })
+}
+
 /// MultiPV 候補を hcpe3 の policy 分布 `(move16, visit)` へ変換する。
 ///
-/// 各候補スコアを温度 `temp` の softmax で確率化し、largest-remainder 法で `total` 票へ
-/// 厳密配分する（`sum(visit) == total`）。詰みは `±10000` にクリップして softmax を安定
-/// させる。決定性のため multipv 昇順で安定ソートし、余り票も端数の大きい順（同点は multipv
-/// 昇順）で決定的に配る。PV1 は必ず 1 票以上残す（0 票の候補は落とす）。
-fn multipv_to_policy(candidates: &[MultiPvCandidate], total: u16, temp: f64) -> Vec<(u16, u16)> {
+/// 各候補に最低 1 票を与え、残りを温度 `temp` の softmax と largest-remainder 法で
+/// 厳密配分する。決定性のため候補と同端数の配分順は multipv 昇順にする。
+fn multipv_to_policy(
+    candidates: &[MultiPvCandidate],
+    selected_move16: u16,
+    total: u16,
+    temp: f64,
+    eval_drop_threshold: i32,
+) -> Vec<(u16, u16)> {
     let mut sorted: Vec<&MultiPvCandidate> = candidates.iter().collect();
     sorted.sort_by_key(|c| c.multipv);
 
-    // 符号付きの score_cp（詰みも大きな正/負の値で符号を持つ）を ±10000 にクリップして
-    // softmax 入力にする。score_mate は手数のみで勝敗符号を持たない経路があるため使わない。
-    let scalar = |c: &MultiPvCandidate| -> f64 { f64::from(c.score_cp.clamp(-10000, 10000)) };
-    let max_s = sorted.iter().map(|c| scalar(c)).fold(f64::NEG_INFINITY, f64::max);
-    let weights: Vec<f64> = sorted.iter().map(|c| ((scalar(c) - max_s) / temp).exp()).collect();
+    let scalar = candidate_eval;
+    if eval_drop_threshold >= 0 && !sorted.is_empty() {
+        let best_score = sorted.iter().map(|c| scalar(c)).max().unwrap_or(i32::MIN);
+        let filtered: Vec<&MultiPvCandidate> = sorted
+            .iter()
+            .copied()
+            .filter(|c| {
+                best_score.saturating_sub(scalar(c)) <= eval_drop_threshold
+                    || move_to_psv_move16(c.first_move) == selected_move16
+            })
+            .collect();
+        if !filtered.is_empty() {
+            sorted = filtered;
+        }
+    }
+
+    let total = u32::from(total).max(sorted.len() as u32).min(u32::from(u16::MAX));
+    let mut visits = vec![1u32; sorted.len()];
+    let remaining = total - sorted.len() as u32;
+    if remaining == 0 {
+        return sorted.iter().map(|c| (move_to_psv_move16(c.first_move), 1)).collect();
+    }
+
+    if temp <= 0.0 {
+        let best_score = sorted.iter().map(|c| scalar(c)).max().unwrap_or(i32::MIN);
+        let best = sorted.iter().position(|c| scalar(c) == best_score).unwrap_or(0);
+        visits[best] += remaining;
+        return sorted
+            .iter()
+            .zip(visits)
+            .map(|(c, visit)| (move_to_psv_move16(c.first_move), visit as u16))
+            .collect();
+    }
+
+    let max_s = sorted.iter().map(|c| f64::from(scalar(c))).fold(f64::NEG_INFINITY, f64::max);
+    let weights: Vec<f64> = sorted
+        .iter()
+        .map(|c| ((f64::from(scalar(c)) - max_s) / temp).clamp(-700.0, 700.0).exp())
+        .collect();
     let sum: f64 = weights.iter().sum();
 
-    // 各候補の理想票と floor を取り、不足分を端数の大きい順に 1 票ずつ配る。
-    let ideals: Vec<f64> = weights.iter().map(|w| w / sum * total as f64).collect();
-    let mut visits: Vec<u32> = ideals.iter().map(|x| x.floor() as u32).collect();
-    let mut leftover = total as u32 - visits.iter().sum::<u32>();
+    let ideals: Vec<f64> = weights.iter().map(|w| w / sum * f64::from(remaining)).collect();
+    for (visit, ideal) in visits.iter_mut().zip(&ideals) {
+        *visit += ideal.floor() as u32;
+    }
+    let mut leftover = total - visits.iter().sum::<u32>();
     let mut order: Vec<usize> = (0..sorted.len()).collect();
     order.sort_by(|&a, &b| {
         let ra = ideals[a] - ideals[a].floor();
@@ -1626,23 +1736,11 @@ fn multipv_to_policy(candidates: &[MultiPvCandidate], total: u16, temp: f64) -> 
         leftover -= 1;
     }
 
-    // PV1 は最低 1 票。0 票なら最大票の候補から 1 票移す（総票数は不変）。
-    if let Some(pv1) = sorted.iter().position(|c| c.multipv == 1)
-        && visits[pv1] == 0
-        && let Some(donor) = (0..visits.len()).max_by_key(|&i| visits[i])
-        && visits[donor] > 0
-    {
-        visits[donor] -= 1;
-        visits[pv1] += 1;
-    }
-
-    let mut out: Vec<(u16, u16)> = Vec::with_capacity(sorted.len());
-    for (c, &v) in sorted.iter().zip(&visits) {
-        if v > 0 {
-            out.push((move_to_psv_move16(c.first_move), v as u16));
-        }
-    }
-    out
+    sorted
+        .iter()
+        .zip(visits)
+        .map(|(c, visit)| (move_to_psv_move16(c.first_move), visit as u16))
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1884,6 +1982,7 @@ struct WorkerConfig {
     training_format: TrainingFormat,
     hcpe3_policy_total: u16,
     hcpe3_policy_temp: f64,
+    hcpe3_eval_drop_threshold: i32,
     // gensfen: NativeBackend モード
     native_mode: bool,
     /// USI 単一エンジン最適化（先後同一エンジン時に 1 プロセスで兼用）。
@@ -1997,6 +2096,8 @@ fn worker_main(
                 cfg.training_format,
                 cfg.hcpe3_policy_total,
                 cfg.hcpe3_policy_temp,
+                cfg.hcpe3_eval_drop_threshold,
+                cfg.max_moves,
                 cfg.game_id_sidecar_path.as_deref(),
                 cfg.append_checkpoints,
             )?)
@@ -2465,7 +2566,12 @@ fn worker_main(
             }
 
             if let Some(ref mut collector) = training_data_collector {
-                collector.finish_game(outcome, training_disposition, game_idx + 1)?;
+                collector.finish_game_with_reason(
+                    outcome,
+                    outcome_reason,
+                    training_disposition,
+                    game_idx + 1,
+                )?;
             }
             if training_disposition.is_adopted()
                 && let Some(dedup_hash) = dedup_hash.as_deref()
@@ -3064,6 +3170,20 @@ fn validate_resume_fingerprint(meta: Option<&Value>, current: &Value) -> Result<
         "--resume: generation fingerprint mismatch in fields: {}",
         differences.join(", ")
     )
+}
+
+fn add_hcpe3_policy_fingerprint(
+    fingerprint: &mut Value,
+    format: TrainingFormat,
+    eval_drop_threshold: i32,
+) {
+    if format == TrainingFormat::Hcpe3 {
+        // psv / pack の既存 run を巻き込まず、hcpe3 の policy 生成規約が変わった
+        // checkpoint からの resume を拒否するため、hcpe3 のときだけ常に記録する。
+        fingerprint["training"]["hcpe3_eval_drop_threshold"] =
+            serde_json::json!(eval_drop_threshold);
+        fingerprint["training"]["hcpe3_policy_algo"] = serde_json::json!(HCPE3_POLICY_ALGO_VERSION);
+    }
 }
 
 fn collect_json_differences(prefix: &str, left: &Value, right: &Value, out: &mut Vec<String>) {
@@ -4620,6 +4740,11 @@ fn main() -> Result<()> {
         // relabel_psv --deblunder の境界判定を silent に壊すため resume で拒否する。
         generation_fingerprint["auxiliary_outputs"]["omit_diversions"] = serde_json::json!(true);
     }
+    add_hcpe3_policy_fingerprint(
+        &mut generation_fingerprint,
+        training_format,
+        cli.hcpe3_eval_drop_threshold,
+    );
     if let Some(state) = &resume_state {
         validate_resume_fingerprint(state.fingerprint.as_ref(), &generation_fingerprint)?;
     }
@@ -4907,6 +5032,7 @@ fn main() -> Result<()> {
                 training_format,
                 hcpe3_policy_total: cli.hcpe3_policy_total,
                 hcpe3_policy_temp: cli.hcpe3_policy_temp,
+                hcpe3_eval_drop_threshold: cli.hcpe3_eval_drop_threshold,
                 native_mode,
                 usi_single,
                 eval_hash_size_mb: DEFAULT_EVAL_HASH_SIZE_MB,
@@ -6987,6 +7113,30 @@ mod tests {
     }
 
     #[test]
+    fn hcpe3_policy_fingerprint_is_format_specific() {
+        let mut psv = serde_json::json!({"training": {}});
+        add_hcpe3_policy_fingerprint(
+            &mut psv,
+            TrainingFormat::Psv,
+            DEFAULT_HCPE3_EVAL_DROP_THRESHOLD,
+        );
+        assert!(psv["training"].get("hcpe3_eval_drop_threshold").is_none());
+        assert!(psv["training"].get("hcpe3_policy_algo").is_none());
+
+        let mut hcpe3 = serde_json::json!({"training": {}});
+        add_hcpe3_policy_fingerprint(
+            &mut hcpe3,
+            TrainingFormat::Hcpe3,
+            DEFAULT_HCPE3_EVAL_DROP_THRESHOLD,
+        );
+        assert_eq!(
+            hcpe3["training"]["hcpe3_eval_drop_threshold"],
+            DEFAULT_HCPE3_EVAL_DROP_THRESHOLD
+        );
+        assert_eq!(hcpe3["training"]["hcpe3_policy_algo"], HCPE3_POLICY_ALGO_VERSION);
+    }
+
+    #[test]
     fn failed_training_commit_does_not_write_result() {
         let result = ResultLog {
             kind: "result",
@@ -7173,7 +7323,7 @@ mod tests {
                 first_move: m2,
             },
         ];
-        let policy = multipv_to_policy(&candidates, 1000, 600.0);
+        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
         assert!(!policy.is_empty());
         // PV1 (m1) が先頭で 1 票以上
         assert_eq!(policy[0].0, move_to_psv_move16(m1));
@@ -7204,7 +7354,7 @@ mod tests {
                 first_move: m2,
             },
         ];
-        let policy = multipv_to_policy(&candidates, 1000, 600.0);
+        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
         assert_eq!(policy.len(), 2);
         assert_eq!(policy[0].1, policy[1].1);
     }
@@ -7214,7 +7364,7 @@ mod tests {
         // hcpe3 は中間スキップ・不正 policy パラメータを拒否する
         assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, true, 1000, 600.0).is_err());
         assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, false, 0, 600.0).is_err());
-        assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, false, 1000, 0.0).is_err());
+        assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, false, 1000, 0.0).is_ok());
         assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, false, 1000, f64::NAN).is_err());
         assert!(validate_hcpe3_opts(TrainingFormat::Hcpe3, false, 1000, 600.0).is_ok());
         // 他形式には制約を課さない
@@ -7615,7 +7765,7 @@ mod tests {
         assert_eq!(bytes.len(), 46);
         assert_eq!(u16::from_le_bytes([bytes[32], bytes[33]]), 1); // moveNum
         assert_eq!(bytes[34], 1); // result = BLACK_WIN
-        assert_eq!(bytes[35], 0); // opponent(予約)
+        assert_eq!(bytes[35], 4); // gameInfo: max_moves=256
         assert_eq!(i16::from_le_bytes([bytes[38], bytes[39]]), 123); // eval
         assert_eq!(u16::from_le_bytes([bytes[40], bytes[41]]), 1); // candidateNum
         assert_eq!(bytes[36..38], bytes[42..44]); // selectedMove16 == 候補 move16
@@ -7707,12 +7857,31 @@ mod tests {
             legal_candidate(5, -120, "5g5f"),
         ];
         for total in [1u16, 7, 1000, 1001, 65535] {
-            let policy = multipv_to_policy(&candidates, total, 600.0);
+            let policy = multipv_to_policy(&candidates, 0, total, 600.0, -1);
             let sum: u32 = policy.iter().map(|(_, v)| *v as u32).sum();
-            assert_eq!(sum, total as u32, "total={total}");
+            assert_eq!(sum, u32::from(total).max(candidates.len() as u32), "total={total}");
             assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
-            assert!(policy[0].1 >= 1);
+            assert!(policy.iter().all(|(_, visit)| *visit >= 1));
         }
+    }
+
+    #[test]
+    fn multipv_to_policy_filters_eval_drop_but_keeps_selected_move() {
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(1, 1000, "7g7f"),
+            legal_candidate(2, 499, "2g2f"),
+            legal_candidate(3, 498, "3g3f"),
+        ];
+        let selected = move_to_psv_move16(candidates[2].first_move);
+        let policy = multipv_to_policy(&candidates, selected, 100, 100.0, 500);
+
+        assert_eq!(policy.len(), 2);
+        assert_eq!(policy[0].0, move_to_psv_move16(candidates[0].first_move));
+        assert_eq!(policy[1].0, selected);
+        assert_eq!(policy.iter().map(|(_, visit)| u32::from(*visit)).sum::<u32>(), 100);
+        assert!(policy.iter().all(|(_, visit)| *visit >= 1));
     }
 
     #[test]
@@ -7722,9 +7891,41 @@ mod tests {
             legal_candidate(1, 100, "7g7f"),
             legal_candidate(2, 63, "2g2f"),
         ];
-        let a = multipv_to_policy(&candidates, 1000, 600.0);
-        let b = multipv_to_policy(&candidates, 1000, 600.0);
+        let a = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
+        let b = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn multipv_to_policy_greedy_selects_first_best_candidate() {
+        use tools::packed_sfen::move_to_psv_move16;
+
+        let candidates = vec![
+            legal_candidate(3, 50, "3g3f"),
+            legal_candidate(2, 100, "2g2f"),
+            legal_candidate(1, 100, "7g7f"),
+        ];
+
+        for temp in [0.0, -1.0] {
+            let policy = multipv_to_policy(&candidates, 0, 100, temp, -1);
+            assert_eq!(policy[0], (move_to_psv_move16(candidates[2].first_move), 98));
+            assert_eq!(policy[1], (move_to_psv_move16(candidates[1].first_move), 1));
+            assert_eq!(policy[2], (move_to_psv_move16(candidates[0].first_move), 1));
+        }
+    }
+
+    #[test]
+    fn hcpe3_game_info_and_result_flags_match_dlshogi_layout() {
+        assert_eq!(hcpe3_game_info(256), 4);
+        assert_eq!(hcpe3_game_info(320), 8);
+        assert_eq!(hcpe3_game_info(512), 12);
+        assert_eq!(hcpe3_game_info(400), 0);
+
+        assert_eq!(hcpe3_result(GameOutcome::Draw, OutcomeReason::Sennichite), 4);
+        assert_eq!(hcpe3_result(GameOutcome::WhiteWin, OutcomeReason::PerpetualCheck), 6);
+        assert_eq!(hcpe3_result(GameOutcome::BlackWin, OutcomeReason::Win), 9);
+        assert_eq!(hcpe3_result(GameOutcome::Draw, OutcomeReason::MaxMoves), 16);
+        assert_eq!(hcpe3_result(GameOutcome::BlackWin, OutcomeReason::Mate), 1);
     }
 
     #[test]
@@ -7735,7 +7936,7 @@ mod tests {
 
         let good = Move::from_usi("7g7f").unwrap();
         let losing = Move::from_usi("2g2f").unwrap();
-        // PV2 は負け詰み: score_mate は手数のみで正(5)、勝敗符号は score_cp(大きな負)に残る
+        // PV2 は負け詰み
         let candidates = vec![
             MultiPvCandidate {
                 multipv: 1,
@@ -7750,7 +7951,8 @@ mod tests {
                 first_move: losing,
             },
         ];
-        let policy = multipv_to_policy(&candidates, 1000, 600.0);
+        assert_eq!(candidate_eval(&candidates[1]), -31995);
+        let policy = multipv_to_policy(&candidates, 0, 1000, 600.0, -1);
         let good_v = policy
             .iter()
             .find(|(m, _)| *m == move_to_psv_move16(good))
@@ -7761,6 +7963,24 @@ mod tests {
             .map_or(0, |(_, v)| *v);
         // 符号付き score_cp で負け詰みは大きく減点され、PV1 を上回らない
         assert!(good_v > losing_v);
+    }
+
+    #[test]
+    fn candidate_eval_handles_signed_usi_mate_and_cp_fallback() {
+        use rshogi_core::types::Move;
+        use tools::selfplay::MultiPvCandidate;
+
+        let candidate = |score_cp, score_mate| MultiPvCandidate {
+            multipv: 1,
+            score_cp,
+            score_mate,
+            first_move: Move::from_usi("7g7f").unwrap(),
+        };
+
+        assert_eq!(candidate_eval(&candidate(30000, Some(-5))), -31995);
+        assert_eq!(candidate_eval(&candidate(30000, Some(5))), 31995);
+        assert_eq!(candidate_eval(&candidate(30000, None)), 30000);
+        assert_eq!(candidate_eval(&candidate(-30000, None)), -30000);
     }
 
     #[test]

--- a/crates/tools/src/bin/gensfen.rs
+++ b/crates/tools/src/bin/gensfen.rs
@@ -3160,16 +3160,39 @@ fn validate_resume_fingerprint(meta: Option<&Value>, current: &Value) -> Result<
     let meta = meta.context(
         "--resume: meta has no generation fingerprint; move existing outputs aside and start a new run",
     )?;
-    if meta == current {
+    let mut saved = meta.clone();
+    let mut current = current.clone();
+    // hcpe3 policy のキーは psv / pack の fingerprint にも書かれるが、これらの形式では
+    // 生成物に影響しない。既定値を変えたときに無関係な差分で resume を拒否しないよう、
+    // hcpe3 以外では両側から対称に除外して比較する (片側だけだとキー欠落が差分になる)。
+    if current.pointer("/training/format").and_then(Value::as_str) != Some("hcpe3") {
+        remove_hcpe3_policy_fingerprint(&mut saved);
+        remove_hcpe3_policy_fingerprint(&mut current);
+    }
+    if saved == current {
         return Ok(());
     }
     let mut differences = Vec::new();
-    collect_json_differences("", meta, current, &mut differences);
+    collect_json_differences("", &saved, &current, &mut differences);
     differences.sort();
     bail!(
         "--resume: generation fingerprint mismatch in fields: {}",
         differences.join(", ")
     )
+}
+
+fn remove_hcpe3_policy_fingerprint(fingerprint: &mut Value) {
+    let Some(training) = fingerprint.get_mut("training").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for key in [
+        "hcpe3_policy_total",
+        "hcpe3_policy_temp",
+        "hcpe3_eval_drop_threshold",
+        "hcpe3_policy_algo",
+    ] {
+        training.remove(key);
+    }
 }
 
 fn add_hcpe3_policy_fingerprint(
@@ -7134,6 +7157,70 @@ mod tests {
             DEFAULT_HCPE3_EVAL_DROP_THRESHOLD
         );
         assert_eq!(hcpe3["training"]["hcpe3_policy_algo"], HCPE3_POLICY_ALGO_VERSION);
+    }
+
+    #[test]
+    fn psv_resume_ignores_legacy_hcpe3_policy_fields() {
+        let saved = serde_json::json!({
+            "training": {
+                "format": "psv",
+                "hcpe3_policy_total": 1000,
+                "hcpe3_policy_temp": 600.0,
+                "hcpe3_eval_drop_threshold": 300,
+                "hcpe3_policy_algo": 1
+            }
+        });
+        let current = serde_json::json!({
+            "training": {
+                "format": "psv",
+                "hcpe3_policy_total": 65535,
+                "hcpe3_policy_temp": 100.0
+            }
+        });
+
+        validate_resume_fingerprint(Some(&saved), &current).unwrap();
+    }
+
+    #[test]
+    fn hcpe3_resume_compares_policy_fields() {
+        let saved = serde_json::json!({
+            "training": {
+                "format": "hcpe3",
+                "hcpe3_policy_total": 1000,
+                "hcpe3_policy_temp": 100.0,
+                "hcpe3_eval_drop_threshold": 500,
+                "hcpe3_policy_algo": HCPE3_POLICY_ALGO_VERSION
+            }
+        });
+        let current = serde_json::json!({
+            "training": {
+                "format": "hcpe3",
+                "hcpe3_policy_total": 65535,
+                "hcpe3_policy_temp": 100.0,
+                "hcpe3_eval_drop_threshold": 500,
+                "hcpe3_policy_algo": HCPE3_POLICY_ALGO_VERSION
+            }
+        });
+
+        let error = validate_resume_fingerprint(Some(&saved), &current).unwrap_err().to_string();
+        assert!(error.contains("training.hcpe3_policy_total"));
+    }
+
+    #[test]
+    fn hcpe3_checkpoint_cannot_resume_as_psv() {
+        let saved = serde_json::json!({
+            "training": {
+                "format": "hcpe3",
+                "hcpe3_policy_total": 65535,
+                "hcpe3_policy_temp": 100.0,
+                "hcpe3_eval_drop_threshold": 500,
+                "hcpe3_policy_algo": HCPE3_POLICY_ALGO_VERSION
+            }
+        });
+        let current = serde_json::json!({"training": {"format": "psv"}});
+
+        let error = validate_resume_fingerprint(Some(&saved), &current).unwrap_err().to_string();
+        assert!(error.contains("training.format"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`gensfen --training-data-format hcpe3` の policy 分布生成を、dlshogi 本家の同等実装
`dlshogi/utils/usi_selfplay_multipv_to_hcpe3.py` の設計判断・既定値に揃える。

従来の既定 (`temp=600` / フィルタなし) では、評価値差 0/30/60/90cp の 4 候補が
26.9 / 25.6 / 24.3 / 23.2% とほぼ一様分布になっていた。参照実装は温度 100 と
eval-drop 500cp を併用して「最善から 500cp 以内の候補だけを鋭く配分する」形を採る。

## 変更内容

| 項目 | 変更前 | 変更後 (参照実装と同値) |
|---|---|---|
| `--hcpe3-policy-temp` | 600 | **100** |
| `--hcpe3-policy-total` | 1000 | **65535** |
| `--hcpe3-eval-drop-threshold` | (なし) | **500** (負値で無効) |
| 最低票 | PV1 のみ 1 票、0 票候補は除去 | **全候補に 1 票**を配ってから残りを配分 |
| `temp <= 0` | エラー | **greedy** (最善へ全票、同点は multipv 昇順で先頭) |
| 詰みスコア | softmax 入力は ±10000 クリップ、eval は ±(32000-ply) | **両者を同一値に統一** |
| ヘッダ 4 byte 目 | 0 固定 | **gameInfo** (max_moves コード 256:1 / 320:2 / 512:3) |
| result 上位ビット | 0 固定 | **千日手 4 / 入玉宣言 8 / 最大手数 16** |

doc には、dlshogi の `score_to_value` が `sigmoid(score / 756.086)` 固定であるため
学習時に `--use_evalfix` が必要である旨の注記も追加した。

## 設計判断: resume fingerprint の後方互換

hcpe3 固有キー (`hcpe3_eval_drop_threshold` / `hcpe3_policy_algo`) は
`format == hcpe3` のときだけ差し込む。

| checkpoint | 挙動 | 理由 |
|---|---|---|
| 旧 psv / pack | 影響なし | hcpe3 固有キーが両側に現れない |
| 旧 hcpe3 | resume 拒否 | `hcpe3_policy_algo` 欠落。量子化アルゴリズム自体が変わったため拒否が正しい |
| 新規 hcpe3 同士 | 設定差分を検出 | 両側にキーが立ち値比較になる |

無条件キーにすると、キーを持たない既存 psv run が CLI で値を合わせても回避不能な
mismatch に落ちる (走行中の教師生成 run が該当する)。一方、既定値との差分だけを条件に
すると、旧 hcpe3 checkpoint を旧 total/temp を明示して resume した際に新アルゴリズムが
黙って適用され、1 ファイル内に新旧の policy が混ざる。format gate + algo 版数キーは
この両方を同時に満たす。

## 参照実装との既知の差異

`MoveInfo.eval` には PV1 の評価値を書いており、参照実装が書く「実着手の score」とは
異なる。MultiPV ランダム着手を使う場合に値がずれるが、局面の value としては PV1 の
評価値の方が適切と判断して現状を維持している。

## 非スコープ

- MultiPV 候補数の既定変更 (参照実装は 10、gensfen 運用は 4)
- policy 収集と着手多様化のフラグ分離
- eval スケールの焼き込みオプション (doc 注記のみ)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p tools --all-targets` warning ゼロ
- [x] `cargo test -p tools` 全 pass (gensfen 89 tests)
- [x] `bash scripts/check-tracked-abs-paths.sh` OK
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Fable) APPROVE

追加したテスト: eval-drop フィルタ (実着手の保持を含む) / 全候補最低 1 票 /
`sum(visit) == total` / 決定性 / greedy 経路と同点時の PV1 優先 /
USI・native 両形式の詰み符号復元 / gameInfo と result フラグ /
fingerprint の format 依存キー