### PR TITLE
chore(deps): lru を 0.18.2 へ更新 (RUSTSEC-2026-0253 解消)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,9 +1460,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]


### PR DESCRIPTION
## 概要

Security Audit CI が main で失敗し続けている原因の RUSTSEC-2026-0253 (lru 0.18.0 の `LruCache::pop()` unsound、ratatui-core 経由の推移依存) を解消する。Cargo.lock のみの更新 (0.18.0 → 0.18.2、advisory の patched 範囲 >= 0.18.2)。

## 検証

- `cargo audit --deny warnings` PASS (警告ゼロ)
- lru の直接消費元 kifu_player の release build 成功
- ratatui-core 0.1.2 の要求 `^0.18` と両立 (cargo metadata --locked で解決確認)
- local dual review 済み (Codex APPROVE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiE3qM6aiwAxw1ZKgqGRXK