### PR TITLE
test(csa-server): storage::file のパス assert を Windows のパス区切りでも通るようにする

### DIFF
--- a/crates/rshogi-csa-server/src/storage/file.rs
+++ b/crates/rshogi-csa-server/src/storage/file.rs
@@ -183,7 +183,11 @@ mod tests {
         let store = FileKifuStorage::new(&dir);
         let game_id = GameId::new("20260417120000");
         let key = store.save(&game_id, "V2.2\nN+alice\n").await.unwrap();
-        assert_eq!(key.as_str(), "2026/04/17/20260417120000.csa");
+        // StorageKey は OS のパス区切りを含むため、PathBuf 比較で OS 非依存にする。
+        assert_eq!(
+            PathBuf::from(key.as_str()),
+            PathBuf::from("2026").join("04").join("17").join("20260417120000.csa")
+        );
         let abs = dir.join(key.as_str());
         let body = fs::read_to_string(&abs).await.unwrap();
         assert_eq!(body, "V2.2\nN+alice\n");
@@ -217,7 +221,7 @@ mod tests {
         let store = FileKifuStorage::new(&dir);
         let game_id = GameId::new("buoy-123");
         let key = store.save(&game_id, "V2.2\n").await.unwrap();
-        assert_eq!(key.as_str(), "unknown/buoy-123.csa");
+        assert_eq!(PathBuf::from(key.as_str()), PathBuf::from("unknown").join("buoy-123.csa"));
         let _ = fs::remove_dir_all(&dir).await;
     }
 
@@ -228,7 +232,7 @@ mod tests {
         let store = FileKifuStorage::new(&dir);
         let game_id = GameId::new("20261340abcd");
         let key = store.save(&game_id, "V2.2\n").await.unwrap();
-        assert_eq!(key.as_str(), "unknown/20261340abcd.csa");
+        assert_eq!(PathBuf::from(key.as_str()), PathBuf::from("unknown").join("20261340abcd.csa"));
         let _ = fs::remove_dir_all(&dir).await;
     }
 


### PR DESCRIPTION
## Summary

- `cargo test -p rshogi-csa-server --lib` の storage::file::tests 3 件 (save_writes_kifu_under_dated_directory / save_falls_back_to_unknown_for_non_dated_id / save_falls_back_to_unknown_for_invalid_calendar_date) が Windows で失敗していたのを修正
- `StorageKey` は `rel.to_string_lossy()` 由来のため Windows では `\` 区切りになるが、テスト期待値が `/` 固定の文字列比較だったのが原因。比較を `PathBuf` ベース (components 比較) に変更して OS 非依存にする
- #977 (merge_psv の同種問題) と同じ流儀。プロダクションコードは変更なし

## 関連

- #977 (c4d525cc): merge_psv テストの同種修正

## Test plan

- [x] cargo fmt --all -- --check clean
- [x] cargo clippy -p rshogi-csa-server --tests warning ゼロ
- [x] cargo test -p rshogi-csa-server --lib 344 件全 pass (Windows)
- [x] scripts/check-tracked-abs-paths.sh OK
- [x] local reviewer #1 (Codex, gpt-5.6-sol) APPROVE
- [x] local reviewer #2 (Claude 独立 subagent) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)