### PR TITLE
fix(csa-client): Windows で tungstenite 等が解決されない依存セクション配置を修正

### DIFF
--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -62,14 +62,6 @@ rshogi-csa-server = { path = "../rshogi-csa-server", default-features = false }
 # コード側のため feature gate せず常時必須。
 libc = "0.2"
 
-# `nix` は engine 死亡時の process group 単位 kill (`killpg`) を unsafe を
-# 使わず safe wrapper 経由で呼ぶために unix 限定で依存。`signal` feature だけ
-# あれば `killpg` / `Signal::SIGKILL` / `Pid::from_raw` が揃う。
-# version は workspace 上 (ctrlc 経由) で既に解決されている `0.31` 系に揃え、
-# Cargo.lock の dup を回避する。
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
-
 # CSA-over-WebSocket 用の sync ハンドシェイク + フレーミング。
 # rustls + webpki ルートで TLS を実装し、native-tls 経由の OpenSSL 依存を避ける。
 tungstenite = { version = "0.27", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"], optional = true }
@@ -82,3 +74,14 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 clap = { workspace = true, optional = true }
 ctrlc = { version = "3.4", optional = true }
 env_logger = { workspace = true, optional = true }
+
+# `nix` は engine 死亡時の process group 単位 kill (`killpg`) を unsafe を
+# 使わず safe wrapper 経由で呼ぶために unix 限定で依存。`signal` feature だけ
+# あれば `killpg` / `Signal::SIGKILL` / `Pid::from_raw` が揃う。
+# version は workspace 上 (ctrlc 経由) で既に解決されている `0.31` 系に揃え、
+# Cargo.lock の dup を回避する。
+# NOTE: この target 固有セクションは必ずファイル末尾に置くこと。汎用
+# [dependencies] より上に置くと、後続の依存 (tungstenite 等) がこの
+# セクションに吸われて unix 限定になり、Windows build が壊れる (#673 の regression)。
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["signal"] }

--- a/crates/rshogi-csa-client/Cargo.toml
+++ b/crates/rshogi-csa-client/Cargo.toml
@@ -81,7 +81,8 @@ env_logger = { workspace = true, optional = true }
 # version は workspace 上 (ctrlc 経由) で既に解決されている `0.31` 系に揃え、
 # Cargo.lock の dup を回避する。
 # NOTE: この target 固有セクションは必ずファイル末尾に置くこと。汎用
-# [dependencies] より上に置くと、後続の依存 (tungstenite 等) がこの
-# セクションに吸われて unix 限定になり、Windows build が壊れる (#673 の regression)。
+# [dependencies] の途中 (後続の依存定義より上) に置くと、それ以降の依存
+# (tungstenite 等) がこのセクションに吸われて unix 限定になり、
+# Windows build が壊れる (#673 の regression)。
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }


### PR DESCRIPTION
## Summary

- #673 が `nix` 追加時に `[target.'cfg(unix)'.dependencies]` セクションヘッダを既存の tungstenite / rustls / clap / ctrlc / env_logger 定義の**上**に挿入したため、TOML の仕様上これら 5 依存がすべて unix 限定テーブルに吸い込まれていた
- 結果、Windows native では `cargo check -p rshogi-csa-client` が E0432/E0433 (unresolved `tungstenite` ×9, `into_client_request` 不在) で失敗。CI は全ジョブ ubuntu-latest のため検出されず green のままだった
- cfg(unix) セクションをファイル末尾へ移動して汎用 `[dependencies]` を復元し、再発防止の NOTE コメントを追加。依存のバージョン・feature・optional 指定は一切不変 (`cargo metadata` で 5 依存の target が null / nix のみ cfg(unix) を確認済み)

## 関連

- Regression 導入元: #673
- 根本対策 (CI への Windows ジョブ追加) は本 PR の非スコープ

## Test plan

- [x] Windows native: `cargo check -p rshogi-csa-client` (default / `--no-default-features --features tcp` / `tcp,websocket` の matrix)
- [x] `cargo clippy -p rshogi-csa-client --tests` warning ゼロ
- [x] `cargo test -p rshogi-csa-client` (12 passed + doctest)
- [x] `cargo fmt --all -- --check` / `bash scripts/check-tracked-abs-paths.sh`
- [x] 他 crate の target セクションに同種の吸い込みが無いことを横断確認 (rshogi-core / rshogi-csa-server-workers)
- [x] local reviewer #1 (Codex, read-only sandbox) APPROVE
- [x] local reviewer #2 (Claude 独立 subagent) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)