### PR TITLE
feat(tools): bitmap mask による PSV 行抽出ツール psv_select_by_mask を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -37,6 +37,7 @@
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
 | `psv_dual_label` | dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
+| `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順に抽出（[詳細](docs/psv_select_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
@@ -117,6 +118,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
 - [psv_dual_label](docs/psv_dual_label.md) - dual-label PSV の生成・sidecar 抽出・fail-closed 検証
+- [psv_select_by_mask](docs/psv_select_by_mask.md) - bitmap mask の bit 1 に対応する PSV 行の順序保持抽出
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応）

--- a/crates/tools/docs/psv_select_by_mask.md
+++ b/crates/tools/docs/psv_select_by_mask.md
@@ -1,0 +1,37 @@
+# psv_select_by_mask — bitmap mask による PSV 行抽出
+
+教師 PSV shard から mask の bit 1 に対応する行だけを入力順のまま抽出し、`rescore_psv`
+などへ渡す compact PSV を作ります。40 byte レコードは解釈・変更せず、そのままコピーします。
+入力全体をメモリへ載せないチャンクストリーミング処理です。
+
+## 使い方
+
+```bash
+cargo run --release -p tools --bin psv_select_by_mask -- \
+  --input shard.psv \
+  --mask entered.bits \
+  --out compact.psv
+```
+
+正常終了時は次の形式で件数を標準出力へ表示します。
+
+```text
+records=1000000 selected=12345 (1.2345%)
+```
+
+## mask 契約
+
+- LSB-first bitmap。byte `j` の bit `k` は record `j * 8 + k` に対応する
+- bit 1 の行だけを抽出し、bit 0 の行は出力しない
+- サイズは `ceil(records / 8)` byte と厳密に一致する
+- 最終 byte でレコードに対応しない未使用 bit はすべて 0 とする
+
+入力 PSV のサイズが 40 byte の倍数でない場合、mask のサイズが一致しない場合、または
+未使用 bit が 1 の場合は出力を確定せずに失敗します。出力は `<out>.partial` へ書き、抽出件数から
+求めた期待サイズとの一致を検査してから `--out` へ rename します。
+
+## compact PSV の書き戻し対応
+
+再ラベル後の compact PSV を元の shard に対応付けるときは、`shard + mask + compact 列` を
+先頭から同時に walk します。mask の bit 1 ごとに compact 側を 1 行進め、その行を同じ shard
+行へ対応させます。抽出順は shard 内の行順から変わらないため、追加の行 ID や並べ替えは不要です。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -59,6 +59,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
 | `psv_gate_by_king_zone` | 入玉ドメインで base / override score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
 | `psv_dual_label` | 通常 PSV + DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
+| `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順にストリーミング抽出（[詳細](psv_select_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |

--- a/crates/tools/src/bin/psv_select_by_mask.rs
+++ b/crates/tools/src/bin/psv_select_by_mask.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use tools::output_path::ensure_safe_output_path;
+use tools::output_path::{ensure_distinct_output_paths, ensure_safe_output_path};
 use tools::packed_sfen::PackedSfenValue;
 
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
@@ -109,6 +109,7 @@ fn select_by_mask(input: &Path, mask: &Path, out: &Path, chunk_records: usize) -
     let staged = partial_path(out);
     ensure_safe_output_path(&staged, input)?;
     ensure_safe_output_path(&staged, mask)?;
+    ensure_distinct_output_paths(out, &staged)?;
 
     let records = checked_input_records(input)?;
     validate_mask(mask, records)?;
@@ -302,6 +303,27 @@ mod tests {
         assert!(select_by_mask(&input, &mask, &out, 8).is_err());
         assert_eq!(fs::read(&out)?, b"sentinel");
         assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn hardlinked_staging_is_rejected_without_truncating_output() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let out = dir.path().join("compact.psv");
+        let staged = partial_path(&out);
+        fs::write(&input, records(8))?;
+        fs::write(&mask, [0xff])?;
+        fs::write(&out, b"sentinel")?;
+        if let Err(error) = fs::hard_link(&out, &staged) {
+            eprintln!("hardlink を作成できないためテストをスキップします: {error}");
+            return Ok(());
+        }
+
+        let error = select_by_mask(&input, &mask, &out, 8).expect_err("operation must fail");
+        assert!(error.to_string().contains("resolve to the same file"));
+        assert_eq!(fs::read(&out)?, b"sentinel");
         Ok(())
     }
 

--- a/crates/tools/src/bin/psv_select_by_mask.rs
+++ b/crates/tools/src/bin/psv_select_by_mask.rs
@@ -1,0 +1,314 @@
+//! LSB-first bitmap mask で PSV の行を入力順に抽出する。
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tools::output_path::ensure_safe_output_path;
+use tools::packed_sfen::PackedSfenValue;
+
+const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const BUFFER_SIZE: usize = 8 << 20;
+const CHUNK_RECORDS: usize = 1 << 18;
+
+// full chunk ごとに mask byte 境界へ戻し、次 chunk の bit 0 を行先頭に対応させる。
+const _: () = assert!(CHUNK_RECORDS.is_multiple_of(8));
+
+#[derive(Parser)]
+#[command(about = "bitmap mask の bit=1 に対応する PSV 行を入力順に抽出")]
+struct Cli {
+    /// 入力 PSV shard（40 byte/record）
+    #[arg(long)]
+    input: PathBuf,
+    /// LSB-first bitmap mask
+    #[arg(long)]
+    mask: PathBuf,
+    /// 抽出後の compact PSV
+    #[arg(long)]
+    out: PathBuf,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Stats {
+    records: u64,
+    selected: u64,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let stats = select_by_mask(&cli.input, &cli.mask, &cli.out, CHUNK_RECORDS)?;
+    let percent = if stats.records == 0 {
+        0.0
+    } else {
+        stats.selected as f64 / stats.records as f64 * 100.0
+    };
+    println!("records={} selected={} ({percent:.4}%)", stats.records, stats.selected);
+    Ok(())
+}
+
+fn partial_path(out: &Path) -> PathBuf {
+    let mut path = out.as_os_str().to_os_string();
+    path.push(".partial");
+    PathBuf::from(path)
+}
+
+fn checked_input_records(input: &Path) -> Result<u64> {
+    let bytes = fs::metadata(input)
+        .with_context(|| format!("Failed to stat input {}", input.display()))?
+        .len();
+    anyhow::ensure!(
+        bytes % RECORD_SIZE as u64 == 0,
+        "Input size is not a multiple of {RECORD_SIZE}: {} ({bytes} bytes)",
+        input.display()
+    );
+    Ok(bytes / RECORD_SIZE as u64)
+}
+
+fn validate_mask(mask: &Path, records: u64) -> Result<()> {
+    let expected_bytes = records.div_ceil(8);
+    let actual_bytes = fs::metadata(mask)
+        .with_context(|| format!("Failed to stat mask {}", mask.display()))?
+        .len();
+    anyhow::ensure!(
+        actual_bytes == expected_bytes,
+        "Mask size mismatch: expected {expected_bytes} bytes for {records} records, got {actual_bytes}: {}",
+        mask.display()
+    );
+
+    let used_bits = (records % 8) as u32;
+    if used_bits != 0 {
+        let mut file = File::open(mask)?;
+        file.seek(SeekFrom::End(-1))?;
+        let mut last = [0u8; 1];
+        file.read_exact(&mut last)?;
+        let unused_mask = !((1u8 << used_bits) - 1);
+        anyhow::ensure!(
+            last[0] & unused_mask == 0,
+            "Mask has non-zero unused bits in final byte: {}",
+            mask.display()
+        );
+    }
+    Ok(())
+}
+
+fn validate_chunk_records(chunk_records: usize) -> Result<()> {
+    anyhow::ensure!(chunk_records > 0, "chunk record count must be positive");
+    anyhow::ensure!(
+        chunk_records.is_multiple_of(8),
+        "chunk record count must be a multiple of 8: {chunk_records}"
+    );
+    Ok(())
+}
+
+fn select_by_mask(input: &Path, mask: &Path, out: &Path, chunk_records: usize) -> Result<Stats> {
+    validate_chunk_records(chunk_records)?;
+    ensure_safe_output_path(out, input)?;
+    ensure_safe_output_path(out, mask)?;
+    let staged = partial_path(out);
+    ensure_safe_output_path(&staged, input)?;
+    ensure_safe_output_path(&staged, mask)?;
+
+    let records = checked_input_records(input)?;
+    validate_mask(mask, records)?;
+
+    let result = write_selected(input, mask, &staged, records, chunk_records);
+    let stats = match result {
+        Ok(stats) => stats,
+        Err(error) => {
+            let _ = fs::remove_file(&staged);
+            return Err(error);
+        }
+    };
+
+    let expected_bytes = stats
+        .selected
+        .checked_mul(RECORD_SIZE as u64)
+        .ok_or_else(|| anyhow::anyhow!("Output size overflow"))?;
+    let actual_bytes = fs::metadata(&staged)?.len();
+    if actual_bytes != expected_bytes {
+        let _ = fs::remove_file(&staged);
+        anyhow::bail!("Output size mismatch: expected {expected_bytes} bytes, got {actual_bytes}");
+    }
+
+    fs::rename(&staged, out)
+        .with_context(|| format!("Failed to rename {} to {}", staged.display(), out.display()))?;
+    Ok(stats)
+}
+
+fn write_selected(
+    input: &Path,
+    mask: &Path,
+    staged: &Path,
+    records: u64,
+    chunk_records: usize,
+) -> Result<Stats> {
+    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(input)?);
+    let mut mask_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
+    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(staged)?);
+    let mut input_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+    let mut mask_chunk = Vec::with_capacity(chunk_records / 8);
+    let mut first_row = 0u64;
+    let mut selected = 0u64;
+
+    while first_row < records {
+        let rows = (records - first_row).min(chunk_records as u64) as usize;
+        input_chunk.resize(rows * RECORD_SIZE, 0);
+        mask_chunk.resize(rows.div_ceil(8), 0);
+        reader.read_exact(&mut input_chunk)?;
+        mask_reader.read_exact(&mut mask_chunk)?;
+
+        for (offset, record) in input_chunk.chunks_exact(RECORD_SIZE).enumerate() {
+            if mask_chunk[offset / 8] & (1 << (offset % 8)) != 0 {
+                writer.write_all(record)?;
+                selected += 1;
+            }
+        }
+        first_row += rows as u64;
+    }
+    writer.flush()?;
+    drop(writer);
+
+    Ok(Stats { records, selected })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn records(count: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(count * RECORD_SIZE);
+        for row in 0..count {
+            let mut record = [0u8; RECORD_SIZE];
+            for (column, byte) in record.iter_mut().enumerate() {
+                *byte = row.wrapping_mul(41).wrapping_add(column) as u8;
+            }
+            bytes.extend_from_slice(&record);
+        }
+        bytes
+    }
+
+    fn expected_rows(input: &[u8], selected: &[usize]) -> Vec<u8> {
+        let mut expected = Vec::with_capacity(selected.len() * RECORD_SIZE);
+        for &row in selected {
+            expected.extend_from_slice(&input[row * RECORD_SIZE..(row + 1) * RECORD_SIZE]);
+        }
+        expected
+    }
+
+    fn run_case(count: usize, mask_bytes: &[u8], selected: &[usize], chunk: usize) -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let out = dir.path().join("compact.psv");
+        let input_bytes = records(count);
+        fs::write(&input, &input_bytes)?;
+        fs::write(&mask, mask_bytes)?;
+
+        let stats = select_by_mask(&input, &mask, &out, chunk)?;
+        assert_eq!(
+            stats,
+            Stats {
+                records: count as u64,
+                selected: selected.len() as u64
+            }
+        );
+        assert_eq!(fs::read(&out)?, expected_rows(&input_bytes, selected));
+        assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn boundary_masks_preserve_selected_records_bit_exactly() -> Result<()> {
+        run_case(7, &[0b0101_0101], &[0, 2, 4, 6], 8)?;
+        run_case(8, &[0b1000_0001], &[0, 7], 8)?;
+        run_case(9, &[0b1010_0110, 0b0000_0001], &[1, 2, 5, 7, 8], 8)?;
+        run_case(17, &[0b1000_0001, 0b0100_0010, 0b0000_0001], &[0, 7, 9, 14, 16], 24)?;
+        Ok(())
+    }
+
+    #[test]
+    fn all_zero_and_all_one_masks() -> Result<()> {
+        run_case(17, &[0, 0, 0], &[], 8)?;
+        run_case(17, &[0xff, 0xff, 0x01], &(0..17).collect::<Vec<_>>(), 8)?;
+        Ok(())
+    }
+
+    #[test]
+    fn selection_crosses_small_chunk_boundaries() -> Result<()> {
+        run_case(17, &[0b1000_0000, 0b1000_0001, 0b0000_0001], &[7, 8, 15, 16], 8)
+    }
+
+    #[test]
+    fn mask_size_mismatch_is_rejected() -> Result<()> {
+        for mask_bytes in [&[0xff][..], &[0xff, 0xff, 0][..]] {
+            let dir = tempdir()?;
+            let input = dir.path().join("shard.psv");
+            let mask = dir.path().join("entered.bits");
+            fs::write(&input, records(9))?;
+            fs::write(&mask, mask_bytes)?;
+            assert!(select_by_mask(&input, &mask, &dir.path().join("out.psv"), 8).is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn non_zero_unused_bits_are_rejected() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        fs::write(&input, records(9))?;
+        fs::write(&mask, [0, 0b0000_0010])?;
+        assert!(select_by_mask(&input, &mask, &dir.path().join("out.psv"), 8).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_input_size_is_rejected() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        fs::write(&input, [0u8; RECORD_SIZE - 1])?;
+        fs::write(&mask, [])?;
+        assert!(select_by_mask(&input, &mask, &dir.path().join("out.psv"), 8).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn output_equal_to_input_is_rejected_without_truncation() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let original = records(8);
+        fs::write(&input, &original)?;
+        fs::write(&mask, [0xff])?;
+        assert!(select_by_mask(&input, &mask, &input, 8).is_err());
+        assert_eq!(fs::read(input)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn staged_write_preserves_output_sentinel_on_validation_failure() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let out = dir.path().join("compact.psv");
+        fs::write(&input, records(9))?;
+        fs::write(&mask, [0, 0b1000_0000])?;
+        fs::write(&out, b"sentinel")?;
+
+        assert!(select_by_mask(&input, &mask, &out, 8).is_err());
+        assert_eq!(fs::read(&out)?, b"sentinel");
+        assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_chunk_size_is_rejected() {
+        assert!(validate_chunk_records(0).is_err());
+        assert!(validate_chunk_records(7).is_err());
+        assert!(validate_chunk_records(8).is_ok());
+    }
+}


### PR DESCRIPTION
## 概要

教師 PSV シャードから LSB-first bitmap mask (`entered.bits` 等、既存 sidecar 契約と同一) の bit=1 行だけを入力順で抽出したコンパクト PSV を作るツール。depth9 リラベル (全行 rescore の回避) の前処理に使う。書き戻しの行対応は「shard + mask + コンパクト列の walk」で決まる (doc 記載)。

## 変更内容

- `psv_select_by_mask` (新規 bin): streaming 抽出、mask 契約の fail-closed 検査 (サイズ厳密一致・最終 byte 未使用 bit・チャンクは 8 の倍数 compile-time assert)、staged write (`<out>.partial` → 検査後 rename、out と staging の hardlink 迂回も拒否)、終了時サイズ検算
- docs: `crates/tools/docs/psv_select_by_mask.md` 新規 + 索引 2 件

## 検証

- 単体テスト 10 件 (bit 境界・全 0/全 1・チャンク境界跨ぎ・fail-closed 各種・sentinel 保全・hardlink 拒否)
- 実データ: expand 68 + aoba 31 shard (計 15.4B 行) から entered 1,542,959,706 行を抽出し、独立生成された mask 統計 (psv_gate_by_king_zone) の per-shard 件数と全 99 shard で一致。再抽出の bit 一致も確認
- `cargo fmt` / `clippy -D warnings` / `cargo test -p tools` / `check-tracked-abs-paths.sh` PASS
- Codex + Claude の独立 dual review (staged write の hardlink 迂回 1 件を解消) 両 APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)