### PR TITLE
fix(tools): nyugyoku_gensfen の staged 出力 fsync を Windows でも通るようにする

### DIFF
--- a/crates/tools/docs/nyugyoku_gensfen.md
+++ b/crates/tools/docs/nyugyoku_gensfen.md
@@ -143,5 +143,5 @@ best-effort 検出用で、暗号学的 digest ではない）。resume 時は�
 切り戻してから再処理する。公開は `out.work/` から同一 filesystem 内の rename
 （Linux では `RENAME_NOREPLACE`）で行う。
 Windows でも動作し、ファイル本体の flush・sync は同様に行うが、ディレクトリ
-エントリの fsync は Unix 専用で Windows では no-op（rename・作成の crash 耐久性は
-NTFS のメタデータジャーナリングに委ねる）。
+エントリの fsync は Unix 専用で Windows では no-op。Windows では rename・ファイル
+作成の crash 耐久性を本ツールでは保証せず、OS・filesystem の挙動に依存する。

--- a/crates/tools/docs/nyugyoku_gensfen.md
+++ b/crates/tools/docs/nyugyoku_gensfen.md
@@ -142,3 +142,6 @@ best-effort 検出用で、暗号学的 digest ではない）。resume 時は�
 参照 CSA 内容の累積 SHA-256 を照合し、checkpoint より後の一時データは記録済み byte 位置へ
 切り戻してから再処理する。公開は `out.work/` から同一 filesystem 内の rename
 （Linux では `RENAME_NOREPLACE`）で行う。
+Windows でも動作し、ファイル本体の flush・sync は同様に行うが、ディレクトリ
+エントリの fsync は Unix 専用で Windows では no-op（rename・作成の crash 耐久性は
+NTFS のメタデータジャーナリングに委ねる）。

--- a/crates/tools/src/bin/nyugyoku_gensfen.rs
+++ b/crates/tools/src/bin/nyugyoku_gensfen.rs
@@ -664,7 +664,9 @@ fn validate_output_checkpoint(path: &Path, expected_len: u64, expected_hash: u64
 
 fn publish_staged_file(staged: &Path, final_path: &Path) -> Result<()> {
     if staged.exists() {
-        File::open(staged)?.sync_all()?;
+        // Windows の FlushFileBuffers は書き込みアクセスを要求するため、
+        // 読み取り専用ハンドルでは ERROR_ACCESS_DENIED になる。
+        OpenOptions::new().write(true).open(staged)?.sync_all()?;
         fs::rename(staged, final_path)?;
     } else {
         ensure!(final_path.is_file(), "missing staged output: {}", staged.display());

--- a/crates/tools/src/bin/nyugyoku_gensfen.rs
+++ b/crates/tools/src/bin/nyugyoku_gensfen.rs
@@ -664,8 +664,12 @@ fn validate_output_checkpoint(path: &Path, expected_len: u64, expected_hash: u64
 
 fn publish_staged_file(staged: &Path, final_path: &Path) -> Result<()> {
     if staged.exists() {
-        // Windows の FlushFileBuffers は書き込みアクセスを要求するため、
-        // 読み取り専用ハンドルでは ERROR_ACCESS_DENIED になる。
+        // Windows の FlushFileBuffers は書き込みアクセスを要求するため書き込み
+        // ハンドルで開く。Unix は read-only な staged ファイルも同期できる
+        // 読み取りハンドルを維持する。
+        #[cfg(unix)]
+        File::open(staged)?.sync_all()?;
+        #[cfg(not(unix))]
         OpenOptions::new().write(true).open(staged)?.sync_all()?;
         fs::rename(staged, final_path)?;
     } else {
@@ -1475,6 +1479,22 @@ mod tests {
         assert!(rename_noreplace(&source, &destination).is_err());
         assert!(source.is_dir());
         assert!(destination.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publish_syncs_read_only_staged_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("startpos.txt.tmp");
+        fs::write(&staged, "position sfen x\n").unwrap();
+        fs::set_permissions(&staged, fs::Permissions::from_mode(0o444)).unwrap();
+        let final_path = dir.path().join("startpos.txt");
+
+        publish_staged_file(&staged, &final_path).unwrap();
+        assert!(final_path.is_file());
+        assert!(!staged.exists());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- nyugyoku_gensfen のユニットテスト 4 件 (finalize に到達するもの) が Windows で「アクセスが拒否されました (os error 5)」で失敗していたのを修正。
- 原因は `publish_staged_file` が staged ファイルを読み取り専用 (`File::open`) で開いて `sync_all` していたこと。Windows の `FlushFileBuffers` はハンドルに書き込みアクセスを要求するため ERROR_ACCESS_DENIED になる。
- 修正は cfg 分岐: Windows (非 Unix) は `write(true)` open で fsync、Unix は従来どおり読み取りハンドルを維持 (read-only staged ファイルの publish が退行しないよう)。read-only staged の Unix regression テストを追加。

## Test plan

- [x] Windows: `cargo test -p tools --bin nyugyoku_gensfen` 18/18 pass (修正前 14/18)
- [x] Linux (WSL): 同テスト 20/20 pass (unix 限定テスト含む)
- [x] `cargo fmt --all -- --check` clean / clippy tools crate warning ゼロ / `scripts/check-tracked-abs-paths.sh` OK
- [x] local reviewer #1 (Codex CLI, 敵対的レビュー): 初回 REQUEST CHANGES (Unix read-only 退行) → 対応後 APPROVE
- [x] local reviewer #2 (独立レビュー): APPROVE (2 回)

備考: Windows では `cargo clippy -- -D warnings` が rshogi-core の既存 dead-code 警告 (`ENV_KILL_SWITCH`) で落ちる (main 既存・本 PR スコープ外、別途対応予定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)