### PR TITLE
fix(search): stack[0]/stack[1] の cutoff_cnt を探索開始時にクリアする

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1402,6 +1402,12 @@ where
 {
     let is_main = main_state.is_some();
 
+    // cutoff_cnt は各ノードが孫スロット stack[ply+2] をクリアする方式のため、担当ノード
+    // (ply-2) が存在しない stack[0]/stack[1] だけは go をまたいで蓄積してしまう。YO の
+    // 反復深化開始時 stack ゼロ初期化に合わせ毎 go クリアする (go 内の蓄積は YO 同様保持)。
+    worker.state.stack[0].cutoff_cnt = 0;
+    worker.state.stack[1].cutoff_cnt = 0;
+
     // ルート手を初期化
     worker.state.root_moves = super::RootMoves::from_legal_moves(pos, &limits.search_moves);
 

--- a/crates/rshogi-core/src/search/tests/cutoff_cnt.rs
+++ b/crates/rshogi-core/src/search/tests/cutoff_cnt.rs
@@ -1,0 +1,54 @@
+//! cutoff_cnt の探索開始時クリアの回帰テスト
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use crate::eval::EvalHash;
+use crate::position::Position;
+use crate::search::alpha_beta::SearchWorker;
+use crate::search::engine::search_helper;
+use crate::search::{LimitsType, SearchTuneParams, TimeManagement};
+use crate::tt::TranspositionTable;
+
+#[test]
+fn iterative_deepening_clears_low_cutoff_counts_for_each_search() {
+    const STACK_SIZE: usize = 64 * 1024 * 1024;
+
+    std::thread::Builder::new()
+        .stack_size(STACK_SIZE)
+        .spawn(|| {
+            let tt = Arc::new(TranspositionTable::new(16));
+            let eval_hash = Arc::new(EvalHash::new(1));
+            let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+            let mut pos = Position::new();
+            pos.set_hirate();
+            let limits = LimitsType::new();
+            let increase_depth = AtomicBool::new(true);
+
+            for dirty_value in [3, 7] {
+                worker.state.stack[0].cutoff_cnt = dirty_value;
+                worker.state.stack[1].cutoff_cnt = dirty_value;
+                let mut time_manager = TimeManagement::new(
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicBool::new(false)),
+                );
+
+                search_helper(
+                    &mut worker,
+                    &mut pos,
+                    &limits,
+                    &mut time_manager,
+                    0,
+                    false,
+                    None,
+                    &increase_depth,
+                );
+
+                assert_eq!(worker.state.stack[0].cutoff_cnt, 0);
+                assert_eq!(worker.state.stack[1].cutoff_cnt, 0);
+            }
+        })
+        .expect("failed to spawn test thread with large stack")
+        .join()
+        .expect("test thread panicked");
+}

--- a/crates/rshogi-core/src/search/tests/mod.rs
+++ b/crates/rshogi-core/src/search/tests/mod.rs
@@ -1,6 +1,9 @@
 //! 探索モジュールのテスト
 
 mod alpha_beta;
+// search_helper が wasm32 (wasm-threads なし) では configured out されるため合わせて gate する
+#[cfg(any(not(target_arch = "wasm32"), feature = "wasm-threads"))]
+mod cutoff_cnt;
 mod history_update;
 mod multi_pv;
 mod skill;


### PR DESCRIPTION
## Summary

- `cutoff_cnt` は各ノードが孫スロット `stack[ply+2]` をクリアする YO イディオムのため、クリア担当 (ply-2) が存在しない `stack[0]`/`stack[1]` だけが探索・対局をまたいで単調蓄積していた。release profile (overflow-checks=true) では gensfen 長期実行 (5.5 日 / 579,910 局) で i32 オーバーフロー panic が実発生、production profile では wrap により `stack[1].cutoff_cnt > 2` を参照する aspiration/LMR 系 4 分岐がプロセス長寿命下で常時 true 化し探索品質が静かに劣化する
- YO は `iterative_deepening()` のローカル配列 `Stack stack[MAX_PLY+10] = {};` を毎 go ゼロ初期化しており、stack を `SearchState` に永続保持する rshogi にはその対応物が欠けていた (PR #381 の孫スロット方式移植時に、YO 側で変数ライフサイクルが暗黙に担保していた不変条件が漏れたもの)
- main/helper 両スレッドの共通入口 `iterative_deepening()` 冒頭で低位 2 スロットを毎 go クリアする。`search_root` 冒頭 (aspiration retry ごと) には置かない — YO は go 内の反復をまたぐ蓄積を保持するため。回帰テストは同一 SearchWorker の連続探索で汚れ値が各 go 開始時にクリアされることを assert (修正前は fail することを確認済み)

## 検証

- [x] cargo fmt --check / clippy 警告ゼロ / cargo test --workspace 全 pass / check-tracked-abs-paths.sh
- [x] wasm32 CI 相当 (`cargo test -p rshogi-core affine_reference --target wasm32-wasip1 --no-run`) ビルド通過
- [x] yo-measure: fresh プロセス単発探索は修正前後で bit 一致 (nodes 58,895 / 18,466)。TT/履歴クリア後の同一局面再探索ノード数は YO 19,510→19,510・修正版 58,895→58,895 で「前歴に依存しない」不変条件が成立、baseline は 58,895→24,807 に乖離 → YO へ揃う方向を実測確認
- [x] local dual review 2 ラウンド (codex-rescue + 独立 Claude reviewer 各 2 名) 計 4 判定 APPROVE。第 1 ラウンド指摘の wasm32 cfg gate / WHY コメントは反映済み
- [ ] selfplay SPRT 非劣化確認 (base=main vs test=本修正、300k nodes 固定、H0=-5/H1=0 nelo): **進行中**。924 ペア時点で LLR +1.185 (境界 ±2.944)、nelo +13.0 ± 15.8 (test 視点) と非劣化側へ単調進行中。判定確定後に本 PR へ結果を追記する

## 関連

- Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWkRccEFm5QKSyiZjqjqYY