### PR TITLE
perf: reduce Finny cache accumulator copies

### DIFF
--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -108,6 +108,10 @@ impl<const L1: usize> Default for AccumulatorLayerStacks<L1> {
 #[repr(C, align(64))]
 struct AccCacheEntry<const L1: usize> {
     /// キャッシュされたアキュムレータ値
+    ///
+    /// `refresh_or_cache` がこの field を aligned SIMD load/store を使う
+    /// add/sub weight 関数へ直接渡すため、struct の `align(64)` と field 先頭
+    /// 配置 (offset 0) が 64-byte アライメントの前提として load-bearing。
     accumulation: [i16; L1],
     /// キャッシュされた PSQT アキュムレータ値
     ///
@@ -209,12 +213,20 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
         FS: Fn(&mut [i16; L1], usize),
     {
         let entry = &mut self.entries[king_sq.raw() as usize][perspective as usize];
+        // add_fn/sub_fn は aligned SIMD load/store を使うため、entry.accumulation を
+        // 直接渡すには AccCacheEntry の align(64) + field 先頭配置が必須。
+        debug_assert_eq!(entry.accumulation.as_ptr() as usize % 64, 0);
 
-        if entry.valid {
+        let was_valid = entry.valid;
+        // entry.accumulation を作業領域として直接更新するため、差分適用の途中で
+        // unwind すると entry が不整合になる。valid を先に落とし、全 field の
+        // 書き戻し完了後に立て直すことで半更新 entry の再利用を防ぐ。
+        entry.valid = false;
+
+        if was_valid {
             crate::nnue::stats::count_cache_hit!();
-            // cache entryを直接更新する。従来はentry→accumulationへコピーして差分を適用し、
-            // 最後にaccumulation→entryへ戻していた。entryを作業領域にすれば、cache hit時の
-            // L1要素全量コピーを最後のentry→accumulation 1回だけにできる。
+            // entry を作業領域にすることで、cache hit 時の L1 要素全量コピーを
+            // 最後の entry→accumulation 1回だけにする。
             let mut diff_count = 0usize;
             for (cached_bp, &current_bp) in entry.piece_list.iter().copied().zip(piece_list.iter())
             {

--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -1042,6 +1042,37 @@ mod tests {
             |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
         );
         assert_eq!(acc3[0], 35);
+
+        // 4回目: in-place 更新済み entry へさらに非ゼロ差分を適用 (hit→mutate→hit chain)
+        let mut pl3 = pl2;
+        pl3[0] = BonaPiece(7);
+        let mut acc4 = [0i16; TEST_L1];
+        cache.refresh_or_cache(
+            king_sq,
+            perspective,
+            &pl3,
+            &biases,
+            &mut acc4,
+            |bp| bp.0 as usize,
+            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
+            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+        );
+        // hit: 35 - 5 + 7 = 37
+        assert_eq!(acc4[0], 37);
+
+        // 5回目: pl3 のまま再読。piece_list の書き戻しが stale なら差分が重複適用される。
+        let mut acc5 = [0i16; TEST_L1];
+        cache.refresh_or_cache(
+            king_sq,
+            perspective,
+            &pl3,
+            &biases,
+            &mut acc5,
+            |bp| bp.0 as usize,
+            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
+            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+        );
+        assert_eq!(acc5[0], 37);
     }
 
     /// refresh_or_cache: slot 消滅 (capture)

--- a/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
+++ b/crates/rshogi-core/src/nnue/accumulator_layer_stacks.rs
@@ -212,20 +212,19 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
 
         if entry.valid {
             crate::nnue::stats::count_cache_hit!();
-            // キャッシュのアキュムレータ値をコピー
-            accumulation.copy_from_slice(&entry.accumulation);
-
-            // 40 slot 比較して変化した slot のみ差分適用
+            // cache entryを直接更新する。従来はentry→accumulationへコピーして差分を適用し、
+            // 最後にaccumulation→entryへ戻していた。entryを作業領域にすれば、cache hit時の
+            // L1要素全量コピーを最後のentry→accumulation 1回だけにできる。
             let mut diff_count = 0usize;
             for (cached_bp, &current_bp) in entry.piece_list.iter().copied().zip(piece_list.iter())
             {
                 if cached_bp != current_bp {
                     if cached_bp != BonaPiece::ZERO {
-                        sub_fn(accumulation, idx_fn(cached_bp));
+                        sub_fn(&mut entry.accumulation, idx_fn(cached_bp));
                         diff_count += 1;
                     }
                     if current_bp != BonaPiece::ZERO {
-                        add_fn(accumulation, idx_fn(current_bp));
+                        add_fn(&mut entry.accumulation, idx_fn(current_bp));
                         diff_count += 1;
                     }
                 }
@@ -234,16 +233,16 @@ impl<const L1: usize> AccumulatorCacheLayerStacks<L1> {
         } else {
             crate::nnue::stats::count_cache_miss!();
             // キャッシュ無効 → バイアスから full refresh
-            accumulation.copy_from_slice(biases);
+            entry.accumulation.copy_from_slice(biases);
             for &bp in piece_list.iter() {
                 if bp != BonaPiece::ZERO {
-                    add_fn(accumulation, idx_fn(bp));
+                    add_fn(&mut entry.accumulation, idx_fn(bp));
                 }
             }
         }
 
-        // キャッシュを更新
-        entry.accumulation.copy_from_slice(accumulation);
+        // 更新済みcache entryを探索stack側へ公開する。
+        accumulation.copy_from_slice(&entry.accumulation);
         entry.piece_list.copy_from_slice(piece_list);
         entry.valid = true;
     }
@@ -1017,6 +1016,20 @@ mod tests {
         );
         // hit: 30 - 15 + 20 = 35
         assert_eq!(acc2[0], 35);
+
+        // 3回目: 同じpiece listなら、2回目に更新したcache entryをそのまま返す。
+        let mut acc3 = [0i16; TEST_L1];
+        cache.refresh_or_cache(
+            king_sq,
+            perspective,
+            &pl2,
+            &biases,
+            &mut acc3,
+            |bp| bp.0 as usize,
+            |acc, idx| acc[0] = acc[0].wrapping_add(idx as i16),
+            |acc, idx| acc[0] = acc[0].wrapping_sub(idx as i16),
+        );
+        assert_eq!(acc3[0], 35);
     }
 
     /// refresh_or_cache: slot 消滅 (capture)


### PR DESCRIPTION
## Summary

- apply LayerStacks Finny cache-hit diffs directly to the cache entry
- publish the updated entry to the search accumulator with one full copy instead of two
- cover the following unchanged cache hit in the unit test

## Correctness

- 4 positions x depths 1..16: nodes, score, and PV exact at all 64 completed depths; bestmove 4/4 exact
- targeted LayerStacks accumulator tests: 9 passed
- cargo fmt, clippy, full cargo test, tracked absolute-path check, and diff check passed
- independent review: APPROVE

## Performance

Production, target-cpu=native, LayerStacks HalfKaHmMerged 1536x16x32 none, kingrank9, Threads=1, Hash=256 MiB, CPU8, 4 positions, ABBA x3:

| run | NPS | cycles/node | instructions/node |
|---|---:|---:|---:|
| 5s | +2.47% | -2.38% | +0.00% |
| 10s | +3.12% | -3.01% | -0.03% |

The 10s run improved NPS and cycles/node in all four positions and all three rounds. Search work and instructions/node remained effectively unchanged.