### PR TITLE
feat(tools): psv_dedup_partition の partition buffer を自動サイズ化

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -48,7 +48,7 @@
 | `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行（[詳細](docs/migrate_psv_move16.md)） |
 | `pack_to_psv` | GenSfen .pack → PSV 変換（move16 は実着手ラベルの実 YaneuraOu 形式） |
 | `fix_scores` | スコアの補正 |
-| `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
+| `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。partition 方式は Phase 1 buffer 自動調整対応。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・重複除去・決定的 shuffle・分割（[詳細](docs/prep_hcpe.md)） |
 | `hcpe_to_psv` | hcpe → PSV 変換（Linux/macOS・Windows対応、hardlinkを含む入力と出力の同一実体を拒否。外部公開 hcpe プールの学習/検証投入用、[詳細](docs/hcpe_to_psv.md)） |
 

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -92,7 +92,7 @@ Phase 2 のピークメモリはおおよそ次の式で決まる:
 peak_memory ≈ (total_records / partitions) × entry_overhead
 ```
 
-`entry_overhead` は `HashSet<[u8; 32]>` で 1 エントリあたり 50〜70 B 程度（バケット + エントリ + load factor）。
+`entry_overhead` は `HashSet<[u8; 32]>` で 1 エントリあたり約 56 B と見積もる（バケット + エントリ + load factor）。
 
 ### 参考値（均等分布を仮定）
 
@@ -102,7 +102,25 @@ peak_memory ≈ (total_records / partitions) × entry_overhead
 | 100 億     | ~600 MiB      | ~150 MiB      |
 | 250 億     | ~1.5 GiB      | ~370 MiB      |
 
-Phase 1 の固定コストは `partitions × partition_buffer_kb`。デフォルト (`1024 × 64 KiB = 64 MiB`) で十分で、メモリが更に厳しい場合は `--partition-buffer-kb 16` 等に縮小できる。
+Phase 2 は 1 partition 分のユニーク局面を `HashSet` に載せるため、概算で
+`入力行数 / partitions × 約 56 B` が RAM に収まる partition 数を選ぶ。実際には
+ハッシュ分布の偏りと reference 分の余裕も見込むこと。
+
+### partition 数と Phase 1 buffer
+
+`--partition-buffer-kb` を省略すると、合計 1 GiB の予算を partition 数で割り、
+1 partition あたり 64 KiB〜16 MiB に clamp する。既定の 1024 partitions では
+1 MiB/partition、合計 1 GiB になる。明示指定した値はそのまま使われる。
+buffer は `BufWriter` の capacity だけを変え、partition ファイルや最終出力の
+バイト列には影響しない。
+
+HDD 上で temp を入力と同一ディスクに置く場合は、Phase 2 の概算メモリが収まる範囲で
+`--partitions` を減らし、partition ごとの buffer を厚くすると、分散 append の粒度を
+大きくできる。
+
+`--partitions` は dedup 出力の行順に影響する。出力は bucket 番号順に partition を
+連結するため、値を変えると同じユニーク集合でも行順が変わる。既存レシピの出力を
+bit 再現するには同じ値が必要であり、この互換性のため既定値は 1024 のまま維持する。
 
 ## 一時ディスク
 
@@ -226,7 +244,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 | `--output` | 出力ファイルパス | — |
 | `--temp-dir` | パーティション一時ファイルの置き場 | `./psv_dedup_partition_tmp` |
 | `--partitions` | パーティション数 | `1024` |
-| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB) | `64` |
+| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB)。省略時は合計 1 GiB 予算で自動算出 | 自動 (64 KiB〜16 MiB/partition) |
 | `--max-positions` | 処理する入力レコードの最大件数（0 = 全件、試走用）。参照は常に全件 | `0` |
 | `--dedup-only` | Phase 1 をスキップして既存一時ファイルから再開（ref/ は自動検出） | off |
 | `--partition-only` | Phase 2 をスキップして Phase 1 (振り分け) のみ実行（既存 partition には append） | off |
@@ -251,4 +269,4 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 
 - 入力と出力が同一ファイルの場合はエラー
 - キーは PackedSfen のみ。同一局面に対する複数の教師手がある場合は `psv_dedup` と同様、最初の出現だけ残す
-- パーティション出力の順序は保存されない（ハッシュ順）。順序を保ちたい場合は後段で `shuffle_psv` 等を使う
+- パーティション出力の順序は保存されない（bucket 番号順）。`--partitions` を変えると行順も変わるため、bit 再現には同じ値を使う

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -108,11 +108,58 @@ Phase 2 は 1 partition 分のユニーク局面を `HashSet` に載せるため
 
 ### partition 数と Phase 1 buffer
 
-`--partition-buffer-kb` を省略すると、合計 1 GiB の予算を partition 数で割り、
-1 partition あたり 64 KiB〜16 MiB に clamp する。既定の 1024 partitions では
-1 MiB/partition、合計 1 GiB になる。明示指定した値はそのまま使われる。
+`--partition-buffer-kb` を省略すると、合計最大 1 GiB（起動時の利用可能メモリの
+50% 以下）の予算を partition 数で割り、1 partition あたり 64 KiB〜16 MiB に
+clamp する。利用可能メモリが 2 GiB 以上なら、
+既定の 1024 partitions では
+1 MiB/partition、合計 1 GiB になる。低メモリ環境では自動的に縮小し、従来の
+合計 64 MiB を下限とする（partition 数を変えた場合の合計下限も変わる）。
+明示指定した値はそのまま使われる。
 buffer は `BufWriter` の capacity だけを変え、partition ファイルや最終出力の
 バイト列には影響しない。
+
+#### buffer 予算の実測 (2026-08-22)
+
+既定値は、実運用の 1.95 TB PSV の先頭 6 億レコード (24.0 GB) を使い、入力と
+temp を同じ単発 HDD に置いた Phase 1 の A/B で決めた。Windows 11
+(10.0.26200)、計測開始時の利用可能メモリ 102.5 GiB、`release` build
+(`7d3df59d`) で、先行 warm-up 後に旧既定と新既定を 5 回ずつ実行した。試行順は
+`old→new / old→new / new→old / old→new / new→old` とした。wall time は最終 flush
+を含み、プロセスの working set と private bytes は 250 ms 間隔で採取した。
+
+```powershell
+target/release/psv_dedup_partition.exe `
+  --input /path/to/production.psv `
+  --temp-dir /path/to/same-hdd/temp `
+  --partitions 1024 `
+  --partition-buffer-kb <64|256|1024> `
+  --max-positions 600000000 `
+  --partition-only
+```
+
+| buffer / partition | 合計 buffer | wall time (raw) | 中央値 | 平均 throughput | peak working set | peak private bytes |
+|---:|---:|---:|---:|---:|---:|---:|
+| 64 KiB (旧既定) | 64 MiB | 154.1 / 168.9 / 179.9 / 186.4 / 178.3 s | 178.3 s | 3.46 M rec/s | 24.2 MiB | 73.9 MiB |
+| 1 MiB (新上限) | 1 GiB | 152.8 / 154.1 / 202.3 / 162.4 / 166.7 s | 162.4 s | 3.58 M rec/s | 35.6 MiB | 1039.8 MiB |
+
+1 MiB は paired 5 回中 4 回で速く、平均 wall time は 3.4%短縮、paired 改善率の
+中央値は 6.5%だった。ただし raw range は重なり、1 回は 12.5%悪化しているため、
+これは分散 write 改善の存在を示す探索的測定であり、安定した効果量の推定ではない。
+参考に 256 KiB も 2 回測ったが 163.2 / 165.7 s で、1 MiB の代替になる明確な結果は
+得られなかった。
+
+Windows の peak working set 増加は 11.5 MiB でも private commit は約 966 MiB 増える。
+このため 1 GiB は無条件の固定値ではなく、高メモリ環境での自動予算の上限とした。
+利用可能メモリが 2 GiB 未満ならその 50%を目標に縮小し（既定 1024 partitions では
+合計 64 MiB が下限）、preflight が判定する Phase 1 memory は private commit に
+合わせる。メモリを優先する環境や測定結果が異なる
+ストレージでは `--partition-buffer-kb` を明示して縮小する。
+
+この A/B は分散 write の定常挙動を比較する warm-cache 測定であり、2 TB 全体の
+before/after 実測ではないため、2 TB の所要時間へは外挿しない。別途、同じ 2.08 TB
+の本番処理は 256 partitions × 16 MiB (合計 4 GiB)、入力 HDD・
+temp NVMe の条件で 2.8 h (5.2 M rec/s) だった。この本番値は規模の sanity check で、
+partition 数とストレージ配置が違うため上記 A/B の効果量には含めない。
 
 HDD 上で temp を入力と同一ディスクに置く場合は、Phase 2 の概算メモリが収まる範囲で
 `--partitions` を減らし、partition ごとの buffer を厚くすると、分散 append の粒度を
@@ -244,7 +291,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 | `--output` | 出力ファイルパス | — |
 | `--temp-dir` | パーティション一時ファイルの置き場 | `./psv_dedup_partition_tmp` |
 | `--partitions` | パーティション数 | `1024` |
-| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB)。省略時は合計 1 GiB 予算で自動算出 | 自動 (64 KiB〜16 MiB/partition) |
+| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB)。省略時は合計最大 1 GiB・利用可能メモリの 50% 以下で自動算出 | 自動 (64 KiB〜16 MiB/partition) |
 | `--max-positions` | 処理する入力レコードの最大件数（0 = 全件、試走用）。参照は常に全件 | `0` |
 | `--dedup-only` | Phase 1 をスキップして既存一時ファイルから再開（ref/ は自動検出） | off |
 | `--partition-only` | Phase 2 をスキップして Phase 1 (振り分け) のみ実行（既存 partition には append） | off |

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -63,7 +63,7 @@ Phase 2 の流れ (パーティションごと):
 === Resource Estimate ===
 Total input records:  17000000000 (680000000000 bytes / 40)
 Phase 1 temp disk:    633.2 GiB (cleaned up on success)
-Phase 1 memory:       0.5 GiB (fixed: partitions × buffer)
+Phase 1 memory:       1.0 GiB (fixed: partitions × buffer)
 Phase 2 peak memory:  1.3 GiB (HashSet of largest partition, ~1.20x variance)
 Memory available:     64.0 GiB (threshold 80% = 51.2 GiB)
 Temp disk available:  8.0 TiB (/fast/ssd/tmp)
@@ -72,7 +72,7 @@ Output disk:          same filesystem as temp (/fast/ssd). 追加 headroom ...
 
 チェック内容:
 
-- **メモリ**: `Phase1 mem` と `Phase2 peak mem` のうち大きい方が OS の利用可能メモリ × 80% を超えたら Err。利用可能メモリを取得できない場合も `--force` なしでは停止
+- **メモリ**: `Phase1 mem` と `Phase2 peak mem` のうち大きい方が OS の利用可能メモリ × 80% を超えたら Err。`--dedup-only` では Phase 2 のみを検査する。利用可能メモリを取得できない場合も `--force` なしでは停止
 - **temp ディスク**: 入力合計 × 1.05 が `--temp-dir` の空きを超えたら Err
 - **output ディスク**: 出力上限 = 入力合計（dedup しない最悪ケース）× 1.05 が出力親ディレクトリの空きを超えたら Err。temp と同一ファイルシステムの場合もチェックは省略しない。`--keep-temp` なしでは「処理中の最大 input partition」ぶんの追加 headroom、`--keep-temp` ありでは output 全量ぶんの追加空き容量を要求する
 - 不足時は停止。`--force` を付けると Warning を出して続行する（swap 多用・途中失敗のリスクを許容する場合のみ）

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -64,7 +64,7 @@ Phase 2 の流れ (パーティションごと):
 Total input records:  17000000000 (680000000000 bytes / 40)
 Phase 1 temp disk:    633.2 GiB (cleaned up on success)
 Phase 1 memory:       1.0 GiB (fixed: partitions × buffer)
-Phase 2 peak memory:  1.3 GiB (HashSet of largest partition, ~1.20x variance)
+Phase 2 peak memory:  1.0 GiB (HashSet of largest partition, ~1.20x variance)
 Memory available:     64.0 GiB (threshold 80% = 51.2 GiB)
 Temp disk available:  8.0 TiB (/fast/ssd/tmp)
 Output disk:          same filesystem as temp (/fast/ssd). 追加 headroom ...

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -79,7 +79,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 |--------|------|
 | `psv_dedup` | PSV ファイルの局面重複削除（HashSet 方式、中規模向け） |
 | `psv_dedup_bloom` | 大規模 PSV ファイルのブルームフィルタ重複除去（数百億レコード対応、近似） |
-| `psv_dedup_partition` | ディスクパーティション方式の exact 重複除去（低メモリ・大規模向け） |
+| `psv_dedup_partition` | ディスクパーティション方式の exact 重複除去（低メモリ・大規模向け、Phase 1 buffer 自動調整） |
 | `psv_dedup_check` | PSV ファイルの重複率を統計出力（近似モード・正確モード対応） |
 | `validate_sfens` | SFEN テキストの不正局面を検出・除去（文法・玉の存在・駒数超過・二歩など） |
 

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -62,6 +62,9 @@ use tools::common::memory::available_memory_bytes;
 
 const INPUT_SUBDIR: &str = "input";
 const REF_SUBDIR: &str = "ref";
+const PARTITION_BUFFER_BUDGET_KB: usize = 1024 * 1024;
+const MIN_PARTITION_BUFFER_KB: usize = 64;
+const MAX_PARTITION_BUFFER_KB: usize = 16 * 1024;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -95,14 +98,15 @@ struct Args {
     #[arg(long, default_value = "./psv_dedup_partition_tmp")]
     temp_dir: PathBuf,
 
-    /// パーティション数。多いほど Phase 2 の 1 パーティションあたりメモリが減るが
-    /// file descriptor と出力バッファの総量が増える。
+    /// パーティション数。多いほど Phase 2 の 1 パーティションあたりメモリが減るが、
+    /// file descriptor が増える。Phase 1 の自動バッファは合計約 1 GiB。
     #[arg(long, default_value = "1024")]
     partitions: usize,
 
-    /// Phase 1 でパーティションごとに確保する BufWriter のバッファサイズ (KiB)
-    #[arg(long, default_value = "64")]
-    partition_buffer_kb: usize,
+    /// Phase 1 でパーティションごとに確保する BufWriter のバッファサイズ (KiB)。
+    /// 省略時は合計 1 GiB を partitions で割り、64 KiB〜16 MiB に収める。
+    #[arg(long)]
+    partition_buffer_kb: Option<usize>,
 
     /// 処理する入力レコードの最大件数（0 = 全件、試走向け）。
     /// 参照ファイルは常に全件読み込まれる。
@@ -152,6 +156,13 @@ const DISK_SAFETY_FACTOR: f64 = 1.05;
 
 /// メモリ不足判定のしきい値（利用可能メモリの 80%）。
 const MEM_THRESHOLD_FACTOR: f64 = 0.8;
+
+fn resolve_partition_buffer_kb(requested_kb: Option<usize>, num_partitions: usize) -> usize {
+    requested_kb.unwrap_or_else(|| {
+        (PARTITION_BUFFER_BUDGET_KB / num_partitions)
+            .clamp(MIN_PARTITION_BUFFER_KB, MAX_PARTITION_BUFFER_KB)
+    })
+}
 
 struct ResourceEstimate {
     total_records: u64,
@@ -278,7 +289,11 @@ fn preflight_check_with_available_memory(
         HASH_VARIANCE_FACTOR,
     );
 
-    let peak_mem = estimate.phase1_memory_bytes.max(estimate.phase2_peak_memory_bytes);
+    let peak_mem = if skip_temp_check {
+        estimate.phase2_peak_memory_bytes
+    } else {
+        estimate.phase1_memory_bytes.max(estimate.phase2_peak_memory_bytes)
+    };
 
     // --- メモリチェック ---
     if let Some(avail) = available_memory {
@@ -896,7 +911,7 @@ fn main() -> io::Result<()> {
             "--partitions は 1 以上を指定してください",
         ));
     }
-    if args.partition_buffer_kb == 0 {
+    if args.partition_buffer_kb == Some(0) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "--partition-buffer-kb は 1 以上を指定してください",
@@ -939,7 +954,9 @@ fn main() -> io::Result<()> {
         ));
     }
 
-    let partition_buffer_bytes = args.partition_buffer_kb * 1024;
+    let partition_buffer_kb =
+        resolve_partition_buffer_kb(args.partition_buffer_kb, args.partitions);
+    let partition_buffer_bytes = partition_buffer_kb * 1024;
     let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
     let ref_subdir = args.temp_dir.join(REF_SUBDIR);
     // --partition-only では temp を消したら意味がない（次回起動で再利用するため）。
@@ -1079,7 +1096,7 @@ fn main() -> io::Result<()> {
         eprintln!("=== Phase 1: Partitioning ({partitions} partitions) ===");
         eprintln!(
             "  partition buffer: {} KiB/partition (total ~{:.1} MiB)",
-            args.partition_buffer_kb,
+            partition_buffer_kb,
             (partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
         );
 
@@ -1298,7 +1315,7 @@ fn run_partition_only(
     );
     eprintln!(
         "  partition buffer: {} KiB/partition (total ~{:.1} MiB)",
-        args.partition_buffer_kb,
+        resolve_partition_buffer_kb(args.partition_buffer_kb, partitions),
         (partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
     );
 
@@ -1385,10 +1402,10 @@ mod tests {
     }
 
     #[test]
-    fn dedup_only_preflight_succeeds_when_memory_is_available() {
+    fn dedup_only_preflight_ignores_phase1_buffer_memory() {
         let dir = TempDir::new().unwrap();
         let output = dir.path().join("output.bin");
-        let estimate = estimate_resources(0, 0, 1, 0);
+        let estimate = estimate_resources(0, 0, 1, 1 << 30);
 
         preflight_check_with_available_memory(
             &estimate,
@@ -1397,9 +1414,90 @@ mod tests {
             true,
             false,
             false,
-            Some(u64::MAX),
+            Some(1 << 30),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn partition_buffer_auto_size_uses_budget_and_clamps() {
+        assert_eq!(resolve_partition_buffer_kb(None, 1), 16 * 1024);
+        assert_eq!(resolve_partition_buffer_kb(None, 1024), 1024);
+        assert_eq!(resolve_partition_buffer_kb(None, 32 * 1024), 64);
+        assert_eq!(resolve_partition_buffer_kb(Some(8192), 1024), 8192);
+    }
+
+    #[test]
+    fn partition_and_dedup_output_is_independent_of_buffer_size() {
+        let make_psv = |sfen_seed: u8, payload: u8| -> [u8; PSV_SIZE] {
+            let mut buf = [payload; PSV_SIZE];
+            for (i, b) in buf[..SFEN_SIZE].iter_mut().enumerate() {
+                *b = sfen_seed.wrapping_add(i as u8);
+            }
+            buf
+        };
+        let records = [
+            make_psv(1, 10),
+            make_psv(2, 20),
+            make_psv(1, 11),
+            make_psv(3, 30),
+            make_psv(2, 21),
+            make_psv(4, 40),
+        ];
+        let workdir = TempDir::new().unwrap();
+        let input = workdir.path().join("input.bin");
+        {
+            let mut file = File::create(&input).unwrap();
+            for record in records {
+                file.write_all(&record).unwrap();
+            }
+        }
+
+        let small_dir = workdir.path().join("small");
+        let large_dir = workdir.path().join("large");
+        let small_partitions = small_dir.join(INPUT_SUBDIR);
+        let large_partitions = large_dir.join(INPUT_SUBDIR);
+        let num_partitions = 4;
+
+        partition_files_into(
+            "input",
+            std::slice::from_ref(&input),
+            &small_partitions,
+            num_partitions,
+            64 * 1024,
+            0,
+            false,
+            false,
+        )
+        .unwrap();
+        partition_files_into(
+            "input",
+            std::slice::from_ref(&input),
+            &large_partitions,
+            num_partitions,
+            8 * 1024 * 1024,
+            0,
+            false,
+            false,
+        )
+        .unwrap();
+
+        for partition in 0..num_partitions {
+            let small =
+                std::fs::read(small_partitions.join(partition_filename(partition))).unwrap();
+            let large =
+                std::fs::read(large_partitions.join(partition_filename(partition))).unwrap();
+            assert_eq!(small, large, "partition {partition} differs");
+        }
+
+        let small_output = small_dir.join("output.bin");
+        let large_output = large_dir.join("output.bin");
+        deduplicate_partitions(&small_partitions, None, num_partitions, &small_output, true)
+            .unwrap();
+        deduplicate_partitions(&large_partitions, None, num_partitions, &large_output, true)
+            .unwrap();
+
+        assert_eq!(std::fs::read(small_output).unwrap(), std::fs::read(large_output).unwrap());
     }
 
     #[test]

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -219,13 +219,13 @@ fn same_fs_output_headroom_bytes(estimate: &ResourceEstimate, keep_temp: bool) -
 fn output_disk_required_bytes(
     estimate: &ResourceEstimate,
     same_fs: bool,
-    skip_temp_check: bool,
+    phase1_skipped: bool,
     keep_temp: bool,
 ) -> u64 {
     if same_fs {
         let same_fs_headroom =
             (same_fs_output_headroom_bytes(estimate, keep_temp) as f64 * DISK_SAFETY_FACTOR) as u64;
-        if skip_temp_check {
+        if phase1_skipped {
             same_fs_headroom
         } else {
             ((estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64)
@@ -244,7 +244,7 @@ fn preflight_check(
     estimate: &ResourceEstimate,
     temp_dir: &Path,
     output_path: Option<&Path>,
-    skip_temp_check: bool,
+    phase1_skipped: bool,
     keep_temp: bool,
     force: bool,
 ) -> io::Result<()> {
@@ -252,7 +252,7 @@ fn preflight_check(
         estimate,
         temp_dir,
         output_path,
-        skip_temp_check,
+        phase1_skipped,
         keep_temp,
         force,
         available_memory_bytes(),
@@ -263,7 +263,7 @@ fn preflight_check_with_available_memory(
     estimate: &ResourceEstimate,
     temp_dir: &Path,
     output_path: Option<&Path>,
-    skip_temp_check: bool,
+    phase1_skipped: bool,
     keep_temp: bool,
     force: bool,
     available_memory: Option<u64>,
@@ -273,7 +273,7 @@ fn preflight_check_with_available_memory(
         "Total input records:  {} ({} bytes / {})",
         estimate.total_records, estimate.phase1_temp_bytes, PSV_SIZE
     );
-    if !skip_temp_check {
+    if !phase1_skipped {
         eprintln!(
             "Phase 1 temp disk:    {} (cleaned up on success)",
             format_gib(estimate.phase1_temp_bytes),
@@ -289,7 +289,7 @@ fn preflight_check_with_available_memory(
         HASH_VARIANCE_FACTOR,
     );
 
-    let peak_mem = if skip_temp_check {
+    let peak_mem = if phase1_skipped {
         estimate.phase2_peak_memory_bytes
     } else {
         estimate.phase1_memory_bytes.max(estimate.phase2_peak_memory_bytes)
@@ -340,7 +340,7 @@ fn preflight_check_with_available_memory(
         }
     });
 
-    if !skip_temp_check {
+    if !phase1_skipped {
         let temp_required = (estimate.phase1_temp_bytes as f64 * DISK_SAFETY_FACTOR) as u64;
         if let Some(avail) = get_disk_available(temp_dir) {
             eprintln!("Temp disk available:  {} ({})", format_gib(avail), temp_dir.display());
@@ -385,9 +385,9 @@ fn preflight_check_with_available_memory(
                     }
                 );
                 let same_fs_required =
-                    output_disk_required_bytes(estimate, true, skip_temp_check, keep_temp);
+                    output_disk_required_bytes(estimate, true, phase1_skipped, keep_temp);
                 if same_fs_required > avail {
-                    let msg = if skip_temp_check {
+                    let msg = if phase1_skipped {
                         format!(
                             "出力ディスク不足: same filesystem 上で Phase 2 に追加 headroom {} 必要ですが \
                              {} しか空きがありません ({})。\n\
@@ -1051,7 +1051,7 @@ fn main() -> io::Result<()> {
             &estimate,
             &args.temp_dir,
             Some(output_path),
-            /* skip_temp_check = */ true,
+            /* phase1_skipped = */ true,
             args.keep_temp,
             args.force,
         )?;
@@ -1088,7 +1088,7 @@ fn main() -> io::Result<()> {
             &estimate,
             &args.temp_dir,
             Some(output_path),
-            /* skip_temp_check = */ false,
+            /* phase1_skipped = */ false,
             args.keep_temp,
             args.force,
         )?;
@@ -1300,7 +1300,7 @@ fn run_partition_only(
         &estimate,
         &args.temp_dir,
         /* output_path = */ None,
-        /* skip_temp_check = */ false,
+        /* phase1_skipped = */ false,
         keep_temp,
         args.force,
     )?;
@@ -1315,7 +1315,7 @@ fn run_partition_only(
     );
     eprintln!(
         "  partition buffer: {} KiB/partition (total ~{:.1} MiB)",
-        resolve_partition_buffer_kb(args.partition_buffer_kb, partitions),
+        partition_buffer_bytes / 1024,
         (partitions * partition_buffer_bytes) as f64 / (1024.0 * 1024.0),
     );
 
@@ -1429,27 +1429,27 @@ mod tests {
 
     #[test]
     fn partition_and_dedup_output_is_independent_of_buffer_size() {
-        let make_psv = |sfen_seed: u8, payload: u8| -> [u8; PSV_SIZE] {
+        let make_psv = |sfen_seed: u32, payload: u8| -> [u8; PSV_SIZE] {
             let mut buf = [payload; PSV_SIZE];
-            for (i, b) in buf[..SFEN_SIZE].iter_mut().enumerate() {
-                *b = sfen_seed.wrapping_add(i as u8);
+            buf[..4].copy_from_slice(&sfen_seed.to_le_bytes());
+            for (i, b) in buf[4..SFEN_SIZE].iter_mut().enumerate() {
+                *b = i as u8;
             }
             buf
         };
-        let records = [
-            make_psv(1, 10),
-            make_psv(2, 20),
-            make_psv(1, 11),
-            make_psv(3, 30),
-            make_psv(2, 21),
-            make_psv(4, 40),
-        ];
+        let mut records: Vec<_> = (0..2_000).map(|i| make_psv(i, (i % 251) as u8)).collect();
+        let small_buffer_bytes = 64 * 1024;
+        let first_record_after_flush = small_buffer_bytes / PSV_SIZE;
+        records[first_record_after_flush - 1] = make_psv(9_000, 0xa1);
+        records[first_record_after_flush] = make_psv(9_001, 0xb2);
+        records[first_record_after_flush + 1] = make_psv(9_000, 0xc3);
+        assert!(records.len() * PSV_SIZE > small_buffer_bytes);
         let workdir = TempDir::new().unwrap();
         let input = workdir.path().join("input.bin");
         {
             let mut file = File::create(&input).unwrap();
-            for record in records {
-                file.write_all(&record).unwrap();
+            for record in &records {
+                file.write_all(record).unwrap();
             }
         }
 
@@ -1457,14 +1457,14 @@ mod tests {
         let large_dir = workdir.path().join("large");
         let small_partitions = small_dir.join(INPUT_SUBDIR);
         let large_partitions = large_dir.join(INPUT_SUBDIR);
-        let num_partitions = 4;
+        let num_partitions = 1;
 
         partition_files_into(
             "input",
             std::slice::from_ref(&input),
             &small_partitions,
             num_partitions,
-            64 * 1024,
+            small_buffer_bytes,
             0,
             false,
             false,

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -65,6 +65,7 @@ const REF_SUBDIR: &str = "ref";
 const PARTITION_BUFFER_BUDGET_KB: usize = 1024 * 1024;
 const MIN_PARTITION_BUFFER_KB: usize = 64;
 const MAX_PARTITION_BUFFER_KB: usize = 16 * 1024;
+const AUTO_BUFFER_AVAILABLE_MEMORY_DIVISOR: u64 = 2;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -99,12 +100,13 @@ struct Args {
     temp_dir: PathBuf,
 
     /// パーティション数。多いほど Phase 2 の 1 パーティションあたりメモリが減るが、
-    /// file descriptor が増える。Phase 1 の自動バッファは合計約 1 GiB。
+    /// file descriptor が増える。Phase 1 の自動バッファは合計最大 1 GiB。
     #[arg(long, default_value = "1024")]
     partitions: usize,
 
     /// Phase 1 でパーティションごとに確保する BufWriter のバッファサイズ (KiB)。
-    /// 省略時は合計 1 GiB を partitions で割り、64 KiB〜16 MiB に収める。
+    /// 省略時は合計最大 1 GiB（利用可能メモリの 50% 以下）を partitions で割り、
+    /// 64 KiB〜16 MiB に収める。既定の 1024 partitions では合計 64 MiB が下限。
     #[arg(long)]
     partition_buffer_kb: Option<usize>,
 
@@ -157,10 +159,20 @@ const DISK_SAFETY_FACTOR: f64 = 1.05;
 /// メモリ不足判定のしきい値（利用可能メモリの 80%）。
 const MEM_THRESHOLD_FACTOR: f64 = 0.8;
 
-fn resolve_partition_buffer_kb(requested_kb: Option<usize>, num_partitions: usize) -> usize {
+fn resolve_partition_buffer_kb(
+    requested_kb: Option<usize>,
+    num_partitions: usize,
+    available_memory: Option<u64>,
+) -> usize {
     requested_kb.unwrap_or_else(|| {
-        (PARTITION_BUFFER_BUDGET_KB / num_partitions)
-            .clamp(MIN_PARTITION_BUFFER_KB, MAX_PARTITION_BUFFER_KB)
+        let memory_budget_kb = available_memory
+            .map(|bytes| {
+                usize::try_from(bytes / AUTO_BUFFER_AVAILABLE_MEMORY_DIVISOR / 1024)
+                    .unwrap_or(usize::MAX)
+            })
+            .unwrap_or(PARTITION_BUFFER_BUDGET_KB);
+        let budget_kb = PARTITION_BUFFER_BUDGET_KB.min(memory_budget_kb);
+        (budget_kb / num_partitions).clamp(MIN_PARTITION_BUFFER_KB, MAX_PARTITION_BUFFER_KB)
     })
 }
 
@@ -247,6 +259,7 @@ fn preflight_check(
     phase1_skipped: bool,
     keep_temp: bool,
     force: bool,
+    available_memory: Option<u64>,
 ) -> io::Result<()> {
     preflight_check_with_available_memory(
         estimate,
@@ -255,7 +268,7 @@ fn preflight_check(
         phase1_skipped,
         keep_temp,
         force,
-        available_memory_bytes(),
+        available_memory,
     )
 }
 
@@ -308,7 +321,8 @@ fn preflight_check_with_available_memory(
             let msg = format!(
                 "メモリ不足: 推定ピーク {} が threshold {} を超えます。\n\
                  対処法:\n\
-                 - --partitions を大きくする（1 パーティションのメモリが減る）\n\
+                 - Phase 1 memory が支配的なら --partition-buffer-kb を小さくする\n\
+                 - Phase 2 memory が支配的なら --partitions を大きくする\n\
                  - --force で強制続行（swap 使用の可能性）",
                 format_gib(peak_mem),
                 format_gib(threshold),
@@ -954,8 +968,9 @@ fn main() -> io::Result<()> {
         ));
     }
 
+    let available_memory = available_memory_bytes();
     let partition_buffer_kb =
-        resolve_partition_buffer_kb(args.partition_buffer_kb, args.partitions);
+        resolve_partition_buffer_kb(args.partition_buffer_kb, args.partitions, available_memory);
     let partition_buffer_bytes = partition_buffer_kb * 1024;
     let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
     let ref_subdir = args.temp_dir.join(REF_SUBDIR);
@@ -969,6 +984,7 @@ fn main() -> io::Result<()> {
             &ref_subdir,
             partition_buffer_bytes,
             keep_temp,
+            available_memory,
         );
     }
 
@@ -1054,6 +1070,7 @@ fn main() -> io::Result<()> {
             /* phase1_skipped = */ true,
             args.keep_temp,
             args.force,
+            available_memory,
         )?;
 
         (0u64, 0u64)
@@ -1091,6 +1108,7 @@ fn main() -> io::Result<()> {
             /* phase1_skipped = */ false,
             args.keep_temp,
             args.force,
+            available_memory,
         )?;
 
         eprintln!("=== Phase 1: Partitioning ({partitions} partitions) ===");
@@ -1203,6 +1221,7 @@ fn run_partition_only(
     ref_subdir: &Path,
     partition_buffer_bytes: usize,
     keep_temp: bool,
+    available_memory: Option<u64>,
 ) -> io::Result<()> {
     // ---- 早期検証 (重い I/O 前に全て返す) ----
     let ref_paths = match args.reference.as_deref() {
@@ -1303,6 +1322,7 @@ fn run_partition_only(
         /* phase1_skipped = */ false,
         keep_temp,
         args.force,
+        available_memory,
     )?;
 
     eprintln!(
@@ -1420,11 +1440,34 @@ mod tests {
     }
 
     #[test]
-    fn partition_buffer_auto_size_uses_budget_and_clamps() {
-        assert_eq!(resolve_partition_buffer_kb(None, 1), 16 * 1024);
-        assert_eq!(resolve_partition_buffer_kb(None, 1024), 1024);
-        assert_eq!(resolve_partition_buffer_kb(None, 32 * 1024), 64);
-        assert_eq!(resolve_partition_buffer_kb(Some(8192), 1024), 8192);
+    fn partition_buffer_auto_size_uses_memory_aware_budget_and_clamps() {
+        assert_eq!(resolve_partition_buffer_kb(None, 1, None), 16 * 1024);
+        assert_eq!(resolve_partition_buffer_kb(None, 1024, None), 1024);
+        assert_eq!(resolve_partition_buffer_kb(None, 32 * 1024, None), 64);
+        assert_eq!(resolve_partition_buffer_kb(None, 1024, Some(1 << 30)), 512);
+        assert_eq!(resolve_partition_buffer_kb(None, 1024, Some(128 << 20)), 64);
+        assert_eq!(resolve_partition_buffer_kb(Some(8192), 1024, Some(1)), 8192);
+    }
+
+    #[test]
+    fn low_memory_auto_buffer_preserves_small_job_preflight() {
+        let dir = TempDir::new().unwrap();
+        let available_memory = 1 << 30;
+        let partitions = 1024;
+        let buffer_kb = resolve_partition_buffer_kb(None, partitions, Some(available_memory));
+        let estimate = estimate_resources(0, PSV_SIZE as u64, partitions, buffer_kb * 1024);
+
+        preflight_check_with_available_memory(
+            &estimate,
+            dir.path(),
+            None,
+            false,
+            true,
+            false,
+            Some(available_memory),
+        )
+        .unwrap();
+        assert_eq!(estimate.phase1_memory_bytes, 512 << 20);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`--partition-buffer-kb` の既定 (64 KiB 固定) は、既定 `--partitions 1024` と合わせると Phase 1 の出力バッファ合計が 64 MiB しかなく、TB 級入力を HDD 上で処理する際に 1024 ファイルへの細粒度分散 append が extent 断片化と seek を生む (gated50b campaign の I/O 調査 2026-08-19 で顕在化)。

- `--partition-buffer-kb` を省略時自動サイズ化: 合計予算 1 GiB / partitions を 64 KiB〜16 MiB に clamp。明示指定時は従来どおり
- バッファサイズは出力バイト列に影響しない (BufWriter capacity のみ) — 64 KiB flush 境界を跨ぐ 2,000 レコード入力で partition ファイル・最終出力のバイト一致を検証する回帰テストを追加
- `--dedup-only` のメモリ見積りから実行しない Phase 1 バッファを除外 (引数名も `phase1_skipped` に rename して実責務に整合)
- `--partitions` の既定 1024 は**据え置き** (出力の行順に影響するため既存レシピの bit 再現性を壊さない)。doc に理由と用途別推奨を追記

## レビュー

Codex 実装 + Fable/Codex 敵対的 dual review 2 巡 (blocking 1 = flush 境界テスト、minor 4 — 全解消)。

## テスト

- `cargo test -p tools` / clippy `-D warnings` / fmt: PASS (workspace 全体では変更範囲外の既存 flaky `rshogi-usi::book_flow` のみ失敗 — 本変更と無関係)

🤖 Generated with [Claude Code](https://claude.com/claude-code)