### PR TITLE
perf(mate): reuse cached gold-like pieces

### DIFF
--- a/crates/rshogi-core/src/mate/move_mate.rs
+++ b/crates/rshogi-core/src/mate/move_mate.rs
@@ -245,11 +245,7 @@ pub fn check_move_mate(pos: &Position, us: Color) -> Option<Move> {
     }
 
     // GOLD相当（Gold/ProPawn/ProLance/ProKnight/ProSilver）
-    let gold_like = pos.pieces(us, PieceType::Gold)
-        | pos.pieces(us, PieceType::ProPawn)
-        | pos.pieces(us, PieceType::ProLance)
-        | pos.pieces(us, PieceType::ProKnight)
-        | pos.pieces(us, PieceType::ProSilver);
+    let gold_like = pos.golds_c(us);
     let mut bb = check_cand_bb(us, PieceTypeCheck::Gold, sq_king) & gold_like;
     while bb.is_not_empty() {
         let from = bb.pop();


### PR DESCRIPTION
## 概要

`check_move_mate()` の金相当駒列挙で、5駒種を毎回ORする代わりに `Position` が維持している `golds_bb` を `pos.golds_c(us)` 経由で再利用します。

## 理由

movegenでは既に合成Bitboardを使っていますが、移動による1手詰め判定だけが Gold / ProPawn / ProLance / ProKnight / ProSilver を再構成していました。候補手・列挙順・探索処理を変えない1行の意味保存最適化です。

## 性能

production edition、CPU 8固定、Threads=1、Hash=256 MiB、kingrank9、4局面、ABBA x3 rounds:

- 5秒: NPS +1.00%、cycles/node -0.98%
- 10秒: NPS +1.21%、cycles/node -1.20%
- 5秒・10秒とも4/4局面、3/3 roundでNPS改善
- instructions/nodeはほぼ不変

## 検証

- 4局面 x depth 1--16: nodes / score / PV / bestmove 64/64完全一致
- `cargo fmt --check`
- production edition lib clippy `-D warnings`
- `cargo test -p rshogi-core`: lib 1,005 passed / 6 ignored、integration 40 passed
- `bash scripts/check-tracked-abs-paths.sh`
- 独立レビュー APPROVE

test込みclippyは差分外の既知 `clone_on_copy` 4件（PR #985系）で停止するため、本PRでは変更していません。