### PR TITLE
perf(position): remove redundant empty pin check

### DIFF
--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -649,7 +649,7 @@ impl Position {
         let mut result = Bitboard::EMPTY;
         for pinner_sq in pinners.iter() {
             let between = crate::bitboard::between_bb(ksq, pinner_sq) & pieces_without_avoid;
-            if !between.is_empty() && !between.more_than_one() {
+            if !between.more_than_one() {
                 result |= between & self.pieces_c(them);
             }
         }


### PR DESCRIPTION
## Summary

- remove the redundant empty-bitboard gate in `pinned_pieces_excluding()`
- match YaneuraOu control flow by relying on `more_than_one()` alone
- preserve the empty case because OR-ing an empty bitboard is a no-op

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rshogi-core`: 1001 passed, 6 ignored; integration 40 passed
- production-edition lib clippy with `-D warnings`
- tracked absolute-path check
- deterministic search: 4 positions x depths 1..16, nodes/score/PV/bestmove exact
- 5s ABBA x3: NPS +1.11%, cycles/node -1.11%
- 10s ABBA x3: NPS +0.71%, cycles/node -0.71%; all 4 positions and all 3 rounds positive

## Measurement context

Measured on top of the accepted combined performance stack because this function is byte-identical between that stack and current `main`. The published PR contains only this one-line change on `main`.
