### PR TITLE
feat(tools): dual-label PSV の生成・抽出・検証ツール psv_dual_label を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -36,6 +36,7 @@
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](docs/relabel_psv.md)） |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
+| `psv_dual_label` | dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
@@ -115,6 +116,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
+- [psv_dual_label](docs/psv_dual_label.md) - dual-label PSV の生成・sidecar 抽出・fail-closed 検証
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応）

--- a/crates/tools/docs/psv_dual_label.md
+++ b/crates/tools/docs/psv_dual_label.md
@@ -91,3 +91,5 @@ cargo run -p tools --release --bin psv_dual_label -- validate \
 出力がいずれかの入力と同じパス・hardlink を指す場合や symlink の場合は、truncate 前に
 拒否します。extract の複数出力も同じ実体を指定できません。処理完了時には全出力のサイズを
 契約値と照合します。
+`embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・flush・サイズ検算の
+成功後だけ最終パスへ publish します。途中でエラーになった場合は既存の最終パスを変更せず、`.partial` を削除します。

--- a/crates/tools/docs/psv_dual_label.md
+++ b/crates/tools/docs/psv_dual_label.md
@@ -1,0 +1,93 @@
+# psv_dual_label
+
+`psv_dual_label` は通常 PSV と行対応 sidecar から dual-label PSV を生成し、逆抽出と
+fail-closed 検証を行うツールです。dual-label PSV は dedup / shuffle で base score、
+DL score、entered gate bit を一つの 40 byte レコードとして原子的に運ぶための形式です。
+
+## レコード形式
+
+1 レコードは通常 PSV と同じ 40 byte 固定長です。整数は little-endian です。
+
+| offset | 通常 PSV | dual-label PSV |
+|---|---|---|
+| 0-31 | packed sfen | 同じ |
+| 32-33 | score (i16 LE) | **base score** |
+| 34-35 | move16 | **DL score (i16 LE)** |
+| 36-37 | gamePly | 同じ |
+| 38 | game_result | 同じ |
+| 39 | padding (常に 0) | **bit0 = entered gate bit** (1 = 学習側で base を温存)、**bit1-7 は必ず 0** |
+
+入力 sidecar の契約は次のとおりです。
+
+- `dl.i16`: i16 LE × records。サイズは `records × 2 byte` と厳密一致する。
+- `entered.bits`: LSB-first bitmap。byte `j` の bit `k` は record
+  `j * 8 + k` に対応し、bit 1 が entered。サイズは `ceil(records / 8) byte` と
+  厳密一致し、最終 byte の未使用 bit は 0。
+
+学習側 trainer が all 相当で読む場合は全レコードの DL score を使います。gated 相当では
+entered gate bit が 1 のレコードだけ base score を温存し、それ以外は DL score を使います。
+offset 34-35 は dual-label PSV では指し手ではないため、通常 PSV として読ませてはいけません。
+
+## embed: sidecar を埋め込む
+
+```bash
+cargo run -p tools --release --bin psv_dual_label -- embed \
+  --base base.psv \
+  --scores dl.i16 \
+  --mask entered.bits \
+  --out dual.psv
+```
+
+base のサイズ、sidecar の厳密なサイズ、mask 最終 byte の未使用 bit を出力作成前に検査し、
+base の各行は streaming 中に padding が 0 であることを検査します。base の move16 は
+DL score で上書きされます。
+非ゼロ move16 を上書きした件数は `overwritten_nonzero_move16` として表示されます。
+
+## extract: sidecar へ戻す
+
+```bash
+cargo run -p tools --release --bin psv_dual_label -- extract \
+  --dual dual.psv \
+  --out-base base.psv \
+  --out-scores dl.i16 \
+  --out-mask entered.bits
+```
+
+出力は一つ以上を指定し、必要なものだけ省略できます。一回の streaming 走査で同時生成します。
+`--out-base` は move16 と padding を 0 に戻し、base score と他フィールドを保持します。
+`--out-mask` の最終 byte の未使用 bit は常に 0 です。reserved bit (padding bit1-7) が
+立っている入力は行番号付きで拒否します。
+
+`embed` に渡した base の move16 が全行 0 なら、続けて `extract` した
+`base.psv`、`dl.i16`、`entered.bits` は元の入力と bit 一致します。
+
+## validate: fail-closed 検証
+
+```bash
+cargo run -p tools --release --bin psv_dual_label -- validate \
+  --dual dual.psv
+
+# 局面 decode を決定的な等間隔 100 万件に限定
+cargo run -p tools --release --bin psv_dual_label -- validate \
+  --dual dual.psv --sample 1000000
+```
+
+次を検証し、一つでも違反があれば非ゼロで終了します。統計は成否にかかわらず stdout に
+出力します。
+
+- ファイルサイズが 40 byte の倍数で、padding bit1-7 が全行 0。
+- entered gate bit が packed sfen 由来の判定と一致する。entered は
+  「先手玉 rank ≤ 2 または後手玉 rank ≥ 6」。
+- DL score の絶対値が `--dl-abs-max`（既定 32000）以下。
+- DL score の 16 bit を通常 PSV の move16 と解釈したとき、局面の合法手になる割合が
+  `--max-move-like-frac`（既定 0.05）未満。
+
+`--sample N` は entered 整合と move-like 判定だけを先頭固定の決定的な等間隔最大 N 件へ
+限定します。サイズ、reserved bit、DL range は常に全件を走査します。
+
+## 安全性とメモリ
+
+各処理は固定上限の chunk で streaming し、ピークメモリは入力レコード数に依存しません。
+出力がいずれかの入力と同じパス・hardlink を指す場合や symlink の場合は、truncate 前に
+拒否します。extract の複数出力も同じ実体を指定できません。処理完了時には全出力のサイズを
+契約値と照合します。

--- a/crates/tools/docs/psv_dual_label.md
+++ b/crates/tools/docs/psv_dual_label.md
@@ -81,7 +81,7 @@ cargo run -p tools --release --bin psv_dual_label -- validate \
   「先手玉 rank ≤ 2 または後手玉 rank ≥ 6」。
 - DL score の絶対値が `--dl-abs-max`（既定 32000）以下。
 - DL score の 16 bit を通常 PSV の move16 と解釈したとき、局面の合法手になる割合が
-  `--max-move-like-frac`（既定 0.05）未満。
+  `--max-move-like-frac`（既定 0.05）以下。0 を指定すると move-like 行を 1 行も許容しない。
 
 `--sample N` は entered 整合と move-like 判定だけを先頭固定の決定的な等間隔最大 N 件へ
 限定します。サイズ、reserved bit、DL range は常に全件を走査します。
@@ -92,8 +92,11 @@ cargo run -p tools --release --bin psv_dual_label -- validate \
 出力がいずれかの入力と同じパス・hardlink を指す場合や symlink の場合は、truncate 前に
 拒否します。extract の複数出力も同じ実体を指定できません。処理完了時には全出力のサイズを
 契約値と照合します。
-`embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・flush・サイズ検算の
-成功後だけ最終パスへ publish します。publish 前にエラーになった場合は既存の最終パスを変更せず、
+空 (0 レコード) の入力は embed / extract とも拒否します (validate が不正とする空の
+dual PSV を成功として publish しない)。
+`embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・fsync・サイズ検算の
+成功後だけ最終パスへ publish し、publish 後に親ディレクトリを sync します (電源断でも
+publish 済み出力が空・切り詰め状態に巻き戻らない)。publish 前にエラーになった場合は既存の最終パスを変更せず、
 `.partial` を削除します。複数出力の publish 途中で後続の rename に失敗した場合、先に publish 済みの
 最終出力は検証済み成果物として残し、未 publish の `.partial` だけを削除します。エラーには publish 済み・
 未 publish のパスを列挙します。

--- a/crates/tools/docs/psv_dual_label.md
+++ b/crates/tools/docs/psv_dual_label.md
@@ -15,7 +15,7 @@ DL score、entered gate bit を一つの 40 byte レコードとして原子的�
 | 34-35 | move16 | **DL score (i16 LE)** |
 | 36-37 | gamePly | 同じ |
 | 38 | game_result | 同じ |
-| 39 | padding (常に 0) | **bit0 = entered gate bit** (1 = 学習側で base を温存)、**bit1-7 は必ず 0** |
+| 39 | padding（生成系によっては非ゼロ） | **bit0 = entered gate bit** (1 = 学習側で base を温存)、**bit1-7 は必ず 0** |
 
 入力 sidecar の契約は次のとおりです。
 
@@ -38,10 +38,11 @@ cargo run -p tools --release --bin psv_dual_label -- embed \
   --out dual.psv
 ```
 
-base のサイズ、sidecar の厳密なサイズ、mask 最終 byte の未使用 bit を出力作成前に検査し、
-base の各行は streaming 中に padding が 0 であることを検査します。base の move16 は
-DL score で上書きされます。
-非ゼロ move16 を上書きした件数は `overwritten_nonzero_move16` として表示されます。
+base のサイズ、sidecar の厳密なサイズ、mask 最終 byte の未使用 bit を出力作成前に検査します。
+base の move16 は DL score、padding は entered gate bit（bit0 のみ）で上書きされます。
+生成系によっては base の padding が非ゼロの場合がありますが、embed は拒否せず上書きします。
+非ゼロ move16 と非ゼロ padding を上書きした件数は、それぞれ
+`overwritten_nonzero_move16` と `overwritten_nonzero_padding` として表示されます。
 
 ## extract: sidecar へ戻す
 
@@ -58,7 +59,7 @@ cargo run -p tools --release --bin psv_dual_label -- extract \
 `--out-mask` の最終 byte の未使用 bit は常に 0 です。reserved bit (padding bit1-7) が
 立っている入力は行番号付きで拒否します。
 
-`embed` に渡した base の move16 が全行 0 なら、続けて `extract` した
+`embed` に渡した base の move16 と padding が全行 0 なら、続けて `extract` した
 `base.psv`、`dl.i16`、`entered.bits` は元の入力と bit 一致します。
 
 ## validate: fail-closed 検証
@@ -92,4 +93,7 @@ cargo run -p tools --release --bin psv_dual_label -- validate \
 拒否します。extract の複数出力も同じ実体を指定できません。処理完了時には全出力のサイズを
 契約値と照合します。
 `embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・flush・サイズ検算の
-成功後だけ最終パスへ publish します。途中でエラーになった場合は既存の最終パスを変更せず、`.partial` を削除します。
+成功後だけ最終パスへ publish します。publish 前にエラーになった場合は既存の最終パスを変更せず、
+`.partial` を削除します。複数出力の publish 途中で後続の rename に失敗した場合、先に publish 済みの
+最終出力は検証済み成果物として残し、未 publish の `.partial` だけを削除します。エラーには publish 済み・
+未 publish のパスを列挙します。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -58,6 +58,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](relabel_psv.md)） |
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
 | `psv_gate_by_king_zone` | 入玉ドメインで base / override score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
+| `psv_dual_label` | 通常 PSV + DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |

--- a/crates/tools/src/bin/migrate_psv_move16.rs
+++ b/crates/tools/src/bin/migrate_psv_move16.rs
@@ -6,11 +6,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::position::Position;
 use rshogi_core::types::Move;
+use tools::common::io::partial_path;
 use tools::packed_sfen::{
-    PackedSfenValue, PsvMove16Class, classify_psv_move16, legacy_move16_to_move,
+    PackedSfenValue, PsvMove16Class, classify_psv_move16, is_legal_psv_move, legacy_move16_to_move,
     move_to_psv_move16, unpack_sfen_to_parts,
 };
 
@@ -90,17 +90,6 @@ fn convert_record_move16(
     (record, mv)
 }
 
-fn same_move(lhs: Move, rhs: Move) -> bool {
-    lhs.to() == rhs.to()
-        && lhs.is_drop() == rhs.is_drop()
-        && lhs.is_promote() == rhs.is_promote()
-        && if lhs.is_drop() {
-            lhs.drop_piece_type() == rhs.drop_piece_type()
-        } else {
-            lhs.from() == rhs.from()
-        }
-}
-
 fn is_legal_move(psv: &PackedSfenValue, mv: Move) -> bool {
     if mv.is_none() {
         return psv.move16 == 0;
@@ -112,15 +101,7 @@ fn is_legal_move(psv: &PackedSfenValue, mv: Move) -> bool {
     if pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move).is_err() {
         return false;
     }
-    let mut legal_moves = MoveList::new();
-    generate_legal_all(&pos, &mut legal_moves);
-    legal_moves.iter().any(|legal| same_move(*legal, mv))
-}
-
-fn partial_path(output: &Path) -> PathBuf {
-    let mut path = output.as_os_str().to_os_string();
-    path.push(".partial");
-    PathBuf::from(path)
+    is_legal_psv_move(&pos, mv)
 }
 
 fn main() -> Result<()> {

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -84,6 +84,7 @@ enum Command {
 struct EmbedStats {
     records: u64,
     overwritten_nonzero_move16: u64,
+    overwritten_nonzero_padding: u64,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -197,23 +198,36 @@ fn remove_staging(paths: &[PathBuf]) {
 
 fn publish_staged(outputs: &[(&Path, &Path)]) -> Result<()> {
     let mut published: Vec<&Path> = Vec::new();
-    for &(staging, output) in outputs {
+    for (index, &(staging, output)) in outputs.iter().enumerate() {
         if let Err(error) = fs::rename(staging, output) {
-            let staging_paths: Vec<PathBuf> =
-                outputs.iter().map(|(path, _)| (*path).to_path_buf()).collect();
-            remove_staging(&staging_paths);
-            for published_path in published {
-                if let Err(cleanup_error) = fs::remove_file(published_path)
-                    && cleanup_error.kind() != std::io::ErrorKind::NotFound
-                {
-                    eprintln!(
-                        "published file cleanup failed: {}: {cleanup_error}",
-                        published_path.display()
-                    );
-                }
-            }
+            let unpublished_outputs: Vec<&Path> =
+                outputs[index..].iter().map(|(_, path)| *path).collect();
+            let unpublished_staging: Vec<PathBuf> =
+                outputs[index..].iter().map(|(path, _)| (*path).to_path_buf()).collect();
+            remove_staging(&unpublished_staging);
+            let format_paths = |paths: &[&Path]| {
+                paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            let unpublished_staging_refs: Vec<&Path> =
+                unpublished_staging.iter().map(PathBuf::as_path).collect();
+            let publish_state = if published.is_empty() {
+                "publish 未完了"
+            } else {
+                "部分 publish 状態"
+            };
             return Err(error).with_context(|| {
-                format!("{} -> {} の publish に失敗", staging.display(), output.display())
+                format!(
+                    "{} -> {} の publish に失敗（{publish_state}）。publish 済み最終出力=[{}]; 未 publish 最終出力=[{}]; cleanup 対象の未 publish staging=[{}]",
+                    staging.display(),
+                    output.display(),
+                    format_paths(&published),
+                    format_paths(&unpublished_outputs),
+                    format_paths(&unpublished_staging_refs)
+                )
             });
         }
         published.push(output);
@@ -258,14 +272,11 @@ fn embed_with_chunk_records(
             read_bytes(&mut mask_reader, &mut mask_chunk, current_records.div_ceil(8))?;
 
             for (offset, record) in base_chunk.chunks_exact_mut(RECORD_SIZE).enumerate() {
-                let row = stats.records + offset as u64;
-                anyhow::ensure!(
-                    record[PADDING_OFFSET] == 0,
-                    "base padding is non-zero at row {row}: 0x{:02x}",
-                    record[PADDING_OFFSET]
-                );
                 if record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2] != [0, 0] {
                     stats.overwritten_nonzero_move16 += 1;
+                }
+                if record[PADDING_OFFSET] != 0 {
+                    stats.overwritten_nonzero_padding += 1;
                 }
                 record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]
                     .copy_from_slice(&score_chunk[offset * 2..offset * 2 + 2]);
@@ -671,6 +682,7 @@ fn main() -> Result<()> {
             let stats = embed(&base, &scores, &mask, &out)?;
             println!("records={}", stats.records);
             println!("overwritten_nonzero_move16={}", stats.overwritten_nonzero_move16);
+            println!("overwritten_nonzero_padding={}", stats.overwritten_nonzero_padding);
         }
         Command::Extract {
             dual,
@@ -866,15 +878,22 @@ mod tests {
     }
 
     #[test]
-    fn embed_rejects_nonzero_base_padding() -> Result<()> {
+    fn embed_overwrites_and_counts_nonzero_base_padding() -> Result<()> {
         let dir = tempdir()?;
         let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
         let mut bytes = fs::read(&base)?;
-        bytes[RECORD_SIZE + PADDING_OFFSET] = 1;
+        bytes[PADDING_OFFSET] = 0x02;
+        bytes[RECORD_SIZE + PADDING_OFFSET] = 0x03;
         fs::write(&base, bytes)?;
-        let error = embed(&base, &scores, &mask, &dir.path().join("dual.psv"))
-            .expect_err("padding must fail");
-        assert!(error.to_string().contains("row 1"));
+        let dual = dir.path().join("dual.psv");
+
+        let stats = embed(&base, &scores, &mask, &dual)?;
+
+        assert_eq!(stats.overwritten_nonzero_padding, 2);
+        let dual_bytes = fs::read(dual)?;
+        assert_eq!(dual_bytes[PADDING_OFFSET], 1);
+        assert_eq!(dual_bytes[RECORD_SIZE + PADDING_OFFSET], 0);
+        assert_eq!(dual_bytes[2 * RECORD_SIZE + PADDING_OFFSET], 0);
         Ok(())
     }
 
@@ -882,9 +901,7 @@ mod tests {
     fn embed_error_preserves_existing_output_and_removes_staging() -> Result<()> {
         let dir = tempdir()?;
         let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
-        let mut bytes = fs::read(&base)?;
-        bytes[RECORD_SIZE + PADDING_OFFSET] = 1;
-        fs::write(&base, bytes)?;
+        fs::write(&scores, [0u8; 5])?;
         let output = dir.path().join("dual.psv");
         let sentinel = b"existing valid output";
         fs::write(&output, sentinel)?;
@@ -968,20 +985,29 @@ mod tests {
     }
 
     #[test]
-    fn extract_publish_failure_removes_staging_and_already_published_outputs() -> Result<()> {
+    fn extract_publish_failure_keeps_already_published_output() -> Result<()> {
         let dir = tempdir()?;
         let staging_a = dir.path().join("a.partial");
         let staging_b = dir.path().join("b.partial");
         let output_a = dir.path().join("a.out");
-        let output_b = dir.path().join("directory-output");
-        fs::write(&staging_a, b"a")?;
-        fs::write(&staging_b, b"b")?;
-        fs::create_dir(&output_b)?;
+        let output_b = dir.path().join("missing-parent").join("b.out");
+        fs::write(&output_a, b"sentinel")?;
+        fs::write(&staging_a, b"new validated a")?;
+        fs::write(&staging_b, b"new validated b")?;
 
-        assert!(publish_staged(&[(&staging_a, &output_a), (&staging_b, &output_b)]).is_err());
+        let error = publish_staged(&[(&staging_a, &output_a), (&staging_b, &output_b)])
+            .expect_err("the second publish must fail");
+
         assert!(!staging_a.exists());
         assert!(!staging_b.exists());
-        assert!(!output_a.exists());
+        assert_eq!(fs::read(&output_a)?, b"new validated a");
+        assert!(!output_b.exists());
+        let message = error.to_string();
+        assert!(message.contains("部分 publish 状態"));
+        assert!(message.contains("publish 済み最終出力"));
+        assert!(message.contains(output_a.to_string_lossy().as_ref()));
+        assert!(message.contains("未 publish 最終出力"));
+        assert!(message.contains(output_b.to_string_lossy().as_ref()));
         Ok(())
     }
 

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -7,12 +7,15 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use rayon::prelude::*;
-use rshogi_core::movegen::{MoveList, generate_legal_all};
 use rshogi_core::position::Position;
-use rshogi_core::types::Move;
+use tools::common::io::{partial_path, sync_directory};
 use tools::king_zone::{ENTERED_TIER, classify};
-use tools::output_path::{ensure_distinct_output_paths, ensure_safe_output_path};
-use tools::packed_sfen::{PackedSfenValue, psv_move16_to_move, unpack_sfen_to_parts};
+use tools::output_path::{
+    ensure_created_paths_distinct, ensure_distinct_output_paths, ensure_safe_output_path,
+};
+use tools::packed_sfen::{
+    PackedSfenValue, is_legal_psv_move, psv_move16_to_move, unpack_sfen_to_parts,
+};
 
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
 const DL_SCORE_OFFSET: usize = 34;
@@ -74,7 +77,8 @@ enum Command {
         /// 許容する DL score の絶対値上限
         #[arg(long, default_value_t = DEFAULT_DL_ABS_MAX)]
         dl_abs_max: u32,
-        /// 通常 PSV の move16 に見える行の許容割合。この値以上なら失敗
+        /// 通常 PSV の move16 に見える行の許容割合。この値を超えたら失敗
+        /// (0 は move-like 行を 1 行も許容しない最厳設定)
         #[arg(long, default_value_t = DEFAULT_MAX_MOVE_LIKE_FRAC)]
         max_move_like_frac: f64,
     },
@@ -180,12 +184,6 @@ fn embed(base: &Path, scores: &Path, mask: &Path, out: &Path) -> Result<EmbedSta
     embed_with_chunk_records(base, scores, mask, out, CHUNK_RECORDS)
 }
 
-fn partial_path(output: &Path) -> PathBuf {
-    let mut path = output.as_os_str().to_os_string();
-    path.push(".partial");
-    PathBuf::from(path)
-}
-
 fn remove_staging(paths: &[PathBuf]) {
     for path in paths {
         if let Err(error) = fs::remove_file(path)
@@ -232,6 +230,16 @@ fn publish_staged(outputs: &[(&Path, &Path)]) -> Result<()> {
         }
         published.push(output);
     }
+    // rename の永続化: crash 後に publish 済みエントリが巻き戻らないよう親 directory を sync。
+    let mut synced: Vec<&Path> = Vec::new();
+    for (_, output) in outputs {
+        let parent =
+            output.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or(Path::new("."));
+        if !synced.contains(&parent) {
+            sync_directory(parent)?;
+            synced.push(parent);
+        }
+    }
     Ok(())
 }
 
@@ -247,6 +255,7 @@ fn embed_with_chunk_records(
         "chunk_records must be a positive multiple of 8"
     );
     let records = checked_psv_records(base)?;
+    anyhow::ensure!(records > 0, "{} が空です (0 レコード)", base.display());
     checked_sidecar_sizes(scores, mask, records)?;
     let staging = partial_path(out);
     for input in [base, scores, mask] {
@@ -287,7 +296,7 @@ fn embed_with_chunk_records(
         }
 
         writer.flush()?;
-        drop(writer);
+        writer.into_inner()?.sync_all()?;
         let expected = records * RECORD_SIZE as u64;
         let actual = file_size(&staging)?;
         anyhow::ensure!(
@@ -355,6 +364,7 @@ fn extract_with_chunk_records(
         "chunk_records must be a positive multiple of 8"
     );
     let records = checked_psv_records(dual)?;
+    anyhow::ensure!(records > 0, "{} が空です (0 レコード)", dual.display());
     let outputs = output_paths(out_base, out_scores, out_mask);
     let base_staging = out_base.map(partial_path);
     let scores_staging = out_scores.map(partial_path);
@@ -370,8 +380,10 @@ fn extract_with_chunk_records(
         let mut base_writer = create_writer(base_staging.as_deref())?;
         let mut score_writer = create_writer(scores_staging.as_deref())?;
         let mut mask_writer = create_writer(mask_staging.as_deref())?;
+        // 予測パス比較は case-insensitive filesystem の alias を見逃すため、
+        // 作成済み staging の実体でも同一性を検査する (書き込み前)。
+        ensure_created_paths_distinct(&staging_paths)?;
         let mut dual_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
-        let mut base_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
         let mut score_chunk = Vec::with_capacity(chunk_records * 2);
         let mut mask_chunk = Vec::with_capacity(chunk_records.div_ceil(8));
         let mut stats = ExtractStats::default();
@@ -389,15 +401,6 @@ fn extract_with_chunk_records(
                 );
             }
 
-            if let Some(writer) = &mut base_writer {
-                base_chunk.clear();
-                base_chunk.extend_from_slice(&dual_chunk);
-                for record in base_chunk.chunks_exact_mut(RECORD_SIZE) {
-                    record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2].fill(0);
-                    record[PADDING_OFFSET] = 0;
-                }
-                writer.write_all(&base_chunk)?;
-            }
             if let Some(writer) = &mut score_writer {
                 score_chunk.clear();
                 score_chunk.reserve(current_records * 2);
@@ -414,14 +417,21 @@ fn extract_with_chunk_records(
                 }
                 writer.write_all(&mask_chunk)?;
             }
+            // score / mask の gather 後なら dual_chunk を直接 base 化してよい
+            // (chunk 全量の複製を避ける)。
+            if let Some(writer) = &mut base_writer {
+                for record in dual_chunk.chunks_exact_mut(RECORD_SIZE) {
+                    record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2].fill(0);
+                    record[PADDING_OFFSET] = 0;
+                }
+                writer.write_all(&dual_chunk)?;
+            }
             stats.records += current_records as u64;
         }
 
-        for writer in [&mut base_writer, &mut score_writer, &mut mask_writer].into_iter().flatten()
-        {
-            writer.flush()?;
+        for writer in [base_writer, score_writer, mask_writer].into_iter().flatten() {
+            writer.into_inner()?.sync_all()?;
         }
-        drop((base_writer, score_writer, mask_writer));
 
         if let Some(path) = &base_staging {
             let expected = records * RECORD_SIZE as u64;
@@ -453,25 +463,9 @@ fn extract_with_chunk_records(
     result
 }
 
-fn same_move(lhs: Move, rhs: Move) -> bool {
-    lhs.to() == rhs.to()
-        && lhs.is_drop() == rhs.is_drop()
-        && lhs.is_promote() == rhs.is_promote()
-        && if lhs.is_drop() {
-            lhs.drop_piece_type() == rhs.drop_piece_type()
-        } else {
-            lhs.from() == rhs.from()
-        }
-}
-
 fn move16_is_legal(pos: &Position, move16: u16) -> bool {
     let mv = psv_move16_to_move(move16);
-    if mv.is_none() {
-        return false;
-    }
-    let mut legal_moves = MoveList::new();
-    generate_legal_all(pos, &mut legal_moves);
-    legal_moves.iter().any(|legal| same_move(*legal, mv))
+    !mv.is_none() && is_legal_psv_move(pos, mv)
 }
 
 /// `floor(i * total / count)` (`i=0..count`) で選ばれる等間隔行か判定する。
@@ -637,11 +631,9 @@ fn validation_failures(stats: &ValidationStats, config: ValidateConfig) -> Vec<S
         ));
     }
     let fraction = move_like_fraction(stats);
-    if stats.sampled_records != 0 && fraction >= config.max_move_like_frac {
-        failures.push(format!(
-            "move-like fraction {:.6} >= {:.6}",
-            fraction, config.max_move_like_frac
-        ));
+    if stats.sampled_records != 0 && fraction > config.max_move_like_frac {
+        failures
+            .push(format!("move-like fraction {:.6} > {:.6}", fraction, config.max_move_like_frac));
     }
     failures
 }
@@ -656,7 +648,7 @@ fn print_validation_stats(stats: &ValidationStats, config: ValidateConfig, passe
     println!("dl_abs_exceeded={} (limit={})", stats.dl_abs_exceeded, config.dl_abs_max);
     println!("decode_errors={}", stats.decode_errors);
     println!(
-        "move_like={} fraction={:.6} (fail_at={:.6})",
+        "move_like={} fraction={:.6} (fail_above={:.6})",
         stats.move_like,
         move_like_fraction(stats),
         config.max_move_like_frac
@@ -716,6 +708,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rshogi_core::movegen::{MoveList, generate_legal_all};
     use tempfile::tempdir;
     use tools::packed_sfen::{move_to_psv_move16, pack_position};
 
@@ -807,6 +800,55 @@ mod tests {
             assert_eq!(fs::read(&extracted_scores)?, fs::read(&scores)?);
             assert_eq!(fs::read(&extracted_mask)?, fs::read(&mask)?);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn embed_writes_dl_score_little_endian_golden() -> Result<()> {
+        // roundtrip は両方向を同じ実装で処理するため byte swap を検出できない。
+        // 生成物の生 byte を golden 値で直接固定する。
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 1, 0, 0x1234)?;
+        fs::write(&mask, [1u8])?;
+        let dual = dir.path().join("dual.psv");
+        embed(&base, &scores, &mask, &dual)?;
+        let bytes = fs::read(&dual)?;
+        assert_eq!(&bytes[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2], &[0x34, 0x12]);
+        assert_eq!(bytes[PADDING_OFFSET], 1);
+
+        let extracted_scores = dir.path().join("extracted.i16");
+        extract(&dual, None, Some(&extracted_scores), None)?;
+        assert_eq!(fs::read(&extracted_scores)?, vec![0x34, 0x12]);
+        Ok(())
+    }
+
+    #[test]
+    fn embed_and_extract_reject_empty_inputs() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("base.psv");
+        let scores = dir.path().join("dl.i16");
+        let mask = dir.path().join("entered.bits");
+        let dual = dir.path().join("dual.psv");
+        for path in [&base, &scores, &mask, &dual] {
+            fs::write(path, [])?;
+        }
+        assert!(embed(&base, &scores, &mask, &dir.path().join("out.psv")).is_err());
+        assert!(extract(&dual, Some(&dir.path().join("out.psv")), None, None).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_passes_clean_file_at_zero_move_like_threshold() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        let dual = dir.path().join("dual.psv");
+        embed(&base, &scores, &mask, &dual)?;
+        let config = ValidateConfig {
+            max_move_like_frac: 0.0,
+            ..valid_config()
+        };
+        let stats = validate(&dual, config)?;
+        assert_eq!(stats.move_like, 0);
         Ok(())
     }
 

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -11,7 +11,8 @@ use rshogi_core::position::Position;
 use tools::common::io::{partial_path, sync_directory};
 use tools::king_zone::{ENTERED_TIER, classify};
 use tools::output_path::{
-    ensure_created_paths_distinct, ensure_distinct_output_paths, ensure_safe_output_path,
+    ensure_created_paths_distinct, ensure_distinct_output_paths, ensure_no_entity_overlap,
+    ensure_safe_output_path,
 };
 use tools::packed_sfen::{
     PackedSfenValue, is_legal_psv_move, psv_move16_to_move, unpack_sfen_to_parts,
@@ -381,8 +382,11 @@ fn extract_with_chunk_records(
         let mut score_writer = create_writer(scores_staging.as_deref())?;
         let mut mask_writer = create_writer(mask_staging.as_deref())?;
         // 予測パス比較は case-insensitive filesystem の alias を見逃すため、
-        // 作成済み staging の実体でも同一性を検査する (書き込み前)。
+        // 作成済み staging の実体でも同一性を検査する (書き込み前)。staging の
+        // 作成が別出力の最終パスを実体化させるケースがあるため、最終出力との
+        // クロス比較も掛ける。
         ensure_created_paths_distinct(&staging_paths)?;
+        ensure_no_entity_overlap(&staging_paths, &outputs)?;
         let mut dual_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
         let mut score_chunk = Vec::with_capacity(chunk_records * 2);
         let mut mask_chunk = Vec::with_capacity(chunk_records.div_ceil(8));

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -19,6 +19,8 @@ const DL_SCORE_OFFSET: usize = 34;
 const PADDING_OFFSET: usize = 39;
 const BUFFER_SIZE: usize = 32 << 20;
 const CHUNK_RECORDS: usize = 1 << 18;
+// mask の bit 添字を chunk 内 offset で計算するため、chunk 境界を byte 境界に揃える。
+const _: () = assert!(CHUNK_RECORDS.is_multiple_of(8));
 const DEFAULT_DL_ABS_MAX: u32 = 32_000;
 const DEFAULT_MAX_MOVE_LIKE_FRAC: f64 = 0.05;
 
@@ -174,54 +176,120 @@ fn read_bytes<R: Read>(reader: &mut R, buffer: &mut Vec<u8>, bytes: usize) -> Re
 }
 
 fn embed(base: &Path, scores: &Path, mask: &Path, out: &Path) -> Result<EmbedStats> {
+    embed_with_chunk_records(base, scores, mask, out, CHUNK_RECORDS)
+}
+
+fn partial_path(output: &Path) -> PathBuf {
+    let mut path = output.as_os_str().to_os_string();
+    path.push(".partial");
+    PathBuf::from(path)
+}
+
+fn remove_staging(paths: &[PathBuf]) {
+    for path in paths {
+        if let Err(error) = fs::remove_file(path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!("staging file cleanup failed: {}: {error}", path.display());
+        }
+    }
+}
+
+fn publish_staged(outputs: &[(&Path, &Path)]) -> Result<()> {
+    let mut published: Vec<&Path> = Vec::new();
+    for &(staging, output) in outputs {
+        if let Err(error) = fs::rename(staging, output) {
+            let staging_paths: Vec<PathBuf> =
+                outputs.iter().map(|(path, _)| (*path).to_path_buf()).collect();
+            remove_staging(&staging_paths);
+            for published_path in published {
+                if let Err(cleanup_error) = fs::remove_file(published_path)
+                    && cleanup_error.kind() != std::io::ErrorKind::NotFound
+                {
+                    eprintln!(
+                        "published file cleanup failed: {}: {cleanup_error}",
+                        published_path.display()
+                    );
+                }
+            }
+            return Err(error).with_context(|| {
+                format!("{} -> {} の publish に失敗", staging.display(), output.display())
+            });
+        }
+        published.push(output);
+    }
+    Ok(())
+}
+
+fn embed_with_chunk_records(
+    base: &Path,
+    scores: &Path,
+    mask: &Path,
+    out: &Path,
+    chunk_records: usize,
+) -> Result<EmbedStats> {
+    anyhow::ensure!(
+        chunk_records > 0 && chunk_records.is_multiple_of(8),
+        "chunk_records must be a positive multiple of 8"
+    );
     let records = checked_psv_records(base)?;
     checked_sidecar_sizes(scores, mask, records)?;
+    let staging = partial_path(out);
     for input in [base, scores, mask] {
         ensure_safe_output_path(out, input)?;
+        ensure_safe_output_path(&staging, input)?;
     }
+    ensure_distinct_output_paths(out, &staging)?;
 
-    let mut base_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(base)?);
-    let mut score_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(scores)?);
-    let mut mask_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
-    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(out)?);
-    let mut base_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
-    let mut score_chunk = Vec::with_capacity(CHUNK_RECORDS * 2);
-    let mut mask_chunk = Vec::with_capacity(CHUNK_RECORDS.div_ceil(8));
-    let mut stats = EmbedStats::default();
+    let result = (|| {
+        let mut base_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(base)?);
+        let mut score_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(scores)?);
+        let mut mask_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
+        let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(&staging)?);
+        let mut base_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+        let mut score_chunk = Vec::with_capacity(chunk_records * 2);
+        let mut mask_chunk = Vec::with_capacity(chunk_records.div_ceil(8));
+        let mut stats = EmbedStats::default();
 
-    while stats.records < records {
-        let chunk_records = (records - stats.records).min(CHUNK_RECORDS as u64) as usize;
-        read_bytes(&mut base_reader, &mut base_chunk, chunk_records * RECORD_SIZE)?;
-        read_bytes(&mut score_reader, &mut score_chunk, chunk_records * 2)?;
-        read_bytes(&mut mask_reader, &mut mask_chunk, chunk_records.div_ceil(8))?;
+        while stats.records < records {
+            let current_records = (records - stats.records).min(chunk_records as u64) as usize;
+            read_bytes(&mut base_reader, &mut base_chunk, current_records * RECORD_SIZE)?;
+            read_bytes(&mut score_reader, &mut score_chunk, current_records * 2)?;
+            read_bytes(&mut mask_reader, &mut mask_chunk, current_records.div_ceil(8))?;
 
-        for (offset, record) in base_chunk.chunks_exact_mut(RECORD_SIZE).enumerate() {
-            let row = stats.records + offset as u64;
-            anyhow::ensure!(
-                record[PADDING_OFFSET] == 0,
-                "base padding is non-zero at row {row}: 0x{:02x}",
-                record[PADDING_OFFSET]
-            );
-            if record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2] != [0, 0] {
-                stats.overwritten_nonzero_move16 += 1;
+            for (offset, record) in base_chunk.chunks_exact_mut(RECORD_SIZE).enumerate() {
+                let row = stats.records + offset as u64;
+                anyhow::ensure!(
+                    record[PADDING_OFFSET] == 0,
+                    "base padding is non-zero at row {row}: 0x{:02x}",
+                    record[PADDING_OFFSET]
+                );
+                if record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2] != [0, 0] {
+                    stats.overwritten_nonzero_move16 += 1;
+                }
+                record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]
+                    .copy_from_slice(&score_chunk[offset * 2..offset * 2 + 2]);
+                record[PADDING_OFFSET] = (mask_chunk[offset / 8] >> (offset % 8)) & 1;
             }
-            record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]
-                .copy_from_slice(&score_chunk[offset * 2..offset * 2 + 2]);
-            record[PADDING_OFFSET] = (mask_chunk[offset / 8] >> (offset % 8)) & 1;
+            writer.write_all(&base_chunk)?;
+            stats.records += current_records as u64;
         }
-        writer.write_all(&base_chunk)?;
-        stats.records += chunk_records as u64;
-    }
 
-    writer.flush()?;
-    drop(writer);
-    let expected = records * RECORD_SIZE as u64;
-    anyhow::ensure!(
-        file_size(out)? == expected,
-        "output size mismatch: expected={expected}, actual={}",
-        file_size(out)?
-    );
-    Ok(stats)
+        writer.flush()?;
+        drop(writer);
+        let expected = records * RECORD_SIZE as u64;
+        let actual = file_size(&staging)?;
+        anyhow::ensure!(
+            actual == expected,
+            "output size mismatch: expected={expected}, actual={actual}"
+        );
+        publish_staged(&[(&staging, out)])?;
+        Ok(stats)
+    })();
+    if result.is_err() {
+        remove_staging(&[staging]);
+    }
+    result
 }
 
 fn output_paths<'a>(
@@ -232,14 +300,15 @@ fn output_paths<'a>(
     [out_base, out_scores, out_mask].into_iter().flatten().collect()
 }
 
-fn check_extract_paths(dual: &Path, outputs: &[&Path]) -> Result<()> {
+fn check_extract_paths(dual: &Path, outputs: &[&Path], staging_paths: &[&Path]) -> Result<()> {
     anyhow::ensure!(!outputs.is_empty(), "少なくとも 1 つの出力を指定してください");
-    for output in outputs {
-        ensure_safe_output_path(output, dual)?;
+    let all_paths: Vec<&Path> = outputs.iter().chain(staging_paths).copied().collect();
+    for path in &all_paths {
+        ensure_safe_output_path(path, dual)?;
     }
-    for i in 0..outputs.len() {
-        for j in i + 1..outputs.len() {
-            ensure_distinct_output_paths(outputs[i], outputs[j])?;
+    for i in 0..all_paths.len() {
+        for j in i + 1..all_paths.len() {
+            ensure_distinct_output_paths(all_paths[i], all_paths[j])?;
         }
     }
     Ok(())
@@ -260,79 +329,117 @@ fn extract(
     out_scores: Option<&Path>,
     out_mask: Option<&Path>,
 ) -> Result<ExtractStats> {
+    extract_with_chunk_records(dual, out_base, out_scores, out_mask, CHUNK_RECORDS)
+}
+
+fn extract_with_chunk_records(
+    dual: &Path,
+    out_base: Option<&Path>,
+    out_scores: Option<&Path>,
+    out_mask: Option<&Path>,
+    chunk_records: usize,
+) -> Result<ExtractStats> {
+    anyhow::ensure!(
+        chunk_records > 0 && chunk_records.is_multiple_of(8),
+        "chunk_records must be a positive multiple of 8"
+    );
     let records = checked_psv_records(dual)?;
     let outputs = output_paths(out_base, out_scores, out_mask);
-    check_extract_paths(dual, &outputs)?;
+    let base_staging = out_base.map(partial_path);
+    let scores_staging = out_scores.map(partial_path);
+    let mask_staging = out_mask.map(partial_path);
+    let staging_paths =
+        output_paths(base_staging.as_deref(), scores_staging.as_deref(), mask_staging.as_deref());
+    check_extract_paths(dual, &outputs, &staging_paths)?;
+    let owned_staging_paths: Vec<PathBuf> =
+        staging_paths.iter().map(|path| path.to_path_buf()).collect();
 
-    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(dual)?);
-    let mut base_writer = create_writer(out_base)?;
-    let mut score_writer = create_writer(out_scores)?;
-    let mut mask_writer = create_writer(out_mask)?;
-    let mut dual_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
-    let mut base_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
-    let mut score_chunk = Vec::with_capacity(CHUNK_RECORDS * 2);
-    let mut mask_chunk = Vec::with_capacity(CHUNK_RECORDS.div_ceil(8));
-    let mut stats = ExtractStats::default();
+    let result = (|| {
+        let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(dual)?);
+        let mut base_writer = create_writer(base_staging.as_deref())?;
+        let mut score_writer = create_writer(scores_staging.as_deref())?;
+        let mut mask_writer = create_writer(mask_staging.as_deref())?;
+        let mut dual_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+        let mut base_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+        let mut score_chunk = Vec::with_capacity(chunk_records * 2);
+        let mut mask_chunk = Vec::with_capacity(chunk_records.div_ceil(8));
+        let mut stats = ExtractStats::default();
 
-    while stats.records < records {
-        let chunk_records = (records - stats.records).min(CHUNK_RECORDS as u64) as usize;
-        read_bytes(&mut reader, &mut dual_chunk, chunk_records * RECORD_SIZE)?;
+        while stats.records < records {
+            let current_records = (records - stats.records).min(chunk_records as u64) as usize;
+            read_bytes(&mut reader, &mut dual_chunk, current_records * RECORD_SIZE)?;
 
-        for (offset, record) in dual_chunk.chunks_exact(RECORD_SIZE).enumerate() {
-            let row = stats.records + offset as u64;
-            anyhow::ensure!(
-                record[PADDING_OFFSET] & !1 == 0,
-                "dual padding bit1-7 is non-zero at row {row}: 0x{:02x}",
-                record[PADDING_OFFSET]
-            );
-        }
-
-        if let Some(writer) = &mut base_writer {
-            base_chunk.clear();
-            base_chunk.extend_from_slice(&dual_chunk);
-            for record in base_chunk.chunks_exact_mut(RECORD_SIZE) {
-                record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2].fill(0);
-                record[PADDING_OFFSET] = 0;
-            }
-            writer.write_all(&base_chunk)?;
-        }
-        if let Some(writer) = &mut score_writer {
-            score_chunk.clear();
-            score_chunk.reserve(chunk_records * 2);
-            for record in dual_chunk.chunks_exact(RECORD_SIZE) {
-                score_chunk.extend_from_slice(&record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]);
-            }
-            writer.write_all(&score_chunk)?;
-        }
-        if let Some(writer) = &mut mask_writer {
-            mask_chunk.clear();
-            mask_chunk.resize(chunk_records.div_ceil(8), 0);
             for (offset, record) in dual_chunk.chunks_exact(RECORD_SIZE).enumerate() {
-                mask_chunk[offset / 8] |= (record[PADDING_OFFSET] & 1) << (offset % 8);
+                let row = stats.records + offset as u64;
+                anyhow::ensure!(
+                    record[PADDING_OFFSET] & !1 == 0,
+                    "dual padding bit1-7 is non-zero at row {row}: 0x{:02x}",
+                    record[PADDING_OFFSET]
+                );
             }
-            writer.write_all(&mask_chunk)?;
+
+            if let Some(writer) = &mut base_writer {
+                base_chunk.clear();
+                base_chunk.extend_from_slice(&dual_chunk);
+                for record in base_chunk.chunks_exact_mut(RECORD_SIZE) {
+                    record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2].fill(0);
+                    record[PADDING_OFFSET] = 0;
+                }
+                writer.write_all(&base_chunk)?;
+            }
+            if let Some(writer) = &mut score_writer {
+                score_chunk.clear();
+                score_chunk.reserve(current_records * 2);
+                for record in dual_chunk.chunks_exact(RECORD_SIZE) {
+                    score_chunk.extend_from_slice(&record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]);
+                }
+                writer.write_all(&score_chunk)?;
+            }
+            if let Some(writer) = &mut mask_writer {
+                mask_chunk.clear();
+                mask_chunk.resize(current_records.div_ceil(8), 0);
+                for (offset, record) in dual_chunk.chunks_exact(RECORD_SIZE).enumerate() {
+                    mask_chunk[offset / 8] |= (record[PADDING_OFFSET] & 1) << (offset % 8);
+                }
+                writer.write_all(&mask_chunk)?;
+            }
+            stats.records += current_records as u64;
         }
-        stats.records += chunk_records as u64;
-    }
 
-    for writer in [&mut base_writer, &mut score_writer, &mut mask_writer].into_iter().flatten() {
-        writer.flush()?;
-    }
-    drop((base_writer, score_writer, mask_writer));
+        for writer in [&mut base_writer, &mut score_writer, &mut mask_writer].into_iter().flatten()
+        {
+            writer.flush()?;
+        }
+        drop((base_writer, score_writer, mask_writer));
 
-    if let Some(path) = out_base {
-        let expected = records * RECORD_SIZE as u64;
-        anyhow::ensure!(file_size(path)? == expected, "base output size mismatch");
+        if let Some(path) = &base_staging {
+            let expected = records * RECORD_SIZE as u64;
+            anyhow::ensure!(file_size(path)? == expected, "base output size mismatch");
+        }
+        if let Some(path) = &scores_staging {
+            let expected = records * 2;
+            anyhow::ensure!(file_size(path)? == expected, "score output size mismatch");
+        }
+        if let Some(path) = &mask_staging {
+            let expected = records.div_ceil(8);
+            anyhow::ensure!(file_size(path)? == expected, "mask output size mismatch");
+        }
+
+        let publish_outputs: Vec<(&Path, &Path)> = [
+            base_staging.as_deref().zip(out_base),
+            scores_staging.as_deref().zip(out_scores),
+            mask_staging.as_deref().zip(out_mask),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        publish_staged(&publish_outputs)?;
+        Ok(stats)
+    })();
+    if result.is_err() {
+        remove_staging(&owned_staging_paths);
     }
-    if let Some(path) = out_scores {
-        let expected = records * 2;
-        anyhow::ensure!(file_size(path)? == expected, "score output size mismatch");
-    }
-    if let Some(path) = out_mask {
-        let expected = records.div_ceil(8);
-        anyhow::ensure!(file_size(path)? == expected, "mask output size mismatch");
-    }
-    Ok(stats)
+    result
 }
 
 fn same_move(lhs: Move, rhs: Move) -> bool {
@@ -483,6 +590,9 @@ fn move_like_fraction(stats: &ValidationStats) -> f64 {
 
 fn validation_failures(stats: &ValidationStats, config: ValidateConfig) -> Vec<String> {
     let mut failures = Vec::new();
+    if stats.records == 0 {
+        failures.push("レコードが 0 件です".to_owned());
+    }
     if stats.trailing_bytes != 0 {
         failures.push(format!("末尾に {} byte の端数があります", stats.trailing_bytes));
     }
@@ -597,6 +707,16 @@ mod tests {
     use tempfile::tempdir;
     use tools::packed_sfen::{move_to_psv_move16, pack_position};
 
+    #[cfg(unix)]
+    fn symlink_file(original: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(original, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(original: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(original, link)
+    }
+
     fn record(sfen: &str, score: i16, move16: u16, padding: u8) -> Result<[u8; RECORD_SIZE]> {
         let mut pos = Position::new();
         pos.set_sfen(sfen)?;
@@ -679,6 +799,35 @@ mod tests {
     }
 
     #[test]
+    fn embed_extract_roundtrip_across_streaming_chunk_boundary() -> Result<()> {
+        const TEST_CHUNK_RECORDS: usize = 16;
+        for count in [
+            TEST_CHUNK_RECORDS - 1,
+            TEST_CHUNK_RECORDS,
+            TEST_CHUNK_RECORDS + 1,
+        ] {
+            let dir = tempdir()?;
+            let (base, scores, mask) = write_embed_inputs(dir.path(), count, 0, -1)?;
+            let dual = dir.path().join("dual.psv");
+            let extracted_base = dir.path().join("extracted.psv");
+            let extracted_scores = dir.path().join("extracted.i16");
+            let extracted_mask = dir.path().join("extracted.bits");
+            embed_with_chunk_records(&base, &scores, &mask, &dual, TEST_CHUNK_RECORDS)?;
+            extract_with_chunk_records(
+                &dual,
+                Some(&extracted_base),
+                Some(&extracted_scores),
+                Some(&extracted_mask),
+                TEST_CHUNK_RECORDS,
+            )?;
+            assert_eq!(fs::read(&extracted_base)?, fs::read(&base)?);
+            assert_eq!(fs::read(&extracted_scores)?, fs::read(&scores)?);
+            assert_eq!(fs::read(&extracted_mask)?, fs::read(&mask)?);
+        }
+        Ok(())
+    }
+
+    #[test]
     fn embed_counts_overwritten_nonzero_move16() -> Result<()> {
         let dir = tempdir()?;
         let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 42, -1)?;
@@ -730,12 +879,54 @@ mod tests {
     }
 
     #[test]
+    fn embed_error_preserves_existing_output_and_removes_staging() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        let mut bytes = fs::read(&base)?;
+        bytes[RECORD_SIZE + PADDING_OFFSET] = 1;
+        fs::write(&base, bytes)?;
+        let output = dir.path().join("dual.psv");
+        let sentinel = b"existing valid output";
+        fs::write(&output, sentinel)?;
+
+        assert!(embed(&base, &scores, &mask, &output).is_err());
+        assert_eq!(fs::read(&output)?, sentinel);
+        assert!(!partial_path(&output).exists());
+        Ok(())
+    }
+
+    #[test]
     fn embed_rejects_output_equal_to_input_without_truncating() -> Result<()> {
         let dir = tempdir()?;
         let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
         let original = fs::read(&base)?;
         assert!(embed(&base, &scores, &mask, &base).is_err());
         assert_eq!(fs::read(base)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_scores_and_mask_as_output_aliases() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        for output in [&scores, &mask] {
+            let original = fs::read(output)?;
+            assert!(embed(&base, &scores, &mask, output).is_err());
+            assert_eq!(fs::read(output)?, original);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_staging_path_aliasing_input() -> Result<()> {
+        let dir = tempdir()?;
+        let (_, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        let output = dir.path().join("dual.psv");
+        let base = partial_path(&output);
+        fs::write(&base, base_records(3, 0)?)?;
+        let original = fs::read(&base)?;
+        assert!(embed(&base, &scores, &mask, &output).is_err());
+        assert_eq!(fs::read(&base)?, original);
         Ok(())
     }
 
@@ -747,6 +938,84 @@ mod tests {
         let error = extract(&dual, Some(&dir.path().join("base.psv")), None, None)
             .expect_err("reserved bit must fail");
         assert!(error.to_string().contains("row 0"));
+        Ok(())
+    }
+
+    #[test]
+    fn extract_error_preserves_all_existing_outputs_and_removes_staging() -> Result<()> {
+        let dir = tempdir()?;
+        let dual = dir.path().join("dual.psv");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&record("4k4/9/9/9/9/9/9/9/4K4 b - 1", 0, 1, 0)?);
+        bytes.extend_from_slice(&record("4k4/9/9/9/9/9/9/9/4K4 b - 1", 0, 1, 2)?);
+        fs::write(&dual, bytes)?;
+        let outputs = [
+            dir.path().join("base.psv"),
+            dir.path().join("scores.i16"),
+            dir.path().join("mask.bits"),
+        ];
+        let sentinels: [&[u8]; 3] = [b"base sentinel", b"scores sentinel", b"mask sentinel"];
+        for (path, sentinel) in outputs.iter().zip(sentinels) {
+            fs::write(path, sentinel)?;
+        }
+
+        assert!(extract(&dual, Some(&outputs[0]), Some(&outputs[1]), Some(&outputs[2])).is_err());
+        for (path, sentinel) in outputs.iter().zip(sentinels) {
+            assert_eq!(fs::read(path)?, sentinel);
+            assert!(!partial_path(path).exists());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn extract_publish_failure_removes_staging_and_already_published_outputs() -> Result<()> {
+        let dir = tempdir()?;
+        let staging_a = dir.path().join("a.partial");
+        let staging_b = dir.path().join("b.partial");
+        let output_a = dir.path().join("a.out");
+        let output_b = dir.path().join("directory-output");
+        fs::write(&staging_a, b"a")?;
+        fs::write(&staging_b, b"b")?;
+        fs::create_dir(&output_b)?;
+
+        assert!(publish_staged(&[(&staging_a, &output_a), (&staging_b, &output_b)]).is_err());
+        assert!(!staging_a.exists());
+        assert!(!staging_b.exists());
+        assert!(!output_a.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn extract_path_aliases_are_rejected_table_driven() -> Result<()> {
+        let dir = tempdir()?;
+        let dual = dir.path().join("dual.psv");
+        fs::write(&dual, [0u8; RECORD_SIZE])?;
+
+        let same = dir.path().join("same.out");
+        let hardlink_a = dir.path().join("hardlink-a.out");
+        let hardlink_b = dir.path().join("hardlink-b.out");
+        fs::write(&hardlink_a, b"output")?;
+        fs::hard_link(&hardlink_a, &hardlink_b)?;
+        let dual_hardlink = dir.path().join("dual-hardlink.out");
+        fs::hard_link(&dual, &dual_hardlink)?;
+        let symlink_target = dir.path().join("symlink-target.out");
+        let symlink_output = dir.path().join("symlink-output.out");
+        fs::write(&symlink_target, b"target")?;
+
+        let mut cases: Vec<(&str, [&Path; 2])> = vec![
+            ("same path", [&same, &same]),
+            ("output hardlink", [&hardlink_a, &hardlink_b]),
+            ("output-dual hardlink", [&dual_hardlink, &same]),
+        ];
+        match symlink_file(&symlink_target, &symlink_output) {
+            Ok(()) => cases.push(("symlink output", [&symlink_output, &same])),
+            #[cfg(windows)]
+            Err(error) if error.raw_os_error() == Some(1314) => {}
+            Err(error) => return Err(error.into()),
+        }
+        for (name, outputs) in cases {
+            assert!(check_extract_paths(&dual, &outputs, &[]).is_err(), "{name}");
+        }
         Ok(())
     }
 
@@ -809,6 +1078,16 @@ mod tests {
         let mut config = valid_config();
         config.dl_abs_max = 100;
         assert!(validate(&dual, config).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_rejects_empty_file() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("empty.psv");
+        fs::write(&input, [])?;
+        let error = validate(&input, valid_config()).expect_err("empty input must fail");
+        assert!(error.to_string().contains("0 件"));
         Ok(())
     }
 

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -1,0 +1,826 @@
+//! 通常 PSV と sidecar を dual-label PSV に相互変換し、形式を検証する。
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use rayon::prelude::*;
+use rshogi_core::movegen::{MoveList, generate_legal_all};
+use rshogi_core::position::Position;
+use rshogi_core::types::Move;
+use tools::king_zone::{ENTERED_TIER, classify};
+use tools::output_path::{ensure_distinct_output_paths, ensure_safe_output_path};
+use tools::packed_sfen::{PackedSfenValue, psv_move16_to_move, unpack_sfen_to_parts};
+
+const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const DL_SCORE_OFFSET: usize = 34;
+const PADDING_OFFSET: usize = 39;
+const BUFFER_SIZE: usize = 32 << 20;
+const CHUNK_RECORDS: usize = 1 << 18;
+const DEFAULT_DL_ABS_MAX: u32 = 32_000;
+const DEFAULT_MAX_MOVE_LIKE_FRAC: f64 = 0.05;
+
+#[derive(Parser)]
+#[command(name = "psv_dual_label", about = "dual-label PSV の生成・抽出・検証")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// 通常 PSV と score/mask sidecar を dual-label PSV に埋め込む
+    Embed {
+        /// base score を持つ通常 PSV
+        #[arg(long)]
+        base: PathBuf,
+        /// little-endian i16 × records の DL score sidecar
+        #[arg(long)]
+        scores: PathBuf,
+        /// LSB-first の entered bitmap
+        #[arg(long)]
+        mask: PathBuf,
+        /// 出力 dual-label PSV
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// dual-label PSV を通常 PSV と sidecar に分解する
+    Extract {
+        /// 入力 dual-label PSV
+        #[arg(long)]
+        dual: PathBuf,
+        /// move16=0、padding=0 に復元した通常 PSV
+        #[arg(long)]
+        out_base: Option<PathBuf>,
+        /// little-endian i16 × records の DL score sidecar
+        #[arg(long)]
+        out_scores: Option<PathBuf>,
+        /// LSB-first の entered bitmap
+        #[arg(long)]
+        out_mask: Option<PathBuf>,
+    },
+    /// dual-label PSV の形式・entered bit・DL 値・move-like 率を検証する
+    Validate {
+        /// 入力 dual-label PSV
+        #[arg(long)]
+        dual: PathBuf,
+        /// 局面 decode を伴う検査の最大サンプル数（未指定なら全件）
+        #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+        sample: Option<u64>,
+        /// 許容する DL score の絶対値上限
+        #[arg(long, default_value_t = DEFAULT_DL_ABS_MAX)]
+        dl_abs_max: u32,
+        /// 通常 PSV の move16 に見える行の許容割合。この値以上なら失敗
+        #[arg(long, default_value_t = DEFAULT_MAX_MOVE_LIKE_FRAC)]
+        max_move_like_frac: f64,
+    },
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct EmbedStats {
+    records: u64,
+    overwritten_nonzero_move16: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ExtractStats {
+    records: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ValidationStats {
+    records: u64,
+    trailing_bytes: u64,
+    sampled_records: u64,
+    reserved_padding_nonzero: u64,
+    entered_mismatches: u64,
+    dl_abs_exceeded: u64,
+    move_like: u64,
+    decode_errors: u64,
+    first_reserved_padding_row: Option<u64>,
+    first_entered_mismatch_row: Option<u64>,
+    first_dl_abs_exceeded_row: Option<u64>,
+    first_decode_error_row: Option<u64>,
+}
+
+#[derive(Debug, Default)]
+struct RecordCheck {
+    sampled: bool,
+    reserved_padding_nonzero: bool,
+    entered_mismatch: bool,
+    dl_abs_exceeded: bool,
+    move_like: bool,
+    decode_error: bool,
+}
+
+#[derive(Clone, Copy)]
+struct ValidateConfig {
+    sample: Option<u64>,
+    dl_abs_max: u32,
+    max_move_like_frac: f64,
+}
+
+fn file_size(path: &Path) -> Result<u64> {
+    Ok(fs::metadata(path)
+        .with_context(|| format!("{} の情報を取得できません", path.display()))?
+        .len())
+}
+
+fn checked_psv_records(path: &Path) -> Result<u64> {
+    let size = file_size(path)?;
+    anyhow::ensure!(
+        size.is_multiple_of(RECORD_SIZE as u64),
+        "{} のサイズ {size} byte が PSV レコード長 {RECORD_SIZE} の倍数ではありません",
+        path.display()
+    );
+    Ok(size / RECORD_SIZE as u64)
+}
+
+fn checked_sidecar_sizes(scores: &Path, mask: &Path, records: u64) -> Result<()> {
+    let expected_scores = records * 2;
+    let actual_scores = file_size(scores)?;
+    anyhow::ensure!(
+        actual_scores == expected_scores,
+        "score sidecar size mismatch: expected={expected_scores}, actual={actual_scores}"
+    );
+
+    let expected_mask = records.div_ceil(8);
+    let actual_mask = file_size(mask)?;
+    anyhow::ensure!(
+        actual_mask == expected_mask,
+        "mask size mismatch: expected={expected_mask}, actual={actual_mask}"
+    );
+    if !records.is_multiple_of(8) {
+        let mut file = File::open(mask)?;
+        file.seek(SeekFrom::End(-1))?;
+        let mut last = [0u8; 1];
+        file.read_exact(&mut last)?;
+        let used_bits = records % 8;
+        anyhow::ensure!(
+            last[0] >> used_bits == 0,
+            "mask final byte has non-zero unused bits: 0x{:02x}",
+            last[0]
+        );
+    }
+    Ok(())
+}
+
+fn read_bytes<R: Read>(reader: &mut R, buffer: &mut Vec<u8>, bytes: usize) -> Result<()> {
+    buffer.resize(bytes, 0);
+    reader.read_exact(buffer)?;
+    Ok(())
+}
+
+fn embed(base: &Path, scores: &Path, mask: &Path, out: &Path) -> Result<EmbedStats> {
+    let records = checked_psv_records(base)?;
+    checked_sidecar_sizes(scores, mask, records)?;
+    for input in [base, scores, mask] {
+        ensure_safe_output_path(out, input)?;
+    }
+
+    let mut base_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(base)?);
+    let mut score_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(scores)?);
+    let mut mask_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
+    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(out)?);
+    let mut base_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut score_chunk = Vec::with_capacity(CHUNK_RECORDS * 2);
+    let mut mask_chunk = Vec::with_capacity(CHUNK_RECORDS.div_ceil(8));
+    let mut stats = EmbedStats::default();
+
+    while stats.records < records {
+        let chunk_records = (records - stats.records).min(CHUNK_RECORDS as u64) as usize;
+        read_bytes(&mut base_reader, &mut base_chunk, chunk_records * RECORD_SIZE)?;
+        read_bytes(&mut score_reader, &mut score_chunk, chunk_records * 2)?;
+        read_bytes(&mut mask_reader, &mut mask_chunk, chunk_records.div_ceil(8))?;
+
+        for (offset, record) in base_chunk.chunks_exact_mut(RECORD_SIZE).enumerate() {
+            let row = stats.records + offset as u64;
+            anyhow::ensure!(
+                record[PADDING_OFFSET] == 0,
+                "base padding is non-zero at row {row}: 0x{:02x}",
+                record[PADDING_OFFSET]
+            );
+            if record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2] != [0, 0] {
+                stats.overwritten_nonzero_move16 += 1;
+            }
+            record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]
+                .copy_from_slice(&score_chunk[offset * 2..offset * 2 + 2]);
+            record[PADDING_OFFSET] = (mask_chunk[offset / 8] >> (offset % 8)) & 1;
+        }
+        writer.write_all(&base_chunk)?;
+        stats.records += chunk_records as u64;
+    }
+
+    writer.flush()?;
+    drop(writer);
+    let expected = records * RECORD_SIZE as u64;
+    anyhow::ensure!(
+        file_size(out)? == expected,
+        "output size mismatch: expected={expected}, actual={}",
+        file_size(out)?
+    );
+    Ok(stats)
+}
+
+fn output_paths<'a>(
+    out_base: Option<&'a Path>,
+    out_scores: Option<&'a Path>,
+    out_mask: Option<&'a Path>,
+) -> Vec<&'a Path> {
+    [out_base, out_scores, out_mask].into_iter().flatten().collect()
+}
+
+fn check_extract_paths(dual: &Path, outputs: &[&Path]) -> Result<()> {
+    anyhow::ensure!(!outputs.is_empty(), "少なくとも 1 つの出力を指定してください");
+    for output in outputs {
+        ensure_safe_output_path(output, dual)?;
+    }
+    for i in 0..outputs.len() {
+        for j in i + 1..outputs.len() {
+            ensure_distinct_output_paths(outputs[i], outputs[j])?;
+        }
+    }
+    Ok(())
+}
+
+fn create_writer(path: Option<&Path>) -> Result<Option<BufWriter<File>>> {
+    path.map(|path| {
+        File::create(path)
+            .with_context(|| format!("{} を作成できません", path.display()))
+            .map(|file| BufWriter::with_capacity(BUFFER_SIZE, file))
+    })
+    .transpose()
+}
+
+fn extract(
+    dual: &Path,
+    out_base: Option<&Path>,
+    out_scores: Option<&Path>,
+    out_mask: Option<&Path>,
+) -> Result<ExtractStats> {
+    let records = checked_psv_records(dual)?;
+    let outputs = output_paths(out_base, out_scores, out_mask);
+    check_extract_paths(dual, &outputs)?;
+
+    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(dual)?);
+    let mut base_writer = create_writer(out_base)?;
+    let mut score_writer = create_writer(out_scores)?;
+    let mut mask_writer = create_writer(out_mask)?;
+    let mut dual_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut base_chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut score_chunk = Vec::with_capacity(CHUNK_RECORDS * 2);
+    let mut mask_chunk = Vec::with_capacity(CHUNK_RECORDS.div_ceil(8));
+    let mut stats = ExtractStats::default();
+
+    while stats.records < records {
+        let chunk_records = (records - stats.records).min(CHUNK_RECORDS as u64) as usize;
+        read_bytes(&mut reader, &mut dual_chunk, chunk_records * RECORD_SIZE)?;
+
+        for (offset, record) in dual_chunk.chunks_exact(RECORD_SIZE).enumerate() {
+            let row = stats.records + offset as u64;
+            anyhow::ensure!(
+                record[PADDING_OFFSET] & !1 == 0,
+                "dual padding bit1-7 is non-zero at row {row}: 0x{:02x}",
+                record[PADDING_OFFSET]
+            );
+        }
+
+        if let Some(writer) = &mut base_writer {
+            base_chunk.clear();
+            base_chunk.extend_from_slice(&dual_chunk);
+            for record in base_chunk.chunks_exact_mut(RECORD_SIZE) {
+                record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2].fill(0);
+                record[PADDING_OFFSET] = 0;
+            }
+            writer.write_all(&base_chunk)?;
+        }
+        if let Some(writer) = &mut score_writer {
+            score_chunk.clear();
+            score_chunk.reserve(chunk_records * 2);
+            for record in dual_chunk.chunks_exact(RECORD_SIZE) {
+                score_chunk.extend_from_slice(&record[DL_SCORE_OFFSET..DL_SCORE_OFFSET + 2]);
+            }
+            writer.write_all(&score_chunk)?;
+        }
+        if let Some(writer) = &mut mask_writer {
+            mask_chunk.clear();
+            mask_chunk.resize(chunk_records.div_ceil(8), 0);
+            for (offset, record) in dual_chunk.chunks_exact(RECORD_SIZE).enumerate() {
+                mask_chunk[offset / 8] |= (record[PADDING_OFFSET] & 1) << (offset % 8);
+            }
+            writer.write_all(&mask_chunk)?;
+        }
+        stats.records += chunk_records as u64;
+    }
+
+    for writer in [&mut base_writer, &mut score_writer, &mut mask_writer].into_iter().flatten() {
+        writer.flush()?;
+    }
+    drop((base_writer, score_writer, mask_writer));
+
+    if let Some(path) = out_base {
+        let expected = records * RECORD_SIZE as u64;
+        anyhow::ensure!(file_size(path)? == expected, "base output size mismatch");
+    }
+    if let Some(path) = out_scores {
+        let expected = records * 2;
+        anyhow::ensure!(file_size(path)? == expected, "score output size mismatch");
+    }
+    if let Some(path) = out_mask {
+        let expected = records.div_ceil(8);
+        anyhow::ensure!(file_size(path)? == expected, "mask output size mismatch");
+    }
+    Ok(stats)
+}
+
+fn same_move(lhs: Move, rhs: Move) -> bool {
+    lhs.to() == rhs.to()
+        && lhs.is_drop() == rhs.is_drop()
+        && lhs.is_promote() == rhs.is_promote()
+        && if lhs.is_drop() {
+            lhs.drop_piece_type() == rhs.drop_piece_type()
+        } else {
+            lhs.from() == rhs.from()
+        }
+}
+
+fn move16_is_legal(pos: &Position, move16: u16) -> bool {
+    let mv = psv_move16_to_move(move16);
+    if mv.is_none() {
+        return false;
+    }
+    let mut legal_moves = MoveList::new();
+    generate_legal_all(pos, &mut legal_moves);
+    legal_moves.iter().any(|legal| same_move(*legal, mv))
+}
+
+/// `floor(i * total / count)` (`i=0..count`) で選ばれる等間隔行か判定する。
+fn is_sampled_row(row: u64, total: u64, count: u64) -> bool {
+    if count == 0 || total == 0 {
+        return false;
+    }
+    if count >= total {
+        return true;
+    }
+    let row = u128::from(row);
+    let total = u128::from(total);
+    let count = u128::from(count);
+    let sample_index = (row * count).div_ceil(total);
+    sample_index < count && sample_index * total / count == row
+}
+
+fn check_record(
+    record: &[u8],
+    row: u64,
+    records: u64,
+    sample_records: u64,
+    dl_abs_max: u32,
+) -> RecordCheck {
+    let padding = record[PADDING_OFFSET];
+    let dl_score = i16::from_le_bytes([record[DL_SCORE_OFFSET], record[DL_SCORE_OFFSET + 1]]);
+    let sampled = is_sampled_row(row, records, sample_records);
+    let mut check = RecordCheck {
+        sampled,
+        reserved_padding_nonzero: padding & !1 != 0,
+        dl_abs_exceeded: i32::from(dl_score).unsigned_abs() > dl_abs_max,
+        ..RecordCheck::default()
+    };
+    if !sampled {
+        return check;
+    }
+
+    let psv = PackedSfenValue::from_bytes(record).expect("固定長レコード");
+    let Ok(parts) = unpack_sfen_to_parts(&psv.sfen) else {
+        check.decode_error = true;
+        return check;
+    };
+    let mut pos = Position::new();
+    if pos.set_from_parts(&parts.board, &parts.hands, parts.side_to_move).is_err() {
+        check.decode_error = true;
+        return check;
+    }
+    let expected_entered = classify(&pos) == ENTERED_TIER;
+    check.entered_mismatch = (padding & 1 != 0) != expected_entered;
+    check.move_like = move16_is_legal(
+        &pos,
+        u16::from_le_bytes([record[DL_SCORE_OFFSET], record[DL_SCORE_OFFSET + 1]]),
+    );
+    check
+}
+
+fn scan_dual(path: &Path, config: ValidateConfig) -> Result<ValidationStats> {
+    anyhow::ensure!(
+        config.max_move_like_frac.is_finite() && (0.0..=1.0).contains(&config.max_move_like_frac),
+        "--max-move-like-frac は 0.0..=1.0 の有限値で指定してください"
+    );
+    let size = file_size(path)?;
+    let records = size / RECORD_SIZE as u64;
+    let sample_records = config.sample.unwrap_or(records).min(records);
+    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(path)?);
+    let mut chunk = Vec::with_capacity(CHUNK_RECORDS * RECORD_SIZE);
+    let mut stats = ValidationStats {
+        records,
+        trailing_bytes: size % RECORD_SIZE as u64,
+        ..ValidationStats::default()
+    };
+    let mut first_row = 0u64;
+
+    while first_row < records {
+        let chunk_records = (records - first_row).min(CHUNK_RECORDS as u64) as usize;
+        read_bytes(&mut reader, &mut chunk, chunk_records * RECORD_SIZE)?;
+        let checks: Vec<RecordCheck> = chunk
+            .par_chunks_exact(RECORD_SIZE)
+            .enumerate()
+            .map(|(offset, record)| {
+                check_record(
+                    record,
+                    first_row + offset as u64,
+                    records,
+                    sample_records,
+                    config.dl_abs_max,
+                )
+            })
+            .collect();
+        for (offset, check) in checks.into_iter().enumerate() {
+            let row = first_row + offset as u64;
+            if check.sampled {
+                stats.sampled_records += 1;
+            }
+            if check.reserved_padding_nonzero {
+                stats.reserved_padding_nonzero += 1;
+                stats.first_reserved_padding_row.get_or_insert(row);
+            }
+            if check.entered_mismatch {
+                stats.entered_mismatches += 1;
+                stats.first_entered_mismatch_row.get_or_insert(row);
+            }
+            if check.dl_abs_exceeded {
+                stats.dl_abs_exceeded += 1;
+                stats.first_dl_abs_exceeded_row.get_or_insert(row);
+            }
+            if check.move_like {
+                stats.move_like += 1;
+            }
+            if check.decode_error {
+                stats.decode_errors += 1;
+                stats.first_decode_error_row.get_or_insert(row);
+            }
+        }
+        first_row += chunk_records as u64;
+    }
+    Ok(stats)
+}
+
+fn move_like_fraction(stats: &ValidationStats) -> f64 {
+    if stats.sampled_records == 0 {
+        0.0
+    } else {
+        stats.move_like as f64 / stats.sampled_records as f64
+    }
+}
+
+fn validation_failures(stats: &ValidationStats, config: ValidateConfig) -> Vec<String> {
+    let mut failures = Vec::new();
+    if stats.trailing_bytes != 0 {
+        failures.push(format!("末尾に {} byte の端数があります", stats.trailing_bytes));
+    }
+    if stats.reserved_padding_nonzero != 0 {
+        failures.push(format!(
+            "padding bit1-7 非ゼロ: {} 行（先頭 row {}）",
+            stats.reserved_padding_nonzero,
+            stats.first_reserved_padding_row.expect("count is non-zero")
+        ));
+    }
+    if stats.entered_mismatches != 0 {
+        failures.push(format!(
+            "entered bit 不一致: {} 行（先頭 row {}）",
+            stats.entered_mismatches,
+            stats.first_entered_mismatch_row.expect("count is non-zero")
+        ));
+    }
+    if stats.dl_abs_exceeded != 0 {
+        failures.push(format!(
+            "|DL score| > {}: {} 行（先頭 row {}）",
+            config.dl_abs_max,
+            stats.dl_abs_exceeded,
+            stats.first_dl_abs_exceeded_row.expect("count is non-zero")
+        ));
+    }
+    if stats.decode_errors != 0 {
+        failures.push(format!(
+            "局面 decode エラー: {} 行（先頭 row {}）",
+            stats.decode_errors,
+            stats.first_decode_error_row.expect("count is non-zero")
+        ));
+    }
+    let fraction = move_like_fraction(stats);
+    if stats.sampled_records != 0 && fraction >= config.max_move_like_frac {
+        failures.push(format!(
+            "move-like fraction {:.6} >= {:.6}",
+            fraction, config.max_move_like_frac
+        ));
+    }
+    failures
+}
+
+fn print_validation_stats(stats: &ValidationStats, config: ValidateConfig, passed: bool) {
+    println!("status={}", if passed { "PASS" } else { "FAIL" });
+    println!("records={}", stats.records);
+    println!("trailing_bytes={}", stats.trailing_bytes);
+    println!("sampled_records={}", stats.sampled_records);
+    println!("reserved_padding_nonzero={}", stats.reserved_padding_nonzero);
+    println!("entered_mismatches={}", stats.entered_mismatches);
+    println!("dl_abs_exceeded={} (limit={})", stats.dl_abs_exceeded, config.dl_abs_max);
+    println!("decode_errors={}", stats.decode_errors);
+    println!(
+        "move_like={} fraction={:.6} (fail_at={:.6})",
+        stats.move_like,
+        move_like_fraction(stats),
+        config.max_move_like_frac
+    );
+}
+
+fn validate(path: &Path, config: ValidateConfig) -> Result<ValidationStats> {
+    let stats = scan_dual(path, config)?;
+    let failures = validation_failures(&stats, config);
+    print_validation_stats(&stats, config, failures.is_empty());
+    anyhow::ensure!(failures.is_empty(), "{}", failures.join("; "));
+    Ok(stats)
+}
+
+fn main() -> Result<()> {
+    match Cli::parse().command {
+        Command::Embed {
+            base,
+            scores,
+            mask,
+            out,
+        } => {
+            let stats = embed(&base, &scores, &mask, &out)?;
+            println!("records={}", stats.records);
+            println!("overwritten_nonzero_move16={}", stats.overwritten_nonzero_move16);
+        }
+        Command::Extract {
+            dual,
+            out_base,
+            out_scores,
+            out_mask,
+        } => {
+            let stats =
+                extract(&dual, out_base.as_deref(), out_scores.as_deref(), out_mask.as_deref())?;
+            println!("records={}", stats.records);
+        }
+        Command::Validate {
+            dual,
+            sample,
+            dl_abs_max,
+            max_move_like_frac,
+        } => {
+            validate(
+                &dual,
+                ValidateConfig {
+                    sample,
+                    dl_abs_max,
+                    max_move_like_frac,
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tools::packed_sfen::{move_to_psv_move16, pack_position};
+
+    fn record(sfen: &str, score: i16, move16: u16, padding: u8) -> Result<[u8; RECORD_SIZE]> {
+        let mut pos = Position::new();
+        pos.set_sfen(sfen)?;
+        Ok(PackedSfenValue {
+            sfen: pack_position(&pos),
+            score,
+            move16,
+            game_ply: 1,
+            game_result: 0,
+            padding,
+        }
+        .to_bytes())
+    }
+
+    fn base_records(count: usize, move16: u16) -> Result<Vec<u8>> {
+        let sfens = [
+            "4K3k/9/9/9/9/9/9/9/9 b - 1",
+            "4k4/9/9/9/4K4/9/9/9/9 b - 1",
+            "4k4/9/9/9/9/9/9/9/4K4 b - 1",
+        ];
+        let mut bytes = Vec::with_capacity(count * RECORD_SIZE);
+        for i in 0..count {
+            bytes.extend_from_slice(&record(sfens[i % 3], i as i16, move16, 0)?);
+        }
+        Ok(bytes)
+    }
+
+    fn sidecars(count: usize, dl_score: i16) -> (Vec<u8>, Vec<u8>) {
+        let mut scores = Vec::with_capacity(count * 2);
+        let mut mask = vec![0u8; count.div_ceil(8)];
+        for i in 0..count {
+            scores.extend_from_slice(&dl_score.to_le_bytes());
+            if i % 3 == 0 {
+                mask[i / 8] |= 1 << (i % 8);
+            }
+        }
+        (scores, mask)
+    }
+
+    fn write_embed_inputs(
+        dir: &Path,
+        count: usize,
+        move16: u16,
+        dl_score: i16,
+    ) -> Result<(PathBuf, PathBuf, PathBuf)> {
+        let base = dir.join("base.psv");
+        let scores = dir.join("dl.i16");
+        let mask = dir.join("entered.bits");
+        let (score_bytes, mask_bytes) = sidecars(count, dl_score);
+        fs::write(&base, base_records(count, move16)?)?;
+        fs::write(&scores, score_bytes)?;
+        fs::write(&mask, mask_bytes)?;
+        Ok((base, scores, mask))
+    }
+
+    fn valid_config() -> ValidateConfig {
+        ValidateConfig {
+            sample: None,
+            dl_abs_max: DEFAULT_DL_ABS_MAX,
+            max_move_like_frac: DEFAULT_MAX_MOVE_LIKE_FRAC,
+        }
+    }
+
+    #[test]
+    fn embed_extract_roundtrip_at_bitmap_boundaries() -> Result<()> {
+        for count in [7, 8, 9, 17] {
+            let dir = tempdir()?;
+            let (base, scores, mask) = write_embed_inputs(dir.path(), count, 0, -1)?;
+            let dual = dir.path().join("dual.psv");
+            let extracted_base = dir.path().join("extracted.psv");
+            let extracted_scores = dir.path().join("extracted.i16");
+            let extracted_mask = dir.path().join("extracted.bits");
+            embed(&base, &scores, &mask, &dual)?;
+            extract(&dual, Some(&extracted_base), Some(&extracted_scores), Some(&extracted_mask))?;
+            assert_eq!(fs::read(&extracted_base)?, fs::read(&base)?);
+            assert_eq!(fs::read(&extracted_scores)?, fs::read(&scores)?);
+            assert_eq!(fs::read(&extracted_mask)?, fs::read(&mask)?);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn embed_counts_overwritten_nonzero_move16() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 42, -1)?;
+        let stats = embed(&base, &scores, &mask, &dir.path().join("dual.psv"))?;
+        assert_eq!(stats.overwritten_nonzero_move16, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_score_size_mismatch() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        fs::write(&scores, [0u8; 5])?;
+        assert!(embed(&base, &scores, &mask, &dir.path().join("dual.psv")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_mask_size_mismatch() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 9, 0, -1)?;
+        fs::write(&mask, [0u8; 1])?;
+        assert!(embed(&base, &scores, &mask, &dir.path().join("dual.psv")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_nonzero_unused_mask_bits() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 7, 0, -1)?;
+        let mut mask_bytes = fs::read(&mask)?;
+        mask_bytes[0] |= 0x80;
+        fs::write(&mask, mask_bytes)?;
+        assert!(embed(&base, &scores, &mask, &dir.path().join("dual.psv")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_nonzero_base_padding() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        let mut bytes = fs::read(&base)?;
+        bytes[RECORD_SIZE + PADDING_OFFSET] = 1;
+        fs::write(&base, bytes)?;
+        let error = embed(&base, &scores, &mask, &dir.path().join("dual.psv"))
+            .expect_err("padding must fail");
+        assert!(error.to_string().contains("row 1"));
+        Ok(())
+    }
+
+    #[test]
+    fn embed_rejects_output_equal_to_input_without_truncating() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, -1)?;
+        let original = fs::read(&base)?;
+        assert!(embed(&base, &scores, &mask, &base).is_err());
+        assert_eq!(fs::read(base)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn extract_rejects_reserved_padding_bits() -> Result<()> {
+        let dir = tempdir()?;
+        let dual = dir.path().join("dual.psv");
+        fs::write(&dual, record("4k4/9/9/9/9/9/9/9/4K4 b - 1", 0, 1, 2)?)?;
+        let error = extract(&dual, Some(&dir.path().join("base.psv")), None, None)
+            .expect_err("reserved bit must fail");
+        assert!(error.to_string().contains("row 0"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_accepts_correct_dual_file() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 17, 0, -1)?;
+        let dual = dir.path().join("dual.psv");
+        embed(&base, &scores, &mask, &dual)?;
+        validate(&dual, valid_config())?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_rejects_flipped_entered_bit() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 17, 0, -1)?;
+        let dual = dir.path().join("dual.psv");
+        embed(&base, &scores, &mask, &dual)?;
+        let mut bytes = fs::read(&dual)?;
+        bytes[PADDING_OFFSET] ^= 1;
+        fs::write(&dual, bytes)?;
+        assert!(validate(&dual, valid_config()).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_rejects_normal_psv_as_move_like() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("normal.psv");
+        let mut pos = Position::new();
+        pos.set_hirate();
+        let mut legal_moves = MoveList::new();
+        generate_legal_all(&pos, &mut legal_moves);
+        let move16 = move_to_psv_move16(*legal_moves.iter().next().expect("legal move"));
+        let psv = PackedSfenValue {
+            sfen: pack_position(&pos),
+            score: 0,
+            move16,
+            game_ply: 1,
+            game_result: 0,
+            padding: 0,
+        }
+        .to_bytes();
+        let mut bytes = Vec::new();
+        for _ in 0..20 {
+            bytes.extend_from_slice(&psv);
+        }
+        fs::write(&input, bytes)?;
+        assert!(validate(&input, valid_config()).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_rejects_dl_score_over_limit() -> Result<()> {
+        let dir = tempdir()?;
+        let (base, scores, mask) = write_embed_inputs(dir.path(), 3, 0, 101)?;
+        let dual = dir.path().join("dual.psv");
+        embed(&base, &scores, &mask, &dual)?;
+        let mut config = valid_config();
+        config.dl_abs_max = 100;
+        assert!(validate(&dual, config).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn deterministic_sampling_selects_requested_count_and_first_row() {
+        for total in 1..30 {
+            for requested in 1..=total {
+                let selected: Vec<u64> =
+                    (0..total).filter(|row| is_sampled_row(*row, total, requested)).collect();
+                assert_eq!(selected.len(), requested as usize);
+                assert_eq!(selected[0], 0);
+            }
+        }
+    }
+}

--- a/crates/tools/src/bin/psv_gate_by_king_zone.rs
+++ b/crates/tools/src/bin/psv_gate_by_king_zone.rs
@@ -1,14 +1,15 @@
 //! 行対応 PSV の入玉ドメイン score 合成、またはゲート bitmap 生成を行う。
 
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use rayon::prelude::*;
 use rshogi_core::position::Position;
-use rshogi_core::types::Color;
+use tools::king_zone::classify;
+use tools::output_path::ensure_safe_output_path;
 use tools::packed_sfen::{PackedSfenValue, unpack_sfen_to_parts};
 
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
@@ -84,19 +85,6 @@ fn parse_tiers(value: &str) -> Result<[bool; 3]> {
     Ok(tiers)
 }
 
-/// 玉位置から 0=entered、1=advancing、2=normal を返す。
-fn classify(pos: &Position) -> usize {
-    let black = pos.king_square(Color::Black).rank() as usize;
-    let white = pos.king_square(Color::White).rank() as usize;
-    if black <= 2 || white >= 6 {
-        0
-    } else if (3..=5).contains(&black) || (3..=5).contains(&white) {
-        1
-    } else {
-        2
-    }
-}
-
 fn classify_record(record: &[u8], row: u64) -> Result<(usize, i16)> {
     let psv = PackedSfenValue::from_bytes(record)
         .ok_or_else(|| anyhow::anyhow!("PSV parse failed at row {row}"))?;
@@ -123,51 +111,6 @@ fn checked_records(path: &Path) -> Result<u64> {
         path.display()
     );
     Ok(size / RECORD_SIZE as u64)
-}
-
-fn canonicalize_predicted_path(path: &Path) -> Result<PathBuf> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("Path has no file name: {}", path.display()))?;
-    let canonical_parent = parent
-        .canonicalize()
-        .with_context(|| format!("Failed to canonicalize parent {}", parent.display()))?;
-    Ok(canonical_parent.join(file_name))
-}
-
-fn is_same_file(a: &Path, b: &Path) -> Result<bool> {
-    match same_file::is_same_file(a, b) {
-        Ok(same) => Ok(same),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error).with_context(|| {
-            format!("Failed to compare file identities: {} and {}", a.display(), b.display())
-        }),
-    }
-}
-
-/// 出力が入力実体を指す場合は、truncate 前に拒否する。
-fn ensure_safe_output_path(output: &Path, input: &Path) -> Result<()> {
-    let canonical_input = input
-        .canonicalize()
-        .with_context(|| format!("Failed to canonicalize input {}", input.display()))?;
-    if let Ok(meta) = fs::symlink_metadata(output)
-        && meta.file_type().is_symlink()
-    {
-        anyhow::bail!("Output path is a symlink: {}", output.display());
-    }
-    let predicted = canonicalize_predicted_path(output)?;
-    if predicted == canonical_input || is_same_file(output, &canonical_input)? {
-        anyhow::bail!(
-            "Output path resolves to input file: {} -> {}",
-            output.display(),
-            canonical_input.display()
-        );
-    }
-    Ok(())
 }
 
 fn classify_chunk(chunk: &[u8], first_row: u64) -> Vec<Result<(usize, i16)>> {
@@ -389,14 +332,6 @@ mod tests {
                 &expected[i * RECORD_SIZE + 32..i * RECORD_SIZE + 34]
             );
         }
-        Ok(())
-    }
-
-    #[test]
-    fn bare_relative_output_path_is_supported() -> Result<()> {
-        let predicted = canonicalize_predicted_path(Path::new("out.psv"))?;
-        assert_eq!(predicted.file_name(), Some(std::ffi::OsStr::new("out.psv")));
-        assert_eq!(predicted.parent(), Some(std::env::current_dir()?.canonicalize()?.as_path()));
         Ok(())
     }
 

--- a/crates/tools/src/common/io.rs
+++ b/crates/tools/src/common/io.rs
@@ -2,7 +2,7 @@
 
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const READER_BUF_CAP: usize = 128 * 1024; // 128 KiB
 
@@ -109,6 +109,13 @@ pub fn write_atomic_durable(path: &Path, content: &str) -> anyhow::Result<()> {
         .with_context(|| format!("publish durable file {}", path.display()))?;
     sync_directory(parent)?;
     Ok(())
+}
+
+/// staged write 用の `<output>.partial` パスを返す。
+pub fn partial_path(output: &Path) -> PathBuf {
+    let mut path = output.as_os_str().to_os_string();
+    path.push(".partial");
+    PathBuf::from(path)
 }
 
 /// dangling symlinkも含め、path entryの存在を確認する。

--- a/crates/tools/src/king_zone.rs
+++ b/crates/tools/src/king_zone.rs
@@ -1,0 +1,22 @@
+//! 玉位置に基づく入玉ドメイン分類。
+
+use rshogi_core::position::Position;
+use rshogi_core::types::Color;
+
+/// 入玉済みの tier 番号。
+pub const ENTERED_TIER: usize = 0;
+
+/// 玉位置から 0=entered、1=advancing、2=normal を返す。
+///
+/// entered は先手玉の rank が 2 以下、または後手玉の rank が 6 以上の局面。
+pub fn classify(pos: &Position) -> usize {
+    let black = pos.king_square(Color::Black).rank() as usize;
+    let white = pos.king_square(Color::White).rank() as usize;
+    if black <= 2 || white >= 6 {
+        ENTERED_TIER
+    } else if (3..=5).contains(&black) || (3..=5).contains(&white) {
+        1
+    } else {
+        2
+    }
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -50,6 +50,7 @@ pub mod dlshogi_features;
 pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;
+pub mod king_zone;
 pub mod nnue_saturation_tool;
 // nyugyoku_metrics は CSA replay (`replay` モジュール) に依存するため csa-replay に gate する。
 #[cfg(feature = "csa-replay")]
@@ -57,6 +58,7 @@ pub mod nyugyoku_metrics;
 #[cfg(feature = "dlshogi-onnx")]
 pub mod onnx_value;
 pub mod ort_teardown;
+pub mod output_path;
 pub mod packed_sfen;
 pub mod positions;
 pub mod progress;

--- a/crates/tools/src/output_path.rs
+++ b/crates/tools/src/output_path.rs
@@ -7,17 +7,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 fn canonicalize_predicted_path(path: &Path) -> Result<PathBuf> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("Path has no file name: {}", path.display()))?;
-    let canonical_parent = parent
-        .canonicalize()
-        .with_context(|| format!("Failed to canonicalize parent {}", parent.display()))?;
-    Ok(canonical_parent.join(file_name))
+    crate::common::dedup::canonicalize_maybe_new(path)
+        .with_context(|| format!("Failed to canonicalize {}", path.display()))
 }
 
 fn is_same_file(a: &Path, b: &Path) -> Result<bool> {
@@ -57,6 +48,31 @@ pub fn ensure_distinct_output_paths(a: &Path, b: &Path) -> Result<()> {
     let predicted_b = canonicalize_predicted_path(b)?;
     if predicted_a == predicted_b || is_same_file(a, b)? {
         anyhow::bail!("Output paths resolve to the same file: {} and {}", a.display(), b.display());
+    }
+    Ok(())
+}
+
+/// 作成済みファイル群の実体をペア毎に比較し、同一実体があれば拒否する。
+/// 未作成パスの予測比較は case-insensitive filesystem の alias
+/// (`Score.bin` と `score.bin` 等) を検出できないため、staging ファイルを
+/// 作成した直後・書き込み前にこの実体検査を通すこと。
+pub fn ensure_created_paths_distinct(paths: &[&Path]) -> Result<()> {
+    for i in 0..paths.len() {
+        for j in i + 1..paths.len() {
+            if same_file::is_same_file(paths[i], paths[j]).with_context(|| {
+                format!(
+                    "Failed to compare file identities: {} and {}",
+                    paths[i].display(),
+                    paths[j].display()
+                )
+            })? {
+                anyhow::bail!(
+                    "Output paths resolve to the same file: {} and {}",
+                    paths[i].display(),
+                    paths[j].display()
+                );
+            }
+        }
     }
     Ok(())
 }

--- a/crates/tools/src/output_path.rs
+++ b/crates/tools/src/output_path.rs
@@ -1,0 +1,75 @@
+//! 入力を truncate しないための出力パス検査。
+
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+fn canonicalize_predicted_path(path: &Path) -> Result<PathBuf> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Path has no file name: {}", path.display()))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize parent {}", parent.display()))?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn is_same_file(a: &Path, b: &Path) -> Result<bool> {
+    match same_file::is_same_file(a, b) {
+        Ok(same) => Ok(same),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| {
+            format!("Failed to compare file identities: {} and {}", a.display(), b.display())
+        }),
+    }
+}
+
+/// 出力が入力実体を指す場合は、truncate 前に拒否する。
+pub fn ensure_safe_output_path(output: &Path, input: &Path) -> Result<()> {
+    let canonical_input = input
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize input {}", input.display()))?;
+    if let Ok(meta) = fs::symlink_metadata(output)
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!("Output path is a symlink: {}", output.display());
+    }
+    let predicted = canonicalize_predicted_path(output)?;
+    if predicted == canonical_input || is_same_file(output, &canonical_input)? {
+        anyhow::bail!(
+            "Output path resolves to input file: {} -> {}",
+            output.display(),
+            canonical_input.display()
+        );
+    }
+    Ok(())
+}
+
+/// 二つの出力パスが同じ実体または同じ生成予定パスなら拒否する。
+pub fn ensure_distinct_output_paths(a: &Path, b: &Path) -> Result<()> {
+    let predicted_a = canonicalize_predicted_path(a)?;
+    let predicted_b = canonicalize_predicted_path(b)?;
+    if predicted_a == predicted_b || is_same_file(a, b)? {
+        anyhow::bail!("Output paths resolve to the same file: {} and {}", a.display(), b.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_relative_output_path_is_supported() -> Result<()> {
+        let predicted = canonicalize_predicted_path(Path::new("out.psv"))?;
+        assert_eq!(predicted.file_name(), Some(std::ffi::OsStr::new("out.psv")));
+        assert_eq!(predicted.parent(), Some(std::env::current_dir()?.canonicalize()?.as_path()));
+        Ok(())
+    }
+}

--- a/crates/tools/src/output_path.rs
+++ b/crates/tools/src/output_path.rs
@@ -59,27 +59,60 @@ pub fn ensure_distinct_output_paths(a: &Path, b: &Path) -> Result<()> {
 pub fn ensure_created_paths_distinct(paths: &[&Path]) -> Result<()> {
     for i in 0..paths.len() {
         for j in i + 1..paths.len() {
-            if same_file::is_same_file(paths[i], paths[j]).with_context(|| {
-                format!(
-                    "Failed to compare file identities: {} and {}",
-                    paths[i].display(),
-                    paths[j].display()
-                )
-            })? {
-                anyhow::bail!(
-                    "Output paths resolve to the same file: {} and {}",
-                    paths[i].display(),
-                    paths[j].display()
-                );
-            }
+            ensure_not_same_entity(paths[i], paths[j])?;
         }
     }
+    Ok(())
+}
+
+/// 作成済みパス群と対象パス群の実体をクロス比較し、同一実体があれば拒否する。
+/// staging の作成が別出力の最終パスを実体化させる alias
+/// (例: `out_scores=X` の staging `X.partial` が最終出力 `x.partial` と一致)
+/// は staging 同士の比較では検出できないため、staging×最終出力にも掛けること。
+/// 対象パスが未作成 (NotFound) のペアは不一致として扱う。
+pub fn ensure_no_entity_overlap(created: &[&Path], targets: &[&Path]) -> Result<()> {
+    for created_path in created {
+        for target in targets {
+            ensure_not_same_entity(created_path, target)?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_not_same_entity(a: &Path, b: &Path) -> Result<()> {
+    let same = match same_file::is_same_file(a, b) {
+        Ok(same) => same,
+        Err(error) if error.kind() == ErrorKind::NotFound => false,
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("Failed to compare file identities: {} and {}", a.display(), b.display())
+            });
+        }
+    };
+    anyhow::ensure!(
+        !same,
+        "Output paths resolve to the same file: {} and {}",
+        a.display(),
+        b.display()
+    );
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn entity_overlap_detects_hardlinked_paths_and_tolerates_missing() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let created = dir.path().join("created.partial");
+        let target = dir.path().join("final.out");
+        std::fs::write(&created, [0u8])?;
+        std::fs::hard_link(&created, &target)?;
+        assert!(ensure_no_entity_overlap(&[&created], &[&target]).is_err());
+        assert!(ensure_no_entity_overlap(&[&created], &[&dir.path().join("missing")]).is_ok());
+        Ok(())
+    }
 
     #[test]
     fn bare_relative_output_path_is_supported() -> Result<()> {

--- a/crates/tools/src/packed_sfen.rs
+++ b/crates/tools/src/packed_sfen.rs
@@ -1175,6 +1175,26 @@ pub fn psv_move16_to_move(move16: u16) -> Move {
     }
 }
 
+/// PSV move16 の表現力での指し手一致判定。move16 は駒種 bit を持たないため、
+/// Move 同士の等値比較ではなく to / drop / promote / from(または打ち駒種) のみを比べる。
+pub fn same_psv_move(lhs: Move, rhs: Move) -> bool {
+    lhs.to() == rhs.to()
+        && lhs.is_drop() == rhs.is_drop()
+        && lhs.is_promote() == rhs.is_promote()
+        && if lhs.is_drop() {
+            lhs.drop_piece_type() == rhs.drop_piece_type()
+        } else {
+            lhs.from() == rhs.from()
+        }
+}
+
+/// `mv` が `pos` の合法手に (PSV move16 の表現力で) 含まれるか判定する。
+pub fn is_legal_psv_move(pos: &Position, mv: Move) -> bool {
+    let mut legal_moves = rshogi_core::movegen::MoveList::new();
+    rshogi_core::movegen::generate_legal_all(pos, &mut legal_moves);
+    legal_moves.iter().any(|legal| same_psv_move(*legal, mv))
+}
+
 /// 実 YaneuraOu PSV 形式 (A) の Move16 を USI 形式へ変換する。
 pub fn psv_move16_to_usi(move16: u16) -> String {
     let mv = psv_move16_to_move(move16);


### PR DESCRIPTION
## 概要

dual-label PSV (base score + DL score + entered gate bit を 40B レコード内部に原子的に保持する形式) の生成・逆抽出・fail-closed 検証ツール `psv_dual_label` を追加する。dedup/shuffle を 2 ラベルが一緒に通過できるようにし、sidecar 方式の「行対応ズレ」故障モードを構造的に消すための運搬形式。既存の sidecar 方式 (`rescore_psv --out-scores` / `psv_gate_by_king_zone --out-mask`) は無変更で共存する。

## レコード形式

| offset | 通常 PSV | dual-label PSV |
|---|---|---|
| 32-33 | score | base score |
| 34-35 | move16 | DL score (i16 LE) |
| 39 | padding | bit0 = entered gate bit、bit1-7 は必ず 0 |

## 変更内容

- `psv_dual_label` (新規 bin): `embed` (base + dl.i16 + entered.bits → dual PSV) / `extract` (逆変換、pipeline fallback 用) / `validate` (形式・entered bit の sfen 判定一致・DL range・move16 合法手率による通常 PSV 誤投入検出)
- 出力は staged write (`<out>.partial` → 全検査後 rename publish)。エラー時に最終パスを変更しない。publish 途中失敗時は検証済みの公開分を保持し部分 publish 状態を明示
- entered 判定 (`classify`) を `tools::king_zone` へ昇格し `psv_gate_by_king_zone` と共有 (gate ツールの CLI・挙動は不変)
- 出力パス安全検査を `tools::output_path` へ共通化
- 実データ知見: 通常 PSV の padding byte は常に 0 ではない (production v1 base の 2.35% が 0x01-0x03)。embed は上書きして `overwritten_nonzero_padding` として報告する
- docs: `crates/tools/docs/psv_dual_label.md` 新規 + 索引 2 件更新

## 検証

- 単体テスト 27 件 (roundtrip bitmap/chunk 境界、fail-closed 各種、staged write の sentinel 保全、path alias/hardlink/symlink)
- 実データ e2e (production v1 base 先頭 5M 局面): embed → validate 全件 PASS (entered bit 一致 5M/5M、move-like 率 0.19%) → extract で dl.i16 / entered.bits が元と bit 一致
- 学習側 loader batch stream の bit 一致: sidecar 経路 vs インライン経路 (gated/all) vs 抽出 fallback 経路の digest が 11,468,800 局面 (2 epoch 超、wrap 込み) で完全一致
- `cargo fmt` / `clippy -D warnings` / `cargo test -p tools` / `check-tracked-abs-paths.sh` PASS
- Codex + Claude の独立 dual review 3 巡 (Major 2 件・Minor 4 件を解消) 両 APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)