### PR TITLE
feat(tools): compact PSV の score を mask 対応で元 shard に書き戻す psv_scatter_by_mask を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -38,6 +38,7 @@
 | `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
 | `psv_dual_label` | dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順に抽出（[詳細](docs/psv_select_by_mask.md)） |
+| `psv_scatter_by_mask` | compact PSV の score を mask 対応で元 shard に書き戻す（[詳細](docs/psv_scatter_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
 | `preprocess_psv` | PSV ファイルの前処理（qsearch leaf置換等） |
 | `validate_psv` | PSV ファイルの不正局面検出・除去 |
@@ -119,6 +120,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
 - [psv_dual_label](docs/psv_dual_label.md) - dual-label PSV の生成・sidecar 抽出・fail-closed 検証
 - [psv_select_by_mask](docs/psv_select_by_mask.md) - bitmap mask の bit 1 に対応する PSV 行の順序保持抽出
+- [psv_scatter_by_mask](docs/psv_scatter_by_mask.md) - compact PSV の score を mask 対応で元 shard に書き戻し
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder
 - [rescore_hcpe](docs/rescore_hcpe.md) - hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（共有コアで yardstick とラベル bit 一致、分散ラベリング・チャンク単位 + 途中 resume 対応）
 - [psv_to_hcpe3](docs/psv_to_hcpe3.md) - PSV → dlshogi 学習用 hcpe3 / hcpe 変換（cshogi 互換、streaming、`move16=0` の有効な着手なしレコードを件数付きスキップ、`--evalfix-a` 対応）

--- a/crates/tools/docs/psv_scatter_by_mask.md
+++ b/crates/tools/docs/psv_scatter_by_mask.md
@@ -1,0 +1,57 @@
+# psv_scatter_by_mask — compact PSV の score 書き戻し
+
+`psv_select_by_mask` で抽出し、入力順を保ったまま再スコアした compact PSV の score を、
+同じ mask に従って元 shard の対応行へ書き戻します。入力全体をメモリへ載せない
+チャンクストリーミング処理です。
+
+## 使い方
+
+```bash
+cargo run --release -p tools --bin psv_scatter_by_mask -- \
+  --input shard.psv \
+  --mask entered.bits \
+  --compact relabeled.psv \
+  --out out.psv
+```
+
+`--out` のレコード数と順序は `--input` と同じです。mask の bit 0 の行は入力レコードを
+そのままコピーし、bit 1 の行は対応する compact レコードの score（offset 32--33、i16 LE）
+だけを差し替えます。
+
+compact 側の move16、gamePly、game_result、padding は使用しません。再スコア処理が move16
+などを更新する場合でも、このツールの目的は score の差し替えだけです。また move16 スロットは
+後段の `psv_dual_label embed` が DL score に使用するため、score 以外は元 shard を正とします。
+
+## mask 契約
+
+- LSB-first bitmap。byte `j` の bit `k` は record `j * 8 + k` に対応する
+- bit 1 ごとに compact 側を 1 レコード進め、同じ shard 行へ対応させる
+- サイズは `ceil(records / 8)` byte と厳密に一致する
+- 最終 byte でレコードに対応しない未使用 bit はすべて 0 とする
+- mask 全体の popcount は compact PSV のレコード数と厳密に一致する
+
+`psv_select_by_mask` の出力順を変更した compact PSV は使用できません。
+
+## 検証と fail-closed
+
+出力を作成する前に、入力 PSV と compact PSV が 40 byte/record であること、mask 契約、
+popcount と compact レコード数の一致を検証します。書き戻し時には各 bit 1 行について、元 shard と
+compact の packed SFEN（offset 0--31）が一致することも検証します。不一致時のエラーには元 shard の
+0-origin レコード番号を表示します。
+
+出力は `<out>.partial` へ書き、元 shard と同じ期待サイズであることを検査してから `--out` へ
+rename します。処理中にエラーが起きた場合は partial を削除し、既存の `--out` を温存します。
+`--out` と `<out>.partial` は、`--input`、`--mask`、`--compact` のいずれかと同じパスまたは
+同じファイル実体にできません。
+
+## 統計の読み方
+
+正常終了時は次の形式で標準出力へ表示します。
+
+```text
+records=1000000 replaced=12345 changed=12001
+```
+
+- `records`: 元 shard と出力の全レコード数
+- `replaced`: mask の bit 1 の数。compact の全レコード数と同じ
+- `changed`: 書き戻し前後で score の値が実際に変わったレコード数

--- a/crates/tools/docs/psv_select_by_mask.md
+++ b/crates/tools/docs/psv_select_by_mask.md
@@ -32,6 +32,6 @@ records=1000000 selected=12345 (1.2345%)
 
 ## compact PSV の書き戻し対応
 
-再ラベル後の compact PSV を元の shard に対応付けるときは、`shard + mask + compact 列` を
-先頭から同時に walk します。mask の bit 1 ごとに compact 側を 1 行進め、その行を同じ shard
-行へ対応させます。抽出順は shard 内の行順から変わらないため、追加の行 ID や並べ替えは不要です。
+再ラベル後の compact PSV の score は
+[`psv_scatter_by_mask`](psv_scatter_by_mask.md) で元 shard の対応行へ書き戻せます。
+抽出時と同じ mask、および抽出順を変更していない compact PSV を指定してください。

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -60,6 +60,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `psv_gate_by_king_zone` | 入玉ドメインで base / override score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
 | `psv_dual_label` | 通常 PSV + DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順にストリーミング抽出（[詳細](psv_select_by_mask.md)） |
+| `psv_scatter_by_mask` | compact PSV の score を mask 対応で元 shard にストリーミング書き戻し（[詳細](psv_scatter_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |
 | `preprocess_psv` | PSV ファイルに qsearch leaf 置換を適用。チャンクストリーミング処理対応 |
 | `filter_teacher_data` | 王手除外・スコアフィルタ・クリップなどの前処理を適用 |

--- a/crates/tools/src/bin/psv_scatter_by_mask.rs
+++ b/crates/tools/src/bin/psv_scatter_by_mask.rs
@@ -1,0 +1,428 @@
+//! compact PSV の score を mask 対応で元 shard に書き戻す。
+
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tools::mask_io::{checked_input_records, partial_path, validate_chunk_records, validate_mask};
+use tools::output_path::{ensure_distinct_output_paths, ensure_safe_output_path};
+use tools::packed_sfen::PackedSfenValue;
+
+const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const PACKED_SFEN_SIZE: usize = 32;
+const SCORE_OFFSET: usize = 32;
+const SCORE_SIZE: usize = 2;
+const BUFFER_SIZE: usize = 8 << 20;
+const CHUNK_RECORDS: usize = 1 << 18;
+
+// full chunk ごとに mask byte 境界へ戻し、次 chunk の bit 0 を行先頭に対応させる。
+const _: () = assert!(CHUNK_RECORDS.is_multiple_of(8));
+
+#[derive(Parser)]
+#[command(about = "compact PSV の score を mask 対応で元 shard に書き戻す")]
+struct Cli {
+    /// 元の入力 PSV shard（40 byte/record）
+    #[arg(long)]
+    input: PathBuf,
+    /// LSB-first bitmap mask
+    #[arg(long)]
+    mask: PathBuf,
+    /// 抽出順のまま再スコア済みの compact PSV
+    #[arg(long)]
+    compact: PathBuf,
+    /// score 書き戻し後の PSV
+    #[arg(long)]
+    out: PathBuf,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Stats {
+    records: u64,
+    replaced: u64,
+    changed: u64,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let stats = scatter_by_mask(&cli.input, &cli.mask, &cli.compact, &cli.out, CHUNK_RECORDS)?;
+    println!("{}", format_stats(&stats));
+    Ok(())
+}
+
+fn format_stats(stats: &Stats) -> String {
+    format!(
+        "records={} replaced={} changed={}",
+        stats.records, stats.replaced, stats.changed
+    )
+}
+
+fn mask_popcount(mask: &Path) -> Result<u64> {
+    let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
+    let mut buffer = vec![0u8; BUFFER_SIZE];
+    let mut popcount = 0u64;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        popcount += buffer[..read].iter().map(|byte| u64::from(byte.count_ones())).sum::<u64>();
+    }
+    Ok(popcount)
+}
+
+fn scatter_by_mask(
+    input: &Path,
+    mask: &Path,
+    compact: &Path,
+    out: &Path,
+    chunk_records: usize,
+) -> Result<Stats> {
+    validate_chunk_records(chunk_records)?;
+    for source in [input, mask, compact] {
+        ensure_safe_output_path(out, source)?;
+    }
+    let staged = partial_path(out);
+    for source in [input, mask, compact] {
+        ensure_safe_output_path(&staged, source)?;
+    }
+    ensure_distinct_output_paths(out, &staged)?;
+
+    let records = checked_input_records(input)?;
+    validate_mask(mask, records)?;
+    let compact_records = checked_input_records(compact)?;
+    let replaced = mask_popcount(mask)?;
+    anyhow::ensure!(
+        replaced == compact_records,
+        "Mask popcount does not match compact records: mask={replaced}, compact={compact_records}"
+    );
+
+    let result = write_scattered(input, mask, compact, &staged, records, replaced, chunk_records)
+        .and_then(|stats| {
+            let expected_bytes = records
+                .checked_mul(RECORD_SIZE as u64)
+                .ok_or_else(|| anyhow::anyhow!("Output size overflow"))?;
+            let actual_bytes = fs::metadata(&staged)?.len();
+            anyhow::ensure!(
+                actual_bytes == expected_bytes,
+                "Output size mismatch: expected {expected_bytes} bytes, got {actual_bytes}"
+            );
+            Ok(stats)
+        });
+    let stats = match result {
+        Ok(stats) => stats,
+        Err(error) => {
+            let _ = fs::remove_file(&staged);
+            return Err(error);
+        }
+    };
+
+    if let Err(error) = fs::rename(&staged, out)
+        .with_context(|| format!("Failed to rename {} to {}", staged.display(), out.display()))
+    {
+        let _ = fs::remove_file(&staged);
+        return Err(error);
+    }
+    Ok(stats)
+}
+
+fn write_scattered(
+    input: &Path,
+    mask: &Path,
+    compact: &Path,
+    staged: &Path,
+    records: u64,
+    replaced: u64,
+    chunk_records: usize,
+) -> Result<Stats> {
+    let mut input_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(input)?);
+    let mut mask_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(mask)?);
+    let mut compact_reader = BufReader::with_capacity(BUFFER_SIZE, File::open(compact)?);
+    let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(staged)?);
+    let mut input_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+    let mut mask_chunk = Vec::with_capacity(chunk_records / 8);
+    let mut compact_record = [0u8; RECORD_SIZE];
+    let mut first_row = 0u64;
+    let mut changed = 0u64;
+
+    while first_row < records {
+        let rows = (records - first_row).min(chunk_records as u64) as usize;
+        input_chunk.resize(rows * RECORD_SIZE, 0);
+        mask_chunk.resize(rows.div_ceil(8), 0);
+        input_reader.read_exact(&mut input_chunk)?;
+        mask_reader.read_exact(&mut mask_chunk)?;
+
+        for (offset, input_record) in input_chunk.chunks_exact(RECORD_SIZE).enumerate() {
+            if mask_chunk[offset / 8] & (1 << (offset % 8)) == 0 {
+                writer.write_all(input_record)?;
+                continue;
+            }
+
+            compact_reader.read_exact(&mut compact_record)?;
+            let row = first_row + offset as u64;
+            anyhow::ensure!(
+                input_record[..PACKED_SFEN_SIZE] == compact_record[..PACKED_SFEN_SIZE],
+                "Packed SFEN mismatch at input record {row}"
+            );
+            let mut output_record = [0u8; RECORD_SIZE];
+            output_record.copy_from_slice(input_record);
+            let score = SCORE_OFFSET..SCORE_OFFSET + SCORE_SIZE;
+            if input_record[score.clone()] != compact_record[score.clone()] {
+                changed += 1;
+            }
+            output_record[score.clone()].copy_from_slice(&compact_record[score]);
+            writer.write_all(&output_record)?;
+        }
+        first_row += rows as u64;
+    }
+    writer.flush()?;
+    drop(writer);
+
+    Ok(Stats {
+        records,
+        replaced,
+        changed,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn records(count: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(count * RECORD_SIZE);
+        for row in 0..count {
+            let mut record = [0u8; RECORD_SIZE];
+            for (column, byte) in record.iter_mut().enumerate() {
+                *byte = row.wrapping_mul(41).wrapping_add(column) as u8;
+            }
+            record[SCORE_OFFSET..SCORE_OFFSET + SCORE_SIZE]
+                .copy_from_slice(&(row as i16).to_le_bytes());
+            bytes.extend_from_slice(&record);
+        }
+        bytes
+    }
+
+    fn selected_records(input: &[u8], selected: &[usize]) -> Vec<u8> {
+        let mut compact = Vec::with_capacity(selected.len() * RECORD_SIZE);
+        for &row in selected {
+            compact.extend_from_slice(&input[row * RECORD_SIZE..(row + 1) * RECORD_SIZE]);
+        }
+        compact
+    }
+
+    fn run_case(
+        count: usize,
+        mask_bytes: &[u8],
+        selected: &[usize],
+        chunk_records: usize,
+    ) -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let compact = dir.path().join("compact.psv");
+        let out = dir.path().join("out.psv");
+        let input_bytes = records(count);
+        let mut compact_bytes = selected_records(&input_bytes, selected);
+        for (index, record) in compact_bytes.chunks_exact_mut(RECORD_SIZE).enumerate() {
+            record[SCORE_OFFSET..SCORE_OFFSET + SCORE_SIZE]
+                .copy_from_slice(&(-(index as i16) - 100).to_le_bytes());
+            record[34..].fill(0xa5);
+        }
+        fs::write(&input, &input_bytes)?;
+        fs::write(&mask, mask_bytes)?;
+        fs::write(&compact, &compact_bytes)?;
+
+        let stats = scatter_by_mask(&input, &mask, &compact, &out, chunk_records)?;
+        assert_eq!(stats.records, count as u64);
+        assert_eq!(stats.replaced, selected.len() as u64);
+        assert_eq!(stats.changed, selected.len() as u64);
+        let output = fs::read(&out)?;
+        let mut compact_index = 0;
+        for row in 0..count {
+            let range = row * RECORD_SIZE..(row + 1) * RECORD_SIZE;
+            if selected.contains(&row) {
+                let compact_range = compact_index * RECORD_SIZE..(compact_index + 1) * RECORD_SIZE;
+                assert_eq!(
+                    &output[range.start + SCORE_OFFSET..range.start + SCORE_OFFSET + SCORE_SIZE],
+                    &compact_bytes[compact_range.start + SCORE_OFFSET
+                        ..compact_range.start + SCORE_OFFSET + SCORE_SIZE]
+                );
+                assert_eq!(
+                    &output[range.start..range.start + SCORE_OFFSET],
+                    &input_bytes[range.start..range.start + SCORE_OFFSET]
+                );
+                assert_eq!(
+                    &output[range.start + SCORE_OFFSET + SCORE_SIZE..range.end],
+                    &input_bytes[range.start + SCORE_OFFSET + SCORE_SIZE..range.end]
+                );
+                compact_index += 1;
+            } else {
+                assert_eq!(&output[range.clone()], &input_bytes[range]);
+            }
+        }
+        assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn boundary_masks_replace_matching_scores() -> Result<()> {
+        run_case(7, &[0b0101_0101], &[0, 2, 4, 6], 8)?;
+        run_case(8, &[0b1000_0001], &[0, 7], 8)?;
+        run_case(9, &[0b1010_0110, 0b0000_0001], &[1, 2, 5, 7, 8], 8)?;
+        run_case(17, &[0b1000_0001, 0b0100_0010, 0b0000_0001], &[0, 7, 9, 14, 16], 24)?;
+        Ok(())
+    }
+
+    #[test]
+    fn replacement_crosses_small_chunk_boundaries() -> Result<()> {
+        run_case(17, &[0b1000_0000, 0b1000_0001, 0b0000_0001], &[7, 8, 15, 16], 8)
+    }
+
+    #[test]
+    fn unchanged_compact_is_bit_exact_identity() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let compact = dir.path().join("compact.psv");
+        let out = dir.path().join("out.psv");
+        let input_bytes = records(9);
+        fs::write(&input, &input_bytes)?;
+        fs::write(&mask, [0b1010_0110, 1])?;
+        fs::write(&compact, selected_records(&input_bytes, &[1, 2, 5, 7, 8]))?;
+
+        let stats = scatter_by_mask(&input, &mask, &compact, &out, 8)?;
+        assert_eq!(
+            stats,
+            Stats {
+                records: 9,
+                replaced: 5,
+                changed: 0
+            }
+        );
+        assert_eq!(fs::read(out)?, input_bytes);
+        Ok(())
+    }
+
+    #[test]
+    fn packed_sfen_mismatch_is_fail_closed() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let compact = dir.path().join("compact.psv");
+        let out = dir.path().join("out.psv");
+        let input_bytes = records(8);
+        let mut compact_bytes = selected_records(&input_bytes, &[3]);
+        compact_bytes[0] ^= 1;
+        fs::write(&input, input_bytes)?;
+        fs::write(&mask, [0b0000_1000])?;
+        fs::write(&compact, compact_bytes)?;
+        fs::write(&out, b"sentinel")?;
+
+        let error = scatter_by_mask(&input, &mask, &compact, &out, 8).expect_err("must fail");
+        assert!(error.to_string().contains("input record 3"));
+        assert_eq!(fs::read(&out)?, b"sentinel");
+        assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn compact_record_count_must_equal_mask_popcount() -> Result<()> {
+        for compact_count in [1, 3] {
+            let dir = tempdir()?;
+            let input = dir.path().join("shard.psv");
+            let mask = dir.path().join("entered.bits");
+            let compact = dir.path().join("compact.psv");
+            let out = dir.path().join("out.psv");
+            fs::write(&input, records(8))?;
+            fs::write(&mask, [0b0000_0011])?;
+            fs::write(&compact, records(compact_count))?;
+            assert!(scatter_by_mask(&input, &mask, &compact, &out, 8).is_err());
+            assert!(!out.exists());
+            assert!(!partial_path(&out).exists());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_compact_size_is_rejected_before_output_creation() -> Result<()> {
+        let dir = tempdir()?;
+        let input = dir.path().join("shard.psv");
+        let mask = dir.path().join("entered.bits");
+        let compact = dir.path().join("compact.psv");
+        let out = dir.path().join("out.psv");
+        fs::write(&input, records(8))?;
+        fs::write(&mask, [1])?;
+        fs::write(&compact, [0u8; RECORD_SIZE - 1])?;
+
+        assert!(scatter_by_mask(&input, &mask, &compact, &out, 8).is_err());
+        assert!(!out.exists());
+        assert!(!partial_path(&out).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_inputs_are_rejected_before_output_creation() -> Result<()> {
+        for (input_bytes, mask_bytes) in [
+            (records(9), vec![0xff]),
+            (records(9), vec![0, 0b0000_0010]),
+            (vec![0u8; RECORD_SIZE - 1], vec![]),
+        ] {
+            let dir = tempdir()?;
+            let input = dir.path().join("shard.psv");
+            let mask = dir.path().join("entered.bits");
+            let compact = dir.path().join("compact.psv");
+            let out = dir.path().join("out.psv");
+            fs::write(&input, input_bytes)?;
+            fs::write(&mask, mask_bytes)?;
+            fs::write(&compact, [])?;
+            assert!(scatter_by_mask(&input, &mask, &compact, &out, 8).is_err());
+            assert!(!out.exists());
+            assert!(!partial_path(&out).exists());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn output_equal_to_an_input_is_rejected_without_truncation() -> Result<()> {
+        for output_source in 0..3 {
+            let dir = tempdir()?;
+            let input = dir.path().join("shard.psv");
+            let mask = dir.path().join("entered.bits");
+            let compact = dir.path().join("compact.psv");
+            let input_bytes = records(8);
+            let compact_bytes = selected_records(&input_bytes, &[0]);
+            fs::write(&input, &input_bytes)?;
+            fs::write(&mask, [1])?;
+            fs::write(&compact, &compact_bytes)?;
+            let out = [&input, &mask, &compact][output_source];
+
+            assert!(scatter_by_mask(&input, &mask, &compact, out, 8).is_err());
+            assert_eq!(fs::read(&input)?, input_bytes);
+            assert_eq!(fs::read(&mask)?, [1]);
+            assert_eq!(fs::read(&compact)?, compact_bytes);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn statistics_format_is_exact() {
+        let stats = Stats {
+            records: 17,
+            replaced: 5,
+            changed: 3,
+        };
+        assert_eq!(format_stats(&stats), "records=17 replaced=5 changed=3");
+    }
+
+    #[test]
+    fn invalid_chunk_size_is_rejected() -> Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("unused");
+        assert!(scatter_by_mask(&path, &path, &path, &path, 0).is_err());
+        assert!(scatter_by_mask(&path, &path, &path, &path, 7).is_err());
+        Ok(())
+    }
+}

--- a/crates/tools/src/bin/psv_select_by_mask.rs
+++ b/crates/tools/src/bin/psv_select_by_mask.rs
@@ -1,11 +1,12 @@
 //! LSB-first bitmap mask で PSV の行を入力順に抽出する。
 
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use tools::mask_io::{checked_input_records, partial_path, validate_chunk_records, validate_mask};
 use tools::output_path::{ensure_distinct_output_paths, ensure_safe_output_path};
 use tools::packed_sfen::PackedSfenValue;
 
@@ -45,60 +46,6 @@ fn main() -> Result<()> {
         stats.selected as f64 / stats.records as f64 * 100.0
     };
     println!("records={} selected={} ({percent:.4}%)", stats.records, stats.selected);
-    Ok(())
-}
-
-fn partial_path(out: &Path) -> PathBuf {
-    let mut path = out.as_os_str().to_os_string();
-    path.push(".partial");
-    PathBuf::from(path)
-}
-
-fn checked_input_records(input: &Path) -> Result<u64> {
-    let bytes = fs::metadata(input)
-        .with_context(|| format!("Failed to stat input {}", input.display()))?
-        .len();
-    anyhow::ensure!(
-        bytes % RECORD_SIZE as u64 == 0,
-        "Input size is not a multiple of {RECORD_SIZE}: {} ({bytes} bytes)",
-        input.display()
-    );
-    Ok(bytes / RECORD_SIZE as u64)
-}
-
-fn validate_mask(mask: &Path, records: u64) -> Result<()> {
-    let expected_bytes = records.div_ceil(8);
-    let actual_bytes = fs::metadata(mask)
-        .with_context(|| format!("Failed to stat mask {}", mask.display()))?
-        .len();
-    anyhow::ensure!(
-        actual_bytes == expected_bytes,
-        "Mask size mismatch: expected {expected_bytes} bytes for {records} records, got {actual_bytes}: {}",
-        mask.display()
-    );
-
-    let used_bits = (records % 8) as u32;
-    if used_bits != 0 {
-        let mut file = File::open(mask)?;
-        file.seek(SeekFrom::End(-1))?;
-        let mut last = [0u8; 1];
-        file.read_exact(&mut last)?;
-        let unused_mask = !((1u8 << used_bits) - 1);
-        anyhow::ensure!(
-            last[0] & unused_mask == 0,
-            "Mask has non-zero unused bits in final byte: {}",
-            mask.display()
-        );
-    }
-    Ok(())
-}
-
-fn validate_chunk_records(chunk_records: usize) -> Result<()> {
-    anyhow::ensure!(chunk_records > 0, "chunk record count must be positive");
-    anyhow::ensure!(
-        chunk_records.is_multiple_of(8),
-        "chunk record count must be a multiple of 8: {chunk_records}"
-    );
     Ok(())
 }
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -51,6 +51,7 @@ pub mod ek_testset;
 pub mod eval_sfens_tool;
 pub mod kif;
 pub mod king_zone;
+pub mod mask_io;
 pub mod nnue_saturation_tool;
 // nyugyoku_metrics は CSA replay (`replay` モジュール) に依存するため csa-replay に gate する。
 #[cfg(feature = "csa-replay")]

--- a/crates/tools/src/mask_io.rs
+++ b/crates/tools/src/mask_io.rs
@@ -1,0 +1,68 @@
+//! PSV と LSB-first bitmap mask を組み合わせるツール向けの共通 I/O 検証。
+
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::packed_sfen::PackedSfenValue;
+
+/// `<out>.partial` 形式の staging パスを返す。
+pub fn partial_path(out: &Path) -> PathBuf {
+    let mut path = out.as_os_str().to_os_string();
+    path.push(".partial");
+    PathBuf::from(path)
+}
+
+/// PSV のサイズを検証し、レコード数を返す。
+pub fn checked_input_records(input: &Path) -> Result<u64> {
+    let bytes = fs::metadata(input)
+        .with_context(|| format!("Failed to stat input {}", input.display()))?
+        .len();
+    anyhow::ensure!(
+        bytes % PackedSfenValue::SIZE as u64 == 0,
+        "Input size is not a multiple of {}: {} ({bytes} bytes)",
+        PackedSfenValue::SIZE,
+        input.display()
+    );
+    Ok(bytes / PackedSfenValue::SIZE as u64)
+}
+
+/// mask のサイズと最終 byte の未使用 bit を検証する。
+pub fn validate_mask(mask: &Path, records: u64) -> Result<()> {
+    let expected_bytes = records.div_ceil(8);
+    let actual_bytes = fs::metadata(mask)
+        .with_context(|| format!("Failed to stat mask {}", mask.display()))?
+        .len();
+    anyhow::ensure!(
+        actual_bytes == expected_bytes,
+        "Mask size mismatch: expected {expected_bytes} bytes for {records} records, got {actual_bytes}: {}",
+        mask.display()
+    );
+
+    let used_bits = (records % 8) as u32;
+    if used_bits != 0 {
+        let mut file = File::open(mask)?;
+        file.seek(SeekFrom::End(-1))?;
+        let mut last = [0u8; 1];
+        file.read_exact(&mut last)?;
+        let unused_mask = !((1u8 << used_bits) - 1);
+        anyhow::ensure!(
+            last[0] & unused_mask == 0,
+            "Mask has non-zero unused bits in final byte: {}",
+            mask.display()
+        );
+    }
+    Ok(())
+}
+
+/// chunk のレコード数が正かつ mask の byte 境界に揃うことを検証する。
+pub fn validate_chunk_records(chunk_records: usize) -> Result<()> {
+    anyhow::ensure!(chunk_records > 0, "chunk record count must be positive");
+    anyhow::ensure!(
+        chunk_records.is_multiple_of(8),
+        "chunk record count must be a multiple of 8: {chunk_records}"
+    );
+    Ok(())
+}

--- a/crates/tools/tests/psv_scatter_by_mask_integration.rs
+++ b/crates/tools/tests/psv_scatter_by_mask_integration.rs
@@ -1,0 +1,188 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+use tools::packed_sfen::PackedSfenValue;
+
+const SELECT_BIN: &str = env!("CARGO_BIN_EXE_psv_select_by_mask");
+const SCATTER_BIN: &str = env!("CARGO_BIN_EXE_psv_scatter_by_mask");
+
+fn records(count: usize) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(count * PackedSfenValue::SIZE);
+    for row in 0..count {
+        let mut sfen = [0u8; 32];
+        for (column, byte) in sfen.iter_mut().enumerate() {
+            *byte = row.wrapping_mul(41).wrapping_add(column) as u8;
+        }
+        bytes.extend_from_slice(
+            &PackedSfenValue {
+                sfen,
+                score: row as i16 * 10 - 50,
+                move16: row as u16 + 100,
+                game_ply: row as u16 + 200,
+                game_result: row as i8 % 3 - 1,
+                padding: row as u8,
+            }
+            .to_bytes(),
+        );
+    }
+    bytes
+}
+
+fn run_select(input: &Path, mask: &Path, compact: &Path) -> Output {
+    Command::new(SELECT_BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--mask",
+            mask.to_str().unwrap(),
+            "--out",
+            compact.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+}
+
+fn run_scatter(input: &Path, mask: &Path, compact: &Path, out: &Path) -> Output {
+    Command::new(SCATTER_BIN)
+        .args([
+            "--input",
+            input.to_str().unwrap(),
+            "--mask",
+            mask.to_str().unwrap(),
+            "--compact",
+            compact.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap()
+}
+
+fn assert_stats(output: &Output, expected: &[(&str, u64)]) {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+    let stats: BTreeMap<_, _> = stdout
+        .split_whitespace()
+        .filter_map(|field| field.split_once('='))
+        .filter_map(|(key, value)| value.parse::<u64>().ok().map(|value| (key, value)))
+        .collect();
+    for &(key, value) in expected {
+        assert_eq!(stats.get(key), Some(&value), "stdout: {stdout}");
+    }
+}
+
+fn replace_scores(bytes: &mut [u8], scores: &[i16]) {
+    assert_eq!(bytes.len(), scores.len() * PackedSfenValue::SIZE);
+    for (record, &score) in bytes.chunks_exact_mut(PackedSfenValue::SIZE).zip(scores) {
+        let mut value = PackedSfenValue::from_bytes(record).unwrap();
+        value.score = score;
+        record.copy_from_slice(&value.to_bytes());
+    }
+}
+
+#[test]
+fn real_binary_roundtrip_preserves_rows_and_counts_only_changed_scores() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let mask = dir.path().join("mask.bits");
+    let compact = dir.path().join("compact.psv");
+    let out = dir.path().join("out.psv");
+    let input_bytes = records(9);
+    let selected = [0usize, 2, 5, 7, 8];
+    fs::write(&input, &input_bytes).unwrap();
+    fs::write(&mask, [0b1010_0101, 0b0000_0001]).unwrap();
+
+    let select = run_select(&input, &mask, &compact);
+    assert_stats(&select, &[("records", 9), ("selected", 5)]);
+    let mut compact_bytes = fs::read(&compact).unwrap();
+    for (compact_row, &input_row) in selected.iter().enumerate() {
+        let compact_start = compact_row * PackedSfenValue::SIZE;
+        let input_start = input_row * PackedSfenValue::SIZE;
+        assert_eq!(
+            &compact_bytes[compact_start..compact_start + PackedSfenValue::SIZE],
+            &input_bytes[input_start..input_start + PackedSfenValue::SIZE]
+        );
+    }
+
+    let scores = [-300, -30, -301, 20, -302];
+    replace_scores(&mut compact_bytes, &scores);
+    fs::write(&compact, &compact_bytes).unwrap();
+    let scatter = run_scatter(&input, &mask, &compact, &out);
+    assert_stats(&scatter, &[("records", 9), ("replaced", 5), ("changed", 3)]);
+
+    let output = fs::read(out).unwrap();
+    let mut expected = input_bytes.clone();
+    for (&row, &score) in selected.iter().zip(&scores) {
+        let start = row * PackedSfenValue::SIZE;
+        let mut value =
+            PackedSfenValue::from_bytes(&expected[start..start + PackedSfenValue::SIZE]).unwrap();
+        value.score = score;
+        expected[start..start + PackedSfenValue::SIZE].copy_from_slice(&value.to_bytes());
+    }
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn unchanged_compact_is_bit_exact_identity() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let mask = dir.path().join("mask.bits");
+    let compact = dir.path().join("compact.psv");
+    let out = dir.path().join("out.psv");
+    let input_bytes = records(9);
+    fs::write(&input, &input_bytes).unwrap();
+    fs::write(&mask, [0b1010_0110, 0b0000_0001]).unwrap();
+
+    let select = run_select(&input, &mask, &compact);
+    assert_stats(&select, &[("records", 9), ("selected", 5)]);
+    let scatter = run_scatter(&input, &mask, &compact, &out);
+    assert_stats(&scatter, &[("records", 9), ("replaced", 5), ("changed", 0)]);
+    assert_eq!(fs::read(out).unwrap(), input_bytes);
+}
+
+#[test]
+fn empty_input_roundtrip_succeeds_with_zero_stats() {
+    let dir = TempDir::new().unwrap();
+    let input = dir.path().join("input.psv");
+    let mask = dir.path().join("mask.bits");
+    let compact = dir.path().join("compact.psv");
+    let out = dir.path().join("out.psv");
+    fs::write(&input, []).unwrap();
+    fs::write(&mask, []).unwrap();
+
+    let select = run_select(&input, &mask, &compact);
+    assert_stats(&select, &[("records", 0), ("selected", 0)]);
+    assert!(fs::read(&compact).unwrap().is_empty());
+    let scatter = run_scatter(&input, &mask, &compact, &out);
+    assert_stats(&scatter, &[("records", 0), ("replaced", 0), ("changed", 0)]);
+    assert!(fs::read(out).unwrap().is_empty());
+}
+
+#[test]
+fn all_zero_and_all_one_masks_roundtrip() {
+    for (name, mask_bytes, selected) in [("zero", [0, 0], 0u64), ("one", [0xff, 0x01], 9u64)] {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join(format!("{name}-input.psv"));
+        let mask = dir.path().join(format!("{name}-mask.bits"));
+        let compact = dir.path().join(format!("{name}-compact.psv"));
+        let out = dir.path().join(format!("{name}-out.psv"));
+        let input_bytes = records(9);
+        fs::write(&input, &input_bytes).unwrap();
+        fs::write(&mask, mask_bytes).unwrap();
+
+        let select = run_select(&input, &mask, &compact);
+        assert_stats(&select, &[("records", 9), ("selected", selected)]);
+        assert_eq!(fs::metadata(&compact).unwrap().len(), selected * PackedSfenValue::SIZE as u64);
+        let scatter = run_scatter(&input, &mask, &compact, &out);
+        assert_stats(&scatter, &[("records", 9), ("replaced", selected), ("changed", 0)]);
+        assert_eq!(fs::read(out).unwrap(), input_bytes);
+    }
+}


### PR DESCRIPTION
## 概要

psv_select_by_mask (#1001) で抽出し再スコアした compact PSV の score を、同じ mask に従って元 shard の対応行へ書き戻すツール。psv_select_by_mask の doc に仕様のみ記載されていた「compact PSV の書き戻し対応」の実装。gated50b 教師 campaign の entered 層 d9 リラベル値の書き戻し工程で使用する。

- 書き戻しは score (offset 32-33) のみ。move16 等は元 shard を正とする (move16 スロットは後段の psv_dual_label embed が DL score 用に使うため)
- bit=1 行ごとに packed SFEN (offset 0-31) の一致を検証し、不一致はレコード番号付きで即エラー
- mask popcount == compact レコード数を出力作成前に照合
- `.partial` staging + 期待サイズ検査 + rename の fail-closed (失敗時は既存出力を温存)
- チャンクストリーミングでピークメモリは入力サイズ非依存
- mask 検証ヘルパを `mask_io` として共有化 (psv_select_by_mask は関数移動のみ、既存テスト不変)
- 統計出力: `records= replaced= changed=` (changed は score が実際に変化した行数)

## 検証

- unit test 10 + integration test 4 (実 binary での select → score 変更 → scatter roundtrip / 恒等 / 空入力 / all-zero・all-one mask / changed 混在集計)
- 実データ: リラベル済み shard 21,705,890 行で書き戻し全行照合 (score 列 = リスコア値・他 byte 不変・全行 SFEN 一致)、およびランダム 4.3% mask での select → 無変更 scatter が元ファイルと bit 一致
- `cargo fmt` / `cargo clippy --tests` 警告ゼロ / `scripts/check-tracked-abs-paths.sh` PASS
- local dual review 済み (Codex REQUEST_CHANGES → integration test 追加 → APPROVE + Claude 全 diff レビュー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiE3qM6aiwAxw1ZKgqGRXK