### PR TITLE
refactor: drop dead StateInfo::material_key and game_ply fields

### DIFF
--- a/crates/rshogi-core/src/position/pos.rs
+++ b/crates/rshogi-core/src/position/pos.rs
@@ -168,13 +168,11 @@ impl Position {
         // StateInfoの全フィールドを網羅し、追加時にコピー/再構築の分類漏れを
         // コンパイルエラーとして検出する。`_`のフィールドはdo_move内で再構築する。
         let &StateInfo {
-            material_key,
             pawn_key,
             minor_piece_key,
             non_pawn_key,
             plies_from_null,
             continuous_check,
-            game_ply,
             pass_rights,
             board_key,
             hand_key,
@@ -192,13 +190,11 @@ impl Position {
             last_move: _,
         } = previous;
 
-        next.material_key = material_key;
         next.pawn_key = pawn_key;
         next.minor_piece_key = minor_piece_key;
         next.non_pawn_key = non_pawn_key;
         next.plies_from_null = plies_from_null;
         next.continuous_check = continuous_check;
-        next.game_ply = game_ply;
         next.pass_rights = pass_rights;
         next.board_key = board_key;
         next.hand_key = hand_key;

--- a/crates/rshogi-core/src/position/state.rs
+++ b/crates/rshogi-core/src/position/state.rs
@@ -67,8 +67,6 @@ pub(crate) fn check_sq_index(pt: PieceType) -> Option<usize> {
 #[derive(Clone)]
 pub struct StateInfo {
     // === do_move時にコピーされる部分 ===
-    /// 駒割ハッシュ
-    pub material_key: u64,
     /// 歩のハッシュ（打ち歩詰め判定用）
     pub pawn_key: u64,
     /// 小駒（香・桂・銀・金・その成り駒）のハッシュ
@@ -79,8 +77,6 @@ pub struct StateInfo {
     pub plies_from_null: i32,
     /// 連続王手カウンタ [Color]
     pub continuous_check: [i32; Color::NUM],
-    /// ゲーム開始からの総手数（320手ルール用）
-    pub game_ply: u16,
     /// パス権残数（パック形式）
     /// 上位4bit: 先手のパス権 (0-15)
     /// 下位4bit: 後手のパス権 (0-15)
@@ -129,13 +125,11 @@ impl StateInfo {
     /// 空の状態を生成
     pub fn new() -> Self {
         StateInfo {
-            material_key: 0,
             pawn_key: zobrist_no_pawns(),
             minor_piece_key: 0,
             non_pawn_key: [0; Color::NUM],
             plies_from_null: 0,
             continuous_check: [0; Color::NUM],
-            game_ply: 0,
             pass_rights: 0, // パス権なし＝通常将棋
             board_key: 0,
             hand_key: 0,
@@ -205,13 +199,11 @@ impl StateInfo {
     /// ここでは初期化しない。do_moveの主なコストはBitboard/ハッシュ更新のみになる。
     pub fn partial_clone(&self) -> Self {
         StateInfo {
-            material_key: self.material_key,
             pawn_key: self.pawn_key,
             minor_piece_key: self.minor_piece_key,
             non_pawn_key: self.non_pawn_key,
             plies_from_null: self.plies_from_null,
             continuous_check: self.continuous_check,
-            game_ply: self.game_ply,
             pass_rights: self.pass_rights, // パス権をコピー
             // 以下は再計算される
             board_key: self.board_key,
@@ -266,14 +258,12 @@ mod tests {
     #[test]
     fn test_state_info_partial_clone() {
         let mut state = StateInfo::new();
-        state.material_key = 100;
         state.plies_from_null = 5;
         state.continuous_check = [3, 2];
         state.minor_piece_key = 42;
         state.non_pawn_key = [7, 11];
 
         let cloned = state.partial_clone();
-        assert_eq!(cloned.material_key, 100);
         assert_eq!(cloned.plies_from_null, 5);
         assert_eq!(cloned.continuous_check, [3, 2]);
         assert_eq!(cloned.minor_piece_key, 42);


### PR DESCRIPTION
## 概要

`StateInfo::material_key` と `StateInfo::game_ply` を削除する。どちらも書き手 (常に 0) と読み手が存在しない dead field で、320手ルールは `Position::game_ply` を使用している。do_move の引き継ぎコピーは 12→10 フィールドになる。struct サイズは tail padding 吸収により 336 bytes のまま不変。

## 検証

- 全 workspace grep で両 field の読み手ゼロを確認 (feature-gated 経路 5 構成の cargo check 含む)
- StateInfo に layout/size 依存なし (serde / repr(C) / size_of / transmute いずれも不使用、derive は Clone のみ)
- pos.rs の網羅 destructure は残 20 field を `..` なしで列挙 (compile-error tripwire 維持)
- `cargo fmt --check` / `cargo clippy -p rshogi-core --all-targets -- -D warnings` / `cargo test -p rshogi-core --lib`: 1001 passed
- 独立 dual review (Claude + Codex): 両者 APPROVE

## 備考

base は #988 (`perf/stateinfo-inplace-20260807`)。#988 merge 後に base を main へ retarget してから merge する (base branch 削除による auto-close に注意)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdXf5qjwrnAA3r96WyTvvD