### PR TITLE
feat(tools): PSV score sidecar 出力と入玉ゲート bitmap を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -35,6 +35,7 @@
 | `merge_psv` | 複数の PSV ファイルを順序どおり結合 |
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](docs/relabel_psv.md)） |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
+| `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
@@ -112,6 +113,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [nyugyoku_metrics](docs/nyugyoku_metrics.md) - 終局 CSA から宣言ルール距離ペアと探索読み切り詰み距離を抽出し、NNUE 静的評価の順序一致率 / concordance / 詰み手 top-1 率を採点
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
+- [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの depth9/DL 合成と行対応 mask bitmap
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応）

--- a/crates/tools/docs/psv_gate_by_king_zone.md
+++ b/crates/tools/docs/psv_gate_by_king_zone.md
@@ -1,0 +1,54 @@
+# psv_gate_by_king_zone — 入玉ドメインのゲート生成
+
+行対応する depth9 / DL ラベルを入玉ドメインで合成するか、同じ判定を bitmap として
+出力するストリーミングツール。固定サイズのチャンクを読み、局面 classify を Rayon で
+並列化してから元の行順で書き出す。ピークメモリは入力件数に依存しない。
+
+## 行対応の不変条件とファイル契約
+
+base PSV の行順と行数が唯一の対応キーであり、sidecar / bitmap は行を追加・削除・
+並べ替えしない。入力 PSV のサイズが 40 byte の倍数でない場合や、merge 入力の行数・
+非 score フィールドが一致しない場合は fail-closed で停止する。出力がいずれかの入力と
+同じファイル実体を指す場合も、出力を作成・truncate する前に拒否する。
+
+- score sidecar: little-endian i16 × records。record `i` は offset `i * 2`。サイズは
+  `records * 2` byte に厳密一致する。
+- mask bitmap: byte `j` の bit `k`（`k=0` が LSB）は record `j*8+k` に対応する。
+  bit 1 はゲート対象。最終 partial byte の余り bit は 0。サイズは
+  `ceil(records / 8)` byte に厳密一致する。
+
+trainer は mask bit 1 の行では base（depth9）score を温存し、bit 0 の行だけ score
+sidecar で override する。
+
+## merge モード
+
+```bash
+psv_gate_by_king_zone \
+  --d9 depth9.psv --dl dl.psv --out merged.psv \
+  --tiers entered,advancing [--d9-abs-max 3000]
+```
+
+2 本を lockstep で読み、対象行だけ DL 側の score を depth9 score に差し替える。
+全行で sfen / move / ply / result が一致することを検査し、出力サイズが入力サイズと
+一致することも完了時に検証する。
+
+## mask モード
+
+```bash
+psv_gate_by_king_zone \
+  --input depth9.psv --out-mask gate.mask \
+  --tiers entered,advancing [--d9-abs-max 3000]
+```
+
+depth9 base を 1 本だけ読み、対象行を bitmap の bit 1 として出力する。同一入力と同一
+オプションからは常に bit 一致する。`--d9-abs-max N` 指定時は `|score| < N` も満たす
+行だけが対象になる（境界の `|score| == N` は対象外）。
+
+## tier
+
+- `entered`: 先手玉 rank 0..=2、または後手玉 rank 6..=8
+- `advancing`: `entered` ではなく、いずれかの玉が rank 3..=5
+- `normal`: 上記以外（ゲート指定不可）
+
+両モードは排他で、merge 用と mask 用の引数を混在させるとエラーになる。終了時には
+entered / advancing / normal と gated の件数・割合を同じ形式で表示する。

--- a/crates/tools/docs/rescore_psv-internals.md
+++ b/crates/tools/docs/rescore_psv-internals.md
@@ -76,18 +76,21 @@ atomic rename + `sync_all()` で書く。プロセス kill / panic に耐える�
 
 再実行時の判定:
 
-- marker の fingerprint が現在の CLI と完全一致 + 出力サイズが記録と一致 → skip
+- `.done` marker の fingerprint が現在の CLI と完全一致 + 出力サイズが記録と一致 → skip
 - fingerprint 不一致 → rescore / expand / replacement 全出力を truncate して再生成
-- marker なし + expand / replacement / `--qsearch-leaf-label` いずれも無効 →
-  レコード数ベース resume にフォールバック
-- marker なし + 上記いずれか有効 → 全出力を truncate して最初から処理
+- `--out-scores` で `.done` なし → `.in-progress` fingerprint 一致時だけ
+  レコード数ベース resume。不一致・欠落・破損時は sidecar を truncate
+- full PSV で marker なし + expand / replacement / `--qsearch-leaf-label` いずれも無効 →
+  従来のレコード数ベース resume にフォールバック
+- full PSV で marker なし + 上記いずれか有効 → 全出力を truncate して最初から処理
 
 fingerprint に含まれる項目:
 
 - モデルパス（canonicalize 済み）、モデルサイズ、モデル mtime（ns）
 - 入力パス、入力サイズ、入力 mtime（ns）
 - `process_count`（`--limit` 適用後）
-- `--skip-in-check`、`--score-clip`、`--onnx-eval-scale`（`f32::to_bits()` の hex）
+- `--out-scores`、`--skip-in-check`、`--score-clip`、`--onnx-eval-scale`
+  （`f32::to_bits()` の hex）、`--onnx-tensorrt`
 - AobaZero モデル時のみ `--onnx-draw-ply`
 - `--qsearch-leaf-label`、および有効時のみ `--max-ply` と葉探索用 `--nnue` の
   パス・サイズ・mtime（葉 PV = 出力が NNUE に依存するため差し替えを検知する）
@@ -96,8 +99,12 @@ fingerprint に含まれる項目:
 - replacement 有効時: `--qsearch-leaf-replacement-output` の canonicalize 済みパス
   とその出力サイズ
 
-後方互換: 旧 marker の `--qsearch-leaf-label` / `replacement` キー欠落は `false`
-扱い。`--qsearch-leaf-label=true` だが
+後方互換: 旧 marker の `use_tensorrt` キー欠落は unknown として読み、現在値の
+`true` / `false` のどちらとも fingerprint を一致させない。このためキー無し旧 marker は
+更新後の初回実行で出力を truncate して一度だけ再生成され、再生成後の marker には同キーが入る。
+`out_scores` キー欠落は従来どおり `false` 扱い（旧 sidecar 出力は存在しないため安全）。
+旧 marker の `--qsearch-leaf-label` / `replacement` キー欠落も `false` 扱い。
+`--qsearch-leaf-label=true` だが
 葉探索 NNUE キーを持たない旧 marker は NNUE メタを `None` として読み、現設定と
 fingerprint 不一致になって再生成される。
 

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -144,7 +144,7 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 | `--output-dir` | （必須） | 出力ディレクトリ（入力ファイル名で出力） |
 | `--out-scores` | false | dlshogi ONNX の score のみを `<入力名>.scores.i16` に出力（後述） |
 | `--threads` | 0（論理コア数） | 並列処理スレッド数 |
-| `--limit` | 0（無制限） | 各入力ファイルで処理するレコード数上限 |
+| `--limit` | 0（無制限） | 各入力ファイルで処理するレコード数上限（`--out-scores` と併用不可） |
 | `--score-clip` | 10000 | スコアを ± この値にクリップ |
 | `--skip-in-check` | false | 王手局面を出力から除外 |
 | `--delete-input` | false | 各ファイル処理完了後に入力を削除（ディスク節約、`--out-scores` と併用不可） |
@@ -233,16 +233,22 @@ rescore_psv --input "data/*.psv" --output-dir scores/ \
 
 フル PSV の代わりに `<入力ファイル名>.scores.i16` を生成する。record `i` の score は
 offset `i * 2` にある little-endian i16 で、ファイルサイズは厳密に
-`処理対象 records（--limit=0 なら入力件数、それ以外は min(--limit, 入力件数)）× 2` byte となる。通常のフル PSV
+`base PSV の全 records × 2` byte となる。通常のフル PSV
 出力と同じ推論・符号変換・clip を通り、
 通常出力の offset 32..34 を行順に抽出したものと bit 一致する。
 
 このモードは `--dlshogi-onnx-model` の直接推論専用で、NNUE、qsearch、search、外部
 engine、AobaZero ONNX、leaf label/replacement、expand、入力を削除する `--delete-input`、
-および行を減らす `--skip-in-check` とは併用できない。入力は 40 byte の倍数、既存 sidecar は 2 byte の
-倍数でなければ即時エラーになる。中断後は sidecar サイズを 2 で割った record 位置から
-追記再開し、完了時に全 record 数との厳密一致を再検証する。decode / 局面構築エラーを
-含むバッチは書き出し前に停止するため、既存 sidecar の prefix は常に base PSV と行対応する。
+処理件数を制限する `--limit`（0 より大きい値）、および行を減らす `--skip-in-check` とは
+併用できない。入力は 40 byte の倍数でなければ
+即時エラーになる。run 開始時に `<入力名>.scores.i16.in-progress` を作り、
+入力・ONNX モデル・ラベル条件の fingerprint を記録する。中断後はこの marker が現在の
+設定と一致し、既存 sidecar が 2 byte の倍数であるときだけ、サイズを 2 で割った record
+位置から追記再開する。一致時に奇数 byte なら即時エラーになる。marker が無い、壊れている、
+または fingerprint が異なる場合は、既存サイズにかかわらず sidecar を truncate して最初から生成する。
+完了時は全 record 数との厳密一致を再検証して `.done` marker を書き、in-progress marker を
+削除する。decode / 局面構築エラーを含むバッチは書き出し前に停止するため、既存 sidecar の
+prefix は常に base PSV と行対応する。
 
 ### 王手局面を教師データから除外する
 
@@ -332,7 +338,16 @@ rescore_psv --input data.bin --output-dir rescored/ \
 - **ONNX モード**: 入力ファイルごとに完了マーカー `<出力名>.done` を書く。
   再実行時、マーカーの設定 fingerprint（モデル・入力・主要フラグ）が現在の CLI と
   一致し出力サイズも一致すれば skip、不一致なら該当ファイルの全出力を truncate
-  して自動再生成する。`Ctrl-C` 中断時はマーカーを書かない。
+  して自動再生成する。`Ctrl-C` 中断時は `.done` を書かない。
+- **`--out-scores` の中断再開**: `<出力名>.in-progress` に `.done` と同じ形式の
+  fingerprint を保持する。入力 path/size/mtime、モデル path/size/mtime、全入力件数、
+  `--onnx-eval-scale`、`--score-clip`、`--onnx-tensorrt` など fingerprint が追跡する
+  条件が一致する場合だけ既存 prefix へ追記する。不一致・marker 欠落時は truncate して
+  再生成する。run 中に入力またはモデルの metadata が変化した場合も `.done` を書かず、
+  次回実行時に再生成する。出力 sidecar
+  自身の mtime は fingerprint に含めないため、追記による mtime 更新は resume を妨げない。
+  `Ctrl-C` 中断時は in-progress marker を残し、正常完了時だけ `.done` へ昇格する。
+  同じ出力 sidecar への複数プロセスからの同時書き込みは非対応。
 - **NNUE / 探索 / 外部エンジンモード**: マーカーは使わず、出力レコード数が入力
   レコード数以上のファイルを skip する（ファイル粒度。中途半端なファイルは最初
   から再処理）。

--- a/crates/tools/docs/rescore_psv.md
+++ b/crates/tools/docs/rescore_psv.md
@@ -142,11 +142,12 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 |---|---|---|
 | `--input` | （必須） | 入力 PSV。glob / 複数指定可 |
 | `--output-dir` | （必須） | 出力ディレクトリ（入力ファイル名で出力） |
+| `--out-scores` | false | dlshogi ONNX の score のみを `<入力名>.scores.i16` に出力（後述） |
 | `--threads` | 0（論理コア数） | 並列処理スレッド数 |
 | `--limit` | 0（無制限） | 各入力ファイルで処理するレコード数上限 |
 | `--score-clip` | 10000 | スコアを ± この値にクリップ |
 | `--skip-in-check` | false | 王手局面を出力から除外 |
-| `--delete-input` | false | 各ファイル処理完了後に入力を削除（ディスク節約） |
+| `--delete-input` | false | 各ファイル処理完了後に入力を削除（ディスク節約、`--out-scores` と併用不可） |
 | `--verbose` | false | 詳細出力 |
 
 ### ONNX モード
@@ -222,6 +223,26 @@ ort は load-dynamic のためビルド時に libonnxruntime は不要（実行�
 スタートのコマンドがそのままこの形（`--input "data/shard_*.bin"`）。
 `nohup` / `tmux` で流しっぱなしにしておき、GPU 温度で止めた後の再開や、モデル
 差し替え時の一括再スコアに使える。
+
+### score sidecar 出力（`--out-scores`）
+
+```bash
+rescore_psv --input "data/*.psv" --output-dir scores/ \
+  --dlshogi-onnx-model model.onnx --out-scores
+```
+
+フル PSV の代わりに `<入力ファイル名>.scores.i16` を生成する。record `i` の score は
+offset `i * 2` にある little-endian i16 で、ファイルサイズは厳密に
+`処理対象 records（--limit=0 なら入力件数、それ以外は min(--limit, 入力件数)）× 2` byte となる。通常のフル PSV
+出力と同じ推論・符号変換・clip を通り、
+通常出力の offset 32..34 を行順に抽出したものと bit 一致する。
+
+このモードは `--dlshogi-onnx-model` の直接推論専用で、NNUE、qsearch、search、外部
+engine、AobaZero ONNX、leaf label/replacement、expand、入力を削除する `--delete-input`、
+および行を減らす `--skip-in-check` とは併用できない。入力は 40 byte の倍数、既存 sidecar は 2 byte の
+倍数でなければ即時エラーになる。中断後は sidecar サイズを 2 で割った record 位置から
+追記再開し、完了時に全 record 数との厳密一致を再検証する。decode / 局面構築エラーを
+含むバッチは書き出し前に停止するため、既存 sidecar の prefix は常に base PSV と行対応する。
 
 ### 王手局面を教師データから除外する
 

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -57,6 +57,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `merge_psv` | 複数の PSV ファイルを順序どおりストリーミング結合 |
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](relabel_psv.md)） |
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
+| `psv_gate_by_king_zone` | 入玉ドメインで depth9 / DL score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |

--- a/crates/tools/src/bin/psv_gate_by_king_zone.rs
+++ b/crates/tools/src/bin/psv_gate_by_king_zone.rs
@@ -414,6 +414,15 @@ mod tests {
     }
 
     #[test]
+    fn white_king_in_middle_zone_is_advancing() -> Result<()> {
+        // 後手玉が中央（rank 3..=5）へ進み、先手玉は自陣に残るケース。
+        let bytes = record("9/9/9/9/4k4/9/9/9/4K4 b - 1", 0)?;
+        let (tier, _) = classify_record(&bytes, 0)?;
+        assert_eq!(tier, 1);
+        Ok(())
+    }
+
+    #[test]
     fn mask_rejects_output_equal_to_input_without_truncating() -> Result<()> {
         let dir = tempdir()?;
         let input = dir.path().join("input.psv");

--- a/crates/tools/src/bin/psv_gate_by_king_zone.rs
+++ b/crates/tools/src/bin/psv_gate_by_king_zone.rs
@@ -1,0 +1,527 @@
+//! 行対応 PSV の入玉ドメイン score 合成、またはゲート bitmap 生成を行う。
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rayon::prelude::*;
+use rshogi_core::position::Position;
+use rshogi_core::types::Color;
+use tools::packed_sfen::{PackedSfenValue, unpack_sfen_to_parts};
+
+const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const BUFFER_SIZE: usize = 32 << 20;
+const CHUNK_RECORDS: usize = 1 << 18;
+
+#[derive(Parser)]
+#[command(about = "入玉ドメインの PSV 合成またはゲート bitmap 生成")]
+struct Cli {
+    /// depth9 ラベル PSV
+    #[arg(long)]
+    d9: Option<PathBuf>,
+    /// DL リスコア PSV
+    #[arg(long)]
+    dl: Option<PathBuf>,
+    /// merge 出力 PSV
+    #[arg(long)]
+    out: Option<PathBuf>,
+    /// mask 判定元の base PSV
+    #[arg(long)]
+    input: Option<PathBuf>,
+    /// mask bitmap 出力
+    #[arg(long)]
+    out_mask: Option<PathBuf>,
+    /// 対象 tier（entered,advancing のカンマ区切り）
+    #[arg(long, default_value = "entered,advancing")]
+    tiers: String,
+    /// `|depth9 score| < N` の行だけを対象にする
+    #[arg(long)]
+    d9_abs_max: Option<i32>,
+}
+
+#[derive(Clone, Copy)]
+struct GateConfig {
+    tiers: [bool; 3],
+    d9_abs_max: Option<i32>,
+}
+
+#[derive(Default)]
+struct Stats {
+    tiers: [u64; 3],
+    gated: u64,
+    records: u64,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let config = GateConfig {
+        tiers: parse_tiers(&cli.tiers)?,
+        d9_abs_max: cli.d9_abs_max,
+    };
+    match (cli.d9, cli.dl, cli.out, cli.input, cli.out_mask) {
+        (Some(d9), Some(dl), Some(out), None, None) => {
+            print_stats(&merge(&d9, &dl, &out, config)?);
+        }
+        (None, None, None, Some(input), Some(out_mask)) => {
+            print_stats(&write_mask(&input, &out_mask, config)?);
+        }
+        _ => anyhow::bail!(
+            "Specify exactly one mode: --d9/--dl/--out or --input/--out-mask; modes cannot be mixed"
+        ),
+    }
+    Ok(())
+}
+
+fn parse_tiers(value: &str) -> Result<[bool; 3]> {
+    let mut tiers = [false; 3];
+    for name in value.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        match name {
+            "entered" => tiers[0] = true,
+            "advancing" => tiers[1] = true,
+            other => anyhow::bail!("Unknown tier: {other} (expected entered or advancing)"),
+        }
+    }
+    anyhow::ensure!(tiers[0] || tiers[1], "--tiers must not be empty");
+    Ok(tiers)
+}
+
+/// 玉位置から 0=entered、1=advancing、2=normal を返す。
+fn classify(pos: &Position) -> usize {
+    let black = pos.king_square(Color::Black).rank() as usize;
+    let white = pos.king_square(Color::White).rank() as usize;
+    if black <= 2 || white >= 6 {
+        0
+    } else if (3..=5).contains(&black) || (3..=5).contains(&white) {
+        1
+    } else {
+        2
+    }
+}
+
+fn classify_record(record: &[u8], row: u64) -> Result<(usize, i16)> {
+    let psv = PackedSfenValue::from_bytes(record)
+        .ok_or_else(|| anyhow::anyhow!("PSV parse failed at row {row}"))?;
+    let parts = unpack_sfen_to_parts(&psv.sfen)
+        .map_err(|error| anyhow::anyhow!("unpack failed at row {row}: {error}"))?;
+    let mut pos = Position::new();
+    pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move)
+        .with_context(|| format!("invalid position at row {row}"))?;
+    Ok((classify(&pos), psv.score))
+}
+
+fn is_gated(config: GateConfig, tier: usize, score: i16) -> bool {
+    config.tiers[tier] && config.d9_abs_max.is_none_or(|limit| i32::from(score).abs() < limit)
+}
+
+fn checked_records(path: &Path) -> Result<u64> {
+    let size = std::fs::metadata(path)
+        .with_context(|| format!("Failed to stat {}", path.display()))?
+        .len();
+    anyhow::ensure!(
+        size % RECORD_SIZE as u64 == 0,
+        "Input size is not a multiple of {RECORD_SIZE}: {} ({size} bytes)",
+        path.display()
+    );
+    Ok(size / RECORD_SIZE as u64)
+}
+
+fn canonicalize_predicted_path(path: &Path) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Path has no file name: {}", path.display()))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize parent {}", parent.display()))?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn is_same_file(a: &Path, b: &Path) -> Result<bool> {
+    match same_file::is_same_file(a, b) {
+        Ok(same) => Ok(same),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| {
+            format!("Failed to compare file identities: {} and {}", a.display(), b.display())
+        }),
+    }
+}
+
+/// 出力が入力実体を指す場合は、truncate 前に拒否する。
+fn ensure_safe_output_path(output: &Path, input: &Path) -> Result<()> {
+    let canonical_input = input
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize input {}", input.display()))?;
+    if let Ok(meta) = fs::symlink_metadata(output)
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!("Output path is a symlink: {}", output.display());
+    }
+    let predicted = canonicalize_predicted_path(output)?;
+    if predicted == canonical_input || is_same_file(output, &canonical_input)? {
+        anyhow::bail!(
+            "Output path resolves to input file: {} -> {}",
+            output.display(),
+            canonical_input.display()
+        );
+    }
+    Ok(())
+}
+
+fn classify_chunk(chunk: &[u8], first_row: u64) -> Vec<Result<(usize, i16)>> {
+    chunk
+        .par_chunks_exact(RECORD_SIZE)
+        .enumerate()
+        .map(|(offset, record)| classify_record(record, first_row + offset as u64))
+        .collect()
+}
+
+fn read_record_chunk<R: Read>(reader: &mut R, buffer: &mut Vec<u8>, records: usize) -> Result<()> {
+    let bytes = records
+        .checked_mul(RECORD_SIZE)
+        .ok_or_else(|| anyhow::anyhow!("chunk byte size overflow: {records} records"))?;
+    buffer.resize(bytes, 0);
+    reader.read_exact(buffer)?;
+    Ok(())
+}
+
+fn merge(d9: &Path, dl: &Path, out: &Path, config: GateConfig) -> Result<Stats> {
+    ensure_safe_output_path(out, d9)?;
+    ensure_safe_output_path(out, dl)?;
+    let d9_records = checked_records(d9)?;
+    let dl_records = checked_records(dl)?;
+    anyhow::ensure!(
+        dl_records == d9_records,
+        "Input record counts differ: d9={d9_records}, dl={dl_records}"
+    );
+    let mut d9_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(d9)?);
+    let mut dl_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(dl)?);
+    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(out)?);
+    let mut d9_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut dl_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut stats = Stats::default();
+    let mut first_row = 0u64;
+    while first_row < d9_records {
+        let chunk_records = (d9_records - first_row).min(CHUNK_RECORDS as u64) as usize;
+        read_record_chunk(&mut d9_reader, &mut d9_chunk, chunk_records)?;
+        read_record_chunk(&mut dl_reader, &mut dl_chunk, chunk_records)?;
+        let classifications = classify_chunk(&d9_chunk, first_row);
+        for (offset, ((d9_record, dl_record), classification)) in d9_chunk
+            .chunks_exact(RECORD_SIZE)
+            .zip(dl_chunk.chunks_exact_mut(RECORD_SIZE))
+            .zip(classifications)
+            .enumerate()
+        {
+            let row = first_row + offset as u64;
+            anyhow::ensure!(
+                d9_record[..32] == dl_record[..32] && d9_record[34..39] == dl_record[34..39],
+                "Non-score fields differ at row {row}"
+            );
+            let (tier, score) = classification?;
+            stats.tiers[tier] += 1;
+            if is_gated(config, tier, score) {
+                dl_record[32..34].copy_from_slice(&d9_record[32..34]);
+                stats.gated += 1;
+            }
+        }
+        writer.write_all(&dl_chunk)?;
+        first_row += chunk_records as u64;
+        stats.records += chunk_records as u64;
+    }
+    writer.flush()?;
+    let expected = d9_records * RECORD_SIZE as u64;
+    anyhow::ensure!(fs::metadata(out)?.len() == expected, "Output size mismatch");
+    Ok(stats)
+}
+
+fn write_mask(input: &Path, out: &Path, config: GateConfig) -> Result<Stats> {
+    ensure_safe_output_path(out, input)?;
+    let records = checked_records(input)?;
+    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(input)?);
+    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(out)?);
+    let mut chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut stats = Stats::default();
+    let mut byte = 0u8;
+    let mut first_row = 0u64;
+    while first_row < records {
+        let chunk_records = (records - first_row).min(CHUNK_RECORDS as u64) as usize;
+        read_record_chunk(&mut reader, &mut chunk, chunk_records)?;
+        let classifications = classify_chunk(&chunk, first_row);
+        for (offset, classification) in classifications.into_iter().enumerate() {
+            let row = first_row + offset as u64;
+            let (tier, score) = classification?;
+            stats.tiers[tier] += 1;
+            if is_gated(config, tier, score) {
+                byte |= 1 << (row % 8);
+                stats.gated += 1;
+            }
+            if row % 8 == 7 {
+                writer.write_all(&[byte])?;
+                byte = 0;
+            }
+        }
+        first_row += chunk_records as u64;
+        stats.records += chunk_records as u64;
+    }
+    if records % 8 != 0 {
+        writer.write_all(&[byte])?;
+    }
+    writer.flush()?;
+    let expected = records.div_ceil(8);
+    anyhow::ensure!(fs::metadata(out)?.len() == expected, "Mask size mismatch");
+    Ok(stats)
+}
+
+fn print_stats(stats: &Stats) {
+    let percent = |count| {
+        if stats.records == 0 {
+            0.0
+        } else {
+            count as f64 / stats.records as f64 * 100.0
+        }
+    };
+    println!(
+        "done: records={}\n  entered={} ({:.4}%) advancing={} ({:.4}%) normal={} ({:.4}%)\n  gated={} ({:.4}%)",
+        stats.records,
+        stats.tiers[0],
+        percent(stats.tiers[0]),
+        stats.tiers[1],
+        percent(stats.tiers[1]),
+        stats.tiers[2],
+        percent(stats.tiers[2]),
+        stats.gated,
+        percent(stats.gated),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tools::packed_sfen::pack_position;
+
+    fn record(sfen: &str, score: i16) -> Result<[u8; RECORD_SIZE]> {
+        let mut pos = Position::new();
+        pos.set_sfen(sfen)?;
+        Ok(PackedSfenValue {
+            sfen: pack_position(&pos),
+            score,
+            move16: 0,
+            game_ply: 1,
+            game_result: 0,
+            padding: 0,
+        }
+        .to_bytes())
+    }
+
+    fn samples(count: usize, score_base: i16) -> Result<Vec<u8>> {
+        let sfens = [
+            "4K3k/9/9/9/9/9/9/9/9 b - 1",
+            "4k4/9/9/9/4K4/9/9/9/9 b - 1",
+            "4k4/9/9/9/9/9/9/9/4K4 b - 1",
+        ];
+        let mut bytes = Vec::with_capacity(count * RECORD_SIZE);
+        for i in 0..count {
+            bytes.extend_from_slice(&record(sfens[i % sfens.len()], score_base + i as i16)?);
+        }
+        Ok(bytes)
+    }
+
+    #[test]
+    fn mask_bit_order_and_partial_byte() -> Result<()> {
+        for count in [7, 8, 9, 15, 16, 17] {
+            let dir = tempdir()?;
+            let input = dir.path().join("input.psv");
+            let output = dir.path().join("mask.bin");
+            std::fs::write(&input, samples(count, 0)?)?;
+            write_mask(
+                &input,
+                &output,
+                GateConfig {
+                    tiers: [true, false, false],
+                    d9_abs_max: None,
+                },
+            )?;
+            let mask = std::fs::read(output)?;
+            assert_eq!(mask.len(), count.div_ceil(8));
+            for i in 0..count {
+                assert_eq!((mask[i / 8] >> (i % 8)) & 1, u8::from(i % 3 == 0));
+            }
+            if count % 8 != 0 {
+                assert_eq!(mask[count / 8] >> (count % 8), 0);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn merge_matches_mask_selection() -> Result<()> {
+        let dir = tempdir()?;
+        let d9 = dir.path().join("d9.psv");
+        let dl = dir.path().join("dl.psv");
+        let merged = dir.path().join("merged.psv");
+        let mask = dir.path().join("mask.bin");
+        std::fs::write(&d9, samples(17, 10)?)?;
+        std::fs::write(&dl, samples(17, 100)?)?;
+        let config = GateConfig {
+            tiers: [true, true, false],
+            d9_abs_max: Some(25),
+        };
+        merge(&d9, &dl, &merged, config)?;
+        write_mask(&d9, &mask, config)?;
+        let (d9b, dlb, mb, bits) = (
+            std::fs::read(d9)?,
+            std::fs::read(dl)?,
+            std::fs::read(merged)?,
+            std::fs::read(mask)?,
+        );
+        for i in 0..17 {
+            let expected = if (bits[i / 8] >> (i % 8)) & 1 == 1 {
+                &d9b
+            } else {
+                &dlb
+            };
+            assert_eq!(
+                &mb[i * RECORD_SIZE + 32..i * RECORD_SIZE + 34],
+                &expected[i * RECORD_SIZE + 32..i * RECORD_SIZE + 34]
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn bare_relative_output_path_is_supported() -> Result<()> {
+        let predicted = canonicalize_predicted_path(Path::new("out.psv"))?;
+        assert_eq!(predicted.file_name(), Some(std::ffi::OsStr::new("out.psv")));
+        assert_eq!(predicted.parent(), Some(std::env::current_dir()?.canonicalize()?.as_path()));
+        Ok(())
+    }
+
+    #[test]
+    fn d9_abs_max_boundary_is_exclusive() {
+        let config = GateConfig {
+            tiers: [true, false, false],
+            d9_abs_max: Some(25),
+        };
+        assert!(is_gated(config, 0, 24));
+        assert!(is_gated(config, 0, -24));
+        assert!(!is_gated(config, 0, 25));
+        assert!(!is_gated(config, 0, -25));
+    }
+
+    #[test]
+    fn mask_rejects_output_equal_to_input_without_truncating() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("input.psv");
+        let original = samples(3, 0)?;
+        std::fs::write(&input, &original)?;
+        let error = write_mask(
+            &input,
+            &input,
+            GateConfig {
+                tiers: [true, true, false],
+                d9_abs_max: None,
+            },
+        )
+        .err()
+        .expect("operation must fail");
+        assert!(error.to_string().contains("resolves to input file"));
+        assert_eq!(std::fs::read(input)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn mask_rejects_hardlink_output_without_truncating() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("input.psv");
+        let output = dir.path().join("mask.bin");
+        let original = samples(3, 0)?;
+        std::fs::write(&input, &original)?;
+        if let Err(error) = std::fs::hard_link(&input, &output) {
+            eprintln!("hardlink を作成できないためテストをスキップします: {error}");
+            return Ok(());
+        }
+        let error = write_mask(
+            &input,
+            &output,
+            GateConfig {
+                tiers: [true, true, false],
+                d9_abs_max: None,
+            },
+        )
+        .err()
+        .expect("operation must fail");
+        assert!(error.to_string().contains("resolves to input file"));
+        assert_eq!(std::fs::read(input)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn merge_rejects_output_equal_to_input_without_truncating() -> Result<()> {
+        let dir = tempdir()?;
+        let d9 = dir.path().join("d9.psv");
+        let dl = dir.path().join("dl.psv");
+        let original = samples(3, 0)?;
+        std::fs::write(&d9, &original)?;
+        std::fs::write(&dl, samples(3, 100)?)?;
+        let error = merge(
+            &d9,
+            &dl,
+            &d9,
+            GateConfig {
+                tiers: [true, true, false],
+                d9_abs_max: None,
+            },
+        )
+        .err()
+        .expect("operation must fail");
+        assert!(error.to_string().contains("resolves to input file"));
+        assert_eq!(std::fs::read(d9)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn merge_count_mismatch_reports_both_counts() -> Result<()> {
+        let dir = tempdir()?;
+        let d9 = dir.path().join("d9.psv");
+        let dl = dir.path().join("dl.psv");
+        std::fs::write(&d9, samples(1, 0)?)?;
+        std::fs::write(&dl, samples(2, 0)?)?;
+        let error = merge(
+            &d9,
+            &dl,
+            &dir.path().join("out.psv"),
+            GateConfig {
+                tiers: [true, true, false],
+                d9_abs_max: None,
+            },
+        )
+        .err()
+        .expect("operation must fail");
+        assert!(error.to_string().contains("d9=1, dl=2"));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_input_size_fails_closed() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("bad.psv");
+        std::fs::write(&input, [0u8; RECORD_SIZE - 1])?;
+        assert!(
+            write_mask(
+                &input,
+                &dir.path().join("mask"),
+                GateConfig {
+                    tiers: [true, true, false],
+                    d9_abs_max: None
+                }
+            )
+            .is_err()
+        );
+        Ok(())
+    }
+}

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -308,6 +308,8 @@ enum OnnxMarkerDecision {
     Skip,
     /// rescore + expand 出力を truncate して最初から処理
     TruncateAndProcess,
+    /// score sidecar の in-progress marker が一致。件数ベースで追記再開
+    ResumeSidecar,
     /// marker 不存在 + expand 無効 → 既存の record-count resume にフォールバック
     LegacyResume,
 }
@@ -491,6 +493,9 @@ fn onnx_marker_decide(
             };
 
         if marker.fingerprint == current && bodies_match {
+            if cli.out_scores {
+                remove_in_progress_marker(rescore_output_path)?;
+            }
             return Ok(OnnxMarkerDecision::Skip);
         }
 
@@ -567,10 +572,21 @@ fn onnx_marker_decide(
         // 6. marker 削除（最後）
         fs::remove_file(&marker_path)
             .with_context(|| format!("Failed to remove stale marker {}", marker_path.display()))?;
+        if cli.out_scores {
+            prepare_in_progress_marker(rescore_output_path, &current, true)?;
+        }
         return Ok(OnnxMarkerDecision::TruncateAndProcess);
     }
 
     // marker 不存在
+    if cli.out_scores {
+        let decision = prepare_in_progress_marker(rescore_output_path, &current, false)?
+            .context("out_scores=true did not create an in-progress marker")?;
+        return match decision {
+            SidecarStartDecision::Resume => Ok(OnnxMarkerDecision::ResumeSidecar),
+            SidecarStartDecision::Truncate => Ok(OnnxMarkerDecision::TruncateAndProcess),
+        };
+    }
     // leaf-label は marker 必須にする。record 数ベースの legacy resume では、旧通常 rescore の
     // marker 無し出力（レコード数だけ一致）を完了扱いし、葉ラベルを生成せず stale 出力を温存する。
     if expand_output_path.is_some() || replacement_output.is_some() || cli.qsearch_leaf_label {
@@ -637,6 +653,11 @@ fn main() -> Result<()> {
     let use_dlshogi_onnx = cli.dlshogi_onnx_model.is_some();
 
     if cli.out_scores {
+        if cli.limit > 0 {
+            anyhow::bail!(
+                "--out-scores cannot be combined with --limit because the score sidecar must cover every base PSV record"
+            );
+        }
         if cli.delete_input {
             anyhow::bail!(
                 "--out-scores cannot be combined with --delete-input because the base PSV is required to interpret the score sidecar"
@@ -1045,6 +1066,14 @@ fn main() -> Result<()> {
                         input_path.display()
                     );
                 }
+                OnnxMarkerDecision::ResumeSidecar => {
+                    eprintln!(
+                        "=== [{}/{}] Resuming (in-progress marker matches): {} ===",
+                        file_idx + 1,
+                        total_files,
+                        input_path.display()
+                    );
+                }
                 OnnxMarkerDecision::LegacyResume => {
                     use_legacy_resume_check = true;
                 }
@@ -1062,30 +1091,10 @@ fn main() -> Result<()> {
             }
             if output_path.exists() {
                 let out_size = fs::metadata(&output_path)?.len();
-                let output_record_size = if cli.out_scores {
-                    std::mem::size_of::<i16>() as u64
-                } else {
-                    PackedSfenValue::SIZE as u64
-                };
-                if cli.out_scores && out_size % output_record_size != 0 {
-                    anyhow::bail!(
-                        "Output size is not a multiple of {output_record_size}: {} ({out_size} bytes)",
-                        output_path.display()
-                    );
-                }
+                let output_record_size = PackedSfenValue::SIZE as u64;
                 let out_records = out_size / output_record_size;
-                if cli.out_scores && out_records > process_count {
-                    anyhow::bail!(
-                        "score sidecar has {out_records} records, exceeding expected {process_count}: {}",
-                        output_path.display()
-                    );
-                }
-                let complete = if cli.out_scores {
-                    out_records == process_count
-                } else {
-                    out_records >= input_record_count
-                        && out_size % PackedSfenValue::SIZE as u64 == 0
-                };
+                let complete = out_records >= input_record_count
+                    && out_size % PackedSfenValue::SIZE as u64 == 0;
                 if complete {
                     eprintln!(
                         "=== [{}/{}] Skipping (complete: {} records): {} ===",
@@ -2215,8 +2224,10 @@ fn prepare_resume_count(
     }
     if out_scores {
         anyhow::bail!(
-            "Output size is not a multiple of {output_record_size}: {} ({out_size} bytes)",
-            output_path.display()
+            "Output size is not a multiple of {output_record_size}: {} ({out_size} bytes). \
+             Delete the .in-progress marker {} so the next run truncates and regenerates the sidecar.",
+            output_path.display(),
+            in_progress_marker_path_for(output_path).display()
         );
     }
 
@@ -2325,6 +2336,9 @@ struct RunFingerprint {
     skip_in_check: bool,
     score_clip: i16,
     eval_scale_bits: u32,
+    // 旧 marker のキー欠落は unknown (`None`)。現行実行は常に `Some` を設定するため、
+    // CUDA / TensorRT のどちらとも一致せず一度だけ再生成される。
+    use_tensorrt: Option<bool>,
     onnx_draw_ply: i32,
     // 出力内容を変える要素: root 据え置き・葉ラベルモードと葉探索深さ。
     // モード差で resume / marker が誤って一致しないよう fingerprint に含める。
@@ -2372,6 +2386,14 @@ fn marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// `<rescore_output>.in-progress` を返す
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn in_progress_marker_path_for(rescore_output: &std::path::Path) -> PathBuf {
+    let mut s = rescore_output.as_os_str().to_owned();
+    s.push(".in-progress");
+    PathBuf::from(s)
+}
+
 /// ファイルの `(len, modified_unix_ns)` を取得
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn file_size_mtime_ns(path: &std::path::Path) -> Result<(u64, u128)> {
@@ -2405,6 +2427,9 @@ fn serialize_marker(marker: &DoneMarker) -> String {
     let _ = writeln!(out, "skip_in_check={}", f.skip_in_check);
     let _ = writeln!(out, "score_clip={}", f.score_clip);
     let _ = writeln!(out, "eval_scale_bits=0x{:08x}", f.eval_scale_bits);
+    if let Some(use_tensorrt) = f.use_tensorrt {
+        let _ = writeln!(out, "use_tensorrt={use_tensorrt}");
+    }
     let _ = writeln!(out, "onnx_draw_ply={}", f.onnx_draw_ply);
     let _ = writeln!(out, "qsearch_leaf_label={}", f.qsearch_leaf_label);
     if f.qsearch_leaf_label {
@@ -2557,6 +2582,9 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         skip_in_check: parse_bool(get("skip_in_check")?)?,
         score_clip: get("score_clip")?.parse().context("invalid score_clip")?,
         eval_scale_bits: parse_hex_u32(get("eval_scale_bits")?)?,
+        // 旧 marker は実行 backend を追跡していなかった。欠落は unknown として保持し、
+        // 現行の CUDA / TensorRT のどちらとも fingerprint が一致しないようにする。
+        use_tensorrt: map.get("use_tensorrt").map(|v| parse_bool(v)).transpose()?,
         onnx_draw_ply: get("onnx_draw_ply")?.parse().context("invalid onnx_draw_ply")?,
         qsearch_leaf_label,
         qsearch_max_ply: if qsearch_leaf_label {
@@ -2635,13 +2663,19 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
 #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
 fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) -> Result<()> {
     let final_path = marker_path_for(rescore_output);
+    write_marker_atomic_at(&final_path, marker)
+}
+
+/// 指定したパスへマーカーを atomic に書き出す。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn write_marker_atomic_at(final_path: &std::path::Path, marker: &DoneMarker) -> Result<()> {
     let mut tmp_os = final_path.as_os_str().to_owned();
     tmp_os.push(".tmp");
     let tmp_path = PathBuf::from(tmp_os);
 
     // symlink 拒否: final / tmp どちらも symlink 経由の書き込みをブロック。
     // tmp に前回クラッシュの残骸 (通常ファイル) があれば事前削除する。
-    for p in [&final_path, &tmp_path] {
+    for p in [final_path, tmp_path.as_path()] {
         if let Ok(meta) = fs::symlink_metadata(p)
             && meta.file_type().is_symlink()
         {
@@ -2669,10 +2703,165 @@ fn write_marker_atomic(rescore_output: &std::path::Path, marker: &DoneMarker) ->
         f.write_all(body.as_bytes())?;
         f.sync_all()?;
     }
-    fs::rename(&tmp_path, &final_path).with_context(|| {
+    fs::rename(&tmp_path, final_path).with_context(|| {
         format!("Failed to rename marker {} → {}", tmp_path.display(), final_path.display())
     })?;
     Ok(())
+}
+
+/// score sidecar の run 開始時に選ぶ処理方法。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SidecarStartDecision {
+    Resume,
+    Truncate,
+}
+
+/// in-progress marker が通常ファイルなら削除する。symlink は追跡せず拒否する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn remove_in_progress_marker(rescore_output: &std::path::Path) -> Result<()> {
+    let path = in_progress_marker_path_for(rescore_output);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to stat in-progress marker {}", path.display()));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "In-progress marker path is a symlink (refusing to remove): {}",
+            path.display()
+        );
+    }
+    fs::remove_file(&path)
+        .with_context(|| format!("Failed to remove in-progress marker {}", path.display()))
+}
+
+/// score sidecar の in-progress marker を書く。
+///
+/// 完了 marker と同じ key=value 形式を再利用し、output size は未完了を表す 0 とする。
+/// fingerprint だけを resume の根拠にし、変化する sidecar 自身の mtime は記録しない。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn write_in_progress_marker(
+    rescore_output: &std::path::Path,
+    fingerprint: &RunFingerprint,
+) -> Result<()> {
+    let marker = DoneMarker {
+        fingerprint: fingerprint.clone(),
+        output_sizes: OutputSizes {
+            rescore_output_size: 0,
+            expand_output_size: None,
+            replacement_output_size: None,
+        },
+    };
+    write_marker_atomic_at(&in_progress_marker_path_for(rescore_output), &marker)
+}
+
+/// score sidecar の安全な resume 条件を確認し、run 開始状態を用意する。
+///
+/// full PSV では何もせず、従来の marker / record-count 判定へ委ねる。sidecar では
+/// 出力と in-progress marker の両方が存在し fingerprint が一致するときだけ追記を許可する。
+/// それ以外は出力を truncate して現在 fingerprint の marker を書き直す。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn prepare_in_progress_marker(
+    rescore_output: &std::path::Path,
+    current: &RunFingerprint,
+    force_truncate: bool,
+) -> Result<Option<SidecarStartDecision>> {
+    if !current.out_scores {
+        return Ok(None);
+    }
+
+    let in_progress_path = in_progress_marker_path_for(rescore_output);
+    let marker_matches = if force_truncate || !rescore_output.exists() {
+        false
+    } else {
+        match fs::symlink_metadata(&in_progress_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "In-progress marker path is a symlink (refusing to resume): {}",
+                    in_progress_path.display()
+                );
+            }
+            Ok(_) => match parse_marker(&in_progress_path) {
+                Ok(marker) => marker.fingerprint == *current,
+                Err(error) => {
+                    eprintln!(
+                        "Warning: invalid in-progress marker {}, regenerating sidecar: {error:#}",
+                        in_progress_path.display()
+                    );
+                    false
+                }
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to stat in-progress marker {}", in_progress_path.display())
+                });
+            }
+        }
+    };
+
+    if marker_matches {
+        return Ok(Some(SidecarStartDecision::Resume));
+    }
+
+    if rescore_output.exists() {
+        File::options().write(true).open(rescore_output)?.set_len(0)?;
+    }
+    remove_in_progress_marker(rescore_output)?;
+    write_in_progress_marker(rescore_output, current)?;
+    Ok(Some(SidecarStartDecision::Truncate))
+}
+
+/// sidecar の正常完了を `.done` へ昇格し、その後 in-progress marker を削除する。
+/// この順序なら両操作の間で停止しても、次回は `.done` を正として回収できる。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn promote_score_sidecar_marker(
+    rescore_output: &std::path::Path,
+    marker: &DoneMarker,
+) -> Result<()> {
+    write_marker_atomic(rescore_output, marker)?;
+    remove_in_progress_marker(rescore_output)
+}
+
+/// sidecar run の開始時 fingerprint が現在も有効か確認する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn ensure_sidecar_fingerprint_unchanged(
+    start: &RunFingerprint,
+    current: &RunFingerprint,
+    phase: &str,
+) -> Result<()> {
+    if start != current {
+        anyhow::bail!(
+            "score sidecar fingerprint changed {phase}; refusing to finalize mixed/stale output"
+        );
+    }
+    Ok(())
+}
+
+/// run 中の fingerprint 変更を検出した sidecar を、次回 resume 不能な状態へ戻す。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn reject_changed_sidecar_fingerprint(
+    rescore_output: &std::path::Path,
+    start: &RunFingerprint,
+    current: &RunFingerprint,
+    phase: &str,
+) -> Result<()> {
+    let error = match ensure_sidecar_fingerprint_unchanged(start, current, phase) {
+        Ok(()) => return Ok(()),
+        Err(error) => error,
+    };
+
+    // marker だけを残すと入力/model の mtime を元に戻した際に満杯の sidecar が再利用
+    // され得る。出力を空にしてから marker を削除し、次回を必ず先頭から始める。
+    if rescore_output.exists() {
+        File::options().write(true).open(rescore_output)?.set_len(0)?;
+    }
+    remove_in_progress_marker(rescore_output)?;
+    Err(error)
 }
 
 /// マーカーの `key=value\n` テキスト形式で安全に round-trip できないパスを拒否する。
@@ -2774,6 +2963,7 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         skip_in_check: config.skip_in_check,
         score_clip: config.score_clip,
         eval_scale_bits: config.eval_scale.to_bits(),
+        use_tensorrt: Some(config.use_tensorrt),
         onnx_draw_ply: config.onnx_draw_ply,
         qsearch_leaf_label: config.qsearch_leaf_label,
         qsearch_max_ply: config.qsearch_leaf_label.then_some(config.qsearch_max_ply),
@@ -2938,6 +3128,18 @@ where
         qsearch_nnue_path: _,
         replacement_output,
     } = *config;
+
+    // marker 判定から Session/load 開始までの間に入力・モデルが変わっていないことを確認し、
+    // この run の基準 fingerprint を固定する。完了時にも再検証し、run 中の差し替えを
+    // 新しい条件の .done として誤って確定しない。
+    let sidecar_start_fingerprint = if out_scores {
+        let marker = parse_marker(&in_progress_marker_path_for(output_path))?;
+        let current = build_run_fingerprint(config)?;
+        ensure_sidecar_fingerprint_unchanged(&marker.fingerprint, &current, "before processing")?;
+        Some(current)
+    } else {
+        None
+    };
     use ort::ep::ExecutionProvider;
     use ort::memory::{AllocationDevice, AllocatorType, MemoryInfo, MemoryType};
     use ort::session::Session;
@@ -3160,6 +3362,16 @@ where
         PackedSfenValue::SIZE as u64
     };
     let resume_count = prepare_resume_count(output_path, output_record_size, out_scores)?;
+    anyhow::ensure!(
+        resume_count <= process_count,
+        "{} has {resume_count} records, exceeding expected {process_count}: {}",
+        if out_scores {
+            "score sidecar"
+        } else {
+            "output"
+        },
+        output_path.display()
+    );
 
     let out_file = File::options()
         .create(true)
@@ -3193,8 +3405,8 @@ where
         None
     };
 
-    // 既存レコード分の入力をスキップ（expand 無効 + marker 不存在の legacy
-    // resume パス。main 側で truncate(0) 済みなら resume_count == 0 になり no-op）
+    // 既存レコード分の入力をスキップ（score sidecar の marker 一致 resume、または
+    // full PSV の legacy resume。main 側で truncate(0) 済みなら no-op）
     let mut remaining = process_count;
     if resume_count > 0 {
         let skip = resume_count.min(remaining);
@@ -4132,7 +4344,20 @@ where
                 );
             }
         }
-        let fingerprint = build_run_fingerprint(config)?;
+        let fingerprint = if let Some(start) = sidecar_start_fingerprint {
+            let current = build_run_fingerprint(config)?;
+            reject_changed_sidecar_fingerprint(output_path, &start, &current, "during processing")?;
+            let active_marker = parse_marker(&in_progress_marker_path_for(output_path))?;
+            reject_changed_sidecar_fingerprint(
+                output_path,
+                &start,
+                &active_marker.fingerprint,
+                "in the active marker",
+            )?;
+            start
+        } else {
+            build_run_fingerprint(config)?
+        };
         let rescore_size = fs::metadata(output_path)?.len();
         let expand_size = match expand {
             Some(e) => Some(fs::metadata(e.output_path)?.len()),
@@ -4150,7 +4375,11 @@ where
                 replacement_output_size: replacement_size,
             },
         };
-        write_marker_atomic(output_path, &marker)?;
+        if out_scores {
+            promote_score_sidecar_marker(output_path, &marker)?;
+        } else {
+            write_marker_atomic(output_path, &marker)?;
+        }
         eprintln!("Marker written: {}", marker_path_for(output_path).display());
     }
 
@@ -4349,6 +4578,21 @@ mod marker_tests {
     }
 
     #[test]
+    fn old_marker_without_tensorrt_is_unknown_and_mismatches_both_values() {
+        let old = parse_text(&base_marker(""));
+        assert_eq!(old.fingerprint.use_tensorrt, None);
+
+        let cuda = parse_text(&base_marker("use_tensorrt=false\n"));
+        assert_eq!(cuda.fingerprint.use_tensorrt, Some(false));
+        assert_ne!(old.fingerprint, cuda.fingerprint);
+
+        let tensorrt = parse_text(&base_marker("use_tensorrt=true\n"));
+        assert_eq!(tensorrt.fingerprint.use_tensorrt, Some(true));
+        assert_ne!(old.fingerprint, tensorrt.fingerprint);
+        assert_eq!(tensorrt, parse_text(&serialize_marker(&tensorrt)));
+    }
+
+    #[test]
     fn new_marker_leaf_label_true_roundtrips() {
         let m = parse_text(&base_marker(LEAF_LABEL_KEYS));
         assert!(m.fingerprint.qsearch_leaf_label);
@@ -4427,6 +4671,164 @@ mod marker_tests {
         }
     }
 
+    fn test_fingerprint(out_scores: bool) -> RunFingerprint {
+        let extra = if out_scores { "out_scores=true\n" } else { "" };
+        parse_text(&base_marker(extra)).fingerprint
+    }
+
+    fn sidecar_bytes(records: &[PackedSfenValue]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for record in records {
+            append_rescore_bytes(&mut bytes, record, true);
+        }
+        bytes
+    }
+
+    #[test]
+    fn in_progress_marker_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let fingerprint = test_fingerprint(true);
+
+        write_in_progress_marker(&output, &fingerprint).unwrap();
+
+        let parsed = parse_marker(&in_progress_marker_path_for(&output)).unwrap();
+        assert_eq!(parsed.fingerprint, fingerprint);
+        assert_eq!(parsed.output_sizes.rescore_output_size, 0);
+    }
+
+    #[test]
+    fn matching_in_progress_marker_resumes_bit_identically() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let fingerprint = test_fingerprint(true);
+        let complete = sidecar_bytes(&[test_psv(-5), test_psv(6), test_psv(300)]);
+
+        assert_eq!(
+            prepare_in_progress_marker(&output, &fingerprint, false).unwrap(),
+            Some(SidecarStartDecision::Truncate)
+        );
+        std::fs::write(&output, &complete[..2]).unwrap();
+        assert_eq!(
+            prepare_in_progress_marker(&output, &fingerprint, false).unwrap(),
+            Some(SidecarStartDecision::Resume)
+        );
+        assert_eq!(std::fs::read(&output).unwrap(), complete[..2]);
+
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&output)
+            .unwrap()
+            .write_all(&complete[2..])
+            .unwrap();
+        assert_eq!(std::fs::read(output).unwrap(), complete);
+    }
+
+    #[test]
+    fn mismatched_in_progress_marker_truncates_and_regenerates() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let fingerprint = test_fingerprint(true);
+        let complete = sidecar_bytes(&[test_psv(-5), test_psv(6), test_psv(300)]);
+
+        prepare_in_progress_marker(&output, &fingerprint, false).unwrap();
+        std::fs::write(&output, &complete[..2]).unwrap();
+
+        let mut changed = fingerprint.clone();
+        changed.score_clip = 9999;
+        assert_eq!(
+            prepare_in_progress_marker(&output, &changed, false).unwrap(),
+            Some(SidecarStartDecision::Truncate)
+        );
+        assert_eq!(std::fs::metadata(&output).unwrap().len(), 0);
+        assert_eq!(
+            parse_marker(&in_progress_marker_path_for(&output)).unwrap().fingerprint,
+            changed
+        );
+
+        std::fs::write(&output, &complete).unwrap();
+        assert_eq!(std::fs::read(output).unwrap(), complete);
+    }
+
+    #[test]
+    fn missing_in_progress_marker_truncates_existing_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let fingerprint = test_fingerprint(true);
+        std::fs::write(&output, sidecar_bytes(&[test_psv(-5)])).unwrap();
+
+        assert_eq!(
+            prepare_in_progress_marker(&output, &fingerprint, false).unwrap(),
+            Some(SidecarStartDecision::Truncate)
+        );
+        assert_eq!(std::fs::metadata(&output).unwrap().len(), 0);
+        assert!(in_progress_marker_path_for(&output).exists());
+    }
+
+    #[test]
+    fn completed_sidecar_promotes_done_and_removes_in_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let fingerprint = test_fingerprint(true);
+        let complete = sidecar_bytes(&[test_psv(-5), test_psv(6)]);
+
+        prepare_in_progress_marker(&output, &fingerprint, false).unwrap();
+        std::fs::write(&output, &complete).unwrap();
+        let done = DoneMarker {
+            fingerprint: fingerprint.clone(),
+            output_sizes: OutputSizes {
+                rescore_output_size: complete.len() as u64,
+                expand_output_size: None,
+                replacement_output_size: None,
+            },
+        };
+
+        promote_score_sidecar_marker(&output, &done).unwrap();
+
+        assert_eq!(parse_marker(&marker_path_for(&output)).unwrap(), done);
+        assert!(!in_progress_marker_path_for(&output).exists());
+    }
+
+    #[test]
+    fn full_psv_mode_does_not_create_in_progress_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("output.psv");
+        std::fs::write(&output, [1, 2, 3]).unwrap();
+
+        assert_eq!(
+            prepare_in_progress_marker(&output, &test_fingerprint(false), false).unwrap(),
+            None
+        );
+        assert_eq!(std::fs::read(&output).unwrap(), [1, 2, 3]);
+        assert!(!in_progress_marker_path_for(&output).exists());
+    }
+
+    #[test]
+    fn changed_input_fingerprint_is_not_finalized() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("scores.i16");
+        let start = test_fingerprint(true);
+        let mut changed = start.clone();
+        changed.input_mtime_ns += 1;
+
+        prepare_in_progress_marker(&output, &start, false).unwrap();
+        std::fs::write(&output, [1, 2, 3, 4]).unwrap();
+        assert!(
+            reject_changed_sidecar_fingerprint(&output, &start, &start, "during processing")
+                .is_ok()
+        );
+        let error =
+            reject_changed_sidecar_fingerprint(&output, &start, &changed, "during processing")
+                .unwrap_err();
+        assert!(error.to_string().contains("changed during processing"));
+        assert_eq!(std::fs::metadata(&output).unwrap().len(), 0);
+        assert!(!in_progress_marker_path_for(&output).exists());
+        assert_eq!(
+            prepare_in_progress_marker(&output, &start, false).unwrap(),
+            Some(SidecarStartDecision::Truncate)
+        );
+    }
+
     #[test]
     fn score_sidecar_matches_full_psv_score_column() {
         let records = [test_psv(-1234), test_psv(0), test_psv(9876)];
@@ -4479,7 +4881,8 @@ mod marker_tests {
 
         let sidecar = dir.path().join("scores.i16");
         std::fs::write(&sidecar, [0u8; 3]).unwrap();
-        assert!(prepare_resume_count(&sidecar, 2, true).is_err());
+        let error = prepare_resume_count(&sidecar, 2, true).unwrap_err();
+        assert!(error.to_string().contains("Delete the .in-progress marker"));
         assert_eq!(std::fs::metadata(sidecar).unwrap().len(), 3);
     }
 

--- a/crates/tools/src/bin/rescore_psv.rs
+++ b/crates/tools/src/bin/rescore_psv.rs
@@ -51,6 +51,8 @@ use rayon::prelude::*;
 use std::cell::RefCell;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+use std::io::{Seek, SeekFrom};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -96,6 +98,10 @@ struct Cli {
     /// 出力ディレクトリ（入力ファイル名で出力）
     #[arg(short, long)]
     output_dir: PathBuf,
+
+    /// フル PSV の代わりに little-endian i16 の score sidecar を出力
+    #[arg(long)]
+    out_scores: bool,
 
     /// NNUEモデルファイル（--engine未使用時に必須）
     #[arg(long)]
@@ -422,6 +428,7 @@ fn onnx_marker_decide(
         onnx_path,
         input_path,
         output_path: rescore_output_path,
+        out_scores: cli.out_scores,
         process_count,
         batch_size: cli.onnx_batch_size,
         gpu_id: cli.onnx_gpu_id,
@@ -628,6 +635,36 @@ fn main() -> Result<()> {
     let use_engine = cli.engine.is_some();
     let use_onnx = cli.onnx_model.is_some();
     let use_dlshogi_onnx = cli.dlshogi_onnx_model.is_some();
+
+    if cli.out_scores {
+        if cli.delete_input {
+            anyhow::bail!(
+                "--out-scores cannot be combined with --delete-input because the base PSV is required to interpret the score sidecar"
+            );
+        }
+        if !use_dlshogi_onnx {
+            anyhow::bail!("--out-scores requires --dlshogi-onnx-model");
+        }
+        if use_onnx
+            || use_engine
+            || cli.nnue.is_some()
+            || cli.use_qsearch
+            || cli.search_depth.is_some()
+            || cli.qsearch_leaf_label
+            || cli.apply_qsearch_leaf
+            || cli.expand_output_dir.is_some()
+            || cli.qsearch_leaf_replacement_output.is_some()
+        {
+            anyhow::bail!(
+                "--out-scores supports only direct --dlshogi-onnx-model inference and cannot be combined with other evaluation, qsearch, search, expand, or replacement modes"
+            );
+        }
+        if cli.skip_in_check {
+            anyhow::bail!(
+                "--out-scores cannot be combined with --skip-in-check because it breaks row alignment"
+            );
+        }
+    }
 
     // 排他チェック
     if use_onnx && (use_dlshogi_onnx || use_engine || cli.use_qsearch || cli.search_depth.is_some())
@@ -939,7 +976,13 @@ fn main() -> Result<()> {
         let file_name = input_path
             .file_name()
             .ok_or_else(|| anyhow::anyhow!("Invalid input file name: {}", input_path.display()))?;
-        let output_path = cli.output_dir.join(file_name);
+        let output_path = if cli.out_scores {
+            let mut sidecar_name = file_name.to_os_string();
+            sidecar_name.push(".scores.i16");
+            cli.output_dir.join(sidecar_name)
+        } else {
+            cli.output_dir.join(file_name)
+        };
         #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
         let expand_output_path = canonical_expand_dir.as_ref().map(|d| d.join(file_name));
         #[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
@@ -947,6 +990,13 @@ fn main() -> Result<()> {
 
         // 入力ファイルサイズと process_count を最初に確定（marker 判定の前提）
         let input_file_size = fs::metadata(input_path)?.len();
+        if cli.out_scores && input_file_size % PackedSfenValue::SIZE as u64 != 0 {
+            anyhow::bail!(
+                "Input size is not a multiple of {}: {} ({input_file_size} bytes)",
+                PackedSfenValue::SIZE,
+                input_path.display()
+            );
+        }
         let input_record_count = input_file_size / PackedSfenValue::SIZE as u64;
         let process_count = if cli.limit > 0 && cli.limit < input_record_count {
             cli.limit
@@ -1012,9 +1062,31 @@ fn main() -> Result<()> {
             }
             if output_path.exists() {
                 let out_size = fs::metadata(&output_path)?.len();
-                let out_records = out_size / PackedSfenValue::SIZE as u64;
-                if out_records >= input_record_count && out_size % PackedSfenValue::SIZE as u64 == 0
-                {
+                let output_record_size = if cli.out_scores {
+                    std::mem::size_of::<i16>() as u64
+                } else {
+                    PackedSfenValue::SIZE as u64
+                };
+                if cli.out_scores && out_size % output_record_size != 0 {
+                    anyhow::bail!(
+                        "Output size is not a multiple of {output_record_size}: {} ({out_size} bytes)",
+                        output_path.display()
+                    );
+                }
+                let out_records = out_size / output_record_size;
+                if cli.out_scores && out_records > process_count {
+                    anyhow::bail!(
+                        "score sidecar has {out_records} records, exceeding expected {process_count}: {}",
+                        output_path.display()
+                    );
+                }
+                let complete = if cli.out_scores {
+                    out_records == process_count
+                } else {
+                    out_records >= input_record_count
+                        && out_size % PackedSfenValue::SIZE as u64 == 0
+                };
+                if complete {
                     eprintln!(
                         "=== [{}/{}] Skipping (complete: {} records): {} ===",
                         file_idx + 1,
@@ -2095,6 +2167,79 @@ fn onnx_ort_err(e: ort::Error) -> anyhow::Error {
     anyhow::anyhow!("ONNX Runtime error: {e}")
 }
 
+/// score 決定後のレコードを通常 PSV または score sidecar として直列化する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn append_rescore_bytes(output: &mut Vec<u8>, psv: &PackedSfenValue, out_scores: bool) {
+    if out_scores {
+        output.extend_from_slice(&psv.score.to_le_bytes());
+    } else {
+        output.extend_from_slice(&psv.to_bytes());
+    }
+}
+
+/// score sidecar ではエラーを含むバッチを 1 byte も書かない。
+///
+/// reader の decode 失敗と producer の局面構築失敗を同じ errors に集約し、
+/// seq 順 writer が書き出し直前に拒否することで、既存 prefix の行対応を保つ。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn write_rescore_batch<W: Write>(
+    writer: &mut W,
+    bytes: &[u8],
+    out_scores: bool,
+    errors: u64,
+) -> Result<()> {
+    if out_scores && errors > 0 {
+        anyhow::bail!(
+            "score sidecar aborted before writing batch: {errors} input record(s) failed to decode or build"
+        );
+    }
+    writer.write_all(bytes)?;
+    Ok(())
+}
+
+/// 既存出力のレコード数を返す。通常 PSV の末尾 partial record は従来どおり
+/// 切り捨てて自己修復するが、事後検出不能な score sidecar は fail-closed にする。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn prepare_resume_count(
+    output_path: &std::path::Path,
+    output_record_size: u64,
+    out_scores: bool,
+) -> Result<u64> {
+    if !output_path.exists() {
+        return Ok(0);
+    }
+    let out_size = fs::metadata(output_path)?.len();
+    let remainder = out_size % output_record_size;
+    if remainder == 0 {
+        return Ok(out_size / output_record_size);
+    }
+    if out_scores {
+        anyhow::bail!(
+            "Output size is not a multiple of {output_record_size}: {} ({out_size} bytes)",
+            output_path.display()
+        );
+    }
+
+    let aligned_size = out_size - remainder;
+    File::options().write(true).open(output_path)?.set_len(aligned_size)?;
+    eprintln!(
+        "Truncated partial output record: {} ({out_size} -> {aligned_size} bytes)",
+        output_path.display()
+    );
+    Ok(aligned_size / output_record_size)
+}
+
+/// 入力を既処理レコードの直後へ移動する。巨大 sidecar の resume で入力 prefix を
+/// 空読みせず、checked offset に直接 seek する。
+#[cfg(any(feature = "aobazero-onnx", feature = "dlshogi-onnx"))]
+fn seek_to_record<R: Seek>(reader: &mut R, record_count: u64) -> Result<u64> {
+    let offset = record_count
+        .checked_mul(PackedSfenValue::SIZE as u64)
+        .ok_or_else(|| anyhow::anyhow!("resume input offset overflow: {record_count} records"))?;
+    reader.seek(SeekFrom::Start(offset))?;
+    Ok(offset)
+}
+
 /// ONNX 直接推論パイプラインの共通設定
 ///
 /// 全フィールドが `Copy` のため、関数内で destructure して既存ローカル変数名と
@@ -2107,6 +2252,8 @@ struct OnnxPipelineConfig<'a> {
     onnx_path: &'a std::path::Path,
     input_path: &'a std::path::Path,
     output_path: &'a std::path::Path,
+    /// score sidecar（little-endian i16 × records）として出力する
+    out_scores: bool,
     process_count: u64,
     batch_size: usize,
     gpu_id: i32,
@@ -2174,6 +2321,7 @@ struct RunFingerprint {
     input_size: u64,
     input_mtime_ns: u128,
     process_count: u64,
+    out_scores: bool,
     skip_in_check: bool,
     score_clip: i16,
     eval_scale_bits: u32,
@@ -2253,6 +2401,7 @@ fn serialize_marker(marker: &DoneMarker) -> String {
     let _ = writeln!(out, "input_size={}", f.input_size);
     let _ = writeln!(out, "input_mtime_ns={}", f.input_mtime_ns);
     let _ = writeln!(out, "process_count={}", f.process_count);
+    let _ = writeln!(out, "out_scores={}", f.out_scores);
     let _ = writeln!(out, "skip_in_check={}", f.skip_in_check);
     let _ = writeln!(out, "score_clip={}", f.score_clip);
     let _ = writeln!(out, "eval_scale_bits=0x{:08x}", f.eval_scale_bits);
@@ -2400,6 +2549,11 @@ fn parse_marker(path: &std::path::Path) -> Result<DoneMarker> {
         input_size: get("input_size")?.parse().context("invalid input_size")?,
         input_mtime_ns: get("input_mtime_ns")?.parse().context("invalid input_mtime_ns")?,
         process_count: get("process_count")?.parse().context("invalid process_count")?,
+        // 旧 marker はフル PSV 出力なので false として扱う。
+        out_scores: match map.get("out_scores") {
+            Some(v) => parse_bool(v)?,
+            None => false,
+        },
         skip_in_check: parse_bool(get("skip_in_check")?)?,
         score_clip: get("score_clip")?.parse().context("invalid score_clip")?,
         eval_scale_bits: parse_hex_u32(get("eval_scale_bits")?)?,
@@ -2616,6 +2770,7 @@ fn build_run_fingerprint(config: &OnnxPipelineConfig<'_>) -> Result<RunFingerpri
         input_size,
         input_mtime_ns,
         process_count: config.process_count,
+        out_scores: config.out_scores,
         skip_in_check: config.skip_in_check,
         score_clip: config.score_clip,
         eval_scale_bits: config.eval_scale.to_bits(),
@@ -2760,6 +2915,7 @@ where
         onnx_path,
         input_path,
         output_path,
+        out_scores,
         process_count,
         batch_size,
         gpu_id,
@@ -2998,19 +3154,12 @@ where
     let mut reader = BufReader::new(in_file);
 
     // レジューム対応: 出力ファイルに既存レコードがあればスキップして追記
-    let resume_count = if output_path.exists() {
-        let out_size = fs::metadata(output_path)?.len();
-        let records = out_size / PackedSfenValue::SIZE as u64;
-        // 不完全レコードがあれば切り捨て
-        let clean_size = records * PackedSfenValue::SIZE as u64;
-        if out_size != clean_size {
-            let f = File::options().write(true).open(output_path)?;
-            f.set_len(clean_size)?;
-        }
-        records
+    let output_record_size = if out_scores {
+        std::mem::size_of::<i16>() as u64
     } else {
-        0
+        PackedSfenValue::SIZE as u64
     };
+    let resume_count = prepare_resume_count(output_path, output_record_size, out_scores)?;
 
     let out_file = File::options()
         .create(true)
@@ -3049,18 +3198,11 @@ where
     let mut remaining = process_count;
     if resume_count > 0 {
         let skip = resume_count.min(remaining);
-        let mut skip_buf = [0u8; PackedSfenValue::SIZE];
-        let mut skipped = 0u64;
-        for _ in 0..skip {
-            if reader.read_exact(&mut skip_buf).is_err() {
-                break;
-            }
-            remaining -= 1;
-            skipped += 1;
-        }
+        seek_to_record(&mut reader, skip)?;
+        remaining -= skip;
         // 既処理分を進捗の起点として反映（per-file/overall とも前進）。
-        progress.advance_start(skipped);
-        eprintln!("Resuming: skipped {skipped} already-processed records");
+        progress.advance_start(skip);
+        eprintln!("Resuming: skipped {skip} already-processed records");
     }
 
     let mut skipped_count: u64 = 0;
@@ -3322,7 +3464,8 @@ where
                 // skip_in_check が真かつ親が王手の場合は書き出しを抑制（推論結果は破棄）。
                 let mut skipped = 0u64;
                 let mut clipped_n = 0u64;
-                let mut rescore_bytes = Vec::with_capacity(actual_batch * PackedSfenValue::SIZE);
+                let mut rescore_bytes =
+                    Vec::with_capacity(actual_batch * output_record_size as usize);
                 let mut replacement_bytes = if want_replacement {
                     Vec::with_capacity(actual_batch * PackedSfenValue::SIZE)
                 } else {
@@ -3361,7 +3504,7 @@ where
                         game_result: psv.game_result,
                         padding: 0,
                     };
-                    rescore_bytes.extend_from_slice(&new_psv.to_bytes());
+                    append_rescore_bytes(&mut rescore_bytes, &new_psv, out_scores);
 
                     // leaf-REPLACEMENT arm（有効時のみ、leaf-LABEL と 1:1 lockstep）。
                     // `--apply-qsearch-leaf` → DL rescore の 2 工程と bit 一致させる:
@@ -3808,12 +3951,19 @@ where
                 // 揃った分だけ seq 順に書き出す。pending は同時生存 slot 数で抑えられる。
                 while let Some(done) = pending.remove(&next_seq) {
                     next_seq += 1;
+                    let phase_t = Instant::now();
+                    // sidecar は i16 列だけで行ずれを事後検出できない。reader / producer
+                    // 由来のどちらのエラーも、当該バッチの最初の byte より前で拒否する。
+                    write_rescore_batch(
+                        &mut writer,
+                        &done.rescore_bytes,
+                        out_scores,
+                        done.slot.errors,
+                    )?;
                     stats.errors += done.slot.errors;
                     if done.slot.actual_batch == 0 {
                         break 'writer_loop; // EOF / 中断 sentinel（最終 seq）
                     }
-                    let phase_t = Instant::now();
-                    writer.write_all(&done.rescore_bytes)?;
                     if let Some(rw) = replacement_writer.as_mut() {
                         rw.write_all(&done.replacement_bytes)?;
                     }
@@ -3927,6 +4077,11 @@ where
     // 統計情報
     let rescore_written = total_processed.saturating_sub(skipped_count);
     let total = total_processed + error_count;
+    if out_scores && error_count > 0 {
+        anyhow::bail!(
+            "score sidecar aborted: {error_count} input record(s) failed to decode or build; row alignment cannot be guaranteed"
+        );
+    }
     if error_count > 0 {
         // 破損/パース不能でスキップしたレコードは推論バッチに入らず進捗に計上されないため、
         // それらがあると進捗表示が 100% に届かないことがある（rescore 出力は有効分のみで正常）。
@@ -3965,6 +4120,18 @@ where
     // INTERRUPTED が立っている場合（Ctrl-C で残ファイル分を打ち切った場合）も
     // 書き出した分は完了扱いとはせず、marker を作らない。
     if !INTERRUPTED.load(Ordering::SeqCst) {
+        if out_scores {
+            let expected_size = process_count
+                .checked_mul(output_record_size)
+                .context("Expected output size overflow")?;
+            let actual_size = fs::metadata(output_path)?.len();
+            if actual_size != expected_size {
+                anyhow::bail!(
+                    "Output size mismatch: {} has {actual_size} bytes, expected {expected_size}",
+                    output_path.display()
+                );
+            }
+        }
         let fingerprint = build_run_fingerprint(config)?;
         let rescore_size = fs::metadata(output_path)?.len();
         let expand_size = match expand {
@@ -4020,6 +4187,7 @@ fn process_file_with_onnx(
         onnx_path: cli.onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
+        out_scores: cli.out_scores,
         process_count,
         batch_size: cli.onnx_batch_size,
         gpu_id: cli.onnx_gpu_id,
@@ -4081,6 +4249,7 @@ fn process_file_with_dlshogi_onnx(
         onnx_path: cli.dlshogi_onnx_model.as_ref().unwrap(),
         input_path,
         output_path,
+        out_scores: cli.out_scores,
         process_count,
         batch_size: cli.onnx_batch_size,
         gpu_id: cli.onnx_gpu_id,
@@ -4116,7 +4285,7 @@ fn process_file_with_dlshogi_onnx(
 #[cfg(all(test, any(feature = "aobazero-onnx", feature = "dlshogi-onnx")))]
 mod marker_tests {
     use super::*;
-    use std::io::Write;
+    use std::io::{Read, Write};
 
     /// 必須キーを満たす最小 marker テキスト（expand=false）。`extra` に qsearch 系の追加行を差し込む。
     fn base_marker(extra: &str) -> String {
@@ -4164,6 +4333,19 @@ mod marker_tests {
         assert_eq!(m.fingerprint.qsearch_nnue_path, None);
         assert_eq!(m.fingerprint.qsearch_nnue_size, None);
         assert_eq!(m.fingerprint.qsearch_nnue_mtime_ns, None);
+    }
+
+    #[test]
+    fn old_marker_without_out_scores_defaults_to_false() {
+        let m = parse_text(&base_marker(""));
+        assert!(!m.fingerprint.out_scores);
+    }
+
+    #[test]
+    fn out_scores_true_roundtrips() {
+        let m = parse_text(&base_marker("out_scores=true\n"));
+        assert!(m.fingerprint.out_scores);
+        assert_eq!(m, parse_text(&serialize_marker(&m)));
     }
 
     #[test]
@@ -4232,5 +4414,86 @@ mod marker_tests {
         assert_eq!(m.output_sizes.replacement_output_size, Some(320));
         // serialize → parse で一致（replacement_* 行は replacement=true 時のみ出力）
         assert_eq!(m, parse_text(&serialize_marker(&m)));
+    }
+
+    fn test_psv(score: i16) -> PackedSfenValue {
+        PackedSfenValue {
+            sfen: [7; 32],
+            score,
+            move16: 123,
+            game_ply: 45,
+            game_result: -1,
+            padding: 0,
+        }
+    }
+
+    #[test]
+    fn score_sidecar_matches_full_psv_score_column() {
+        let records = [test_psv(-1234), test_psv(0), test_psv(9876)];
+        let mut full = Vec::new();
+        let mut scores = Vec::new();
+        for record in &records {
+            append_rescore_bytes(&mut full, record, false);
+            append_rescore_bytes(&mut scores, record, true);
+        }
+        let extracted: Vec<u8> = full
+            .chunks_exact(PackedSfenValue::SIZE)
+            .flat_map(|record| record[32..34].iter().copied())
+            .collect();
+        assert_eq!(scores, extracted);
+    }
+
+    #[test]
+    fn score_sidecar_resume_prefix_is_bit_identical() {
+        let records = [test_psv(-5), test_psv(6), test_psv(300)];
+        let mut complete = Vec::new();
+        for record in &records {
+            append_rescore_bytes(&mut complete, record, true);
+        }
+        let mut resumed = complete[..2].to_vec();
+        for record in &records[1..] {
+            append_rescore_bytes(&mut resumed, record, true);
+        }
+        assert_eq!(resumed, complete);
+    }
+
+    #[test]
+    fn score_sidecar_error_batch_keeps_clean_prefix() {
+        let mut output = Vec::new();
+        write_rescore_batch(&mut output, &[9, 8], true, 0).unwrap();
+        let error = write_rescore_batch(&mut output, &[1, 2], true, 1).unwrap_err();
+        assert!(error.to_string().contains("before writing batch"));
+        assert_eq!(output, [9, 8]);
+
+        write_rescore_batch(&mut output, &[3, 4], false, 1).unwrap();
+        assert_eq!(output, [9, 8, 3, 4]);
+    }
+
+    #[test]
+    fn normal_resume_truncates_partial_record_but_sidecar_rejects_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let normal = dir.path().join("normal.psv");
+        std::fs::write(&normal, vec![0u8; PackedSfenValue::SIZE + 1]).unwrap();
+        assert_eq!(prepare_resume_count(&normal, PackedSfenValue::SIZE as u64, false).unwrap(), 1);
+        assert_eq!(std::fs::metadata(normal).unwrap().len(), PackedSfenValue::SIZE as u64);
+
+        let sidecar = dir.path().join("scores.i16");
+        std::fs::write(&sidecar, [0u8; 3]).unwrap();
+        assert!(prepare_resume_count(&sidecar, 2, true).is_err());
+        assert_eq!(std::fs::metadata(sidecar).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn sidecar_resume_seek_preserves_record_alignment() {
+        let mut input = Vec::new();
+        for score in [-5, 6, 300] {
+            input.extend_from_slice(&test_psv(score).to_bytes());
+        }
+        let mut cursor = std::io::Cursor::new(input);
+        assert_eq!(seek_to_record(&mut cursor, 2).unwrap(), 2 * PackedSfenValue::SIZE as u64);
+        let mut record = [0u8; PackedSfenValue::SIZE];
+        cursor.read_exact(&mut record).unwrap();
+        assert_eq!(PackedSfenValue::from_bytes(&record).unwrap().score, 300);
+        assert!(seek_to_record(&mut cursor, u64::MAX).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- production 規模 2 ラベル教師 (depth9 base PSV + DL リスコア) を、DL 版フル PSV (660 GB) を実体化せずに扱うための生成側ツール群。tatara [SH11235/tatara#392](https://github.com/SH11235/tatara/pull/392) の `--score-override` / `--score-override-mask` と形式契約を共有する (i16 LE sidecar = records×2B / LSB-first bitmap = ceil(records/8)B、bit 1 = ゲート該当)
- `rescore_psv --out-scores`: dlshogi ONNX 直接推論の score 列のみを `<入力名>.scores.i16` に出力。生成ピークが 1.35 TB → ~0.7 TB になる
- `psv_gate_by_king_zone` を実験ディレクトリから `crates/tools` に昇格し、merge モード (従来挙動) + mask モード (`--input`/`--out-mask`) の 2 モード化

## 設計 (fail-closed の要点)

- **行対応が唯一の対応キー**: `--out-scores` は行数が変わりうる全モード (`--skip-in-check` / expand / leaf-label 系 / `--delete-input`) と排他。エラー行を含むバッチは**書き出し前に**拒否し、正常 prefix の整列を不変条件化 (resume は同じ行で必ず再失敗)
- resume: sidecar サイズ/2 → checked offset + `SeekFrom::Start`。marker fingerprint に `out_scores` を含め、旧 marker は false に defaults
- gate: 出力=入力の同一実体 (パス一致 / symlink / hardlink) を `same-file` で検査してから作成。サイズ検査 (40 の倍数 / bitmap = ceil(records/8)) を入出力両側で実施
- classify はチャンク (262,144 rec) + rayon 並列 + `unpack_sfen_to_parts` 化 (String 往復除去)。**実測 253,775 → 8,000,000 records/s (31.5×)**、出力 SHA-256 一致 (2M records・release)。16.5B 行 ≈ 35 分の見込み

## Test plan

- [x] `cargo test -p tools` 全 pass (bitmap bit 順序 7/8/9/15/16/17 境界 / merge↔mask 整合 / sidecar 抽出 bit 一致 / resume 整列 / エラーバッチの prefix 非汚染 / hardlink 非破壊 / marker roundtrip / d9_abs_max 排他境界)
- [x] `cargo clippy --tests -- -D warnings` / `cargo fmt --all -- --check` / `bash scripts/check-tracked-abs-paths.sh`
- [x] local reviewer #1 (Codex) APPROVE / local reviewer #2 (Claude) APPROVE (2 巡の iteration 後)

## 関連

- 消費側: [SH11235/tatara#392](https://github.com/SH11235/tatara/pull/392) (CI green)
- 背景: rshogi-notes `rshogi/plans/20260808_production_teacher_handoff.md` §3b (sidecar 設計)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
