### PR TITLE
fix(search): cutoff_cnt の毎 go クリアを stack 全スロットに拡張する

### DIFF
--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1402,11 +1402,12 @@ where
 {
     let is_main = main_state.is_some();
 
-    // cutoff_cnt は各ノードが孫スロット stack[ply+2] をクリアする方式のため、担当ノード
-    // (ply-2) が存在しない stack[0]/stack[1] だけは go をまたいで蓄積してしまう。YO の
-    // 反復深化開始時 stack ゼロ初期化に合わせ毎 go クリアする (go 内の蓄積は YO 同様保持)。
-    worker.state.stack[0].cutoff_cnt = 0;
-    worker.state.stack[1].cutoff_cnt = 0;
+    // YO の反復深化開始時の stack 全体ゼロ初期化に合わせ、毎 go 全スロットをクリアする。
+    // 孫スロットをクリアする経路に穴があっても go をまたぐ寿命比例の蓄積と i32 overflow を
+    // 防ぎ、go 内の蓄積は YO 同様に保持する。
+    for stack in &mut worker.state.stack {
+        stack.cutoff_cnt = 0;
+    }
 
     // ルート手を初期化
     worker.state.root_moves = super::RootMoves::from_legal_moves(pos, &limits.search_moves);

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -1402,9 +1402,9 @@ where
 {
     let is_main = main_state.is_some();
 
-    // YO の反復深化開始時の stack 全体ゼロ初期化に合わせ、毎 go 全スロットをクリアする。
-    // 孫スロットをクリアする経路に穴があっても go をまたぐ寿命比例の蓄積と i32 overflow を
-    // 防ぎ、go 内の蓄積は YO 同様に保持する。
+    // 毎 go の開始時に全スロットの cutoff_cnt をクリアする。孫スロット方式のクリア経路に
+    // 穴があっても go をまたぐ寿命比例の蓄積と i32 overflow を起こさないための防御で、
+    // go 内の蓄積は保持される。
     for stack in &mut worker.state.stack {
         stack.cutoff_cnt = 0;
     }

--- a/crates/rshogi-core/src/search/tests/cutoff_cnt.rs
+++ b/crates/rshogi-core/src/search/tests/cutoff_cnt.rs
@@ -52,3 +52,48 @@ fn iterative_deepening_clears_low_cutoff_counts_for_each_search() {
         .join()
         .expect("test thread panicked");
 }
+
+/// 毎 go の全スロットクリアが退行すると、寿命積算を模擬した poison が残存して
+/// 検出されることを確認する。
+#[test]
+fn iterative_deepening_clears_poisoned_cutoff_counts_before_search() {
+    const STACK_SIZE: usize = 64 * 1024 * 1024;
+
+    std::thread::Builder::new()
+        .stack_size(STACK_SIZE)
+        .spawn(|| {
+            let tt = Arc::new(TranspositionTable::new(16));
+            let eval_hash = Arc::new(EvalHash::new(1));
+            let mut worker = SearchWorker::new(tt, eval_hash, 0, 0, SearchTuneParams::default());
+            let mut pos = Position::new();
+            pos.set_hirate();
+            let limits = LimitsType::new();
+            let increase_depth = AtomicBool::new(true);
+
+            for stack in &mut worker.state.stack {
+                stack.cutoff_cnt = i32::MAX;
+            }
+
+            let mut time_manager = TimeManagement::new(
+                Arc::new(AtomicBool::new(false)),
+                Arc::new(AtomicBool::new(false)),
+            );
+            search_helper(
+                &mut worker,
+                &mut pos,
+                &limits,
+                &mut time_manager,
+                0,
+                false,
+                None,
+                &increase_depth,
+            );
+
+            for (index, stack) in worker.state.stack.iter().enumerate() {
+                assert_eq!(stack.cutoff_cnt, 0, "stack[{index}].cutoff_cnt に poison が残っている");
+            }
+        })
+        .expect("failed to spawn test thread with large stack")
+        .join()
+        .expect("test thread panicked");
+}


### PR DESCRIPTION
## Summary

- 2026-08-05 の gensfen 全 worker 同時 panic (6.42 日稼働で `attempt to add with overflow` @ alpha_beta.rs:3363) の再発防止。クラッシュしたバイナリは #979 以前のビルドで、`stack[1].cutoff_cnt` が worker 寿命全体で単調蓄積して i32 を溢れさせた
- 現 main のクリア経路は帰納的に完備だが (監査済み: ply0/1 毎 go / ply2 root 関数毎 / ply>=3 祖父の `stack[ply+2]` クリア先行)、帰納が将来壊れても go を跨ぐ寿命積算が起きないよう、iterative_deepening 冒頭の stack[0]/[1] クリアを全スロットに拡張
- YO は `Stack stack[MAX_PLY+10] = {};` (ローカル配列) で毎 go 全体ゼロ初期化しており、その対応物になる。go 内の兄弟蓄積は従来どおり保持され、正しい実行では no-op

## 設計判断

- **saturating_add は不採用**: 読み出しは全て `> 2` 比較なので clamp でも挙動同値だが、クリア漏れ regression を恒久的に隠す (該当スロットが永久に `> 2` → LMR が静かに歪む)。`+=` を overflow-checks (release で有効) の canary として残す
- **poison 回帰テスト**: 全 256 スロットに `i32::MAX` を仕込み go 開始で全スロット 0 になることを検証 (決定論的・グローバル状態非依存)。毎 go クリアが退行すると未クリアスロットの残存で即検出。mutation check 済み (クリア拡張を外すと `stack[2]` 残存で FAIL)

## 関連

- 事故記録: rshogi-notes notes/20260805-gensfen-cutoffcnt-i32-overflow-incident.md (別 repo)
- 先行修正: #979 (stack[0]/[1] の毎 go クリア)

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy (本変更由来の警告ゼロ)
- [x] cargo test -p rshogi-core --lib: 996 passed
- [x] mutation check (修正を外すと poison テストが FAIL することを確認)
- [x] scripts/check-tracked-abs-paths.sh
- [x] local reviewer #1 (Codex) APPROVE (round 2)
- [x] local reviewer #2 (Claude) APPROVE (round 2)
- 既存の Windows 固有失敗 (rshogi-csa-client ビルド / rshogi-csa-server パス区切りテスト 3 件 / rshogi-usi book_flow 1 件) は本変更と無関係に main で再現 (別タスク化済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)