### PR TITLE
ci: claude-review の prompt 先頭に紛れ込んでいた重複行を削除

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## 概要

claude-code-review.yml の `prompt:` ブロック先頭に paste ミスで `prompt: |` という行が本文として二重に入っており、レビュー指示文の 1 行目がゴミになっていた。該当 1 行を削除 (YAML validate 済み)。

本 PR 自体が #1003 (action 版修正) 後の claude-review 復活確認を兼ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiE3qM6aiwAxw1ZKgqGRXK