### PR TITLE
feat(tools): psv_dedup_partition に fused shuffle (--shuffle-seed) を追加

### DIFF
--- a/crates/tools/README.md
+++ b/crates/tools/README.md
@@ -48,7 +48,7 @@
 | `migrate_psv_move16` | 旧リポジトリ形式 (B) の PSV move16 を実 YaneuraOu 形式 (A) へ移行（[詳細](docs/migrate_psv_move16.md)） |
 | `pack_to_psv` | GenSfen .pack → PSV 変換（move16 は実着手ラベルの実 YaneuraOu 形式） |
 | `fix_scores` | スコアの補正 |
-| `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（3 方式。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
+| `psv_dedup` / `psv_dedup_bloom` / `psv_dedup_partition` | PSV 局面の重複除去（partition 方式は fused shuffle 対応。使い分けは [pack_tools.md](docs/pack_tools.md#重複除去ツールの選び方)） |
 | `prep_hcpe` | hcpe 教師プールの汚染除去・重複除去・決定的 shuffle・分割（[詳細](docs/prep_hcpe.md)） |
 | `hcpe_to_psv` | hcpe → PSV 変換（Linux/macOS・Windows対応、hardlinkを含む入力と出力の同一実体を拒否。外部公開 hcpe プールの学習/検証投入用、[詳細](docs/hcpe_to_psv.md)） |
 

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -33,7 +33,7 @@
 
 `--shuffle-seed <u64>` を指定すると、Phase 2 で first-wins の unique 選別を終えた後、書き出し直前にパーティション内のレコード列を Fisher-Yates で shuffle する。勝者選択後に順序だけを変えるため、seed の有無によって残るレコードの集合は変わらない。full mode と `--dedup-only` で利用でき、Phase 2 を実行しない `--partition-only` との同時指定はエラーになる。
 
-乱数列は seed と partition index から SplitMix64 で状態を導出した xoshiro256++ で生成する。同じ順序の入力バイト列・partition 数・seed なら、プラットフォームをまたいで同じ出力バイト列を再現する。glob 展開や path ソートの結果が環境によって変わり、入力順が異なる場合はこの前提に含まれない。
+乱数列は seed と partition index から SplitMix64 で状態を導出した xoshiro256++ で生成する。同じ実効入力 (入力バイト列とその順序・reference 内容・`--max-positions`)・partition 数・seed なら、プラットフォームをまたいで同じ出力バイト列を再現する。glob 展開や path ソートの結果が環境によって変わり、入力順が異なる場合はこの前提に含まれない。
 
 PackedSfen の FNV hash による bucket 割当、bucket 内 shuffle、bucket 番号順の連結という、`shuffle_psv` の chunked shuffle と同様の二段構成（ランダム散布 + 区画内 shuffle + 連結）を取る。ただし fused shuffle は bucket 間を移動できないため順列分布は同一ではなく、学習用途への適合性は用途側で判断する必要がある。bucket の作り方と乱数列も異なるため、`shuffle_psv` と同じ seed を指定しても出力はバイト互換にならない。
 

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -33,9 +33,9 @@
 
 `--shuffle-seed <u64>` を指定すると、Phase 2 で first-wins の unique 選別を終えた後、書き出し直前にパーティション内のレコード列を Fisher-Yates で shuffle する。勝者選択後に順序だけを変えるため、seed の有無によって残るレコードの集合は変わらない。full mode と `--dedup-only` で利用でき、Phase 2 を実行しない `--partition-only` との同時指定はエラーになる。
 
-乱数列は seed と partition index から SplitMix64 で状態を導出した xoshiro256++ で生成し、プラットフォームに依存しない。同じ入力順・partition 数・seed で同一環境から再実行すれば、同じ出力バイト列を再現する。
+乱数列は seed と partition index から SplitMix64 で状態を導出した xoshiro256++ で生成する。同じ順序の入力バイト列・partition 数・seed なら、プラットフォームをまたいで同じ出力バイト列を再現する。glob 展開や path ソートの結果が環境によって変わり、入力順が異なる場合はこの前提に含まれない。
 
-PackedSfen の FNV hash による擬似ランダムな bucket 割当、bucket 内の一様 shuffle、bucket 番号順の連結という構成は、`shuffle_psv` の chunked shuffle（ランダムな chunk 割当、chunk 内 shuffle、chunk 順連結）と同族の順列生成であり、学習用途には統計的に同等である。ただし bucket の作り方と乱数列が異なるため、`shuffle_psv` と同じ seed を指定しても出力はバイト互換にならない。
+PackedSfen の FNV hash による bucket 割当、bucket 内 shuffle、bucket 番号順の連結という、`shuffle_psv` の chunked shuffle と同様の二段構成（ランダム散布 + 区画内 shuffle + 連結）を取る。ただし fused shuffle は bucket 間を移動できないため順列分布は同一ではなく、学習用途への適合性は用途側で判断する必要がある。bucket の作り方と乱数列も異なるため、`shuffle_psv` と同じ seed を指定しても出力はバイト互換にならない。
 
 ### 一時ディレクトリ構造
 
@@ -57,7 +57,7 @@ PackedSfen の FNV hash による擬似ランダムな bucket 割当、bucket �
 Phase 2 の流れ (パーティションごと):
 
 1. `ref/partition_{i}.bin` を HashSet に全件ロード（出力しない）
-2. `input/partition_{i}.bin` を streaming し、HashSet に未登録なら出力 + 挿入
+2. `input/partition_{i}.bin` を streaming し、HashSet に未登録なら選別 + 挿入
 3. HashSet を解放して次パーティションへ
 
 これにより、既存ファイルと新規ファイルを結合してから dedup するよりも I/O が少なく、かつ reference 側の重複は出力に回らない。`psv_dedup_bloom --reference` の完全一致版に相当。
@@ -156,7 +156,7 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
   --shuffle-seed 42
 ```
 
-同じ入力順・`--partitions`・seed で同一環境から再実行すると、出力は bit 単位で一致する。既存 temp から再開する場合も `--dedup-only --shuffle-seed 42` のように指定できる。
+既存 temp から再開する場合も `--dedup-only --shuffle-seed 42` のように指定できる。
 
 ### メモリをさらに絞る
 
@@ -277,4 +277,3 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 - 入力と出力が同一ファイルの場合はエラー
 - キーは PackedSfen のみ。同一局面に対する複数の教師手がある場合は `psv_dedup` と同様、最初の出現だけ残す
 - seed 未指定でもパーティション番号順に連結するため、入力全体の順序は保存されない（従来どおり）。`--shuffle-seed` 指定時はパーティション内の順序も shuffle される
-- fused shuffle は学習用途で `shuffle_psv` と統計的に同等だが、同じ seed でも出力バイト列は一致しない

--- a/crates/tools/docs/psv_dedup_partition.md
+++ b/crates/tools/docs/psv_dedup_partition.md
@@ -7,6 +7,7 @@
 - 出力: 最初に出現した局面のみを残した単一ファイル
 - 方式: ディスクパーティショニング → パーティションごとに `HashSet<[u8; 32]>`
 - 特徴: **偽陽性・偽陰性なし**、メモリは「最大パーティション分」に抑えられる
+- 任意機能: `--shuffle-seed` で dedup と学習用 shuffle を同じ Phase 2 に統合
 
 巨大データでも exact に dedup したいが、`psv_dedup`（全件 HashSet 保持）ではメモリが足りないケース向けです。
 
@@ -24,9 +25,17 @@
 
 ### Phase 2: Deduplication
 
-各パーティションファイルを 1 つずつ読み込み、`HashSet<[u8; 32]>` で first-wins の重複判定を行い、出力ファイルに追記する。処理済みパーティションは `HashSet` ごと解放してから次へ進むため、ピークメモリは「最大パーティション 1 つぶんのユニーク局面」で決まる。
+各パーティションファイルを 1 つずつ読み込み、`HashSet<[u8; 32]>` で first-wins の重複判定を行い、出力ファイルに追記する。`--shuffle-seed` 指定時は unique レコードをパーティション単位で保持し、後述の shuffle 後に書き出す。処理済みパーティションの作業領域は次へ進む前に解放する。
 
 `--keep-temp` を指定しない限り、処理済みパーティションは逐次削除される。
+
+### fused shuffle (`--shuffle-seed`)
+
+`--shuffle-seed <u64>` を指定すると、Phase 2 で first-wins の unique 選別を終えた後、書き出し直前にパーティション内のレコード列を Fisher-Yates で shuffle する。勝者選択後に順序だけを変えるため、seed の有無によって残るレコードの集合は変わらない。full mode と `--dedup-only` で利用でき、Phase 2 を実行しない `--partition-only` との同時指定はエラーになる。
+
+乱数列は seed と partition index から SplitMix64 で状態を導出した xoshiro256++ で生成し、プラットフォームに依存しない。同じ入力順・partition 数・seed で同一環境から再実行すれば、同じ出力バイト列を再現する。
+
+PackedSfen の FNV hash による擬似ランダムな bucket 割当、bucket 内の一様 shuffle、bucket 番号順の連結という構成は、`shuffle_psv` の chunked shuffle（ランダムな chunk 割当、chunk 内 shuffle、chunk 順連結）と同族の順列生成であり、学習用途には統計的に同等である。ただし bucket の作り方と乱数列が異なるため、`shuffle_psv` と同じ seed を指定しても出力はバイト互換にならない。
 
 ### 一時ディレクトリ構造
 
@@ -93,6 +102,7 @@ peak_memory ≈ (total_records / partitions) × entry_overhead
 ```
 
 `entry_overhead` は `HashSet<[u8; 32]>` で 1 エントリあたり 50〜70 B 程度（バケット + エントリ + load factor）。
+`--shuffle-seed` 指定時は、これに最大 input partition のレコード列（1 件 40 B）が加わる。起動時の事前見積りもこの shuffle buffer を含める。
 
 ### 参考値（均等分布を仮定）
 
@@ -114,6 +124,8 @@ Phase 2 の進行に合わせて一時ファイルは削除されるので、ピ
 
 合計 I/O は通常 dedup の約 2 倍（Phase 1 で write once、Phase 2 で read once）。一方 `psv_dedup_bloom` は 1 パスなので、「メモリ vs ディスク I/O」のトレードオフになる。
 
+`--shuffle-seed` は Phase 2 の書き出し前に shuffle を済ませるため、後段の `shuffle_psv` が必要とする 2 パスの chunked shuffle（read × 2 + write × 2）を工程ごと省略できる。fused shuffle 自体は dedup に追加のディスクパスを増やさない。
+
 ## FD 上限
 
 `--partitions 1024` 指定時は ulimit の soft limit が 1024 以上必要。起動時にチェックして不足なら警告する。Linux のデフォルトは 1024 なので、多くの環境で次の指定が必要:
@@ -133,6 +145,18 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
   --output /path/to/deduped.bin \
   --temp-dir /fast/ssd/psv_tmp
 ```
+
+### dedup と学習用 shuffle を同時に行う
+
+```bash
+cargo run --release -p tools --bin psv_dedup_partition -- \
+  --input-dir /path/to/dir \
+  --output deduped_shuffled.bin \
+  --temp-dir /fast/ssd/psv_tmp \
+  --shuffle-seed 42
+```
+
+同じ入力順・`--partitions`・seed で同一環境から再実行すると、出力は bit 単位で一致する。既存 temp から再開する場合も `--dedup-only --shuffle-seed 42` のように指定できる。
 
 ### メモリをさらに絞る
 
@@ -219,19 +243,20 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 
 | オプション | 説明 | デフォルト |
 |---|---|---|
-| `--reference` | 参照ファイル（カンマ区切り）。HashSet に登録するが出力しない | — |
+| `--reference` | 参照ファイル。`--dedup-only` は指定値を使わず `ref/` を自動検出 | — |
 | `--input` | 入力ファイル、ディレクトリ、glob（カンマ区切り）。`--input-dir` と排他 | — |
 | `--input-dir` | 入力ディレクトリ。`--pattern` と組み合わせ | — |
 | `--pattern` | `--input-dir` 使用時の glob パターン | `*.bin` |
-| `--output` | 出力ファイルパス | — |
+| `--output` | 出力ファイルパス。full / `--dedup-only` では必須、`--partition-only` では指定不可 | — |
 | `--temp-dir` | パーティション一時ファイルの置き場 | `./psv_dedup_partition_tmp` |
-| `--partitions` | パーティション数 | `1024` |
-| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB) | `64` |
-| `--max-positions` | 処理する入力レコードの最大件数（0 = 全件、試走用）。参照は常に全件 | `0` |
-| `--dedup-only` | Phase 1 をスキップして既存一時ファイルから再開（ref/ は自動検出） | off |
-| `--partition-only` | Phase 2 をスキップして Phase 1 (振り分け) のみ実行（既存 partition には append） | off |
+| `--partitions` | パーティション数（1 以上）。`--dedup-only` は既存 temp から自動検出 | `1024` |
+| `--partition-buffer-kb` | 各パーティションの BufWriter バッファ (KiB、1 以上) | `64` |
+| `--max-positions` | Phase 1 で処理する入力レコード上限（0 = 全件）。参照は常に全件 | `0` |
+| `--dedup-only` | 既存一時ファイルから Phase 2 を再開。`--input` / `--input-dir` / `--partition-only` と併用不可 | off |
+| `--partition-only` | Phase 1 のみ実行（既存 partition へ append）。`--dedup-only` と併用不可 | off |
 | `--delete-input-on-success` | `--partition-only` で各入力ファイルの処理成功後に元ファイルを削除する | off |
 | `--keep-temp` | 完了後も一時ファイル・ディレクトリを削除しない（`--partition-only` では暗黙で有効） | off |
+| `--shuffle-seed` | Phase 2 の unique レコードをパーティション内 shuffle する seed。`--partition-only` と併用不可 | — |
 | `--force` | メモリ/ディスク不足でも警告のみで続行する | off |
 
 ## `psv_dedup` / `psv_dedup_bloom` との比較
@@ -251,4 +276,5 @@ cargo run --release -p tools --bin psv_dedup_partition -- \
 
 - 入力と出力が同一ファイルの場合はエラー
 - キーは PackedSfen のみ。同一局面に対する複数の教師手がある場合は `psv_dedup` と同様、最初の出現だけ残す
-- パーティション出力の順序は保存されない（ハッシュ順）。順序を保ちたい場合は後段で `shuffle_psv` 等を使う
+- seed 未指定でもパーティション番号順に連結するため、入力全体の順序は保存されない（従来どおり）。`--shuffle-seed` 指定時はパーティション内の順序も shuffle される
+- fused shuffle は学習用途で `shuffle_psv` と統計的に同等だが、同じ seed でも出力バイト列は一致しない

--- a/crates/tools/docs/tools-reference.md
+++ b/crates/tools/docs/tools-reference.md
@@ -79,7 +79,7 @@ crates/tools/src/bin/ 配下の主要バイナリの一覧と解説。
 |--------|------|
 | `psv_dedup` | PSV ファイルの局面重複削除（HashSet 方式、中規模向け） |
 | `psv_dedup_bloom` | 大規模 PSV ファイルのブルームフィルタ重複除去（数百億レコード対応、近似） |
-| `psv_dedup_partition` | ディスクパーティション方式の exact 重複除去（低メモリ・大規模向け） |
+| `psv_dedup_partition` | ディスクパーティション方式の exact 重複除去（低メモリ・大規模向け、fused shuffle 対応） |
 | `psv_dedup_check` | PSV ファイルの重複率を統計出力（近似モード・正確モード対応） |
 | `validate_sfens` | SFEN テキストの不正局面を検出・除去（文法・玉の存在・駒数超過・二歩など） |
 

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -618,7 +618,8 @@ fn partition_files_into(
 
                 let sfen: &[u8; SFEN_SIZE] = buf[..SFEN_SIZE].try_into().unwrap();
                 let h = hash_packed_sfen(sfen);
-                let partition = (h as usize) % num_partitions;
+                // 剰余は u64 上で取る (usize cast 先行だと 32-bit 環境で割当が変わる)
+                let partition = (h % num_partitions as u64) as usize;
                 writers[partition].write_all(&buf)?;
 
                 total_records += 1;

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -847,7 +847,7 @@ fn deduplicate_partitions(
             }
         }
 
-        // --- Phase 2b: input partition を streaming し、未登録なら出力 ---
+        // --- Phase 2b: input partition を streaming し、未登録なら選別 ---
         let input_path = input_subdir.join(partition_filename(partition));
         if !input_path.exists() {
             return Err(io::Error::new(
@@ -1483,24 +1483,54 @@ mod tests {
         record
     }
 
-    fn run_dedup(records: &[[u8; PSV_SIZE]], shuffle_seed: Option<u64>) -> Vec<[u8; PSV_SIZE]> {
+    fn run_dedup_partitions(
+        input_partitions: &[Vec<[u8; PSV_SIZE]>],
+        reference_partitions: Option<&[Vec<[u8; PSV_SIZE]>]>,
+        shuffle_seed: Option<u64>,
+    ) -> Vec<[u8; PSV_SIZE]> {
         let dir = TempDir::new().unwrap();
         let input_dir = dir.path().join(INPUT_SUBDIR);
         std::fs::create_dir(&input_dir).unwrap();
-        let input_path = input_dir.join(partition_filename(0));
-        let mut input = File::create(input_path).unwrap();
-        for record in records {
-            input.write_all(record).unwrap();
+        for (partition, records) in input_partitions.iter().enumerate() {
+            let mut input = File::create(input_dir.join(partition_filename(partition))).unwrap();
+            for record in records {
+                input.write_all(record).unwrap();
+            }
         }
-        drop(input);
+
+        let reference_dir = reference_partitions.map(|partitions| {
+            assert_eq!(partitions.len(), input_partitions.len());
+            let reference_dir = dir.path().join(REF_SUBDIR);
+            std::fs::create_dir(&reference_dir).unwrap();
+            for (partition, records) in partitions.iter().enumerate() {
+                let mut reference =
+                    File::create(reference_dir.join(partition_filename(partition))).unwrap();
+                for record in records {
+                    reference.write_all(record).unwrap();
+                }
+            }
+            reference_dir
+        });
 
         let output_path = dir.path().join("output.bin");
-        deduplicate_partitions(&input_dir, None, 1, &output_path, true, shuffle_seed).unwrap();
+        deduplicate_partitions(
+            &input_dir,
+            reference_dir.as_deref(),
+            input_partitions.len(),
+            &output_path,
+            true,
+            shuffle_seed,
+        )
+        .unwrap();
         std::fs::read(output_path)
             .unwrap()
             .chunks_exact(PSV_SIZE)
             .map(|chunk| chunk.try_into().unwrap())
             .collect()
+    }
+
+    fn run_dedup(records: &[[u8; PSV_SIZE]], shuffle_seed: Option<u64>) -> Vec<[u8; PSV_SIZE]> {
+        run_dedup_partitions(&[records.to_vec()], None, shuffle_seed)
     }
 
     fn sorted(mut records: Vec<[u8; PSV_SIZE]>) -> Vec<[u8; PSV_SIZE]> {
@@ -1509,13 +1539,50 @@ mod tests {
     }
 
     #[test]
-    fn shuffle_same_seed_is_byte_deterministic() {
-        let input: Vec<_> = (0..32).map(|key| make_psv(key, key.wrapping_add(1))).collect();
+    fn shuffle_same_seed_is_byte_deterministic_across_partitions() {
+        let partitions: Vec<Vec<_>> = [0u8, 64]
+            .into_iter()
+            .map(|base| (0..32).map(|offset| make_psv(base + offset, offset)).collect())
+            .collect();
 
-        let first = run_dedup(&input, Some(42));
-        let second = run_dedup(&input, Some(42));
+        let first = run_dedup_partitions(&partitions, None, Some(42));
+        let second = run_dedup_partitions(&partitions, None, Some(42));
 
         assert_eq!(first, second);
+        let first_order: Vec<_> = first[..32].iter().map(|record| record[SFEN_SIZE]).collect();
+        let second_order: Vec<_> = first[32..].iter().map(|record| record[SFEN_SIZE]).collect();
+        assert_ne!(first_order, second_order);
+    }
+
+    #[test]
+    fn rng_golden_vectors_include_partition_index() {
+        let mut partition_0 = Xoshiro256PlusPlus::from_seed_and_partition(42, 0);
+        assert_eq!(
+            std::array::from_fn::<_, 4, _>(|_| partition_0.next_u64()),
+            [
+                15_021_278_609_987_233_951,
+                5_881_210_131_331_364_753,
+                18_149_643_915_985_481_100,
+                12_933_668_939_759_105_464,
+            ]
+        );
+
+        let mut partition_1 = Xoshiro256PlusPlus::from_seed_and_partition(42, 1);
+        assert_eq!(
+            std::array::from_fn::<_, 4, _>(|_| partition_1.next_u64()),
+            [
+                10_223_986_022_227_093_464,
+                15_122_917_447_189_544_937,
+                17_379_014_863_014_967_558,
+                1_955_285_833_234_038_687,
+            ]
+        );
+    }
+
+    #[test]
+    fn rng_index_one_is_zero() {
+        let mut rng = Xoshiro256PlusPlus::from_seed_and_partition(42, 0);
+        assert_eq!(rng.index(1), 0);
     }
 
     #[test]
@@ -1530,7 +1597,8 @@ mod tests {
     }
 
     #[test]
-    fn shuffle_does_not_change_first_wins_records() {
+    fn shuffle_preserves_first_wins_with_reference_and_input_duplicates() {
+        let reference = vec![vec![make_psv(1, 1)]];
         let input = vec![
             make_psv(1, 10),
             make_psv(2, 20),
@@ -1539,14 +1607,25 @@ mod tests {
             make_psv(2, 98),
         ];
 
-        let unshuffled = run_dedup(&input, None);
-        let shuffled = run_dedup(&input, Some(7));
+        let unshuffled = run_dedup_partitions(std::slice::from_ref(&input), Some(&reference), None);
+        let shuffled = run_dedup_partitions(&[input], Some(&reference), Some(7));
+        let expected = sorted(vec![make_psv(2, 20), make_psv(3, 30)]);
 
-        assert!(shuffled.contains(&make_psv(1, 10)));
-        assert!(shuffled.contains(&make_psv(2, 20)));
-        assert!(!shuffled.contains(&make_psv(1, 99)));
-        assert!(!shuffled.contains(&make_psv(2, 98)));
-        assert_eq!(sorted(unshuffled), sorted(shuffled));
+        assert!(!shuffled.iter().any(|record| record[..SFEN_SIZE] == [1; SFEN_SIZE]));
+        assert_eq!(sorted(unshuffled), expected);
+        assert_eq!(sorted(shuffled), expected);
+    }
+
+    #[test]
+    fn resource_estimate_adds_shuffle_buffer() {
+        let unshuffled = estimate_resources(400, 4_000, 4, 64 * 1024, false);
+        let shuffled = estimate_resources(400, 4_000, 4, 64 * 1024, true);
+
+        assert_eq!(shuffled.phase2_shuffle_buffer_bytes, 1_200);
+        assert_eq!(
+            shuffled.phase2_peak_memory_bytes,
+            unshuffled.phase2_peak_memory_bytes + shuffled.phase2_shuffle_buffer_bytes
+        );
     }
 
     #[test]

--- a/crates/tools/src/bin/psv_dedup_partition.rs
+++ b/crates/tools/src/bin/psv_dedup_partition.rs
@@ -11,7 +11,8 @@
 /// 2. **Phase 2 (deduplication)**: 各パーティションを 1 つずつ `HashSet<[u8;32]>`
 ///    にロードし、first-wins で出力ファイルへ追記する。参照パーティションが
 ///    あれば先に HashSet に入れ（出力はしない）、続けて入力パーティションを
-///    照合して新規局面だけ出力する。
+///    照合して新規局面だけ出力する。`--shuffle-seed` 指定時は、各パーティションの
+///    unique レコードを決定的に shuffle してから出力する。
 ///
 /// ピークメモリは「全ユニーク局面」ではなく「最大パーティションのユニーク局面」に
 /// 抑えられるため、`psv_dedup` では載らない規模でも exact dedup が可能。
@@ -133,6 +134,11 @@ struct Args {
     #[arg(long)]
     keep_temp: bool,
 
+    /// Phase 2 で first-wins の unique レコードをパーティション内 shuffle してから
+    /// 出力する seed。`--partition-only` とは併用不可。
+    #[arg(long)]
+    shuffle_seed: Option<u64>,
+
     /// メモリ/ディスクの事前見積りチェックをスキップして強制実行する。
     /// swap 多用・途中失敗のリスクを許容する場合のみ使う。
     #[arg(long)]
@@ -165,6 +171,7 @@ struct ResourceEstimate {
     phase2_peak_partition_input_bytes: u64,
     phase1_memory_bytes: u64,
     phase2_peak_memory_bytes: u64,
+    phase2_shuffle_buffer_bytes: u64,
 }
 
 fn estimate_resources(
@@ -172,13 +179,14 @@ fn estimate_resources(
     input_size_bytes: u64,
     num_partitions: usize,
     partition_buffer_bytes: usize,
+    shuffle: bool,
 ) -> ResourceEstimate {
     let total_bytes = ref_size_bytes + input_size_bytes;
     let total_records = total_bytes / PSV_SIZE as u64;
     let avg_records_per_partition = total_records as f64 / num_partitions.max(1) as f64;
     let peak_records_per_partition =
         (avg_records_per_partition * HASH_VARIANCE_FACTOR).ceil() as u64;
-    let phase2_peak_mem = peak_records_per_partition.saturating_mul(HASHSET_ENTRY_BYTES);
+    let phase2_hashset_mem = peak_records_per_partition.saturating_mul(HASHSET_ENTRY_BYTES);
     let phase1_mem = (num_partitions as u64).saturating_mul(partition_buffer_bytes as u64);
     let input_records = input_size_bytes / PSV_SIZE as u64;
     let avg_input_records_per_partition = input_records as f64 / num_partitions.max(1) as f64;
@@ -186,6 +194,12 @@ fn estimate_resources(
         (avg_input_records_per_partition * HASH_VARIANCE_FACTOR).ceil() as u64;
     let phase2_peak_partition_input_bytes =
         peak_input_records_per_partition.saturating_mul(PSV_SIZE as u64);
+    let phase2_shuffle_buffer_bytes = if shuffle {
+        phase2_peak_partition_input_bytes
+    } else {
+        0
+    };
+    let phase2_peak_mem = phase2_hashset_mem.saturating_add(phase2_shuffle_buffer_bytes);
 
     ResourceEstimate {
         total_records,
@@ -194,6 +208,7 @@ fn estimate_resources(
         phase2_peak_partition_input_bytes,
         phase1_memory_bytes: phase1_mem,
         phase2_peak_memory_bytes: phase2_peak_mem,
+        phase2_shuffle_buffer_bytes,
     }
 }
 
@@ -272,11 +287,20 @@ fn preflight_check_with_available_memory(
             format_gib(estimate.phase1_memory_bytes),
         );
     }
-    eprintln!(
-        "Phase 2 peak memory:  {} (HashSet of largest partition, ~{:.2}x variance)",
-        format_gib(estimate.phase2_peak_memory_bytes),
-        HASH_VARIANCE_FACTOR,
-    );
+    if estimate.phase2_shuffle_buffer_bytes == 0 {
+        eprintln!(
+            "Phase 2 peak memory:  {} (HashSet of largest partition, ~{:.2}x variance)",
+            format_gib(estimate.phase2_peak_memory_bytes),
+            HASH_VARIANCE_FACTOR,
+        );
+    } else {
+        eprintln!(
+            "Phase 2 peak memory:  {} (HashSet + shuffle buffer {}, ~{:.2}x variance)",
+            format_gib(estimate.phase2_peak_memory_bytes),
+            format_gib(estimate.phase2_shuffle_buffer_bytes),
+            HASH_VARIANCE_FACTOR,
+        );
+    }
 
     let peak_mem = estimate.phase1_memory_bytes.max(estimate.phase2_peak_memory_bytes);
 
@@ -715,6 +739,60 @@ fn read_partition_records(
     Ok(count)
 }
 
+struct Xoshiro256PlusPlus {
+    state: [u64; 4],
+}
+
+impl Xoshiro256PlusPlus {
+    fn from_seed_and_partition(seed: u64, partition: usize) -> Self {
+        let mut splitmix_state = seed ^ (partition as u64).wrapping_mul(0xd2b7_4407_b1ce_6e93);
+        let mut state = [0u64; 4];
+        for value in &mut state {
+            splitmix_state = splitmix_state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut z = splitmix_state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            *value = z ^ (z >> 31);
+        }
+        Self { state }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let result = self.state[0]
+            .wrapping_add(self.state[3])
+            .rotate_left(23)
+            .wrapping_add(self.state[0]);
+        let t = self.state[1] << 17;
+
+        self.state[2] ^= self.state[0];
+        self.state[3] ^= self.state[1];
+        self.state[1] ^= self.state[2];
+        self.state[0] ^= self.state[3];
+        self.state[2] ^= t;
+        self.state[3] = self.state[3].rotate_left(45);
+
+        result
+    }
+
+    fn index(&mut self, upper_exclusive: u64) -> usize {
+        let threshold = upper_exclusive.wrapping_neg() % upper_exclusive;
+        loop {
+            let value = self.next_u64();
+            if value >= threshold {
+                return (value % upper_exclusive) as usize;
+            }
+        }
+    }
+}
+
+fn shuffle_records(records: &mut [[u8; PSV_SIZE]], seed: u64, partition: usize) {
+    let mut rng = Xoshiro256PlusPlus::from_seed_and_partition(seed, partition);
+    for i in (1..records.len()).rev() {
+        let j = rng.index((i + 1) as u64);
+        records.swap(i, j);
+    }
+}
+
 /// Phase 2: 各パーティションを HashSet で exact dedup し、出力に追記する。
 ///
 /// `ref_subdir` が `Some` ならパーティション先頭で reference を HashSet に
@@ -727,6 +805,7 @@ fn deduplicate_partitions(
     num_partitions: usize,
     output_path: &Path,
     keep_temp: bool,
+    shuffle_seed: Option<u64>,
 ) -> io::Result<(u64, u64, u64)> {
     if let Some(parent) = output_path.parent()
         && !parent.as_os_str().is_empty()
@@ -781,13 +860,30 @@ fn deduplicate_partitions(
         }
 
         let mut unique_in_partition = 0u64;
+        let input_capacity = if shuffle_seed.is_some() {
+            (input_path.metadata()?.len() / PSV_SIZE as u64) as usize
+        } else {
+            0
+        };
+        let mut unique_records = shuffle_seed.map(|_| Vec::with_capacity(input_capacity));
         let input_records = read_partition_records(&input_path, |rec, sfen| {
             if seen.insert(*sfen) {
-                writer.write_all(rec)?;
+                if let Some(records) = &mut unique_records {
+                    records.push(*rec);
+                } else {
+                    writer.write_all(rec)?;
+                }
                 unique_in_partition += 1;
             }
             Ok(())
         })?;
+
+        if let (Some(seed), Some(records)) = (shuffle_seed, &mut unique_records) {
+            shuffle_records(records, seed, partition);
+            for record in records {
+                writer.write_all(record)?;
+            }
+        }
 
         total_seen += input_records;
         total_unique += unique_in_partition;
@@ -887,9 +983,7 @@ fn has_any_partition_file(dir: &Path) -> io::Result<bool> {
     Ok(false)
 }
 
-fn main() -> io::Result<()> {
-    let args = Args::parse();
-
+fn validate_args(args: &Args) -> io::Result<()> {
     if args.partitions == 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -906,6 +1000,12 @@ fn main() -> io::Result<()> {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "--partition-only と --dedup-only は同時に指定できません",
+        ));
+    }
+    if args.partition_only && args.shuffle_seed.is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--shuffle-seed は Phase 2 の機能のため --partition-only とは併用できません",
         ));
     }
     if !args.partition_only && args.output.is_none() {
@@ -938,6 +1038,13 @@ fn main() -> io::Result<()> {
             "--delete-input-on-success と --max-positions は併用できません（入力を途中までしか読まないため）",
         ));
     }
+
+    Ok(())
+}
+
+fn main() -> io::Result<()> {
+    let args = Args::parse();
+    validate_args(&args)?;
 
     let partition_buffer_bytes = args.partition_buffer_kb * 1024;
     let input_subdir = args.temp_dir.join(INPUT_SUBDIR);
@@ -1029,6 +1136,7 @@ fn main() -> io::Result<()> {
             existing_input_bytes,
             partitions,
             partition_buffer_bytes,
+            args.shuffle_seed.is_some(),
         );
         preflight_check(
             &estimate,
@@ -1065,8 +1173,13 @@ fn main() -> io::Result<()> {
         } else {
             input_size
         };
-        let estimate =
-            estimate_resources(ref_size, capped_input_size, partitions, partition_buffer_bytes);
+        let estimate = estimate_resources(
+            ref_size,
+            capped_input_size,
+            partitions,
+            partition_buffer_bytes,
+            args.shuffle_seed.is_some(),
+        );
         preflight_check(
             &estimate,
             &args.temp_dir,
@@ -1138,6 +1251,7 @@ fn main() -> io::Result<()> {
         partitions,
         output_path,
         args.keep_temp,
+        args.shuffle_seed,
     )?;
 
     if !args.keep_temp {
@@ -1278,7 +1392,7 @@ fn run_partition_only(
         input_size
     };
     let estimate =
-        estimate_resources(ref_size, capped_input_size, partitions, partition_buffer_bytes);
+        estimate_resources(ref_size, capped_input_size, partitions, partition_buffer_bytes, false);
     preflight_check(
         &estimate,
         &args.temp_dir,
@@ -1362,23 +1476,111 @@ mod tests {
     use std::io::Cursor;
     use tempfile::TempDir;
 
+    fn make_psv(key: u8, payload: u8) -> [u8; PSV_SIZE] {
+        let mut record = [0u8; PSV_SIZE];
+        record[..SFEN_SIZE].fill(key);
+        record[SFEN_SIZE..].fill(payload);
+        record
+    }
+
+    fn run_dedup(records: &[[u8; PSV_SIZE]], shuffle_seed: Option<u64>) -> Vec<[u8; PSV_SIZE]> {
+        let dir = TempDir::new().unwrap();
+        let input_dir = dir.path().join(INPUT_SUBDIR);
+        std::fs::create_dir(&input_dir).unwrap();
+        let input_path = input_dir.join(partition_filename(0));
+        let mut input = File::create(input_path).unwrap();
+        for record in records {
+            input.write_all(record).unwrap();
+        }
+        drop(input);
+
+        let output_path = dir.path().join("output.bin");
+        deduplicate_partitions(&input_dir, None, 1, &output_path, true, shuffle_seed).unwrap();
+        std::fs::read(output_path)
+            .unwrap()
+            .chunks_exact(PSV_SIZE)
+            .map(|chunk| chunk.try_into().unwrap())
+            .collect()
+    }
+
+    fn sorted(mut records: Vec<[u8; PSV_SIZE]>) -> Vec<[u8; PSV_SIZE]> {
+        records.sort_unstable();
+        records
+    }
+
+    #[test]
+    fn shuffle_same_seed_is_byte_deterministic() {
+        let input: Vec<_> = (0..32).map(|key| make_psv(key, key.wrapping_add(1))).collect();
+
+        let first = run_dedup(&input, Some(42));
+        let second = run_dedup(&input, Some(42));
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn shuffle_different_seeds_change_order_but_not_multiset() {
+        let input: Vec<_> = (0..32).map(|key| make_psv(key, key.wrapping_add(1))).collect();
+
+        let first = run_dedup(&input, Some(1));
+        let second = run_dedup(&input, Some(2));
+
+        assert_ne!(first, second);
+        assert_eq!(sorted(first), sorted(second));
+    }
+
+    #[test]
+    fn shuffle_does_not_change_first_wins_records() {
+        let input = vec![
+            make_psv(1, 10),
+            make_psv(2, 20),
+            make_psv(1, 99),
+            make_psv(3, 30),
+            make_psv(2, 98),
+        ];
+
+        let unshuffled = run_dedup(&input, None);
+        let shuffled = run_dedup(&input, Some(7));
+
+        assert!(shuffled.contains(&make_psv(1, 10)));
+        assert!(shuffled.contains(&make_psv(2, 20)));
+        assert!(!shuffled.contains(&make_psv(1, 99)));
+        assert!(!shuffled.contains(&make_psv(2, 98)));
+        assert_eq!(sorted(unshuffled), sorted(shuffled));
+    }
+
+    #[test]
+    fn partition_only_rejects_shuffle_seed() {
+        let args = Args::try_parse_from([
+            "psv_dedup_partition",
+            "--partition-only",
+            "--shuffle-seed",
+            "42",
+        ])
+        .unwrap();
+
+        let err = validate_args(&args).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("--partition-only"));
+    }
+
     #[test]
     fn same_fs_headroom_without_keep_temp_is_peak_partition_only() {
-        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024, false);
 
         assert_eq!(same_fs_output_headroom_bytes(&estimate, false), 1_200);
     }
 
     #[test]
     fn same_fs_headroom_with_keep_temp_is_full_output() {
-        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024, false);
 
         assert_eq!(same_fs_output_headroom_bytes(&estimate, true), 4_000);
     }
 
     #[test]
     fn dedup_only_same_fs_uses_headroom_not_full_output() {
-        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024);
+        let estimate = estimate_resources(400, 4_000, 4, 64 * 1024, false);
 
         assert_eq!(output_disk_required_bytes(&estimate, true, true, false), 1_260);
         assert_eq!(output_disk_required_bytes(&estimate, false, true, false), 4_200);
@@ -1388,7 +1590,7 @@ mod tests {
     fn dedup_only_preflight_succeeds_when_memory_is_available() {
         let dir = TempDir::new().unwrap();
         let output = dir.path().join("output.bin");
-        let estimate = estimate_resources(0, 0, 1, 0);
+        let estimate = estimate_resources(0, 0, 1, 0, false);
 
         preflight_check_with_available_memory(
             &estimate,


### PR DESCRIPTION
## 概要

TB 級教師 PSV の構築は現在「dedup → shuffle_psv (2 パス chunked shuffle)」の直列で、shuffle だけで入力の 4 倍の I/O がかかる。dedup Phase 2 は partition 単位で unique レコードを保持してから書き出すため、書き出し直前に partition 内 shuffle を済ませれば **shuffle 工程を丸ごと省略できる** (gated50b 級で I/O ~7.6TB 削減)。

- `--shuffle-seed <u64>` (opt-in、省略時は完全に従来動作): Phase 2 で first-wins の unique 選別後、書き出し直前に partition 内 Fisher-Yates shuffle
- RNG = seed × partition index から SplitMix64 で状態導出した xoshiro256++ (自前実装、外部 crate なし)。同じ実効入力・partitions・seed でプラットフォームをまたいで bit 再現 (partition 割当の剰余を u64 上で取る修正込み — 64-bit では出力不変)
- **勝者選択に影響しない**: shuffle は出力順のみ。どの重複が生き残るかは seed の有無で不変 (テストで保証)
- `--partition-only` とは fail-closed で排他。preflight のメモリ見積りに shuffle buffer を加算
- doc: 方式と適用条件を記載。chunked shuffle と「同様の二段構成だが順列分布は同一ではない」ことを明記 (学習用途への適合性は用途側判断 — 採用時は campaign 事前登録に組み込む前提)

## テスト

- 2 partition での同 seed bit 決定性 / partition 0/1 の RNG golden vector (partition index 混合の退行を検知) / 異 seed で順序変化 + multiset 一致 / reference 重複 + 入力内重複の first-wins 不変 / estimate の shuffle buffer 加算 / index(1)==0 境界 — 17 tests PASS
- clippy `-D warnings` / fmt: PASS (workspace の既存 flaky `rshogi-usi::book_flow` は本変更と無関係)

## レビュー

Codex 実装 + Fable/Codex 敵対的 dual review 2 巡 (blocking 1 = テスト補強、minor 4 + P2 1 — 全解消)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)