### PR TITLE
perf: tile Finny accumulator updates

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -176,24 +176,13 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
         }
     }
 
-    /// キャッシュからの差分で refresh を実行（Stockfish 風 piece_list 差分方式）
+    /// キャッシュ差分のfeature indexをまとめて適用するrefresh。
     ///
-    /// キャッシュが有効な場合、現在の `PieceList` と cache の `PieceList` を
-    /// slot-wise に比較し、変化した slot のみ `idx_fn` で feature index を
-    /// 算出して add/sub を適用する。
-    /// キャッシュが無効な場合は biases から full refresh し、cache を更新する。
-    ///
-    /// # 引数
-    ///
-    /// - `king_sq`: この視点の玉位置（cache key）
-    /// - `perspective`: 視点（cache key）
-    /// - `piece_list`: 現在の perspective 固有 `PieceList`（`piece_list_fb` / `piece_list_fw`）
-    /// - `biases`: Feature Transformer のバイアス
-    /// - `accumulation`: 更新先のアキュムレータ値
-    /// - `idx_fn`: BonaPiece (非 ZERO) → feature index の変換
-    /// - `add_fn`: 重み加算関数
-    /// - `sub_fn`: 重み減算関数
-    pub(crate) fn refresh_or_cache<FI, FA, FS>(
+    /// add/subを1件ずつ呼ぶ代わりに、全indexを固定長listへ集めて`apply_fn`へ渡す。
+    /// Feature Transformer側はこのlistを使い、accumulatorをtileごとに1回だけ
+    /// load/storeできる。
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn refresh_or_cache<FI, FApply>(
         &mut self,
         king_sq: Square,
         perspective: Color,
@@ -201,48 +190,48 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
         biases: &[i16; L1],
         accumulation: &mut [i16; L1],
         idx_fn: FI,
-        add_fn: FA,
-        sub_fn: FS,
+        apply_fn: FApply,
     ) where
         FI: Fn(BonaPiece) -> usize,
-        FA: Fn(&mut [i16; L1], usize),
-        FS: Fn(&mut [i16; L1], usize),
+        FApply:
+            Fn(&mut [i16; L1], &IndexList<{ PieceNumber::NB }>, &IndexList<{ PieceNumber::NB }>),
     {
         let entry = &mut self.entries[king_sq.raw() as usize][perspective as usize];
+        // 各駒slotはremoved/addedへ最大1件ずつ入るため、容量40を超えない。
+        let mut removed = IndexList::<{ PieceNumber::NB }>::new();
+        let mut added = IndexList::<{ PieceNumber::NB }>::new();
 
         if entry.valid {
             crate::nnue::stats::count_cache_hit!();
-            // キャッシュのアキュムレータ値をコピー
             accumulation.copy_from_slice(&entry.accumulation);
 
-            // 40 slot 比較して変化した slot のみ差分適用
-            let mut diff_count = 0usize;
             for (cached_bp, &current_bp) in entry.piece_list.iter().copied().zip(piece_list.iter())
             {
                 if cached_bp != current_bp {
                     if cached_bp != BonaPiece::ZERO {
-                        sub_fn(accumulation, idx_fn(cached_bp));
-                        diff_count += 1;
+                        let pushed = removed.push(idx_fn(cached_bp));
+                        debug_assert!(pushed);
                     }
                     if current_bp != BonaPiece::ZERO {
-                        add_fn(accumulation, idx_fn(current_bp));
-                        diff_count += 1;
+                        let pushed = added.push(idx_fn(current_bp));
+                        debug_assert!(pushed);
                     }
                 }
             }
-            crate::nnue::stats::count_refresh_diff!(diff_count);
+            crate::nnue::stats::count_refresh_diff!(removed.len() + added.len());
         } else {
             crate::nnue::stats::count_cache_miss!();
-            // キャッシュ無効 → バイアスから full refresh
             accumulation.copy_from_slice(biases);
             for &bp in piece_list.iter() {
                 if bp != BonaPiece::ZERO {
-                    add_fn(accumulation, idx_fn(bp));
+                    let pushed = added.push(idx_fn(bp));
+                    debug_assert!(pushed);
                 }
             }
         }
 
-        // キャッシュを更新
+        apply_fn(accumulation, &removed, &added);
+
         entry.accumulation.copy_from_slice(accumulation);
         entry.piece_list.copy_from_slice(piece_list);
         entry.valid = true;
@@ -887,6 +876,19 @@ mod tests {
     /// テスト用の具体的な L1 サイズ
     const TEST_L1: usize = NNUE_PYTORCH_L1; // 1536
 
+    fn apply_test_changes(
+        acc: &mut [i16; TEST_L1],
+        removed: &IndexList<{ PieceNumber::NB }>,
+        added: &IndexList<{ PieceNumber::NB }>,
+    ) {
+        for idx in removed.iter() {
+            acc[0] = acc[0].wrapping_sub(idx as i16);
+        }
+        for idx in added.iter() {
+            acc[0] = acc[0].wrapping_add(idx as i16);
+        }
+    }
+
     #[test]
     fn test_accumulator_new() {
         let acc = AccumulatorLayerStacks::<TEST_L1>::new();
@@ -960,8 +962,7 @@ mod tests {
             &biases,
             &mut accumulation,
             |bp| bp.0 as usize,
-            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
-            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+            apply_test_changes,
         );
 
         // biases[0] + 5 + 10 + 15 = 130
@@ -996,8 +997,7 @@ mod tests {
             &biases,
             &mut acc1,
             |bp| bp.0 as usize,
-            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
-            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+            apply_test_changes,
         );
         assert_eq!(acc1[0], 30);
 
@@ -1012,8 +1012,7 @@ mod tests {
             &biases,
             &mut acc2,
             |bp| bp.0 as usize,
-            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
-            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+            apply_test_changes,
         );
         // hit: 30 - 15 + 20 = 35
         assert_eq!(acc2[0], 35);
@@ -1038,8 +1037,7 @@ mod tests {
             &biases,
             &mut acc1,
             |bp| bp.0 as usize,
-            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
-            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+            apply_test_changes,
         );
         assert_eq!(acc1[0], 15);
 
@@ -1054,8 +1052,7 @@ mod tests {
             &biases,
             &mut acc2,
             |bp| bp.0 as usize,
-            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
-            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+            apply_test_changes,
         );
         // hit: 15 - 10 = 5
         assert_eq!(acc2[0], 5);

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -13,6 +13,12 @@ use super::accumulator_layer_stacks::{
 use super::bona_piece::BonaPiece;
 #[cfg(feature = "nnue-psqt")]
 use super::constants::MAX_LAYER_STACK_BUCKETS;
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx2",
+    not(target_feature = "avx512bw")
+))]
+use super::constants::NNUE_PYTORCH_L1;
 use super::features::{Feature, FeatureSet};
 use super::leb128::read_compressed_tensor_i16_all;
 use super::ls_feature_spec::LsFeatureSpec;
@@ -1162,8 +1168,7 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             &self.biases.0,
             accumulation,
             idx_fn,
-            |acc, idx| self.add_weights(acc, idx),
-            |acc, idx| self.sub_weights(acc, idx),
+            |acc, removed, added| self.apply_weight_changes_tiled(acc, removed, added),
         );
     }
 
@@ -1318,6 +1323,86 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
         stack.current_mut().accumulator.computed_accumulation = true;
         stack.current_mut().accumulator.computed_score = false;
         true
+    }
+
+    /// 複数featureの差分をaccumulatorのtile単位でまとめて適用する。
+    #[inline]
+    fn apply_weight_changes_tiled(
+        &self,
+        accumulation: &mut [i16; L1],
+        removed: &IndexList<{ PieceNumber::NB }>,
+        added: &IndexList<{ PieceNumber::NB }>,
+    ) {
+        if removed.is_empty() && added.is_empty() {
+            return;
+        }
+
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
+        {
+            const VALUES_PER_REG: usize = 16;
+            const TILE_REGS: usize = 16;
+            const TILE_VALUES: usize = VALUES_PER_REG * TILE_REGS;
+
+            if L1 == NNUE_PYTORCH_L1 {
+                // SAFETY:
+                // - accumulationとweight rowは64-byte alignedで、tile offsetは512-byte単位。
+                // - NNUE_PYTORCH_L1はTILE_VALUESの倍数なので、各load/storeは配列内に収まる。
+                // - weight_rowが各feature indexとrow長L1の境界を検証する。
+                unsafe {
+                    use std::arch::x86_64::*;
+
+                    let acc_ptr = accumulation.as_mut_ptr();
+                    for tile_offset in (0..L1).step_by(TILE_VALUES) {
+                        let mut tile = [_mm256_setzero_si256(); TILE_REGS];
+                        for (k, value) in tile.iter_mut().enumerate() {
+                            *value = _mm256_load_si256(
+                                acc_ptr.add(tile_offset + k * VALUES_PER_REG) as *const __m256i,
+                            );
+                        }
+
+                        for index in removed.iter() {
+                            let weights = self.weight_row(index);
+                            let weight_ptr = weights.as_ptr().add(tile_offset);
+                            for (k, value) in tile.iter_mut().enumerate() {
+                                let weight = _mm256_load_si256(
+                                    weight_ptr.add(k * VALUES_PER_REG) as *const __m256i
+                                );
+                                *value = _mm256_sub_epi16(*value, weight);
+                            }
+                        }
+                        for index in added.iter() {
+                            let weights = self.weight_row(index);
+                            let weight_ptr = weights.as_ptr().add(tile_offset);
+                            for (k, value) in tile.iter_mut().enumerate() {
+                                let weight = _mm256_load_si256(
+                                    weight_ptr.add(k * VALUES_PER_REG) as *const __m256i
+                                );
+                                *value = _mm256_add_epi16(*value, weight);
+                            }
+                        }
+
+                        for (k, &value) in tile.iter().enumerate() {
+                            _mm256_store_si256(
+                                acc_ptr.add(tile_offset + k * VALUES_PER_REG) as *mut __m256i,
+                                value,
+                            );
+                        }
+                    }
+                }
+                return;
+            }
+        }
+
+        for index in removed.iter() {
+            self.sub_weights(accumulation, index);
+        }
+        for index in added.iter() {
+            self.add_weights(accumulation, index);
+        }
     }
 
     /// 重みを累積値に加算（SIMD最適化版）
@@ -1989,6 +2074,42 @@ mod tests {
         for index in added.iter() {
             ft.add_weights(accumulation, index);
         }
+    }
+
+    #[cfg(not(feature = "nnue-effect-bucket"))]
+    #[test]
+    fn test_apply_weight_changes_tiled_matches_sequential_with_wrapping() {
+        let mut ft = make_test_transformer();
+        for (index, seed) in [0usize, 1, 2, 3].into_iter().zip([31i16, -47, 83, -109]) {
+            fill_weight_row(&mut ft, index, seed);
+        }
+
+        let mut removed = IndexList::<{ PieceNumber::NB }>::new();
+        let mut added = IndexList::<{ PieceNumber::NB }>::new();
+        assert!(removed.push(0));
+        assert!(removed.push(1));
+        assert!(added.push(2));
+        assert!(added.push(3));
+
+        let mut sequential = Aligned([0i16; TEST_L1]);
+        for (i, value) in sequential.0.iter_mut().enumerate() {
+            *value = if i % 2 == 0 {
+                i16::MAX.wrapping_sub((i % 97) as i16)
+            } else {
+                i16::MIN.wrapping_add((i % 89) as i16)
+            };
+        }
+        let mut tiled = Aligned(sequential.0);
+
+        for index in removed.iter() {
+            ft.sub_weights(&mut sequential.0, index);
+        }
+        for index in added.iter() {
+            ft.add_weights(&mut sequential.0, index);
+        }
+        ft.apply_weight_changes_tiled(&mut tiled.0, &removed, &added);
+
+        assert_eq!(sequential.0, tiled.0);
     }
 
     // effect bucket build は `EffectBucket=` token 付き arch を要求するため、非 EffectBucket

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -13,12 +13,6 @@ use super::accumulator_layer_stacks::{
 use super::bona_piece::BonaPiece;
 #[cfg(feature = "nnue-psqt")]
 use super::constants::MAX_LAYER_STACK_BUCKETS;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "avx2",
-    not(target_feature = "avx512bw")
-))]
-use super::constants::NNUE_PYTORCH_L1;
 use super::features::{Feature, FeatureSet};
 use super::leb128::read_compressed_tensor_i16_all;
 use super::ls_feature_spec::LsFeatureSpec;
@@ -1347,10 +1341,10 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             const TILE_REGS: usize = 16;
             const TILE_VALUES: usize = VALUES_PER_REG * TILE_REGS;
 
-            if L1 == NNUE_PYTORCH_L1 {
+            if L1.is_multiple_of(TILE_VALUES) {
                 // SAFETY:
                 // - accumulationとweight rowは64-byte alignedで、tile offsetは512-byte単位。
-                // - NNUE_PYTORCH_L1はTILE_VALUESの倍数なので、各load/storeは配列内に収まる。
+                // - L1がTILE_VALUESの倍数のときだけ入るため、各load/storeは配列内に収まる。
                 // - weight_rowが各feature indexとrow長L1の境界を検証する。
                 unsafe {
                     use std::arch::x86_64::*;


### PR DESCRIPTION
## Summary
- collect Finny cache removed/added feature indices before applying weights
- update the 1536-element accumulator in 256-value AVX2 tiles so each tile is loaded/stored once
- keep PSQT, non-AVX2, AVX-512, and other L1 shapes on their existing paths; skip empty diffs

## Validation
- depth 1 through 16: nodes identical at every depth for all 4 positions; bestmove 4/4 identical
- 5-second ABBA x3: NPS +1.62%, cycles/node -1.53%, instructions/node -1.65%
- 10-second ABBA x3: NPS +3.54%, cycles/node -3.37%, instructions/node -1.66%
- cargo fmt --check
- cargo clippy -p rshogi-core --lib -- -D warnings
- non-AVX2 cargo check with warnings denied
- 768 and PSQT preset cargo checks
- cargo test

A noinline follow-up was measured independently and rejected: NPS -1.01%, cycles/node +1.04%.