### PR TITLE
feat(tools): psv_dual_label に通常 PSV の score 列を退避する dump-scores を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -36,7 +36,7 @@
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](docs/relabel_psv.md)） |
 | `rescore_psv` | 局面の再評価（探索スコア付与） |
 | `psv_gate_by_king_zone` | 入玉ドメインの score 合成 / mask bitmap 生成 |
-| `psv_dual_label` | dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
+| `psv_dual_label` | 通常 PSV の score 退避、dual-label PSV の生成・sidecar 抽出・fail-closed 検証（[詳細](docs/psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順に抽出（[詳細](docs/psv_select_by_mask.md)） |
 | `psv_scatter_by_mask` | compact PSV の score を mask 対応で元 shard に書き戻す（[詳細](docs/psv_scatter_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（分散ラベリング・チャンク単位 + 途中 resume 対応） |
@@ -118,7 +118,7 @@ cargo run -p tools --release --bin benchmark -- --internal
 - [nnue_saturation](docs/nnue_saturation.md) - LayerStacks NNUE の活性飽和率（u8 127 張り付き）を実局面で計測
 - [rescore_psv](docs/rescore_psv.md) - PSV 評価値の再スコアリング（推奨: dlshogi ONNX + TensorRT FP16。qsearch-leaf ラベル / policy 展開 / レジューム対応）
 - [psv_gate_by_king_zone](docs/psv_gate_by_king_zone.md) - 入玉ドメインの base/override score 合成と行対応 mask bitmap
-- [psv_dual_label](docs/psv_dual_label.md) - dual-label PSV の生成・sidecar 抽出・fail-closed 検証
+- [psv_dual_label](docs/psv_dual_label.md) - 通常 PSV の score 退避、dual-label PSV の生成・sidecar 抽出・fail-closed 検証
 - [psv_select_by_mask](docs/psv_select_by_mask.md) - bitmap mask の bit 1 に対応する PSV 行の順序保持抽出
 - [psv_scatter_by_mask](docs/psv_scatter_by_mask.md) - compact PSV の score を mask 対応で元 shard に書き戻し
 - [relabel_psv](docs/relabel_psv.md) - PSV score の勝敗ラベル置換、宣言勝ち override、diversion 整合性 deblunder

--- a/crates/tools/docs/psv_dual_label.md
+++ b/crates/tools/docs/psv_dual_label.md
@@ -1,7 +1,7 @@
 # psv_dual_label
 
-`psv_dual_label` は通常 PSV と行対応 sidecar から dual-label PSV を生成し、逆抽出と
-fail-closed 検証を行うツールです。dual-label PSV は dedup / shuffle で base score、
+`psv_dual_label` は通常 PSV の score sidecar への退避、行対応 sidecar からの
+dual-label PSV 生成、逆抽出、fail-closed 検証を行うツールです。dual-label PSV は dedup / shuffle で base score、
 DL score、entered gate bit を一つの 40 byte レコードとして原子的に運ぶための形式です。
 
 ## レコード形式
@@ -27,6 +27,21 @@ DL score、entered gate bit を一つの 40 byte レコードとして原子的�
 学習側 trainer が all 相当で読む場合は全レコードの DL score を使います。gated 相当では
 entered gate bit が 1 のレコードだけ base score を温存し、それ以外は DL score を使います。
 offset 34-35 は dual-label PSV では指し手ではないため、通常 PSV として読ませてはいけません。
+
+## dump-scores: 通常 PSV の score を退避する
+
+```bash
+cargo run -p tools --release --bin psv_dual_label -- dump-scores \
+  --base plain.psv \
+  --out-scores dl.i16
+```
+
+通常 PSV の各 40 byte レコードから score 列 (offset 32-33) を little-endian の 2 byte の
+まま入力順に転記します。出力サイズは `records × 2 byte` です。局面の decode は行いません。
+空の通常 PSV も受理し、空の sidecar を生成します。
+
+`extract --out-scores` は dual-label PSV の DL score 列 (offset 34-35、通常 PSV の move16
+列) を抽出する別の操作です。通常 PSV の score 列を退避するときは `dump-scores` を使います。
 
 ## embed: sidecar を埋め込む
 
@@ -94,7 +109,7 @@ cargo run -p tools --release --bin psv_dual_label -- validate \
 契約値と照合します。
 空 (0 レコード) の入力は embed / extract とも拒否します (validate が不正とする空の
 dual PSV を成功として publish しない)。
-`embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・fsync・サイズ検算の
+`dump-scores` / `embed` / `extract` は同じディレクトリの `<出力>.partial` に書き、全検査・fsync・サイズ検算の
 成功後だけ最終パスへ publish し、publish 後に親ディレクトリを sync します (電源断でも
 publish 済み出力が空・切り詰め状態に巻き戻らない)。publish 前にエラーになった場合は既存の最終パスを変更せず、
 `.partial` を削除します。複数出力の publish 途中で後続の rename に失敗した場合、先に publish 済みの

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -58,7 +58,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 | `relabel_psv` | PSV の score を game_result 由来値へ置換し、宣言勝ち override / diversion 整合性 deblunder / dry-run / verdict sidecar に対応（[詳細](relabel_psv.md)） |
 | `rescore_psv` | PSV 評価値を NNUE / 外部エンジン / ONNX (dlshogi・AobaZero, GPU/TensorRT) で再計算。qsearch-leaf ラベル・policy 展開・レジューム対応（[詳細](rescore_psv.md)） |
 | `psv_gate_by_king_zone` | 入玉ドメインで base / override score を合成、または行対応 mask bitmap を生成（[詳細](psv_gate_by_king_zone.md)） |
-| `psv_dual_label` | 通常 PSV + DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
+| `psv_dual_label` | 通常 PSV の score 退避、DL score / entered sidecar と dual-label PSV の相互変換・fail-closed 検証（[詳細](psv_dual_label.md)） |
 | `psv_select_by_mask` | LSB-first bitmap mask の bit 1 に対応する PSV 行を入力順にストリーミング抽出（[詳細](psv_select_by_mask.md)） |
 | `psv_scatter_by_mask` | compact PSV の score を mask 対応で元 shard にストリーミング書き戻し（[詳細](psv_scatter_by_mask.md)） |
 | `rescore_hcpe` | hcpe 教師の eval を NNUE 固定 depth 探索で付け替え（局面/結果は保持）。共有コア `teacher_labeler` 経由で `yardstick_label` とラベル bit 一致。fresh-per-position で分散ラベリング可、チャンク単位 + 途中（intra-chunk）resume 対応 |

--- a/crates/tools/src/bin/psv_dual_label.rs
+++ b/crates/tools/src/bin/psv_dual_label.rs
@@ -19,6 +19,7 @@ use tools::packed_sfen::{
 };
 
 const RECORD_SIZE: usize = PackedSfenValue::SIZE;
+const SCORE_OFFSET: usize = 32;
 const DL_SCORE_OFFSET: usize = 34;
 const PADDING_OFFSET: usize = 39;
 const BUFFER_SIZE: usize = 32 << 20;
@@ -37,6 +38,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// 通常 PSV の score 列を sidecar に退避する
+    DumpScores {
+        /// score を読み出す通常 PSV
+        #[arg(long)]
+        base: PathBuf,
+        /// little-endian i16 × records の score sidecar
+        #[arg(long)]
+        out_scores: PathBuf,
+    },
     /// 通常 PSV と score/mask sidecar を dual-label PSV に埋め込む
     Embed {
         /// base score を持つ通常 PSV
@@ -90,6 +100,11 @@ struct EmbedStats {
     records: u64,
     overwritten_nonzero_move16: u64,
     overwritten_nonzero_padding: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DumpScoresStats {
+    records: u64,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -193,6 +208,62 @@ fn remove_staging(paths: &[PathBuf]) {
             eprintln!("staging file cleanup failed: {}: {error}", path.display());
         }
     }
+}
+
+fn dump_scores(base: &Path, out_scores: &Path) -> Result<DumpScoresStats> {
+    dump_scores_with_chunk_records(base, out_scores, CHUNK_RECORDS)
+}
+
+fn dump_scores_with_chunk_records(
+    base: &Path,
+    out_scores: &Path,
+    chunk_records: usize,
+) -> Result<DumpScoresStats> {
+    anyhow::ensure!(chunk_records > 0, "chunk_records must be positive");
+    let staging = partial_path(out_scores);
+    // preflight (サイズ・パス検査) の失敗でも過去 run の残骸 .partial を掃除するため、
+    // 検査もすべて cleanup 付きクロージャの内側で行う
+    let result = (|| {
+        let records = checked_psv_records(base)?;
+        ensure_safe_output_path(out_scores, base)?;
+        ensure_safe_output_path(&staging, base)?;
+        ensure_distinct_output_paths(out_scores, &staging)?;
+        let mut reader = BufReader::with_capacity(BUFFER_SIZE, File::open(base)?);
+        let mut writer = BufWriter::with_capacity(BUFFER_SIZE, File::create(&staging)?);
+        let mut base_chunk = Vec::with_capacity(chunk_records * RECORD_SIZE);
+        let mut score_chunk = Vec::with_capacity(chunk_records * 2);
+        let mut stats = DumpScoresStats::default();
+
+        while stats.records < records {
+            let current_records = (records - stats.records).min(chunk_records as u64) as usize;
+            read_bytes(&mut reader, &mut base_chunk, current_records * RECORD_SIZE)?;
+            score_chunk.clear();
+            score_chunk.reserve(current_records * 2);
+            for record in base_chunk.chunks_exact(RECORD_SIZE) {
+                score_chunk.extend_from_slice(&record[SCORE_OFFSET..SCORE_OFFSET + 2]);
+            }
+            writer.write_all(&score_chunk)?;
+            stats.records += current_records as u64;
+        }
+
+        writer.flush()?;
+        writer.into_inner()?.sync_all()?;
+        let expected = records * 2;
+        let actual = file_size(&staging)?;
+        anyhow::ensure!(
+            actual == expected,
+            "score output size mismatch: expected={expected}, actual={actual}"
+        );
+        publish_staged(&[(&staging, out_scores)])?;
+        Ok(stats)
+    })();
+    if result.is_err() {
+        // base が「<out>.partial」そのものだと staging == base になる — 入力を消さない
+        if ensure_safe_output_path(&staging, base).is_ok() {
+            remove_staging(&[staging]);
+        }
+    }
+    result
 }
 
 fn publish_staged(outputs: &[(&Path, &Path)]) -> Result<()> {
@@ -669,6 +740,10 @@ fn validate(path: &Path, config: ValidateConfig) -> Result<ValidationStats> {
 
 fn main() -> Result<()> {
     match Cli::parse().command {
+        Command::DumpScores { base, out_scores } => {
+            let stats = dump_scores(&base, &out_scores)?;
+            println!("records={}", stats.records);
+        }
         Command::Embed {
             base,
             scores,
@@ -804,6 +879,113 @@ mod tests {
             assert_eq!(fs::read(&extracted_scores)?, fs::read(&scores)?);
             assert_eq!(fs::read(&extracted_mask)?, fs::read(&mask)?);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn dump_embed_extract_scores_roundtrip() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("plain.psv");
+        let dumped_scores = dir.path().join("dumped.i16");
+        let mask = dir.path().join("entered.bits");
+        let dual = dir.path().join("dual.psv");
+        let extracted_scores = dir.path().join("extracted.i16");
+        fs::write(&base, base_records(17, 0)?)?;
+        fs::write(&mask, sidecars(17, 0).1)?;
+
+        let stats = dump_scores(&base, &dumped_scores)?;
+        embed(&base, &dumped_scores, &mask, &dual)?;
+        extract(&dual, None, Some(&extracted_scores), None)?;
+
+        assert_eq!(stats.records, 17);
+        assert_eq!(fs::read(&extracted_scores)?, fs::read(&dumped_scores)?);
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_handles_empty_single_and_chunk_boundary_inputs() -> Result<()> {
+        const TEST_CHUNK_RECORDS: usize = 3;
+        for count in [0, 1, TEST_CHUNK_RECORDS + 1] {
+            let dir = tempdir()?;
+            let base = dir.path().join("plain.psv");
+            let output = dir.path().join("scores.i16");
+            fs::write(&base, base_records(count, 0x5678)?)?;
+
+            let stats = dump_scores_with_chunk_records(&base, &output, TEST_CHUNK_RECORDS)?;
+
+            assert_eq!(stats.records, count as u64);
+            let actual = fs::read(output)?;
+            let expected: Vec<u8> =
+                (0..count).flat_map(|score| (score as i16).to_le_bytes()).collect();
+            assert_eq!(actual, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_reads_score_column_little_endian_golden() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("plain.psv");
+        let output = dir.path().join("scores.i16");
+        fs::write(&base, record("4k4/9/9/9/9/9/9/9/4K4 b - 1", 0x1234, 0x5678, 0)?)?;
+
+        dump_scores(&base, &output)?;
+
+        assert_eq!(fs::read(output)?, [0x34, 0x12]);
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_rejects_trailing_bytes_without_output() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("plain.psv");
+        let output = dir.path().join("scores.i16");
+        fs::write(&base, [0u8; RECORD_SIZE + 1])?;
+
+        assert!(dump_scores(&base, &output).is_err());
+        assert!(!output.exists());
+        assert!(!partial_path(&output).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_rejects_output_equal_to_base_without_truncating() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("plain.psv");
+        fs::write(&base, base_records(1, 0)?)?;
+        let original = fs::read(&base)?;
+
+        assert!(dump_scores(&base, &base).is_err());
+        assert_eq!(fs::read(base)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_base_named_like_staging_is_rejected_without_deleting_input() -> Result<()> {
+        let dir = tempdir()?;
+        let out = dir.path().join("scores.i16");
+        let base = partial_path(&out);
+        let original = base_records(1, 0)?;
+        fs::write(&base, &original)?;
+
+        assert!(dump_scores(&base, &out).is_err());
+        assert_eq!(fs::read(&base)?, original);
+        Ok(())
+    }
+
+    #[test]
+    fn dump_scores_error_preserves_existing_output_and_removes_staging() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path().join("plain.psv");
+        let output = dir.path().join("scores.i16");
+        let sentinel = b"existing scores";
+        fs::write(&base, [0u8; RECORD_SIZE + 1])?;
+        fs::write(&output, sentinel)?;
+        fs::write(partial_path(&output), b"stale partial")?;
+
+        assert!(dump_scores(&base, &output).is_err());
+        assert_eq!(fs::read(&output)?, sentinel);
+        assert!(!partial_path(&output).exists());
         Ok(())
     }
 


### PR DESCRIPTION
## 概要

`psv_dual_label embed` の `--scores` 入力 (i16 LE × records) を、通常 PSV の score 列 (offset 32-33) から生成する `dump-scores` subcommand。gated50b campaign の expand per-source dual-label 化 (score 列を d9 リラベルで書き換える前に元の DL ラベルを sidecar 退避する工程) で使用する。

- score 列の streaming 生バイト転記 (decode なし、ピークメモリ入力非依存)
- `.partial` staging + サイズ検査 (records×2) + fsync + rename の fail-closed。エラー時は staging を掃除しつつ、**staging が入力と同一実体の場合 (base が `<out>.partial` という名前) は入力を保護**
- `extract --out-scores` (dual-label PSV の move16 列を読む) との違いを doc に明記
- 既存 3 subcommand (embed/extract/validate) は挙動不変 (diff は追加のみ)

## 検証

- unit test 31 本 (roundtrip / golden byte による LE・offset 固定 / 空入力・チャンク境界 / 異常系・sentinel 温存 / staging==入力の regression)
- 実データ: 21,705,890 行の実 shard で dump 出力が numpy `[:,32:34]` と完全一致
- `cargo fmt` / `cargo clippy --tests` 警告ゼロ / abs-paths チェック PASS
- local dual review 済み (Codex 3-round: MEDIUM 2 件指摘 → 修正 → APPROVE + Claude 全 diff レビュー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiE3qM6aiwAxw1ZKgqGRXK