### PR TITLE
perf: fuse LayerStacks copy and diff update

### DIFF
--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -2219,8 +2219,8 @@ mod tests {
                 _ => (i as i16).wrapping_mul(97),
             };
         }
-        let mut generic = source.clone();
-        let mut fast = source.clone();
+        let mut generic = source;
+        let mut fast = source;
         let mut from_source = Aligned([123i16; TEST_L1]);
         apply_generic(&ft, &mut generic.0, &dirty_piece, Color::Black, king_sq);
         assert!(ft.try_apply_dirty_piece_fast(&mut fast.0, &dirty_piece, Color::Black, king_sq));
@@ -2298,8 +2298,8 @@ mod tests {
                 _ => (i as i16).wrapping_mul(-113),
             };
         }
-        let mut generic = source.clone();
-        let mut fast = source.clone();
+        let mut generic = source;
+        let mut fast = source;
         let mut from_source = Aligned([-321i16; TEST_L1]);
         apply_generic(&ft, &mut generic.0, &dirty_piece, Color::Black, king_sq);
         assert!(ft.try_apply_dirty_piece_fast(&mut fast.0, &dirty_piece, Color::Black, king_sq));

--- a/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/feature_transformer_layer_stacks.rs
@@ -760,8 +760,8 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                 let mut added = IndexList::new();
                 let prev = prev_acc.get(p);
                 let curr = acc.get_mut(p);
-                curr.copy_from_slice(prev);
-                let fast_applied = self.try_apply_dirty_piece_fast(
+                let fast_applied = self.try_apply_dirty_piece_fast_from_source(
+                    prev,
                     curr,
                     dirty_piece,
                     perspective,
@@ -779,6 +779,7 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                     );
                 }
                 if !fast_applied {
+                    curr.copy_from_slice(prev);
                     for index in removed.iter() {
                         self.sub_weights(curr, index);
                     }
@@ -919,8 +920,8 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                 let mut added = IndexList::new();
                 let prev = prev_acc.get(p);
                 let curr = acc.get_mut(p);
-                curr.copy_from_slice(prev);
-                let fast_applied = self.try_apply_dirty_piece_fast(
+                let fast_applied = self.try_apply_dirty_piece_fast_from_source(
+                    prev,
                     curr,
                     dirty_piece,
                     perspective,
@@ -938,6 +939,7 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                     );
                 }
                 if !fast_applied {
+                    curr.copy_from_slice(prev);
                     for index in removed.iter() {
                         self.sub_weights(curr, index);
                     }
@@ -1451,6 +1453,43 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
         perspective: Color,
         king_sq: crate::types::Square,
     ) -> bool {
+        self.try_apply_dirty_piece_fast_impl::<false>(
+            None,
+            accumulation,
+            dirty_piece,
+            perspective,
+            king_sq,
+        )
+    }
+
+    /// `source` のコピーと通常差分更新を1回の走査で行う。
+    #[inline]
+    fn try_apply_dirty_piece_fast_from_source(
+        &self,
+        source: &[i16; L1],
+        accumulation: &mut [i16; L1],
+        dirty_piece: &DirtyPiece,
+        perspective: Color,
+        king_sq: crate::types::Square,
+    ) -> bool {
+        self.try_apply_dirty_piece_fast_impl::<true>(
+            Some(source),
+            accumulation,
+            dirty_piece,
+            perspective,
+            king_sq,
+        )
+    }
+
+    #[inline]
+    fn try_apply_dirty_piece_fast_impl<const FROM_SOURCE: bool>(
+        &self,
+        source: Option<&[i16; L1]>,
+        accumulation: &mut [i16; L1],
+        dirty_piece: &DirtyPiece,
+        perspective: Color,
+        king_sq: crate::types::Square,
+    ) -> bool {
         if cfg!(feature = "nnue-effect-bucket") {
             return false;
         }
@@ -1497,11 +1536,20 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
             1 => {
                 let (old_bp, new_bp) = old_new(0);
                 if old_bp != BonaPiece::ZERO && new_bp != BonaPiece::ZERO {
-                    self.apply_sub_add_fused(
-                        accumulation,
-                        feature_index_from_bona_piece::<FT>(old_bp, perspective, king_sq),
-                        feature_index_from_bona_piece::<FT>(new_bp, perspective, king_sq),
-                    );
+                    let sub_index =
+                        feature_index_from_bona_piece::<FT>(old_bp, perspective, king_sq);
+                    let add_index =
+                        feature_index_from_bona_piece::<FT>(new_bp, perspective, king_sq);
+                    if FROM_SOURCE {
+                        self.apply_sub_add_fused_from_source(
+                            source.expect("source is present when FROM_SOURCE is true"),
+                            accumulation,
+                            sub_index,
+                            add_index,
+                        );
+                    } else {
+                        self.apply_sub_add_fused(accumulation, sub_index, add_index);
+                    }
                     true
                 } else {
                     false
@@ -1515,19 +1563,147 @@ impl<const L1: usize, FT: LsFeatureSpec> FeatureTransformerLayerStacks<L1, FT> {
                     && old_bp1 != BonaPiece::ZERO
                     && new_bp1 != BonaPiece::ZERO
                 {
-                    self.apply_double_sub_add_fused(
-                        accumulation,
-                        feature_index_from_bona_piece::<FT>(old_bp0, perspective, king_sq),
-                        feature_index_from_bona_piece::<FT>(new_bp0, perspective, king_sq),
-                        feature_index_from_bona_piece::<FT>(old_bp1, perspective, king_sq),
-                        feature_index_from_bona_piece::<FT>(new_bp1, perspective, king_sq),
-                    );
+                    let sub_index0 =
+                        feature_index_from_bona_piece::<FT>(old_bp0, perspective, king_sq);
+                    let add_index0 =
+                        feature_index_from_bona_piece::<FT>(new_bp0, perspective, king_sq);
+                    let sub_index1 =
+                        feature_index_from_bona_piece::<FT>(old_bp1, perspective, king_sq);
+                    let add_index1 =
+                        feature_index_from_bona_piece::<FT>(new_bp1, perspective, king_sq);
+                    if FROM_SOURCE {
+                        self.apply_double_sub_add_fused_from_source(
+                            source.expect("source is present when FROM_SOURCE is true"),
+                            accumulation,
+                            sub_index0,
+                            add_index0,
+                            sub_index1,
+                            add_index1,
+                        );
+                    } else {
+                        self.apply_double_sub_add_fused(
+                            accumulation,
+                            sub_index0,
+                            add_index0,
+                            sub_index1,
+                            add_index1,
+                        );
+                    }
                     true
                 } else {
                     false
                 }
             }
             _ => false,
+        }
+    }
+
+    #[inline]
+    fn apply_sub_add_fused_from_source(
+        &self,
+        source: &[i16; L1],
+        accumulation: &mut [i16; L1],
+        sub_index: usize,
+        add_index: usize,
+    ) {
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
+        {
+            let sub_weights = self.weight_row(sub_index);
+            let add_weights = self.weight_row(add_index);
+
+            // SAFETY:
+            // - source / accumulation は別の AccumulatorLayerStacks 内
+            //   Aligned<[i16; L1]> で、ともに32バイトアライン。
+            // - weight rowも64バイトアラインかつ各行長L1は16の倍数。
+            // - L1要素を16要素ずつ完全に走査し、sourceとweightを読んでから
+            //   対応するaccumulation chunkへstoreする。
+            unsafe {
+                use std::arch::x86_64::*;
+                let source_ptr = source.as_ptr();
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr = sub_weights.as_ptr();
+                let add_ptr = add_weights.as_ptr();
+
+                for i in 0..(L1 / 16) {
+                    let source_vec = _mm256_load_si256(source_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec = _mm256_load_si256(sub_ptr.add(i * 16) as *const __m256i);
+                    let add_vec = _mm256_load_si256(add_ptr.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(_mm256_sub_epi16(source_vec, sub_vec), add_vec);
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        {
+            accumulation.copy_from_slice(source);
+            self.apply_sub_add_fused(accumulation, sub_index, add_index);
+        }
+    }
+
+    #[inline]
+    fn apply_double_sub_add_fused_from_source(
+        &self,
+        source: &[i16; L1],
+        accumulation: &mut [i16; L1],
+        sub_index0: usize,
+        add_index0: usize,
+        sub_index1: usize,
+        add_index1: usize,
+    ) {
+        #[cfg(all(
+            target_arch = "x86_64",
+            target_feature = "avx2",
+            not(target_feature = "avx512bw")
+        ))]
+        {
+            let sub_weights0 = self.weight_row(sub_index0);
+            let add_weights0 = self.weight_row(add_index0);
+            let sub_weights1 = self.weight_row(sub_index1);
+            let add_weights1 = self.weight_row(add_index1);
+
+            // SAFETY: apply_sub_add_fused_from_sourceと同じ。4本のweight rowも
+            // すべてL1要素あり、16要素単位で完全に走査する。
+            unsafe {
+                use std::arch::x86_64::*;
+                let source_ptr = source.as_ptr();
+                let acc_ptr = accumulation.as_mut_ptr();
+                let sub_ptr0 = sub_weights0.as_ptr();
+                let add_ptr0 = add_weights0.as_ptr();
+                let sub_ptr1 = sub_weights1.as_ptr();
+                let add_ptr1 = add_weights1.as_ptr();
+
+                for i in 0..(L1 / 16) {
+                    let source_vec = _mm256_load_si256(source_ptr.add(i * 16) as *const __m256i);
+                    let sub_vec0 = _mm256_load_si256(sub_ptr0.add(i * 16) as *const __m256i);
+                    let add_vec0 = _mm256_load_si256(add_ptr0.add(i * 16) as *const __m256i);
+                    let sub_vec1 = _mm256_load_si256(sub_ptr1.add(i * 16) as *const __m256i);
+                    let add_vec1 = _mm256_load_si256(add_ptr1.add(i * 16) as *const __m256i);
+                    let result = _mm256_add_epi16(
+                        _mm256_add_epi16(_mm256_sub_epi16(source_vec, sub_vec0), add_vec0),
+                        _mm256_sub_epi16(add_vec1, sub_vec1),
+                    );
+                    _mm256_store_si256(acc_ptr.add(i * 16) as *mut __m256i, result);
+                }
+            }
+            return;
+        }
+
+        #[allow(unreachable_code)]
+        {
+            accumulation.copy_from_slice(source);
+            self.apply_double_sub_add_fused(
+                accumulation,
+                sub_index0,
+                add_index0,
+                sub_index1,
+                add_index1,
+            );
         }
     }
 
@@ -2035,11 +2211,28 @@ mod tests {
         fill_weight_row(&mut ft, old_index, 11);
         fill_weight_row(&mut ft, new_index, 37);
 
-        let mut generic = Aligned([5i16; TEST_L1]);
-        let mut fast = Aligned([5i16; TEST_L1]);
+        let mut source = Aligned([0i16; TEST_L1]);
+        for (i, slot) in source.0.iter_mut().enumerate() {
+            *slot = match i % 3 {
+                0 => i16::MIN.wrapping_add(i as i16),
+                1 => i16::MAX.wrapping_sub(i as i16),
+                _ => (i as i16).wrapping_mul(97),
+            };
+        }
+        let mut generic = source.clone();
+        let mut fast = source.clone();
+        let mut from_source = Aligned([123i16; TEST_L1]);
         apply_generic(&ft, &mut generic.0, &dirty_piece, Color::Black, king_sq);
         assert!(ft.try_apply_dirty_piece_fast(&mut fast.0, &dirty_piece, Color::Black, king_sq));
+        assert!(ft.try_apply_dirty_piece_fast_from_source(
+            &source.0,
+            &mut from_source.0,
+            &dirty_piece,
+            Color::Black,
+            king_sq,
+        ));
         assert_eq!(generic.0, fast.0);
+        assert_eq!(generic.0, from_source.0);
     }
 
     // effect bucket build は `EffectBucket=` token 付き arch を要求するため、非 EffectBucket
@@ -2097,11 +2290,28 @@ mod tests {
             fill_weight_row(&mut ft, index, *seed);
         }
 
-        let mut generic = Aligned([7i16; TEST_L1]);
-        let mut fast = Aligned([7i16; TEST_L1]);
+        let mut source = Aligned([0i16; TEST_L1]);
+        for (i, slot) in source.0.iter_mut().enumerate() {
+            *slot = match i % 3 {
+                0 => i16::MIN.wrapping_add((i * 3) as i16),
+                1 => i16::MAX.wrapping_sub((i * 5) as i16),
+                _ => (i as i16).wrapping_mul(-113),
+            };
+        }
+        let mut generic = source.clone();
+        let mut fast = source.clone();
+        let mut from_source = Aligned([-321i16; TEST_L1]);
         apply_generic(&ft, &mut generic.0, &dirty_piece, Color::Black, king_sq);
         assert!(ft.try_apply_dirty_piece_fast(&mut fast.0, &dirty_piece, Color::Black, king_sq));
+        assert!(ft.try_apply_dirty_piece_fast_from_source(
+            &source.0,
+            &mut from_source.0,
+            &dirty_piece,
+            Color::Black,
+            king_sq,
+        ));
         assert_eq!(generic.0, fast.0);
+        assert_eq!(generic.0, from_source.0);
     }
 
     // effect bucket build は `EffectBucket=` token 付き arch を要求するため、非 EffectBucket


### PR DESCRIPTION
## What changed

- Fuse the LayerStacks accumulator source copy with the normal/capture dirty-piece subtraction/addition.
- Keep the existing slow paths, PSQT updates, effect-bucket handling, king-piece handling, and forward incremental update semantics unchanged.
- Add direct equivalence coverage using patterned accumulator values near the `i16` limits.

## Why

The backward accumulator update previously copied the full 3 KiB source accumulator and then made another pass for the dirty-piece update. Loading the source lanes and storing the updated destination in one AVX2 pass removes that redundant memory traffic while preserving wrapping `i16` arithmetic.

## Validation

- Independent code review: APPROVE
- `cargo fmt --check`
- Native clippy with `-D warnings`
- Non-AVX2 `cargo check` with `-D warnings`
- LayerStacks L1=768 non-PSQT and L1=1536 PSQT checks
- `cargo test -p rshogi-core`: 1001 passed, 6 ignored
- Fixed-depth search: 4 positions x depth 1..16, completed-depth nodes and bestmoves exactly match baseline
- Formal stripped production binary SHA-256 matches the measured candidate

## Performance

Single-thread, Hash 256 MiB, CPU 8 pinned, ABBA, 4 positions, 3 rounds:

| Window | Baseline NPS | Candidate NPS | NPS | cycles/node |
|---|---:|---:|---:|---:|
| 5 s | 706,853 | 728,353 | +3.04% | -2.96% |
| 10 s | 695,211 | 723,849 | +4.12% | -3.97% |

Every position and every round improved in both NPS and cycles/node. Selfplay was not run because the fixed-depth search tree and evaluations are bit-for-bit unchanged.