### PR TITLE
test(tools): merge_psv の再帰収集テストを Windows のパス区切りでも通るようにする

### DIFF
--- a/crates/tools/src/bin/merge_psv.rs
+++ b/crates/tools/src/bin/merge_psv.rs
@@ -487,10 +487,16 @@ mod tests {
         let paths = collect_merge_input_paths(dir.path(), "train_*.bin", true).unwrap();
         let names: Vec<_> = paths
             .iter()
-            .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
+            .map(|path| path.strip_prefix(dir.path()).unwrap().to_path_buf())
             .collect();
 
-        assert_eq!(names, vec!["train_000.bin", "archive/train_001.bin"]);
+        assert_eq!(
+            names,
+            vec![
+                PathBuf::from("train_000.bin"),
+                PathBuf::from("archive").join("train_001.bin")
+            ]
+        );
     }
 
     #[test]
@@ -516,16 +522,16 @@ mod tests {
         let paths = collect_merge_input_paths(dir.path(), "train_*.bin", true).unwrap();
         let names: Vec<_> = paths
             .iter()
-            .map(|path| path.strip_prefix(dir.path()).unwrap().to_string_lossy().into_owned())
+            .map(|path| path.strip_prefix(dir.path()).unwrap().to_path_buf())
             .collect();
 
         assert_eq!(
             names,
             vec![
-                "a/train_000.bin",
-                "b/train_001.bin",
-                "a/train_002.bin",
-                "b/train_003.bin"
+                PathBuf::from("a").join("train_000.bin"),
+                PathBuf::from("b").join("train_001.bin"),
+                PathBuf::from("a").join("train_002.bin"),
+                PathBuf::from("b").join("train_003.bin")
             ]
         );
     }


### PR DESCRIPTION
## Summary

- merge_psv.rs のユニットテスト 2 件 (`collect_merge_input_paths_includes_nested_dirs_when_recursive` / `collect_merge_input_paths_preserves_global_shard_order_across_recursive_dirs`) が Windows で失敗していた。期待値がパス区切り `/` 固定の文字列で、Windows では `\` が返るため
- 比較を `PathBuf` ベース (`PathBuf::from("a").join("train_000.bin")` 等) に変更して OS 非依存化。テストコードのみの変更でプロダクションコードは無変更
- Linux では `strip_prefix` の結果と期待値が成分・バイト列とも完全一致するため従来と同値 (挙動変化なし)

## 関連

- 同 package の nyugyoku_gensfen にも Windows 既存テスト失敗 4 件 (os error 5) があるが、origin/main でも再現する別問題のためスコープ外 (別途対応予定)

## Test plan

- [x] Windows: cargo test -p tools --bin merge_psv 9/9 pass
- [x] cargo fmt --all -- --check clean / clippy -p tools --all-targets で tools 由来の警告ゼロ
- [x] scripts/check-tracked-abs-paths.sh pass
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Fable) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)