### PR TITLE
perf(nnue): fuse LayerStacks output activation

### DIFF
--- a/crates/rshogi-core/src/nnue/layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/layer_stacks.rs
@@ -1220,6 +1220,10 @@ mod tests {
 
         assert_eq!(optimized_inline, reference);
         assert_eq!(optimized, reference);
+
+        // hot path と診断 path は別実装のため、非自明入力での bit 一致をここで固定する
+        let mut counts = LsSaturationCounts::default();
+        assert_eq!(bucket.propagate_counting_saturation(&input.0, &mut counts), reference);
     }
 
     /// l1_out の値が大きい場合（i32 乗算でオーバーフローするケース）の回帰テスト。

--- a/crates/rshogi-core/src/nnue/layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/layer_stacks.rs
@@ -115,7 +115,9 @@ impl<
         let mut l1_out = [0i32; LS_L1_OUT];
         let mut l2_input = Aligned([0u8; LS_L2_PADDED_INPUT]);
         let mut l2_out = [0i32; NNUE_PYTORCH_L3];
+        #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
         let mut l2_relu = Aligned([0u8; OUTPUT_PADDED_INPUT]);
+        #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
         let mut output_arr = [0i32; 1];
 
         // L1: L1 → LS_L1_OUT
@@ -132,13 +134,17 @@ impl<
 
         // L2: LS_L2_IN → 32
         self.l2.propagate(&l2_input.0, &mut l2_out);
-        clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
-
-        // Output: 32 → 1
-        self.output.propagate(&l2_relu.0, &mut output_arr);
+        #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+        let output = clipped_relu_affine_32_to_1_avx2(&l2_out, &self.output);
+        #[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
+        let output = {
+            clipped_relu_i32_to_u8(&l2_out, &mut l2_relu.0);
+            self.output.propagate(&l2_relu.0, &mut output_arr);
+            output_arr[0]
+        };
 
         // Skip connection
-        output_arr[0] + l1_skip
+        output + l1_skip
     }
 
     /// 順伝播しつつ各活性段の 127 飽和を数える（診断用、ホットパス外）。
@@ -420,6 +426,56 @@ fn clipped_relu_i32_to_u8(input: &[i32; NNUE_PYTORCH_L3], output: &mut [u8]) {
         for (out, &val) in output.iter_mut().zip(input.iter()) {
             *out = (val >> 6).clamp(0, 127) as u8;
         }
+    }
+}
+
+/// LayerStacks の L2 ClippedReLU と 32→1 affine を中間配列なしで計算する。
+///
+/// `packus` が負値を0へ飽和するため、shift後は上限127だけを明示的にclampすれば
+/// `clamp(input >> 6, 0, 127)` と一致する。32要素をレジスタ内でu8へpackし、そのまま
+/// 出力層の内積へ渡すことで、従来の32-byte store/reloadを省く。
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[inline]
+fn clipped_relu_affine_32_to_1_avx2(
+    input: &[i32; NNUE_PYTORCH_L3],
+    affine: &AffineTransform<NNUE_PYTORCH_L3, 1>,
+) -> i32 {
+    const { assert!(NNUE_PYTORCH_L3 == 32) };
+
+    // SAFETY:
+    // - input は32要素なので4本の256-bit loadが有効。
+    // - affine.weights は32要素以上かつ64-byte aligned。
+    // - shift/clamp後は[0,127]なので maddubs の隣接2項和はi16に収まる。
+    unsafe {
+        use std::arch::x86_64::*;
+
+        let input_ptr = input.as_ptr() as *const __m256i;
+        let max127 = _mm256_set1_epi32(127);
+        let v0 = _mm256_min_epi32(_mm256_srai_epi32(_mm256_loadu_si256(input_ptr), 6), max127);
+        let v1 =
+            _mm256_min_epi32(_mm256_srai_epi32(_mm256_loadu_si256(input_ptr.add(1)), 6), max127);
+        let v2 =
+            _mm256_min_epi32(_mm256_srai_epi32(_mm256_loadu_si256(input_ptr.add(2)), 6), max127);
+        let v3 =
+            _mm256_min_epi32(_mm256_srai_epi32(_mm256_loadu_si256(input_ptr.add(3)), 6), max127);
+
+        let words01 = _mm256_packs_epi32(v0, v1);
+        let words23 = _mm256_packs_epi32(v2, v3);
+        let packed = _mm256_packus_epi16(words01, words23);
+        // pack命令は128-bit laneごとに動くため、4-byte groupを入力順へ戻す。
+        let reorder = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+        let activations = _mm256_permutevar8x32_epi32(packed, reorder);
+
+        let weights = _mm256_load_si256(affine.weights.as_ptr() as *const __m256i);
+        let product16 = _mm256_maddubs_epi16(activations, weights);
+        let product32 = _mm256_madd_epi16(product16, _mm256_set1_epi16(1));
+
+        let lo = _mm256_castsi256_si128(product32);
+        let hi = _mm256_extracti128_si256(product32, 1);
+        let sum128 = _mm_add_epi32(lo, hi);
+        let sum64 = _mm_add_epi32(sum128, _mm_unpackhi_epi64(sum128, sum128));
+        let sum32 = _mm_add_epi32(sum64, _mm_shuffle_epi32(sum64, 1));
+        affine.biases[0] + _mm_cvtsi128_si32(sum32)
     }
 }
 
@@ -996,6 +1052,64 @@ mod tests {
         }
 
         assert_eq!(opt, reference);
+    }
+
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    #[test]
+    fn test_clipped_relu_affine_32_to_1_avx2_matches_scalar_reference() {
+        let input = [
+            i32::MIN,
+            -1_000_000,
+            -32769,
+            -32768,
+            -65,
+            -64,
+            -63,
+            -1,
+            0,
+            1,
+            63,
+            64,
+            127,
+            128,
+            8127,
+            8128,
+            8191,
+            8192,
+            32767,
+            32768,
+            65535,
+            65536,
+            100_000,
+            1_000_000,
+            i32::MAX,
+            -4096,
+            4096,
+            -8192,
+            16_384,
+            24_576,
+            32_768,
+            40_000,
+        ];
+        let weights: [i8; NNUE_PYTORCH_L3] = [
+            -128, 127, -127, 126, -64, 63, -32, 31, -16, 15, -8, 7, -4, 3, -2, 1, 0, -1, 2, -3, 4,
+            -7, 8, -15, 16, -31, 32, -63, 64, -126, 127, -128,
+        ];
+        let bias = 123_456i32;
+        let mut bytes = Vec::with_capacity(4 + weights.len());
+        bytes.extend_from_slice(&bias.to_le_bytes());
+        bytes.extend(weights.iter().map(|&weight| weight as u8));
+        let affine =
+            AffineTransform::<NNUE_PYTORCH_L3, 1>::read(&mut &bytes[..]).expect("valid affine");
+
+        let reference = bias
+            + input
+                .iter()
+                .zip(weights)
+                .map(|(&value, weight)| (value >> 6).clamp(0, 127) * i32::from(weight))
+                .sum::<i32>();
+
+        assert_eq!(clipped_relu_affine_32_to_1_avx2(&input, &affine), reference);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fuse the AVX2 LayerStacks L2 ClippedReLU with the 32-to-1 output affine transform
- keep the 32 packed activations in a register and remove the intermediate 32-byte store/reload
- preserve the existing non-AVX2 and diagnostic paths
- add an AVX2 scalar-reference test covering i32 extremes, clamp boundaries, lane ordering, and i8 weight extremes

## Performance

Production/native, HalfKaHmMerged LayerStacks 1536x16x32 none, kingrank9, Threads=1, Hash=256 MiB, CPU8, 4 positions, ABBA x3:

| run | NPS | cycles/node | instructions/node |
|---|---:|---:|---:|
| 5 seconds | +3.11% | -3.01% | -0.06% |
| 10 seconds | +2.24% | -2.20% | -0.06% |

The 10-second run improved NPS and cycles/node on all four positions and in all three rounds. Candidate binary SHA256: `099b1f252a13a0860c9c802bd3a48ae9a766878394b38f07a725ce8ae4bc7bec`.

## Verification

- `cargo fmt`
- `cargo clippy --fix --allow-dirty --tests`
- `cargo test`
- `bash scripts/check-tracked-abs-paths.sh`
- 4 positions, d1..d16: nodes, score, and PV exact at every depth; bestmove 4/4 exact
- independent code review: APPROVE

Selfplay was not run because the score/PV/search tree is bit-exact and this is a search-invariant execution optimization.