### PR TITLE
test(core): search テストの material 評価依存を明示化し、eval グローバルを guard で直列化・復元する

### DIFF
--- a/crates/rshogi-core/src/eval/material.rs
+++ b/crates/rshogi-core/src/eval/material.rs
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn test_material_eval_hirate() {
-        let _guard = test_support::lock_material();
+        let guard = test_support::lock_material();
 
         let mut pos = Position::new();
         pos.set_sfen(SFEN_HIRATE).unwrap();
@@ -703,6 +703,8 @@ mod tests {
 
         // 初期局面はほぼ互角（MaterialLvにより0から僅かにずれる場合がある）
         assert!(value.raw().abs() < 200);
+
+        drop(guard);
     }
 
     #[test]
@@ -735,7 +737,7 @@ mod tests {
 
     #[test]
     fn test_get_set_material_level() {
-        let _guard = test_support::lock_material();
+        let guard = test_support::lock_material();
 
         set_material_level(MaterialLevel::Lv1);
         assert_eq!(get_material_level(), MaterialLevel::Lv1);
@@ -747,6 +749,8 @@ mod tests {
 
         disable_material();
         assert!(!is_material_enabled());
+
+        drop(guard);
     }
 
     // =========================================================================
@@ -808,7 +812,7 @@ mod tests {
     fn test_pass_right_value_global_and_evaluation() {
         use crate::types::Color;
 
-        let _guard = test_support::lock_material();
+        let guard = test_support::lock_material();
 
         // --- Part 1: set_pass_right_value_phased のテスト ---
         set_pass_right_value_phased(50, 200);
@@ -861,5 +865,7 @@ mod tests {
             negamax_combined < 0,
             "Negamax combined score should be negative: got {negamax_combined}"
         );
+
+        drop(guard);
     }
 }

--- a/crates/rshogi-core/src/eval/material.rs
+++ b/crates/rshogi-core/src/eval/material.rs
@@ -644,6 +644,49 @@ pub fn evaluate_material(pos: &Position) -> Value {
     }
 }
 
+/// テスト専用: eval グローバル状態 (MATERIAL_LEVEL / MATERIAL_ENABLED /
+/// PASS_RIGHT_VALUE_EARLY / PASS_RIGHT_VALUE_LATE) を触るテストの直列化と状態復元
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    /// eval グローバルを変更するテストを直列化するロック
+    static EVAL_GLOBAL_LOCK: Mutex<()> = Mutex::new(());
+
+    /// ロック取得時点の material グローバル状態を Drop で復元する guard
+    pub(crate) struct MaterialGuard {
+        _lock: MutexGuard<'static, ()>,
+        level: u8,
+        enabled: bool,
+        pass_right_early: i32,
+        pass_right_late: i32,
+    }
+
+    /// ロックを取得し、現在の material グローバル状態を snapshot する
+    ///
+    /// panic したテストが持っていた poison は無視してよい (Drop で状態復元済みのため)。
+    pub(crate) fn lock_material() -> MaterialGuard {
+        let lock = EVAL_GLOBAL_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        MaterialGuard {
+            _lock: lock,
+            level: MATERIAL_LEVEL.load(Ordering::Relaxed),
+            enabled: MATERIAL_ENABLED.load(Ordering::Relaxed),
+            pass_right_early: PASS_RIGHT_VALUE_EARLY.load(Ordering::Relaxed),
+            pass_right_late: PASS_RIGHT_VALUE_LATE.load(Ordering::Relaxed),
+        }
+    }
+
+    impl Drop for MaterialGuard {
+        fn drop(&mut self) {
+            MATERIAL_LEVEL.store(self.level, Ordering::Relaxed);
+            MATERIAL_ENABLED.store(self.enabled, Ordering::Relaxed);
+            PASS_RIGHT_VALUE_EARLY.store(self.pass_right_early, Ordering::Relaxed);
+            PASS_RIGHT_VALUE_LATE.store(self.pass_right_late, Ordering::Relaxed);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -651,6 +694,8 @@ mod tests {
 
     #[test]
     fn test_material_eval_hirate() {
+        let _guard = test_support::lock_material();
+
         let mut pos = Position::new();
         pos.set_sfen(SFEN_HIRATE).unwrap();
 
@@ -690,8 +735,7 @@ mod tests {
 
     #[test]
     fn test_get_set_material_level() {
-        let original = get_material_level();
-        let original_enabled = is_material_enabled();
+        let _guard = test_support::lock_material();
 
         set_material_level(MaterialLevel::Lv1);
         assert_eq!(get_material_level(), MaterialLevel::Lv1);
@@ -703,10 +747,6 @@ mod tests {
 
         disable_material();
         assert!(!is_material_enabled());
-
-        if original_enabled {
-            set_material_level(original);
-        }
     }
 
     // =========================================================================
@@ -768,10 +808,7 @@ mod tests {
     fn test_pass_right_value_global_and_evaluation() {
         use crate::types::Color;
 
-        // 設定を保存
-        let orig_early = PASS_RIGHT_VALUE_EARLY.load(std::sync::atomic::Ordering::Relaxed);
-        let orig_late = PASS_RIGHT_VALUE_LATE.load(std::sync::atomic::Ordering::Relaxed);
-        let orig_level = get_material_level();
+        let _guard = test_support::lock_material();
 
         // --- Part 1: set_pass_right_value_phased のテスト ---
         set_pass_right_value_phased(50, 200);
@@ -824,9 +861,5 @@ mod tests {
             negamax_combined < 0,
             "Negamax combined score should be negative: got {negamax_combined}"
         );
-
-        // 設定を復元
-        set_pass_right_value_phased(orig_early, orig_late);
-        set_material_level(orig_level);
     }
 }

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -2284,6 +2284,10 @@ mod tests {
 
     #[test]
     fn test_search_basic() {
+        // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+        let _guard = crate::eval::material::test_support::lock_material();
+        crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
         // スタックサイズを増やした別スレッドで実行
         std::thread::Builder::new()
             .stack_size(STACK_SIZE)
@@ -2309,6 +2313,10 @@ mod tests {
 
     #[test]
     fn test_search_with_callback() {
+        // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+        let _guard = crate::eval::material::test_support::lock_material();
+        crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
         // スタックサイズを増やした別スレッドで実行
         std::thread::Builder::new()
             .stack_size(STACK_SIZE)
@@ -2341,6 +2349,10 @@ mod tests {
 
     #[test]
     fn test_search_with_callback_last_info_matches_best_move() {
+        // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+        let _guard = crate::eval::material::test_support::lock_material();
+        crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
         // スタックサイズを増やした別スレッドで実行
         std::thread::Builder::new()
             .stack_size(STACK_SIZE)

--- a/crates/rshogi-core/src/search/engine.rs
+++ b/crates/rshogi-core/src/search/engine.rs
@@ -2285,7 +2285,7 @@ mod tests {
     #[test]
     fn test_search_basic() {
         // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-        let _guard = crate::eval::material::test_support::lock_material();
+        let guard = crate::eval::material::test_support::lock_material();
         crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
         // スタックサイズを増やした別スレッドで実行
@@ -2309,12 +2309,14 @@ mod tests {
             .unwrap()
             .join()
             .unwrap();
+
+        drop(guard);
     }
 
     #[test]
     fn test_search_with_callback() {
         // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-        let _guard = crate::eval::material::test_support::lock_material();
+        let guard = crate::eval::material::test_support::lock_material();
         crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
         // スタックサイズを増やした別スレッドで実行
@@ -2345,12 +2347,14 @@ mod tests {
             .unwrap()
             .join()
             .unwrap();
+
+        drop(guard);
     }
 
     #[test]
     fn test_search_with_callback_last_info_matches_best_move() {
         // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-        let _guard = crate::eval::material::test_support::lock_material();
+        let guard = crate::eval::material::test_support::lock_material();
         crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
         // スタックサイズを増やした別スレッドで実行
@@ -2386,6 +2390,8 @@ mod tests {
             .unwrap()
             .join()
             .unwrap();
+
+        drop(guard);
     }
 
     #[test]

--- a/crates/rshogi-core/src/search/tests/history_update.rs
+++ b/crates/rshogi-core/src/search/tests/history_update.rs
@@ -14,6 +14,10 @@ const STACK_SIZE: usize = 64 * 1024 * 1024; // 64MB
 /// TT手がbestだった場合にTTMoveHistoryが加点されることを確認
 #[test]
 fn tt_move_history_updates_on_bestmove() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(|| {
@@ -45,6 +49,10 @@ fn tt_move_history_updates_on_bestmove() {
 /// 簡易的に探索が完了することを確認するのみ
 #[test]
 fn continuation_history_updates_on_quiet_best() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(|| {

--- a/crates/rshogi-core/src/search/tests/history_update.rs
+++ b/crates/rshogi-core/src/search/tests/history_update.rs
@@ -15,7 +15,7 @@ const STACK_SIZE: usize = 64 * 1024 * 1024; // 64MB
 #[test]
 fn tt_move_history_updates_on_bestmove() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     std::thread::Builder::new()
@@ -42,6 +42,8 @@ fn tt_move_history_updates_on_bestmove() {
         .unwrap()
         .join()
         .unwrap();
+
+    drop(guard);
 }
 
 /// ContinuationHistoryがquiet bestmoveで更新されることを確認
@@ -50,7 +52,7 @@ fn tt_move_history_updates_on_bestmove() {
 #[test]
 fn continuation_history_updates_on_quiet_best() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     std::thread::Builder::new()
@@ -83,6 +85,8 @@ fn continuation_history_updates_on_quiet_best() {
         .unwrap()
         .join()
         .unwrap();
+
+    drop(guard);
 }
 
 // =============================================================================

--- a/crates/rshogi-core/src/search/tests/multi_pv.rs
+++ b/crates/rshogi-core/src/search/tests/multi_pv.rs
@@ -253,7 +253,7 @@ fn test_no_early_exit_when_mated() {
 #[test]
 fn test_multi_pv_3_integration() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -310,13 +310,15 @@ fn test_multi_pv_3_integration() {
             first_moves.len()
         );
     });
+
+    drop(guard);
 }
 
 /// MultiPV=1でも multipv 1 を出力することを確認
 #[test]
 fn test_multi_pv_1_outputs_multipv_field() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -355,13 +357,15 @@ fn test_multi_pv_1_outputs_multipv_field() {
             "USI出力に 'multipv 1' が含まれる。実際: {usi_string}"
         );
     });
+
+    drop(guard);
 }
 
 /// 合法手数を超えるMultiPV値がクランプされることを確認
 #[test]
 fn test_multi_pv_clamped_to_legal_moves_integration() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -408,13 +412,15 @@ fn test_multi_pv_clamped_to_legal_moves_integration() {
             assert_eq!(value, i + 1, "multipv値が1から連続している");
         }
     });
+
+    drop(guard);
 }
 
 /// MultiPV出力がスコア降順で並ぶことを確認
 #[test]
 fn test_multi_pv_scores_sorted_desc() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -466,6 +472,8 @@ fn test_multi_pv_scores_sorted_desc() {
             );
         }
     });
+
+    drop(guard);
 }
 
 /// aspiration window が平均・二乗平均スコアを使うことを確認
@@ -495,7 +503,7 @@ fn test_aspiration_window_defaults_to_full_window_when_unseeded() {
 #[test]
 fn test_multi_pv_outputs_once_per_depth() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -534,6 +542,8 @@ fn test_multi_pv_outputs_once_per_depth() {
         let multipv: Vec<_> = depth1_infos.iter().map(|info| info.multi_pv).collect();
         assert_eq!(multipv, vec![1, 2, 1], "最後は採択ラインのmultipv 1を再出力する");
     });
+
+    drop(guard);
 }
 
 // =============================================================================
@@ -544,7 +554,7 @@ fn test_multi_pv_outputs_once_per_depth() {
 #[test]
 fn test_previous_score_seeding() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     use crate::position::Position;
@@ -566,6 +576,8 @@ fn test_previous_score_seeding() {
         let result = search.go(&mut pos, limits, None::<fn(&_)>);
         assert_ne!(result.best_move, Move::NONE);
     });
+
+    drop(guard);
 }
 
 /// MultiPV>1で最終ソートが正しく動作することを確認

--- a/crates/rshogi-core/src/search/tests/multi_pv.rs
+++ b/crates/rshogi-core/src/search/tests/multi_pv.rs
@@ -252,6 +252,10 @@ fn test_no_early_exit_when_mated() {
 /// MultiPV=3で3つのPVライン出力
 #[test]
 fn test_multi_pv_3_integration() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::{Search, SearchInfo};
@@ -311,6 +315,10 @@ fn test_multi_pv_3_integration() {
 /// MultiPV=1でも multipv 1 を出力することを確認
 #[test]
 fn test_multi_pv_1_outputs_multipv_field() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::{Search, SearchInfo};
@@ -352,6 +360,10 @@ fn test_multi_pv_1_outputs_multipv_field() {
 /// 合法手数を超えるMultiPV値がクランプされることを確認
 #[test]
 fn test_multi_pv_clamped_to_legal_moves_integration() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::{Search, SearchInfo};
@@ -401,6 +413,10 @@ fn test_multi_pv_clamped_to_legal_moves_integration() {
 /// MultiPV出力がスコア降順で並ぶことを確認
 #[test]
 fn test_multi_pv_scores_sorted_desc() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::{Search, SearchInfo};
@@ -478,6 +494,10 @@ fn test_aspiration_window_defaults_to_full_window_when_unseeded() {
 /// depthごとにMultiPV本数分のinfoが出て、最後に採択ラインが再出力される
 #[test]
 fn test_multi_pv_outputs_once_per_depth() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::{Search, SearchInfo};
@@ -523,6 +543,10 @@ fn test_multi_pv_outputs_once_per_depth() {
 /// Depth完了後にprevious_scoreがシードされることを統合テストで確認
 #[test]
 fn test_previous_score_seeding() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     use crate::position::Position;
     use crate::search::LimitsType;
     use crate::search::engine::Search;

--- a/crates/rshogi-core/src/search/tests/skill.rs
+++ b/crates/rshogi-core/src/search/tests/skill.rs
@@ -9,6 +9,10 @@ const STACK_SIZE: usize = 64 * 1024 * 1024;
 
 #[test]
 fn skill_forces_multipv_to_four() {
+    // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
+    let _guard = crate::eval::material::test_support::lock_material();
+    crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
+
     std::thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(|| {

--- a/crates/rshogi-core/src/search/tests/skill.rs
+++ b/crates/rshogi-core/src/search/tests/skill.rs
@@ -10,7 +10,7 @@ const STACK_SIZE: usize = 64 * 1024 * 1024;
 #[test]
 fn skill_forces_multipv_to_four() {
     // NNUE 未ロードでも探索できるよう material 評価を有効化 (guard が終了時に復元)
-    let _guard = crate::eval::material::test_support::lock_material();
+    let guard = crate::eval::material::test_support::lock_material();
     crate::eval::set_material_level(crate::eval::MaterialLevel::Lv1);
 
     std::thread::Builder::new()
@@ -48,4 +48,6 @@ fn skill_forces_multipv_to_four() {
         .unwrap()
         .join()
         .unwrap();
+
+    drop(guard);
 }

--- a/crates/rshogi-core/src/search/tt_sanity.rs
+++ b/crates/rshogi-core/src/search/tt_sanity.rs
@@ -234,7 +234,7 @@ mod trace {
         if seq >= MAX_TRACE_LOGS {
             return;
         }
-        let _guard = TRACE_LOCK.lock().ok();
+        let guard = TRACE_LOCK.lock().ok();
         eprintln!(
             "[TT-TRACE] seq={} kind=probe stage={} tid={} ply={} root={} hit={} key=0x{:016x} depth={} bound={:?} move={} stored={} converted={} eval={}",
             seq,
@@ -251,6 +251,7 @@ mod trace {
             log.converted_value.raw(),
             log.eval.raw(),
         );
+        drop(guard);
     }
 
     pub(in crate::search) fn maybe_trace_tt_write(log: TtWriteTrace<'_>) {
@@ -261,7 +262,7 @@ mod trace {
         if seq >= MAX_TRACE_LOGS {
             return;
         }
-        let _guard = TRACE_LOCK.lock().ok();
+        let guard = TRACE_LOCK.lock().ok();
         eprintln!(
             "[TT-TRACE] seq={} kind=write stage={} tid={} ply={} root={} key=0x{:016x} depth={} bound={:?} pv={} move={} stored={} eval={}",
             seq,
@@ -277,6 +278,7 @@ mod trace {
             log.stored_value.raw(),
             log.eval.raw(),
         );
+        drop(guard);
     }
 
     pub(in crate::search) fn maybe_trace_tt_cutoff(log: TtCutoffTrace<'_>) {
@@ -287,7 +289,7 @@ mod trace {
         if seq >= MAX_TRACE_LOGS {
             return;
         }
-        let _guard = TRACE_LOCK.lock().ok();
+        let guard = TRACE_LOCK.lock().ok();
         eprintln!(
             "[TT-TRACE] seq={} kind=cutoff stage={} tid={} ply={} root={} key=0x{:016x} search_depth={} depth={} bound={:?} value={} beta={}",
             seq,
@@ -302,6 +304,7 @@ mod trace {
             log.value.raw(),
             log.beta.raw(),
         );
+        drop(guard);
     }
 }
 


### PR DESCRIPTION
## 概要

search 系テストが NNUE 未ロード環境で通るのは、同一バイナリ内の material テストが末尾で `set_material_level(orig)` を呼び `MATERIAL_ENABLED=true` を残す副作用に依存した偶然だった。単体実行や実行順次第でパニックする。

```
$ cargo test -p rshogi-core --lib test_search_basic   # main で失敗
panicked at nnue/network.rs: NNUE network not loaded and MaterialLevel not set.
```

## 変更

- `material::test_support::lock_material()` を追加: eval グローバルを触るテストを Mutex で直列化し、`MaterialGuard` の Drop で状態を復元 (panic 時も漏れない)
- search テスト (engine 3 本 / multi_pv 6 本 / history_update 2 本 / skill 1 本) が自分で `set_material_level(Lv1)` を宣言
- material テスト側の手動 save/restore を guard に置き換え

## 検証

- `cargo test -p rshogi-core --lib test_search_basic` 単体で pass
- `cargo test -p rshogi-core --lib` (既定 / `--test-threads=1`) 1003 passed
- `cargo fmt --check` / `cargo clippy -p rshogi-core --all-targets -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
