### PR TITLE
perf: index repetition history directly

### DIFF
--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -122,7 +122,8 @@ impl Position {
     fn cur_state(&self) -> &StateInfo {
         debug_assert!(self.state_idx < self.state_stack.len());
         // SAFETY: state_idx は push_state で設定され、常に state_stack.len() 未満。
-        //         state_stack は do_move で push / undo_move で pop され、不変条件を維持する。
+        //         state_stack は push_state で伸長するのみで縮小されず、undo 系は
+        //         state_idx を戻すだけなので不変条件が維持される。
         unsafe { self.state_stack.get_unchecked(self.state_idx) }
     }
 
@@ -1561,8 +1562,8 @@ impl Position {
         };
 
         // push_state() は常に current_idx + 1 へ保存するため、同一局面履歴上の
-        // n手前は state_stack[current_idx - n] にある。previous を二段ずつ
-        // たどる代わりに直接index化する。
+        // n手前は state_stack[current_idx - n] にある。
+        debug_assert!(current_idx == 0 || self.cur_state().previous == current_idx - 1);
         let max_back = plies_from_null.min(16).min(current_idx as i32);
         let mut repetition = 0;
         let mut repetition_times = 0;
@@ -1574,7 +1575,8 @@ impl Position {
             while dist <= max_back {
                 let st_idx = current_idx - dist as usize;
                 debug_assert!(st_idx < self.state_stack.len());
-                // SAFETY: dist <= max_back <= current_idx なので範囲内。
+                // SAFETY: dist <= max_back <= current_idx、かつ cur_state の不変条件より
+                //         current_idx < state_stack.len() なので範囲内。
                 let stp = unsafe { self.state_stack.get_unchecked(st_idx) };
                 if stp.board_key == board_key {
                     let prev_hand = stp.hand_snapshot[side.index()];
@@ -2165,17 +2167,58 @@ mod tests {
         }
         assert_eq!(pos.repetition_state(0), RepetitionState::Draw);
 
-        // 直前cycleをundoして同じdepthへ指し直し、古いstate slotを上書きしても
-        // 4回目の繰り返し情報が同じになることを確認する。
+        // 直前cycleをundoし、別手順で古いstate slotを異なる内容に上書きしてから
+        // 同じdepthへ指し直しても繰り返し情報が変わらないことを確認する。
         for mv in cycle.into_iter().rev() {
             pos.undo_move(mv);
         }
         assert_eq!(pos.cur_state().repetition_times, 2);
+        let alt_line = [
+            Move::new_move(
+                Square::new(File::File4, Rank::Rank9),
+                Square::new(File::File4, Rank::Rank8),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File4, Rank::Rank1),
+                Square::new(File::File4, Rank::Rank2),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File4, Rank::Rank8),
+                Square::new(File::File4, Rank::Rank9),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File4, Rank::Rank2),
+                Square::new(File::File4, Rank::Rank1),
+                false,
+            ),
+        ];
+        for mv in alt_line {
+            assert!(pos.is_legal(mv));
+            let gives_check = pos.gives_check(mv);
+            assert!(!gives_check);
+            pos.do_move(mv, gives_check);
+        }
+        for mv in alt_line.into_iter().rev() {
+            pos.undo_move(mv);
+        }
         for mv in cycle {
             let gives_check = pos.gives_check(mv);
             pos.do_move(mv, gives_check);
         }
         assert_eq!(pos.cur_state().repetition_times, 3);
+        assert_eq!(pos.cur_state().repetition, -4);
+        assert_eq!(pos.cur_state().repetition_type, RepetitionState::Draw);
+
+        // さらに1周指し、上書き再利用したslotが繰り返し走査の比較対象に入る
+        // 深さでも正しく数えられることを確認する。
+        for mv in cycle {
+            let gives_check = pos.gives_check(mv);
+            pos.do_move(mv, gives_check);
+        }
+        assert_eq!(pos.cur_state().repetition_times, 4);
         assert_eq!(pos.cur_state().repetition, -4);
         assert_eq!(pos.cur_state().repetition_type, RepetitionState::Draw);
     }

--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -1548,42 +1548,33 @@ impl Position {
     fn update_repetition_info(&mut self) {
         // 初期化
         let side = self.side_to_move;
-        let (plies_from_null, board_key, hand_snapshot, prev_idx, cc_side, cc_opp) = {
+        let current_idx = self.state_idx;
+        let (plies_from_null, board_key, hand_snapshot, cc_side, cc_opp) = {
             let st = self.cur_state();
             (
                 st.plies_from_null,
                 st.board_key,
                 st.hand_snapshot,
-                st.previous,
                 st.continuous_check[side.index()],
                 st.continuous_check[(!side).index()],
             )
         };
 
-        let max_back = plies_from_null.min(16);
+        // push_state() は常に current_idx + 1 へ保存するため、同一局面履歴上の
+        // n手前は state_stack[current_idx - n] にある。previous を二段ずつ
+        // たどる代わりに直接index化する。
+        let max_back = plies_from_null.min(16).min(current_idx as i32);
         let mut repetition = 0;
         let mut repetition_times = 0;
         let mut repetition_type = RepetitionState::None;
 
-        if max_back >= 4 && prev_idx != StateInfo::NO_PREVIOUS {
+        if max_back >= 4 {
             // 千日手は最短4手で成立するため4手前から比較開始
             let mut dist = 4;
-            let mut st_idx = prev_idx;
-            for _ in 0..3 {
+            while dist <= max_back {
+                let st_idx = current_idx - dist as usize;
                 debug_assert!(st_idx < self.state_stack.len());
-                // SAFETY: ループ不変条件: st_idx はループ先頭時点で常に有効なインデックス。
-                //   - 1回目: prev_idx は関数先頭で NO_PREVIOUS チェック済み。
-                //   - 2・3回目: 前の反復で NO_PREVIOUS なら break するため無効値では到達しない。
-                //   push_state で設定された .previous は常に有効なインデックスか NO_PREVIOUS。
-                st_idx = unsafe { self.state_stack.get_unchecked(st_idx) }.previous;
-                if st_idx == StateInfo::NO_PREVIOUS {
-                    break;
-                }
-            }
-
-            while dist <= max_back && st_idx != StateInfo::NO_PREVIOUS {
-                debug_assert!(st_idx < self.state_stack.len());
-                // SAFETY: 同上。
+                // SAFETY: dist <= max_back <= current_idx なので範囲内。
                 let stp = unsafe { self.state_stack.get_unchecked(st_idx) };
                 if stp.board_key == board_key {
                     let prev_hand = stp.hand_snapshot[side.index()];
@@ -1623,13 +1614,6 @@ impl Position {
                     }
                 }
 
-                let prev_same_side = stp.previous;
-                if prev_same_side == StateInfo::NO_PREVIOUS {
-                    break;
-                }
-                debug_assert!(prev_same_side < self.state_stack.len());
-                // SAFETY: prev_same_side は .previous チェーンの有効なインデックス。
-                st_idx = unsafe { self.state_stack.get_unchecked(prev_same_side) }.previous;
                 dist += 2;
             }
         }
@@ -2138,6 +2122,62 @@ mod tests {
         assert_eq!(pos.piece_on(sq77), Piece::B_PAWN);
         assert_eq!(pos.piece_on(sq76), Piece::NONE);
         assert_eq!(pos.side_to_move(), Color::Black);
+    }
+
+    #[test]
+    fn test_repetition_info_survives_state_slot_reuse() {
+        let mut pos = Position::new();
+        pos.set_hirate();
+
+        let cycle = [
+            Move::new_move(
+                Square::new(File::File5, Rank::Rank9),
+                Square::new(File::File5, Rank::Rank8),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File5, Rank::Rank1),
+                Square::new(File::File5, Rank::Rank2),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File5, Rank::Rank8),
+                Square::new(File::File5, Rank::Rank9),
+                false,
+            ),
+            Move::new_move(
+                Square::new(File::File5, Rank::Rank2),
+                Square::new(File::File5, Rank::Rank1),
+                false,
+            ),
+        ];
+
+        for expected_times in 1..=3 {
+            for mv in cycle {
+                assert!(pos.is_legal(mv));
+                let gives_check = pos.gives_check(mv);
+                assert!(!gives_check);
+                pos.do_move(mv, gives_check);
+            }
+            assert_eq!(pos.cur_state().repetition_times, expected_times);
+            assert_eq!(pos.cur_state().repetition_type, RepetitionState::Draw);
+            assert_eq!(pos.cur_state().repetition, if expected_times >= 3 { -4 } else { 4 });
+        }
+        assert_eq!(pos.repetition_state(0), RepetitionState::Draw);
+
+        // 直前cycleをundoして同じdepthへ指し直し、古いstate slotを上書きしても
+        // 4回目の繰り返し情報が同じになることを確認する。
+        for mv in cycle.into_iter().rev() {
+            pos.undo_move(mv);
+        }
+        assert_eq!(pos.cur_state().repetition_times, 2);
+        for mv in cycle {
+            let gives_check = pos.gives_check(mv);
+            pos.do_move(mv, gives_check);
+        }
+        assert_eq!(pos.cur_state().repetition_times, 3);
+        assert_eq!(pos.cur_state().repetition, -4);
+        assert_eq!(pos.cur_state().repetition_type, RepetitionState::Draw);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- replace the two-link `StateInfo::previous` walk in `update_repetition_info()` with direct `state_stack[current_idx - dist]` indexing
- cap the scan by the available contiguous state depth as well as `plies_from_null` and 16 plies
- add a fourfold-repetition regression test that also undoes and reuses the same state slots

## Why

`push_state()` always writes `state_idx + 1` and links it to `state_idx`, so the current path is contiguous even after sibling-slot reuse. The accepted-combination profile attributed about 2.9% of four-position cycles, and 4.09% on hirate-like, to `update_repetition_info()`. Direct indexing removes the redundant linked-index loads without changing the repetition rules.

## Performance

Production, `target-cpu=native`, Threads=1, CPU 8 pinned, four positions, ABBA x3 (24 samples per variant):

| run | NPS | cycles/node | instructions/node |
|---|---:|---:|---:|
| 5s | +1.44% | -1.43% | -0.46% |
| 10s | +1.22% | -1.22% | -0.53% |

## Validation

- four positions, depth 1 through 16: 64/64 exact match for nodes, score, PV, and bestmove
- explicit fourfold-repetition and state-slot-reuse regression test
- `cargo clippy -p rshogi-core --all-targets --no-default-features --features edition-layerstacks-halfka_hm_merged-1536x16x32-none -- -D warnings`
- `cargo test -p rshogi-core`: 1002 passed, 6 ignored; 40 integration tests passed; doc tests completed
- final production binary is byte-identical to the measured candidate (`f3436f3de77a07b7f31e9b17a06428b3150563d9a05051a839b2770795f6fe12`)
